### PR TITLE
nix: use nixpkgs prebuilt Python packages on all platforms

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -61,44 +61,112 @@ let
         ] (_: null)
       );
 
+  # Packages to substitute with nixpkgs prebuilt versions.
+  #
+  # uv2nix builds every Python dependency from source (wheel or sdist).
+  # Many of these packages already exist in nixpkgs with identical upstream
+  # versions, and nixpkgs builds are cached on cache.nixos.org.  Substituting
+  # them with mkPrebuiltOverride eliminates hundreds of derivations from the
+  # build graph, cutting build time from hours to minutes on a fresh install.
+  #
+  # The overrides below apply on ALL platforms.  The original Darwin-only
+  # restriction was added because some wheel-only transitive deps (e.g.
+  # onnxruntime's coloredlogs) don't build from sdist on aarch64-darwin.
+  # On Linux everything builds, but substituting from nixpkgs is still
+  # strictly better: same upstream version, cached, no local compilation.
+  #
+  # Dependency lists: mkPrebuiltOverride replaces the package's passthru
+  # with a minimal stub.  The `dependencies` attrset tells the venv resolver
+  # which deps the prebuilt package needs.  Passing `{}` means "no deps
+  # declared here" — the deps are still resolved transitively through the
+  # root package (hermes-agent) and other packages in the venv.  Explicit
+  # deps are only listed for packages whose deps might not be pulled in by
+  # anything else in the venv (e.g. onnxruntime → coloredlogs).
+  prebuiltOverrides = final: {
+    # ── Native/compiled packages (slow to build from source) ──────────
+    numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
+
+    av = mkPrebuiltOverride final python312.pkgs.av { };
+
+    pillow = mkPrebuiltOverride final python312.pkgs.pillow { };
+
+    sounddevice = mkPrebuiltOverride final python312.pkgs.sounddevice { };
+
+    onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
+      coloredlogs = [ ];
+      numpy = [ ];
+      packaging = [ ];
+    };
+
+    ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
+      numpy = [ ];
+      pyyaml = [ ];
+    };
+
+    faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
+      av = [ ];
+      ctranslate2 = [ ];
+      huggingface-hub = [ ];
+      onnxruntime = [ ];
+      tokenizers = [ ];
+      tqdm = [ ];
+    };
+
+    tokenizers = mkPrebuiltOverride final python312.pkgs.tokenizers { };
+
+    flatbuffers = mkPrebuiltOverride final python312.pkgs.flatbuffers { };
+
+    # ── Crypto / C extensions ─────────────────────────────────────────
+    cryptography = mkPrebuiltOverride final python312.pkgs.cryptography { };
+
+    cffi = mkPrebuiltOverride final python312.pkgs.cffi { };
+
+    pycparser = mkPrebuiltOverride final python312.pkgs.pycparser { };
+
+    # ── Rust-backed packages ──────────────────────────────────────────
+    pydantic-core = mkPrebuiltOverride final python312.pkgs.pydantic-core { };
+
+    jiter = mkPrebuiltOverride final python312.pkgs.jiter { };
+
+    rpds-py = mkPrebuiltOverride final python312.pkgs.rpds-py { };
+
+    watchfiles = mkPrebuiltOverride final python312.pkgs.watchfiles { };
+
+    hf-xet = mkPrebuiltOverride final python312.pkgs.hf-xet { };
+
+    # ── Cython / C extension packages ──────────────────────────────────
+    msgpack = mkPrebuiltOverride final python312.pkgs.msgpack { };
+
+    brotlicffi = mkPrebuiltOverride final python312.pkgs.brotlicffi { };
+
+    uvloop = mkPrebuiltOverride final python312.pkgs.uvloop { };
+
+    asyncpg = mkPrebuiltOverride final python312.pkgs.asyncpg { };
+
+    propcache = mkPrebuiltOverride final python312.pkgs.propcache { };
+
+    cbor2 = mkPrebuiltOverride final python312.pkgs.cbor2 { };
+
+    ruamel-yaml-clib = mkPrebuiltOverride final python312.pkgs.ruamel-yaml-clib { };
+
+    # ── Platform-specific (Darwin-only, kept for aarch64-darwin) ───────
+    pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
+
+    humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
+
+    coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
+      humanfriendly = [ ];
+    };
+  };
+
   pythonPackageOverrides =
     final: _prev:
