### PR TITLE
feat(tools): make tool-result truncation caps configurable via tool_budget:

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -556,6 +556,27 @@ compression:
   # auxiliary section below (auxiliary.compression.provider / model).
 
 # =============================================================================
+# Tool-result truncation budget (optional; top-level block)
+# =============================================================================
+# Controls when a large tool/MCP result is persisted-and-truncated before it is
+# handed back to the model. The defaults (100K chars per result, 200K per turn)
+# are correct for large-window models but silently truncate big MCP payloads
+# (e.g. a code-search server returning a 200K-char snippet) with no config lever
+# — tool_output.max_bytes only bounds *terminal* output, not generic results.
+# With NO tool_budget block, behavior is byte-identical to the built-in defaults.
+# Resolution order per tool is unchanged: pinned > overrides > registry > default.
+#
+# tool_budget:
+#   default_result_size_chars: 500000   # per tool result ("inf"/"unlimited" = uncapped)
+#   turn_budget_chars: 2000000          # aggregate across all tool results in one turn
+#   preview_size_chars: 8000            # inline preview shown before the truncation note
+#   per_result_window_fraction: 0.5     # of the model window a single result may occupy
+#   per_turn_window_fraction: 1.0       # of the model window the whole turn may occupy
+#   unlimited_tools:                    # pin specific tools to no cap (like read_file)
+#     - search_code
+#     - get_code_snippet
+
+# =============================================================================
 # Anthropic prompt caching TTL
 # =============================================================================
 # When prompt caching is active (Claude via OpenRouter or native Anthropic),

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -173,3 +173,52 @@ class TestBudgetForContextWindow:
         threshold = cfg.resolve_threshold("mcp_firecrawl_firecrawl_search")
         assert threshold < huge_len
         assert cfg.default_result_size < huge_len
