### PR TITLE
feat(olympus): add hermetic phase1 adapter

### DIFF
--- a/docs/plans/OLYMPUS_PHASE1_GATE2_CHANGE_REVIEW.md
+++ b/docs/plans/OLYMPUS_PHASE1_GATE2_CHANGE_REVIEW.md
@@ -1,0 +1,229 @@
+# Olympus Phase 1 Gate 2 Change Review
+
+Status: `TECHNICAL_APPROVE; HOLD_FOR_SEPARATE_COMMIT_AUTHORIZATION`
+
+Date: 2026-08-06
+
+This record covers the inert, source-checkout-only Hermes adapter for the frozen
+Olympus Phase 1 fake-transport seam. It grants no runtime, deployment, staging,
+push, merge, or production authority. A local commit requires a separate
+operator authorization after the external closeout binds this file and the
+complete eleven-path manifest.
+
+## Authority and frozen scope
+
+The operator approved all eleven literal Gate 2 allowlist paths, accepted the
+hostile-same-effective-UID residual risk, and authorized creation of the frozen
+branch/worktree plus implementation only. The operator explicitly withheld
+commit authority.
+
+No existing tracked file is modified. The only durable paths are:
+
+1. `olympus_phase1_adapter/__init__.py`
+2. `olympus_phase1_adapter/contracts.py`
+3. `olympus_phase1_adapter/receipt_store.py`
+4. `olympus_phase1_adapter/adapter.py`
+5. `olympus_phase1_adapter/schemas/v1/phase1-operation-v1.schema.json`
+6. `olympus_phase1_adapter/schemas/v1/phase1-receipt-v1.schema.json`
+7. `olympus_phase1_adapter/schemas/v1/phase1-ownership-record-v1.schema.json`
+8. `tests/olympus_phase1_adapter/conftest.py`
+9. `tests/olympus_phase1_adapter/test_contracts_and_adapter.py`
+10. `tests/olympus_phase1_adapter/test_receipt_store.py`
+11. `docs/plans/OLYMPUS_PHASE1_GATE2_CHANGE_REVIEW.md`
+
+The sole allowed validation transient is `test_durations.json`. `.pytest_cache`,
+bytecode files, build products, package metadata, and every other repo-local
+generated path are forbidden.
+
+## Immutable provenance
+
+| Binding | Exact value |
+| --- | --- |
+| Branch | `gate2/olympus-phase1-hermetic-adapter-20260806` |
+| Worktree | `/Users/macmini/Hermes-Handoff/worktrees/olympus-phase1-gate2-20260806` |
+| Base commit | `de85a4eee4820281c5cf8826a5424e7ec23b2360` |
+| Base tree | `c36f97f9497dd17d3eb99b4d997377bb1b2447e7` |
+| Gate 1 raw SHA-256 | `6ef02d1e63d19853e0794b6c324f0e7233ec082744419fae529ed16e6e11cacf` |
+| Gate 2 raw SHA-256 | `445f0ce7bbf3c063ce84d7b1ae47154241e5bb6f148969790a5d63dfca4f6d25` |
+| Phase 1 contract digest | `e5db4065e1e39134a5274152a01363d2ed3a0c79fb5d4bdb9c1773d36a2b1de1` |
+| Engine contract digest | `2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85` |
+| Phase 0 runtime binding | `366f41af5292272b183605cb1f6f5ab75b3a259c453d3396eab34a34bb83cb12` |
+| Isolation-profile digest | `1463fab53b426fee1b11c61745e439f124f69e54c3af886b53d3a94c3f2ff67a` |
+
+The controlling Gate 2 packet is:
+
+`/Users/macmini/Hermes-Handoff/reviews/olympus-phase1-gate2-design-freeze-20260806T130942Z/OLYMPUS_PHASE1_GATE2_IMPLEMENTATION_DESIGN_FREEZE_PACKET.json`
+
+It was reverified as a mode `0400`, 191315-byte regular file with the Gate 2
+raw SHA-256 above.
+
+## Exact technical-file inventory
+
+Every entry has intended Git mode `100644`. This table intentionally binds the
+other ten allowlisted files only. This change-review file must not contain or
+attempt to predict its own hash.
+
+| Path | Bytes | Raw SHA-256 |
+| --- | ---: | --- |
+| `olympus_phase1_adapter/__init__.py` | 95 | `3ad914b81af3257228e0846c031d9ecd957952668417c8a5ab605c1d5775c77d` |
+| `olympus_phase1_adapter/contracts.py` | 47191 | `dddb4738a6b07ae1842d430dec9f27373be59add94efcbe96baed54e3b2ad6fd` |
+| `olympus_phase1_adapter/receipt_store.py` | 106354 | `b5a4fc89b52fc3e4639c83157c44aa78b644ebbd5ee582c3ab8f688ed0ba1d35` |
+| `olympus_phase1_adapter/adapter.py` | 29548 | `d2903d09e53cfb679c53a6512a674db05e194377a43c60af1f7810651380f7f0` |
+| `olympus_phase1_adapter/schemas/v1/phase1-operation-v1.schema.json` | 5064 | `c154d9b90e0b409b88271bcab13c0947e49b973578a0cb3bce83bee659c46708` |
+| `olympus_phase1_adapter/schemas/v1/phase1-receipt-v1.schema.json` | 22706 | `338ee017b61aa43c87e6999d64266d6963dde13e4c1c9ce522fb0b7770d42ce9` |
+| `olympus_phase1_adapter/schemas/v1/phase1-ownership-record-v1.schema.json` | 9478 | `3b107dc9578c0a99df4d6aa8ee6d733174a28f7f1828d8dfe96862e91f822f83` |
+| `tests/olympus_phase1_adapter/conftest.py` | 5454 | `a6936d1a07a71c565ebacde23689e5f6254f96f5d497368c2795d1cfc4f8512f` |
+| `tests/olympus_phase1_adapter/test_contracts_and_adapter.py` | 61809 | `22cde3858def6bc02fb9da16e5bbd1dc2f124053790243515c3f168bf7eb167f` |
+| `tests/olympus_phase1_adapter/test_receipt_store.py` | 100522 | `c0699f1adca54c9ac8967e6b3c29ad1451b57583b2a54d18c7df0589d64d9526` |
+
+## Implemented behavior
+
+- Accepts only the closed frozen Phase 1 envelope and canonical JSON profile,
+  with deterministic digest-domain, schema, size, depth, and reason precedence.
+- Pins every required Phase 0 source/schema byte and import origin before any
+  `olympus_engine` import or workflow construction.
+- Accepts only exact, unused in-process `FakePairATransport` and
+  `FakePairBTransport` instances. There is no live transport, network,
+  subprocess, provider, tool, service, delivery, or runtime integration path.
+- Constructs and runs the Phase 0 workflow at most once for the first durable
+  owner. Replay never imports Phase 0, reads the evidence root, or invokes the
+  engine again.
+- Independently verifies the exact on-disk evidence package and binds the
+  returned request, terminal, manifest, artifact records, event chain, and
+  package identity before publishing `ENGINE_EVIDENCE_VERIFIED`.
+- Uses append-only, digest-chained ownership records, immutable sequence-one
+  anchoring, same-process registry protection, cross-process advisory locks,
+  no-replace publication, bounded enumeration, and child/parent fsync gates.
+- Re-fsyncs accepted existing ancestry before later ownership can depend on it,
+  including recovery after interrupted child or parent directory fsync.
+- Enforces frozen root rejection precedence:
+  `UNSAFE_RECEIPT_ROOT`, `ROOTS_OVERLAP`, `UNSAFE_EVIDENCE_ROOT`, then
+  `UNSAFE_REPOSITORY_ROOT`, including lower-priority symlink aliases used only
+  for classification. Capability acceptance remains strict and symlink-free.
+- Binds every sealed receipt state, reason, and engine-evidence field to its
+  exact predecessor record. Canonical but semantically relabeled receipts fail
+  closed.
+- Returns byte-identical safely revalidated sealed receipts after ordinary
+  finalization ambiguity. Exact receipt/final-record staging aliases are
+  repaired only on a later locked recovery call; unsafe ambiguity yields the
+  exact typed no-retry exception.
+- Re-raises `KeyboardInterrupt`, `SystemExit`, and `asyncio.CancelledError` as
+  the identical object while applying only the frozen best-effort record/seal
+  behavior for the already crossed lifecycle boundary.
+- Remains absent from package discovery, source distributions, wheels, CLI
+  entry points, plugins, tools, gateway routes, and runtime configuration.
+
+## Validation evidence
+
+Pre-closeout confirmation on the final technical bytes:
+
+| Command | Result |
+| --- | --- |
+| `scripts/run_tests.sh tests/olympus_phase1_adapter -q -p no:cacheprovider` | `245 passed, 0 failed` |
+| `scripts/run_tests.sh tests/test_packaging_metadata.py -q -p no:cacheprovider` | `11 passed, 0 failed` |
+| `git diff --check` | pass |
+| untracked production/test `git diff --no-index --check` | no whitespace errors |
+| forbidden import/process/network/runtime-registration scan | clean |
+| credential-shaped literal scan | clean; `secrets.token_hex` is the sole expected name match |
+
+The final post-document canonical rerun and exact allowed transient receipt are:
+
+- Adapter suite: `245 passed, 0 failed`
+- Packaging suite: `11 passed, 0 failed`
+- `test_durations.json`: repository-relative path `test_durations.json`, mode
+  `0644`, 182 bytes, raw SHA-256
+  `fc0beaf388bd3f9ad74c90e24eb9c87721663e58e950a45f4859e98ced3b9a95`.
+  It was produced by the final packaging command after the adapter command,
+  recorded here, then removed alone with `apply_patch`. It is not part of the
+  durable eleven-path manifest.
+
+The tests cover T01 through T23, including real spawned-process and threaded
+contention, exact provenance tamper classes, canonical recomputed receipt
+adversaries, operation-agnostic conflict validation, topology and syscall fault
+matrices, retry-after-interrupted ancestry fsync, receipt/final-record alias
+recovery, twenty-one partial metadata-finalization prefixes, control-flow
+identity, packaging exclusion, and static/runtime capability guards.
+
+## Independent review disposition
+
+- The core exact-byte review independently recomputed the Gate/contract/runtime
+  bindings and reviewed the full implementation. After the final narrow
+  symlink-alias correction it returned `APPROVE` on the exact current
+  `receipt_store.py` and store-test hashes, with all other reviewed bytes
+  unchanged.
+- The governance/durability exact-byte review returned `TECHNICAL APPROVE` after
+  closure of ancestry refsync, receipt/predecessor semantics, safe sealed
+  publication, concurrency, cancellation, and T14/T22 proof gaps. Its final
+  symlink-alias correction was independently approved by the core review.
+- The final-freeze audit found no runtime, packaging, capability, credential,
+  allowlist, or source-level test-harness blocker. Its remaining HOLD items were
+  this mandatory document and final transient/generated-path cleanup.
+
+No reviewer ran tests under the read-only review mandate; the controller ran
+the canonical commands and supplied their exact results.
+
+## Risk and rollback
+
+Accepted residual risk is exact and narrow: hostile behavior by another process
+with the same effective UID can race userspace hash-to-import and filesystem
+checks. This implementation is authorized only for an owner-controlled,
+cooperative, local, fake-only hermetic test namespace. Shared, hostile,
+multi-tenant, live, or production use requires a new gate and OS-enforced
+isolation such as a separate UID, sandbox, container, or VM.
+
+There is no runtime rollback because nothing is registered, packaged, enabled,
+reloaded, routed, deployed, or activated.
+
+- Before commit, rollback is to abandon only this exact worktree and branch
+  after verifying they contain no non-allowlisted or user work. Review artifacts
+  are preserved.
+- After a separately authorized commit, rollback is one forward Git revert of
+  that exact commit under separate approval. History must not be reset or
+  rewritten, and the dirty canonical checkout must remain untouched.
+
+## Eleven-path manifest algorithm
+
+The tracked document pins the other ten files. The external implementation
+closeout must bind this document and the complete eleven-path manifest using
+exactly `olympus.phase1.gate2.allowlist-manifest/v1`:
+
+1. Require the literal eleven-path set above exactly. Reject missing, extra,
+   duplicate, absolute, backslash-containing, `.`/`..` component, symlink, and
+   non-regular paths.
+2. Record intended Git mode `100644`, repository-relative path, raw SHA-256, and
+   byte size for every entry. Each entry has exactly the keys
+   `git_mode`, `path`, `raw_sha256`, and `size_bytes`.
+3. Sort entries by unsigned UTF-8 bytes of `path`.
+4. Form the root object with exactly:
+   `{"algorithm":"olympus.phase1.gate2.allowlist-manifest/v1","entries":[...]}`.
+5. Encode canonical JSON as UTF-8 with keys sorted, separators `,` and `:`,
+   `ensure_ascii=false`, `allow_nan=false`, and no trailing newline.
+6. The manifest digest is SHA-256 of those canonical bytes.
+
+This document intentionally contains neither its own raw SHA-256 nor the full
+manifest digest. Both must be computed from final disk bytes and recorded only
+in the external closeout packet.
+
+## Execution incident disclosure
+
+During the initial schema addition, three schema files were accidentally
+created under `/Users/macmini/olympus_phase1_adapter` instead of the frozen
+worktree. The exact three files were immediately removed with `apply_patch`, the
+empty directories were removed with `rmdir`, and the outside path was verified
+absent. No other outside-worktree implementation path was created or changed.
+
+## Closeout state and remaining gates
+
+- Both post-document canonical commands passed with no skips or failures.
+- The sole allowed transient was hash-recorded and removed alone.
+- The empty test-created `__pycache__` directory was removed with `rmdir`.
+- No bytecode, pytest cache, build, distribution, or package-metadata artifact
+  remains.
+- Git status contains exactly the eleven untracked allowlist paths, with
+  nothing staged, modified, or extra.
+
+The external controller must now compute this document's raw SHA-256 and the
+complete eleven-path manifest, record both with the final validation and review
+evidence in an external closeout artifact, and then stop at
+`HOLD_FOR_COMMIT_APPROVAL`. Do not stage or commit without a separate explicit
+operator authorization.

--- a/olympus_phase1_adapter/__init__.py
+++ b/olympus_phase1_adapter/__init__.py
@@ -1,0 +1,3 @@
+"""Inert, source-checkout-only Hermes adapter for Olympus Phase 1."""
+
+__all__: list[str] = []

--- a/olympus_phase1_adapter/adapter.py
+++ b/olympus_phase1_adapter/adapter.py
@@ -1,0 +1,837 @@
+"""Synchronous, fake-only Phase 1 adapter with no registration surface."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import inspect
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from .contracts import (
+    PHASE0_RUNTIME_BINDING_DIGEST,
+    ContractValidationError,
+    JSONValue,
+    Operation,
+    canonical_bytes,
+    canonical_digest,
+    parse_operation,
+    transient_rejection,
+    validate_hex_digest,
+)
+from .receipt_store import (
+    OLYMPUS_CHECKOUT,
+    OwnerHandle,
+    PersistenceError,
+    ReceiptStore,
+    RootSafetyError,
+    StoreIndeterminate,
+    StoreIndeterminateUnavailable,
+    StorePreInvokeUnavailable,
+    StoreSealedUnavailable,
+    open_root_set,
+)
+
+_EXPECTED_OLYMPUS_ORIGIN = (
+    OLYMPUS_CHECKOUT / "src" / "olympus_engine" / "__init__.py"
+)
+_CONTROL_FLOW = (KeyboardInterrupt, SystemExit, asyncio.CancelledError)
+
+_PHASE0_FILES = (
+    (
+        "pyproject.toml",
+        "100644",
+        304,
+        "7393770eb30641478439da2a595be33bff034cb462a4fef5ff5fff0e5f525af7",
+        "5ac8a57913e39cdbe6e35c66fc4a6f7f55aeebf4",
+    ),
+    (
+        "schemas/v1/repo-analysis-authorization-v1.schema.json",
+        "100644",
+        1605,
+        "4592e578f8f66922f1112d8c4886c0cd1c0c6634b9b064906903d6a919d84de6",
+        "2637bf45bef2dcd9ddbe7ab24e63f054ef09ac95",
+    ),
+    (
+        "schemas/v1/repo-analysis-comparison-v1.schema.json",
+        "100644",
+        1352,
+        "b50046ea7711070df3140ae4e8e0ee2f461b47d5243e0d7e0735e44d49f2315d",
+        "0126077d27c806194404a46aaede0367ed47cd1b",
+    ),
+    (
+        "schemas/v1/repo-analysis-evidence-manifest-v1.schema.json",
+        "100644",
+        3803,
+        "03de62db10054291bdf1c80462204d1da2198f283f28edae4a1fee2fbef43fab",
+        "1798908e534b0228a90ef4562dcd8f417be4b13b",
+    ),
+    (
+        "schemas/v1/repo-analysis-request-v1.schema.json",
+        "100644",
+        3627,
+        "4568da179616ac76e83b7b81e9bfc37d81c9908d021d86d9c8db2a9b315e7780",
+        "7fbb70bf7ddf3ecf52c707e6f998775d8e4bab5d",
+    ),
+    (
+        "schemas/v1/repo-analysis-reviewer-result-v1.schema.json",
+        "100644",
+        1594,
+        "b91ace11fc8cbecd2e4b1c7c038cfe59c29a51bce6a2b4c9a07529ed530c1556",
+        "9bf4676ccd12e9e985bdfcb3688d8198876b1ba3",
+    ),
+    (
+        "schemas/v1/repo-analysis-terminal-report-v1.schema.json",
+        "100644",
+        1601,
+        "68d458043ce4f9e400ef0240197dc89502069a7bc57a95d5cc060a5327c76ace",
+        "fc0cffacf7ef7100d9a9147f56cc7c6599cd3d16",
+    ),
+    (
+        "schemas/v1/repo-analysis-worker-result-v1.schema.json",
+        "100644",
+        1863,
+        "006a912dd8cde1164115dab0cd6baa09b0cc88d6e90abb61412f0d595e2d738c",
+        "239ab07b907b269674042a172d793aa663444b8d",
+    ),
+    (
+        "src/olympus_engine/__init__.py",
+        "100644",
+        2370,
+        "ce1720a097ae19543f8bf30d6766fa31c5eec7d3753c93f90305eea431b9b1ba",
+        "ecd0247e97111f96d2becf2385a8a34afa55dc1b",
+    ),
+    (
+        "src/olympus_engine/authorization.py",
+        "100644",
+        3080,
+        "d1a35cbde6214c4a7c67039d7c5592955a17eca78757abde1e5bf7301c4dcd1e",
+        "3effe27bb1ba8a217e47e33876fdbdf4fd744a80",
+    ),
+    (
+        "src/olympus_engine/canonical.py",
+        "100644",
+        5727,
+        "7dd308bcadf615e1f45cbc602bd3b0dce44f1ebdfbcf30c7a9769a6ef2779697",
+        "1f7450296685c1a792273d5eb39dc208d3980117",
+    ),
+    (
+        "src/olympus_engine/comparator.py",
+        "100644",
+        6506,
+        "ae8039ae77c9075561ad98bc0ee6bb9f47bbeef8e4a7757d957b5c78cc35ea7b",
+        "e982e22ab6b96a27c11ae8ebbbb2ee0b571a3508",
+    ),
+    (
+        "src/olympus_engine/contracts.py",
+        "100644",
+        36584,
+        "87170fa2ee3099009e7327ec32f4c2d26287da4b94e28ea78336729347205955",
+        "7740a6101cd95ff67740abfd9a0587cde0551b4e",
+    ),
+    (
+        "src/olympus_engine/evidence.py",
+        "100644",
+        41545,
+        "db496c33bd6bd248cc322fcea4f39cfe57ffdebf945fc69e0781f010f9d85d32",
+        "b7a87f18afb779d7e805bec955d6b15008272c42",
+    ),
+    (
+        "src/olympus_engine/packetizer.py",
+        "100644",
+        15645,
+        "3ace4275c4a68f329f7b1657a398119ddf068c826c68b14d1445301c77b18489",
+        "47f0e1ba86fefa56796a1c1b9830b69d21214c22",
+    ),
+    (
+        "src/olympus_engine/renderer.py",
+        "100644",
+        3314,
+        "19db15a2bdcd43605358eb901439ada5338f64a729aab65f49b4b3a2bea74b99",
+        "10c0815a7d6af409bfaa58a06bb549c552f81cd4",
+    ),
+    (
+        "src/olympus_engine/safe_fs.py",
+        "100644",
+        31624,
+        "850b822b5c0968b7d17e449ee05a84be6f170915d9cd68b47818b0df563e36bc",
+        "8216434a0f4a1aaeb74f59989ed4162f6e24dd44",
+    ),
+    (
+        "src/olympus_engine/transports.py",
+        "100644",
+        2119,
+        "4c1a92ae90f530e82f1225cd381f3d40b151d3c6693dca9135515929d58d53fe",
+        "b0d6453814fab7f2b4831614b9d032edc7b001c2",
+    ),
+    (
+        "src/olympus_engine/workflow.py",
+        "100644",
+        18073,
+        "e31aa321ef1235d687df36a973d65a97c96697dd4e2ec92fe89c6abdf14fa120",
+        "7947e9b6f7908759f8dbfa0cfb36657fab4d1526",
+    ),
+)
+
+
+class IndeterminateReceiptUnavailable(RuntimeError):
+    """A consumed attempt has no safely returnable sealed receipt."""
+
+    def __init__(
+        self, *, idempotency_key_digest: str, operation_digest: str
+    ) -> None:
+        self.idempotency_key_digest = validate_hex_digest(
+            idempotency_key_digest, "idempotency_key_digest"
+        )
+        self.operation_digest = validate_hex_digest(
+            operation_digest, "operation_digest"
+        )
+        self.receipt_state = "INDETERMINATE_NO_RETRY"
+        self.reason_code = "PERSISTENCE_CORRUPTION"
+        self.automatic_engine_retry_permitted = False
+        super().__init__(
+            "Phase 1 attempt is indeterminate and no sealed receipt is "
+            "available; automatic retry is forbidden"
+        )
+
+
+class PreInvokeReceiptUnavailable(RuntimeError):
+    """Ownership exists, invocation did not occur, and no receipt is available."""
+
+    def __init__(
+        self, *, idempotency_key_digest: str, operation_digest: str
+    ) -> None:
+        self.idempotency_key_digest = validate_hex_digest(
+            idempotency_key_digest, "idempotency_key_digest"
+        )
+        self.operation_digest = validate_hex_digest(
+            operation_digest, "operation_digest"
+        )
+        self.receipt_state = "REJECTED_PRE_INVOKE"
+        self.reason_code = "PERSISTENCE_CORRUPTION"
+        self.engine_invocation_occurred = False
+        self.automatic_engine_retry_permitted = False
+        super().__init__(
+            "Phase 1 invocation did not occur, but no sealed rejection receipt "
+            "is available; automatic retry is forbidden"
+        )
+
+
+class SealedReceiptUnavailable(RuntimeError):
+    """A durably sealed receipt cannot be safely returned."""
+
+    def __init__(
+        self,
+        *,
+        idempotency_key_digest: str,
+        operation_digest: str,
+        receipt_digest: str,
+        receipt_state: Literal[
+            "REJECTED_PRE_INVOKE", "ENGINE_TERMINAL", "INDETERMINATE_NO_RETRY"
+        ],
+    ) -> None:
+        self.idempotency_key_digest = validate_hex_digest(
+            idempotency_key_digest, "idempotency_key_digest"
+        )
+        self.operation_digest = validate_hex_digest(
+            operation_digest, "operation_digest"
+        )
+        self.receipt_digest = validate_hex_digest(
+            receipt_digest, "receipt_digest"
+        )
+        if receipt_state not in {
+            "REJECTED_PRE_INVOKE",
+            "ENGINE_TERMINAL",
+            "INDETERMINATE_NO_RETRY",
+        }:
+            raise ValueError("invalid sealed receipt state")
+        self.receipt_state = receipt_state
+        self.reason_code = "PERSISTENCE_CORRUPTION"
+        self.receipt_was_durably_sealed = True
+        self.automatic_engine_retry_permitted = False
+        super().__init__(
+            "A Phase 1 receipt was durably sealed but cannot be safely "
+            "returned; automatic retry is forbidden"
+        )
+
+
+class _FreshRejection(RuntimeError):
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+class _EvidenceFailure(RuntimeError):
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+@dataclass(frozen=True, slots=True)
+class _Phase0API:
+    FakePairATransport: type
+    FakePairBTransport: type
+    OlympusWorkflow: type
+    canonical_bytes: Any
+    canonical_digest: Any
+    strict_loads: Any
+    verify_evidence_package: Any
+
+
+def _phase0_manifest() -> list[dict[str, JSONValue]]:
+    return [
+        {
+            "path": path,
+            "mode": mode,
+            "raw_bytes": size,
+            "raw_sha256": digest,
+            "git_blob": blob,
+        }
+        for path, mode, size, digest, blob in _PHASE0_FILES
+    ]
+
+
+def _read_frozen_phase0_file(
+    relative: str, expected_size: int, expected_digest: str
+) -> None:
+    path = OLYMPUS_CHECKOUT / relative
+    try:
+        entry = os.lstat(path)
+        if (
+            not stat.S_ISREG(entry.st_mode)
+            or stat.S_ISLNK(entry.st_mode)
+            or entry.st_uid != os.geteuid()
+            or entry.st_nlink != 1
+            or stat.S_IMODE(entry.st_mode) != 0o644
+            or entry.st_size != expected_size
+        ):
+            raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(
+            os, "O_CLOEXEC", 0
+        )
+        fd = os.open(path, flags)
+        try:
+            held = os.fstat(fd)
+            hasher = hashlib.sha256()
+            total = 0
+            while True:
+                chunk = os.read(fd, 65_536)
+                if not chunk:
+                    break
+                total += len(chunk)
+                hasher.update(chunk)
+            after = os.fstat(fd)
+        finally:
+            os.close(fd)
+    except _FreshRejection:
+        raise
+    except OSError as exc:
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH") from exc
+    if (
+        (entry.st_dev, entry.st_ino)
+        != (held.st_dev, held.st_ino)
+        or (held.st_dev, held.st_ino) != (after.st_dev, after.st_ino)
+        or total != expected_size
+        or hasher.hexdigest() != expected_digest
+    ):
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+
+
+def _object_origin(value: Any) -> Path | None:
+    try:
+        source = inspect.getsourcefile(value)
+        return None if source is None else Path(source).resolve(strict=True)
+    except (OSError, TypeError, RuntimeError):
+        return None
+
+
+def _verify_phase0_provenance() -> _Phase0API:
+    if canonical_digest("phase1-phase0-binding", _phase0_manifest()) != (
+        PHASE0_RUNTIME_BINDING_DIGEST
+    ):
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+    for relative, _mode, size, digest, _blob in _PHASE0_FILES:
+        _read_frozen_phase0_file(relative, size, digest)
+
+    existing = sys.modules.get("olympus_engine")
+    if existing is not None:
+        origin = getattr(existing, "__file__", None)
+        try:
+            resolved = None if origin is None else Path(origin).resolve(strict=True)
+        except (OSError, RuntimeError):
+            resolved = None
+        if resolved != _EXPECTED_OLYMPUS_ORIGIN:
+            raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+    try:
+        module = (
+            existing
+            if existing is not None
+            else importlib.import_module("olympus_engine")
+        )
+    except Exception as exc:
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH") from exc
+    try:
+        module_origin = Path(module.__file__).resolve(strict=True)
+    except (AttributeError, OSError, RuntimeError) as exc:
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH") from exc
+    if module_origin != _EXPECTED_OLYMPUS_ORIGIN:
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+
+    names = (
+        "FakePairATransport",
+        "FakePairBTransport",
+        "OlympusWorkflow",
+        "canonical_bytes",
+        "canonical_digest",
+        "strict_loads",
+        "verify_evidence_package",
+    )
+    try:
+        values = {name: getattr(module, name) for name in names}
+    except AttributeError as exc:
+        raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH") from exc
+    expected_origins = {
+        "FakePairATransport": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "transports.py",
+        "FakePairBTransport": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "transports.py",
+        "OlympusWorkflow": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "workflow.py",
+        "canonical_bytes": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "canonical.py",
+        "canonical_digest": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "canonical.py",
+        "strict_loads": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "canonical.py",
+        "verify_evidence_package": OLYMPUS_CHECKOUT
+        / "src"
+        / "olympus_engine"
+        / "evidence.py",
+    }
+    for name, expected in expected_origins.items():
+        if _object_origin(values[name]) != expected:
+            raise _FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+    return _Phase0API(**values)
+
+
+def _validate_fakes(api: _Phase0API, pair_a: Any, pair_b: Any) -> None:
+    if type(pair_a) is not api.FakePairATransport:
+        raise _FreshRejection("FAKE_TRANSPORT_INVALID")
+    if type(pair_b) is not api.FakePairBTransport:
+        raise _FreshRejection("FAKE_TRANSPORT_INVALID")
+    if (
+        type(pair_a.call_count) is not int
+        or pair_a.call_count != 0
+        or type(pair_a.received_packets) is not list
+        or pair_a.received_packets
+        or type(pair_b.call_count) is not int
+        or pair_b.call_count != 0
+        or type(pair_b.received_packets) is not list
+        or pair_b.received_packets
+        or type(pair_b.received_worker_results) is not list
+        or pair_b.received_worker_results
+    ):
+        raise _FreshRejection("FAKE_TRANSPORT_INVALID")
+
+
+def _preflight(pair_a: Any, pair_b: Any) -> _Phase0API:
+    api = _verify_phase0_provenance()
+    _validate_fakes(api, pair_a, pair_b)
+    return api
+
+
+def _translate_store_error(error: BaseException) -> BaseException:
+    if isinstance(error, StoreSealedUnavailable):
+        return SealedReceiptUnavailable(
+            idempotency_key_digest=error.idempotency_key_digest,
+            operation_digest=error.operation_digest,
+            receipt_digest=error.receipt_digest,
+            receipt_state=error.receipt_state,
+        )
+    if isinstance(error, StorePreInvokeUnavailable):
+        return PreInvokeReceiptUnavailable(
+            idempotency_key_digest=error.idempotency_key_digest,
+            operation_digest=error.operation_digest,
+        )
+    if isinstance(
+        error, (StoreIndeterminate, StoreIndeterminateUnavailable)
+    ):
+        return IndeterminateReceiptUnavailable(
+            idempotency_key_digest=error.idempotency_key_digest,
+            operation_digest=error.operation_digest,
+        )
+    return error
+
+
+def _refresh_or_indeterminate(owner: OwnerHandle) -> str:
+    try:
+        owner.refresh_active()
+    except StoreIndeterminate as exc:
+        raise IndeterminateReceiptUnavailable(
+            idempotency_key_digest=exc.idempotency_key_digest,
+            operation_digest=exc.operation_digest,
+        ) from None
+    return str(owner.last_record["state"])
+
+
+def _seal_preinvoke(owner: OwnerHandle, reason_code: str) -> bytes:
+    state = _refresh_or_indeterminate(owner)
+    if state == "OWNERSHIP_ACQUIRED":
+        try:
+            owner.append("PREINVOKE_REJECTED", reason_code=reason_code)
+        except Exception:
+            state = _refresh_or_indeterminate(owner)
+            if state != "PREINVOKE_REJECTED":
+                if state in {
+                    "INVOCATION_CLAIMED",
+                    "ENGINE_EVIDENCE_VERIFIED",
+                    "INDETERMINATE_NO_RETRY",
+                }:
+                    return _seal_indeterminate(owner, "PERSISTENCE_CORRUPTION")
+                raise PreInvokeReceiptUnavailable(
+                    idempotency_key_digest=owner.operation.idempotency_key_digest,
+                    operation_digest=owner.operation.operation_digest,
+                ) from None
+    elif state != "PREINVOKE_REJECTED":
+        if state in {
+            "INVOCATION_CLAIMED",
+            "ENGINE_EVIDENCE_VERIFIED",
+            "INDETERMINATE_NO_RETRY",
+        }:
+            return _seal_indeterminate(owner, "PERSISTENCE_CORRUPTION")
+        raise PreInvokeReceiptUnavailable(
+            idempotency_key_digest=owner.operation.idempotency_key_digest,
+            operation_digest=owner.operation.operation_digest,
+        ) from None
+    persisted_reason = str(owner.last_record["reason_code"])
+    try:
+        return owner.seal(
+            receipt_state="REJECTED_PRE_INVOKE",
+            reason_code=persisted_reason,
+        )
+    except StoreSealedUnavailable as exc:
+        raise _translate_store_error(exc) from None
+    except Exception:
+        if owner.sealed_raw is not None:
+            owner.best_effort_finalize()
+            return owner.sealed_raw
+        raise PreInvokeReceiptUnavailable(
+            idempotency_key_digest=owner.operation.idempotency_key_digest,
+            operation_digest=owner.operation.operation_digest,
+        ) from None
+
+
+def _seal_indeterminate(owner: OwnerHandle, reason_code: str) -> bytes:
+    if owner.sealed_raw is not None:
+        owner.best_effort_finalize()
+        return owner.sealed_raw
+    state = _refresh_or_indeterminate(owner)
+    if state in {"INVOCATION_CLAIMED", "ENGINE_EVIDENCE_VERIFIED"}:
+        try:
+            owner.append("INDETERMINATE_NO_RETRY", reason_code=reason_code)
+        except Exception:
+            state = _refresh_or_indeterminate(owner)
+            if state != "INDETERMINATE_NO_RETRY":
+                raise IndeterminateReceiptUnavailable(
+                    idempotency_key_digest=owner.operation.idempotency_key_digest,
+                    operation_digest=owner.operation.operation_digest,
+                ) from None
+    elif state != "INDETERMINATE_NO_RETRY":
+        raise IndeterminateReceiptUnavailable(
+            idempotency_key_digest=owner.operation.idempotency_key_digest,
+            operation_digest=owner.operation.operation_digest,
+        ) from None
+    persisted_reason = str(owner.last_record["reason_code"])
+    try:
+        return owner.seal(
+            receipt_state="INDETERMINATE_NO_RETRY",
+            reason_code=persisted_reason,
+        )
+    except StoreSealedUnavailable as exc:
+        raise _translate_store_error(exc) from None
+    except Exception:
+        if owner.sealed_raw is not None:
+            owner.best_effort_finalize()
+            return owner.sealed_raw
+        raise IndeterminateReceiptUnavailable(
+            idempotency_key_digest=owner.operation.idempotency_key_digest,
+            operation_digest=owner.operation.operation_digest,
+        ) from None
+
+
+def _best_effort_control_flow(
+    owner: OwnerHandle,
+    *,
+    invocation_claimed: bool,
+) -> None:
+    try:
+        if owner.sealed_raw is not None:
+            owner.best_effort_finalize()
+        elif invocation_claimed:
+            _seal_indeterminate(owner, "CANCELLED_AFTER_INVOCATION_CLAIM")
+        else:
+            _seal_preinvoke(owner, "CANCELLED_BEFORE_INVOCATION_CLAIM")
+    except BaseException:
+        pass
+
+
+def _verify_phase0_result(
+    *,
+    api: _Phase0API,
+    operation: Operation,
+    owner: OwnerHandle,
+    result: Any,
+) -> tuple[dict[str, JSONValue], dict[str, JSONValue]]:
+    destination = owner.evidence_destination
+    manifest_object = getattr(result, "evidence_manifest", None)
+    if manifest_object is None or not destination.is_dir():
+        raise _EvidenceFailure("EVIDENCE_MISSING")
+    try:
+        request_value = result.request.to_dict()
+        terminal = result.terminal_report.to_dict()
+        manifest = manifest_object.to_dict()
+        verified = api.verify_evidence_package(destination)
+        verified_manifest = verified.to_dict()
+        if request_value != operation.payload:
+            raise ContractValidationError("Phase 0 request result mismatch")
+        request_bytes = api.canonical_bytes(operation.payload)
+        if api.strict_loads(request_bytes) != operation.payload:
+            raise ContractValidationError("Phase 0 request canonical mismatch")
+        if api.canonical_digest("request", request_value) != (
+            operation.payload_request_digest
+        ):
+            raise ContractValidationError("Phase 0 request digest mismatch")
+        if verified_manifest != manifest:
+            raise ContractValidationError("Phase 0 verified manifest mismatch")
+        terminal_bytes = api.canonical_bytes(terminal)
+        terminal_digest = api.canonical_digest("terminal-report", terminal)
+        if terminal_digest != result.terminal_report.digest:
+            raise ContractValidationError("Phase 0 terminal digest mismatch")
+        manifest_digest = api.canonical_digest("evidence-manifest", manifest)
+        if manifest_digest != manifest_object.digest:
+            raise ContractValidationError("Phase 0 manifest digest mismatch")
+        if (
+            terminal.get("request_id") != operation.payload_request_id
+            or verified_manifest.get("request_id") != operation.payload_request_id
+        ):
+            raise ContractValidationError("Phase 0 manifest request mismatch")
+        if verified_manifest.get("terminal_report_digest") != terminal_digest:
+            raise ContractValidationError("Phase 0 manifest terminal mismatch")
+        artifacts = verified_manifest.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise ContractValidationError("Phase 0 manifest artifacts mismatch")
+        artifacts_by_name = {
+            artifact.get("name"): artifact
+            for artifact in artifacts
+            if isinstance(artifact, dict)
+        }
+        request_artifact = artifacts_by_name.get("01-request.json")
+        terminal_artifact = artifacts_by_name.get("07-terminal-report.json")
+        if not isinstance(request_artifact, dict) or (
+            request_artifact.get("digest") != operation.payload_request_digest
+            or request_artifact.get("size") != len(request_bytes)
+        ):
+            raise ContractValidationError("Phase 0 request artifact mismatch")
+        if not isinstance(terminal_artifact, dict) or (
+            terminal_artifact.get("digest") != terminal_digest
+            or terminal_artifact.get("size") != len(terminal_bytes)
+        ):
+            raise ContractValidationError("Phase 0 terminal artifact mismatch")
+        identity_fields = (
+            "request_id",
+            "packetization_status",
+            "pair_a_status",
+            "pair_b_status",
+            "repository_postcheck_status",
+            "artifacts",
+            "events",
+            "repository_pre_digest",
+            "repository_post_digest",
+            "terminal_report_digest",
+        )
+        expected_package_id = api.canonical_digest(
+            "evidence-package",
+            {field: verified_manifest.get(field) for field in identity_fields},
+        )
+        if verified_manifest.get("package_id") != expected_package_id:
+            raise ContractValidationError("Phase 0 evidence package mismatch")
+        # Local canonicalization must be byte-identical to the frozen engine.
+        if terminal_bytes != canonical_bytes(terminal):
+            raise ContractValidationError("terminal canonicalization drift")
+        if api.canonical_bytes(manifest) != canonical_bytes(manifest):
+            raise ContractValidationError("manifest canonicalization drift")
+    except _CONTROL_FLOW:
+        raise
+    except Exception as exc:
+        raise _EvidenceFailure("EVIDENCE_VERIFICATION_FAILED") from exc
+    return terminal, manifest
+
+
+def _execute_first_owner(
+    *,
+    owner: OwnerHandle,
+    pair_a: Any,
+    pair_b: Any,
+) -> bytes:
+    api = owner.preflight_result
+    if not isinstance(api, _Phase0API):
+        return _seal_preinvoke(owner, "PERSISTENCE_CORRUPTION")
+    invocation_claimed = False
+    try:
+        try:
+            owner.roots.revalidate_all()
+            owner.append("INVOCATION_CLAIMED")
+            invocation_claimed = True
+        except _CONTROL_FLOW:
+            try:
+                owner.refresh_active()
+                invocation_claimed = str(owner.last_record["state"]) in {
+                    "INVOCATION_CLAIMED",
+                    "ENGINE_EVIDENCE_VERIFIED",
+                    "INDETERMINATE_NO_RETRY",
+                }
+            except BaseException:
+                pass
+            raise
+        except Exception:
+            return _seal_preinvoke(owner, "PERSISTENCE_CORRUPTION")
+
+        request_bytes = api.canonical_bytes(owner.operation.payload)
+        try:
+            workflow = api.OlympusWorkflow(
+                request_json=request_bytes,
+                repository_root=owner.roots.repository.path,
+                pair_a=pair_a,
+                pair_b=pair_b,
+                evidence_destination=owner.evidence_destination,
+            )
+        except _CONTROL_FLOW:
+            raise
+        except Exception:
+            return _seal_indeterminate(owner, "WORKFLOW_CONSTRUCTION_FAILED")
+        try:
+            result = workflow.run()
+        except _CONTROL_FLOW:
+            raise
+        except Exception:
+            return _seal_indeterminate(
+                owner, "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT"
+            )
+        try:
+            terminal, manifest = _verify_phase0_result(
+                api=api,
+                operation=owner.operation,
+                owner=owner,
+                result=result,
+            )
+        except _CONTROL_FLOW:
+            raise
+        except _EvidenceFailure as exc:
+            return _seal_indeterminate(owner, exc.reason_code)
+
+        terminal_digest = canonical_digest("terminal-report", terminal)
+        manifest_digest = canonical_digest("evidence-manifest", manifest)
+        try:
+            owner.roots.revalidate_all()
+            owner.append(
+                "ENGINE_EVIDENCE_VERIFIED",
+                reason_code="PHASE0_TERMINAL",
+                phase0_terminal_report_digest=terminal_digest,
+                phase0_evidence_manifest_digest=manifest_digest,
+                phase0_evidence_directory_name=owner.evidence_destination.name,
+            )
+            return owner.seal(
+                receipt_state="ENGINE_TERMINAL",
+                reason_code="PHASE0_TERMINAL",
+                phase0_terminal_report=terminal,
+                phase0_evidence_manifest=manifest,
+            )
+        except _CONTROL_FLOW:
+            raise
+        except StoreSealedUnavailable as exc:
+            raise _translate_store_error(exc) from None
+        except Exception:
+            return _seal_indeterminate(owner, "PERSISTENCE_CORRUPTION")
+    except _CONTROL_FLOW:
+        _best_effort_control_flow(
+            owner, invocation_claimed=invocation_claimed
+        )
+        raise
+
+
+def execute_operation(
+    envelope_json: str | bytes,
+    *,
+    repository_root: str | Path,
+    receipt_root: str | Path,
+    evidence_root: str | Path,
+    pair_a: olympus_engine.FakePairATransport,
+    pair_b: olympus_engine.FakePairBTransport,
+) -> bytes:
+    """Execute or replay exactly one frozen fake-only Phase 1 operation."""
+
+    try:
+        operation = parse_operation(envelope_json)
+    except ContractValidationError as exc:
+        reason = getattr(exc, "reason_code", "ENVELOPE_INVALID_JSON")
+        return transient_rejection(reason)
+
+    try:
+        roots = open_root_set(
+            repository_root=repository_root,
+            receipt_root=receipt_root,
+            evidence_root=evidence_root,
+        )
+    except RootSafetyError as exc:
+        return transient_rejection(exc.reason_code)
+
+    with roots:
+        store = ReceiptStore(roots)
+        try:
+            claim = store.claim(
+                operation,
+                fresh_preflight=lambda: _preflight(pair_a, pair_b),
+            )
+        except _FreshRejection as exc:
+            return transient_rejection(exc.reason_code)
+        except RootSafetyError as exc:
+            return transient_rejection(exc.reason_code)
+        except (StoreIndeterminate, StoreIndeterminateUnavailable) as exc:
+            raise _translate_store_error(exc) from None
+        except StorePreInvokeUnavailable as exc:
+            raise _translate_store_error(exc) from None
+        except StoreSealedUnavailable as exc:
+            raise _translate_store_error(exc) from None
+        except _CONTROL_FLOW:
+            raise
+        except (PersistenceError, OSError):
+            return transient_rejection("PERSISTENCE_CORRUPTION")
+
+        if claim.response is not None:
+            return claim.response
+        owner = claim.owner
+        if owner is None:
+            raise AssertionError("claim returned no outcome")
+        with owner:
+            return _execute_first_owner(
+                owner=owner,
+                pair_a=pair_a,
+                pair_b=pair_b,
+            )

--- a/olympus_phase1_adapter/contracts.py
+++ b/olympus_phase1_adapter/contracts.py
@@ -1,0 +1,1164 @@
+"""Frozen Phase 1 JSON contracts and local digest validation.
+
+This module intentionally uses only the Python standard library.  In
+particular, validating an operation, record, or sealed receipt must not import
+Olympus Engine; replay is a local, side-effect-free operation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeAlias
+
+JSONScalar: TypeAlias = None | bool | int | str
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+GATE1_PACKET_SHA256 = (
+    "6ef02d1e63d19853e0794b6c324f0e7233ec082744419fae529ed16e6e11cacf"
+)
+GATE2_PACKET_SHA256 = (
+    "445f0ce7bbf3c063ce84d7b1ae47154241e5bb6f148969790a5d63dfca4f6d25"
+)
+ENGINE_CONTRACT_DIGEST = (
+    "2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85"
+)
+PHASE1_CONTRACT_DIGEST = (
+    "e5db4065e1e39134a5274152a01363d2ed3a0c79fb5d4bdb9c1773d36a2b1de1"
+)
+PHASE0_RUNTIME_BINDING_DIGEST = (
+    "366f41af5292272b183605cb1f6f5ab75b3a259c453d3396eab34a34bb83cb12"
+)
+ISOLATION_PROFILE_DIGEST = (
+    "1463fab53b426fee1b11c61745e439f124f69e54c3af886b53d3a94c3f2ff67a"
+)
+
+OPERATION_SCHEMA_ID = "olympus.hermes.phase1.operation/v1"
+RECEIPT_SCHEMA_ID = "olympus.hermes.phase1.receipt/v1"
+OWNERSHIP_SCHEMA_ID = "olympus.hermes.phase1.ownership-record/v1"
+
+MAX_ENVELOPE_BYTES = 65_536
+MAX_RECEIPT_BYTES = 65_536
+MAX_RECORD_BYTES = 16_384
+MAX_IDEMPOTENCY_KEY_BYTES = 128
+MAX_RECORDS_PER_KEY = 8
+MAX_DIRECTORY_ENTRIES_PER_KEY = 24
+MAX_JSON_NESTING = 64
+
+_HASH_PREFIX = b"OLYMPUS_ENGINE_SHA256_V1\x00"
+_DOMAIN_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_RECORD_NAME_RE = re.compile(
+    r"^(?P<sequence>[0-9]{6})-(?P<state>[A-Z][A-Z0-9_]*)\.json$"
+)
+
+_SCHEMA_ROOT = Path(__file__).with_name("schemas") / "v1"
+_SCHEMA_SPECS = {
+    "operation": (
+        _SCHEMA_ROOT / "phase1-operation-v1.schema.json",
+        5_064,
+        "c154d9b90e0b409b88271bcab13c0947e49b973578a0cb3bce83bee659c46708",
+        OPERATION_SCHEMA_ID,
+        "9acd65e2814a6229b62760ecd20aa71e232974dd0532c6557d6273377b66ad46",
+    ),
+    "receipt": (
+        _SCHEMA_ROOT / "phase1-receipt-v1.schema.json",
+        22_706,
+        "338ee017b61aa43c87e6999d64266d6963dde13e4c1c9ce522fb0b7770d42ce9",
+        RECEIPT_SCHEMA_ID,
+        "a8f941641570e8f0f96dd2ff368e94ee97b2e20fbf59fcb5c351dd73420f8a2a",
+    ),
+    "record": (
+        _SCHEMA_ROOT / "phase1-ownership-record-v1.schema.json",
+        9_478,
+        "3b107dc9578c0a99df4d6aa8ee6d733174a28f7f1828d8dfe96862e91f822f83",
+        OWNERSHIP_SCHEMA_ID,
+        "75a2e09260f7565514ac67539da295cd642afb3302f9f6f2c42ac8102af07eec",
+    ),
+}
+_SCHEMA_CACHE: dict[str, dict[str, JSONValue]] = {}
+
+PHASE1_REASON_PRECEDENCE = (
+    "ENVELOPE_TOO_LARGE",
+    "ENVELOPE_INVALID_JSON",
+    "ENGINE_CONTRACT_MISMATCH",
+    "ENVELOPE_SCHEMA_MISMATCH",
+    "UNSAFE_RECEIPT_ROOT",
+    "ROOTS_OVERLAP",
+    "UNSAFE_EVIDENCE_ROOT",
+    "UNSAFE_REPOSITORY_ROOT",
+    "PHASE0_PROVENANCE_MISMATCH",
+    "FAKE_TRANSPORT_INVALID",
+    "PERSISTENCE_CORRUPTION",
+    "KEY_BOUND_TO_DIFFERENT_OPERATION",
+    "ACTIVE_OWNER",
+    "CANCELLED_BEFORE_INVOCATION_CLAIM",
+    "RECOVERED_BEFORE_INVOCATION_CLAIM",
+    "WORKFLOW_CONSTRUCTION_FAILED",
+    "CANCELLED_AFTER_INVOCATION_CLAIM",
+    "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+    "EVIDENCE_MISSING",
+    "EVIDENCE_VERIFICATION_FAILED",
+    "RECOVERED_AFTER_INVOCATION_CLAIM",
+    "PHASE0_TERMINAL",
+)
+
+OWNERSHIP_STATES = (
+    "OWNERSHIP_ACQUIRED",
+    "INVOCATION_CLAIMED",
+    "ENGINE_EVIDENCE_VERIFIED",
+    "PREINVOKE_REJECTED",
+    "INDETERMINATE_NO_RETRY",
+    "RECEIPT_FINALIZED",
+)
+ALLOWED_TRANSITIONS = frozenset(
+    {
+        (None, "OWNERSHIP_ACQUIRED"),
+        ("OWNERSHIP_ACQUIRED", "PREINVOKE_REJECTED"),
+        ("OWNERSHIP_ACQUIRED", "INVOCATION_CLAIMED"),
+        ("INVOCATION_CLAIMED", "ENGINE_EVIDENCE_VERIFIED"),
+        ("INVOCATION_CLAIMED", "INDETERMINATE_NO_RETRY"),
+        ("ENGINE_EVIDENCE_VERIFIED", "INDETERMINATE_NO_RETRY"),
+        ("ENGINE_EVIDENCE_VERIFIED", "RECEIPT_FINALIZED"),
+        ("PREINVOKE_REJECTED", "RECEIPT_FINALIZED"),
+        ("INDETERMINATE_NO_RETRY", "RECEIPT_FINALIZED"),
+    }
+)
+SEALED_RECEIPT_STATES = frozenset(
+    {"REJECTED_PRE_INVOKE", "ENGINE_TERMINAL", "INDETERMINATE_NO_RETRY"}
+)
+_SEALED_RECEIPT_STATE_BY_PREDECESSOR = {
+    "PREINVOKE_REJECTED": "REJECTED_PRE_INVOKE",
+    "ENGINE_EVIDENCE_VERIFIED": "ENGINE_TERMINAL",
+    "INDETERMINATE_NO_RETRY": "INDETERMINATE_NO_RETRY",
+}
+_ENGINE_EVIDENCE_RECORD_FIELDS = (
+    "phase0_terminal_report_digest",
+    "phase0_evidence_manifest_digest",
+    "phase0_evidence_directory_name",
+)
+
+_PHASE0_ARTIFACT_SPECS = {
+    "01-request.json": ("request", "REQUEST_CAPTURED"),
+    "02-authorization.json": ("authorization", "AUTHORIZATION_RECORDED"),
+    "03-packet.json": ("sealed-packet", "PACKET_SEALED"),
+    "04-worker-result.json": ("worker-result", "PAIR_A_RECORDED"),
+    "05-reviewer-result.json": ("reviewer-result", "PAIR_B_RECORDED"),
+    "06-comparison.json": ("comparison", "COMPARISON_RECORDED"),
+    "07-terminal-report.json": ("terminal-report", "TERMINAL_RECORDED"),
+}
+_PHASE0_REQUIRED_ARTIFACTS = {
+    "01-request.json",
+    "02-authorization.json",
+    "06-comparison.json",
+    "07-terminal-report.json",
+}
+
+
+class CanonicalJSONError(ValueError):
+    """Input is outside the frozen deterministic JSON profile."""
+
+
+class JSONSizeError(CanonicalJSONError):
+    """JSON input exceeds its contract byte limit."""
+
+
+class DuplicateKeyError(CanonicalJSONError):
+    """A JSON object repeated a key."""
+
+
+class ContractValidationError(ValueError):
+    """A decoded value violates a frozen Phase 1 contract."""
+
+
+class EnvelopeValidationError(ContractValidationError):
+    """Operation envelope rejection with its deterministic reason code."""
+
+    def __init__(self, reason_code: str) -> None:
+        if reason_code not in {
+            "ENVELOPE_TOO_LARGE",
+            "ENVELOPE_INVALID_JSON",
+            "ENGINE_CONTRACT_MISMATCH",
+            "ENVELOPE_SCHEMA_MISMATCH",
+        }:
+            raise ValueError("invalid envelope rejection reason")
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+def _reject_constant(value: str) -> None:
+    raise CanonicalJSONError(f"non-finite JSON number is forbidden: {value}")
+
+
+def _reject_float(value: str) -> None:
+    raise CanonicalJSONError(f"floating-point JSON numbers are forbidden: {value}")
+
+
+def _parse_integer(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise CanonicalJSONError(
+            "JSON integer exceeds the deterministic conversion limit"
+        ) from exc
+
+
+def _object_from_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateKeyError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def validate_json_value(value: Any, *, _depth: int = 0) -> None:
+    if _depth > MAX_JSON_NESTING:
+        raise CanonicalJSONError("JSON nesting limit exceeded")
+    if value is None or isinstance(value, bool) or isinstance(value, int):
+        return
+    if isinstance(value, float):
+        raise CanonicalJSONError("floating-point values are forbidden")
+    if isinstance(value, str):
+        try:
+            value.encode("utf-8", "strict")
+        except UnicodeEncodeError as exc:
+            raise CanonicalJSONError("unpaired Unicode surrogate is forbidden") from exc
+        return
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise CanonicalJSONError("JSON object keys must be strings")
+            validate_json_value(key, _depth=_depth + 1)
+            validate_json_value(child, _depth=_depth + 1)
+        return
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray, memoryview)
+    ):
+        for child in value:
+            validate_json_value(child, _depth=_depth + 1)
+        return
+    raise CanonicalJSONError(f"unsupported JSON value type: {type(value).__name__}")
+
+
+def strict_loads(data: str | bytes, *, max_bytes: int | None = None) -> JSONValue:
+    if isinstance(data, bytes):
+        encoded = data
+        try:
+            text = data.decode("utf-8", "strict")
+        except UnicodeDecodeError as exc:
+            raise CanonicalJSONError("JSON input is not valid UTF-8") from exc
+    elif isinstance(data, str):
+        text = data
+        try:
+            encoded = data.encode("utf-8", "strict")
+        except UnicodeEncodeError as exc:
+            raise CanonicalJSONError(
+                "JSON input contains an unpaired surrogate"
+            ) from exc
+    else:
+        raise TypeError("JSON input must be str or bytes")
+    if max_bytes is not None and len(encoded) > max_bytes:
+        raise JSONSizeError(
+            f"JSON input is {len(encoded)} bytes; maximum is {max_bytes} bytes"
+        )
+    if text.startswith("\ufeff"):
+        raise CanonicalJSONError("UTF-8 BOM is forbidden")
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_from_pairs,
+            parse_constant=_reject_constant,
+            parse_float=_reject_float,
+            parse_int=_parse_integer,
+        )
+    except (json.JSONDecodeError, RecursionError, ValueError) as exc:
+        if isinstance(exc, CanonicalJSONError):
+            raise
+        raise CanonicalJSONError("malformed JSON input") from exc
+    validate_json_value(value)
+    return value
+
+
+def canonical_bytes(value: Any) -> bytes:
+    validate_json_value(value)
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise CanonicalJSONError("value cannot be serialized canonically") from exc
+    return text.encode("utf-8", "strict")
+
+
+def domain_separated_sha256(domain: str, payload: bytes) -> str:
+    if not isinstance(domain, str) or _DOMAIN_RE.fullmatch(domain) is None:
+        raise ValueError("invalid digest domain")
+    if not isinstance(payload, bytes):
+        raise TypeError("digest payload must be bytes")
+    domain_bytes = domain.encode("ascii")
+    framed = b"".join(
+        (
+            _HASH_PREFIX,
+            len(domain_bytes).to_bytes(2, "big"),
+            domain_bytes,
+            len(payload).to_bytes(8, "big"),
+            payload,
+        )
+    )
+    return hashlib.sha256(framed).hexdigest()
+
+
+def canonical_digest(domain: str, value: Any) -> str:
+    return domain_separated_sha256(domain, canonical_bytes(value))
+
+
+def validate_hex_digest(value: Any, path: str) -> str:
+    if not isinstance(value, str) or _HEX_DIGEST_RE.fullmatch(value) is None:
+        raise ContractValidationError(f"{path}: expected 64 lowercase hex")
+    return value
+
+
+def _json_type_matches(expected: str, value: Any) -> bool:
+    if expected == "null":
+        return value is None
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, Mapping)
+    return False
+
+
+def _json_equal(left: Any, right: Any) -> bool:
+    try:
+        return canonical_bytes(left) == canonical_bytes(right)
+    except CanonicalJSONError:
+        return False
+
+
+def _schema_document(name: str) -> dict[str, JSONValue]:
+    cached = _SCHEMA_CACHE.get(name)
+    if cached is not None:
+        return cached
+    try:
+        path, expected_size, expected_sha, expected_id, expected_digest = (
+            _SCHEMA_SPECS[name]
+        )
+    except KeyError as exc:
+        raise ContractValidationError("unknown frozen schema") from exc
+    entry = path.lstat()
+    if (
+        not stat.S_ISREG(entry.st_mode)
+        or entry.st_nlink != 1
+        or stat.S_ISLNK(entry.st_mode)
+    ):
+        raise ContractValidationError(f"{name} schema is not a regular unique file")
+    raw = path.read_bytes()
+    if len(raw) != expected_size or hashlib.sha256(raw).hexdigest() != expected_sha:
+        raise ContractValidationError(f"{name} schema raw bytes do not match Gate 2")
+    parsed = strict_loads(raw, max_bytes=MAX_RECEIPT_BYTES)
+    if not isinstance(parsed, dict):
+        raise ContractValidationError(f"{name} schema is not an object")
+    if canonical_digest("json-schema", parsed) != expected_digest:
+        raise ContractValidationError(f"{name} schema digest does not match Gate 2")
+    if parsed.get("$id") != expected_id:
+        raise ContractValidationError(f"{name} schema identifier does not match Gate 2")
+    expected_raw = (
+        json.dumps(
+            parsed,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            indent=2,
+        ).encode("utf-8")
+        + b"\n"
+    )
+    if raw != expected_raw:
+        raise ContractValidationError(f"{name} schema serialization is not frozen")
+    _SCHEMA_CACHE[name] = parsed
+    return parsed
+
+
+def verify_frozen_schemas() -> None:
+    for name in _SCHEMA_SPECS:
+        _schema_document(name)
+
+
+def _resolve_schema_ref(root: Mapping[str, Any], reference: str) -> Mapping[str, Any]:
+    if not reference.startswith("#/"):
+        raise ContractValidationError("external schema references are forbidden")
+    node: Any = root
+    for component in reference[2:].split("/"):
+        component = component.replace("~1", "/").replace("~0", "~")
+        if not isinstance(node, Mapping) or component not in node:
+            raise ContractValidationError("invalid local schema reference")
+        node = node[component]
+    if not isinstance(node, Mapping):
+        raise ContractValidationError("schema reference does not resolve to an object")
+    return node
+
+
+def _validate_schema_node(
+    value: Any,
+    schema: Mapping[str, Any],
+    root: Mapping[str, Any],
+    path: str,
+) -> None:
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str):
+            raise ContractValidationError("invalid schema reference")
+        _validate_schema_node(value, _resolve_schema_ref(root, reference), root, path)
+
+    for child in schema.get("allOf", []):
+        _validate_schema_node(value, child, root, path)
+
+    one_of = schema.get("oneOf")
+    if one_of is not None:
+        matches = 0
+        for child in one_of:
+            try:
+                _validate_schema_node(value, child, root, path)
+            except ContractValidationError:
+                continue
+            matches += 1
+        if matches != 1:
+            raise ContractValidationError(f"{path}: expected exactly one schema branch")
+
+    conditional = schema.get("if")
+    if conditional is not None:
+        try:
+            _validate_schema_node(value, conditional, root, path)
+        except ContractValidationError:
+            alternate = schema.get("else")
+            if alternate is not None:
+                _validate_schema_node(value, alternate, root, path)
+        else:
+            consequence = schema.get("then")
+            if consequence is not None:
+                _validate_schema_node(value, consequence, root, path)
+
+    declared = schema.get("type")
+    if declared is not None:
+        types = [declared] if isinstance(declared, str) else declared
+        if not isinstance(types, list) or not all(isinstance(item, str) for item in types):
+            raise ContractValidationError("invalid frozen schema type declaration")
+        if not any(_json_type_matches(item, value) for item in types):
+            raise ContractValidationError(f"{path}: value has the wrong JSON type")
+
+    if "const" in schema and not _json_equal(value, schema["const"]):
+        raise ContractValidationError(f"{path}: value does not match the frozen constant")
+    if "enum" in schema and not any(
+        _json_equal(value, candidate) for candidate in schema["enum"]
+    ):
+        raise ContractValidationError(f"{path}: value is outside the frozen enumeration")
+
+    if isinstance(value, Mapping):
+        required = schema.get("required", [])
+        missing = [field for field in required if field not in value]
+        if missing:
+            raise ContractValidationError(f"{path}: missing fields {missing!r}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            if extra:
+                raise ContractValidationError(f"{path}: unexpected fields {extra!r}")
+        for field, child in properties.items():
+            if field in value:
+                _validate_schema_node(value[field], child, root, f"{path}.{field}")
+
+    if isinstance(value, list):
+        minimum = schema.get("minItems")
+        maximum = schema.get("maxItems")
+        if minimum is not None and len(value) < minimum:
+            raise ContractValidationError(f"{path}: array is too short")
+        if maximum is not None and len(value) > maximum:
+            raise ContractValidationError(f"{path}: array is too long")
+        if schema.get("uniqueItems"):
+            encoded = [canonical_bytes(item) for item in value]
+            if len(encoded) != len(set(encoded)):
+                raise ContractValidationError(f"{path}: array items are not unique")
+        child = schema.get("items")
+        if child is not None:
+            for index, item in enumerate(value):
+                _validate_schema_node(item, child, root, f"{path}[{index}]")
+
+    if isinstance(value, str):
+        minimum = schema.get("minLength")
+        maximum = schema.get("maxLength")
+        if minimum is not None and len(value) < minimum:
+            raise ContractValidationError(f"{path}: string is too short")
+        if maximum is not None and len(value) > maximum:
+            raise ContractValidationError(f"{path}: string is too long")
+        pattern = schema.get("pattern")
+        if pattern is not None and re.search(pattern, value) is None:
+            raise ContractValidationError(f"{path}: string does not match the pattern")
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        if minimum is not None and value < minimum:
+            raise ContractValidationError(f"{path}: integer is too small")
+        if maximum is not None and value > maximum:
+            raise ContractValidationError(f"{path}: integer is too large")
+
+
+def validate_schema(name: str, value: Any) -> None:
+    document = _schema_document(name)
+    _validate_schema_node(value, document, document, name)
+
+
+@dataclass(frozen=True, slots=True)
+class Operation:
+    envelope: dict[str, JSONValue]
+    semantic_body: dict[str, JSONValue]
+    correlation_id: str
+    idempotency_key: str
+    idempotency_key_digest: str
+    operation_digest: str
+    payload: dict[str, JSONValue]
+    payload_request_id: str
+    payload_request_digest: str
+
+
+def parse_operation(envelope_json: str | bytes) -> Operation:
+    if not isinstance(envelope_json, (str, bytes)):
+        raise TypeError("envelope_json must be str or bytes")
+    try:
+        encoded = (
+            envelope_json
+            if isinstance(envelope_json, bytes)
+            else envelope_json.encode("utf-8", "strict")
+        )
+    except UnicodeEncodeError as exc:
+        raise EnvelopeValidationError("ENVELOPE_INVALID_JSON") from exc
+    if len(encoded) > MAX_ENVELOPE_BYTES:
+        raise EnvelopeValidationError("ENVELOPE_TOO_LARGE")
+    try:
+        parsed = strict_loads(envelope_json, max_bytes=MAX_ENVELOPE_BYTES)
+    except CanonicalJSONError as exc:
+        raise EnvelopeValidationError("ENVELOPE_INVALID_JSON") from exc
+    if not isinstance(parsed, dict):
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH")
+    engine_digest = parsed.get("engine_contract_digest")
+    if not isinstance(engine_digest, str):
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH")
+    if engine_digest != ENGINE_CONTRACT_DIGEST:
+        raise EnvelopeValidationError("ENGINE_CONTRACT_MISMATCH")
+    try:
+        validate_schema("operation", parsed)
+    except ContractValidationError as exc:
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH") from exc
+    idempotency_key = parsed["idempotency_key"]
+    payload = parsed["payload"]
+    correlation_id = parsed["correlation_id"]
+    if (
+        not isinstance(idempotency_key, str)
+        or not isinstance(payload, dict)
+        or not isinstance(correlation_id, str)
+    ):
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH")
+    key_bytes = idempotency_key.encode("utf-8")
+    if len(key_bytes) > MAX_IDEMPOTENCY_KEY_BYTES:
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH")
+    semantic_body = {
+        key: value for key, value in parsed.items() if key != "idempotency_key"
+    }
+    request_id = payload.get("request_id")
+    if not isinstance(request_id, str):
+        raise EnvelopeValidationError("ENVELOPE_SCHEMA_MISMATCH")
+    return Operation(
+        envelope=parsed,
+        semantic_body=semantic_body,
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
+        idempotency_key_digest=domain_separated_sha256(
+            "phase1-idempotency-key", key_bytes
+        ),
+        operation_digest=canonical_digest("phase1-operation", semantic_body),
+        payload=payload,
+        payload_request_id=request_id,
+        payload_request_digest=canonical_digest("request", payload),
+    )
+
+
+def _receipt_base() -> dict[str, JSONValue]:
+    return {
+        "schema_version": RECEIPT_SCHEMA_ID,
+        "gate1_packet_sha256": GATE1_PACKET_SHA256,
+        "phase1_contract_digest": PHASE1_CONTRACT_DIGEST,
+        "engine_contract_digest": ENGINE_CONTRACT_DIGEST,
+        "receipt_state": "REJECTED_PRE_INVOKE",
+        "durability": "TRANSIENT",
+        "correlation_id": None,
+        "idempotency_key_digest": None,
+        "operation_digest": None,
+        "payload_request_id": None,
+        "payload_request_digest": None,
+        "bound_operation_digest": None,
+        "ownership_record_digest": None,
+        "reason_codes": ["PERSISTENCE_CORRUPTION"],
+        "phase0_terminal_report": None,
+        "phase0_terminal_report_digest": None,
+        "phase0_evidence_manifest": None,
+        "phase0_evidence_manifest_digest": None,
+        "phase0_evidence_package_id": None,
+        "phase0_evidence_directory_name": None,
+        "automatic_engine_retry_permitted": False,
+        "receipt_digest": "",
+    }
+
+
+def _finish_receipt(receipt: dict[str, JSONValue]) -> bytes:
+    body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    receipt["receipt_digest"] = canonical_digest("phase1-receipt", body)
+    validate_receipt(receipt)
+    return canonical_bytes(receipt)
+
+
+def transient_rejection(reason_code: str) -> bytes:
+    receipt = _receipt_base()
+    receipt["reason_codes"] = [reason_code]
+    return _finish_receipt(receipt)
+
+
+def transient_conflict(
+    operation: Operation,
+    *,
+    bound_operation_digest: str,
+    ownership_record_digest: str,
+) -> bytes:
+    validate_hex_digest(bound_operation_digest, "bound_operation_digest")
+    validate_hex_digest(ownership_record_digest, "ownership_record_digest")
+    different = bound_operation_digest != operation.operation_digest
+    receipt = _receipt_base()
+    receipt.update(
+        {
+            "receipt_state": (
+                "IDEMPOTENCY_CONFLICT" if different else "CONFLICT_IN_PROGRESS"
+            ),
+            "correlation_id": operation.correlation_id,
+            "idempotency_key_digest": operation.idempotency_key_digest,
+            "operation_digest": operation.operation_digest,
+            "payload_request_id": operation.payload_request_id,
+            "payload_request_digest": operation.payload_request_digest,
+            "bound_operation_digest": bound_operation_digest,
+            "ownership_record_digest": ownership_record_digest,
+            "reason_codes": [
+                "KEY_BOUND_TO_DIFFERENT_OPERATION" if different else "ACTIVE_OWNER"
+            ],
+        }
+    )
+    return _finish_receipt(receipt)
+
+
+def build_record(
+    operation: Operation,
+    *,
+    sequence: int,
+    state: str,
+    previous_record_digest: str | None,
+    reason_code: str | None = None,
+    phase0_terminal_report_digest: str | None = None,
+    phase0_evidence_manifest_digest: str | None = None,
+    phase0_evidence_directory_name: str | None = None,
+    receipt_digest: str | None = None,
+) -> tuple[dict[str, JSONValue], bytes]:
+    record: dict[str, JSONValue] = {
+        "schema_version": OWNERSHIP_SCHEMA_ID,
+        "gate1_packet_sha256": GATE1_PACKET_SHA256,
+        "phase1_contract_digest": PHASE1_CONTRACT_DIGEST,
+        "engine_contract_digest": ENGINE_CONTRACT_DIGEST,
+        "sequence": sequence,
+        "state": state,
+        "idempotency_key_digest": operation.idempotency_key_digest,
+        "operation_digest": operation.operation_digest,
+        "correlation_id": operation.correlation_id,
+        "payload_request_id": operation.payload_request_id,
+        "payload_request_digest": operation.payload_request_digest,
+        "previous_record_digest": previous_record_digest,
+        "reason_code": reason_code,
+        "phase0_terminal_report_digest": phase0_terminal_report_digest,
+        "phase0_evidence_manifest_digest": phase0_evidence_manifest_digest,
+        "phase0_evidence_directory_name": phase0_evidence_directory_name,
+        "receipt_digest": receipt_digest,
+        "record_digest": "",
+    }
+    body = {key: value for key, value in record.items() if key != "record_digest"}
+    record["record_digest"] = canonical_digest("phase1-ownership-record", body)
+    validate_record(record)
+    return record, canonical_bytes(record)
+
+
+def sealed_receipt(
+    operation: Operation,
+    *,
+    receipt_state: str,
+    predecessor: Mapping[str, JSONValue],
+    reason_code: str,
+    phase0_terminal_report: Mapping[str, JSONValue] | None = None,
+    phase0_evidence_manifest: Mapping[str, JSONValue] | None = None,
+) -> tuple[dict[str, JSONValue], bytes]:
+    if receipt_state not in SEALED_RECEIPT_STATES:
+        raise ContractValidationError("invalid sealed receipt state")
+    validated_predecessor = validate_record(predecessor)
+    expected_receipt_state = _SEALED_RECEIPT_STATE_BY_PREDECESSOR.get(
+        validated_predecessor["state"]
+    )
+    if expected_receipt_state is None or receipt_state != expected_receipt_state:
+        raise ContractValidationError("sealed receipt predecessor state mismatch")
+    if reason_code != validated_predecessor["reason_code"]:
+        raise ContractValidationError("sealed receipt predecessor reason mismatch")
+    predecessor_digest = validate_hex_digest(
+        validated_predecessor["record_digest"], "predecessor.record_digest"
+    )
+    terminal = None if phase0_terminal_report is None else dict(phase0_terminal_report)
+    manifest = None if phase0_evidence_manifest is None else dict(
+        phase0_evidence_manifest
+    )
+    terminal_digest = (
+        None if terminal is None else canonical_digest("terminal-report", terminal)
+    )
+    manifest_digest = (
+        None if manifest is None else canonical_digest("evidence-manifest", manifest)
+    )
+    package_id = None if manifest is None else manifest.get("package_id")
+    directory_name = (
+        None
+        if receipt_state != "ENGINE_TERMINAL"
+        else f"phase0-{operation.idempotency_key_digest}"
+    )
+    if receipt_state == "ENGINE_TERMINAL":
+        engine_bindings = {
+            "phase0_terminal_report_digest": terminal_digest,
+            "phase0_evidence_manifest_digest": manifest_digest,
+            "phase0_evidence_directory_name": directory_name,
+        }
+        for field in _ENGINE_EVIDENCE_RECORD_FIELDS:
+            if engine_bindings[field] != validated_predecessor[field]:
+                raise ContractValidationError(
+                    f"sealed receipt predecessor evidence mismatch: {field}"
+                )
+    receipt = _receipt_base()
+    receipt.update(
+        {
+            "receipt_state": receipt_state,
+            "durability": "SEALED",
+            "correlation_id": operation.correlation_id,
+            "idempotency_key_digest": operation.idempotency_key_digest,
+            "operation_digest": operation.operation_digest,
+            "payload_request_id": operation.payload_request_id,
+            "payload_request_digest": operation.payload_request_digest,
+            "bound_operation_digest": operation.operation_digest,
+            "ownership_record_digest": predecessor_digest,
+            "reason_codes": [reason_code],
+            "phase0_terminal_report": terminal,
+            "phase0_terminal_report_digest": terminal_digest,
+            "phase0_evidence_manifest": manifest,
+            "phase0_evidence_manifest_digest": manifest_digest,
+            "phase0_evidence_package_id": package_id,
+            "phase0_evidence_directory_name": directory_name,
+        }
+    )
+    raw = _finish_receipt(receipt)
+    validate_receipt(receipt, operation=operation)
+    return receipt, raw
+
+
+def validate_record(record: Mapping[str, Any]) -> dict[str, JSONValue]:
+    value = dict(record)
+    validate_schema("record", value)
+    if value["gate1_packet_sha256"] != GATE1_PACKET_SHA256:
+        raise ContractValidationError("record Gate 1 binding mismatch")
+    if value["phase1_contract_digest"] != PHASE1_CONTRACT_DIGEST:
+        raise ContractValidationError("record Phase 1 binding mismatch")
+    if value["engine_contract_digest"] != ENGINE_CONTRACT_DIGEST:
+        raise ContractValidationError("record engine binding mismatch")
+    claimed = validate_hex_digest(value["record_digest"], "record.record_digest")
+    body = {key: item for key, item in value.items() if key != "record_digest"}
+    if canonical_digest("phase1-ownership-record", body) != claimed:
+        raise ContractValidationError("record digest mismatch")
+    return value
+
+
+def parse_record_bytes(raw: bytes) -> dict[str, JSONValue]:
+    if len(raw) > MAX_RECORD_BYTES:
+        raise ContractValidationError("ownership record exceeds byte limit")
+    try:
+        parsed = strict_loads(raw, max_bytes=MAX_RECORD_BYTES)
+    except CanonicalJSONError as exc:
+        raise ContractValidationError("ownership record is invalid JSON") from exc
+    if not isinstance(parsed, dict) or canonical_bytes(parsed) != raw:
+        raise ContractValidationError("ownership record is not canonical")
+    return validate_record(parsed)
+
+
+def record_filename(record: Mapping[str, Any]) -> str:
+    return f"{int(record['sequence']):06d}-{record['state']}.json"
+
+
+def validate_record_chain(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    filenames: Sequence[str] | None = None,
+) -> list[dict[str, JSONValue]]:
+    if not records or len(records) > MAX_RECORDS_PER_KEY:
+        raise ContractValidationError("ownership chain length is invalid")
+    if filenames is not None and len(filenames) != len(records):
+        raise ContractValidationError("record filename count mismatch")
+    validated: list[dict[str, JSONValue]] = []
+    previous_state: str | None = None
+    previous_digest: str | None = None
+    invariant_fields = (
+        "gate1_packet_sha256",
+        "phase1_contract_digest",
+        "engine_contract_digest",
+        "idempotency_key_digest",
+        "operation_digest",
+        "correlation_id",
+        "payload_request_id",
+        "payload_request_digest",
+    )
+    anchor: dict[str, JSONValue] | None = None
+    invocation_count = 0
+    for index, raw_record in enumerate(records, 1):
+        record = validate_record(raw_record)
+        if record["sequence"] != index:
+            raise ContractValidationError("ownership sequence is not contiguous")
+        if filenames is not None:
+            match = _RECORD_NAME_RE.fullmatch(filenames[index - 1])
+            if (
+                match is None
+                or int(match.group("sequence")) != index
+                or match.group("state") != record["state"]
+                or filenames[index - 1] != record_filename(record)
+            ):
+                raise ContractValidationError("record filename binding mismatch")
+        if record["previous_record_digest"] != previous_digest:
+            raise ContractValidationError("ownership predecessor digest mismatch")
+        state = record["state"]
+        if (previous_state, state) not in ALLOWED_TRANSITIONS:
+            raise ContractValidationError("forbidden ownership transition")
+        if anchor is None:
+            anchor = record
+        else:
+            for field in invariant_fields:
+                if record[field] != anchor[field]:
+                    raise ContractValidationError(
+                        f"ownership invariant changed: {field}"
+                    )
+        if state == "INVOCATION_CLAIMED":
+            invocation_count += 1
+            if invocation_count > 1:
+                raise ContractValidationError("multiple invocation claims")
+        if previous_state == "RECEIPT_FINALIZED":
+            raise ContractValidationError("record follows finalization")
+        validated.append(record)
+        previous_state = str(state)
+        previous_digest = str(record["record_digest"])
+    return validated
+
+
+def _validate_phase0_embedded(
+    receipt: Mapping[str, Any],
+    operation: Operation | None,
+) -> None:
+    terminal = receipt["phase0_terminal_report"]
+    manifest = receipt["phase0_evidence_manifest"]
+    if not isinstance(terminal, dict) or not isinstance(manifest, dict):
+        raise ContractValidationError("terminal receipt lacks embedded evidence")
+    terminal_digest = canonical_digest("terminal-report", terminal)
+    manifest_digest = canonical_digest("evidence-manifest", manifest)
+    if receipt["phase0_terminal_report_digest"] != terminal_digest:
+        raise ContractValidationError("embedded terminal digest mismatch")
+    if receipt["phase0_evidence_manifest_digest"] != manifest_digest:
+        raise ContractValidationError("embedded manifest digest mismatch")
+    request_id = receipt["payload_request_id"]
+    if terminal.get("request_id") != request_id or manifest.get("request_id") != request_id:
+        raise ContractValidationError("embedded Phase 0 request identity mismatch")
+    if manifest.get("terminal_report_digest") != terminal_digest:
+        raise ContractValidationError("manifest terminal binding mismatch")
+
+    identity_fields = (
+        "request_id",
+        "packetization_status",
+        "pair_a_status",
+        "pair_b_status",
+        "repository_postcheck_status",
+        "artifacts",
+        "events",
+        "repository_pre_digest",
+        "repository_post_digest",
+        "terminal_report_digest",
+    )
+    identity_body = {field: manifest.get(field) for field in identity_fields}
+    package_id = canonical_digest("evidence-package", identity_body)
+    if (
+        manifest.get("package_id") != package_id
+        or receipt["phase0_evidence_package_id"] != package_id
+    ):
+        raise ContractValidationError("evidence package identity mismatch")
+    expected_directory = f"phase0-{receipt['idempotency_key_digest']}"
+    if receipt["phase0_evidence_directory_name"] != expected_directory:
+        raise ContractValidationError("evidence directory identity mismatch")
+
+    artifacts = manifest.get("artifacts")
+    events = manifest.get("events")
+    if not isinstance(artifacts, list) or not isinstance(events, list):
+        raise ContractValidationError("manifest arrays are invalid")
+    if len(artifacts) != len(events):
+        raise ContractValidationError("manifest event and artifact counts differ")
+    names = [item.get("name") for item in artifacts if isinstance(item, dict)]
+    if len(names) != len(artifacts) or not _PHASE0_REQUIRED_ARTIFACTS <= set(names):
+        raise ContractValidationError("manifest required artifacts are missing")
+    expected_order = [
+        name for name in _PHASE0_ARTIFACT_SPECS if name in set(names)
+    ]
+    if names != expected_order:
+        raise ContractValidationError("manifest artifact order is invalid")
+    previous_event: str | None = None
+    for sequence, (artifact, event) in enumerate(zip(artifacts, events, strict=True), 1):
+        if not isinstance(artifact, dict) or not isinstance(event, dict):
+            raise ContractValidationError("manifest item is invalid")
+        name = artifact["name"]
+        expected_domain, expected_event_type = _PHASE0_ARTIFACT_SPECS[name]
+        if (
+            artifact["sequence"] != sequence
+            or event["sequence"] != sequence
+            or artifact["domain"] != expected_domain
+            or event["event_type"] != expected_event_type
+            or event["artifact_name"] != name
+            or event["artifact_digest"] != artifact["digest"]
+            or event["previous_event_digest"] != previous_event
+        ):
+            raise ContractValidationError("manifest event chain binding mismatch")
+        body = {
+            "sequence": event["sequence"],
+            "event_type": event["event_type"],
+            "artifact_name": event["artifact_name"],
+            "artifact_digest": event["artifact_digest"],
+            "previous_event_digest": event["previous_event_digest"],
+        }
+        expected_event = canonical_digest("evidence-event", body)
+        if event["event_digest"] != expected_event:
+            raise ContractValidationError("manifest event digest mismatch")
+        previous_event = expected_event
+
+    by_name = {item["name"]: item for item in artifacts}
+    terminal_record = by_name["07-terminal-report.json"]
+    if (
+        terminal_record["digest"] != terminal_digest
+        or terminal_record["size"] != len(canonical_bytes(terminal))
+    ):
+        raise ContractValidationError("terminal artifact binding mismatch")
+    request_record = by_name["01-request.json"]
+    if request_record["digest"] != receipt["payload_request_digest"]:
+        raise ContractValidationError("request artifact binding mismatch")
+    if operation is not None:
+        if operation.payload_request_id != request_id:
+            raise ContractValidationError("receipt request identifier mismatch")
+        if receipt["payload_request_digest"] != operation.payload_request_digest:
+            raise ContractValidationError("receipt request digest mismatch")
+        if request_record["size"] != len(canonical_bytes(operation.payload)):
+            raise ContractValidationError("request artifact binding mismatch")
+
+
+def validate_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    chain: Sequence[Mapping[str, Any]] | None = None,
+    operation: Operation | None = None,
+    require_sealed: bool = False,
+) -> dict[str, JSONValue]:
+    value = dict(receipt)
+    validate_schema("receipt", value)
+    if value["gate1_packet_sha256"] != GATE1_PACKET_SHA256:
+        raise ContractValidationError("receipt Gate 1 binding mismatch")
+    if value["phase1_contract_digest"] != PHASE1_CONTRACT_DIGEST:
+        raise ContractValidationError("receipt Phase 1 binding mismatch")
+    if value["engine_contract_digest"] != ENGINE_CONTRACT_DIGEST:
+        raise ContractValidationError("receipt engine binding mismatch")
+    claimed = validate_hex_digest(value["receipt_digest"], "receipt.receipt_digest")
+    body = {key: item for key, item in value.items() if key != "receipt_digest"}
+    if canonical_digest("phase1-receipt", body) != claimed:
+        raise ContractValidationError("receipt digest mismatch")
+    if require_sealed and value["durability"] != "SEALED":
+        raise ContractValidationError("stored receipt is not sealed")
+    reason_codes = value["reason_codes"]
+    if not isinstance(reason_codes, list) or len(reason_codes) != 1:
+        raise ContractValidationError("receipt must have one reason")
+
+    state = value["receipt_state"]
+    if state == "IDEMPOTENCY_CONFLICT":
+        if value["bound_operation_digest"] == value["operation_digest"]:
+            raise ContractValidationError("idempotency conflict digests must differ")
+    elif value["idempotency_key_digest"] is not None:
+        if value["bound_operation_digest"] != value["operation_digest"]:
+            raise ContractValidationError("keyed receipt operation binding mismatch")
+
+    if operation is not None and value["idempotency_key_digest"] is not None:
+        expected = {
+            "correlation_id": operation.correlation_id,
+            "idempotency_key_digest": operation.idempotency_key_digest,
+            "operation_digest": operation.operation_digest,
+            "payload_request_id": operation.payload_request_id,
+            "payload_request_digest": operation.payload_request_digest,
+        }
+        for field, expected_value in expected.items():
+            if value[field] != expected_value:
+                raise ContractValidationError(f"receipt current operation mismatch: {field}")
+
+    validated_chain: list[dict[str, JSONValue]] | None = None
+    if chain is not None:
+        validated_chain = validate_record_chain(chain)
+        anchor = validated_chain[0]
+        if value["durability"] == "TRANSIENT":
+            if value["idempotency_key_digest"] != anchor["idempotency_key_digest"]:
+                raise ContractValidationError(
+                    "receipt anchor mismatch: idempotency_key_digest"
+                )
+            if value["ownership_record_digest"] != anchor["record_digest"]:
+                raise ContractValidationError("conflict anchor digest mismatch")
+            if value["bound_operation_digest"] != anchor["operation_digest"]:
+                raise ContractValidationError("conflict bound operation mismatch")
+        else:
+            for field in (
+                "idempotency_key_digest",
+                "correlation_id",
+                "payload_request_id",
+                "payload_request_digest",
+            ):
+                if value[field] != anchor[field]:
+                    raise ContractValidationError(f"receipt anchor mismatch: {field}")
+            predecessor = (
+                validated_chain[-2]
+                if validated_chain[-1]["state"] == "RECEIPT_FINALIZED"
+                else validated_chain[-1]
+            )
+            if value["ownership_record_digest"] != predecessor["record_digest"]:
+                raise ContractValidationError("sealed receipt predecessor mismatch")
+            if value["operation_digest"] != anchor["operation_digest"]:
+                raise ContractValidationError("sealed receipt operation mismatch")
+            if reason_codes[0] != predecessor["reason_code"]:
+                raise ContractValidationError("sealed receipt reason mismatch")
+            expected_receipt_state = _SEALED_RECEIPT_STATE_BY_PREDECESSOR.get(
+                predecessor["state"]
+            )
+            if expected_receipt_state is None or state != expected_receipt_state:
+                raise ContractValidationError(
+                    "sealed receipt predecessor state mismatch"
+                )
+            if state == "ENGINE_TERMINAL":
+                for field in _ENGINE_EVIDENCE_RECORD_FIELDS:
+                    if value[field] != predecessor[field]:
+                        raise ContractValidationError(
+                            f"sealed receipt predecessor evidence mismatch: {field}"
+                        )
+            if validated_chain[-1]["state"] == "RECEIPT_FINALIZED":
+                final = validated_chain[-1]
+                if (
+                    final["previous_record_digest"] != predecessor["record_digest"]
+                    or final["receipt_digest"] != value["receipt_digest"]
+                ):
+                    raise ContractValidationError("final record receipt binding mismatch")
+
+    if state == "ENGINE_TERMINAL":
+        _validate_phase0_embedded(value, operation)
+    return value
+
+
+def parse_receipt_bytes(
+    raw: bytes,
+    *,
+    chain: Sequence[Mapping[str, Any]] | None = None,
+    operation: Operation | None = None,
+    require_sealed: bool = True,
+) -> dict[str, JSONValue]:
+    if len(raw) > MAX_RECEIPT_BYTES:
+        raise ContractValidationError("receipt exceeds byte limit")
+    try:
+        parsed = strict_loads(raw, max_bytes=MAX_RECEIPT_BYTES)
+    except CanonicalJSONError as exc:
+        raise ContractValidationError("receipt is invalid JSON") from exc
+    if not isinstance(parsed, dict) or canonical_bytes(parsed) != raw:
+        raise ContractValidationError("receipt is not canonical")
+    return validate_receipt(
+        parsed,
+        chain=chain,
+        operation=operation,
+        require_sealed=require_sealed,
+    )
+
+
+def digest_vectors() -> dict[str, str]:
+    """Return the three primary Gate 2 vector identities for focused tests."""
+
+    envelope = {
+        "schema_version": OPERATION_SCHEMA_ID,
+        "correlation_id": "corr-phase1-gate2-vector",
+        "idempotency_key": "idem-phase1-gate2-vector",
+        "engine_contract_digest": ENGINE_CONTRACT_DIGEST,
+        "payload": {
+            "contract_id": "olympus.repo-analysis.request/v1",
+            "request_id": "req-phase1-gate2-vector",
+            "repository_id": "synthetic-phase1-gate2-vector",
+            "repository_kind": "SYNTHETIC",
+            "repository_path": ".",
+            "requested_paths": ["README.md"],
+            "purpose": "Hermetic Phase 1 Gate 2 digest vector",
+            "authority": {
+                "scope": "OFFLINE_SYNTHETIC_REPOSITORY_ANALYSIS",
+                "granted": True,
+            },
+            "limits": {
+                "max_files": 96,
+                "max_file_bytes": 32_768,
+                "max_total_bytes": 196_608,
+                "max_findings": 64,
+                "max_model_json_bytes": 65_536,
+            },
+            "controls": {
+                "offline": True,
+                "fake_transports_only": True,
+                "tools": [],
+                "max_pair_a_attempts": 1,
+                "max_pair_b_attempts": 1,
+                "allow_retries": False,
+                "allow_response_repair": False,
+                "allow_cloud_fallback": False,
+            },
+        },
+    }
+    operation = parse_operation(canonical_bytes(envelope))
+    first, _ = build_record(
+        operation,
+        sequence=1,
+        state="OWNERSHIP_ACQUIRED",
+        previous_record_digest=None,
+    )
+    return {
+        "idempotency_key_digest": operation.idempotency_key_digest,
+        "operation_digest": operation.operation_digest,
+        "payload_request_digest": operation.payload_request_digest,
+        "first_record_digest": str(first["record_digest"]),
+        "transient_invalid_json_receipt_digest": str(
+            strict_loads(transient_rejection("ENVELOPE_INVALID_JSON"))[
+                "receipt_digest"
+            ]
+        ),
+    }

--- a/olympus_phase1_adapter/receipt_store.py
+++ b/olympus_phase1_adapter/receipt_store.py
@@ -1,0 +1,2983 @@
+"""Owner-only append-only receipt storage for the frozen Phase 1 seam."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+import secrets
+import stat
+import sys
+import threading
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .contracts import (
+    MAX_DIRECTORY_ENTRIES_PER_KEY,
+    MAX_RECORD_BYTES,
+    MAX_RECORDS_PER_KEY,
+    MAX_RECEIPT_BYTES,
+    ContractValidationError,
+    JSONValue,
+    Operation,
+    build_record,
+    canonical_bytes,
+    parse_receipt_bytes,
+    parse_record_bytes,
+    record_filename,
+    sealed_receipt,
+    transient_conflict,
+    validate_record_chain,
+)
+
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_O_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+_DIR_FLAGS = os.O_RDONLY | os.O_DIRECTORY | _O_NOFOLLOW | _O_CLOEXEC
+_READ_FLAGS = os.O_RDONLY | _O_NOFOLLOW | _O_CLOEXEC
+_WRITE_FLAGS = os.O_WRONLY | _O_NOFOLLOW | _O_CLOEXEC
+_LOCK_FLAGS = os.O_RDWR | _O_NOFOLLOW | _O_CLOEXEC
+_EUID = os.geteuid()
+_PUBLICATION_STAGE_PREFIX = ".phase1-stage-"
+
+HERMES_CHECKOUT = Path(__file__).resolve().parents[1]
+OLYMPUS_CHECKOUT = Path("/Users/macmini/Hermes-Handoff/olympus-engine")
+
+
+class RootSafetyError(RuntimeError):
+    """A supplied root is outside the owner-controlled test profile."""
+
+    def __init__(self, reason_code: str) -> None:
+        if reason_code not in {
+            "UNSAFE_RECEIPT_ROOT",
+            "ROOTS_OVERLAP",
+            "UNSAFE_EVIDENCE_ROOT",
+            "UNSAFE_REPOSITORY_ROOT",
+        }:
+            raise ValueError("invalid root safety reason")
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+class PersistenceError(RuntimeError):
+    """A no-retry storage operation failed before safe completion."""
+
+
+class StoreIndeterminate(RuntimeError):
+    """Existing storage cannot safely prove whether invocation occurred."""
+
+    def __init__(self, operation: Operation) -> None:
+        self.idempotency_key_digest = operation.idempotency_key_digest
+        self.operation_digest = operation.operation_digest
+        super().__init__("unclassifiable existing Phase 1 key")
+
+
+class StorePreInvokeUnavailable(PersistenceError):
+    """A clean pre-invocation prefix could not publish a sealed rejection."""
+
+    def __init__(self, operation: Operation) -> None:
+        self.idempotency_key_digest = operation.idempotency_key_digest
+        self.operation_digest = operation.operation_digest
+        super().__init__("pre-invocation receipt is unavailable")
+
+
+class StoreIndeterminateUnavailable(PersistenceError):
+    """A clean consumed-attempt prefix could not publish a sealed receipt."""
+
+    def __init__(self, operation: Operation) -> None:
+        self.idempotency_key_digest = operation.idempotency_key_digest
+        self.operation_digest = operation.operation_digest
+        super().__init__("indeterminate receipt is unavailable")
+
+
+class StoreSealedUnavailable(RuntimeError):
+    """Sealing is proven, but the exact receipt cannot be returned safely."""
+
+    def __init__(
+        self,
+        operation: Operation,
+        *,
+        receipt_digest: str,
+        receipt_state: str,
+    ) -> None:
+        self.idempotency_key_digest = operation.idempotency_key_digest
+        self.operation_digest = operation.operation_digest
+        self.receipt_digest = receipt_digest
+        self.receipt_state = receipt_state
+        super().__init__("sealed Phase 1 receipt is unavailable")
+
+
+class _FinalReceiptUnavailable(PersistenceError):
+    """A validated final record proves sealing without replayable bytes."""
+
+    def __init__(self, *, receipt_digest: str, predecessor_state: str) -> None:
+        self.receipt_digest = receipt_digest
+        self.predecessor_state = predecessor_state
+        super().__init__("final record proves an unavailable receipt")
+
+
+@dataclass(slots=True)
+class _PublicationAttempt:
+    """Side-effect state shared with a publication caller during interruption."""
+
+    link_attempted: bool = False
+    target_observed: bool = False
+    target_parent_fsync_attempted: bool = False
+    target_parent_synced: bool = False
+    unlink_attempted: bool = False
+    stage_absent: bool = False
+    stage_parent_fsync_attempted: bool = False
+    stage_parent_synced: bool = False
+    final_revalidated: bool = False
+
+    @property
+    def committed(self) -> bool:
+        return self.target_observed and self.target_parent_synced
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.committed
+            and self.stage_absent
+            and self.stage_parent_synced
+            and self.final_revalidated
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RootCapability:
+    name: str
+    path: Path
+    fd: int
+    device: int
+    inode: int
+    mutable: bool
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return (self.device, self.inode)
+
+    def revalidate(self) -> None:
+        try:
+            held = os.fstat(self.fd)
+            current = os.stat(self.path, follow_symlinks=False)
+        except OSError as exc:
+            raise PersistenceError(f"{self.name} root vanished") from exc
+        if (
+            not stat.S_ISDIR(held.st_mode)
+            or not stat.S_ISDIR(current.st_mode)
+            or (held.st_dev, held.st_ino) != self.identity
+            or (current.st_dev, current.st_ino) != self.identity
+            or held.st_uid != _EUID
+            or current.st_uid != _EUID
+        ):
+            raise PersistenceError(f"{self.name} root identity changed")
+        mode = stat.S_IMODE(current.st_mode)
+        if self.mutable:
+            if mode != 0o700:
+                raise PersistenceError(f"{self.name} root mode changed")
+        elif mode & 0o022:
+            raise PersistenceError(f"{self.name} root became writable by others")
+
+
+@dataclass(slots=True)
+class RootSet:
+    repository: RootCapability
+    receipt: RootCapability
+    evidence: RootCapability
+    hermes: RootCapability
+    olympus: RootCapability
+    _closed: bool = False
+
+    def __enter__(self) -> "RootSet":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for capability in (
+            self.olympus,
+            self.hermes,
+            self.evidence,
+            self.receipt,
+            self.repository,
+        ):
+            try:
+                os.close(capability.fd)
+            except OSError:
+                pass
+
+    def revalidate_all(self) -> None:
+        for capability in (
+            self.repository,
+            self.receipt,
+            self.evidence,
+            self.hermes,
+            self.olympus,
+        ):
+            capability.revalidate()
+
+
+def _mode(entry: os.stat_result) -> int:
+    return stat.S_IMODE(entry.st_mode)
+
+
+def _path_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current = path
+    while True:
+        components.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    components.reverse()
+    return components
+
+
+def _open_root(
+    value: str | Path,
+    *,
+    name: str,
+    mutable: bool,
+    reason_code: str,
+) -> RootCapability:
+    if not isinstance(value, (str, Path)):
+        raise RootSafetyError(reason_code)
+    raw = os.fspath(value)
+    if not os.path.isabs(raw) or os.path.normpath(raw) != raw:
+        raise RootSafetyError(reason_code)
+    path = Path(raw)
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise RootSafetyError(reason_code) from exc
+    if resolved != path:
+        raise RootSafetyError(reason_code)
+    try:
+        for component in _path_components(path):
+            entry = os.lstat(component)
+            if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+                raise RootSafetyError(reason_code)
+            writable_by_others = bool(_mode(entry) & 0o022)
+            protected_sticky_ancestor = (
+                component != path
+                and entry.st_uid == 0
+                and bool(entry.st_mode & stat.S_ISVTX)
+            )
+            if writable_by_others and not protected_sticky_ancestor:
+                raise RootSafetyError(reason_code)
+            if entry.st_uid not in {0, _EUID}:
+                raise RootSafetyError(reason_code)
+        entry = os.lstat(path)
+        if entry.st_uid != _EUID:
+            raise RootSafetyError(reason_code)
+        if mutable:
+            if _mode(entry) != 0o700 or not os.access(path, os.W_OK | os.X_OK):
+                raise RootSafetyError(reason_code)
+        elif _mode(entry) & 0o022:
+            raise RootSafetyError(reason_code)
+        fd = os.open(path, _DIR_FLAGS)
+        held = os.fstat(fd)
+    except RootSafetyError:
+        raise
+    except OSError as exc:
+        raise RootSafetyError(reason_code) from exc
+    if (
+        not stat.S_ISDIR(held.st_mode)
+        or held.st_uid != _EUID
+        or (held.st_dev, held.st_ino) != (entry.st_dev, entry.st_ino)
+    ):
+        os.close(fd)
+        raise RootSafetyError(reason_code)
+    return RootCapability(
+        name=name,
+        path=path,
+        fd=fd,
+        device=held.st_dev,
+        inode=held.st_ino,
+        mutable=mutable,
+    )
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    try:
+        common = Path(os.path.commonpath((left, right)))
+    except ValueError:
+        return False
+    return common == left or common == right
+
+
+def _lexical_root_path(value: str | Path) -> Path | None:
+    """Return an absolute normalized path without consulting the filesystem."""
+
+    if not isinstance(value, (str, Path)):
+        return None
+    raw = os.fspath(value)
+    if not os.path.isabs(raw):
+        return None
+    return Path(os.path.normpath(raw))
+
+
+def _root_path_representations(value: str | Path) -> tuple[Path, ...]:
+    """Return lexical and best-effort resolved paths for reason classification."""
+
+    lexical = _lexical_root_path(value)
+    if lexical is None:
+        return ()
+    representations = [lexical]
+    try:
+        resolved = lexical.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return tuple(representations)
+    if resolved != lexical:
+        representations.append(resolved)
+    return tuple(representations)
+
+
+def open_root_set(
+    *,
+    repository_root: str | Path,
+    receipt_root: str | Path,
+    evidence_root: str | Path,
+) -> RootSet:
+    opened: list[RootCapability] = []
+    try:
+        # Receipt-root safety has the highest frozen precedence and therefore
+        # must be decided before any lower-priority condition.
+        receipt = _open_root(
+            receipt_root,
+            name="receipt",
+            mutable=True,
+            reason_code="UNSAFE_RECEIPT_ROOT",
+        )
+        opened.append(receipt)
+
+        # Lexical containment and best-effort strict resolution are used only
+        # to classify overlap before a lower-priority safety failure.  These
+        # representations never become capabilities; _open_root still applies
+        # the stricter exact-path contract before any root is accepted.
+        root_representations = [
+            _root_path_representations(value)
+            for value in (
+                receipt_root,
+                evidence_root,
+                repository_root,
+                HERMES_CHECKOUT,
+                OLYMPUS_CHECKOUT,
+            )
+        ]
+        for index, left_paths in enumerate(root_representations):
+            for right_paths in root_representations[index + 1 :]:
+                if any(
+                    _paths_overlap(left, right)
+                    for left in left_paths
+                    for right in right_paths
+                ):
+                    raise RootSafetyError("ROOTS_OVERLAP")
+
+        evidence: RootCapability | None = None
+        repository: RootCapability | None = None
+        hermes: RootCapability | None = None
+        olympus: RootCapability | None = None
+        evidence_unsafe = False
+        repository_unsafe = False
+
+        try:
+            evidence = _open_root(
+                evidence_root,
+                name="evidence",
+                mutable=True,
+                reason_code="UNSAFE_EVIDENCE_ROOT",
+            )
+            opened.append(evidence)
+        except RootSafetyError:
+            evidence_unsafe = True
+
+        repository_specs = (
+            (repository_root, "repository"),
+            (HERMES_CHECKOUT, "hermes"),
+            (OLYMPUS_CHECKOUT, "olympus"),
+        )
+        repository_capabilities: list[RootCapability | None] = []
+        for value, name in repository_specs:
+            try:
+                capability = _open_root(
+                    value,
+                    name=name,
+                    mutable=False,
+                    reason_code="UNSAFE_REPOSITORY_ROOT",
+                )
+                opened.append(capability)
+                repository_capabilities.append(capability)
+            except RootSafetyError:
+                repository_unsafe = True
+                repository_capabilities.append(None)
+        repository, hermes, olympus = repository_capabilities
+
+        # Physical-identity overlap is available only for roots that passed
+        # their individual safety checks.  It still outranks any collected
+        # evidence/repository safety failure.
+        for index, left in enumerate(opened):
+            for right in opened[index + 1 :]:
+                if left.identity == right.identity or _paths_overlap(
+                    left.path, right.path
+                ):
+                    raise RootSafetyError("ROOTS_OVERLAP")
+        if evidence_unsafe:
+            raise RootSafetyError("UNSAFE_EVIDENCE_ROOT")
+        if repository_unsafe:
+            raise RootSafetyError("UNSAFE_REPOSITORY_ROOT")
+        if (
+            repository is None
+            or evidence is None
+            or hermes is None
+            or olympus is None
+        ):
+            raise AssertionError("safe root capability is unavailable")
+
+        roots = RootSet(
+            repository=repository,
+            receipt=receipt,
+            evidence=evidence,
+            hermes=hermes,
+            olympus=olympus,
+        )
+        roots.revalidate_all()
+        return roots
+    except BaseException:
+        for capability in reversed(opened):
+            try:
+                os.close(capability.fd)
+            except OSError:
+                pass
+        raise
+
+
+def _open_directory(path: Path, accepted_modes: set[int]) -> int:
+    try:
+        before = os.lstat(path)
+        if (
+            not stat.S_ISDIR(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or before.st_uid != _EUID
+            or _mode(before) not in accepted_modes
+            or _mode(before) & 0o022
+        ):
+            raise PersistenceError(f"unsafe directory: {path.name}")
+        fd = os.open(path, _DIR_FLAGS)
+        held = os.fstat(fd)
+        after = os.stat(path, follow_symlinks=False)
+    except PersistenceError:
+        raise
+    except OSError as exc:
+        raise PersistenceError(f"cannot open directory: {path.name}") from exc
+    if (
+        len(
+            {
+                (before.st_dev, before.st_ino),
+                (held.st_dev, held.st_ino),
+                (after.st_dev, after.st_ino),
+            }
+        )
+        != 1
+        or not stat.S_ISDIR(held.st_mode)
+        or held.st_uid != _EUID
+    ):
+        os.close(fd)
+        raise PersistenceError(f"directory identity changed: {path.name}")
+    return fd
+
+
+def _fsync_directory(path: Path, accepted_modes: set[int]) -> None:
+    fd = _open_directory(path, accepted_modes)
+    try:
+        os.fsync(fd)
+    except OSError as exc:
+        raise PersistenceError(f"directory fsync failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+
+
+def _fsync_parent(path: Path) -> None:
+    _fsync_directory(path.parent, {0o700, 0o500})
+
+
+def _create_directory(parent: Path, name: str) -> Path:
+    if not name or "/" in name or name in {".", ".."}:
+        raise PersistenceError("invalid directory component")
+    parent_fd = _open_directory(parent, {0o700})
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+    except OSError as exc:
+        raise PersistenceError(f"directory creation failed: {name}") from exc
+    finally:
+        os.close(parent_fd)
+    child = parent / name
+    try:
+        _fsync_directory(child, {0o700})
+        _fsync_directory(parent, {0o700})
+    except BaseException:
+        raise
+    return child
+
+
+def _ensure_directory(parent: Path, name: str) -> Path:
+    child = parent / name
+    try:
+        entry = os.lstat(child)
+    except FileNotFoundError:
+        return _create_directory(parent, name)
+    except OSError as exc:
+        raise PersistenceError(f"directory lookup failed: {name}") from exc
+    if (
+        not stat.S_ISDIR(entry.st_mode)
+        or stat.S_ISLNK(entry.st_mode)
+        or entry.st_uid != _EUID
+        or _mode(entry) != 0o700
+    ):
+        raise PersistenceError(f"existing directory is unsafe: {name}")
+    # A visible directory may have survived an earlier failed child/parent
+    # fsync.  Re-establish both durability edges before permitting any later
+    # topology or ownership operation to depend on it.
+    _fsync_directory(child, {0o700})
+    _fsync_directory(parent, {0o700})
+    return child
+
+
+def _validate_regular_entry(
+    entry: os.stat_result,
+    *,
+    modes: set[int],
+    label: str,
+) -> None:
+    if (
+        not stat.S_ISREG(entry.st_mode)
+        or stat.S_ISLNK(entry.st_mode)
+        or entry.st_uid != _EUID
+        or entry.st_nlink != 1
+        or _mode(entry) not in modes
+    ):
+        raise PersistenceError(f"unsafe regular file: {label}")
+
+
+def _is_publication_stage_name(name: str) -> bool:
+    suffix = name.removeprefix(_PUBLICATION_STAGE_PREFIX)
+    return (
+        name.startswith(_PUBLICATION_STAGE_PREFIX)
+        and len(suffix) == 32
+        and all(character in "0123456789abcdef" for character in suffix)
+    )
+
+
+def _validate_receipt_alias_entry(entry: os.stat_result, *, label: str) -> None:
+    if (
+        not stat.S_ISREG(entry.st_mode)
+        or stat.S_ISLNK(entry.st_mode)
+        or entry.st_uid != _EUID
+        or entry.st_nlink != 2
+        or _mode(entry) != 0o600
+    ):
+        raise PersistenceError(f"unsafe receipt publication alias: {label}")
+
+
+def _read_regular(path: Path, *, modes: set[int], maximum: int) -> bytes:
+    try:
+        before = os.lstat(path)
+        _validate_regular_entry(before, modes=modes, label=path.name)
+        fd = os.open(path, _READ_FLAGS)
+        held = os.fstat(fd)
+        _validate_regular_entry(held, modes=modes, label=path.name)
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(fd, min(remaining, 65_536))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        after_fd = os.fstat(fd)
+        after_path = os.stat(path, follow_symlinks=False)
+    except PersistenceError:
+        raise
+    except OSError as exc:
+        raise PersistenceError(f"file read failed: {path.name}") from exc
+    finally:
+        if "fd" in locals():
+            os.close(fd)
+    raw = b"".join(chunks)
+    if len(raw) > maximum:
+        raise PersistenceError(f"file exceeds byte limit: {path.name}")
+    identities = {
+        (before.st_dev, before.st_ino),
+        (held.st_dev, held.st_ino),
+        (after_fd.st_dev, after_fd.st_ino),
+        (after_path.st_dev, after_path.st_ino),
+    }
+    if len(identities) != 1 or before.st_size != after_path.st_size:
+        raise PersistenceError(f"file identity changed: {path.name}")
+    _validate_regular_entry(after_path, modes=modes, label=path.name)
+    return raw
+
+
+def _revalidate_named_lock(root: RootCapability, fd: int) -> None:
+    name = ".phase1-store.lock"
+    try:
+        held = os.fstat(fd)
+        named = os.stat(
+            name,
+            dir_fd=root.fd,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        raise PersistenceError("global lock identity is unavailable") from exc
+    _validate_regular_entry(held, modes={0o600}, label=name)
+    _validate_regular_entry(named, modes={0o600}, label=name)
+    if (held.st_dev, held.st_ino) != (named.st_dev, named.st_ino):
+        raise PersistenceError("global lock identity changed")
+
+
+def _create_lock_file(root: RootCapability, *, allow_create: bool) -> int:
+    name = ".phase1-store.lock"
+    flags = _LOCK_FLAGS
+    if allow_create:
+        flags |= os.O_CREAT | os.O_EXCL
+    try:
+        fd = os.open(name, flags, 0o600, dir_fd=root.fd)
+    except FileExistsError:
+        if not allow_create:
+            raise PersistenceError("global lock unexpectedly exists") from None
+        try:
+            fd = os.open(name, _LOCK_FLAGS, dir_fd=root.fd)
+        except OSError as exc:
+            raise PersistenceError("global lock open failed") from exc
+    except OSError as exc:
+        action = "creation" if allow_create else "open"
+        raise PersistenceError(f"global lock {action} failed") from exc
+    try:
+        _revalidate_named_lock(root, fd)
+        os.fsync(fd)
+        os.fsync(root.fd)
+        _revalidate_named_lock(root, fd)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _create_permanent_lock(key_directory: Path) -> int:
+    key_fd = _open_directory(key_directory, {0o700})
+    try:
+        fd = os.open(
+            "lock",
+            _LOCK_FLAGS | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=key_fd,
+        )
+        entry = os.fstat(fd)
+        _validate_regular_entry(entry, modes={0o600}, label="lock")
+        os.fsync(fd)
+        os.fsync(key_fd)
+    except BaseException:
+        if "fd" in locals():
+            os.close(fd)
+        raise
+    finally:
+        os.close(key_fd)
+    return fd
+
+
+def _open_permanent_lock(key_directory: Path) -> int:
+    key_fd = _open_directory(key_directory, {0o700, 0o500})
+    try:
+        fd = os.open("lock", _LOCK_FLAGS, dir_fd=key_fd)
+        entry = os.fstat(fd)
+        _validate_regular_entry(entry, modes={0o600}, label="lock")
+    except BaseException:
+        if "fd" in locals():
+            os.close(fd)
+        raise
+    finally:
+        os.close(key_fd)
+    return fd
+
+
+def _publication_target_matches_stage(
+    *,
+    key_fd: int,
+    parent_fd: int,
+    stage_name: str,
+    stage_fd: int,
+    target_name: str,
+    raw: bytes,
+) -> tuple[bool, bool]:
+    """Return (exact target, exact stage name still present)."""
+
+    stage_entry = os.fstat(stage_fd)
+    if (
+        not stat.S_ISREG(stage_entry.st_mode)
+        or stage_entry.st_uid != _EUID
+        or _mode(stage_entry) != 0o600
+        or stage_entry.st_size != len(raw)
+        or stage_entry.st_nlink not in {1, 2}
+    ):
+        return (False, False)
+    try:
+        target_fd = os.open(target_name, _READ_FLAGS, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return (False, False)
+    primary: BaseException | None = None
+    try:
+        target_entry = os.fstat(target_fd)
+        target_named = os.stat(
+            target_name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        identities = {
+            (stage_entry.st_dev, stage_entry.st_ino),
+            (target_entry.st_dev, target_entry.st_ino),
+            (target_named.st_dev, target_named.st_ino),
+        }
+        if len(identities) != 1:
+            return (False, False)
+        initial_attributes = {
+            (
+                entry.st_size,
+                stat.S_IMODE(entry.st_mode),
+                entry.st_uid,
+                entry.st_nlink,
+            )
+            for entry in (stage_entry, target_entry, target_named)
+        }
+        if (
+            len(initial_attributes) != 1
+            or not stat.S_ISREG(target_entry.st_mode)
+            or not stat.S_ISREG(target_named.st_mode)
+            or target_entry.st_uid != _EUID
+            or target_named.st_uid != _EUID
+            or _mode(target_entry) != 0o600
+            or _mode(target_named) != 0o600
+            or target_entry.st_size != len(raw)
+            or target_entry.st_nlink not in {1, 2}
+        ):
+            return (False, False)
+        chunks: list[bytes] = []
+        remaining = len(raw) + 1
+        while remaining:
+            chunk = os.read(target_fd, min(remaining, 65_536))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if b"".join(chunks) != raw:
+            return (False, False)
+        after_fd = os.fstat(target_fd)
+        after_named = os.stat(
+            target_name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        identities.update(
+            {
+                (after_fd.st_dev, after_fd.st_ino),
+                (after_named.st_dev, after_named.st_ino),
+            }
+        )
+        final_attributes = {
+            (
+                entry.st_size,
+                stat.S_IMODE(entry.st_mode),
+                entry.st_uid,
+                entry.st_nlink,
+            )
+            for entry in (stage_entry, target_entry, target_named, after_fd, after_named)
+        }
+        if (
+            len(identities) != 1
+            or len(final_attributes) != 1
+            or not stat.S_ISREG(after_fd.st_mode)
+            or not stat.S_ISREG(after_named.st_mode)
+            or after_fd.st_uid != _EUID
+            or after_named.st_uid != _EUID
+            or _mode(after_fd) != 0o600
+            or _mode(after_named) != 0o600
+            or after_fd.st_size != len(raw)
+            or after_fd.st_nlink not in {1, 2}
+        ):
+            return (False, False)
+    except BaseException as exc:
+        primary = exc
+        raise
+    finally:
+        try:
+            os.close(target_fd)
+        except BaseException:
+            if primary is None:
+                raise
+
+    try:
+        stage_named = os.stat(
+            stage_name,
+            dir_fd=key_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return (after_fd.st_nlink == 1, False)
+    if (
+        (stage_named.st_dev, stage_named.st_ino)
+        != (stage_entry.st_dev, stage_entry.st_ino)
+        or not stat.S_ISREG(stage_named.st_mode)
+        or stage_named.st_uid != _EUID
+        or _mode(stage_named) != 0o600
+        or after_fd.st_nlink != 2
+    ):
+        return (False, False)
+    return (True, True)
+
+
+def _reconcile_publication(
+    *,
+    key_fd: int,
+    parent_fd: int,
+    stage_name: str,
+    stage_fd: int,
+    target_name: str,
+    raw: bytes,
+    attempt: _PublicationAttempt,
+) -> None:
+    target_matches, stage_named = _publication_target_matches_stage(
+        key_fd=key_fd,
+        parent_fd=parent_fd,
+        stage_name=stage_name,
+        stage_fd=stage_fd,
+        target_name=target_name,
+        raw=raw,
+    )
+    if target_matches:
+        attempt.target_observed = True
+        if not attempt.target_parent_fsync_attempted:
+            attempt.target_parent_fsync_attempted = True
+            os.fsync(parent_fd)
+            attempt.target_parent_synced = True
+        if not attempt.target_parent_synced:
+            return
+        if stage_named:
+            if attempt.unlink_attempted:
+                return
+            attempt.unlink_attempted = True
+            os.unlink(stage_name, dir_fd=key_fd)
+            attempt.stage_absent = True
+        else:
+            attempt.stage_absent = True
+        if not attempt.stage_parent_fsync_attempted:
+            attempt.stage_parent_fsync_attempted = True
+            os.fsync(key_fd)
+            attempt.stage_parent_synced = True
+        if not attempt.stage_parent_synced:
+            return
+        target_matches, stage_named = _publication_target_matches_stage(
+            key_fd=key_fd,
+            parent_fd=parent_fd,
+            stage_name=stage_name,
+            stage_fd=stage_fd,
+            target_name=target_name,
+            raw=raw,
+        )
+        if target_matches and not stage_named:
+            attempt.final_revalidated = True
+        return
+
+    # A target that is absent or belongs to another inode was never published
+    # by this attempt. Remove only this attempt's still-named staging inode.
+    try:
+        stage_named_entry = os.stat(
+            stage_name,
+            dir_fd=key_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return
+    held = os.fstat(stage_fd)
+    if (stage_named_entry.st_dev, stage_named_entry.st_ino) == (
+        held.st_dev,
+        held.st_ino,
+    ):
+        if not attempt.unlink_attempted:
+            attempt.unlink_attempted = True
+            os.unlink(stage_name, dir_fd=key_fd)
+            attempt.stage_absent = True
+        if attempt.stage_absent and not attempt.stage_parent_fsync_attempted:
+            attempt.stage_parent_fsync_attempted = True
+            os.fsync(key_fd)
+            attempt.stage_parent_synced = True
+
+
+def _publish_no_replace(
+    *,
+    key_directory: Path,
+    target_parent: Path,
+    target_name: str,
+    raw: bytes,
+    attempt: _PublicationAttempt | None = None,
+) -> None:
+    if not target_name or "/" in target_name or target_name in {".", ".."}:
+        raise PersistenceError("invalid publication target")
+    publication = attempt if attempt is not None else _PublicationAttempt()
+    stage_name = f".phase1-stage-{secrets.token_hex(16)}"
+    key_fd: int | None = None
+    parent_fd: int | None = None
+    stage_fd: int | None = None
+    primary: BaseException | None = None
+    try:
+        key_fd = _open_directory(key_directory, {0o700})
+        parent_fd = _open_directory(target_parent, {0o700})
+        stage_fd = os.open(
+            stage_name,
+            _WRITE_FLAGS | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=key_fd,
+        )
+        view = memoryview(raw)
+        while view:
+            written = os.write(stage_fd, view)
+            if written <= 0:
+                raise PersistenceError("short publication write")
+            view = view[written:]
+        entry = os.fstat(stage_fd)
+        _validate_regular_entry(entry, modes={0o600}, label=stage_name)
+        os.fsync(stage_fd)
+        publication.link_attempted = True
+        os.link(
+            stage_name,
+            target_name,
+            src_dir_fd=key_fd,
+            dst_dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        publication.target_observed = True
+        publication.target_parent_fsync_attempted = True
+        os.fsync(parent_fd)
+        publication.target_parent_synced = True
+        publication.unlink_attempted = True
+        os.unlink(stage_name, dir_fd=key_fd)
+        publication.stage_absent = True
+        publication.stage_parent_fsync_attempted = True
+        os.fsync(key_fd)
+        publication.stage_parent_synced = True
+        target_matches, stage_named = _publication_target_matches_stage(
+            key_fd=key_fd,
+            parent_fd=parent_fd,
+            stage_name=stage_name,
+            stage_fd=stage_fd,
+            target_name=target_name,
+            raw=raw,
+        )
+        if not target_matches or stage_named:
+            raise PersistenceError("published file revalidation failed")
+        publication.final_revalidated = True
+    except BaseException as original:
+        primary = original
+        reconciliation_error: BaseException | None = None
+        if stage_fd is not None and key_fd is not None and parent_fd is not None:
+            try:
+                _reconcile_publication(
+                    key_fd=key_fd,
+                    parent_fd=parent_fd,
+                    stage_name=stage_name,
+                    stage_fd=stage_fd,
+                    target_name=target_name,
+                    raw=raw,
+                    attempt=publication,
+                )
+            except BaseException as exc:
+                reconciliation_error = exc
+        if publication.complete and isinstance(original, Exception):
+            return
+        if not isinstance(original, Exception):
+            raise
+        if reconciliation_error is not None and not isinstance(
+            reconciliation_error, Exception
+        ):
+            raise reconciliation_error
+        if isinstance(original, FileExistsError):
+            raise PersistenceError(
+                f"publication target already exists: {target_name}"
+            ) from original
+        if isinstance(original, PersistenceError):
+            raise
+        if isinstance(original, OSError):
+            raise PersistenceError(f"publication failed: {target_name}") from original
+        raise
+    finally:
+        cleanup_errors: list[BaseException] = []
+        if stage_fd is not None:
+            try:
+                os.close(stage_fd)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if parent_fd is not None:
+            try:
+                os.close(parent_fd)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if key_fd is not None:
+            try:
+                os.close(key_fd)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors and primary is None:
+            raise cleanup_errors[0]
+
+
+def _directory_names(path: Path, *, maximum: int) -> list[str]:
+    fd = _open_directory(path, {0o700, 0o500})
+    names: list[str] = []
+    try:
+        with os.scandir(fd) as entries:
+            for entry in entries:
+                names.append(entry.name)
+                if len(names) > maximum:
+                    raise PersistenceError(
+                        f"directory entry limit exceeded: {path.name}"
+                    )
+    except OSError as exc:
+        raise PersistenceError(f"directory enumeration failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+    return sorted(names)
+
+
+def _directory_has_matching_name(
+    path: Path,
+    predicate: Callable[[str], bool],
+) -> bool:
+    fd = _open_directory(path, {0o700, 0o500})
+    try:
+        with os.scandir(fd) as entries:
+            return any(predicate(entry.name) for entry in entries)
+    except OSError as exc:
+        raise PersistenceError(f"directory enumeration failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+
+
+def _read_committed_receipt_alias(
+    key_directory: Path,
+    stage_name: str,
+) -> bytes:
+    """Read one exact two-name receipt publication without repairing it."""
+
+    if not _is_publication_stage_name(stage_name):
+        raise PersistenceError("invalid receipt publication stage name")
+    key_fd: int | None = None
+    receipt_fd: int | None = None
+    stage_fd: int | None = None
+    primary: BaseException | None = None
+    try:
+        key_fd = _open_directory(key_directory, {0o700, 0o500})
+        receipt_before = os.stat(
+            "receipt.json", dir_fd=key_fd, follow_symlinks=False
+        )
+        stage_before = os.stat(
+            stage_name, dir_fd=key_fd, follow_symlinks=False
+        )
+        receipt_fd = os.open("receipt.json", _READ_FLAGS, dir_fd=key_fd)
+        stage_fd = os.open(stage_name, _READ_FLAGS, dir_fd=key_fd)
+        receipt_held = os.fstat(receipt_fd)
+        stage_held = os.fstat(stage_fd)
+        initial_entries = (
+            receipt_before,
+            stage_before,
+            receipt_held,
+            stage_held,
+        )
+        for entry in initial_entries:
+            _validate_receipt_alias_entry(entry, label=stage_name)
+        if len({(entry.st_dev, entry.st_ino) for entry in initial_entries}) != 1:
+            raise PersistenceError("receipt publication aliases differ")
+        initial_attributes = {
+            (
+                entry.st_size,
+                stat.S_IMODE(entry.st_mode),
+                entry.st_uid,
+                entry.st_nlink,
+            )
+            for entry in initial_entries
+        }
+        if len(initial_attributes) != 1 or receipt_held.st_size > MAX_RECEIPT_BYTES:
+            raise PersistenceError("receipt publication alias changed")
+
+        chunks: list[bytes] = []
+        remaining = MAX_RECEIPT_BYTES + 1
+        while remaining:
+            chunk = os.read(receipt_fd, min(remaining, 65_536))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+
+        receipt_after_fd = os.fstat(receipt_fd)
+        stage_after_fd = os.fstat(stage_fd)
+        receipt_after_name = os.stat(
+            "receipt.json", dir_fd=key_fd, follow_symlinks=False
+        )
+        stage_after_name = os.stat(
+            stage_name, dir_fd=key_fd, follow_symlinks=False
+        )
+        final_entries = (
+            *initial_entries,
+            receipt_after_fd,
+            stage_after_fd,
+            receipt_after_name,
+            stage_after_name,
+        )
+        for entry in final_entries:
+            _validate_receipt_alias_entry(entry, label=stage_name)
+        if (
+            len({(entry.st_dev, entry.st_ino) for entry in final_entries}) != 1
+            or len(
+                {
+                    (
+                        entry.st_size,
+                        stat.S_IMODE(entry.st_mode),
+                        entry.st_uid,
+                        entry.st_nlink,
+                    )
+                    for entry in final_entries
+                }
+            )
+            != 1
+            or len(raw) != receipt_after_fd.st_size
+        ):
+            raise PersistenceError("receipt publication alias changed while read")
+        return raw
+    except BaseException as exc:
+        primary = exc
+        if isinstance(exc, OSError):
+            raise PersistenceError("receipt publication alias is unavailable") from exc
+        raise
+    finally:
+        cleanup_errors: list[BaseException] = []
+        for fd in (stage_fd, receipt_fd, key_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+        if cleanup_errors and primary is None:
+            raise PersistenceError("receipt publication alias close failed") from cleanup_errors[0]
+
+
+def _read_committed_final_record_alias(
+    key_directory: Path,
+    records_directory: Path,
+    stage_name: str,
+    target_name: str,
+) -> bytes:
+    """Read one exact staged alias of the canonical final ownership record."""
+
+    if (
+        not _is_publication_stage_name(stage_name)
+        or not target_name
+        or "/" in target_name
+        or not target_name.endswith("-RECEIPT_FINALIZED.json")
+    ):
+        raise PersistenceError("invalid final-record publication alias")
+    key_fd: int | None = None
+    records_fd: int | None = None
+    target_fd: int | None = None
+    stage_fd: int | None = None
+    primary: BaseException | None = None
+    try:
+        key_fd = _open_directory(key_directory, {0o700, 0o500})
+        records_fd = _open_directory(records_directory, {0o700, 0o500})
+        target_before = os.stat(
+            target_name,
+            dir_fd=records_fd,
+            follow_symlinks=False,
+        )
+        stage_before = os.stat(
+            stage_name,
+            dir_fd=key_fd,
+            follow_symlinks=False,
+        )
+        target_fd = os.open(target_name, _READ_FLAGS, dir_fd=records_fd)
+        stage_fd = os.open(stage_name, _READ_FLAGS, dir_fd=key_fd)
+        target_held = os.fstat(target_fd)
+        stage_held = os.fstat(stage_fd)
+        initial_entries = (target_before, stage_before, target_held, stage_held)
+        for entry in initial_entries:
+            _validate_receipt_alias_entry(entry, label=target_name)
+        if len({(entry.st_dev, entry.st_ino) for entry in initial_entries}) != 1:
+            raise PersistenceError("final-record publication aliases differ")
+        if (
+            len(
+                {
+                    (
+                        entry.st_size,
+                        stat.S_IMODE(entry.st_mode),
+                        entry.st_uid,
+                        entry.st_nlink,
+                    )
+                    for entry in initial_entries
+                }
+            )
+            != 1
+            or target_held.st_size > MAX_RECORD_BYTES
+        ):
+            raise PersistenceError("final-record publication alias changed")
+
+        chunks: list[bytes] = []
+        remaining = MAX_RECORD_BYTES + 1
+        while remaining:
+            chunk = os.read(target_fd, min(remaining, 65_536))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+
+        target_after_fd = os.fstat(target_fd)
+        stage_after_fd = os.fstat(stage_fd)
+        target_after_name = os.stat(
+            target_name,
+            dir_fd=records_fd,
+            follow_symlinks=False,
+        )
+        stage_after_name = os.stat(
+            stage_name,
+            dir_fd=key_fd,
+            follow_symlinks=False,
+        )
+        final_entries = (
+            *initial_entries,
+            target_after_fd,
+            stage_after_fd,
+            target_after_name,
+            stage_after_name,
+        )
+        for entry in final_entries:
+            _validate_receipt_alias_entry(entry, label=target_name)
+        if (
+            len({(entry.st_dev, entry.st_ino) for entry in final_entries}) != 1
+            or len(
+                {
+                    (
+                        entry.st_size,
+                        stat.S_IMODE(entry.st_mode),
+                        entry.st_uid,
+                        entry.st_nlink,
+                    )
+                    for entry in final_entries
+                }
+            )
+            != 1
+            or len(raw) != target_after_fd.st_size
+        ):
+            raise PersistenceError("final-record alias changed while read")
+        return raw
+    except BaseException as exc:
+        primary = exc
+        if isinstance(exc, OSError):
+            raise PersistenceError("final-record alias is unavailable") from exc
+        raise
+    finally:
+        cleanup_errors: list[BaseException] = []
+        for fd in (stage_fd, target_fd, records_fd, key_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+        if cleanup_errors and primary is None:
+            raise PersistenceError("final-record alias close failed") from cleanup_errors[0]
+
+
+@dataclass(frozen=True, slots=True)
+class _RegistryEntry:
+    token: object
+    operation_digest: str
+    ownership_record_digest: str
+    global_lock_identity: tuple[int, int]
+
+
+_REGISTRY_PID = os.getpid()
+_REGISTRY_GUARD = threading.Lock()
+_ACTIVE_KEYS: dict[tuple[int, int, str], _RegistryEntry] = {}
+_ROOT_MUTEXES: dict[tuple[int, int], tuple[threading.Lock, int]] = {}
+
+
+def _ensure_registry_pid() -> None:
+    global _REGISTRY_PID, _REGISTRY_GUARD, _ACTIVE_KEYS, _ROOT_MUTEXES
+    pid = os.getpid()
+    if pid != _REGISTRY_PID:
+        _REGISTRY_PID = pid
+        _REGISTRY_GUARD = threading.Lock()
+        _ACTIVE_KEYS = {}
+        _ROOT_MUTEXES = {}
+
+
+def _registry_lookup(key: tuple[int, int, str]) -> _RegistryEntry | None:
+    _ensure_registry_pid()
+    with _REGISTRY_GUARD:
+        return _ACTIVE_KEYS.get(key)
+
+
+def _registry_insert(
+    key: tuple[int, int, str],
+    *,
+    token: object,
+    operation_digest: str,
+    ownership_record_digest: str,
+    global_lock_identity: tuple[int, int],
+) -> None:
+    _ensure_registry_pid()
+    with _REGISTRY_GUARD:
+        if key in _ACTIVE_KEYS:
+            raise PersistenceError("active-key registry collision")
+        _ACTIVE_KEYS[key] = _RegistryEntry(
+            token,
+            operation_digest,
+            ownership_record_digest,
+            global_lock_identity,
+        )
+
+
+def _registry_remove(key: tuple[int, int, str], token: object) -> None:
+    _ensure_registry_pid()
+    with _REGISTRY_GUARD:
+        current = _ACTIVE_KEYS.get(key)
+        if current is not None and current.token is token:
+            del _ACTIVE_KEYS[key]
+
+
+def _root_mutex_acquire(identity: tuple[int, int]) -> threading.Lock:
+    _ensure_registry_pid()
+    with _REGISTRY_GUARD:
+        current = _ROOT_MUTEXES.get(identity)
+        if current is None:
+            lock = threading.Lock()
+            _ROOT_MUTEXES[identity] = (lock, 1)
+        else:
+            lock, references = current
+            _ROOT_MUTEXES[identity] = (lock, references + 1)
+    try:
+        lock.acquire()
+    except BaseException:
+        with _REGISTRY_GUARD:
+            current = _ROOT_MUTEXES.get(identity)
+            if current is not None and current[0] is lock:
+                if current[1] == 1:
+                    del _ROOT_MUTEXES[identity]
+                else:
+                    _ROOT_MUTEXES[identity] = (lock, current[1] - 1)
+        raise
+    return lock
+
+
+def _root_mutex_release(identity: tuple[int, int], lock: threading.Lock) -> None:
+    lock.release()
+    with _REGISTRY_GUARD:
+        current = _ROOT_MUTEXES.get(identity)
+        if current is None or current[0] is not lock:
+            raise PersistenceError("root mutex registry mismatch")
+        if current[1] == 1:
+            del _ROOT_MUTEXES[identity]
+        else:
+            _ROOT_MUTEXES[identity] = (lock, current[1] - 1)
+
+
+@dataclass(slots=True)
+class _StoredState:
+    records: list[dict[str, JSONValue]]
+    record_names: list[str]
+    record_modes: list[int]
+    receipt_raw: bytes | None
+    receipt: dict[str, JSONValue] | None
+    key_mode: int
+    records_mode: int
+
+
+@dataclass(slots=True)
+class OwnerHandle:
+    roots: RootSet
+    operation: Operation
+    key_directory: Path
+    records_directory: Path
+    evidence_destination: Path
+    key_lock_fd: int
+    registry_key: tuple[int, int, str]
+    registry_token: object
+    records: list[dict[str, JSONValue]]
+    preflight_result: Any = None
+    sealed_raw: bytes | None = None
+    sealed_receipt: dict[str, JSONValue] | None = None
+    _closed: bool = False
+    _finalization_attempted: bool = False
+    _finalization_complete: bool = False
+    _receipt_publication_complete: bool = False
+    _store_ambiguous: bool = False
+
+    def __enter__(self) -> "OwnerHandle":
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        exc: object,
+        _traceback: object,
+    ) -> None:
+        self.close(_primary=exc if isinstance(exc, BaseException) else None)
+
+    def close(self, *, _primary: BaseException | None = None) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        errors: list[BaseException] = []
+        released = False
+        try:
+            fcntl.flock(self.key_lock_fd, fcntl.LOCK_UN)
+            released = True
+        except BaseException as exc:
+            errors.append(exc)
+        try:
+            os.close(self.key_lock_fd)
+            released = True
+        except BaseException as exc:
+            errors.append(exc)
+        if released:
+            try:
+                _registry_remove(self.registry_key, self.registry_token)
+            except BaseException as exc:
+                errors.append(exc)
+        if errors and _primary is None:
+            raise errors[0]
+
+    @property
+    def last_record(self) -> dict[str, JSONValue]:
+        return self.records[-1]
+
+    def append(
+        self,
+        state: str,
+        *,
+        reason_code: str | None = None,
+        phase0_terminal_report_digest: str | None = None,
+        phase0_evidence_manifest_digest: str | None = None,
+        phase0_evidence_directory_name: str | None = None,
+        receipt_digest: str | None = None,
+    ) -> dict[str, JSONValue]:
+        if self._closed:
+            raise PersistenceError("owner handle is closed")
+        if self._store_ambiguous:
+            raise StoreIndeterminate(self.operation)
+        previous = self.last_record
+        record, raw = build_record(
+            self.operation,
+            sequence=len(self.records) + 1,
+            state=state,
+            previous_record_digest=str(previous["record_digest"]),
+            reason_code=reason_code,
+            phase0_terminal_report_digest=phase0_terminal_report_digest,
+            phase0_evidence_manifest_digest=phase0_evidence_manifest_digest,
+            phase0_evidence_directory_name=phase0_evidence_directory_name,
+            receipt_digest=receipt_digest,
+        )
+        validate_record_chain([*self.records, record])
+        publication = _PublicationAttempt()
+        try:
+            _publish_no_replace(
+                key_directory=self.key_directory,
+                target_parent=self.records_directory,
+                target_name=record_filename(record),
+                raw=raw,
+                attempt=publication,
+            )
+        except BaseException:
+            if publication.committed:
+                self.records.append(record)
+                self._store_ambiguous = not publication.complete
+            raise
+        self.records.append(record)
+        return record
+
+    def refresh_active(self) -> list[dict[str, JSONValue]]:
+        """Reload a clean, receipt-free active prefix under the held key lock."""
+
+        if self._store_ambiguous:
+            raise StoreIndeterminate(self.operation)
+        try:
+            state = _load_stored_state(
+                self.key_directory,
+                self.records_directory,
+                self.operation,
+            )
+            _validate_active_permissions(state)
+        except (PersistenceError, ContractValidationError, OSError):
+            raise StoreIndeterminate(self.operation) from None
+        self.records = state.records
+        return self.records
+
+    def seal(
+        self,
+        *,
+        receipt_state: str,
+        reason_code: str,
+        phase0_terminal_report: Mapping[str, JSONValue] | None = None,
+        phase0_evidence_manifest: Mapping[str, JSONValue] | None = None,
+    ) -> bytes:
+        if self._store_ambiguous:
+            if self.sealed_receipt is not None:
+                raise StoreSealedUnavailable(
+                    self.operation,
+                    receipt_digest=str(self.sealed_receipt["receipt_digest"]),
+                    receipt_state=str(self.sealed_receipt["receipt_state"]),
+                ) from None
+            raise StoreIndeterminate(self.operation)
+        receipt, raw = sealed_receipt(
+            self.operation,
+            receipt_state=receipt_state,
+            predecessor=self.last_record,
+            reason_code=reason_code,
+            phase0_terminal_report=phase0_terminal_report,
+            phase0_evidence_manifest=phase0_evidence_manifest,
+        )
+        publication = _PublicationAttempt()
+        try:
+            _publish_no_replace(
+                key_directory=self.key_directory,
+                target_parent=self.key_directory,
+                target_name="receipt.json",
+                raw=raw,
+                attempt=publication,
+            )
+        except BaseException as error:
+            if publication.committed:
+                self.sealed_raw = raw
+                self.sealed_receipt = receipt
+                self._receipt_publication_complete = publication.complete
+                self._store_ambiguous = not publication.complete
+            if self.sealed_raw is not None:
+                if isinstance(error, Exception):
+                    if not publication.complete:
+                        if self._safe_revalidate_sealed():
+                            return raw
+                        raise StoreSealedUnavailable(
+                            self.operation,
+                            receipt_digest=str(receipt["receipt_digest"]),
+                            receipt_state=receipt_state,
+                        ) from None
+                    try:
+                        self._attempt_finalize_once()
+                    except Exception:
+                        if self._safe_revalidate_sealed():
+                            return raw
+                        raise StoreSealedUnavailable(
+                            self.operation,
+                            receipt_digest=str(receipt["receipt_digest"]),
+                            receipt_state=receipt_state,
+                        ) from None
+                    return raw
+                self.best_effort_finalize()
+            raise
+        self.sealed_raw = raw
+        self.sealed_receipt = receipt
+        self._receipt_publication_complete = publication.complete
+        if not publication.complete:
+            raise StoreSealedUnavailable(
+                self.operation,
+                receipt_digest=str(receipt["receipt_digest"]),
+                receipt_state=receipt_state,
+            ) from None
+        try:
+            self._attempt_finalize_once()
+        except Exception:
+            if self._safe_revalidate_sealed():
+                return raw
+            raise StoreSealedUnavailable(
+                self.operation,
+                receipt_digest=str(receipt["receipt_digest"]),
+                receipt_state=receipt_state,
+            ) from None
+        return raw
+
+    def _attempt_finalize_once(self) -> None:
+        if self._finalization_attempted:
+            if self._finalization_complete:
+                return
+            raise PersistenceError("finalization was already attempted in this call")
+        if not self._receipt_publication_complete or self._store_ambiguous:
+            raise PersistenceError("receipt publication is not cleanly finalizable")
+        self._finalization_attempted = True
+        self._finalization_complete = self._finalize_once()
+
+    def _finalize_once(self) -> bool:
+        if self.sealed_raw is None or self.sealed_receipt is None:
+            raise PersistenceError("receipt is not sealed")
+        if self.last_record["state"] != "RECEIPT_FINALIZED":
+            try:
+                self.append(
+                    "RECEIPT_FINALIZED",
+                    receipt_digest=str(self.sealed_receipt["receipt_digest"]),
+                )
+            except Exception:
+                # The receipt is already durably sealed. A final-record
+                # publication fault must not relabel those exact bytes, and
+                # must not trigger another mutation in this owner call.
+                if self._safe_revalidate_sealed():
+                    return False
+                raise
+        _finalize_metadata(
+            key_directory=self.key_directory,
+            records_directory=self.records_directory,
+            records=self.records,
+            operation=self.operation,
+        )
+        return True
+
+    def best_effort_finalize(self) -> None:
+        if (
+            self.sealed_raw is None
+            or self._finalization_attempted
+            or self._store_ambiguous
+        ):
+            return
+        try:
+            self._attempt_finalize_once()
+        except BaseException:
+            pass
+
+    def _safe_revalidate_sealed(self) -> bool:
+        if self.sealed_raw is None or self.sealed_receipt is None:
+            return False
+        try:
+            try:
+                state = _load_stored_state(
+                    self.key_directory,
+                    self.records_directory,
+                    self.operation,
+                )
+            except (PersistenceError, ContractValidationError, OSError):
+                receipt_alias = _load_receipt_alias_state(
+                    key_directory=self.key_directory,
+                    records_directory=self.records_directory,
+                    operation=self.operation,
+                    require_operation_match=True,
+                )
+                if receipt_alias is not None:
+                    state = receipt_alias[0]
+                else:
+                    final_alias = _load_final_record_alias_state(
+                        key_directory=self.key_directory,
+                        records_directory=self.records_directory,
+                        operation=self.operation,
+                        require_operation_match=True,
+                    )
+                    if final_alias is None:
+                        return False
+                    state = final_alias[0]
+            if state.receipt_raw != self.sealed_raw:
+                return False
+            _validate_permission_prefix(
+                key_directory=self.key_directory,
+                records_directory=self.records_directory,
+                state=state,
+            )
+            self.records = state.records
+            return True
+        except (PersistenceError, ContractValidationError, OSError):
+            return False
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimResult:
+    response: bytes | None = None
+    owner: OwnerHandle | None = None
+
+    def __post_init__(self) -> None:
+        if (self.response is None) == (self.owner is None):
+            raise ValueError("claim result must contain exactly one outcome")
+
+
+def _validate_receipt_root_entries(root: RootCapability) -> str:
+    names: list[str] = []
+    try:
+        with os.scandir(root.fd) as entries:
+            for entry in entries:
+                names.append(entry.name)
+                if len(names) > 2:
+                    raise RootSafetyError("UNSAFE_RECEIPT_ROOT")
+    except OSError as exc:
+        raise RootSafetyError("UNSAFE_RECEIPT_ROOT") from exc
+    found = set(names)
+    if len(found) != len(names) or not found <= {".phase1-store.lock", "v1"}:
+        raise RootSafetyError("UNSAFE_RECEIPT_ROOT")
+    if found == set():
+        return "virgin"
+    if found == {".phase1-store.lock"}:
+        return "lock-only"
+    if found == {".phase1-store.lock", "v1"}:
+        return "established"
+    # v1 cannot be made durable before the permanent global lock.
+    if found == {"v1"}:
+        return "missing-lock"
+    raise RootSafetyError("UNSAFE_RECEIPT_ROOT")
+
+
+def _validate_active_registry_store(
+    roots: RootSet,
+    expected_global_lock_identity: tuple[int, int],
+) -> None:
+    """Read-only validation before trusting an in-process active-key entry."""
+
+    lock_fd: int | None = None
+    primary: BaseException | None = None
+    try:
+        roots.revalidate_all()
+        if _validate_receipt_root_entries(roots.receipt) != "established":
+            raise PersistenceError("active registry lacks an established store")
+        v1_entry = os.stat(
+            "v1",
+            dir_fd=roots.receipt.fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISDIR(v1_entry.st_mode)
+            or stat.S_ISLNK(v1_entry.st_mode)
+            or v1_entry.st_uid != _EUID
+            or _mode(v1_entry) != 0o700
+        ):
+            raise PersistenceError("active registry store topology is unsafe")
+        lock_fd = os.open(
+            ".phase1-store.lock",
+            _READ_FLAGS,
+            dir_fd=roots.receipt.fd,
+        )
+        _revalidate_named_lock(roots.receipt, lock_fd)
+        held_lock = os.fstat(lock_fd)
+        if (held_lock.st_dev, held_lock.st_ino) != expected_global_lock_identity:
+            raise PersistenceError("active registry global lock was replaced")
+        roots.revalidate_all()
+        if _validate_receipt_root_entries(roots.receipt) != "established":
+            raise PersistenceError("active registry store topology changed")
+        v1_after = os.stat(
+            "v1",
+            dir_fd=roots.receipt.fd,
+            follow_symlinks=False,
+        )
+        if (
+            (v1_after.st_dev, v1_after.st_ino)
+            != (v1_entry.st_dev, v1_entry.st_ino)
+            or not stat.S_ISDIR(v1_after.st_mode)
+            or stat.S_ISLNK(v1_after.st_mode)
+            or v1_after.st_uid != _EUID
+            or _mode(v1_after) != 0o700
+        ):
+            raise PersistenceError("active registry store topology changed")
+        _revalidate_named_lock(roots.receipt, lock_fd)
+        held_lock_after = os.fstat(lock_fd)
+        if (
+            (held_lock_after.st_dev, held_lock_after.st_ino)
+            != expected_global_lock_identity
+        ):
+            raise PersistenceError("active registry global lock was replaced")
+    except BaseException as exc:
+        primary = exc
+        if isinstance(exc, OSError):
+            raise PersistenceError("active registry store is unavailable") from exc
+        raise
+    finally:
+        if lock_fd is not None:
+            try:
+                os.close(lock_fd)
+            except BaseException as exc:
+                if primary is None:
+                    if isinstance(exc, OSError):
+                        raise PersistenceError(
+                            "active registry lock close failed"
+                        ) from exc
+                    raise
+
+
+def _prepare_evidence_destination(
+    roots: RootSet,
+    operation: Operation,
+) -> Path:
+    v1 = _ensure_directory(roots.evidence.path, "v1")
+    shard = _ensure_directory(v1, operation.idempotency_key_digest[:2])
+    destination_name = f"phase0-{operation.idempotency_key_digest}"
+    destination = shard / destination_name
+    prefix = f".{destination_name}."
+    if _directory_has_matching_name(
+        shard,
+        lambda name: name == destination_name
+        or (name.startswith(prefix) and name.endswith(".staging")),
+    ):
+        raise RootSafetyError("UNSAFE_EVIDENCE_ROOT")
+    roots.revalidate_all()
+    return destination
+
+
+def _load_anchor(records_directory: Path) -> dict[str, JSONValue]:
+    expected = "000001-OWNERSHIP_ACQUIRED.json"
+    raw = _read_regular(
+        records_directory / expected,
+        modes={0o600, 0o400},
+        maximum=MAX_RECORD_BYTES,
+    )
+    record = parse_record_bytes(raw)
+    validate_record_chain([record], filenames=[expected])
+    return record
+
+
+def _load_stored_state(
+    key_directory: Path,
+    records_directory: Path,
+    operation: Operation,
+    *,
+    require_operation_match: bool = True,
+    receipt_stage_name: str | None = None,
+    final_record_alias: tuple[str, str] | None = None,
+) -> _StoredState:
+    names = _directory_names(
+        key_directory, maximum=MAX_DIRECTORY_ENTRIES_PER_KEY
+    )
+    allowed_names = {"lock", "records", "receipt.json"}
+    if receipt_stage_name is not None and final_record_alias is not None:
+        raise PersistenceError("multiple publication aliases are not recoverable")
+    staged_name = receipt_stage_name
+    if final_record_alias is not None:
+        staged_name = final_record_alias[0]
+    if staged_name is not None:
+        if not _is_publication_stage_name(staged_name):
+            raise PersistenceError("invalid receipt publication stage name")
+        allowed_names.add(staged_name)
+    if (
+        not {"lock", "records"} <= set(names)
+        or not set(names) <= allowed_names
+        or (
+            staged_name is not None
+            and staged_name not in set(names)
+        )
+        or (
+            receipt_stage_name is not None
+            and "receipt.json" not in set(names)
+        )
+    ):
+        raise PersistenceError("unexpected key-directory entry")
+    lock_entry = os.lstat(key_directory / "lock")
+    _validate_regular_entry(lock_entry, modes={0o600}, label="lock")
+    record_names = _directory_names(
+        records_directory, maximum=MAX_RECORDS_PER_KEY
+    )
+    if not record_names:
+        raise PersistenceError("ownership chain is empty")
+    records: list[dict[str, JSONValue]] = []
+    modes: list[int] = []
+    for name in record_names:
+        path = records_directory / name
+        entry = os.lstat(path)
+        modes.append(_mode(entry))
+        if final_record_alias is not None and name == final_record_alias[1]:
+            raw = _read_committed_final_record_alias(
+                key_directory,
+                records_directory,
+                final_record_alias[0],
+                final_record_alias[1],
+            )
+        else:
+            raw = _read_regular(
+                path,
+                modes={0o600, 0o400},
+                maximum=MAX_RECORD_BYTES,
+            )
+        records.append(parse_record_bytes(raw))
+    if final_record_alias is not None and final_record_alias[1] not in record_names:
+        raise PersistenceError("final-record publication target is absent")
+    records = validate_record_chain(records, filenames=record_names)
+    anchor = records[0]
+    if (
+        anchor["idempotency_key_digest"] != operation.idempotency_key_digest
+        or (
+            require_operation_match
+            and anchor["operation_digest"] != operation.operation_digest
+        )
+    ):
+        raise ContractValidationError("stored state is bound to another operation")
+
+    key_entry = os.lstat(key_directory)
+    records_entry = os.lstat(records_directory)
+    receipt_raw: bytes | None = None
+    receipt: dict[str, JSONValue] | None = None
+    if "receipt.json" in names:
+        try:
+            if receipt_stage_name is None:
+                receipt_raw = _read_regular(
+                    key_directory / "receipt.json",
+                    modes={0o600, 0o400},
+                    maximum=MAX_RECEIPT_BYTES,
+                )
+            else:
+                receipt_raw = _read_committed_receipt_alias(
+                    key_directory,
+                    receipt_stage_name,
+                )
+            receipt = parse_receipt_bytes(
+                receipt_raw,
+                chain=records,
+                operation=operation if require_operation_match else None,
+                require_sealed=True,
+            )
+        except (PersistenceError, ContractValidationError, OSError):
+            if records[-1]["state"] == "RECEIPT_FINALIZED":
+                raise _FinalReceiptUnavailable(
+                    receipt_digest=str(records[-1]["receipt_digest"]),
+                    predecessor_state=str(records[-2]["state"]),
+                ) from None
+            raise
+    elif records[-1]["state"] == "RECEIPT_FINALIZED":
+        raise _FinalReceiptUnavailable(
+            receipt_digest=str(records[-1]["receipt_digest"]),
+            predecessor_state=str(records[-2]["state"]),
+        )
+    return _StoredState(
+        records=records,
+        record_names=record_names,
+        record_modes=modes,
+        receipt_raw=receipt_raw,
+        receipt=receipt,
+        key_mode=_mode(key_entry),
+        records_mode=_mode(records_entry),
+    )
+
+
+def _validate_active_permissions(state: _StoredState) -> None:
+    if (
+        state.key_mode != 0o700
+        or state.records_mode != 0o700
+        or any(mode != 0o600 for mode in state.record_modes)
+        or state.receipt_raw is not None
+    ):
+        raise PersistenceError("active permission state is invalid")
+
+
+def _validate_permission_prefix(
+    *,
+    key_directory: Path,
+    records_directory: Path,
+    state: _StoredState,
+) -> None:
+    if state.receipt_raw is None:
+        raise PersistenceError("sealed permission check lacks a receipt")
+    receipt_mode = _mode(os.lstat(key_directory / "receipt.json"))
+    modes = state.record_modes
+    first_active = next((index for index, mode in enumerate(modes) if mode == 0o600), len(modes))
+    if any(mode != 0o400 for mode in modes[:first_active]) or any(
+        mode != 0o600 for mode in modes[first_active:]
+    ):
+        raise PersistenceError("record modes are not an ordered prefix")
+    all_records_final = first_active == len(modes)
+    if receipt_mode not in {0o600, 0o400}:
+        raise PersistenceError("receipt mode is invalid")
+    if receipt_mode == 0o400 and not all_records_final:
+        raise PersistenceError("receipt was restricted before every record")
+    if state.records_mode not in {0o700, 0o500}:
+        raise PersistenceError("records directory mode is invalid")
+    if state.records_mode == 0o500 and receipt_mode != 0o400:
+        raise PersistenceError("records directory was restricted out of order")
+    if state.key_mode not in {0o700, 0o500}:
+        raise PersistenceError("key directory mode is invalid")
+    if state.key_mode == 0o500 and state.records_mode != 0o500:
+        raise PersistenceError("key directory was restricted out of order")
+    has_final = state.records[-1]["state"] == "RECEIPT_FINALIZED"
+    any_restricted = (
+        first_active > 0
+        or receipt_mode == 0o400
+        or state.records_mode == 0o500
+        or state.key_mode == 0o500
+    )
+    if any_restricted and not has_final:
+        raise PersistenceError("metadata restricted before final record")
+
+
+def _chmod_file_and_sync(path: Path, mode: int, parent: Path) -> None:
+    fd = os.open(path, _READ_FLAGS)
+    try:
+        entry = os.fstat(fd)
+        _validate_regular_entry(entry, modes={0o600, 0o400}, label=path.name)
+        os.fchmod(fd, mode)
+        os.fsync(fd)
+    except OSError as exc:
+        raise PersistenceError(f"file finalization failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+    _fsync_directory(parent, {0o700, 0o500})
+
+
+def _chmod_directory_and_sync(path: Path, mode: int, parent: Path) -> None:
+    fd = _open_directory(path, {0o700, 0o500})
+    try:
+        os.fchmod(fd, mode)
+        os.fsync(fd)
+    except OSError as exc:
+        raise PersistenceError(f"directory finalization failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+    _fsync_directory(parent, {0o700, 0o500})
+
+
+def _finalize_metadata(
+    *,
+    key_directory: Path,
+    records_directory: Path,
+    records: Sequence[Mapping[str, JSONValue]],
+    operation: Operation,
+) -> None:
+    state = _load_stored_state(
+        key_directory,
+        records_directory,
+        operation,
+    )
+    _validate_permission_prefix(
+        key_directory=key_directory,
+        records_directory=records_directory,
+        state=state,
+    )
+    for name, mode in zip(state.record_names, state.record_modes, strict=True):
+        path = records_directory / name
+        if mode == 0o400:
+            _fsync_file_and_parent(path, records_directory, {0o400})
+        else:
+            _chmod_file_and_sync(path, 0o400, records_directory)
+    receipt_path = key_directory / "receipt.json"
+    receipt_mode = _mode(os.lstat(receipt_path))
+    if receipt_mode == 0o400:
+        _fsync_file_and_parent(receipt_path, key_directory, {0o400})
+    else:
+        _chmod_file_and_sync(receipt_path, 0o400, key_directory)
+    records_mode = _mode(os.lstat(records_directory))
+    if records_mode == 0o500:
+        _fsync_directory(records_directory, {0o500})
+        _fsync_directory(key_directory, {0o700, 0o500})
+    else:
+        _chmod_directory_and_sync(records_directory, 0o500, key_directory)
+    key_mode = _mode(os.lstat(key_directory))
+    if key_mode == 0o500:
+        _fsync_directory(key_directory, {0o500})
+        _fsync_directory(key_directory.parent, {0o700})
+    else:
+        _chmod_directory_and_sync(key_directory, 0o500, key_directory.parent)
+
+
+def _fsync_file_and_parent(path: Path, parent: Path, modes: set[int]) -> None:
+    fd = os.open(path, _READ_FLAGS)
+    try:
+        entry = os.fstat(fd)
+        _validate_regular_entry(entry, modes=modes, label=path.name)
+        os.fsync(fd)
+    except OSError as exc:
+        raise PersistenceError(f"file fsync failed: {path.name}") from exc
+    finally:
+        os.close(fd)
+    _fsync_directory(parent, {0o700, 0o500})
+
+
+def _receipt_state_from_predecessor(state: str) -> str:
+    mapping = {
+        "PREINVOKE_REJECTED": "REJECTED_PRE_INVOKE",
+        "ENGINE_EVIDENCE_VERIFIED": "ENGINE_TERMINAL",
+        "INDETERMINATE_NO_RETRY": "INDETERMINATE_NO_RETRY",
+    }
+    try:
+        return mapping[state]
+    except KeyError as exc:
+        raise PersistenceError("final record has an invalid predecessor") from exc
+
+
+def _load_receipt_alias_state(
+    *,
+    key_directory: Path,
+    records_directory: Path,
+    operation: Operation,
+    require_operation_match: bool,
+) -> tuple[_StoredState, str] | None:
+    """Validate, without mutation, one staged alias of receipt.json."""
+
+    names = _directory_names(
+        key_directory,
+        maximum=MAX_DIRECTORY_ENTRIES_PER_KEY,
+    )
+    stage_names = [name for name in names if _is_publication_stage_name(name)]
+    if len(stage_names) != 1:
+        return None
+    stage_name = stage_names[0]
+    if set(names) != {"lock", "records", "receipt.json", stage_name}:
+        return None
+    stage_entry = os.lstat(key_directory / stage_name)
+    receipt_entry = os.lstat(key_directory / "receipt.json")
+    if (stage_entry.st_dev, stage_entry.st_ino) != (
+        receipt_entry.st_dev,
+        receipt_entry.st_ino,
+    ):
+        return None
+    state = _load_stored_state(
+        key_directory,
+        records_directory,
+        operation,
+        require_operation_match=require_operation_match,
+        receipt_stage_name=stage_name,
+    )
+    if state.receipt is None or state.receipt_raw is None:
+        raise PersistenceError("receipt alias lacks a sealed canonical receipt")
+    return (state, stage_name)
+
+
+def _load_final_record_alias_state(
+    *,
+    key_directory: Path,
+    records_directory: Path,
+    operation: Operation,
+    require_operation_match: bool,
+) -> tuple[_StoredState, str, str] | None:
+    """Validate, without mutation, one staged alias of RECEIPT_FINALIZED."""
+
+    names = _directory_names(
+        key_directory,
+        maximum=MAX_DIRECTORY_ENTRIES_PER_KEY,
+    )
+    stage_names = [name for name in names if _is_publication_stage_name(name)]
+    if len(stage_names) != 1:
+        return None
+    stage_name = stage_names[0]
+    if set(names) != {"lock", "records", "receipt.json", stage_name}:
+        return None
+    record_names = _directory_names(
+        records_directory,
+        maximum=MAX_RECORDS_PER_KEY,
+    )
+    targets = [
+        name for name in record_names if name.endswith("-RECEIPT_FINALIZED.json")
+    ]
+    if len(targets) != 1:
+        return None
+    target_name = targets[0]
+    state = _load_stored_state(
+        key_directory,
+        records_directory,
+        operation,
+        require_operation_match=require_operation_match,
+        final_record_alias=(stage_name, target_name),
+    )
+    if (
+        state.receipt is None
+        or state.receipt_raw is None
+        or state.records[-1]["state"] != "RECEIPT_FINALIZED"
+        or state.record_names[-1] != target_name
+    ):
+        raise PersistenceError("final-record alias lacks a sealed canonical chain")
+    return (state, stage_name, target_name)
+
+
+def _repair_committed_receipt_stage(
+    *,
+    key_directory: Path,
+    records_directory: Path,
+    operation: Operation,
+    require_operation_match: bool,
+) -> bool:
+    """Repair one canonical sealed receipt/final alias under the held key flock."""
+
+    names = _directory_names(
+        key_directory,
+        maximum=MAX_DIRECTORY_ENTRIES_PER_KEY,
+    )
+    stage_names = [name for name in names if _is_publication_stage_name(name)]
+    if not stage_names:
+        return False
+    if len(stage_names) != 1:
+        return False
+    stage_name = stage_names[0]
+    if set(names) != {"lock", "records", "receipt.json", stage_name}:
+        return False
+
+    stage_entry = os.lstat(key_directory / stage_name)
+    receipt_entry = os.lstat(key_directory / "receipt.json")
+    receipt_alias = (stage_entry.st_dev, stage_entry.st_ino) == (
+        receipt_entry.st_dev,
+        receipt_entry.st_ino,
+    )
+    final_target_name: str | None = None
+    if not receipt_alias:
+        record_names = _directory_names(
+            records_directory,
+            maximum=MAX_RECORDS_PER_KEY,
+        )
+        matching_final_targets: list[str] = []
+        for name in record_names:
+            if not name.endswith("-RECEIPT_FINALIZED.json"):
+                continue
+            entry = os.lstat(records_directory / name)
+            if (entry.st_dev, entry.st_ino) == (
+                stage_entry.st_dev,
+                stage_entry.st_ino,
+            ):
+                matching_final_targets.append(name)
+        if len(matching_final_targets) != 1:
+            return False
+        final_target_name = matching_final_targets[0]
+
+    try:
+        if receipt_alias:
+            state = _load_stored_state(
+                key_directory,
+                records_directory,
+                operation,
+                require_operation_match=require_operation_match,
+                receipt_stage_name=stage_name,
+            )
+        else:
+            if final_target_name is None:
+                raise PersistenceError("final-record alias target is unavailable")
+            state = _load_stored_state(
+                key_directory,
+                records_directory,
+                operation,
+                require_operation_match=require_operation_match,
+                final_record_alias=(stage_name, final_target_name),
+            )
+    except _FinalReceiptUnavailable as exc:
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=exc.receipt_digest,
+            receipt_state=_receipt_state_from_predecessor(exc.predecessor_state),
+        ) from None
+    if (
+        state.receipt is None
+        or state.receipt_raw is None
+        or (
+            not receipt_alias
+            and (
+                state.records[-1]["state"] != "RECEIPT_FINALIZED"
+                or state.record_names[-1] != final_target_name
+            )
+        )
+    ):
+        raise PersistenceError("publication alias lacks a canonical sealed chain")
+
+    receipt_digest = str(state.receipt["receipt_digest"])
+    receipt_state = str(state.receipt["receipt_state"])
+    try:
+        _validate_permission_prefix(
+            key_directory=key_directory,
+            records_directory=records_directory,
+            state=state,
+        )
+    except PersistenceError:
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=receipt_digest,
+            receipt_state=receipt_state,
+        ) from None
+
+    target_parent = key_directory if receipt_alias else records_directory
+    target_name = "receipt.json" if receipt_alias else final_target_name
+    if target_name is None:
+        raise PersistenceError("publication alias target is unavailable")
+    target_size = (
+        len(state.receipt_raw)
+        if receipt_alias
+        else len(canonical_bytes(state.records[-1]))
+    )
+
+    key_fd: int | None = None
+    target_parent_fd: int | None = None
+    primary: BaseException | None = None
+    try:
+        key_fd = _open_directory(key_directory, {0o700, 0o500})
+        target_parent_fd = _open_directory(target_parent, {0o700, 0o500})
+        target_before = os.stat(
+            target_name,
+            dir_fd=target_parent_fd,
+            follow_symlinks=False,
+        )
+        stage_before = os.stat(
+            stage_name, dir_fd=key_fd, follow_symlinks=False
+        )
+        _validate_receipt_alias_entry(target_before, label=target_name)
+        _validate_receipt_alias_entry(stage_before, label=stage_name)
+        if (
+            (target_before.st_dev, target_before.st_ino)
+            != (stage_before.st_dev, stage_before.st_ino)
+            or target_before.st_size != target_size
+        ):
+            raise PersistenceError("sealed publication aliases changed")
+
+        # Establish the canonical target name durably before removing its alias.
+        os.fsync(target_parent_fd)
+        target_synced = os.stat(
+            target_name,
+            dir_fd=target_parent_fd,
+            follow_symlinks=False,
+        )
+        stage_synced = os.stat(
+            stage_name, dir_fd=key_fd, follow_symlinks=False
+        )
+        _validate_receipt_alias_entry(target_synced, label=target_name)
+        _validate_receipt_alias_entry(stage_synced, label=stage_name)
+        if len(
+            {
+                (target_before.st_dev, target_before.st_ino),
+                (stage_before.st_dev, stage_before.st_ino),
+                (target_synced.st_dev, target_synced.st_ino),
+                (stage_synced.st_dev, stage_synced.st_ino),
+            }
+        ) != 1:
+            raise PersistenceError("sealed publication aliases changed")
+
+        os.unlink(stage_name, dir_fd=key_fd)
+        os.fsync(key_fd)
+        target_after = os.stat(
+            target_name,
+            dir_fd=target_parent_fd,
+            follow_symlinks=False,
+        )
+        _validate_regular_entry(
+            target_after,
+            modes={0o600},
+            label=target_name,
+        )
+        if (
+            (target_after.st_dev, target_after.st_ino)
+            != (target_before.st_dev, target_before.st_ino)
+            or target_after.st_size != target_size
+        ):
+            raise PersistenceError("repaired sealed target changed")
+        try:
+            os.stat(stage_name, dir_fd=key_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise PersistenceError("receipt publication alias still exists")
+    except BaseException as exc:
+        primary = exc
+        if not isinstance(exc, Exception):
+            raise
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=receipt_digest,
+            receipt_state=receipt_state,
+        ) from None
+    finally:
+        cleanup_errors: list[BaseException] = []
+        for fd in (target_parent_fd, key_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+        if cleanup_errors and primary is None:
+            if not isinstance(cleanup_errors[0], Exception):
+                raise cleanup_errors[0]
+            raise StoreSealedUnavailable(
+                operation,
+                receipt_digest=receipt_digest,
+                receipt_state=receipt_state,
+            ) from None
+
+    try:
+        repaired = _load_stored_state(
+            key_directory,
+            records_directory,
+            operation,
+            require_operation_match=require_operation_match,
+        )
+    except _FinalReceiptUnavailable as exc:
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=exc.receipt_digest,
+            receipt_state=_receipt_state_from_predecessor(exc.predecessor_state),
+        ) from None
+    except BaseException as exc:
+        if not isinstance(exc, Exception):
+            raise
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=receipt_digest,
+            receipt_state=receipt_state,
+        ) from None
+    if (
+        repaired.receipt_raw != state.receipt_raw
+        or repaired.receipt is None
+        or repaired.receipt["receipt_digest"] != receipt_digest
+    ):
+        raise StoreSealedUnavailable(
+            operation,
+            receipt_digest=receipt_digest,
+            receipt_state=receipt_state,
+        ) from None
+    return True
+
+
+def _recover_existing(owner: OwnerHandle) -> bytes:
+    try:
+        state = _load_stored_state(
+            owner.key_directory,
+            owner.records_directory,
+            owner.operation,
+        )
+    except _FinalReceiptUnavailable as exc:
+        raise StoreSealedUnavailable(
+            owner.operation,
+            receipt_digest=exc.receipt_digest,
+            receipt_state=_receipt_state_from_predecessor(exc.predecessor_state),
+        ) from None
+    except (PersistenceError, ContractValidationError, OSError):
+        raise StoreIndeterminate(owner.operation) from None
+    owner.records = state.records
+    if state.receipt_raw is not None and state.receipt is not None:
+        try:
+            _validate_permission_prefix(
+                key_directory=owner.key_directory,
+                records_directory=owner.records_directory,
+                state=state,
+            )
+        except PersistenceError:
+            raise StoreSealedUnavailable(
+                owner.operation,
+                receipt_digest=str(state.receipt["receipt_digest"]),
+                receipt_state=str(state.receipt["receipt_state"]),
+            ) from None
+        owner.sealed_raw = state.receipt_raw
+        owner.sealed_receipt = state.receipt
+        owner._receipt_publication_complete = True
+        try:
+            owner._attempt_finalize_once()
+        except Exception:
+            if not owner._safe_revalidate_sealed():
+                raise StoreSealedUnavailable(
+                    owner.operation,
+                    receipt_digest=str(state.receipt["receipt_digest"]),
+                    receipt_state=str(state.receipt["receipt_state"]),
+                ) from None
+        return state.receipt_raw
+
+    if state.records[-1]["state"] == "RECEIPT_FINALIZED":
+        predecessor = state.records[-2]
+        raise StoreSealedUnavailable(
+            owner.operation,
+            receipt_digest=str(state.records[-1]["receipt_digest"]),
+            receipt_state=_receipt_state_from_predecessor(str(predecessor["state"])),
+        )
+    try:
+        _validate_active_permissions(state)
+    except PersistenceError:
+        raise StoreIndeterminate(owner.operation) from None
+
+    last = owner.last_record
+    last_state = str(last["state"])
+    if last_state in {"OWNERSHIP_ACQUIRED", "PREINVOKE_REJECTED"} and (
+        _matching_evidence_exists(owner.evidence_destination)
+    ):
+        raise StoreIndeterminate(owner.operation) from None
+    if last_state == "OWNERSHIP_ACQUIRED":
+        try:
+            owner.append(
+                "PREINVOKE_REJECTED",
+                reason_code="RECOVERED_BEFORE_INVOCATION_CLAIM",
+            )
+        except Exception:
+            try:
+                owner.refresh_active()
+            except StoreIndeterminate:
+                raise StoreIndeterminate(owner.operation) from None
+            if owner.last_record["state"] != "PREINVOKE_REJECTED":
+                raise StorePreInvokeUnavailable(owner.operation) from None
+        try:
+            return owner.seal(
+                receipt_state="REJECTED_PRE_INVOKE",
+                reason_code="RECOVERED_BEFORE_INVOCATION_CLAIM",
+            )
+        except StoreSealedUnavailable:
+            raise
+        except Exception:
+            raise StorePreInvokeUnavailable(owner.operation) from None
+    if last_state == "PREINVOKE_REJECTED":
+        try:
+            return owner.seal(
+                receipt_state="REJECTED_PRE_INVOKE",
+                reason_code=str(last["reason_code"]),
+            )
+        except StoreSealedUnavailable:
+            raise
+        except Exception:
+            raise StorePreInvokeUnavailable(owner.operation) from None
+    if last_state in {"INVOCATION_CLAIMED", "ENGINE_EVIDENCE_VERIFIED"}:
+        try:
+            owner.append(
+                "INDETERMINATE_NO_RETRY",
+                reason_code="RECOVERED_AFTER_INVOCATION_CLAIM",
+            )
+        except Exception:
+            try:
+                owner.refresh_active()
+            except StoreIndeterminate:
+                raise StoreIndeterminateUnavailable(owner.operation) from None
+            if owner.last_record["state"] != "INDETERMINATE_NO_RETRY":
+                raise StoreIndeterminateUnavailable(owner.operation) from None
+        try:
+            return owner.seal(
+                receipt_state="INDETERMINATE_NO_RETRY",
+                reason_code="RECOVERED_AFTER_INVOCATION_CLAIM",
+            )
+        except StoreSealedUnavailable:
+            raise
+        except Exception:
+            raise StoreIndeterminateUnavailable(owner.operation) from None
+    if last_state == "INDETERMINATE_NO_RETRY":
+        try:
+            return owner.seal(
+                receipt_state="INDETERMINATE_NO_RETRY",
+                reason_code=str(last["reason_code"]),
+            )
+        except StoreSealedUnavailable:
+            raise
+        except Exception:
+            raise StoreIndeterminateUnavailable(owner.operation) from None
+    raise StoreIndeterminate(owner.operation)
+
+
+def _matching_evidence_exists(destination: Path) -> bool:
+    shard = destination.parent
+    prefix = f".{destination.name}."
+    try:
+        return _directory_has_matching_name(
+            shard,
+            lambda name: name == destination.name
+            or (name.startswith(prefix) and name.endswith(".staging")),
+        )
+    except (PersistenceError, OSError):
+        return True
+
+
+def _release_flock_fd(fd: int) -> BaseException | None:
+    """Release one flock/fd once and return, rather than raise, cleanup error."""
+
+    first_error: BaseException | None = None
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except BaseException as exc:
+        first_error = exc
+    try:
+        os.close(fd)
+    except BaseException as exc:
+        if first_error is None:
+            first_error = exc
+    return first_error
+
+
+def _seal_known_preclaim(owner: OwnerHandle, reason_code: str) -> bytes:
+    if owner._store_ambiguous:
+        raise StoreIndeterminate(owner.operation)
+    state = str(owner.last_record["state"])
+    if state == "OWNERSHIP_ACQUIRED":
+        owner.append("PREINVOKE_REJECTED", reason_code=reason_code)
+    elif state != "PREINVOKE_REJECTED":
+        raise StoreIndeterminate(owner.operation)
+    persisted_reason = str(owner.last_record["reason_code"])
+    return owner.seal(
+        receipt_state="REJECTED_PRE_INVOKE",
+        reason_code=persisted_reason,
+    )
+
+
+def _best_effort_known_preclaim(owner: OwnerHandle, reason_code: str) -> None:
+    try:
+        _seal_known_preclaim(owner, reason_code)
+    except BaseException:
+        pass
+
+
+class ReceiptStore:
+    """Acquire one idempotency key or return a replay/conflict response."""
+
+    def __init__(self, roots: RootSet) -> None:
+        self.roots = roots
+
+    def claim(
+        self,
+        operation: Operation,
+        *,
+        fresh_preflight: Callable[[], Any],
+    ) -> ClaimResult:
+        registry_key = (
+            self.roots.receipt.device,
+            self.roots.receipt.inode,
+            operation.idempotency_key_digest,
+        )
+        active = _registry_lookup(registry_key)
+        if active is not None:
+            try:
+                _validate_active_registry_store(
+                    self.roots,
+                    active.global_lock_identity,
+                )
+            except (RootSafetyError, PersistenceError, OSError):
+                raise StoreIndeterminate(operation) from None
+            return ClaimResult(
+                response=transient_conflict(
+                    operation,
+                    bound_operation_digest=active.operation_digest,
+                    ownership_record_digest=active.ownership_record_digest,
+                )
+            )
+
+        root_identity = self.roots.receipt.identity
+        root_mutex = _root_mutex_acquire(root_identity)
+        global_fd: int | None = None
+        global_lock_identity: tuple[int, int] | None = None
+        key_lock_fd: int | None = None
+        release_root = True
+
+        def release_outer_locks() -> BaseException | None:
+            nonlocal global_fd, release_root
+            first_error: BaseException | None = None
+            if global_fd is not None:
+                releasing_global = global_fd
+                global_fd = None
+                error = _release_flock_fd(releasing_global)
+                if error is not None:
+                    first_error = error
+            if release_root:
+                release_root = False
+                try:
+                    _root_mutex_release(root_identity, root_mutex)
+                except BaseException as exc:
+                    if first_error is None:
+                        first_error = exc
+            return first_error
+
+        try:
+            self.roots.revalidate_all()
+            root_state = _validate_receipt_root_entries(self.roots.receipt)
+            if root_state == "missing-lock":
+                raise StoreIndeterminate(operation)
+            try:
+                global_fd = _create_lock_file(
+                    self.roots.receipt,
+                    allow_create=root_state == "virgin",
+                )
+                fcntl.flock(global_fd, fcntl.LOCK_EX)
+                _revalidate_named_lock(self.roots.receipt, global_fd)
+            except (PersistenceError, OSError):
+                if root_state == "established":
+                    raise StoreIndeterminate(operation) from None
+                raise
+            self.roots.revalidate_all()
+            post_lock_state = _validate_receipt_root_entries(self.roots.receipt)
+            if post_lock_state not in {"lock-only", "established"}:
+                raise StoreIndeterminate(operation)
+            _revalidate_named_lock(self.roots.receipt, global_fd)
+            global_lock_entry = os.fstat(global_fd)
+            global_lock_identity = (
+                global_lock_entry.st_dev,
+                global_lock_entry.st_ino,
+            )
+            active = _registry_lookup(registry_key)
+            if active is not None:
+                if active.global_lock_identity != global_lock_identity:
+                    raise StoreIndeterminate(operation)
+                return ClaimResult(
+                    response=transient_conflict(
+                        operation,
+                        bound_operation_digest=active.operation_digest,
+                        ownership_record_digest=active.ownership_record_digest,
+                    )
+                )
+
+            v1 = _ensure_directory(self.roots.receipt.path, "v1")
+            shard = _ensure_directory(v1, operation.idempotency_key_digest[:2])
+            key_directory = shard / operation.idempotency_key_digest
+            try:
+                key_entry = os.lstat(key_directory)
+            except FileNotFoundError:
+                preflight_result = fresh_preflight()
+                evidence_destination = _prepare_evidence_destination(
+                    self.roots, operation
+                )
+                self.roots.revalidate_all()
+                key_directory = _create_directory(
+                    shard, operation.idempotency_key_digest
+                )
+                key_lock_fd = _create_permanent_lock(key_directory)
+                records_directory = _create_directory(key_directory, "records")
+                try:
+                    fcntl.flock(
+                        key_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB
+                    )
+                except OSError as exc:
+                    raise PersistenceError("fresh per-key flock failed") from exc
+                record, raw = build_record(
+                    operation,
+                    sequence=1,
+                    state="OWNERSHIP_ACQUIRED",
+                    previous_record_digest=None,
+                )
+                publication = _PublicationAttempt()
+                publication_error: BaseException | None = None
+                try:
+                    _publish_no_replace(
+                        key_directory=key_directory,
+                        target_parent=records_directory,
+                        target_name=record_filename(record),
+                        raw=raw,
+                        attempt=publication,
+                    )
+                except BaseException as exc:
+                    if not publication.complete:
+                        if publication.target_observed:
+                            if isinstance(exc, Exception):
+                                raise StoreIndeterminate(operation) from None
+                            raise
+                        raise
+                    publication_error = exc
+                token = object()
+                owner = OwnerHandle(
+                    roots=self.roots,
+                    operation=operation,
+                    key_directory=key_directory,
+                    records_directory=records_directory,
+                    evidence_destination=evidence_destination,
+                    key_lock_fd=key_lock_fd,
+                    registry_key=registry_key,
+                    registry_token=token,
+                    records=[record],
+                    preflight_result=preflight_result,
+                )
+                key_lock_fd = None
+                try:
+                    _registry_insert(
+                        registry_key,
+                        token=token,
+                        operation_digest=operation.operation_digest,
+                        ownership_record_digest=str(record["record_digest"]),
+                        global_lock_identity=global_lock_identity,
+                    )
+                except BaseException as exc:
+                    if publication_error is None or isinstance(
+                        publication_error, Exception
+                    ):
+                        publication_error = exc
+                if publication_error is not None:
+                    if not isinstance(publication_error, Exception):
+                        _best_effort_known_preclaim(
+                            owner, "CANCELLED_BEFORE_INVOCATION_CLAIM"
+                        )
+                        release_outer_locks()
+                        owner.close(_primary=publication_error)
+                        raise publication_error
+                    try:
+                        response = _seal_known_preclaim(
+                            owner, "PERSISTENCE_CORRUPTION"
+                        )
+                    except StoreSealedUnavailable as exc:
+                        owner.close(_primary=exc)
+                        raise
+                    except BaseException as exc:
+                        owner.close(_primary=exc)
+                        if not isinstance(exc, Exception):
+                            raise
+                        raise StorePreInvokeUnavailable(operation) from None
+                    release_error = release_outer_locks()
+                    owner.close(_primary=release_error or publication_error)
+                    if release_error is not None and not isinstance(
+                        release_error, Exception
+                    ):
+                        raise release_error
+                    return ClaimResult(response=response)
+                release_error = release_outer_locks()
+                if release_error is None:
+                    return ClaimResult(owner=owner)
+                if not isinstance(release_error, Exception):
+                    _best_effort_known_preclaim(
+                        owner, "CANCELLED_BEFORE_INVOCATION_CLAIM"
+                    )
+                    owner.close(_primary=release_error)
+                    raise release_error
+                try:
+                    response = _seal_known_preclaim(
+                        owner, "PERSISTENCE_CORRUPTION"
+                    )
+                except StoreSealedUnavailable as exc:
+                    owner.close(_primary=exc)
+                    raise
+                except BaseException as exc:
+                    owner.close(_primary=exc)
+                    if not isinstance(exc, Exception):
+                        raise
+                    raise StorePreInvokeUnavailable(operation) from None
+                owner.close(_primary=release_error)
+                return ClaimResult(response=response)
+            except OSError as exc:
+                raise PersistenceError("key lookup failed") from exc
+
+            if (
+                not stat.S_ISDIR(key_entry.st_mode)
+                or stat.S_ISLNK(key_entry.st_mode)
+                or key_entry.st_uid != _EUID
+                or _mode(key_entry) not in {0o700, 0o500}
+            ):
+                raise StoreIndeterminate(operation)
+            records_directory = key_directory / "records"
+            try:
+                records_fd = _open_directory(
+                    records_directory, {0o700, 0o500}
+                )
+            except PersistenceError:
+                raise StoreIndeterminate(operation) from None
+            else:
+                os.close(records_fd)
+            try:
+                anchor = _load_anchor(records_directory)
+                if anchor["idempotency_key_digest"] != operation.idempotency_key_digest:
+                    raise ContractValidationError("anchor key digest mismatch")
+                key_lock_fd = _open_permanent_lock(key_directory)
+            except (PersistenceError, ContractValidationError, OSError):
+                raise StoreIndeterminate(operation) from None
+            try:
+                fcntl.flock(key_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno in {errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK}:
+                    return ClaimResult(
+                        response=transient_conflict(
+                            operation,
+                            bound_operation_digest=str(anchor["operation_digest"]),
+                            ownership_record_digest=str(anchor["record_digest"]),
+                        )
+                    )
+                raise StoreIndeterminate(operation) from None
+            try:
+                _repair_committed_receipt_stage(
+                    key_directory=key_directory,
+                    records_directory=records_directory,
+                    operation=operation,
+                    require_operation_match=(
+                        anchor["operation_digest"] == operation.operation_digest
+                    ),
+                )
+            except StoreSealedUnavailable:
+                raise
+            except (PersistenceError, ContractValidationError, OSError):
+                raise StoreIndeterminate(operation) from None
+            if anchor["operation_digest"] != operation.operation_digest:
+                try:
+                    stored = _load_stored_state(
+                        key_directory,
+                        records_directory,
+                        operation,
+                        require_operation_match=False,
+                    )
+                except _FinalReceiptUnavailable as exc:
+                    raise StoreSealedUnavailable(
+                        operation,
+                        receipt_digest=exc.receipt_digest,
+                        receipt_state=_receipt_state_from_predecessor(
+                            exc.predecessor_state
+                        ),
+                    ) from None
+                except (PersistenceError, ContractValidationError, OSError):
+                    raise StoreIndeterminate(operation) from None
+                if stored.receipt is None:
+                    try:
+                        _validate_active_permissions(stored)
+                    except PersistenceError:
+                        raise StoreIndeterminate(operation) from None
+                else:
+                    try:
+                        _validate_permission_prefix(
+                            key_directory=key_directory,
+                            records_directory=records_directory,
+                            state=stored,
+                        )
+                    except PersistenceError:
+                        raise StoreSealedUnavailable(
+                            operation,
+                            receipt_digest=str(stored.receipt["receipt_digest"]),
+                            receipt_state=str(stored.receipt["receipt_state"]),
+                        ) from None
+                if str(stored.records[-1]["state"]) in {
+                    "OWNERSHIP_ACQUIRED",
+                    "PREINVOKE_REJECTED",
+                } and _matching_evidence_exists(
+                    self.roots.evidence.path
+                    / "v1"
+                    / operation.idempotency_key_digest[:2]
+                    / f"phase0-{operation.idempotency_key_digest}"
+                ):
+                    raise StoreIndeterminate(operation) from None
+                return ClaimResult(
+                    response=transient_conflict(
+                        operation,
+                        bound_operation_digest=str(anchor["operation_digest"]),
+                        ownership_record_digest=str(anchor["record_digest"]),
+                    )
+                )
+            token = object()
+            owner = OwnerHandle(
+                roots=self.roots,
+                operation=operation,
+                key_directory=key_directory,
+                records_directory=records_directory,
+                evidence_destination=(
+                    self.roots.evidence.path
+                    / "v1"
+                    / operation.idempotency_key_digest[:2]
+                    / f"phase0-{operation.idempotency_key_digest}"
+                ),
+                key_lock_fd=key_lock_fd,
+                registry_key=registry_key,
+                registry_token=token,
+                records=[anchor],
+            )
+            key_lock_fd = None
+            try:
+                _registry_insert(
+                    registry_key,
+                    token=token,
+                    operation_digest=str(anchor["operation_digest"]),
+                    ownership_record_digest=str(anchor["record_digest"]),
+                    global_lock_identity=global_lock_identity,
+                )
+            except BaseException as exc:
+                owner.close(_primary=exc)
+                if isinstance(exc, Exception):
+                    raise StoreIndeterminate(operation) from None
+                raise
+            release_error = release_outer_locks()
+            if release_error is not None:
+                owner.close(_primary=release_error)
+                if isinstance(release_error, Exception):
+                    raise StoreIndeterminate(operation) from None
+                raise release_error
+            with owner:
+                response = _recover_existing(owner)
+            return ClaimResult(response=response)
+        finally:
+            primary = sys.exc_info()[1]
+            cleanup_errors: list[BaseException] = []
+            if key_lock_fd is not None:
+                releasing_key = key_lock_fd
+                key_lock_fd = None
+                error = _release_flock_fd(releasing_key)
+                if error is not None:
+                    cleanup_errors.append(error)
+            error = release_outer_locks()
+            if error is not None:
+                cleanup_errors.append(error)
+            if cleanup_errors and primary is None:
+                raise cleanup_errors[0]

--- a/olympus_phase1_adapter/schemas/v1/phase1-operation-v1.schema.json
+++ b/olympus_phase1_adapter/schemas/v1/phase1-operation-v1.schema.json
@@ -1,0 +1,199 @@
+{
+  "$defs": {
+    "phase0_request": {
+      "additionalProperties": false,
+      "properties": {
+        "authority": {
+          "additionalProperties": false,
+          "properties": {
+            "granted": {
+              "type": "boolean"
+            },
+            "scope": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "scope",
+            "granted"
+          ],
+          "type": "object"
+        },
+        "contract_id": {
+          "const": "olympus.repo-analysis.request/v1"
+        },
+        "controls": {
+          "additionalProperties": false,
+          "properties": {
+            "allow_cloud_fallback": {
+              "type": "boolean"
+            },
+            "allow_response_repair": {
+              "type": "boolean"
+            },
+            "allow_retries": {
+              "type": "boolean"
+            },
+            "fake_transports_only": {
+              "type": "boolean"
+            },
+            "max_pair_a_attempts": {
+              "maximum": 4,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "max_pair_b_attempts": {
+              "maximum": 4,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "offline": {
+              "type": "boolean"
+            },
+            "tools": {
+              "items": {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 16,
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "offline",
+            "fake_transports_only",
+            "tools",
+            "max_pair_a_attempts",
+            "max_pair_b_attempts",
+            "allow_retries",
+            "allow_response_repair",
+            "allow_cloud_fallback"
+          ],
+          "type": "object"
+        },
+        "limits": {
+          "additionalProperties": false,
+          "properties": {
+            "max_file_bytes": {
+              "maximum": 10485760,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "max_files": {
+              "maximum": 10000,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "max_findings": {
+              "maximum": 10000,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "max_model_json_bytes": {
+              "maximum": 10485760,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "max_total_bytes": {
+              "maximum": 104857600,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "max_files",
+            "max_file_bytes",
+            "max_total_bytes",
+            "max_findings",
+            "max_model_json_bytes"
+          ],
+          "type": "object"
+        },
+        "purpose": {
+          "maxLength": 256,
+          "minLength": 1,
+          "type": "string"
+        },
+        "repository_id": {
+          "pattern": "^synthetic-[a-z0-9][a-z0-9._-]{0,62}$",
+          "type": "string"
+        },
+        "repository_kind": {
+          "enum": [
+            "SYNTHETIC",
+            "LIVE"
+          ],
+          "type": "string"
+        },
+        "repository_path": {
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "request_id": {
+          "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+          "type": "string"
+        },
+        "requested_paths": {
+          "items": {
+            "maxLength": 240,
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 192,
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "contract_id",
+        "request_id",
+        "repository_id",
+        "repository_kind",
+        "repository_path",
+        "requested_paths",
+        "purpose",
+        "authority",
+        "limits",
+        "controls"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "olympus.hermes.phase1.operation/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "correlation_id": {
+      "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+      "type": "string"
+    },
+    "engine_contract_digest": {
+      "const": "2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85"
+    },
+    "idempotency_key": {
+      "pattern": "^idem-[a-z0-9][a-z0-9._-]{0,122}$",
+      "type": "string"
+    },
+    "payload": {
+      "$ref": "#/$defs/phase0_request"
+    },
+    "schema_version": {
+      "const": "olympus.hermes.phase1.operation/v1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "correlation_id",
+    "idempotency_key",
+    "engine_contract_digest",
+    "payload"
+  ],
+  "title": "olympus.hermes.phase1.operation/v1",
+  "type": "object"
+}

--- a/olympus_phase1_adapter/schemas/v1/phase1-ownership-record-v1.schema.json
+++ b/olympus_phase1_adapter/schemas/v1/phase1-ownership-record-v1.schema.json
@@ -1,0 +1,402 @@
+{
+  "$id": "olympus.hermes.phase1.ownership-record/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "OWNERSHIP_ACQUIRED"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          },
+          "previous_record_digest": {
+            "const": null
+          },
+          "reason_code": {
+            "const": null
+          },
+          "receipt_digest": {
+            "const": null
+          },
+          "sequence": {
+            "const": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "INVOCATION_CLAIMED"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          },
+          "previous_record_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_code": {
+            "const": null
+          },
+          "receipt_digest": {
+            "const": null
+          },
+          "sequence": {
+            "const": 2
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "PREINVOKE_REJECTED"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          },
+          "previous_record_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "CANCELLED_BEFORE_INVOCATION_CLAIM",
+              "PERSISTENCE_CORRUPTION",
+              "RECOVERED_BEFORE_INVOCATION_CLAIM"
+            ],
+            "type": "string"
+          },
+          "receipt_digest": {
+            "const": null
+          },
+          "sequence": {
+            "const": 2
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "ENGINE_EVIDENCE_VERIFIED"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "pattern": "^phase0-[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "phase0_evidence_manifest_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "phase0_terminal_report_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "previous_record_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_code": {
+            "const": "PHASE0_TERMINAL"
+          },
+          "receipt_digest": {
+            "const": null
+          },
+          "sequence": {
+            "const": 3
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "INDETERMINATE_NO_RETRY"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          },
+          "previous_record_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "CANCELLED_AFTER_INVOCATION_CLAIM",
+              "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+              "EVIDENCE_MISSING",
+              "EVIDENCE_VERIFICATION_FAILED",
+              "PERSISTENCE_CORRUPTION",
+              "RECOVERED_AFTER_INVOCATION_CLAIM",
+              "WORKFLOW_CONSTRUCTION_FAILED"
+            ],
+            "type": "string"
+          },
+          "receipt_digest": {
+            "const": null
+          },
+          "sequence": {
+            "enum": [
+              3,
+              4
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "RECEIPT_FINALIZED"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          },
+          "previous_record_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_code": {
+            "const": null
+          },
+          "receipt_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "sequence": {
+            "enum": [
+              3,
+              4,
+              5
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "correlation_id": {
+      "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+      "type": "string"
+    },
+    "engine_contract_digest": {
+      "const": "2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85"
+    },
+    "gate1_packet_sha256": {
+      "const": "6ef02d1e63d19853e0794b6c324f0e7233ec082744419fae529ed16e6e11cacf"
+    },
+    "idempotency_key_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "operation_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "payload_request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "payload_request_id": {
+      "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+      "type": "string"
+    },
+    "phase0_evidence_directory_name": {
+      "pattern": "^phase0-[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_evidence_manifest_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_terminal_report_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase1_contract_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "previous_record_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "reason_code": {
+      "enum": [
+        null,
+        "ACTIVE_OWNER",
+        "CANCELLED_AFTER_INVOCATION_CLAIM",
+        "CANCELLED_BEFORE_INVOCATION_CLAIM",
+        "ENGINE_CONTRACT_MISMATCH",
+        "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+        "ENVELOPE_INVALID_JSON",
+        "ENVELOPE_SCHEMA_MISMATCH",
+        "ENVELOPE_TOO_LARGE",
+        "EVIDENCE_MISSING",
+        "EVIDENCE_VERIFICATION_FAILED",
+        "FAKE_TRANSPORT_INVALID",
+        "KEY_BOUND_TO_DIFFERENT_OPERATION",
+        "PERSISTENCE_CORRUPTION",
+        "PHASE0_PROVENANCE_MISMATCH",
+        "PHASE0_TERMINAL",
+        "RECOVERED_AFTER_INVOCATION_CLAIM",
+        "RECOVERED_BEFORE_INVOCATION_CLAIM",
+        "ROOTS_OVERLAP",
+        "UNSAFE_EVIDENCE_ROOT",
+        "UNSAFE_RECEIPT_ROOT",
+        "UNSAFE_REPOSITORY_ROOT",
+        "WORKFLOW_CONSTRUCTION_FAILED"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "receipt_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "record_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "olympus.hermes.phase1.ownership-record/v1"
+    },
+    "sequence": {
+      "maximum": 8,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "state": {
+      "enum": [
+        "OWNERSHIP_ACQUIRED",
+        "INVOCATION_CLAIMED",
+        "ENGINE_EVIDENCE_VERIFIED",
+        "PREINVOKE_REJECTED",
+        "INDETERMINATE_NO_RETRY",
+        "RECEIPT_FINALIZED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "gate1_packet_sha256",
+    "phase1_contract_digest",
+    "engine_contract_digest",
+    "sequence",
+    "state",
+    "idempotency_key_digest",
+    "operation_digest",
+    "correlation_id",
+    "payload_request_id",
+    "payload_request_digest",
+    "previous_record_digest",
+    "reason_code",
+    "phase0_terminal_report_digest",
+    "phase0_evidence_manifest_digest",
+    "phase0_evidence_directory_name",
+    "receipt_digest",
+    "record_digest"
+  ],
+  "title": "olympus.hermes.phase1.ownership-record/v1",
+  "type": "object"
+}

--- a/olympus_phase1_adapter/schemas/v1/phase1-receipt-v1.schema.json
+++ b/olympus_phase1_adapter/schemas/v1/phase1-receipt-v1.schema.json
@@ -1,0 +1,841 @@
+{
+  "$defs": {
+    "phase0_evidence_manifest": {
+      "additionalProperties": false,
+      "properties": {
+        "artifacts": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "domain": {
+                "pattern": "^[a-z][a-z0-9-]{0,63}$",
+                "type": "string"
+              },
+              "name": {
+                "pattern": "^[0-9]{2}-[a-z0-9-]+\\.json$",
+                "type": "string"
+              },
+              "sequence": {
+                "maximum": 7,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "size": {
+                "maximum": 262144,
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "sequence",
+              "name",
+              "domain",
+              "digest",
+              "size"
+            ],
+            "type": "object"
+          },
+          "maxItems": 7,
+          "minItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "contract_id": {
+          "const": "olympus.repo-analysis.evidence-manifest/v1"
+        },
+        "events": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "artifact_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "artifact_name": {
+                "pattern": "^[0-9]{2}-[a-z0-9-]+\\.json$",
+                "type": "string"
+              },
+              "event_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "event_type": {
+                "pattern": "^[A-Z][A-Z0-9_]{0,63}$",
+                "type": "string"
+              },
+              "previous_event_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sequence": {
+                "maximum": 7,
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "sequence",
+              "event_type",
+              "artifact_name",
+              "artifact_digest",
+              "previous_event_digest",
+              "event_digest"
+            ],
+            "type": "object"
+          },
+          "maxItems": 7,
+          "minItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "package_id": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "packetization_status": {
+          "enum": [
+            "NOT_ATTEMPTED",
+            "REFUSED",
+            "SEALED"
+          ],
+          "type": "string"
+        },
+        "pair_a_status": {
+          "enum": [
+            "NOT_ATTEMPTED",
+            "SUCCEEDED",
+            "TIMEOUT",
+            "MALFORMED",
+            "TRANSPORT_FAILURE"
+          ],
+          "type": "string"
+        },
+        "pair_b_status": {
+          "enum": [
+            "NOT_ATTEMPTED",
+            "SUCCEEDED",
+            "TIMEOUT",
+            "MALFORMED",
+            "TRANSPORT_FAILURE"
+          ],
+          "type": "string"
+        },
+        "repository_post_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository_postcheck_status": {
+          "enum": [
+            "NOT_ATTEMPTED",
+            "UNCHANGED",
+            "CHANGED",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "repository_pre_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_id": {
+          "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+          "type": "string"
+        },
+        "terminal_report_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "contract_id",
+        "package_id",
+        "request_id",
+        "packetization_status",
+        "pair_a_status",
+        "pair_b_status",
+        "repository_postcheck_status",
+        "artifacts",
+        "events",
+        "repository_pre_digest",
+        "repository_post_digest",
+        "terminal_report_digest"
+      ],
+      "type": "object"
+    },
+    "phase0_terminal_report": {
+      "additionalProperties": false,
+      "properties": {
+        "comparison_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "contract_id": {
+          "const": "olympus.repo-analysis.terminal-report/v1"
+        },
+        "outcome": {
+          "enum": [
+            "AGREEMENT",
+            "MINOR_DISAGREEMENT",
+            "MATERIAL_CONTRADICTION",
+            "INCOMPLETE_ANALYSIS",
+            "TIMEOUT",
+            "MALFORMED_RESULT"
+          ],
+          "type": "string"
+        },
+        "reason_codes": {
+          "items": {
+            "pattern": "^[A-Z][A-Z0-9_]{0,63}$",
+            "type": "string"
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "repository_post_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository_pre_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_id": {
+          "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+          "type": "string"
+        },
+        "summary": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "type": "string"
+        },
+        "terminal_state": {
+          "enum": [
+            "COMPLETED",
+            "FAILED",
+            "DENIED"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "contract_id",
+        "request_id",
+        "terminal_state",
+        "outcome",
+        "reason_codes",
+        "comparison_digest",
+        "repository_pre_digest",
+        "repository_post_digest",
+        "summary"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "olympus.hermes.phase1.receipt/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "else": {
+        "properties": {
+          "phase0_evidence_directory_name": {
+            "const": null
+          },
+          "phase0_evidence_manifest": {
+            "const": null
+          },
+          "phase0_evidence_manifest_digest": {
+            "const": null
+          },
+          "phase0_evidence_package_id": {
+            "const": null
+          },
+          "phase0_terminal_report": {
+            "const": null
+          },
+          "phase0_terminal_report_digest": {
+            "const": null
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "receipt_state": {
+            "const": "ENGINE_TERMINAL"
+          }
+        },
+        "required": [
+          "receipt_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "bound_operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "correlation_id": {
+            "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "durability": {
+            "const": "SEALED"
+          },
+          "idempotency_key_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "ownership_record_digest": {
+            "description": "For transient conflict receipts, the immutable sequence-1 OWNERSHIP_ACQUIRED record digest; for SEALED receipts, the exact last pre-final record digest.",
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_id": {
+            "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "phase0_evidence_directory_name": {
+            "pattern": "^phase0-[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "phase0_evidence_manifest": {
+            "type": "object"
+          },
+          "phase0_evidence_manifest_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "phase0_evidence_package_id": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "phase0_terminal_report": {
+            "type": "object"
+          },
+          "phase0_terminal_report_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "reason_codes": {
+            "const": [
+              "PHASE0_TERMINAL"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "receipt_state": {
+            "const": "CONFLICT_IN_PROGRESS"
+          }
+        },
+        "required": [
+          "receipt_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "bound_operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "correlation_id": {
+            "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "durability": {
+            "const": "TRANSIENT"
+          },
+          "idempotency_key_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "ownership_record_digest": {
+            "description": "For transient conflict receipts, the immutable sequence-1 OWNERSHIP_ACQUIRED record digest; for SEALED receipts, the exact last pre-final record digest.",
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_id": {
+            "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "reason_codes": {
+            "const": [
+              "ACTIVE_OWNER"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "receipt_state": {
+            "const": "IDEMPOTENCY_CONFLICT"
+          }
+        },
+        "required": [
+          "receipt_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "bound_operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "correlation_id": {
+            "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "durability": {
+            "const": "TRANSIENT"
+          },
+          "idempotency_key_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "ownership_record_digest": {
+            "description": "For transient conflict receipts, the immutable sequence-1 OWNERSHIP_ACQUIRED record digest; for SEALED receipts, the exact last pre-final record digest.",
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_id": {
+            "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "reason_codes": {
+            "const": [
+              "KEY_BOUND_TO_DIFFERENT_OPERATION"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "receipt_state": {
+            "const": "INDETERMINATE_NO_RETRY"
+          }
+        },
+        "required": [
+          "receipt_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "bound_operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "correlation_id": {
+            "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "durability": {
+            "const": "SEALED"
+          },
+          "idempotency_key_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "operation_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "ownership_record_digest": {
+            "description": "For transient conflict receipts, the immutable sequence-1 OWNERSHIP_ACQUIRED record digest; for SEALED receipts, the exact last pre-final record digest.",
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "payload_request_id": {
+            "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+            "type": "string"
+          },
+          "reason_codes": {
+            "items": {
+              "enum": [
+                "CANCELLED_AFTER_INVOCATION_CLAIM",
+                "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+                "EVIDENCE_MISSING",
+                "EVIDENCE_VERIFICATION_FAILED",
+                "PERSISTENCE_CORRUPTION",
+                "RECOVERED_AFTER_INVOCATION_CLAIM",
+                "WORKFLOW_CONSTRUCTION_FAILED"
+              ],
+              "type": "string"
+            },
+            "maxItems": 1,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "receipt_state": {
+            "const": "REJECTED_PRE_INVOKE"
+          }
+        },
+        "required": [
+          "receipt_state"
+        ]
+      },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "bound_operation_digest": {
+                "const": null
+              },
+              "correlation_id": {
+                "const": null
+              },
+              "durability": {
+                "const": "TRANSIENT"
+              },
+              "idempotency_key_digest": {
+                "const": null
+              },
+              "operation_digest": {
+                "const": null
+              },
+              "ownership_record_digest": {
+                "const": null
+              },
+              "payload_request_digest": {
+                "const": null
+              },
+              "payload_request_id": {
+                "const": null
+              },
+              "reason_codes": {
+                "items": {
+                  "enum": [
+                    "ENGINE_CONTRACT_MISMATCH",
+                    "ENVELOPE_INVALID_JSON",
+                    "ENVELOPE_SCHEMA_MISMATCH",
+                    "ENVELOPE_TOO_LARGE",
+                    "FAKE_TRANSPORT_INVALID",
+                    "PERSISTENCE_CORRUPTION",
+                    "PHASE0_PROVENANCE_MISMATCH",
+                    "ROOTS_OVERLAP",
+                    "UNSAFE_EVIDENCE_ROOT",
+                    "UNSAFE_RECEIPT_ROOT",
+                    "UNSAFE_REPOSITORY_ROOT"
+                  ],
+                  "type": "string"
+                },
+                "maxItems": 1,
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          },
+          {
+            "properties": {
+              "bound_operation_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "correlation_id": {
+                "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+                "type": "string"
+              },
+              "durability": {
+                "const": "SEALED"
+              },
+              "idempotency_key_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "operation_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "ownership_record_digest": {
+                "description": "For transient conflict receipts, the immutable sequence-1 OWNERSHIP_ACQUIRED record digest; for SEALED receipts, the exact last pre-final record digest.",
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "payload_request_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "payload_request_id": {
+                "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+                "type": "string"
+              },
+              "reason_codes": {
+                "items": {
+                  "enum": [
+                    "CANCELLED_BEFORE_INVOCATION_CLAIM",
+                    "PERSISTENCE_CORRUPTION",
+                    "RECOVERED_BEFORE_INVOCATION_CLAIM"
+                  ],
+                  "type": "string"
+                },
+                "maxItems": 1,
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "properties": {
+    "automatic_engine_retry_permitted": {
+      "const": false
+    },
+    "bound_operation_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "correlation_id": {
+      "pattern": "^corr-[a-z0-9][a-z0-9._-]{0,62}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "durability": {
+      "enum": [
+        "SEALED",
+        "TRANSIENT"
+      ],
+      "type": "string"
+    },
+    "engine_contract_digest": {
+      "const": "2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85"
+    },
+    "gate1_packet_sha256": {
+      "const": "6ef02d1e63d19853e0794b6c324f0e7233ec082744419fae529ed16e6e11cacf"
+    },
+    "idempotency_key_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "operation_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "ownership_record_digest": {
+      "description": "Null only for unkeyable transient rejection. For transient conflicts this binds immutable sequence-1 OWNERSHIP_ACQUIRED; for SEALED receipts it binds the exact last pre-final record.",
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload_request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload_request_id": {
+      "pattern": "^req-[a-z0-9][a-z0-9._-]{0,62}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_evidence_directory_name": {
+      "pattern": "^phase0-[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_evidence_manifest": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/phase0_evidence_manifest"
+        }
+      ]
+    },
+    "phase0_evidence_manifest_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_evidence_package_id": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase0_terminal_report": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/phase0_terminal_report"
+        }
+      ]
+    },
+    "phase0_terminal_report_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phase1_contract_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "reason_codes": {
+      "items": {
+        "enum": [
+          "ACTIVE_OWNER",
+          "CANCELLED_AFTER_INVOCATION_CLAIM",
+          "CANCELLED_BEFORE_INVOCATION_CLAIM",
+          "ENGINE_CONTRACT_MISMATCH",
+          "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+          "ENVELOPE_INVALID_JSON",
+          "ENVELOPE_SCHEMA_MISMATCH",
+          "ENVELOPE_TOO_LARGE",
+          "EVIDENCE_MISSING",
+          "EVIDENCE_VERIFICATION_FAILED",
+          "FAKE_TRANSPORT_INVALID",
+          "KEY_BOUND_TO_DIFFERENT_OPERATION",
+          "PERSISTENCE_CORRUPTION",
+          "PHASE0_PROVENANCE_MISMATCH",
+          "PHASE0_TERMINAL",
+          "RECOVERED_AFTER_INVOCATION_CLAIM",
+          "RECOVERED_BEFORE_INVOCATION_CLAIM",
+          "ROOTS_OVERLAP",
+          "UNSAFE_EVIDENCE_ROOT",
+          "UNSAFE_RECEIPT_ROOT",
+          "UNSAFE_REPOSITORY_ROOT",
+          "WORKFLOW_CONSTRUCTION_FAILED"
+        ],
+        "type": "string"
+      },
+      "maxItems": 1,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "receipt_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "receipt_state": {
+      "enum": [
+        "REJECTED_PRE_INVOKE",
+        "CONFLICT_IN_PROGRESS",
+        "IDEMPOTENCY_CONFLICT",
+        "ENGINE_TERMINAL",
+        "INDETERMINATE_NO_RETRY"
+      ],
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "olympus.hermes.phase1.receipt/v1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "gate1_packet_sha256",
+    "phase1_contract_digest",
+    "engine_contract_digest",
+    "receipt_state",
+    "durability",
+    "correlation_id",
+    "idempotency_key_digest",
+    "operation_digest",
+    "payload_request_id",
+    "payload_request_digest",
+    "bound_operation_digest",
+    "ownership_record_digest",
+    "reason_codes",
+    "phase0_terminal_report",
+    "phase0_terminal_report_digest",
+    "phase0_evidence_manifest",
+    "phase0_evidence_manifest_digest",
+    "phase0_evidence_package_id",
+    "phase0_evidence_directory_name",
+    "automatic_engine_retry_permitted",
+    "receipt_digest"
+  ],
+  "title": "olympus.hermes.phase1.receipt/v1",
+  "type": "object"
+}

--- a/tests/olympus_phase1_adapter/conftest.py
+++ b/tests/olympus_phase1_adapter/conftest.py
@@ -1,0 +1,177 @@
+"""Hermetic fixtures for the source-checkout-only Phase 1 adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from olympus_phase1_adapter.adapter import _PHASE0_FILES
+from olympus_phase1_adapter.contracts import (
+    ENGINE_CONTRACT_DIGEST,
+    OPERATION_SCHEMA_ID,
+    canonical_bytes,
+)
+
+PHASE0_ROOT = Path("/Users/macmini/Hermes-Handoff/olympus-engine")
+PHASE0_SRC = PHASE0_ROOT / "src"
+
+# The scoped test process may expose the frozen Phase 0 source only after every
+# file in the Gate 2 runtime binding has independently matched.
+for _relative, _mode, _size, _digest, _blob in _PHASE0_FILES:
+    _path = PHASE0_ROOT / _relative
+    _entry = _path.lstat()
+    assert _path.is_file() and not _path.is_symlink()
+    assert _entry.st_size == _size
+    assert hashlib.sha256(_path.read_bytes()).hexdigest() == _digest
+sys.path.insert(0, str(PHASE0_SRC))
+
+from olympus_engine.authorization import PHASE0_AUTHORITY_SCOPE, authorize
+from olympus_engine.contracts import (
+    REQUEST_CONTRACT,
+    REVIEWER_RESULT_CONTRACT,
+    WORKER_RESULT_CONTRACT,
+    Request,
+    WorkerResult,
+)
+from olympus_engine.packetizer import build_packet
+from olympus_engine.transports import FakePairATransport, FakePairBTransport
+
+
+@pytest.fixture(autouse=True)
+def _owner_only_umask() -> None:
+    previous = os.umask(0o077)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def phase1_roots(tmp_path: Path) -> dict[str, Path]:
+    roots = {
+        "repository": tmp_path / "repository",
+        "receipt": tmp_path / "receipt",
+        "evidence": tmp_path / "evidence",
+    }
+    for root in roots.values():
+        root.mkdir(mode=0o700)
+        root.chmod(0o700)
+    (roots["repository"] / "src").mkdir(mode=0o700)
+    (roots["repository"] / "README.md").write_text(
+        "# Synthetic fixture\n\nOffline review content only.\n",
+        encoding="utf-8",
+        newline="",
+    )
+    (roots["repository"] / "src" / "example.py").write_text(
+        "def add(left: int, right: int) -> int:\n"
+        "    return left + right\n",
+        encoding="utf-8",
+        newline="",
+    )
+    return roots
+
+
+def request_value(*, request_id: str = "req-phase1-test") -> dict[str, Any]:
+    return {
+        "contract_id": REQUEST_CONTRACT,
+        "request_id": request_id,
+        "repository_id": "synthetic-phase1-test",
+        "repository_kind": "SYNTHETIC",
+        "repository_path": ".",
+        "requested_paths": ["README.md", "src/example.py"],
+        "purpose": "bounded offline Phase 1 repository review",
+        "authority": {
+            "scope": PHASE0_AUTHORITY_SCOPE,
+            "granted": True,
+        },
+        "limits": {
+            "max_files": 96,
+            "max_file_bytes": 32768,
+            "max_total_bytes": 196608,
+            "max_findings": 64,
+            "max_model_json_bytes": 65536,
+        },
+        "controls": {
+            "offline": True,
+            "fake_transports_only": True,
+            "tools": [],
+            "max_pair_a_attempts": 1,
+            "max_pair_b_attempts": 1,
+            "allow_retries": False,
+            "allow_response_repair": False,
+            "allow_cloud_fallback": False,
+        },
+    }
+
+
+def operation_value(
+    *,
+    idempotency_key: str = "idem-phase1-test",
+    correlation_id: str = "corr-phase1-test",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": OPERATION_SCHEMA_ID,
+        "correlation_id": correlation_id,
+        "idempotency_key": idempotency_key,
+        "engine_contract_digest": ENGINE_CONTRACT_DIGEST,
+        "payload": request_value() if payload is None else payload,
+    }
+
+
+def operation_bytes(**kwargs: Any) -> bytes:
+    return canonical_bytes(operation_value(**kwargs))
+
+
+def valid_transports(
+    repository: Path,
+    *,
+    payload: dict[str, Any] | None = None,
+) -> tuple[FakePairATransport, FakePairBTransport]:
+    value = request_value() if payload is None else payload
+    request = Request.from_value(value)
+    authorization = authorize(request)
+    assert authorization.decision == "ALLOW"
+    packet = build_packet(repository, request, authorization)
+    worker_value = {
+        "contract_id": WORKER_RESULT_CONTRACT,
+        "request_id": request.request_id,
+        "packet_digest": packet.digest,
+        "status": "COMPLETE",
+        "summary": "Synthetic Pair A analysis.",
+        "findings": [
+            {
+                "id": "F-001",
+                "severity": "MEDIUM",
+                "path": "src/example.py",
+                "line": 1,
+                "category": "CORRECTNESS",
+                "message": "Synthetic addition behavior remains explicit.",
+            }
+        ],
+    }
+    worker = WorkerResult.from_value(worker_value)
+    reviewer_value = {
+        "contract_id": REVIEWER_RESULT_CONTRACT,
+        "request_id": request.request_id,
+        "packet_digest": packet.digest,
+        "worker_result_digest": worker.digest,
+        "status": "COMPLETE",
+        "summary": "Synthetic Pair B review.",
+        "dispositions": [
+            {
+                "finding_id": "F-001",
+                "disposition": "CONFIRM",
+                "rationale": "Independent synthetic review completed.",
+            }
+        ],
+    }
+    return (
+        FakePairATransport(worker_value),
+        FakePairBTransport(reviewer_value),
+    )

--- a/tests/olympus_phase1_adapter/test_contracts_and_adapter.py
+++ b/tests/olympus_phase1_adapter/test_contracts_and_adapter.py
@@ -1,0 +1,1765 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import copy
+import dataclasses
+import hashlib
+import json
+import multiprocessing
+import os
+import socket
+import stat
+import subprocess
+import threading
+import tomllib
+import types
+from pathlib import Path
+from typing import Literal, get_type_hints
+
+import pytest
+
+from olympus_engine.transports import FakePairATransport, FakePairBTransport
+from olympus_engine.workflow import OlympusWorkflow
+
+from olympus_phase1_adapter import adapter
+from olympus_phase1_adapter.adapter import (
+    IndeterminateReceiptUnavailable,
+    PreInvokeReceiptUnavailable,
+    SealedReceiptUnavailable,
+    execute_operation,
+)
+from olympus_phase1_adapter.contracts import (
+    ENGINE_CONTRACT_DIGEST,
+    GATE1_PACKET_SHA256,
+    GATE2_PACKET_SHA256,
+    PHASE0_RUNTIME_BINDING_DIGEST,
+    PHASE1_CONTRACT_DIGEST,
+    ContractValidationError,
+    build_record,
+    canonical_bytes,
+    canonical_digest,
+    digest_vectors,
+    parse_operation,
+    parse_record_bytes,
+    sealed_receipt,
+    strict_loads,
+    transient_conflict,
+    transient_rejection,
+    validate_receipt,
+    verify_frozen_schemas,
+)
+from olympus_phase1_adapter.receipt_store import OwnerHandle, PersistenceError
+
+from conftest import (
+    operation_bytes,
+    operation_value,
+    request_value,
+    valid_transports,
+)
+
+
+def _call(
+    roots: dict[str, Path],
+    envelope: bytes,
+    pair_a: object,
+    pair_b: object,
+) -> bytes:
+    return execute_operation(
+        envelope,
+        repository_root=roots["repository"],
+        receipt_root=roots["receipt"],
+        evidence_root=roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+
+
+def _tree_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
+    snapshot: list[tuple[object, ...]] = []
+    for path in sorted((root, *root.rglob("*")), key=lambda item: item.as_posix()):
+        entry = path.lstat()
+        digest = (
+            hashlib.sha256(path.read_bytes()).hexdigest()
+            if stat.S_ISREG(entry.st_mode)
+            else None
+        )
+        snapshot.append(
+            (
+                path.relative_to(root).as_posix(),
+                stat.S_IFMT(entry.st_mode),
+                stat.S_IMODE(entry.st_mode),
+                entry.st_dev,
+                entry.st_ino,
+                entry.st_size,
+                entry.st_mtime_ns,
+                digest,
+            )
+        )
+    return tuple(snapshot)
+
+
+class _DictObject:
+    def __init__(self, value: dict[str, object], *, digest: str | None = None) -> None:
+        self._value = copy.deepcopy(value)
+        self.digest = digest
+
+    def to_dict(self) -> dict[str, object]:
+        return copy.deepcopy(self._value)
+
+
+def _over_depth_json() -> bytes:
+    return b"[" * 66 + b"0" + b"]" * 66
+
+
+def _wrong_schema_operation() -> bytes:
+    value = operation_value()
+    value["schema_version"] = "olympus.hermes.phase1.operation/v2"
+    return canonical_bytes(value)
+
+
+def _invalid_phase0_request_operation() -> bytes:
+    payload = request_value()
+    payload["requested_paths"] = []
+    return operation_bytes(payload=payload)
+
+
+def _forbidden_payload_field_operation() -> bytes:
+    payload = request_value()
+    payload["provider"] = "forbidden"
+    return operation_bytes(payload=payload)
+
+
+def test_t01_valid_allow_fixture_is_one_shot_and_engine_terminal(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    original_preflight = adapter._preflight
+    original_pair_a = FakePairATransport.analyze
+    original_pair_b = FakePairBTransport.review
+
+    def pair_a_once(self: FakePairATransport, packet: bytes) -> bytes:
+        events.append("pair_a")
+        return original_pair_a(self, packet)
+
+    def pair_b_once(
+        self: FakePairBTransport, packet: bytes, worker: bytes
+    ) -> bytes:
+        events.append("pair_b")
+        return original_pair_b(self, packet, worker)
+
+    def instrumented_preflight(pair_a_value: object, pair_b_value: object):
+        api = original_preflight(pair_a_value, pair_b_value)
+        workflow_type = api.OlympusWorkflow
+        verifier = api.verify_evidence_package
+
+        class InstrumentedWorkflow:
+            def __init__(self, **kwargs: object) -> None:
+                events.append("construct")
+                self._inner = workflow_type(**kwargs)
+
+            def run(self):
+                events.append("run")
+                return self._inner.run()
+
+        def verify_once(destination: Path):
+            events.append("verify")
+            return verifier(destination)
+
+        return dataclasses.replace(
+            api,
+            OlympusWorkflow=InstrumentedWorkflow,
+            verify_evidence_package=verify_once,
+        )
+
+    monkeypatch.setattr(FakePairATransport, "analyze", pair_a_once)
+    monkeypatch.setattr(FakePairBTransport, "review", pair_b_once)
+    monkeypatch.setattr(adapter, "_preflight", instrumented_preflight)
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    raw = _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    receipt = strict_loads(raw)
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert receipt["durability"] == "SEALED"
+    assert receipt["reason_codes"] == ["PHASE0_TERMINAL"]
+    assert receipt["phase0_terminal_report"]["terminal_state"] == "COMPLETED"
+    assert pair_a.call_count == pair_b.call_count == 1
+    assert events == ["construct", "run", "pair_a", "pair_b", "verify"]
+    key = parse_operation(operation_bytes()).idempotency_key_digest
+    key_root = phase1_roots["receipt"] / "v1" / key[:2] / key
+    assert (key_root / "receipt.json").read_bytes() == raw
+    assert (stat_mode(key_root) == 0o500)
+    assert stat_mode(key_root / "records") == 0o500
+    assert stat_mode(key_root / "receipt.json") == 0o400
+    assert all(
+        stat_mode(path) == 0o400
+        for path in (key_root / "records").iterdir()
+    )
+
+
+def stat_mode(path: Path) -> int:
+    return path.stat(follow_symlinks=False).st_mode & 0o7777
+
+
+def test_t02_native_denial_is_preserved_without_pair_calls(
+    phase1_roots: dict[str, Path],
+) -> None:
+    payload = request_value()
+    payload["controls"]["offline"] = False
+    pair_a = FakePairATransport(b"{}")
+    pair_b = FakePairBTransport(b"{}")
+    raw = _call(
+        phase1_roots,
+        operation_bytes(payload=payload),
+        pair_a,
+        pair_b,
+    )
+    receipt = strict_loads(raw)
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert receipt["phase0_terminal_report"]["terminal_state"] == "DENIED"
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("variant", "native_reason"),
+    [
+        ("timeout", "PAIR_A_TIMEOUT"),
+        ("malformed", "PAIR_A_MALFORMED"),
+        ("transport", "PAIR_A_TRANSPORT_FAILURE"),
+    ],
+)
+def test_t03_pair_a_failures_remain_native_phase0_terminal_results(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    variant: str,
+    native_reason: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    if variant == "timeout":
+        pair_a.timeout = True
+    elif variant == "malformed":
+        pair_a.response = b"{}"
+    else:
+        def fail_transport(
+            _self: FakePairATransport, _packet: bytes
+        ) -> bytes:
+            raise RuntimeError("injected Pair A transport failure")
+
+        monkeypatch.setattr(FakePairATransport, "analyze", fail_transport)
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert receipt["reason_codes"] == ["PHASE0_TERMINAL"]
+    assert receipt["phase0_terminal_report"]["terminal_state"] == "FAILED"
+    assert native_reason in receipt["phase0_terminal_report"]["reason_codes"]
+    assert pair_b.call_count == 0
+    assert pair_a.call_count == (0 if variant == "transport" else 1)
+
+
+@pytest.mark.parametrize(
+    ("variant", "native_reason"),
+    [
+        ("timeout", "PAIR_B_TIMEOUT"),
+        ("malformed", "PAIR_B_MALFORMED"),
+        ("transport", "PAIR_B_TRANSPORT_FAILURE"),
+    ],
+)
+def test_t04_pair_b_failures_remain_native_phase0_terminal_results(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    variant: str,
+    native_reason: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    if variant == "timeout":
+        pair_b.timeout = True
+    elif variant == "malformed":
+        pair_b.response = b"{}"
+    else:
+        def fail_transport(
+            _self: FakePairBTransport,
+            _packet: bytes,
+            _worker: bytes,
+        ) -> bytes:
+            raise RuntimeError("injected Pair B transport failure")
+
+        monkeypatch.setattr(FakePairBTransport, "review", fail_transport)
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert receipt["reason_codes"] == ["PHASE0_TERMINAL"]
+    assert receipt["phase0_terminal_report"]["terminal_state"] == "FAILED"
+    assert native_reason in receipt["phase0_terminal_report"]["reason_codes"]
+    assert pair_a.call_count == 1
+    assert pair_b.call_count == (0 if variant == "transport" else 1)
+
+
+def test_t05_sealed_replay_is_byte_identical_and_does_not_consult_fakes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    envelope = operation_bytes()
+    first = _call(phase1_roots, envelope, pair_a, pair_b)
+    operation = parse_operation(envelope)
+    key_root = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    receipt_before = _tree_snapshot(key_root)
+    evidence_before = _tree_snapshot(phase1_roots["evidence"])
+
+    def forbidden_runtime(*_args: object, **_kwargs: object):
+        pytest.fail("replay attempted Phase 0 construction or execution")
+
+    monkeypatch.setattr(
+        adapter.importlib,
+        "import_module",
+        lambda _name: pytest.fail("replay initiated an Olympus import"),
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_preflight",
+        lambda *_args: pytest.fail("replay consulted fresh-owner preflight"),
+    )
+    monkeypatch.setattr(OlympusWorkflow, "__init__", forbidden_runtime)
+    monkeypatch.setattr(OlympusWorkflow, "run", forbidden_runtime)
+    second = _call(phase1_roots, envelope, object(), object())
+    assert second == first
+    assert pair_a.call_count == pair_b.call_count == 1
+    assert (key_root / "receipt.json").read_bytes() == first
+    assert _tree_snapshot(key_root) == receipt_before
+    assert _tree_snapshot(phase1_roots["evidence"]) == evidence_before
+
+
+def test_t06_same_key_different_operation_is_immutable_anchor_conflict(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    first_envelope = operation_bytes()
+    _call(phase1_roots, first_envelope, pair_a, pair_b)
+    changed = operation_value(correlation_id="corr-phase1-other")
+    raw = _call(
+        phase1_roots,
+        canonical_bytes(changed),
+        object(),
+        object(),
+    )
+    receipt = strict_loads(raw)
+    first_operation = parse_operation(first_envelope)
+    current_operation = parse_operation(canonical_bytes(changed))
+    assert receipt["receipt_state"] == "IDEMPOTENCY_CONFLICT"
+    assert receipt["durability"] == "TRANSIENT"
+    assert receipt["operation_digest"] == current_operation.operation_digest
+    assert receipt["bound_operation_digest"] == first_operation.operation_digest
+    assert receipt["bound_operation_digest"] != receipt["operation_digest"]
+    key_root = (
+        phase1_roots["receipt"]
+        / "v1"
+        / first_operation.idempotency_key_digest[:2]
+        / first_operation.idempotency_key_digest
+    )
+    anchor = parse_record_bytes(
+        (key_root / "records" / "000001-OWNERSHIP_ACQUIRED.json").read_bytes()
+    )
+    assert anchor["sequence"] == 1
+    assert anchor["state"] == "OWNERSHIP_ACQUIRED"
+    assert receipt["ownership_record_digest"] == anchor["record_digest"]
+    assert receipt["bound_operation_digest"] == anchor["operation_digest"]
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+def test_t06_different_operation_conflict_validates_current_and_anchor_bindings(
+) -> None:
+    bound_operation = parse_operation(operation_bytes())
+    current_operation = parse_operation(
+        operation_bytes(
+            correlation_id="corr-phase1-other",
+            payload=request_value(request_id="req-phase1-other"),
+        )
+    )
+    anchor, _ = build_record(
+        bound_operation,
+        sequence=1,
+        state="OWNERSHIP_ACQUIRED",
+        previous_record_digest=None,
+    )
+    receipt = strict_loads(
+        transient_conflict(
+            current_operation,
+            bound_operation_digest=bound_operation.operation_digest,
+            ownership_record_digest=str(anchor["record_digest"]),
+        )
+    )
+
+    assert validate_receipt(
+        receipt, chain=[anchor], operation=current_operation
+    ) == receipt
+    assert receipt["correlation_id"] == current_operation.correlation_id
+    assert receipt["payload_request_id"] == current_operation.payload_request_id
+    assert receipt["payload_request_digest"] == current_operation.payload_request_digest
+    assert receipt["bound_operation_digest"] == anchor["operation_digest"]
+    assert receipt["ownership_record_digest"] == anchor["record_digest"]
+
+
+def test_t06_sealed_receipt_retains_full_anchor_identity_validation() -> None:
+    operation = parse_operation(operation_bytes())
+    anchor, _ = build_record(
+        operation,
+        sequence=1,
+        state="OWNERSHIP_ACQUIRED",
+        previous_record_digest=None,
+    )
+    predecessor, _ = build_record(
+        operation,
+        sequence=2,
+        state="PREINVOKE_REJECTED",
+        previous_record_digest=str(anchor["record_digest"]),
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    _, raw = sealed_receipt(
+        operation,
+        receipt_state="REJECTED_PRE_INVOKE",
+        predecessor=predecessor,
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    receipt = strict_loads(raw)
+    receipt["correlation_id"] = "corr-phase1-other"
+    body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    receipt["receipt_digest"] = canonical_digest("phase1-receipt", body)
+
+    with pytest.raises(
+        ContractValidationError,
+        match="receipt anchor mismatch: correlation_id",
+    ):
+        validate_receipt(receipt, chain=[anchor, predecessor])
+
+
+def test_t06_t13_sealed_receipt_state_must_match_predecessor_in_all_directions(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    terminal_raw = _call(phase1_roots, envelope, pair_a, pair_b)
+    terminal_receipt = strict_loads(terminal_raw)
+    assert isinstance(terminal_receipt, dict)
+
+    key = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    stored = [
+        parse_record_bytes(path.read_bytes())
+        for path in sorted((key / "records").iterdir())
+    ]
+    anchor, invocation, engine_predecessor = stored[:3]
+    assert engine_predecessor["state"] == "ENGINE_EVIDENCE_VERIFIED"
+
+    preinvoke_predecessor, _ = build_record(
+        operation,
+        sequence=2,
+        state="PREINVOKE_REJECTED",
+        previous_record_digest=str(anchor["record_digest"]),
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    indeterminate_predecessor, _ = build_record(
+        operation,
+        sequence=3,
+        state="INDETERMINATE_NO_RETRY",
+        previous_record_digest=str(invocation["record_digest"]),
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    chains = {
+        "PREINVOKE_REJECTED": [anchor, preinvoke_predecessor],
+        "ENGINE_EVIDENCE_VERIFIED": [anchor, invocation, engine_predecessor],
+        "INDETERMINATE_NO_RETRY": [anchor, invocation, indeterminate_predecessor],
+    }
+
+    rejected_receipt, _ = sealed_receipt(
+        operation,
+        receipt_state="REJECTED_PRE_INVOKE",
+        predecessor=preinvoke_predecessor,
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    indeterminate_receipt, _ = sealed_receipt(
+        operation,
+        receipt_state="INDETERMINATE_NO_RETRY",
+        predecessor=indeterminate_predecessor,
+        reason_code="PERSISTENCE_CORRUPTION",
+    )
+    receipts = {
+        "REJECTED_PRE_INVOKE": rejected_receipt,
+        "ENGINE_TERMINAL": terminal_receipt,
+        "INDETERMINATE_NO_RETRY": indeterminate_receipt,
+    }
+    expected_predecessors = {
+        "REJECTED_PRE_INVOKE": "PREINVOKE_REJECTED",
+        "ENGINE_TERMINAL": "ENGINE_EVIDENCE_VERIFIED",
+        "INDETERMINATE_NO_RETRY": "INDETERMINATE_NO_RETRY",
+    }
+
+    checked: set[tuple[str, str]] = set()
+    for receipt_state, valid_receipt in receipts.items():
+        for predecessor_state, chain in chains.items():
+            if predecessor_state == expected_predecessors[receipt_state]:
+                continue
+            predecessor = chain[-1]
+            candidate = copy.deepcopy(valid_receipt)
+            candidate["ownership_record_digest"] = predecessor["record_digest"]
+            candidate["receipt_digest"] = canonical_digest(
+                "phase1-receipt",
+                {
+                    key: value
+                    for key, value in candidate.items()
+                    if key != "receipt_digest"
+                },
+            )
+            assert canonical_bytes(strict_loads(canonical_bytes(candidate))) == (
+                canonical_bytes(candidate)
+            )
+            with pytest.raises(ContractValidationError) as caught:
+                validate_receipt(candidate, chain=chain, operation=operation)
+            if {
+                receipt_state,
+                predecessor_state,
+            } == {"REJECTED_PRE_INVOKE", "INDETERMINATE_NO_RETRY"}:
+                assert "predecessor state mismatch" in str(caught.value)
+            checked.add((receipt_state, predecessor_state))
+
+    assert checked == {
+        (receipt_state, predecessor_state)
+        for receipt_state, expected in expected_predecessors.items()
+        for predecessor_state in chains
+        if predecessor_state != expected
+    }
+
+
+@pytest.mark.parametrize(
+    ("record_field", "replacement", "message"),
+    [
+        (
+            "phase0_terminal_report_digest",
+            "0" * 64,
+            r"terminal.*predecessor|predecessor.*terminal",
+        ),
+        (
+            "phase0_evidence_manifest_digest",
+            "0" * 64,
+            r"manifest.*predecessor|predecessor.*manifest",
+        ),
+        (
+            "phase0_evidence_directory_name",
+            "phase0-" + "0" * 64,
+            r"directory.*predecessor|predecessor.*directory",
+        ),
+    ],
+)
+def test_t13_engine_receipt_binds_each_engine_verified_record_field(
+    phase1_roots: dict[str, Path],
+    record_field: str,
+    replacement: str,
+    message: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    raw = _call(phase1_roots, envelope, pair_a, pair_b)
+    receipt = strict_loads(raw)
+    assert isinstance(receipt, dict)
+
+    key = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    chain = [
+        parse_record_bytes(path.read_bytes())
+        for path in sorted((key / "records").iterdir())
+    ][:3]
+    predecessor = copy.deepcopy(chain[-1])
+    assert predecessor["state"] == "ENGINE_EVIDENCE_VERIFIED"
+    assert predecessor[record_field] != replacement
+    predecessor[record_field] = replacement
+    predecessor["record_digest"] = canonical_digest(
+        "phase1-ownership-record",
+        {
+            key: value
+            for key, value in predecessor.items()
+            if key != "record_digest"
+        },
+    )
+    chain[-1] = parse_record_bytes(canonical_bytes(predecessor))
+
+    candidate = copy.deepcopy(receipt)
+    candidate["ownership_record_digest"] = predecessor["record_digest"]
+    candidate["receipt_digest"] = canonical_digest(
+        "phase1-receipt",
+        {
+            key: value
+            for key, value in candidate.items()
+            if key != "receipt_digest"
+        },
+    )
+    with pytest.raises(ContractValidationError, match=message):
+        validate_receipt(candidate, chain=chain, operation=operation)
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        (b" " * 65_537, "ENVELOPE_TOO_LARGE"),
+        (b"{", "ENVELOPE_INVALID_JSON"),
+        (b"\xff", "ENVELOPE_INVALID_JSON"),
+        (_over_depth_json(), "ENVELOPE_INVALID_JSON"),
+        (
+            b'{"engine_contract_digest":"x","engine_contract_digest":"y"}',
+            "ENVELOPE_INVALID_JSON",
+        ),
+        (b'{"engine_contract_digest":1.5}', "ENVELOPE_INVALID_JSON"),
+        (b"[]", "ENVELOPE_SCHEMA_MISMATCH"),
+        (b"{}", "ENVELOPE_SCHEMA_MISMATCH"),
+        (b'{"engine_contract_digest":7}', "ENVELOPE_SCHEMA_MISMATCH"),
+        (_wrong_schema_operation(), "ENVELOPE_SCHEMA_MISMATCH"),
+        (_invalid_phase0_request_operation(), "ENVELOPE_SCHEMA_MISMATCH"),
+        (_forbidden_payload_field_operation(), "ENVELOPE_SCHEMA_MISMATCH"),
+        (
+            b'{"engine_contract_digest":"ffffffffffffffffffffffffffffffff'
+            b'ffffffffffffffffffffffffffffffff"}',
+            "ENGINE_CONTRACT_MISMATCH",
+        ),
+        (
+            canonical_bytes(
+                {
+                    **operation_value(),
+                    "unexpected": True,
+                }
+            ),
+            "ENVELOPE_SCHEMA_MISMATCH",
+        ),
+    ],
+)
+def test_t10_bad_envelope_classes_are_deterministic(
+    raw: bytes,
+    reason: str,
+) -> None:
+    receipt = strict_loads(
+        execute_operation(
+            raw,
+            repository_root="relative",
+            receipt_root="relative",
+            evidence_root="relative",
+            pair_a=object(),
+            pair_b=object(),
+        )
+    )
+    assert receipt["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert receipt["durability"] == "TRANSIENT"
+    assert receipt["reason_codes"] == [reason]
+    assert receipt["idempotency_key_digest"] is None
+
+
+def test_t11_provenance_tamper_fails_before_ownership(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    monkeypatch.setattr(
+        adapter,
+        "_read_frozen_phase0_file",
+        lambda *_args: (_ for _ in ()).throw(
+            adapter._FreshRejection("PHASE0_PROVENANCE_MISMATCH")
+        ),
+    )
+    raw = _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    receipt = strict_loads(raw)
+    assert receipt["reason_codes"] == ["PHASE0_PROVENANCE_MISMATCH"]
+    operation = parse_operation(operation_bytes())
+    key = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    assert not key.exists()
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+def test_t11_wrong_preloaded_import_origin_fails_before_construction(
+    phase1_roots: dict[str, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    wrong_origin = tmp_path / "wrong-olympus-engine.py"
+    wrong_origin.write_text("# wrong origin\n", encoding="utf-8")
+    wrong_module = types.SimpleNamespace(__file__=str(wrong_origin))
+
+    monkeypatch.setitem(adapter.sys.modules, "olympus_engine", wrong_module)
+    monkeypatch.setattr(
+        adapter.importlib,
+        "import_module",
+        lambda _name: pytest.fail("wrong-origin rejection attempted an import"),
+    )
+    monkeypatch.setattr(
+        OlympusWorkflow,
+        "__init__",
+        lambda *_args, **_kwargs: pytest.fail(
+            "wrong-origin rejection constructed a workflow"
+        ),
+    )
+
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    operation = parse_operation(operation_bytes())
+    key_root = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    assert receipt["reason_codes"] == ["PHASE0_PROVENANCE_MISMATCH"]
+    assert not key_root.exists()
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+@pytest.mark.parametrize("tamper", ["mode", "size", "hash", "source-type"])
+def test_t11_actual_frozen_file_tamper_classes_are_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tamper: str,
+) -> None:
+    relative = "frozen-source.py"
+    source = tmp_path / relative
+    original = b"frozen-source\n"
+    source.write_bytes(original)
+    source.chmod(0o644)
+    expected_digest = hashlib.sha256(original).hexdigest()
+    monkeypatch.setattr(adapter, "OLYMPUS_CHECKOUT", tmp_path)
+
+    if tamper == "mode":
+        source.chmod(0o600)
+    elif tamper == "size":
+        source.write_bytes(original + b"x")
+    elif tamper == "hash":
+        source.write_bytes(b"x" * len(original))
+    else:
+        source.unlink()
+        target = tmp_path / "actual-source.py"
+        target.write_bytes(original)
+        target.chmod(0o644)
+        source.symlink_to(target)
+
+    with pytest.raises(adapter._FreshRejection) as caught:
+        adapter._read_frozen_phase0_file(
+            relative,
+            len(original),
+            expected_digest,
+        )
+    assert caught.value.reason_code == "PHASE0_PROVENANCE_MISMATCH"
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "pair-a-subclass",
+        "pair-b-subclass",
+        "pair-a-call-count",
+        "pair-b-call-count",
+        "pair-a-received-packet",
+        "pair-b-received-packet",
+        "pair-b-received-worker",
+    ],
+)
+def test_t12_fake_subclass_and_reused_instances_are_rejected(
+    phase1_roots: dict[str, Path],
+    variant: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+
+    class PairASubclass(FakePairATransport):
+        pass
+
+    class PairBSubclass(FakePairBTransport):
+        pass
+
+    if variant == "pair-a-subclass":
+        pair_a = PairASubclass(pair_a.response)
+    elif variant == "pair-b-subclass":
+        pair_b = PairBSubclass(pair_b.response)
+    elif variant == "pair-a-call-count":
+        pair_a.call_count = 1
+    elif variant == "pair-b-call-count":
+        pair_b.call_count = 1
+    elif variant == "pair-a-received-packet":
+        pair_a.received_packets.append(b"reused")
+    elif variant == "pair-b-received-packet":
+        pair_b.received_packets.append(b"reused")
+    else:
+        pair_b.received_worker_results.append(b"reused")
+
+    raw = _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert strict_loads(raw)["reason_codes"] == ["FAKE_TRANSPORT_INVALID"]
+    operation = parse_operation(operation_bytes())
+    key_root = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    assert not key_root.exists()
+
+
+def test_t13_root_overlap_and_wrong_mode_fail_closed(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["receipt"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert strict_loads(raw)["reason_codes"] == ["ROOTS_OVERLAP"]
+    phase1_roots["receipt"].chmod(0o755)
+    raw = _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert strict_loads(raw)["reason_codes"] == ["UNSAFE_RECEIPT_ROOT"]
+
+
+def test_t13_symlinked_and_traversing_roots_are_rejected(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    receipt_link = phase1_roots["receipt"].parent / "receipt-link"
+    receipt_link.symlink_to(phase1_roots["receipt"], target_is_directory=True)
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=receipt_link,
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert strict_loads(raw)["reason_codes"] == ["UNSAFE_RECEIPT_ROOT"]
+    traversal_parent = phase1_roots["receipt"].parent / "traversal"
+    traversal_parent.mkdir(mode=0o700)
+    traversal = (
+        f"{traversal_parent}/../{phase1_roots['receipt'].name}"
+    )
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=traversal,
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert strict_loads(raw)["reason_codes"] == ["UNSAFE_RECEIPT_ROOT"]
+
+
+@pytest.mark.parametrize(
+    ("variant", "reason"),
+    [
+        ("missing", "EVIDENCE_MISSING"),
+        ("invalid", "EVIDENCE_VERIFICATION_FAILED"),
+        ("wrong-request", "EVIDENCE_VERIFICATION_FAILED"),
+        ("wrong-terminal", "EVIDENCE_VERIFICATION_FAILED"),
+        ("wrong-package", "EVIDENCE_VERIFICATION_FAILED"),
+        ("changed", "EVIDENCE_VERIFICATION_FAILED"),
+    ],
+)
+def test_t15_evidence_verification_mismatch_never_becomes_engine_terminal(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    variant: str,
+    reason: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_preflight = adapter._preflight
+
+    def poisoned_preflight(pair_a_value: object, pair_b_value: object):
+        api = original_preflight(pair_a_value, pair_b_value)
+        workflow_type = api.OlympusWorkflow
+        verifier = api.verify_evidence_package
+
+        class PoisonedWorkflow:
+            def __init__(self, **kwargs: object) -> None:
+                self._destination = Path(kwargs["evidence_destination"])
+                self._inner = workflow_type(**kwargs)
+
+            def run(self):
+                result = self._inner.run()
+                if variant == "missing":
+                    return dataclasses.replace(result, evidence_manifest=None)
+                if variant == "wrong-request":
+                    value = result.request.to_dict()
+                    value["request_id"] = "req-phase1-wrong"
+                    return dataclasses.replace(result, request=_DictObject(value))
+                if variant == "wrong-terminal":
+                    value = result.terminal_report.to_dict()
+                    value["request_id"] = "req-phase1-wrong"
+                    return dataclasses.replace(
+                        result,
+                        terminal_report=_DictObject(
+                            value,
+                            digest=result.terminal_report.digest,
+                        ),
+                    )
+                if variant == "changed":
+                    artifact = self._destination / "01-request.json"
+                    artifact.write_bytes(artifact.read_bytes() + b"\n")
+                return result
+
+        def verify_evidence(destination: Path):
+            if variant == "invalid":
+                raise ValueError("injected evidence mismatch")
+            verified = verifier(destination)
+            if variant == "wrong-package":
+                value = verified.to_dict()
+                value["package_id"] = "f" * 64
+                return _DictObject(value)
+            return verified
+
+        return dataclasses.replace(
+            api,
+            OlympusWorkflow=PoisonedWorkflow,
+            verify_evidence_package=verify_evidence,
+        )
+
+    monkeypatch.setattr(adapter, "_preflight", poisoned_preflight)
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert receipt["reason_codes"] == [reason]
+    assert receipt["phase0_terminal_report"] is None
+    assert receipt["phase0_evidence_manifest"] is None
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+def test_t15_operation_agnostic_terminal_validation_binds_request_artifact_digest(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert isinstance(receipt, dict)
+    manifest = receipt["phase0_evidence_manifest"]
+    assert isinstance(manifest, dict)
+    artifacts = manifest["artifacts"]
+    events = manifest["events"]
+    assert isinstance(artifacts, list) and isinstance(events, list)
+
+    request_artifact = next(
+        artifact
+        for artifact in artifacts
+        if isinstance(artifact, dict) and artifact.get("name") == "01-request.json"
+    )
+    assert isinstance(request_artifact, dict)
+    assert request_artifact["digest"] == receipt["payload_request_digest"]
+    request_artifact["digest"] = "f" * 64
+
+    previous_event_digest: str | None = None
+    for artifact, event in zip(artifacts, events, strict=True):
+        assert isinstance(artifact, dict) and isinstance(event, dict)
+        event["artifact_digest"] = artifact["digest"]
+        event["previous_event_digest"] = previous_event_digest
+        event_body = {
+            "sequence": event["sequence"],
+            "event_type": event["event_type"],
+            "artifact_name": event["artifact_name"],
+            "artifact_digest": event["artifact_digest"],
+            "previous_event_digest": event["previous_event_digest"],
+        }
+        event["event_digest"] = canonical_digest("evidence-event", event_body)
+        previous_event_digest = str(event["event_digest"])
+
+    identity_fields = (
+        "request_id",
+        "packetization_status",
+        "pair_a_status",
+        "pair_b_status",
+        "repository_postcheck_status",
+        "artifacts",
+        "events",
+        "repository_pre_digest",
+        "repository_post_digest",
+        "terminal_report_digest",
+    )
+    manifest["package_id"] = canonical_digest(
+        "evidence-package",
+        {field: manifest.get(field) for field in identity_fields},
+    )
+    receipt["phase0_evidence_manifest_digest"] = canonical_digest(
+        "evidence-manifest", manifest
+    )
+    receipt["phase0_evidence_package_id"] = manifest["package_id"]
+    receipt["receipt_digest"] = canonical_digest(
+        "phase1-receipt",
+        {key: value for key, value in receipt.items() if key != "receipt_digest"},
+    )
+
+    # This deliberately omits ``operation=``. The sealed receipt still has to
+    # bind 01-request.json to its own validated payload_request_digest.
+    with pytest.raises(ContractValidationError, match="request artifact binding"):
+        validate_receipt(receipt)
+
+
+def test_t15_self_consistent_returned_terminal_must_match_verified_manifest(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_preflight = adapter._preflight
+
+    def poisoned_preflight(pair_a_value: object, pair_b_value: object):
+        api = original_preflight(pair_a_value, pair_b_value)
+        workflow_type = api.OlympusWorkflow
+
+        class ReplacedTerminalWorkflow:
+            def __init__(self, **kwargs: object) -> None:
+                self._inner = workflow_type(**kwargs)
+
+            def run(self):
+                result = self._inner.run()
+                terminal = result.terminal_report.to_dict()
+                terminal["summary"] = (
+                    f"{terminal['summary']} replaced after verification"
+                )
+                replacement_digest = canonical_digest("terminal-report", terminal)
+                assert replacement_digest != result.terminal_report.digest
+                return dataclasses.replace(
+                    result,
+                    terminal_report=_DictObject(
+                        terminal,
+                        digest=replacement_digest,
+                    ),
+                )
+
+        return dataclasses.replace(api, OlympusWorkflow=ReplacedTerminalWorkflow)
+
+    monkeypatch.setattr(adapter, "_preflight", poisoned_preflight)
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert receipt["reason_codes"] == ["EVIDENCE_VERIFICATION_FAILED"]
+    assert receipt["phase0_terminal_report"] is None
+    assert receipt["phase0_evidence_manifest"] is None
+
+    operation = parse_operation(operation_bytes())
+    key = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    record_names = sorted(path.name for path in (key / "records").iterdir())
+    assert not any("ENGINE_EVIDENCE_VERIFIED" in name for name in record_names)
+    assert any("INDETERMINATE_NO_RETRY" in name for name in record_names)
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+def test_t16_static_runtime_exclusion_guard() -> None:
+    package = Path(adapter.__file__).parent
+    forbidden_imports = {
+        "_thread",
+        "agent",
+        "agents",
+        "aiohttp",
+        "anthropic",
+        "concurrent",
+        "config",
+        "configparser",
+        "configs",
+        "configuration",
+        "ctypes",
+        "delivery",
+        "dotenv",
+        "fastapi",
+        "ftplib",
+        "gateway",
+        "gateways",
+        "grpc",
+        "hermes_cli",
+        "http",
+        "httpx",
+        "imaplib",
+        "model_tools",
+        "multiprocessing",
+        "openai",
+        "plugin",
+        "plugins",
+        "pluggy",
+        "poplib",
+        "profile",
+        "profiles",
+        "provider",
+        "providers",
+        "pty",
+        "requests",
+        "route",
+        "routes",
+        "service",
+        "services",
+        "smtplib",
+        "socket",
+        "ssl",
+        "starlette",
+        "subprocess",
+        "telnetlib",
+        "tool",
+        "tools",
+        "tomllib",
+        "urllib",
+        "webbrowser",
+        "websockets",
+        "yaml",
+    }
+    forbidden_calls = {
+        "add_api_route",
+        "add_route",
+        "create_service",
+        "deliver",
+        "get_config",
+        "get_profile",
+        "include_router",
+        "load_config",
+        "load_profile",
+        "mount",
+        "read_config",
+        "register",
+        "register_plugin",
+        "register_route",
+        "register_tool",
+        "send",
+        "send_message",
+        "start_service",
+    }
+    forbidden_qualified_calls = {
+        "asyncio.create_subprocess_exec",
+        "asyncio.create_subprocess_shell",
+        "asyncio.create_task",
+        "builtins.compile",
+        "builtins.eval",
+        "builtins.exec",
+        "builtins.__import__",
+        "compile",
+        "eval",
+        "exec",
+        "__import__",
+        "os.fork",
+        "os.forkpty",
+        "os.popen",
+        "os.posix_spawn",
+        "os.posix_spawnp",
+        "os.startfile",
+        "os.system",
+        "threading.Thread",
+        "_thread.start_new_thread",
+    }
+
+    def qualified_name(node: ast.expr, aliases: dict[str, str]) -> str:
+        if isinstance(node, ast.Name):
+            return aliases.get(node.id, node.id)
+        if isinstance(node, ast.Attribute):
+            parent = qualified_name(node.value, aliases)
+            return f"{parent}.{node.attr}" if parent else node.attr
+        return ""
+
+    paths = sorted(package.rglob("*.py"))
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        aliases: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name.split(".", 1)[0])
+                    aliases[alias.asname or alias.name.split(".", 1)[0]] = (
+                        alias.name
+                    )
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".", 1)[0])
+                for alias in node.names:
+                    aliases[alias.asname or alias.name] = (
+                        f"{node.module}.{alias.name}"
+                    )
+        assert not (imported & forbidden_imports), (path, imported & forbidden_imports)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = qualified_name(node.func, aliases)
+            leaf = name.rsplit(".", 1)[-1]
+            assert leaf not in forbidden_calls, (path, name)
+            assert name not in forbidden_qualified_calls, (path, name)
+            assert not name.startswith(
+                ("socket.", "subprocess.", "multiprocessing.")
+            ), (path, name)
+            assert not name.startswith(("os.exec", "os.spawn")), (path, name)
+            if name.startswith("importlib."):
+                assert name == "importlib.import_module", (path, name)
+                assert len(node.args) == 1 and not node.keywords, (path, name)
+                assert isinstance(node.args[0], ast.Constant), (path, name)
+                assert node.args[0].value == "olympus_engine", (path, name)
+
+    source = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    for forbidden in (
+        "AIAgent",
+        "PluginManager",
+        "config.yaml",
+        "gateway/",
+        "/v1/runs",
+        "provider_factory",
+        "run_conversation",
+        "send_message_tool",
+    ):
+        assert forbidden not in source
+
+
+def test_t16_runtime_forbidden_capabilities_are_unreachable(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    violations: list[str] = []
+
+    def denied(label: str):
+        def fail(*_args: object, **_kwargs: object) -> None:
+            violations.append(label)
+            raise AssertionError(f"forbidden Phase 1 capability reached: {label}")
+
+        return fail
+
+    for module, names in (
+        (
+            socket,
+            ("socket", "socketpair", "create_connection", "create_server"),
+        ),
+        (
+            subprocess,
+            (
+                "Popen",
+                "run",
+                "call",
+                "check_call",
+                "check_output",
+                "getoutput",
+                "getstatusoutput",
+            ),
+        ),
+        (multiprocessing, ("Process", "Pool", "get_context")),
+        (
+            asyncio,
+            ("create_task", "create_subprocess_exec", "create_subprocess_shell"),
+        ),
+        (threading, ("Thread",)),
+    ):
+        for name in names:
+            if hasattr(module, name):
+                monkeypatch.setattr(module, name, denied(f"{module.__name__}.{name}"))
+
+    for name in (
+        "fork",
+        "forkpty",
+        "popen",
+        "posix_spawn",
+        "posix_spawnp",
+        "startfile",
+        "system",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+    ):
+        if hasattr(os, name):
+            monkeypatch.setattr(os, name, denied(f"os.{name}"))
+
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert pair_a.call_count == pair_b.call_count == 1
+    assert violations == []
+
+
+def test_t17_package_is_excluded_from_distribution_metadata() -> None:
+    from setuptools import find_namespace_packages, find_packages
+
+    root = Path(adapter.__file__).parents[1]
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    manifest_path = root / "MANIFEST.in"
+    manifest = (
+        manifest_path.read_text(encoding="utf-8")
+        if manifest_path.is_file()
+        else ""
+    )
+    setuptools_metadata = pyproject["tool"]["setuptools"]
+    finder = setuptools_metadata["packages"]["find"]
+    all_packages = set(find_packages(where=str(root)))
+    configured_finder = (
+        find_namespace_packages
+        if finder.get("namespaces", True)
+        else find_packages
+    )
+    configured_packages = set(
+        configured_finder(
+            where=str(root),
+            include=tuple(finder["include"]),
+            exclude=tuple(finder.get("exclude", ())),
+        )
+    )
+    assert "olympus_phase1_adapter" in all_packages
+    assert not any(
+        package == "olympus_phase1_adapter"
+        or package.startswith("olympus_phase1_adapter.")
+        for package in configured_packages
+    )
+
+    published_metadata = {
+        "scripts": pyproject["project"].get("scripts", {}),
+        "gui-scripts": pyproject["project"].get("gui-scripts", {}),
+        "entry-points": pyproject["project"].get("entry-points", {}),
+        "py-modules": setuptools_metadata.get("py-modules", []),
+        "package-data": setuptools_metadata.get("package-data", {}),
+        "data-files": setuptools_metadata.get("data-files", {}),
+    }
+    assert "olympus_phase1_adapter" not in json.dumps(
+        published_metadata, sort_keys=True
+    )
+    assert "olympus_phase1_adapter" not in manifest
+
+
+def test_t17_in_process_wheel_and_sdist_filelists_exclude_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from setuptools import Distribution, find_namespace_packages
+    from setuptools.command.build_py import build_py
+    from setuptools.command.egg_info import egg_info
+    from setuptools.command.sdist import sdist
+
+    root = Path(adapter.__file__).parents[1]
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    setuptools_metadata = pyproject["tool"]["setuptools"]
+    finder = setuptools_metadata["packages"]["find"]
+    packages = sorted(
+        find_namespace_packages(
+            where=str(root),
+            include=tuple(finder["include"]),
+            exclude=tuple(finder.get("exclude", ())),
+        )
+    )
+    scripts = pyproject["project"].get("scripts", {})
+    distribution = Distribution(
+        {
+            "name": pyproject["project"]["name"],
+            "version": pyproject["project"]["version"],
+            "packages": packages,
+            "package_dir": {"": str(root)},
+            "py_modules": setuptools_metadata.get("py-modules", []),
+            "entry_points": {
+                "console_scripts": [
+                    f"{name} = {target}" for name, target in scripts.items()
+                ]
+            },
+        }
+    )
+    distribution.script_name = str(root / "pyproject.toml")
+
+    wheel_command = build_py(distribution)
+    wheel_command.build_lib = str(tmp_path / "wheel-tree")
+    wheel_command.ensure_finalized()
+    wheel_sources = {
+        Path(path).resolve() for path in wheel_command.get_source_files()
+    }
+
+    egg_base = tmp_path / "egg-info"
+    egg_base.mkdir()
+    egg_command = egg_info(distribution)
+    egg_command.egg_base = str(egg_base)
+    egg_command.ensure_finalized()
+    distribution.command_obj["egg_info"] = egg_command
+    sdist_command = sdist(distribution)
+    distribution.command_obj["sdist"] = sdist_command
+    before_repo_egg_info = sorted(root.glob("*.egg-info"))
+    monkeypatch.chdir(root)
+    sdist_command.ensure_finalized()
+    sdist_command.run_command("egg_info")
+    sdist_command.filelist = egg_command.filelist
+    sdist_sources = {
+        (root / path).resolve() for path in sdist_command.filelist.files
+    }
+
+    adapter_root = (root / "olympus_phase1_adapter").resolve()
+
+    def belongs_to_adapter(path: Path) -> bool:
+        return path == adapter_root or adapter_root in path.parents
+
+    assert not any(belongs_to_adapter(path) for path in wheel_sources)
+    assert not any(belongs_to_adapter(path) for path in sdist_sources)
+    assert "olympus_phase1_adapter" not in str(distribution.entry_points)
+    assert sorted(root.glob("*.egg-info")) == before_repo_egg_info
+    assert any(egg_base.rglob("SOURCES.txt"))
+
+
+def test_t18_frozen_digests_vectors_and_schema_bytes() -> None:
+    packet_path = Path(
+        "/Users/macmini/Hermes-Handoff/reviews/"
+        "olympus-phase1-gate2-design-freeze-20260806T130942Z/"
+        "OLYMPUS_PHASE1_GATE2_IMPLEMENTATION_DESIGN_FREEZE_PACKET.json"
+    )
+    packet_raw = packet_path.read_bytes()
+    assert hashlib.sha256(packet_raw).hexdigest() == GATE2_PACKET_SHA256
+    packet = strict_loads(packet_raw)
+    assert isinstance(packet, dict)
+
+    integrity = packet["integrity"]
+    assert isinstance(integrity, dict)
+    integrity_payload = canonical_bytes(
+        {key: value for key, value in packet.items() if key != "integrity"}
+    )
+    assert len(integrity_payload) == integrity["payload_bytes"] == 148_364
+    assert integrity["payload_sha256"] == (
+        "94f7628b0ac1dd95289fdffeed6d661c151a6c543cbd5ca12c686fcf5646842c"
+    )
+    assert hashlib.sha256(integrity_payload).hexdigest() == integrity[
+        "payload_sha256"
+    ]
+
+    contract = packet["contract"]
+    assert isinstance(contract, dict)
+    assert contract["phase1_contract_digest"] == PHASE1_CONTRACT_DIGEST
+    assert canonical_digest("phase1-contract", contract["surface"]) == (
+        PHASE1_CONTRACT_DIGEST
+    )
+    phase0_files = packet["phase0_provenance_and_import"][
+        "source_and_schema_files"
+    ]
+    assert canonical_digest("phase1-phase0-binding", phase0_files) == (
+        PHASE0_RUNTIME_BINDING_DIGEST
+    )
+    gate1 = packet["gate1_binding"]
+    assert gate1["raw_sha256"] == GATE1_PACKET_SHA256
+    assert gate1["engine_contract_digest"] == ENGINE_CONTRACT_DIGEST
+
+    root = Path(adapter.__file__).parents[1]
+    schemas = packet["schemas"]
+    assert isinstance(schemas, list) and len(schemas) == 3
+    for schema in schemas:
+        assert isinstance(schema, dict)
+        schema_raw = (root / str(schema["path"])).read_bytes()
+        assert len(schema_raw) == schema["raw_bytes"]
+        assert hashlib.sha256(schema_raw).hexdigest() == schema["raw_sha256"]
+        document = strict_loads(schema_raw)
+        assert document == schema["document"]
+        assert isinstance(document, dict)
+        assert document["$id"] == schema["schema_id"]
+        assert canonical_digest("json-schema", document) == (
+            schema["canonical_schema_digest"]
+        )
+
+    vectors = packet["digest_vectors"]
+    operation_vector = vectors["operation"]
+    operation = parse_operation(canonical_bytes(operation_vector["envelope"]))
+    assert operation.semantic_body == operation_vector["semantic_body"]
+    assert canonical_bytes(operation.semantic_body).hex() == (
+        operation_vector["canonical_semantic_body_hex"]
+    )
+    assert operation.idempotency_key_digest == (
+        operation_vector["idempotency_key_digest"]
+    )
+    assert operation.operation_digest == operation_vector["operation_digest"]
+    assert operation.payload_request_digest == (
+        operation_vector["payload_request_digest"]
+    )
+
+    record_vector = vectors["first_ownership_record"]
+    record, record_raw = build_record(
+        operation,
+        sequence=1,
+        state="OWNERSHIP_ACQUIRED",
+        previous_record_digest=None,
+    )
+    assert record == record_vector["record"]
+    assert record_raw.hex() == record_vector["canonical_record_hex"]
+
+    receipt_vector = vectors["transient_receipt"]
+    transient_raw = transient_rejection("ENVELOPE_INVALID_JSON")
+    assert strict_loads(transient_raw) == receipt_vector["receipt"]
+    assert transient_raw.hex() == receipt_vector["canonical_receipt_hex"]
+
+    verify_frozen_schemas()
+    assert GATE1_PACKET_SHA256 == (
+        "6ef02d1e63d19853e0794b6c324f0e7233ec082744419fae529ed16e6e11cacf"
+    )
+    assert GATE2_PACKET_SHA256 == (
+        "445f0ce7bbf3c063ce84d7b1ae47154241e5bb6f148969790a5d63dfca4f6d25"
+    )
+    assert PHASE1_CONTRACT_DIGEST == (
+        "e5db4065e1e39134a5274152a01363d2ed3a0c79fb5d4bdb9c1773d36a2b1de1"
+    )
+    assert ENGINE_CONTRACT_DIGEST == (
+        "2c5860582fcc73192b4e301544e043189dac1079b47078bad3c1f93371b8ee85"
+    )
+    assert PHASE0_RUNTIME_BINDING_DIGEST == (
+        "366f41af5292272b183605cb1f6f5ab75b3a259c453d3396eab34a34bb83cb12"
+    )
+    assert digest_vectors() == {
+        "idempotency_key_digest": operation_vector["idempotency_key_digest"],
+        "operation_digest": operation_vector["operation_digest"],
+        "payload_request_digest": operation_vector["payload_request_digest"],
+        "first_record_digest": record_vector["record"]["record_digest"],
+        "transient_invalid_json_receipt_digest": receipt_vector["receipt"][
+            "receipt_digest"
+        ],
+    }
+
+
+def test_t18_sealed_receipt_unavailable_annotation_is_exact() -> None:
+    hints = get_type_hints(SealedReceiptUnavailable.__init__)
+    assert hints["receipt_state"] == Literal[
+        "REJECTED_PRE_INVOKE",
+        "ENGINE_TERMINAL",
+        "INDETERMINATE_NO_RETRY",
+    ]
+
+
+def test_t20_postclaim_receipt_unavailable_raises_exact_exception(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    operation = parse_operation(operation_bytes())
+    monkeypatch.setattr(
+        OwnerHandle,
+        "seal",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PersistenceError("injected receipt failure")
+        ),
+    )
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    error = caught.value
+    assert str(error) == (
+        "Phase 1 attempt is indeterminate and no sealed receipt is available; "
+        "automatic retry is forbidden"
+    )
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    assert error.idempotency_key_digest == operation.idempotency_key_digest
+    assert error.operation_digest == operation.operation_digest
+    assert error.receipt_state == "INDETERMINATE_NO_RETRY"
+    assert error.reason_code == "PERSISTENCE_CORRUPTION"
+    assert error.automatic_engine_retry_permitted is False
+    calls = (pair_a.call_count, pair_b.call_count)
+    monkeypatch.undo()
+    recovered = strict_loads(
+        _call(phase1_roots, operation_bytes(), object(), object())
+    )
+    assert recovered["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert recovered["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+    assert (pair_a.call_count, pair_b.call_count) == calls
+
+
+def test_t21_preinvoke_receipt_unavailable_raises_exact_exception(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    operation = parse_operation(operation_bytes())
+    original_append = OwnerHandle.append
+
+    def fail_claim(self: OwnerHandle, state: str, **kwargs: object):
+        if state == "INVOCATION_CLAIMED":
+            raise PersistenceError("injected claim failure")
+        return original_append(self, state, **kwargs)
+
+    monkeypatch.setattr(OwnerHandle, "append", fail_claim)
+    monkeypatch.setattr(
+        OwnerHandle,
+        "seal",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PersistenceError("injected receipt failure")
+        ),
+    )
+    with pytest.raises(PreInvokeReceiptUnavailable) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    error = caught.value
+    assert str(error) == (
+        "Phase 1 invocation did not occur, but no sealed rejection receipt is "
+        "available; automatic retry is forbidden"
+    )
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    assert error.idempotency_key_digest == operation.idempotency_key_digest
+    assert error.operation_digest == operation.operation_digest
+    assert error.engine_invocation_occurred is False
+    assert error.receipt_state == "REJECTED_PRE_INVOKE"
+    assert error.reason_code == "PERSISTENCE_CORRUPTION"
+    assert error.automatic_engine_retry_permitted is False
+    monkeypatch.undo()
+    recovered = strict_loads(
+        _call(phase1_roots, operation_bytes(), object(), object())
+    )
+    assert recovered["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert recovered["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+def _control_flow_objects() -> list[BaseException]:
+    return [
+        KeyboardInterrupt("injected"),
+        SystemExit(73),
+        asyncio.CancelledError("injected"),
+    ]
+
+
+@pytest.mark.parametrize("injected", _control_flow_objects())
+def test_t23_control_flow_before_ownership_is_identical_and_writes_no_key(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+
+    def interrupt_preflight(_pair_a: object, _pair_b: object):
+        raise injected
+
+    monkeypatch.setattr(adapter, "_preflight", interrupt_preflight)
+    with pytest.raises(type(injected)) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert caught.value is injected
+    operation = parse_operation(operation_bytes())
+    key = (
+        phase1_roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+    assert not key.exists()
+    assert pair_a.call_count == pair_b.call_count == 0
+    assert sorted(path.name for path in phase1_roots["receipt"].iterdir()) == [
+        ".phase1-store.lock",
+        "v1",
+    ]
+    assert list(phase1_roots["evidence"].iterdir()) == []
+
+    monkeypatch.undo()
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    )
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize("injected", _control_flow_objects())
+def test_t23_control_flow_after_ownership_before_claim_is_identical(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_append = OwnerHandle.append
+
+    def interrupt_before_claim(
+        self: OwnerHandle, state: str, **kwargs: object
+    ):
+        if state == "INVOCATION_CLAIMED":
+            raise injected
+        return original_append(self, state, **kwargs)
+
+    monkeypatch.setattr(OwnerHandle, "append", interrupt_before_claim)
+    with pytest.raises(type(injected)) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert caught.value is injected
+    assert pair_a.call_count == pair_b.call_count == 0
+    monkeypatch.undo()
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), object(), object())
+    )
+    assert receipt["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert receipt["reason_codes"] == ["CANCELLED_BEFORE_INVOCATION_CLAIM"]
+
+
+@pytest.mark.parametrize("injected", _control_flow_objects())
+def test_t23_control_flow_after_claim_is_identical_and_never_reinvokes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_append = OwnerHandle.append
+
+    def interrupt_after_claim(
+        self: OwnerHandle, state: str, **kwargs: object
+    ):
+        result = original_append(self, state, **kwargs)
+        if state == "INVOCATION_CLAIMED":
+            raise injected
+        return result
+
+    monkeypatch.setattr(OwnerHandle, "append", interrupt_after_claim)
+    with pytest.raises(type(injected)) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert caught.value is injected
+    assert pair_a.call_count == pair_b.call_count == 0
+    monkeypatch.undo()
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), object(), object())
+    )
+    assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert receipt["reason_codes"] == ["CANCELLED_AFTER_INVOCATION_CLAIM"]
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+@pytest.mark.parametrize("injected", _control_flow_objects())
+def test_t23_control_flow_after_receipt_seal_is_identical_and_replayable(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    finalize_calls = 0
+
+    def interrupt_finalization(_self: OwnerHandle) -> None:
+        nonlocal finalize_calls
+        finalize_calls += 1
+        raise injected
+
+    monkeypatch.setattr(OwnerHandle, "_finalize_once", interrupt_finalization)
+    with pytest.raises(type(injected)) as caught:
+        _call(phase1_roots, operation_bytes(), pair_a, pair_b)
+    assert caught.value is injected
+    assert finalize_calls == 1
+    assert pair_a.call_count == pair_b.call_count == 1
+    monkeypatch.undo()
+    receipt = strict_loads(
+        _call(phase1_roots, operation_bytes(), object(), object())
+    )
+    assert receipt["receipt_state"] == "ENGINE_TERMINAL"
+    assert receipt["reason_codes"] == ["PHASE0_TERMINAL"]
+    assert pair_a.call_count == pair_b.call_count == 1

--- a/tests/olympus_phase1_adapter/test_receipt_store.py
+++ b/tests/olympus_phase1_adapter/test_receipt_store.py
@@ -1,0 +1,2817 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+import fcntl
+import multiprocessing
+import os
+import stat
+import threading
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+import pytest
+
+from olympus_phase1_adapter import receipt_store as store_module
+from olympus_phase1_adapter.adapter import (
+    IndeterminateReceiptUnavailable,
+    SealedReceiptUnavailable,
+    execute_operation,
+)
+from olympus_phase1_adapter.contracts import (
+    ContractValidationError,
+    Operation,
+    canonical_bytes,
+    canonical_digest,
+    parse_operation,
+    strict_loads,
+    validate_receipt,
+)
+from olympus_phase1_adapter.receipt_store import (
+    OwnerHandle,
+    PersistenceError,
+    ReceiptStore,
+    StoreIndeterminate,
+    StoreIndeterminateUnavailable,
+    StorePreInvokeUnavailable,
+    open_root_set,
+)
+
+from conftest import (
+    operation_bytes,
+    operation_value,
+    valid_transports,
+)
+
+
+def _claim_owner(
+    roots: dict[str, Path],
+    envelope: bytes,
+) -> tuple[store_module.RootSet, OwnerHandle]:
+    operation = parse_operation(envelope)
+    capabilities = open_root_set(
+        repository_root=roots["repository"],
+        receipt_root=roots["receipt"],
+        evidence_root=roots["evidence"],
+    )
+    try:
+        result = ReceiptStore(capabilities).claim(
+            operation, fresh_preflight=lambda: None
+        )
+    except BaseException:
+        capabilities.close()
+        raise
+    assert result.response is None and result.owner is not None
+    return capabilities, result.owner
+
+
+def _recover(
+    roots: dict[str, Path],
+    envelope: bytes,
+) -> bytes:
+    operation = parse_operation(envelope)
+    with open_root_set(
+        repository_root=roots["repository"],
+        receipt_root=roots["receipt"],
+        evidence_root=roots["evidence"],
+    ) as capabilities:
+        result = ReceiptStore(capabilities).claim(
+            operation,
+            fresh_preflight=lambda: pytest.fail(
+                "existing key invoked fresh preflight"
+            ),
+        )
+        assert result.owner is None and result.response is not None
+        return result.response
+
+
+def _key_directory(roots: dict[str, Path], operation: Operation) -> Path:
+    return (
+        roots["receipt"]
+        / "v1"
+        / operation.idempotency_key_digest[:2]
+        / operation.idempotency_key_digest
+    )
+
+
+def _snapshot_tree(root: Path) -> dict[str, tuple[str, int, int, int, bytes | None]]:
+    snapshot: dict[str, tuple[str, int, int, int, bytes | None]] = {}
+    for path in sorted((root, *root.rglob("*"))):
+        entry = path.lstat()
+        relative = "." if path == root else path.relative_to(root).as_posix()
+        kind = (
+            "symlink"
+            if stat.S_ISLNK(entry.st_mode)
+            else "directory"
+            if stat.S_ISDIR(entry.st_mode)
+            else "file"
+            if stat.S_ISREG(entry.st_mode)
+            else "other"
+        )
+        raw = path.read_bytes() if kind == "file" else None
+        snapshot[relative] = (
+            kind,
+            stat.S_IMODE(entry.st_mode),
+            entry.st_ino,
+            entry.st_nlink,
+            raw,
+        )
+    return snapshot
+
+
+def _execute_with_objects(roots: dict[str, Path], envelope: bytes) -> bytes:
+    return execute_operation(
+        envelope,
+        repository_root=roots["repository"],
+        receipt_root=roots["receipt"],
+        evidence_root=roots["evidence"],
+        pair_a=object(),
+        pair_b=object(),
+    )
+
+
+@pytest.mark.parametrize("existing_rejection", [False, True])
+def test_t08_clean_preclaim_orphan_recovers_without_invocation(
+    phase1_roots: dict[str, Path],
+    existing_rejection: bool,
+) -> None:
+    envelope = operation_bytes()
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        if existing_rejection:
+            owner.append(
+                "PREINVOKE_REJECTED",
+                reason_code="CANCELLED_BEFORE_INVOCATION_CLAIM",
+            )
+    finally:
+        owner.close()
+        capabilities.close()
+    receipt = strict_loads(_recover(phase1_roots, envelope))
+    assert receipt["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert receipt["reason_codes"] == [
+        (
+            "CANCELLED_BEFORE_INVOCATION_CLAIM"
+            if existing_rejection
+            else "RECOVERED_BEFORE_INVOCATION_CLAIM"
+        )
+    ]
+    operation = parse_operation(envelope)
+    record_names = sorted(
+        path.name
+        for path in (_key_directory(phase1_roots, operation) / "records").iterdir()
+    )
+    assert sum("PREINVOKE_REJECTED" in name for name in record_names) == 1
+    assert record_names[-1].endswith("RECEIPT_FINALIZED.json")
+
+
+@pytest.mark.parametrize("evidence_kind", ["final", "staging"])
+def test_t08_existing_preinvoke_rejection_with_evidence_is_not_mutated(
+    phase1_roots: dict[str, Path],
+    evidence_kind: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        owner.append(
+            "PREINVOKE_REJECTED",
+            reason_code="CANCELLED_BEFORE_INVOCATION_CLAIM",
+        )
+        destination = owner.evidence_destination
+    finally:
+        owner.close()
+        capabilities.close()
+    evidence_path = (
+        destination
+        if evidence_kind == "final"
+        else destination.parent / f".{destination.name}.adversarial.staging"
+    )
+    evidence_path.mkdir(mode=0o700)
+    before_receipt = _snapshot_tree(phase1_roots["receipt"])
+    before_evidence = _snapshot_tree(phase1_roots["evidence"])
+
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, envelope)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+    assert caught.value.operation_digest == operation.operation_digest
+    assert _snapshot_tree(phase1_roots["receipt"]) == before_receipt
+    assert _snapshot_tree(phase1_roots["evidence"]) == before_evidence
+
+
+@pytest.mark.parametrize("evidence_kind", ["final", "staging", "scan-error"])
+def test_t08_different_operation_preclaim_evidence_is_indeterminate(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    evidence_kind: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    destination = owner.evidence_destination
+    owner.close()
+    capabilities.close()
+
+    scan_tripped = False
+    if evidence_kind == "final":
+        destination.mkdir(mode=0o700)
+    elif evidence_kind == "staging":
+        destination.with_name(
+            f".{destination.name}.different-operation.staging"
+        ).mkdir(mode=0o700)
+    else:
+        original_scan = store_module._directory_has_matching_name
+
+        def fail_matching_scan(path: Path, predicate: object) -> bool:
+            nonlocal scan_tripped
+            if path == destination.parent:
+                scan_tripped = True
+                raise PersistenceError("injected evidence scan failure")
+            return original_scan(path, predicate)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            store_module, "_directory_has_matching_name", fail_matching_scan
+        )
+
+    before_receipt = _snapshot_tree(phase1_roots["receipt"])
+    before_evidence = _snapshot_tree(phase1_roots["evidence"])
+    different = operation_bytes(
+        correlation_id="corr-phase1-different-preclaim-operation"
+    )
+    current = parse_operation(different)
+
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, different)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__ is True
+    assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+    assert caught.value.operation_digest == current.operation_digest
+    assert scan_tripped is (evidence_kind == "scan-error")
+    assert _snapshot_tree(phase1_roots["receipt"]) == before_receipt
+    assert _snapshot_tree(phase1_roots["evidence"]) == before_evidence
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_reason"),
+    [
+        ("unsafe-receipt", "UNSAFE_RECEIPT_ROOT"),
+        ("overlap", "ROOTS_OVERLAP"),
+        ("unsafe-evidence", "UNSAFE_EVIDENCE_ROOT"),
+        ("unsafe-repository", "UNSAFE_REPOSITORY_ROOT"),
+    ],
+)
+def test_t13_root_rejection_reason_precedence_is_global_not_argument_order(
+    phase1_roots: dict[str, Path],
+    scenario: str,
+    expected_reason: str,
+) -> None:
+    repository = phase1_roots["repository"]
+    receipt_root = phase1_roots["receipt"]
+    evidence_root = phase1_roots["evidence"]
+    evidence_argument = evidence_root
+
+    repository.chmod(0o777)
+    if scenario == "unsafe-receipt":
+        receipt_root.chmod(0o755)
+        evidence_argument = receipt_root
+    elif scenario == "overlap":
+        evidence_argument = receipt_root
+    elif scenario == "unsafe-evidence":
+        evidence_root.chmod(0o755)
+
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=repository,
+        receipt_root=receipt_root,
+        evidence_root=evidence_argument,
+        pair_a=object(),
+        pair_b=object(),
+    )
+    rejection = strict_loads(raw)
+    assert rejection["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert rejection["durability"] == "TRANSIENT"
+    assert rejection["reason_codes"] == [expected_reason]
+
+
+@pytest.mark.parametrize(
+    ("alias_root", "target_root"),
+    [
+        ("evidence", "receipt"),
+        ("repository", "receipt"),
+        ("evidence", "repository"),
+        ("repository", "evidence"),
+    ],
+)
+def test_t13_symlink_alias_overlap_precedes_lower_root_safety(
+    phase1_roots: dict[str, Path],
+    tmp_path: Path,
+    alias_root: str,
+    target_root: str,
+) -> None:
+    alias = tmp_path / f"{alias_root}-alias-to-{target_root}"
+    alias.symlink_to(phase1_roots[target_root], target_is_directory=True)
+    repository_argument = (
+        alias if alias_root == "repository" else phase1_roots["repository"]
+    )
+    evidence_argument = (
+        alias if alias_root == "evidence" else phase1_roots["evidence"]
+    )
+    before_receipt = _snapshot_tree(phase1_roots["receipt"])
+    before_evidence = _snapshot_tree(phase1_roots["evidence"])
+
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=repository_argument,
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=evidence_argument,
+        pair_a=object(),
+        pair_b=object(),
+    )
+
+    rejection = strict_loads(raw)
+    assert rejection["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert rejection["durability"] == "TRANSIENT"
+    assert rejection["reason_codes"] == ["ROOTS_OVERLAP"]
+    assert _snapshot_tree(phase1_roots["receipt"]) == before_receipt
+    assert _snapshot_tree(phase1_roots["evidence"]) == before_evidence
+
+
+@pytest.mark.parametrize("hold_unlinked_inode", [False, True])
+def test_t13_established_store_never_replaces_missing_global_lock(
+    phase1_roots: dict[str, Path],
+    hold_unlinked_inode: bool,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    owner.close()
+    capabilities.close()
+    lock_path = phase1_roots["receipt"] / ".phase1-store.lock"
+    old_fd: int | None = None
+    if hold_unlinked_inode:
+        old_fd = os.open(lock_path, os.O_RDWR)
+        fcntl.flock(old_fd, fcntl.LOCK_EX)
+    lock_path.unlink()
+    before = _snapshot_tree(phase1_roots["receipt"])
+
+    try:
+        with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+            _execute_with_objects(phase1_roots, envelope)
+        assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+        assert not lock_path.exists()
+        assert _snapshot_tree(phase1_roots["receipt"]) == before
+    finally:
+        if old_fd is not None:
+            fcntl.flock(old_fd, fcntl.LOCK_UN)
+            os.close(old_fd)
+
+
+@pytest.mark.parametrize("lock_adversary", ["wrong-mode", "hardlink"])
+def test_t13_established_store_global_lock_anomaly_is_indeterminate(
+    phase1_roots: dict[str, Path],
+    lock_adversary: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    owner.close()
+    capabilities.close()
+    lock_path = phase1_roots["receipt"] / ".phase1-store.lock"
+    if lock_adversary == "wrong-mode":
+        lock_path.chmod(0o640)
+    else:
+        os.link(lock_path, phase1_roots["evidence"] / "global-lock-alias")
+    before = _snapshot_tree(phase1_roots["receipt"])
+
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, envelope)
+
+    assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+    assert caught.value.operation_digest == operation.operation_digest
+    assert _snapshot_tree(phase1_roots["receipt"]) == before
+
+
+@pytest.mark.parametrize("lock_adversary", ["unlink", "replacement", "wrong-mode"])
+def test_t13_t19_active_owner_never_masks_global_lock_anomaly(
+    phase1_roots: dict[str, Path],
+    lock_adversary: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    lock_path = phase1_roots["receipt"] / ".phase1-store.lock"
+    try:
+        if lock_adversary == "unlink":
+            lock_path.unlink()
+        elif lock_adversary == "replacement":
+            lock_path.unlink()
+            lock_path.write_bytes(b"")
+            lock_path.chmod(0o600)
+        else:
+            lock_path.chmod(0o640)
+        before = _snapshot_tree(phase1_roots["receipt"])
+
+        with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+            _execute_with_objects(phase1_roots, envelope)
+
+        assert caught.value.__cause__ is None
+        assert caught.value.__suppress_context__ is True
+        assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+        assert caught.value.operation_digest == operation.operation_digest
+        assert _snapshot_tree(phase1_roots["receipt"]) == before
+    finally:
+        owner.close()
+        capabilities.close()
+
+
+@pytest.mark.parametrize(
+    "receipt_adversary",
+    ["absent", "truncated", "noncanonical", "wrong-mode", "hardlink"],
+)
+def test_t22_final_record_proves_sealed_receipt_when_bytes_are_unavailable(
+    phase1_roots: dict[str, Path],
+    receipt_adversary: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        predecessor = owner.append(
+            "PREINVOKE_REJECTED",
+            reason_code="CANCELLED_BEFORE_INVOCATION_CLAIM",
+        )
+        raw = owner.seal(
+            receipt_state="REJECTED_PRE_INVOKE",
+            reason_code="CANCELLED_BEFORE_INVOCATION_CLAIM",
+        )
+    finally:
+        owner.close()
+        capabilities.close()
+    receipt = strict_loads(raw)
+    key = _key_directory(phase1_roots, operation)
+    records = key / "records"
+    receipt_path = key / "receipt.json"
+    key.chmod(0o700)
+    records.chmod(0o700)
+    receipt_path.chmod(0o600)
+    if receipt_adversary == "absent":
+        receipt_path.unlink()
+    elif receipt_adversary == "truncated":
+        receipt_path.write_bytes(raw[:19])
+    elif receipt_adversary == "noncanonical":
+        receipt_path.write_bytes(raw + b"\n")
+    elif receipt_adversary == "wrong-mode":
+        receipt_path.chmod(0o640)
+    else:
+        os.link(receipt_path, phase1_roots["evidence"] / "receipt-alias")
+    final_name = max(path.name for path in records.iterdir())
+    assert final_name.endswith("RECEIPT_FINALIZED.json")
+    assert predecessor["record_digest"] != receipt["receipt_digest"]
+    before = _snapshot_tree(phase1_roots["receipt"])
+
+    with pytest.raises(SealedReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, envelope)
+
+    error = caught.value
+    assert error.__cause__ is None
+    assert error.receipt_digest == receipt["receipt_digest"]
+    assert error.receipt_state == "REJECTED_PRE_INVOKE"
+    assert error.idempotency_key_digest == operation.idempotency_key_digest
+    assert error.operation_digest == operation.operation_digest
+    assert _snapshot_tree(phase1_roots["receipt"]) == before
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["INVOCATION_CLAIMED", "ENGINE_EVIDENCE_VERIFIED", "INDETERMINATE_NO_RETRY"],
+)
+def test_t09_consumed_attempt_orphan_recovers_without_second_invocation(
+    phase1_roots: dict[str, Path],
+    prefix: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        owner.append("INVOCATION_CLAIMED")
+        if prefix in {"ENGINE_EVIDENCE_VERIFIED", "INDETERMINATE_NO_RETRY"}:
+            owner.append(
+                "ENGINE_EVIDENCE_VERIFIED",
+                reason_code="PHASE0_TERMINAL",
+                phase0_terminal_report_digest="1" * 64,
+                phase0_evidence_manifest_digest="2" * 64,
+                phase0_evidence_directory_name=(
+                    f"phase0-{operation.idempotency_key_digest}"
+                ),
+            )
+        if prefix == "INDETERMINATE_NO_RETRY":
+            owner.append(
+                "INDETERMINATE_NO_RETRY",
+                reason_code="ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT",
+            )
+    finally:
+        owner.close()
+        capabilities.close()
+    receipt = strict_loads(_recover(phase1_roots, envelope))
+    assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert receipt["reason_codes"] == [
+        (
+            "ENGINE_EXCEPTION_WITHOUT_SEALED_RECEIPT"
+            if prefix == "INDETERMINATE_NO_RETRY"
+            else "RECOVERED_AFTER_INVOCATION_CLAIM"
+        )
+    ]
+    assert receipt["phase0_terminal_report"] is None
+    record_names = sorted(
+        path.name
+        for path in (_key_directory(phase1_roots, operation) / "records").iterdir()
+    )
+    assert sum("INDETERMINATE_NO_RETRY" in name for name in record_names) == 1
+
+
+@pytest.mark.parametrize("evidence_kind", ["final", "staging"])
+def test_t09_consumed_recovery_preserves_matching_evidence_opaquely(
+    phase1_roots: dict[str, Path],
+    evidence_kind: str,
+) -> None:
+    envelope = operation_bytes()
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        owner.append("INVOCATION_CLAIMED")
+        destination = owner.evidence_destination
+    finally:
+        owner.close()
+        capabilities.close()
+    evidence_path = (
+        destination
+        if evidence_kind == "final"
+        else destination.parent / f".{destination.name}.preserved.staging"
+    )
+    evidence_path.mkdir(mode=0o700)
+    artifact = evidence_path / "opaque.bin"
+    artifact.write_bytes(b"opaque Phase 0 evidence\x00")
+    artifact.chmod(0o600)
+    before = _snapshot_tree(phase1_roots["evidence"])
+
+    receipt = strict_loads(_recover(phase1_roots, envelope))
+
+    assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+    assert receipt["reason_codes"] == ["RECOVERED_AFTER_INVOCATION_CLAIM"]
+    assert _snapshot_tree(phase1_roots["evidence"]) == before
+
+
+def _cross_process_owner(
+    repository: str,
+    receipt: str,
+    evidence: str,
+    envelope: bytes,
+    ready: Any,
+    release: Any,
+    queue: Any,
+) -> None:
+    os.umask(0o077)
+    roots = {
+        "repository": Path(repository),
+        "receipt": Path(receipt),
+        "evidence": Path(evidence),
+    }
+    capabilities, owner = _claim_owner(roots, envelope)
+    try:
+        anchor = str(owner.records[0]["record_digest"])
+        owner.append("INVOCATION_CLAIMED")
+        queue.put(("owner", anchor))
+        ready.set()
+        if not release.wait(20):
+            raise RuntimeError("owner release timed out")
+    finally:
+        owner.close()
+        capabilities.close()
+
+
+def _cross_process_contender(
+    repository: str,
+    receipt: str,
+    evidence: str,
+    envelope: bytes,
+    ready: Any,
+    queue: Any,
+    label: str,
+) -> None:
+    os.umask(0o077)
+    if not ready.wait(20):
+        raise RuntimeError("owner readiness timed out")
+    roots = {
+        "repository": Path(repository),
+        "receipt": Path(receipt),
+        "evidence": Path(evidence),
+    }
+    operation = parse_operation(envelope)
+    with open_root_set(
+        repository_root=roots["repository"],
+        receipt_root=roots["receipt"],
+        evidence_root=roots["evidence"],
+    ) as capabilities:
+        result = ReceiptStore(capabilities).claim(
+            operation,
+            fresh_preflight=lambda: (_ for _ in ()).throw(
+                RuntimeError("active key ran preflight")
+            ),
+        )
+        if result.response is None:
+            raise RuntimeError("contender unexpectedly became owner")
+        queue.put((label, result.response))
+
+
+def test_t07_real_spawned_process_contention_uses_sequence_one_anchor(
+    phase1_roots: dict[str, Path],
+) -> None:
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    queue = context.Queue()
+    same = operation_bytes()
+    different = canonical_bytes(
+        operation_value(correlation_id="corr-phase1-process-other")
+    )
+    arguments = tuple(str(phase1_roots[name]) for name in ("repository", "receipt", "evidence"))
+    owner = context.Process(
+        target=_cross_process_owner,
+        args=(*arguments, same, ready, release, queue),
+    )
+    owner.start()
+    assert ready.wait(20)
+    contenders = [
+        context.Process(
+            target=_cross_process_contender,
+            args=(*arguments, envelope, ready, queue, label),
+        )
+        for envelope, label in ((same, "same"), (different, "different"))
+    ]
+    for process in contenders:
+        process.start()
+    results: dict[str, Any] = {}
+    try:
+        for _ in range(3):
+            label, value = queue.get(timeout=20)
+            results[label] = value
+    except Empty as exc:
+        raise AssertionError("spawned contention result timed out") from exc
+    finally:
+        release.set()
+    for process in contenders:
+        process.join(20)
+        assert process.exitcode == 0
+    owner.join(20)
+    assert owner.exitcode == 0
+    anchor = results["owner"]
+    same_receipt = strict_loads(results["same"])
+    different_receipt = strict_loads(results["different"])
+    assert same_receipt["receipt_state"] == "CONFLICT_IN_PROGRESS"
+    assert different_receipt["receipt_state"] == "IDEMPOTENCY_CONFLICT"
+    assert same_receipt["ownership_record_digest"] == anchor
+    assert different_receipt["ownership_record_digest"] == anchor
+    assert same_receipt["bound_operation_digest"] == parse_operation(same).operation_digest
+    assert different_receipt["bound_operation_digest"] == parse_operation(same).operation_digest
+
+
+@pytest.mark.parametrize("adversary", ["unexpected", "torn-record", "hardlink"])
+def test_t13_unclassifiable_existing_key_is_never_mutated(
+    phase1_roots: dict[str, Path],
+    adversary: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    owner.close()
+    capabilities.close()
+    key = _key_directory(phase1_roots, operation)
+    if adversary == "unexpected":
+        unexpected = key / "unexpected"
+        unexpected.write_bytes(b"adversarial")
+        unexpected.chmod(0o600)
+    elif adversary == "torn-record":
+        first = key / "records" / "000001-OWNERSHIP_ACQUIRED.json"
+        first.write_bytes(first.read_bytes() + b"\n")
+        first.chmod(0o600)
+    else:
+        os.link(key / "lock", key / "lock-alias")
+    before = {
+        path.relative_to(key).as_posix(): (
+            path.read_bytes() if path.is_file() else None
+        )
+        for path in key.rglob("*")
+    }
+    with pytest.raises(StoreIndeterminate):
+        _recover(phase1_roots, envelope)
+    after = {
+        path.relative_to(key).as_posix(): (
+            path.read_bytes() if path.is_file() else None
+        )
+        for path in key.rglob("*")
+    }
+    assert after == before
+
+
+@pytest.mark.parametrize("adversary", ["torn-later-record", "unexpected-entry"])
+def test_t13_different_operation_never_masks_existing_store_corruption(
+    phase1_roots: dict[str, Path],
+    adversary: str,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        owner.append("INVOCATION_CLAIMED")
+    finally:
+        owner.close()
+        capabilities.close()
+    key = _key_directory(phase1_roots, operation)
+    if adversary == "torn-later-record":
+        second = key / "records" / "000002-INVOCATION_CLAIMED.json"
+        second.write_bytes(second.read_bytes() + b"\n")
+    else:
+        unexpected = key / "unexpected"
+        unexpected.write_bytes(b"adversarial")
+        unexpected.chmod(0o600)
+    before = _snapshot_tree(phase1_roots["receipt"])
+    different = operation_bytes(correlation_id="corr-phase1-different-operation")
+
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, different)
+
+    current = parse_operation(different)
+    assert caught.value.__cause__ is None
+    assert caught.value.idempotency_key_digest == current.idempotency_key_digest
+    assert caught.value.operation_digest == current.operation_digest
+    assert _snapshot_tree(phase1_roots["receipt"]) == before
+
+
+def test_t13_existing_key_noncontention_flock_failure_is_indeterminate(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    owner.close()
+    capabilities.close()
+    key_lock = _key_directory(phase1_roots, operation) / "lock"
+    key_identity = (key_lock.stat().st_dev, key_lock.stat().st_ino)
+    original_flock = store_module.fcntl.flock
+
+    def fail_key_flock(fd: int, flags: int) -> None:
+        entry = os.fstat(fd)
+        if (
+            (entry.st_dev, entry.st_ino) == key_identity
+            and flags & fcntl.LOCK_EX
+            and flags & fcntl.LOCK_NB
+        ):
+            raise OSError(errno.EIO, "injected existing-key flock failure")
+        original_flock(fd, flags)
+
+    monkeypatch.setattr(store_module.fcntl, "flock", fail_key_flock)
+    before = _snapshot_tree(phase1_roots["receipt"])
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        _execute_with_objects(phase1_roots, envelope)
+    assert caught.value.idempotency_key_digest == operation.idempotency_key_digest
+    assert caught.value.operation_digest == operation.operation_digest
+    assert _snapshot_tree(phase1_roots["receipt"]) == before
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"durability": "SEALED"},
+        {"automatic_engine_retry_permitted": True},
+        {"bound_operation_digest": "f" * 64},
+        {"reason_codes": ["ACTIVE_OWNER", "PHASE0_TERMINAL"]},
+    ],
+)
+def test_t13_receipt_cross_field_adversaries_fail_schema_or_semantics(
+    mutation: dict[str, object],
+) -> None:
+    receipt = strict_loads(
+        store_module.transient_conflict(
+            parse_operation(operation_bytes()),
+            bound_operation_digest=parse_operation(
+                operation_bytes()
+            ).operation_digest,
+            ownership_record_digest="a" * 64,
+        )
+    )
+    receipt.update(mutation)
+    body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    receipt["receipt_digest"] = canonical_digest(
+        "phase1-receipt", body
+    )
+    with pytest.raises(ContractValidationError):
+        validate_receipt(receipt)
+
+
+def test_t13_publication_revalidation_rejects_target_name_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = tmp_path / "key"
+    records = key / "records"
+    key.mkdir(mode=0o700)
+    records.mkdir(mode=0o700)
+    raw = b'{"bounded":"publication"}'
+    original_stat = store_module.os.stat
+    original_open = store_module.os.open
+    original_write = store_module.os.write
+    original_close = store_module.os.close
+    original_rename = store_module.os.rename
+    tripped = False
+
+    def swap_named_target(
+        path: object,
+        *args: object,
+        **kwargs: object,
+    ):
+        nonlocal tripped
+        parent_fd = kwargs.get("dir_fd")
+        if path == "target.json" and isinstance(parent_fd, int) and not tripped:
+            tripped = True
+            original_rename(
+                "target.json",
+                "target.swapped",
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            replacement_fd = original_open(
+                "target.json",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            try:
+                remaining = memoryview(raw)
+                while remaining:
+                    written = original_write(replacement_fd, remaining)
+                    assert written > 0
+                    remaining = remaining[written:]
+            finally:
+                original_close(replacement_fd)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "stat", swap_named_target)
+    attempt = store_module._PublicationAttempt()
+    with pytest.raises(PersistenceError, match="revalidation"):
+        store_module._publish_no_replace(
+            key_directory=key,
+            target_parent=records,
+            target_name="target.json",
+            raw=raw,
+            attempt=attempt,
+        )
+
+    assert tripped
+    assert attempt.final_revalidated is False
+    assert (records / "target.json").read_bytes() == raw
+    assert (records / "target.swapped").read_bytes() == raw
+    assert (records / "target.json").stat().st_ino != (
+        records / "target.swapped"
+    ).stat().st_ino
+
+
+def test_t13_file_append_during_read_revalidation_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "record.json"
+    path.write_bytes(b'{"sequence":1}')
+    path.chmod(0o600)
+    original_stat = store_module.os.stat
+    original_open = store_module.os.open
+    original_write = store_module.os.write
+    original_close = store_module.os.close
+    tripped = False
+
+    def append_before_named_revalidation(
+        value: object,
+        *args: object,
+        **kwargs: object,
+    ):
+        nonlocal tripped
+        if value == path and not tripped:
+            tripped = True
+            append_fd = original_open(path, os.O_WRONLY | os.O_APPEND)
+            try:
+                assert original_write(append_fd, b"\n") == 1
+            finally:
+                original_close(append_fd)
+        return original_stat(value, *args, **kwargs)
+
+    monkeypatch.setattr(
+        store_module.os, "stat", append_before_named_revalidation
+    )
+    with pytest.raises(PersistenceError, match="identity changed"):
+        store_module._read_regular(path, modes={0o600}, maximum=1024)
+    assert tripped
+
+
+@pytest.mark.parametrize(
+    "site",
+    [
+        "global-lock",
+        "global-lock-file-fsync",
+        "global-lock-parent-fsync",
+        "receipt-v1-mkdir",
+        "receipt-v1-child-fsync",
+        "receipt-v1-parent-fsync",
+        "receipt-shard-mkdir",
+        "receipt-shard-child-fsync",
+        "receipt-shard-parent-fsync",
+        "evidence-v1-mkdir",
+        "evidence-v1-child-fsync",
+        "evidence-v1-parent-fsync",
+        "evidence-shard-mkdir",
+        "evidence-shard-child-fsync",
+        "evidence-shard-parent-fsync",
+        "key-mkdir",
+        "key-child-fsync",
+        "key-parent-fsync",
+        "key-lock",
+        "key-lock-file-fsync",
+        "key-lock-parent-fsync",
+        "records-mkdir",
+        "records-child-fsync",
+        "records-parent-fsync",
+        "ownership-publication",
+    ],
+)
+def test_t14_fresh_claim_site_specific_faults_never_invoke(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    site: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    operation = parse_operation(operation_bytes())
+    receipt_v1 = phase1_roots["receipt"] / "v1"
+    receipt_shard = receipt_v1 / operation.idempotency_key_digest[:2]
+    key = receipt_shard / operation.idempotency_key_digest
+    evidence_v1 = phase1_roots["evidence"] / "v1"
+    evidence_shard = evidence_v1 / operation.idempotency_key_digest[:2]
+    global_lock = phase1_roots["receipt"] / ".phase1-store.lock"
+    key_lock = key / "lock"
+    records = key / "records"
+    original_create_directory = store_module._create_directory
+    original_fsync_directory = store_module._fsync_directory
+    original_create_global = store_module._create_lock_file
+    original_create_key = store_module._create_permanent_lock
+    original_publish = store_module._publish_no_replace
+    original_fsync = store_module.os.fsync
+    original_fstat = store_module.os.fstat
+    tripped = False
+
+    def maybe_fail_directory(parent: Path, name: str) -> Path:
+        nonlocal tripped
+        matches = {
+            "receipt-v1-mkdir": parent == phase1_roots["receipt"] and name == "v1",
+            "receipt-shard-mkdir": parent == receipt_v1
+            and name == operation.idempotency_key_digest[:2],
+            "evidence-v1-mkdir": parent == phase1_roots["evidence"] and name == "v1",
+            "evidence-shard-mkdir": parent == evidence_v1
+            and name == operation.idempotency_key_digest[:2],
+            "key-mkdir": parent == receipt_shard
+            and name == operation.idempotency_key_digest,
+            "records-mkdir": parent == key and name == "records",
+        }.get(site, False)
+        if matches and not tripped:
+            tripped = True
+            raise PersistenceError(f"injected site fault: {site}")
+        return original_create_directory(parent, name)
+
+    def maybe_fail_directory_fsync(path: Path, modes: set[int]) -> None:
+        nonlocal tripped
+        matches = {
+            "receipt-v1-child-fsync": path == receipt_v1,
+            "receipt-v1-parent-fsync": path == phase1_roots["receipt"]
+            and receipt_v1.exists(),
+            "receipt-shard-child-fsync": path == receipt_shard,
+            "receipt-shard-parent-fsync": path == receipt_v1
+            and receipt_shard.exists(),
+            "evidence-v1-child-fsync": path == evidence_v1,
+            "evidence-v1-parent-fsync": path == phase1_roots["evidence"]
+            and evidence_v1.exists(),
+            "evidence-shard-child-fsync": path == evidence_shard,
+            "evidence-shard-parent-fsync": path == evidence_v1
+            and evidence_shard.exists(),
+            "key-child-fsync": path == key,
+            "key-parent-fsync": path == receipt_shard and key.exists(),
+            "records-child-fsync": path == records,
+            "records-parent-fsync": path == key and records.exists(),
+        }.get(site, False)
+        if matches and not tripped:
+            tripped = True
+            raise PersistenceError(f"injected directory fsync fault: {site}")
+        original_fsync_directory(path, modes)
+
+    def maybe_fail_global(*args: object, **kwargs: object) -> int:
+        nonlocal tripped
+        if site == "global-lock" and not tripped:
+            tripped = True
+            raise PersistenceError("injected global-lock site fault")
+        return original_create_global(*args, **kwargs)
+
+    def maybe_fail_key_lock(*args: object, **kwargs: object) -> int:
+        nonlocal tripped
+        if site == "key-lock" and not tripped:
+            tripped = True
+            raise PersistenceError("injected key-lock site fault")
+        return original_create_key(*args, **kwargs)
+
+    def maybe_fail_ownership_publish(**kwargs: object) -> None:
+        nonlocal tripped
+        if (
+            site == "ownership-publication"
+            and str(kwargs["target_name"]).endswith("OWNERSHIP_ACQUIRED.json")
+            and not tripped
+        ):
+            tripped = True
+            raise PersistenceError("injected ownership publication site fault")
+        original_publish(**kwargs)
+
+    def fd_matches(fd: int, path: Path) -> bool:
+        try:
+            held = original_fstat(fd)
+            named = path.stat(follow_symlinks=False)
+        except OSError:
+            return False
+        return (held.st_dev, held.st_ino) == (named.st_dev, named.st_ino)
+
+    def maybe_fail_lock_fsync(fd: int) -> None:
+        nonlocal tripped
+        target = {
+            "global-lock-file-fsync": global_lock,
+            "global-lock-parent-fsync": phase1_roots["receipt"],
+            "key-lock-file-fsync": key_lock,
+            "key-lock-parent-fsync": key,
+        }.get(site)
+        if (
+            target is not None
+            and target.exists()
+            and fd_matches(fd, target)
+            and not tripped
+        ):
+            tripped = True
+            raise OSError(errno.EIO, f"injected lock fsync fault: {site}")
+        original_fsync(fd)
+
+    monkeypatch.setattr(store_module, "_create_directory", maybe_fail_directory)
+    monkeypatch.setattr(
+        store_module, "_fsync_directory", maybe_fail_directory_fsync
+    )
+    monkeypatch.setattr(store_module, "_create_lock_file", maybe_fail_global)
+    monkeypatch.setattr(
+        store_module, "_create_permanent_lock", maybe_fail_key_lock
+    )
+    monkeypatch.setattr(
+        store_module, "_publish_no_replace", maybe_fail_ownership_publish
+    )
+    monkeypatch.setattr(store_module.os, "fsync", maybe_fail_lock_fsync)
+
+    receipt = strict_loads(
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    )
+    assert tripped
+    assert receipt["durability"] == "TRANSIENT"
+    assert receipt["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("directory_kind", "boundary"),
+    [
+        (directory_kind, boundary)
+        for directory_kind in (
+            "receipt-v1",
+            "receipt-shard",
+            "evidence-v1",
+            "evidence-shard",
+        )
+        for boundary in ("child-fsync", "parent-fsync")
+    ],
+)
+def test_t14_retry_refsyncs_interrupted_existing_directory_before_ownership(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    directory_kind: str,
+    boundary: str,
+) -> None:
+    operation = parse_operation(operation_bytes())
+    receipt_v1 = phase1_roots["receipt"] / "v1"
+    receipt_shard = receipt_v1 / operation.idempotency_key_digest[:2]
+    evidence_v1 = phase1_roots["evidence"] / "v1"
+    evidence_shard = evidence_v1 / operation.idempotency_key_digest[:2]
+    target, parent = {
+        "receipt-v1": (receipt_v1, phase1_roots["receipt"]),
+        "receipt-shard": (receipt_shard, receipt_v1),
+        "evidence-v1": (evidence_v1, phase1_roots["evidence"]),
+        "evidence-shard": (evidence_shard, evidence_v1),
+    }[directory_kind]
+    key = receipt_shard / operation.idempotency_key_digest
+    original_fsync_directory = store_module._fsync_directory
+    child_seen = False
+    tripped = False
+
+    def interrupt_directory_fsync(path: Path, modes: set[int]) -> None:
+        nonlocal child_seen, tripped
+        if path == target:
+            child_seen = True
+            if boundary == "child-fsync" and not tripped:
+                tripped = True
+                raise PersistenceError(
+                    f"injected interrupted directory fsync: {directory_kind}"
+                )
+        if (
+            path == parent
+            and child_seen
+            and boundary == "parent-fsync"
+            and not tripped
+        ):
+            tripped = True
+            raise PersistenceError(
+                f"injected interrupted parent fsync: {directory_kind}"
+            )
+        original_fsync_directory(path, modes)
+
+    monkeypatch.setattr(
+        store_module, "_fsync_directory", interrupt_directory_fsync
+    )
+    with open_root_set(
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+    ) as capabilities:
+        with pytest.raises(PersistenceError):
+            ReceiptStore(capabilities).claim(
+                operation, fresh_preflight=lambda: None
+            )
+
+    assert tripped
+    assert target.is_dir()
+    assert not key.exists()
+
+    monkeypatch.undo()
+    original_fsync_directory = store_module._fsync_directory
+    original_publish = store_module._publish_no_replace
+    events: list[str] = []
+    retry_child_seen = False
+
+    def observe_directory_fsync(path: Path, modes: set[int]) -> None:
+        nonlocal retry_child_seen
+        original_fsync_directory(path, modes)
+        if path == target:
+            retry_child_seen = True
+            events.append("existing-child-refsync")
+        elif path == parent and retry_child_seen:
+            events.append("existing-parent-refsync")
+
+    def observe_publication(**kwargs: object) -> None:
+        if str(kwargs["target_name"]).endswith("OWNERSHIP_ACQUIRED.json"):
+            events.append("ownership-publication")
+        original_publish(**kwargs)
+
+    monkeypatch.setattr(
+        store_module, "_fsync_directory", observe_directory_fsync
+    )
+    monkeypatch.setattr(store_module, "_publish_no_replace", observe_publication)
+    with open_root_set(
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+    ) as capabilities:
+        result = ReceiptStore(capabilities).claim(
+            operation, fresh_preflight=lambda: None
+        )
+        assert result.response is None and result.owner is not None
+        result.owner.close()
+
+    assert events.index("existing-child-refsync") < events.index(
+        "existing-parent-refsync"
+    )
+    assert events.index("existing-parent-refsync") < events.index(
+        "ownership-publication"
+    )
+    record_names = sorted(path.name for path in (key / "records").iterdir())
+    assert record_names == ["000001-OWNERSHIP_ACQUIRED.json"]
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["mkdir", "write", "fsync", "link", "unlink", "flock"],
+)
+def test_t14_topology_and_publication_faults_fail_before_invocation(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+
+    def fail(*_args: object, **_kwargs: object):
+        raise OSError(errno.EIO, f"injected {boundary} failure")
+
+    if boundary == "mkdir":
+        monkeypatch.setattr(store_module.os, "mkdir", fail)
+    elif boundary == "write":
+        monkeypatch.setattr(store_module.os, "write", fail)
+    elif boundary == "fsync":
+        monkeypatch.setattr(store_module.os, "fsync", fail)
+    elif boundary == "link":
+        monkeypatch.setattr(store_module.os, "link", fail)
+    elif boundary == "unlink":
+        monkeypatch.setattr(store_module.os, "unlink", fail)
+    else:
+        monkeypatch.setattr(store_module.fcntl, "flock", fail)
+    if boundary == "unlink":
+        with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+            execute_operation(
+                operation_bytes(),
+                repository_root=phase1_roots["repository"],
+                receipt_root=phase1_roots["receipt"],
+                evidence_root=phase1_roots["evidence"],
+                pair_a=pair_a,
+                pair_b=pair_b,
+            )
+        assert caught.value.__cause__ is None
+        assert pair_a.call_count == pair_b.call_count == 0
+        return
+    receipt = strict_loads(
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    )
+    assert receipt["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert receipt["durability"] == "TRANSIENT"
+    assert receipt["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+@pytest.mark.parametrize("target_kind", ["ownership", "receipt"])
+def test_t14_postlink_unlink_failure_preserves_phase_classification(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    target_kind: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if isinstance(source, str) and source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def fail_unlink_once(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        target = linked_targets.get(name, "")
+        matches = (
+            target_kind == "ownership" and target.endswith("OWNERSHIP_ACQUIRED.json")
+        ) or (target_kind == "receipt" and target == "receipt.json")
+        if matches and not tripped:
+            tripped = True
+            raise OSError(errno.EIO, "injected post-link unlink failure")
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", fail_unlink_once)
+    if target_kind == "ownership":
+        with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+            execute_operation(
+                operation_bytes(),
+                repository_root=phase1_roots["repository"],
+                receipt_root=phase1_roots["receipt"],
+                evidence_root=phase1_roots["evidence"],
+                pair_a=pair_a,
+                pair_b=pair_b,
+            )
+        assert caught.value.__cause__ is None
+        assert pair_a.call_count == pair_b.call_count == 0
+        assert list(phase1_roots["receipt"].rglob(".phase1-stage-*"))
+        return
+
+    first = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert strict_loads(first)["receipt_state"] == "ENGINE_TERMINAL"
+    assert tripped
+    assert pair_a.call_count == pair_b.call_count == 1
+    assert list(phase1_roots["receipt"].rglob(".phase1-stage-*"))
+
+    replay = execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+    )
+    assert replay == first
+    assert pair_a.call_count == pair_b.call_count == 1
+    assert not list(phase1_roots["receipt"].rglob(".phase1-stage-*"))
+
+
+@pytest.mark.parametrize("boundary", ["link", "unlink"])
+@pytest.mark.parametrize("control_flow", [False, True])
+def test_t14_publication_side_effect_then_raise_is_at_most_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    control_flow: bool,
+) -> None:
+    key = tmp_path / "key"
+    records = key / "records"
+    key.mkdir(mode=0o700)
+    records.mkdir(mode=0o700)
+    raw = b'{"side_effect":"then-raise"}'
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    primary: BaseException = (
+        KeyboardInterrupt(f"{boundary}-after-side-effect")
+        if control_flow
+        else OSError(errno.EIO, f"{boundary}-after-side-effect")
+    )
+    counts = {"link": 0, "unlink": 0}
+    tripped = False
+
+    def link_then_maybe_raise(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        if source.startswith(".phase1-stage-") and target == "target.json":
+            counts["link"] += 1
+            original_link(source, target, *args, **kwargs)
+            if boundary == "link" and not tripped:
+                tripped = True
+                raise primary
+            return
+        original_link(source, target, *args, **kwargs)
+
+    def unlink_then_maybe_raise(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        if name.startswith(".phase1-stage-"):
+            counts["unlink"] += 1
+            original_unlink(name, *args, **kwargs)
+            if boundary == "unlink" and not tripped:
+                tripped = True
+                raise primary
+            return
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", link_then_maybe_raise)
+    monkeypatch.setattr(store_module.os, "unlink", unlink_then_maybe_raise)
+    attempt = store_module._PublicationAttempt()
+    if control_flow:
+        with pytest.raises(type(primary)) as caught:
+            store_module._publish_no_replace(
+                key_directory=key,
+                target_parent=records,
+                target_name="target.json",
+                raw=raw,
+                attempt=attempt,
+            )
+        assert caught.value is primary
+    else:
+        store_module._publish_no_replace(
+            key_directory=key,
+            target_parent=records,
+            target_name="target.json",
+            raw=raw,
+            attempt=attempt,
+        )
+
+    assert tripped
+    assert counts == {"link": 1, "unlink": 1}
+    assert attempt.complete
+    assert (records / "target.json").read_bytes() == raw
+    assert list(key.glob(".phase1-stage-*")) == []
+
+
+@pytest.mark.parametrize("control_flow", [False, True])
+def test_t14_publication_close_fault_preserves_primary_and_closes_every_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    control_flow: bool,
+) -> None:
+    key = tmp_path / "key"
+    records = key / "records"
+    key.mkdir(mode=0o700)
+    records.mkdir(mode=0o700)
+    original_open = store_module.os.open
+    original_close = store_module.os.close
+    original_fstat = store_module.os.fstat
+    opened: list[int] = []
+    close_fault_tripped = False
+    primary: BaseException = (
+        KeyboardInterrupt("publication-primary")
+        if control_flow
+        else PersistenceError("publication-primary")
+    )
+
+    def remember_open(*args: object, **kwargs: object) -> int:
+        fd = original_open(*args, **kwargs)
+        opened.append(fd)
+        return fd
+
+    def fail_write(*_args: object, **_kwargs: object) -> int:
+        raise primary
+
+    def close_then_raise_once(fd: int) -> None:
+        nonlocal close_fault_tripped
+        original_close(fd)
+        if fd in opened and not close_fault_tripped:
+            close_fault_tripped = True
+            raise OSError(errno.EIO, "injected publication close failure")
+
+    monkeypatch.setattr(store_module.os, "open", remember_open)
+    monkeypatch.setattr(store_module.os, "write", fail_write)
+    monkeypatch.setattr(store_module.os, "close", close_then_raise_once)
+    with pytest.raises(type(primary)) as caught:
+        store_module._publish_no_replace(
+            key_directory=key,
+            target_parent=records,
+            target_name="target.json",
+            raw=b"publication-primary",
+        )
+
+    assert caught.value is primary
+    assert close_fault_tripped
+    assert len(opened) == 3
+    for fd in opened:
+        with pytest.raises(OSError) as closed:
+            original_fstat(fd)
+        assert closed.value.errno == errno.EBADF
+
+
+def test_t14_committed_incomplete_claim_record_stops_same_call_mutation(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def fail_claim_stage_unlink(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        target = linked_targets.get(name, "")
+        if target.endswith("INVOCATION_CLAIMED.json") and not tripped:
+            tripped = True
+            raise OSError(errno.EIO, "injected committed claim cleanup failure")
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", fail_claim_stage_unlink)
+    with pytest.raises(IndeterminateReceiptUnavailable) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+
+    assert tripped
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__ is True
+    assert pair_a.call_count == pair_b.call_count == 0
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    record_names = sorted(path.name for path in (key / "records").iterdir())
+    assert any(name.endswith("OWNERSHIP_ACQUIRED.json") for name in record_names)
+    assert any(name.endswith("INVOCATION_CLAIMED.json") for name in record_names)
+    assert not any("PREINVOKE_REJECTED" in name for name in record_names)
+    assert not any("INDETERMINATE_NO_RETRY" in name for name in record_names)
+    assert not any("RECEIPT_FINALIZED" in name for name in record_names)
+    assert not (key / "receipt.json").exists()
+
+
+def _publication_control_flow_objects() -> list[BaseException]:
+    return [
+        KeyboardInterrupt("post-link"),
+        SystemExit(79),
+        asyncio.CancelledError("post-link"),
+    ]
+
+
+@pytest.mark.parametrize("injected", _publication_control_flow_objects())
+def test_t23_postlink_ownership_control_flow_is_identical_and_recoverable(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if isinstance(source, str) and source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def interrupt_after_link(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        target = linked_targets.get(name, "")
+        if target.endswith("OWNERSHIP_ACQUIRED.json") and not tripped:
+            tripped = True
+            raise injected
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", interrupt_after_link)
+    with pytest.raises(type(injected)) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    assert caught.value is injected
+    assert tripped
+    assert pair_a.call_count == pair_b.call_count == 0
+    monkeypatch.undo()
+    with pytest.raises(IndeterminateReceiptUnavailable):
+        _execute_with_objects(phase1_roots, operation_bytes())
+
+
+@pytest.mark.parametrize("injected", _publication_control_flow_objects())
+def test_t23_postlink_receipt_control_flow_preserves_sealed_outcome(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if isinstance(source, str) and source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def interrupt_after_link(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        if linked_targets.get(name) == "receipt.json" and not tripped:
+            tripped = True
+            raise injected
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", interrupt_after_link)
+    with pytest.raises(type(injected)) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    assert caught.value is injected
+    assert tripped
+    assert pair_a.call_count == pair_b.call_count == 1
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    sealed_raw = (key / "receipt.json").read_bytes()
+    assert list(key.rglob(".phase1-stage-*"))
+    monkeypatch.undo()
+    replay = _execute_with_objects(phase1_roots, operation_bytes())
+    assert replay == sealed_raw
+    assert list(key.rglob(".phase1-stage-*")) == []
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize("injected", _publication_control_flow_objects())
+def test_t23_postlink_final_record_control_flow_repairs_and_replays_exact_bytes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def interrupt_after_link(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        target = linked_targets.get(name, "")
+        if target.endswith("RECEIPT_FINALIZED.json") and not tripped:
+            tripped = True
+            raise injected
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", interrupt_after_link)
+    with pytest.raises(type(injected)) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    assert caught.value is injected
+    assert tripped
+    assert pair_a.call_count == pair_b.call_count == 1
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    sealed_raw = (key / "receipt.json").read_bytes()
+    assert list(key.rglob(".phase1-stage-*"))
+
+    monkeypatch.undo()
+    replay = _execute_with_objects(phase1_roots, operation_bytes())
+    assert replay == sealed_raw
+    assert list(key.rglob(".phase1-stage-*")) == []
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize("target_kind", ["receipt", "final-record"])
+def test_t22_postlink_sealed_alias_repair_fault_is_never_indeterminate(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    target_kind: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    linked_targets: dict[str, str] = {}
+    injected = KeyboardInterrupt(f"{target_kind}-post-link")
+    tripped = False
+
+    def remember_link(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        original_link(source, target, *args, **kwargs)
+        if source.startswith(".phase1-stage-"):
+            linked_targets[source] = target
+
+    def interrupt_target_unlink(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        target = linked_targets.get(name, "")
+        matches = (
+            target_kind == "receipt" and target == "receipt.json"
+        ) or (
+            target_kind == "final-record"
+            and target.endswith("RECEIPT_FINALIZED.json")
+        )
+        if matches and not tripped:
+            tripped = True
+            raise injected
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "link", remember_link)
+    monkeypatch.setattr(store_module.os, "unlink", interrupt_target_unlink)
+    with pytest.raises(KeyboardInterrupt) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+    assert caught.value is injected
+    assert tripped
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    sealed = strict_loads((key / "receipt.json").read_bytes())
+    assert list(key.rglob(".phase1-stage-*"))
+
+    monkeypatch.undo()
+    repair_unlink = store_module.os.unlink
+
+    def fail_alias_repair(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        if name.startswith(".phase1-stage-"):
+            raise OSError(errno.EIO, "injected alias repair failure")
+        repair_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.os, "unlink", fail_alias_repair)
+    with pytest.raises(SealedReceiptUnavailable) as unavailable:
+        _execute_with_objects(phase1_roots, operation_bytes())
+
+    error = unavailable.value
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    assert error.idempotency_key_digest == operation.idempotency_key_digest
+    assert error.operation_digest == operation.operation_digest
+    assert error.receipt_digest == sealed["receipt_digest"]
+    assert error.receipt_state == "ENGINE_TERMINAL"
+    assert error.receipt_was_durably_sealed is True
+    assert error.automatic_engine_retry_permitted is False
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "release_boundary", ["global-unlock", "global-close", "root-release"]
+)
+@pytest.mark.parametrize("claim_outcome", ["owner", "sealed-response"])
+def test_t14_t19_fresh_claim_release_fault_has_no_owner_or_fd_leak(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    release_boundary: str,
+    claim_outcome: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    operation = parse_operation(operation_bytes())
+    receipt_entry = phase1_roots["receipt"].stat()
+    root_identity = (receipt_entry.st_dev, receipt_entry.st_ino)
+    registry_key = (*root_identity, operation.idempotency_key_digest)
+    original_create_global = store_module._create_lock_file
+    original_create_key = store_module._create_permanent_lock
+    original_flock = store_module.fcntl.flock
+    original_close = store_module.os.close
+    original_fstat = store_module.os.fstat
+    original_root_release = store_module._root_mutex_release
+    original_registry_insert = store_module._registry_insert
+    global_fds: list[int] = []
+    key_fds: list[int] = []
+    release_tripped = False
+    insert_tripped = False
+
+    def remember_global_fd(*args: object, **kwargs: object) -> int:
+        fd = original_create_global(*args, **kwargs)
+        global_fds.append(fd)
+        return fd
+
+    def remember_key_fd(*args: object, **kwargs: object) -> int:
+        fd = original_create_key(*args, **kwargs)
+        key_fds.append(fd)
+        return fd
+
+    def unlock_then_raise(fd: int, flags: int) -> None:
+        nonlocal release_tripped
+        if (
+            release_boundary == "global-unlock"
+            and fd in global_fds
+            and flags == fcntl.LOCK_UN
+            and not release_tripped
+        ):
+            original_flock(fd, flags)
+            release_tripped = True
+            raise OSError(errno.EIO, "injected global unlock failure")
+        original_flock(fd, flags)
+
+    def close_then_raise(fd: int) -> None:
+        nonlocal release_tripped
+        if (
+            release_boundary == "global-close"
+            and fd in global_fds
+            and not release_tripped
+        ):
+            original_close(fd)
+            release_tripped = True
+            raise OSError(errno.EIO, "injected global close failure")
+        original_close(fd)
+
+    def release_root_then_raise(
+        identity: tuple[int, int], lock: threading.Lock
+    ) -> None:
+        nonlocal release_tripped
+        if (
+            release_boundary == "root-release"
+            and identity == root_identity
+            and not release_tripped
+        ):
+            original_root_release(identity, lock)
+            release_tripped = True
+            raise PersistenceError("injected root release failure")
+        original_root_release(identity, lock)
+
+    def insert_then_maybe_raise(*args: object, **kwargs: object) -> None:
+        nonlocal insert_tripped
+        original_registry_insert(*args, **kwargs)
+        if claim_outcome == "sealed-response" and not insert_tripped:
+            insert_tripped = True
+            raise PersistenceError("injected post-insert failure")
+
+    monkeypatch.setattr(store_module, "_create_lock_file", remember_global_fd)
+    monkeypatch.setattr(store_module, "_create_permanent_lock", remember_key_fd)
+    monkeypatch.setattr(store_module.fcntl, "flock", unlock_then_raise)
+    monkeypatch.setattr(store_module.os, "close", close_then_raise)
+    monkeypatch.setattr(
+        store_module, "_root_mutex_release", release_root_then_raise
+    )
+    monkeypatch.setattr(store_module, "_registry_insert", insert_then_maybe_raise)
+
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    receipt = strict_loads(raw)
+    assert release_tripped
+    assert insert_tripped is (claim_outcome == "sealed-response")
+    assert receipt["receipt_state"] == "REJECTED_PRE_INVOKE"
+    assert receipt["durability"] == "SEALED"
+    assert receipt["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+    assert pair_a.call_count == pair_b.call_count == 0
+    assert store_module._registry_lookup(registry_key) is None
+    assert root_identity not in store_module._ROOT_MUTEXES
+    for fd in [*global_fds, *key_fds]:
+        with pytest.raises(OSError) as closed:
+            original_fstat(fd)
+        assert closed.value.errno == errno.EBADF
+
+    monkeypatch.undo()
+    assert _execute_with_objects(phase1_roots, operation_bytes()) == raw
+    assert pair_a.call_count == pair_b.call_count == 0
+
+
+def test_t19_real_same_process_threads_wait_then_bind_durable_anchor(
+    phase1_roots: dict[str, Path],
+) -> None:
+    envelope = operation_bytes()
+    operation = parse_operation(envelope)
+    preflight_started = threading.Event()
+    allow_preflight = threading.Event()
+    owner_ready = threading.Event()
+    allow_owner_close = threading.Event()
+    contender_done = threading.Event()
+    shared: dict[str, Any] = {}
+
+    def owner_worker() -> None:
+        capabilities = open_root_set(
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+        )
+
+        def preflight() -> None:
+            preflight_started.set()
+            if not allow_preflight.wait(10):
+                raise RuntimeError("threaded preflight timed out")
+
+        result = ReceiptStore(capabilities).claim(
+            operation, fresh_preflight=preflight
+        )
+        assert result.owner is not None
+        owner = result.owner
+        shared["anchor"] = str(owner.records[0]["record_digest"])
+        owner.append("INVOCATION_CLAIMED")
+        owner_ready.set()
+        assert allow_owner_close.wait(10)
+        owner.close()
+        capabilities.close()
+
+    def contender_worker() -> None:
+        capabilities = open_root_set(
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+        )
+        result = ReceiptStore(capabilities).claim(
+            operation,
+            fresh_preflight=lambda: pytest.fail(
+                "thread contender ran fresh preflight"
+            ),
+        )
+        shared["contender"] = result.response
+        capabilities.close()
+        contender_done.set()
+
+    first = threading.Thread(target=owner_worker)
+    second = threading.Thread(target=contender_worker)
+    first.start()
+    assert preflight_started.wait(10)
+    second.start()
+    assert not contender_done.wait(0.1)
+    allow_preflight.set()
+    assert owner_ready.wait(10)
+    assert contender_done.wait(10)
+    contender = strict_loads(shared["contender"])
+    assert contender["receipt_state"] == "CONFLICT_IN_PROGRESS"
+    assert contender["ownership_record_digest"] == shared["anchor"]
+
+    different_same_key = parse_operation(
+        operation_bytes(correlation_id="corr-phase1-thread-other")
+    )
+    capabilities = open_root_set(
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+    )
+    different_conflict = ReceiptStore(capabilities).claim(
+        different_same_key,
+        fresh_preflight=lambda: pytest.fail(
+            "different-operation thread contender ran preflight"
+        ),
+    )
+    capabilities.close()
+    assert different_conflict.response is not None
+    different_receipt = strict_loads(different_conflict.response)
+    assert different_receipt["receipt_state"] == "IDEMPOTENCY_CONFLICT"
+    assert different_receipt["ownership_record_digest"] == shared["anchor"]
+    assert different_receipt["bound_operation_digest"] == operation.operation_digest
+
+    different = parse_operation(
+        operation_bytes(idempotency_key="idem-phase1-independent")
+    )
+    capabilities = open_root_set(
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+    )
+    independent = ReceiptStore(capabilities).claim(
+        different, fresh_preflight=lambda: None
+    )
+    assert independent.owner is not None
+    independent.owner.close()
+    capabilities.close()
+    allow_owner_close.set()
+    first.join(10)
+    second.join(10)
+    assert not first.is_alive() and not second.is_alive()
+
+
+@pytest.mark.parametrize("injected", _publication_control_flow_objects())
+def test_t19_t23_owner_cleanup_preserves_primary_and_removes_released_token(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    injected: BaseException,
+) -> None:
+    envelope = operation_bytes()
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    owner_fd = owner.key_lock_fd
+    registry_key = owner.registry_key
+    original_flock = store_module.fcntl.flock
+    tripped = False
+
+    def fail_unlock_once(fd: int, flags: int) -> None:
+        nonlocal tripped
+        if fd == owner_fd and flags == fcntl.LOCK_UN and not tripped:
+            tripped = True
+            raise OSError(errno.EIO, "injected owner unlock failure")
+        original_flock(fd, flags)
+
+    monkeypatch.setattr(store_module.fcntl, "flock", fail_unlock_once)
+    try:
+        with pytest.raises(type(injected)) as caught:
+            with owner:
+                raise injected
+        assert caught.value is injected
+        assert tripped
+        assert store_module._registry_lookup(registry_key) is None
+    finally:
+        capabilities.close()
+
+
+@pytest.mark.parametrize(
+    ("consumed", "failure_type"),
+    [
+        (False, StorePreInvokeUnavailable),
+        (True, StoreIndeterminateUnavailable),
+    ],
+)
+def test_t20_t21_recovery_append_failure_uses_exact_private_outcome(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    consumed: bool,
+    failure_type: type[BaseException],
+) -> None:
+    envelope = operation_bytes()
+    capabilities, owner = _claim_owner(phase1_roots, envelope)
+    try:
+        if consumed:
+            owner.append("INVOCATION_CLAIMED")
+    finally:
+        owner.close()
+        capabilities.close()
+    original_append = OwnerHandle.append
+
+    def fail_recovery_append(
+        self: OwnerHandle, state: str, **kwargs: object
+    ):
+        if state in {"PREINVOKE_REJECTED", "INDETERMINATE_NO_RETRY"}:
+            raise PersistenceError("injected recovery append failure")
+        return original_append(self, state, **kwargs)
+
+    monkeypatch.setattr(OwnerHandle, "append", fail_recovery_append)
+    with pytest.raises(failure_type):
+        _recover(phase1_roots, envelope)
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "final-record",
+        "record-1-chmod",
+        "record-2-chmod",
+        "record-3-chmod",
+        "record-4-chmod",
+        "receipt-chmod",
+        "records-directory-chmod",
+        "key-directory-chmod",
+    ],
+)
+def test_t22_postseal_failure_returns_safe_bytes_and_replay_finalizes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    tripped = False
+    original_publish = store_module._publish_no_replace
+    original_file_chmod = store_module._chmod_file_and_sync
+    original_directory_chmod = store_module._chmod_directory_and_sync
+
+    def publish(**kwargs: object) -> None:
+        nonlocal tripped
+        target_name = str(kwargs["target_name"])
+        if (
+            boundary == "final-record"
+            and "RECEIPT_FINALIZED" in target_name
+            and not tripped
+        ):
+            tripped = True
+            raise PersistenceError("injected final-record failure")
+        original_publish(**kwargs)
+
+    def file_chmod(path: Path, mode: int, parent: Path) -> None:
+        nonlocal tripped
+        record_boundary = (
+            boundary.startswith("record-") and boundary.endswith("-chmod")
+        )
+        record_sequence = (
+            int(boundary.removeprefix("record-").removesuffix("-chmod"))
+            if record_boundary
+            else None
+        )
+        matches = (
+            record_sequence is not None
+            and parent.name == "records"
+            and path.name.startswith(f"{record_sequence:06d}-")
+        ) or (boundary == "receipt-chmod" and path.name == "receipt.json")
+        if matches and not tripped:
+            tripped = True
+            raise PersistenceError("injected file chmod failure")
+        original_file_chmod(path, mode, parent)
+
+    def directory_chmod(path: Path, mode: int, parent: Path) -> None:
+        nonlocal tripped
+        matches = (
+            boundary == "records-directory-chmod" and path.name == "records"
+        ) or (
+            boundary == "key-directory-chmod" and path.name != "records"
+        )
+        if matches and not tripped:
+            tripped = True
+            raise PersistenceError("injected directory chmod failure")
+        original_directory_chmod(path, mode, parent)
+
+    monkeypatch.setattr(store_module, "_publish_no_replace", publish)
+    monkeypatch.setattr(store_module, "_chmod_file_and_sync", file_chmod)
+    monkeypatch.setattr(
+        store_module, "_chmod_directory_and_sync", directory_chmod
+    )
+    first = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert tripped
+    assert strict_loads(first)["receipt_state"] == "ENGINE_TERMINAL"
+    monkeypatch.undo()
+    replay = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=object(),
+        pair_b=object(),
+    )
+    assert replay == first
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    assert (key.stat().st_mode & 0o7777) == 0o500
+    assert ((key / "records").stat().st_mode & 0o7777) == 0o500
+    assert ((key / "receipt.json").stat().st_mode & 0o7777) == 0o400
+    assert all(
+        (path.stat().st_mode & 0o7777) == 0o400
+        for path in (key / "records").iterdir()
+    )
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "stage-create",
+        "stage-fsync",
+        "link",
+        "target-parent-fsync",
+        "unlink",
+        "stage-parent-fsync",
+    ],
+)
+def test_t22_final_record_publication_syscall_matrix_replays_exact_bytes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_publish = store_module._publish_no_replace
+    original_open = store_module.os.open
+    original_fsync = store_module.os.fsync
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    active_final_record = False
+    tripped = False
+    fault_calls = 0
+    fsync_ordinal = 0
+    fault_fd: int | None = None
+
+    def scoped_publish(**kwargs: object) -> None:
+        nonlocal active_final_record
+        previous = active_final_record
+        active_final_record = str(kwargs["target_name"]).endswith(
+            "RECEIPT_FINALIZED.json"
+        )
+        try:
+            original_publish(**kwargs)
+        finally:
+            active_final_record = previous
+
+    def fail_stage_create_once(*args: object, **kwargs: object) -> int:
+        nonlocal tripped, fault_calls
+        path = args[0] if args else kwargs.get("path")
+        if (
+            active_final_record
+            and boundary == "stage-create"
+            and isinstance(path, str)
+            and path.startswith(".phase1-stage-")
+        ):
+            fault_calls += 1
+            if not tripped:
+                tripped = True
+                raise OSError(errno.EIO, "injected final-record stage create failure")
+        return original_open(*args, **kwargs)
+
+    def fail_fsync_once(fd: int) -> None:
+        nonlocal tripped, fault_calls, fsync_ordinal, fault_fd
+        if active_final_record:
+            fsync_ordinal += 1
+            wanted = {
+                "stage-fsync": 1,
+                "target-parent-fsync": 2,
+                "stage-parent-fsync": 3,
+            }.get(boundary)
+            if fault_fd == fd:
+                fault_calls += 1
+            if wanted == fsync_ordinal and not tripped:
+                tripped = True
+                fault_fd = fd
+                fault_calls = 1
+                raise OSError(errno.EIO, f"injected final-record {boundary}")
+        original_fsync(fd)
+
+    def fail_link_once(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped, fault_calls
+        if active_final_record and boundary == "link":
+            fault_calls += 1
+            if not tripped:
+                tripped = True
+                raise OSError(errno.EIO, "injected final-record link failure")
+        original_link(source, target, *args, **kwargs)
+
+    def fail_unlink_once(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped, fault_calls
+        if (
+            active_final_record
+            and boundary == "unlink"
+            and name.startswith(".phase1-stage-")
+        ):
+            fault_calls += 1
+            if not tripped:
+                tripped = True
+                raise OSError(errno.EIO, "injected final-record unlink failure")
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module, "_publish_no_replace", scoped_publish)
+    supported_dir_fd = set(store_module.os.supports_dir_fd)
+    for original, replacement in (
+        (original_open, fail_stage_create_once),
+        (original_link, fail_link_once),
+        (original_unlink, fail_unlink_once),
+    ):
+        if original in store_module.os.supports_dir_fd:
+            supported_dir_fd.add(replacement)
+    monkeypatch.setattr(store_module.os, "supports_dir_fd", supported_dir_fd)
+    monkeypatch.setattr(store_module.os, "open", fail_stage_create_once)
+    monkeypatch.setattr(store_module.os, "fsync", fail_fsync_once)
+    monkeypatch.setattr(store_module.os, "link", fail_link_once)
+    monkeypatch.setattr(store_module.os, "unlink", fail_unlink_once)
+
+    first = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    assert tripped
+    assert fault_calls == 1
+    assert strict_loads(first)["receipt_state"] == "ENGINE_TERMINAL"
+    assert pair_a.call_count == pair_b.call_count == 1
+
+    monkeypatch.undo()
+    replay = _execute_with_objects(phase1_roots, operation_bytes())
+    assert replay == first
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    assert list(key.rglob(".phase1-stage-*")) == []
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "stage-create",
+        "stage-fsync",
+        "link",
+        "target-parent-fsync",
+        "unlink",
+        "stage-parent-fsync",
+    ],
+)
+def test_t22_receipt_publication_syscall_matrix_preserves_exact_outcome(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    original_publish = store_module._publish_no_replace
+    original_open = store_module.os.open
+    original_fsync = store_module.os.fsync
+    original_link = store_module.os.link
+    original_unlink = store_module.os.unlink
+    active_receipt = False
+    tripped = False
+    fsync_ordinal = 0
+    engine_receipt_raw: bytes | None = None
+
+    def scoped_publish(**kwargs: object) -> None:
+        nonlocal active_receipt, engine_receipt_raw
+        previous = active_receipt
+        active_receipt = kwargs["target_name"] == "receipt.json"
+        if active_receipt and engine_receipt_raw is None:
+            value = kwargs["raw"]
+            assert isinstance(value, bytes)
+            engine_receipt_raw = value
+        try:
+            original_publish(**kwargs)
+        finally:
+            active_receipt = previous
+
+    def fail_stage_create_once(*args: object, **kwargs: object) -> int:
+        nonlocal tripped
+        path = args[0] if args else kwargs.get("path")
+        if (
+            active_receipt
+            and boundary == "stage-create"
+            and isinstance(path, str)
+            and path.startswith(".phase1-stage-")
+            and not tripped
+        ):
+            tripped = True
+            raise OSError(errno.EIO, "injected receipt stage create failure")
+        return original_open(*args, **kwargs)
+
+    def fail_fsync_once(fd: int) -> None:
+        nonlocal fsync_ordinal, tripped
+        if active_receipt:
+            fsync_ordinal += 1
+            wanted = {
+                "stage-fsync": 1,
+                "target-parent-fsync": 2,
+                "stage-parent-fsync": 3,
+            }.get(boundary)
+            if wanted == fsync_ordinal and not tripped:
+                tripped = True
+                raise OSError(errno.EIO, f"injected receipt {boundary}")
+        original_fsync(fd)
+
+    def fail_link_once(
+        source: str,
+        target: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        if active_receipt and boundary == "link" and not tripped:
+            tripped = True
+            raise OSError(errno.EIO, "injected receipt link failure")
+        original_link(source, target, *args, **kwargs)
+
+    def fail_unlink_once(
+        name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal tripped
+        if (
+            active_receipt
+            and boundary == "unlink"
+            and name.startswith(".phase1-stage-")
+            and not tripped
+        ):
+            tripped = True
+            raise OSError(errno.EIO, "injected receipt unlink failure")
+        original_unlink(name, *args, **kwargs)
+
+    monkeypatch.setattr(store_module, "_publish_no_replace", scoped_publish)
+    supported_dir_fd = set(store_module.os.supports_dir_fd)
+    for original, replacement in (
+        (original_open, fail_stage_create_once),
+        (original_link, fail_link_once),
+        (original_unlink, fail_unlink_once),
+    ):
+        if original in store_module.os.supports_dir_fd:
+            supported_dir_fd.add(replacement)
+    monkeypatch.setattr(store_module.os, "supports_dir_fd", supported_dir_fd)
+    monkeypatch.setattr(store_module.os, "open", fail_stage_create_once)
+    monkeypatch.setattr(store_module.os, "fsync", fail_fsync_once)
+    monkeypatch.setattr(store_module.os, "link", fail_link_once)
+    monkeypatch.setattr(store_module.os, "unlink", fail_unlink_once)
+
+    if boundary == "target-parent-fsync":
+        with pytest.raises(IndeterminateReceiptUnavailable) as unavailable:
+            execute_operation(
+                operation_bytes(),
+                repository_root=phase1_roots["repository"],
+                receipt_root=phase1_roots["receipt"],
+                evidence_root=phase1_roots["evidence"],
+                pair_a=pair_a,
+                pair_b=pair_b,
+            )
+        assert unavailable.value.__cause__ is None
+        first = None
+    else:
+        first = execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=pair_a,
+            pair_b=pair_b,
+        )
+
+    assert tripped
+    assert engine_receipt_raw is not None
+    assert pair_a.call_count == pair_b.call_count == 1
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    receipt_path = key / "receipt.json"
+    stages = list(key.glob(".phase1-stage-*"))
+
+    if boundary in {"stage-create", "stage-fsync", "link"}:
+        assert first is not None
+        receipt = strict_loads(first)
+        assert receipt["receipt_state"] == "INDETERMINATE_NO_RETRY"
+        assert receipt["reason_codes"] == ["PERSISTENCE_CORRUPTION"]
+        assert first != engine_receipt_raw
+        assert stages == []
+    elif boundary in {"target-parent-fsync", "unlink"}:
+        assert receipt_path.read_bytes() == engine_receipt_raw
+        assert len(stages) == 1
+        receipt_entry = receipt_path.stat(follow_symlinks=False)
+        stage_entry = stages[0].stat(follow_symlinks=False)
+        assert (receipt_entry.st_dev, receipt_entry.st_ino) == (
+            stage_entry.st_dev,
+            stage_entry.st_ino,
+        )
+        assert receipt_entry.st_nlink == stage_entry.st_nlink == 2
+        if boundary == "unlink":
+            assert first == engine_receipt_raw
+    else:
+        assert boundary == "stage-parent-fsync"
+        assert first == engine_receipt_raw
+        assert receipt_path.read_bytes() == engine_receipt_raw
+        assert stages == []
+
+    monkeypatch.undo()
+    if first is not None:
+        replay = _execute_with_objects(phase1_roots, operation_bytes())
+        assert replay == first
+    else:
+        replay = _execute_with_objects(phase1_roots, operation_bytes())
+        assert replay == engine_receipt_raw
+    assert list(key.glob(".phase1-stage-*")) == []
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "record-1-file-refsync",
+        "record-2-file-refsync",
+        "record-3-file-refsync",
+        "record-4-file-refsync",
+        "record-1-parent-refsync",
+        "record-2-parent-refsync",
+        "record-3-parent-refsync",
+        "record-4-parent-refsync",
+        "receipt-file-refsync",
+        "receipt-parent-refsync",
+        "records-directory-refsync",
+        "records-parent-refsync",
+        "key-directory-refsync",
+        "key-parent-refsync",
+    ],
+)
+def test_t22_recovery_refsync_failure_returns_exact_sealed_bytes(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    records = key / "records"
+    shard = key.parent
+    original_finalize = store_module._finalize_metadata
+    original_file_refsync = store_module._fsync_file_and_parent
+    original_directory_refsync = store_module._fsync_directory
+    active_finalization = False
+    tripped = False
+    directory_counts: dict[Path, int] = {}
+
+    def scoped_finalize(**kwargs: object) -> None:
+        nonlocal active_finalization
+        previous = active_finalization
+        active_finalization = True
+        try:
+            original_finalize(**kwargs)
+        finally:
+            active_finalization = previous
+
+    def fail_file_refsync_once(
+        path: Path, parent: Path, modes: set[int]
+    ) -> None:
+        nonlocal tripped
+        matches = boundary == "receipt-file-refsync" and path.name == "receipt.json"
+        if boundary.startswith("record-") and boundary.endswith("-file-refsync"):
+            sequence = int(
+                boundary.removeprefix("record-").removesuffix("-file-refsync")
+            )
+            matches = parent == records and path.name.startswith(f"{sequence:06d}-")
+        if active_finalization and matches and not tripped:
+            tripped = True
+            raise PersistenceError(f"injected recovery refsync fault: {boundary}")
+        original_file_refsync(path, parent, modes)
+
+    def fail_directory_refsync_once(path: Path, modes: set[int]) -> None:
+        nonlocal tripped
+        if active_finalization:
+            directory_counts[path] = directory_counts.get(path, 0) + 1
+            occurrence = directory_counts[path]
+            wanted: tuple[Path, int] | None = None
+            if boundary.startswith("record-") and boundary.endswith(
+                "-parent-refsync"
+            ):
+                sequence = int(
+                    boundary.removeprefix("record-").removesuffix(
+                        "-parent-refsync"
+                    )
+                )
+                wanted = (records, sequence)
+            else:
+                wanted = {
+                    "receipt-parent-refsync": (key, 1),
+                    "records-directory-refsync": (records, 5),
+                    "records-parent-refsync": (key, 2),
+                    "key-directory-refsync": (key, 3),
+                    "key-parent-refsync": (shard, 1),
+                }.get(boundary)
+            if wanted == (path, occurrence) and not tripped:
+                tripped = True
+                raise PersistenceError(
+                    f"injected recovery directory refsync fault: {boundary}"
+                )
+        original_directory_refsync(path, modes)
+
+    monkeypatch.setattr(store_module, "_finalize_metadata", scoped_finalize)
+    monkeypatch.setattr(
+        store_module, "_fsync_file_and_parent", fail_file_refsync_once
+    )
+    monkeypatch.setattr(
+        store_module, "_fsync_directory", fail_directory_refsync_once
+    )
+    replay = _execute_with_objects(phase1_roots, operation_bytes())
+    assert tripped
+    assert replay == raw
+    assert pair_a.call_count == pair_b.call_count == 1
+
+    monkeypatch.undo()
+    assert _execute_with_objects(phase1_roots, operation_bytes()) == raw
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        "record-1",
+        "record-2",
+        "record-3",
+        "record-4",
+        "receipt",
+        "records-directory",
+        "key-directory",
+    ],
+)
+@pytest.mark.parametrize(
+    "boundary", ["fchmod", "inode-fsync", "parent-fsync"]
+)
+def test_t22_partial_prefix_syscall_fault_replays_without_relabel_or_invocation(
+    phase1_roots: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    node: str,
+    boundary: str,
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    operation = parse_operation(operation_bytes())
+    key = _key_directory(phase1_roots, operation)
+    records_directory = key / "records"
+    receipt_path = key / "receipt.json"
+    records = sorted(records_directory.iterdir())
+    assert len(records) == 4
+    original_names = [path.name for path in records]
+    assert original_names[-1].endswith("RECEIPT_FINALIZED.json")
+
+    key.chmod(0o700)
+    records_directory.chmod(0o700)
+    receipt_path.chmod(0o600)
+    for record in records:
+        record.chmod(0o600)
+
+    if node.startswith("record-"):
+        sequence = int(node.removeprefix("record-"))
+        for record in records[: sequence - 1]:
+            record.chmod(0o400)
+        target = records[sequence - 1]
+        parent = records_directory
+        final_mode = 0o400
+    elif node == "receipt":
+        for record in records:
+            record.chmod(0o400)
+        target = receipt_path
+        parent = key
+        final_mode = 0o400
+    elif node == "records-directory":
+        for record in records:
+            record.chmod(0o400)
+        receipt_path.chmod(0o400)
+        target = records_directory
+        parent = key
+        final_mode = 0o500
+    else:
+        assert node == "key-directory"
+        for record in records:
+            record.chmod(0o400)
+        receipt_path.chmod(0o400)
+        records_directory.chmod(0o500)
+        target = key
+        parent = key.parent
+        final_mode = 0o500
+
+    target_entry = target.stat(follow_symlinks=False)
+    parent_entry = parent.stat(follow_symlinks=False)
+    target_identity = (target_entry.st_dev, target_entry.st_ino)
+    parent_identity = (parent_entry.st_dev, parent_entry.st_ino)
+    original_fchmod = store_module.os.fchmod
+    original_fsync = store_module.os.fsync
+    original_fstat = store_module.os.fstat
+    target_started = False
+    target_synced = False
+    tripped = False
+
+    def fd_identity(fd: int) -> tuple[int, int]:
+        entry = original_fstat(fd)
+        return (entry.st_dev, entry.st_ino)
+
+    def fchmod_then_interrupt(fd: int, mode: int) -> None:
+        nonlocal target_started, tripped
+        if fd_identity(fd) == target_identity and mode == final_mode:
+            original_fchmod(fd, mode)
+            target_started = True
+            if boundary == "fchmod" and not tripped:
+                tripped = True
+                raise OSError(errno.EIO, f"injected {node} fchmod failure")
+            return
+        original_fchmod(fd, mode)
+
+    def fsync_then_interrupt(fd: int) -> None:
+        nonlocal target_synced, tripped
+        identity = fd_identity(fd)
+        if target_started and identity == target_identity:
+            original_fsync(fd)
+            target_synced = True
+            if boundary == "inode-fsync" and not tripped:
+                tripped = True
+                raise OSError(errno.EIO, f"injected {node} inode fsync failure")
+            return
+        if target_synced and identity == parent_identity:
+            original_fsync(fd)
+            if boundary == "parent-fsync" and not tripped:
+                tripped = True
+                raise OSError(errno.EIO, f"injected {node} parent fsync failure")
+            return
+        original_fsync(fd)
+
+    monkeypatch.setattr(store_module.os, "fchmod", fchmod_then_interrupt)
+    monkeypatch.setattr(store_module.os, "fsync", fsync_then_interrupt)
+    replay = _execute_with_objects(phase1_roots, operation_bytes())
+    assert tripped
+    assert replay == raw
+    assert receipt_path.read_bytes() == raw
+    assert [path.name for path in sorted(records_directory.iterdir())] == (
+        original_names
+    )
+    assert pair_a.call_count == pair_b.call_count == 1
+
+    monkeypatch.undo()
+    assert _execute_with_objects(phase1_roots, operation_bytes()) == raw
+    assert stat.S_IMODE(key.stat().st_mode) == 0o500
+    assert stat.S_IMODE(records_directory.stat().st_mode) == 0o500
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o400
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o400 for path in records)
+    assert [path.name for path in sorted(records_directory.iterdir())] == (
+        original_names
+    )
+    assert pair_a.call_count == pair_b.call_count == 1
+
+
+def test_t22_invalid_postseal_permission_order_raises_exact_typed_error(
+    phase1_roots: dict[str, Path],
+) -> None:
+    pair_a, pair_b = valid_transports(phase1_roots["repository"])
+    raw = execute_operation(
+        operation_bytes(),
+        repository_root=phase1_roots["repository"],
+        receipt_root=phase1_roots["receipt"],
+        evidence_root=phase1_roots["evidence"],
+        pair_a=pair_a,
+        pair_b=pair_b,
+    )
+    receipt = strict_loads(raw)
+    operation = parse_operation(operation_bytes())
+    receipt_path = _key_directory(phase1_roots, operation) / "receipt.json"
+    receipt_path.chmod(0o600)
+    with pytest.raises(SealedReceiptUnavailable) as caught:
+        execute_operation(
+            operation_bytes(),
+            repository_root=phase1_roots["repository"],
+            receipt_root=phase1_roots["receipt"],
+            evidence_root=phase1_roots["evidence"],
+            pair_a=object(),
+            pair_b=object(),
+        )
+    error = caught.value
+    assert error.__cause__ is None
+    assert str(error) == (
+        "A Phase 1 receipt was durably sealed but cannot be safely returned; "
+        "automatic retry is forbidden"
+    )
+    assert error.receipt_digest == receipt["receipt_digest"]
+    assert error.receipt_state == "ENGINE_TERMINAL"
+    assert error.reason_code == "PERSISTENCE_CORRUPTION"
+    assert error.receipt_was_durably_sealed is True
+    assert error.automatic_engine_retry_permitted is False


### PR DESCRIPTION
## Summary

- add the frozen, source-checkout-only Olympus Phase 1 adapter and its closed request, ownership, and receipt schemas
- enforce single durable ownership, at-most-once Phase 0 invocation, crash-safe finalization, and byte-identical replay
- verify exact Phase 0 provenance and evidence before sealing a terminal receipt
- add concurrency, recovery, tamper, precedence, packaging-exclusion, and cross-base compatibility coverage

## Why

Olympus needs a dedicated bounded execution seam rather than the general interactive `/v1/runs` path. This change establishes the hermetic proof layer: retries and recovery cannot silently repeat the engine, and every terminal result is bound to durable, independently verifiable evidence.

## Safety boundary

This PR is intentionally inert and fake-only. It adds no package discovery, CLI entry point, plugin, model tool, gateway route, service, provider, subprocess, network, delivery, deployment, or runtime configuration path. Only the exact in-process fake Pair A and Pair B transports are representable.

This draft requests source review only. It grants no ready-for-review, merge, runtime, deployment, pilot, or production authority.

## Publication provenance

- frozen implementation anchor: `69d58e9c52ed8725c33e8a82fb18934902b350ee`
- current-main publication base: `9d4ef04ed00055414c13fcf33925d85790221a3f`
- publication commit: `9f7bacab3ff7604aeb5443c285ab06384a26f292`
- projected eleven-path manifest SHA-256: `88fb332e129b3ba26e991983b0d6d89985420d72d1d3fffc7863c42a95948f4f`

Ten file blobs are identical to the frozen anchor. The sole authorized compatibility amendment is in T17: current main deliberately removed `MANIFEST.in`, so the test now reads it conditionally while retaining the same assertion when the file exists. The adjacent computed wheel/sdist file-list test remains the substantive packaging-exclusion proof.

This clean projection supersedes closed draft #80481, whose divergent frozen lineage caused GitHub to include unrelated historical commits and files.

## Validation

- current-base T17 packaging exclusion: 2 passed
- frozen-base T17 compatibility check in a disposable detached worktree: 2 passed
- `scripts/run_tests.sh tests/olympus_phase1_adapter -q -p no:cacheprovider`: 245 passed
- `scripts/run_tests.sh tests/test_packaging_build_guard.py -q -p no:cacheprovider`: 4 passed
- `scripts/run_tests.sh tests/test_packaging_metadata.py -q -p no:cacheprovider`: 6 passed
- `git diff --check`: passed
- forbidden capability and credential-shaped literal scans: clean
- independent exact-staged-state review: approved
- GitHub compare preflight: one commit, eleven added files, zero commits behind

The full frozen scope, provenance, residual risk, and rollback contract remain recorded in `docs/plans/OLYMPUS_PHASE1_GATE2_CHANGE_REVIEW.md`. A separate external crosswalk binds the frozen anchor, current-main projection, validation, and this draft PR.