-    if isAarch64Darwin then
-      {
-        numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
-
-        pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
-
-        av = mkPrebuiltOverride final python312.pkgs.av { };
-
-        humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
-
-        coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
-          humanfriendly = [ ];
-        };
-
-        onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
-          coloredlogs = [ ];
-          numpy = [ ];
-          packaging = [ ];
-        };
-
-        ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
-          numpy = [ ];
-          pyyaml = [ ];
-        };
-
-        faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
-          av = [ ];
-          ctranslate2 = [ ];
-          huggingface-hub = [ ];
-          onnxruntime = [ ];
-          tokenizers = [ ];
-          tqdm = [ ];
-        };
-      }
-    else
-      { };
+    (prebuiltOverrides final)
+    // lib.optionalAttrs isAarch64Darwin {
+      # aarch64-darwin-only: humanfriendly/coloredlogs are already in
+      # prebuiltOverrides above, but we keep this for clarity and future
+      # Darwin-specific additions.
+    };
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {


### PR DESCRIPTION
## Summary

Extends the existing `mkPrebuiltOverride` pattern from aarch64-darwin-only to **all platforms**, and adds 20 more heavy/compiled Python packages. This eliminates 181 derivations from the build graph on x86_64-linux by substituting them with cached nixpkgs builds.

## Problem

The uv2nix build creates ~296 Python-related derivations (148 wheel fetches + 148 install builds) even though **157 of 162 packages already exist in `nixpkgs.python312.pkgs`** with identical upstream versions. nixpkgs builds are cached on `cache.nixos.org`, so substituting them eliminates local compilation entirely.

The `mkPrebuiltOverride` pattern already existed for aarch64-darwin (added to work around wheel-only transitive deps that don't build from sdist). On Linux, `pythonPackageOverrides` was `{}` (empty) — meaning all 148 packages were built from scratch by uv2nix.

## Changes

### `nix/python.nix`

- Extracts the darwin-only overrides into a shared `prebuiltOverrides` function that applies on **all platforms**
- Adds 20 more heavy/compiled packages:

| Category | Packages |
|----------|----------|
| Native/compiled | `pillow`, `sounddevice`, `tokenizers`, `flatbuffers` |
| Crypto/C | `cryptography`, `cffi`, `pycparser` |
| Rust-backed | `pydantic-core`, `jiter`, `rpds-py`, `watchfiles`, `hf-xet` |
| Cython/C | `msgpack`, `brotlicffi`, `uvloop`, `asyncpg`, `propcache`, `cbor2`, `ruamel-yaml-clib` |

- Preserves all existing darwin overrides (numpy, av, onnxruntime, ctranslate2, faster-whisper, pyarrow, humanfriendly, coloredlogs)
- The `isAarch64Darwin` guard is kept for future Darwin-specific additions but the main overrides now apply everywhere

## Impact

Measured on x86_64-linux with the `full` package (all optional dependency groups):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Derivations to build | 1115 | 934 | **-181 (16%)** |
| Paths fetched from cache | 209 | 359 | +150 (substituted from cache.nixos.org) |

The remaining ~120 pure-Python packages (requests, click, pyyaml, etc.) are still built by uv2nix. A follow-up could extend this to all packages by preserving the original `passthru.dependencies` from the overlay instead of replacing it with a minimal stub.

## Testing

- [x] `nix eval .#packages.x86_64-linux.default.outPath` — evaluates cleanly
- [x] `nix build .#packages.x86_64-linux.default --dry-run` — 934 derivations (down from 1115)
- [ ] `nix flake check` — needs full build (left for CI)
- [ ] aarch64-darwin evaluation — left for CI cross-eval check

## How `mkPrebuiltOverride` works

`mkPrebuiltOverride` replaces a uv2nix-built package with a thin wrapper around the nixpkgs prebuilt version. The `dependencies` parameter tells the venv resolver which deps the prebuilt package needs. Passing `{}` means "no deps declared here" — the deps are still resolved transitively through the root package (hermes-agent) and other packages in the venv. Explicit deps are only listed for packages whose deps might not be pulled in by anything else (e.g. `onnxruntime` → `coloredlogs`).

## Related

- OpenProject WP #1923