+
+
+# ---------------------------------------------------------------------------
+# Config-driven overrides (the optional `tool_budget:` block)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDrivenOverrides:
+    """`tool_budget:` in config.yaml tunes the caps; absent = defaults."""
+
+    def test_no_block_returns_empty(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text("model:\n  default: x\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.budget_config import _load_budget_overrides
+        assert _load_budget_overrides() == {}
+
+    def test_missing_config_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+        from tools.budget_config import _load_budget_overrides
+        assert _load_budget_overrides() == {}
+
+    def test_block_is_read(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  default_result_size_chars: 500000\n"
+            "  unlimited_tools:\n"
+            "    - search_code\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.budget_config import _load_budget_overrides
+        ov = _load_budget_overrides()
+        assert ov["default_result_size_chars"] == 500_000
+        assert ov["unlimited_tools"] == ["search_code"]
+
+    def test_malformed_block_is_ignored(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text("tool_budget: not-a-mapping\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.budget_config import _load_budget_overrides
+        assert _load_budget_overrides() == {}
+
+    def test_ov_num_coerces_and_defaults(self, monkeypatch):
+        import tools.budget_config as b
+        monkeypatch.setattr(
+            b, "_BUDGET_OVERRIDES", {"a": "500000", "b": "inf", "c": "unlimited"}
+        )
+        assert b._ov_num("a", 100) == 500_000
+        assert b._ov_num("b", 100) == float("inf")
+        assert b._ov_num("c", 100) == float("inf")
+        assert b._ov_num("missing", 42) == 42

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -19,6 +19,68 @@ DEFAULT_TURN_BUDGET_CHARS: int = 200_000
 DEFAULT_PREVIEW_SIZE_CHARS: int = 1_500
 
 
+# --- CONFIG-DRIVEN OVERRIDES ---------------------------------------------------
+# The per-result cap (100K chars) silently truncates large MCP/tool results (e.g.
+# a code-search server returning a 200K-char snippet), and there is no config lever
+# for it: `tool_output.max_bytes` only bounds terminal output, not generic results.
+# This reads an OPTIONAL `tool_budget:` block from the active config.yaml so the
+# caps are tunable, and lets specific tools be pinned to no cap. Fully guarded:
+# with no block (or on any error) every constant is byte-identical to before.
+#   tool_budget:
+#     default_result_size_chars: 500000   # per tool result ("inf" = unlimited)
+#     turn_budget_chars: 2000000          # aggregate per assistant turn
+#     preview_size_chars: 8000            # inline preview before the truncation note
+#     per_result_window_fraction: 0.5     # of ctx window a single result may take
+#     per_turn_window_fraction: 1.0       # of ctx window the whole turn may take
+#     unlimited_tools: [get_code_snippet, search_code, get_architecture, trace_path]
+def _load_budget_overrides() -> Dict:
+    """Return the `tool_budget:` mapping from the active config, or {} if absent.
+
+    Reads a single config file — ``$HERMES_HOME/config.yaml`` (falling back to
+    ``~/.hermes/config.yaml`` only when HERMES_HOME is unset). Fully guarded: any
+    error returns {}. Respecting HERMES_HOME keeps this hermetically testable —
+    a test points HERMES_HOME at a tmp dir and gets exactly that config.
+    """
+    import os
+    try:
+        import yaml  # type: ignore
+        home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+        path = os.path.join(home, "config.yaml")
+        if os.path.isfile(path):
+            with open(path, encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            block = data.get("tool_budget")
+            if isinstance(block, dict):
+                return block
+    except Exception:
+        pass
+    return {}
+
+
+_BUDGET_OVERRIDES: Dict = _load_budget_overrides()
+
+
+def _ov_num(key: str, default):
+    v = _BUDGET_OVERRIDES.get(key)
+    if v is None:
+        return default
+    if isinstance(v, str) and v.strip().lower() in ("inf", "unlimited", "none"):
+        return float("inf")
+    try:
+        return type(default)(v)
+    except Exception:
+        return default
+
+
+DEFAULT_RESULT_SIZE_CHARS = _ov_num("default_result_size_chars", DEFAULT_RESULT_SIZE_CHARS)
+DEFAULT_TURN_BUDGET_CHARS = _ov_num("turn_budget_chars", DEFAULT_TURN_BUDGET_CHARS)
+DEFAULT_PREVIEW_SIZE_CHARS = _ov_num("preview_size_chars", DEFAULT_PREVIEW_SIZE_CHARS)
+for _tool in (_BUDGET_OVERRIDES.get("unlimited_tools") or []):
+    if isinstance(_tool, str):
+        PINNED_THRESHOLDS[_tool] = float("inf")
+# -------------------------------------------------------------------------------
+
+
 @dataclass(frozen=True)
 class BudgetConfig:
     """Immutable budget constants for the 3-layer tool result persistence system.
@@ -74,6 +136,9 @@ _CHARS_PER_TOKEN: int = 4
 # compete), so these stay well under 1.0.
 _PER_RESULT_WINDOW_FRACTION: float = 0.15
 _PER_TURN_WINDOW_FRACTION: float = 0.30
+# Config-driven (tool_budget.per_result_window_fraction / per_turn_window_fraction):
+_PER_RESULT_WINDOW_FRACTION = _ov_num("per_result_window_fraction", _PER_RESULT_WINDOW_FRACTION)
+_PER_TURN_WINDOW_FRACTION = _ov_num("per_turn_window_fraction", _PER_TURN_WINDOW_FRACTION)
 
 # Floor so even a tiny-but-admitted model still gets a usable preview/result
 # rather than a 0-char budget.


### PR DESCRIPTION
## What does this PR do?
Adds an optional top-level `tool_budget:` block to the Hermes config so the
tool/MCP result truncation caps in `tools/budget_config.py` — currently hardcoded
at 100K chars per result, 200K per turn, and 0.15/0.30 context-window fractions —
can be tuned without editing installed source. It also adds an `unlimited_tools`
list that pins named tools to no cap (mirroring how `read_file` is already `inf`).

With no `tool_budget:` block present, behavior is byte-identical to today.

## Related Issue
No existing linked issue. Motivation: an MCP code-search server can return a
200K-char snippet, which `maybe_persist_tool_result()` truncates with
`[Truncated: tool response was N chars ...]`, and there is no config lever to
raise it — `tool_output.max_bytes` only bounds *terminal* output, not generic
tool/MCP results. Happy to open a tracking issue if preferred.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Changes Made
- `tools/budget_config.py`: added a guarded `_load_budget_overrides()` that reads
  `tool_budget:` from `$HERMES_HOME/config.yaml` (falling back to
  `~/.hermes/config.yaml`); an `_ov_num()` coercion helper (`"inf"`/`"unlimited"`
  → no cap); and applied the overrides to `DEFAULT_RESULT_SIZE_CHARS`,
  `DEFAULT_TURN_BUDGET_CHARS`, `DEFAULT_PREVIEW_SIZE_CHARS`, the two window
  fractions, and `PINNED_THRESHOLDS` (via `unlimited_tools`). Any error in the
  loader returns `{}`, leaving every constant at its current value.
- `cli-config.yaml.example`: documented the new optional `tool_budget:` block.
- `tests/tools/test_budget_config.py`: added `TestConfigDrivenOverrides` (loader
  parses a block, ignores a missing file / malformed block, and `_ov_num` coerces
  and defaults correctly).

## How to Test
```bash
# hermetic (no tool_budget block) — existing behavior, all tests green:
HERMES_HOME=$(mktemp -d) pytest tests/tools/test_budget_config.py -q   # 21 passed

# with an override in place:
mkdir -p /tmp/hh && cat > /tmp/hh/config.yaml <<'YAML'
tool_budget:
  default_result_size_chars: 500000
  unlimited_tools: [search_code]
YAML
HERMES_HOME=/tmp/hh python -c "import tools.budget_config as b; \
print(b.DEFAULT_RESULT_SIZE_CHARS, b.PINNED_THRESHOLDS.get('search_code'))"
# -> 500000 inf
```

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] Commit message follows Conventional Commits (`feat(tools): ...`)
- [x] PR contains only changes related to a single feature/fix
- [x] `pytest tests/tools/test_budget_config.py -q` passes (21 passed)
- [x] `ruff check tools/budget_config.py` clean (PLW1514 fixed)
- [x] I have added tests covering the change
- [x] I updated `cli-config.yaml.example` for the new config key
- [x] Backward-compatible: no `tool_budget:` block == current behavior
