### PR TITLE
fix(tools,cli): never downgrade lazy deps at runtime; truthful memory status

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -475,6 +475,26 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 # Status
 # ---------------------------------------------------------------------------
 
+def _runtime_lazy_missing(provider_name: str) -> tuple[str, ...]:
+    """Return lazy specs the provider's runtime retain path is missing.
+
+    Mirrors the exact predicate the runtime uses — the memory providers gate
+    retains on ``tools.lazy_deps.ensure(f"memory.{provider_name}")`` — so
+    ``status`` and runtime can never disagree (#80388). Uses the same runtime
+    semantics as ``ensure`` (a newer-than-pin install counts as satisfied and
+    is never reported missing). Empty when the provider has no lazy feature
+    or its deps are satisfied.
+    """
+    feature = f"memory.{provider_name}"
+    try:
+        from tools.lazy_deps import LAZY_DEPS, feature_missing
+    except Exception:
+        return ()  # lazy_deps unavailable — fall back to the plugin's own check
+    if feature not in LAZY_DEPS:
+        return ()
+    return tuple(feature_missing(feature, runtime=True))
+
+
 def cmd_status(args) -> None:
     """Show current memory provider config."""
     from hermes_cli.config import load_config
@@ -528,24 +548,40 @@ def cmd_status(args) -> None:
 
         if provider:
             print("\n  Plugin:    installed ✓")
-            if provider.is_available():
+            runtime_missing = _runtime_lazy_missing(provider_name)
+            plugin_ok = provider.is_available()
+            if plugin_ok and not runtime_missing:
                 print("  Status:    available ✓")
             else:
                 print("  Status:    not available ✗")
-                schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
-                # Check all fields that have env_var (both secret and non-secret)
-                required_fields = [f for f in schema if f.get("env_var")]
-                if required_fields:
-                    print("  Missing:")
-                    for f in required_fields:
-                        env_var = f.get("env_var", "")
-                        url = f.get("url", "")
-                        is_set = bool(os.environ.get(env_var))
-                        mark = "✓" if is_set else "✗"
-                        line = f"    {mark} {env_var}"
-                        if url and not is_set:
-                            line += f"  → {url}"
-                        print(line)
+                if runtime_missing:
+                    print("  Missing runtime deps:")
+                    for spec in runtime_missing:
+                        print(f"    ✗ {spec}")
+                    try:
+                        from tools.lazy_deps import feature_install_command
+
+                        manual = feature_install_command(f"memory.{provider_name}")
+                    except Exception:
+                        manual = None
+                    if manual:
+                        print("  Fix: run 'hermes memory setup' — or install manually:")
+                        print(f"    {manual}")
+                if not plugin_ok:
+                    schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+                    # Check all fields that have env_var (both secret and non-secret)
+                    required_fields = [f for f in schema if f.get("env_var")]
+                    if required_fields:
+                        print("  Missing:")
+                        for f in required_fields:
+                            env_var = f.get("env_var", "")
+                            url = f.get("url", "")
+                            is_set = bool(os.environ.get(env_var))
+                            mark = "✓" if is_set else "✗"
+                            line = f"    {mark} {env_var}"
+                            if url and not is_set:
+                                line += f"  → {url}"
+                            print(line)
         else:
             print("\n  Plugin:    NOT installed ✗")
             print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -11,13 +11,15 @@ import pytest
 from unittest.mock import patch
 
 
-def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
+def _run_cmd_status(capfd, mem_config=None, memory_tools=None, providers=None):
     """Run cmd_status with a mocked config and return captured stdout.
 
     Args:
         mem_config: The "memory" section of config.
         memory_tools: Set of tool names returned by _get_platform_tools.
                       Defaults to {"memory"} (tool enabled).
+        providers: Optional list of (name, kind, provider) tuples returned by
+                   _get_available_providers. Defaults to [] (no plugins).
     """
     from hermes_cli.memory_setup import cmd_status
 
@@ -26,7 +28,7 @@ def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
         memory_tools = {"memory"}
 
     with patch("hermes_cli.config.load_config", return_value=config):
-        with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
+        with patch("hermes_cli.memory_setup._get_available_providers", return_value=providers or []):
             with patch(
                 "hermes_cli.tools_config._get_platform_tools",
                 return_value=memory_tools,
@@ -52,6 +54,93 @@ class TestMemoryStatusLabels:
         out = _run_cmd_status(capfd, mem_config={"memory_enabled": False})
         assert "Memory injection:" in out
         assert "disabled ✗" in out
+
+
+class _StubProvider:
+    """Minimal memory provider with a controllable static availability check."""
+
+    def __init__(self, available=True, schema=None):
+        self._available = available
+        self._schema = schema or []
+
+    def is_available(self):
+        return self._available
+
+    def get_config_schema(self):
+        return self._schema
+
+
+class TestStatusUsesRuntimePredicate:
+    """`hermes memory status` must share the runtime retain-path predicate
+    (issue #80388): a provider whose plugin check passes but whose lazy deps
+    are missing shows "not available" with the reason — status can no longer
+    be green while every retain fails. Healthy output is unchanged."""
+
+    def _run(self, capfd, provider_name, provider, versions=None):
+        import importlib.metadata as _md
+        from importlib.metadata import PackageNotFoundError
+
+        providers = [(provider_name, "stub", provider)]
+        base = dict(mem_config={"provider": provider_name}, providers=providers)
+        if versions is None:
+            return _run_cmd_status(capfd, **base)
+
+        def _version(pkg):
+            if pkg in versions:
+                return versions[pkg]
+            raise PackageNotFoundError(pkg)
+
+        with patch.object(_md, "version", _version):
+            return _run_cmd_status(capfd, **base)
+
+    def test_provider_with_missing_lazy_deps_is_not_available(self, capfd):
+        # Plugin check passes (is_available True) but the runtime retain path
+        # would fail — hindsight-client isn't installed.
+        out = self._run(capfd, "hindsight", _StubProvider(available=True), versions={})
+        assert "available ✓" not in out
+        assert "not available ✗" in out
+        assert "hindsight-client==0.6.1" in out  # reason surfaced
+
+    def test_provider_with_off_pin_install_still_available(self, capfd):
+        # Newer-than-pin installed: runtime is satisfied (never-downgrade),
+        # and the status probe uses the same predicate as ensure().
+        out = self._run(
+            capfd, "hindsight", _StubProvider(available=True),
+            versions={"hindsight-client": "0.8.6"},
+        )
+        assert "available ✓" in out
+        assert "not available ✗" not in out
+
+    def test_healthy_provider_output_unchanged(self, capfd):
+        out = self._run(
+            capfd, "hindsight", _StubProvider(available=True),
+            versions={"hindsight-client": "0.6.1"},
+        )
+        assert "Plugin:    installed ✓" in out
+        assert "Status:    available ✓" in out
+        assert "not available" not in out
+
+    def test_static_failure_still_reports_env_missing(self, capfd):
+        # is_available() False keeps today's behavior: not available + the
+        # schema's env-var "Missing:" block.
+        schema = [{"env_var": "HINDSIGHT_API_KEY", "url": "https://example.com"}]
+        out = self._run(
+            capfd, "hindsight", _StubProvider(available=False, schema=schema),
+            versions={"hindsight-client": "0.6.1"},
+        )
+        assert "Status:    not available ✗" in out
+        assert "Missing:" in out
+        assert "HINDSIGHT_API_KEY" in out
+
+    def test_provider_without_lazy_feature_falls_back_to_plugin_check(self, capfd):
+        # A provider with no LAZY_DEPS entry (e.g. a pure-plugin backend) is
+        # judged by its own is_available() — no change in behavior.
+        out = self._run(capfd, "holographic", _StubProvider(available=True))
+        assert "Status:    available ✓" in out
+
+    def test_no_provider_configured_still_works(self, capfd):
+        out = self._run(capfd, "", _StubProvider())
+        assert "Provider:  (none — built-in only)" in out
 
 
 

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -99,7 +99,7 @@ class TestStatusUsesRuntimePredicate:
         out = self._run(capfd, "hindsight", _StubProvider(available=True), versions={})
         assert "available ✓" not in out
         assert "not available ✗" in out
-        assert "hindsight-client==0.6.1" in out  # reason surfaced
+        assert "hindsight-client>=0.6.1" in out  # reason surfaced
 
     def test_provider_with_off_pin_install_still_available(self, capfd):
         # Newer-than-pin installed: runtime is satisfied (never-downgrade),

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -422,8 +422,10 @@ class TestInstallSpecs:
 # ensure()/feature_missing(runtime=True)/is_available() must treat an
 # installed version NEWER than the pinned floor as satisfied at runtime —
 # otherwise the memory hot path silently downgrades operator-installed
-# backends. The strict default of feature_missing() and the untouched
-# refresh_active_features() keep hermes update's pin propagation intact.
+# backends. The strict default of feature_missing() keeps exact-pin
+# enforcement available to callers that want it, while
+# refresh_active_features() uses the same runtime semantics as ensure() so
+# hermes update's pin propagation upgrades only genuine below-pin staleness.
 # ---------------------------------------------------------------------------
 
 import importlib.metadata as _md  # noqa: E402
@@ -545,7 +547,8 @@ class TestRuntimeNeverDowngrade:
         # The floor pin makes hindsight itself strict-satisfied on newer
         # (see test_floor_pinned_feature_newer_is_strict_satisfied), so the
         # strict-contract probe uses an ==-pinned feature: the default
-        # (strict) predicate is the update path's detector.
+        # (strict) predicate still flags any off-pin version for callers
+        # that request exact-pin enforcement.
         self._patch_env(monkeypatch, {"honcho-ai": "2.3.0"})
         assert ld.feature_missing("memory.honcho") == ("honcho-ai==2.2.0",)
         assert ld._is_satisfied("honcho-ai==2.2.0") is False
@@ -573,6 +576,7 @@ class TestRuntimeNeverDowngrade:
         result = ld.refresh_active_features(prompt=False)
         # ensure() (the only installer) no-ops on newer — nothing downgraded.
         assert fake.installed == []
-        # Strict pre-check still classifies the feature as needing a refresh
-        # (acceptance (c)); the refresh itself is a no-op thanks to ensure().
-        assert result["memory.honcho"] == "refreshed"
+        # The refresh pre-check uses runtime semantics too: a newer-than-pin
+        # install is "current" — claiming "refreshed" for a no-op would be
+        # the same dishonesty as issue #80388.
+        assert result["memory.honcho"] == "current"

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -414,3 +414,137 @@ class TestInstallSpecs:
         result = ld.install_specs(["honcho-ai==2.2.0"])
         assert result.ok is False
         assert "disk on fire" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Runtime never-downgrade semantics (issue #80390)
+#
+# ensure()/feature_missing(runtime=True)/is_available() must treat an
+# installed version NEWER than the pinned floor as satisfied at runtime —
+# otherwise the memory hot path silently downgrades operator-installed
+# backends. The strict default of feature_missing() and the untouched
+# refresh_active_features() keep hermes update's pin propagation intact.
+# ---------------------------------------------------------------------------
+
+import importlib.metadata as _md  # noqa: E402
+
+
+class TestRuntimeNeverDowngrade:
+    """The runtime installer must never downgrade a newer install."""
+
+    _PKG = "hindsight-client"
+    _PIN = ld.LAZY_DEPS["memory.hindsight"][0]
+
+    class _FakeMetadata:
+        """Mutable stand-in for importlib.metadata.version + the pip installer."""
+
+        def __init__(self, versions: dict):
+            self.versions = dict(versions)
+            self.installed: list = []
+
+        def __call__(self, pkg: str) -> str:
+            if pkg in self.versions:
+                return self.versions[pkg]
+            from importlib.metadata import PackageNotFoundError
+            raise PackageNotFoundError(pkg)
+
+        def install(self, specs) -> ld._InstallResult:
+            self.installed.extend(specs)
+            for spec in specs:
+                pkg, _, want = spec.partition("==")
+                if want:
+                    self.versions[pkg] = want
+            return ld._InstallResult(True, "ok", "")
+
+    def _patch_env(self, monkeypatch, versions: dict):
+        fake = self._FakeMetadata(versions)
+        monkeypatch.setattr(_md, "version", fake)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install", lambda specs, **kw: fake.install(specs)
+        )
+        return fake
+
+    # -- acceptance (a): newer-than-pin is satisfied at runtime -------------
+    def test_newer_installed_is_satisfied_at_runtime(self, monkeypatch):
+        fake = self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        assert ld.feature_missing("memory.hindsight", runtime=True) == ()
+        ld.ensure("memory.hindsight", prompt=False)  # must not touch pip
+        assert fake.installed == []
+
+    def test_newer_than_pin_is_available(self, monkeypatch):
+        # is_available is a runtime-readiness predicate: a working newer
+        # install must not report "not available" (wake_word path).
+        self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        assert ld.is_available("memory.hindsight") is True
+
+    def test_absent_is_not_available(self, monkeypatch):
+        self._patch_env(monkeypatch, {})
+        assert ld.is_available("memory.hindsight") is False
+
+    def test_unknown_feature_not_available(self, monkeypatch):
+        self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        assert ld.is_available("memory.no-such-backend") is False
+
+    def test_mismatch_message_distinguishes_version_mismatch(self, monkeypatch):
+        self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        desc = ld._describe_missing(self._PIN)
+        assert "0.8.6" in desc and "version mismatch" in desc
+
+    def test_spec_floor_version(self):
+        from packaging.version import Version
+        assert ld._spec_floor_version("hindsight-client==0.6.1") == Version("0.6.1")
+        assert ld._spec_floor_version("slack-bolt>=1.18.0,<2") == Version("1.18.0")
+        assert ld._spec_floor_version("honcho-ai~=1.4") == Version("1.4")
+        assert ld._spec_floor_version("bare-package") is None
+        assert ld._spec_floor_version("only-ceiling<2") is None
+
+    # -- acceptance (b): genuinely-missing still installs / errors ----------
+    def test_absent_is_missing_and_installs(self, monkeypatch):
+        fake = self._patch_env(monkeypatch, {})
+        assert ld.feature_missing("memory.hindsight", runtime=True) == (self._PIN,)
+        ld.ensure("memory.hindsight", prompt=False)
+        assert fake.installed == [self._PIN]
+
+    def test_older_than_pin_is_missing_and_upgrades(self, monkeypatch):
+        # Below the pin's floor is a real mismatch: ensure() installs the
+        # pin (an upgrade), never a downgrade.
+        fake = self._patch_env(monkeypatch, {self._PKG: "0.5.0"})
+        assert ld.feature_missing("memory.hindsight", runtime=True) == (self._PIN,)
+        ld.ensure("memory.hindsight", prompt=False)
+        assert fake.installed == [self._PIN]
+
+    def test_install_failure_still_raises(self, monkeypatch):
+        fake = self._FakeMetadata({})
+        monkeypatch.setattr(_md, "version", fake)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(False, "", "network unreachable"),
+        )
+        with pytest.raises(ld.FeatureUnavailable, match="pip install failed"):
+            ld.ensure("memory.hindsight", prompt=False)
+
+    def test_post_install_verify_uses_runtime_semantics(self, monkeypatch):
+        # After the (mocked) install the pin is satisfied — no false
+        # "still not importable" failure for the version we just installed.
+        fake = self._patch_env(monkeypatch, {})
+        ld.ensure("memory.hindsight", prompt=False)  # must not raise
+        assert fake.versions[self._PKG] == "0.6.1"
+
+    # -- acceptance (c): hermes update keeps strict pin propagation ---------
+    def test_strict_feature_missing_still_flags_newer(self, monkeypatch):
+        self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        # Default (strict) predicate is the update path's detector.
+        assert ld.feature_missing("memory.hindsight") == (self._PIN,)
+        assert ld._is_satisfied(self._PIN) is False
+
+    def test_refresh_active_features_never_downgrades(self, monkeypatch):
+        fake = self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
+        monkeypatch.setattr(ld, "active_features", lambda: ["memory.hindsight"])
+        result = ld.refresh_active_features(prompt=False)
+        # ensure() (the only installer) no-ops on newer — nothing downgraded.
+        assert fake.installed == []
+        # Strict pre-check still classifies the feature as needing a refresh
+        # (acceptance (c)); the refresh itself is a no-op thanks to ensure().
+        assert result["memory.hindsight"] == "refreshed"

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -451,7 +451,13 @@ class TestRuntimeNeverDowngrade:
         def install(self, specs) -> ld._InstallResult:
             self.installed.extend(specs)
             for spec in specs:
-                pkg, _, want = spec.partition("==")
+                pkg = ld._pkg_name_from_spec(spec)
+                _, _, want = spec.partition("==")
+                if not want:
+                    # Range spec (e.g. "pkg>=0.6.1"): resolve to the floor so
+                    # the post-install verify sees a satisfying version.
+                    floor = ld._spec_floor_version(spec)
+                    want = str(floor[0]) if floor else ""
                 if want:
                     self.versions[pkg] = want
             return ld._InstallResult(True, "ok", "")
@@ -487,15 +493,17 @@ class TestRuntimeNeverDowngrade:
         assert ld.is_available("memory.no-such-backend") is False
 
     def test_mismatch_message_distinguishes_version_mismatch(self, monkeypatch):
-        self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
-        desc = ld._describe_missing(self._PIN)
-        assert "0.8.6" in desc and "version mismatch" in desc
+        self._patch_env(monkeypatch, {"honcho-ai": "2.3.0"})
+        desc = ld._describe_missing("honcho-ai==2.2.0")
+        assert "2.3.0" in desc and "version mismatch" in desc
 
     def test_spec_floor_version(self):
         from packaging.version import Version
-        assert ld._spec_floor_version("hindsight-client==0.6.1") == Version("0.6.1")
-        assert ld._spec_floor_version("slack-bolt>=1.18.0,<2") == Version("1.18.0")
-        assert ld._spec_floor_version("honcho-ai~=1.4") == Version("1.4")
+        assert ld._spec_floor_version("hindsight-client>=0.6.1") == (Version("0.6.1"), False)
+        assert ld._spec_floor_version("slack-bolt>=1.18.0,<2") == (Version("1.18.0"), False)
+        assert ld._spec_floor_version("honcho-ai~=1.4") == (Version("1.4"), False)
+        assert ld._spec_floor_version("pkg>1.0") == (Version("1.0"), True)
+        assert ld._spec_floor_version("pkg>1.0,<2") == (Version("1.0"), True)
         assert ld._spec_floor_version("bare-package") is None
         assert ld._spec_floor_version("only-ceiling<2") is None
 
@@ -534,17 +542,37 @@ class TestRuntimeNeverDowngrade:
 
     # -- acceptance (c): hermes update keeps strict pin propagation ---------
     def test_strict_feature_missing_still_flags_newer(self, monkeypatch):
+        # The floor pin makes hindsight itself strict-satisfied on newer
+        # (see test_floor_pinned_feature_newer_is_strict_satisfied), so the
+        # strict-contract probe uses an ==-pinned feature: the default
+        # (strict) predicate is the update path's detector.
+        self._patch_env(monkeypatch, {"honcho-ai": "2.3.0"})
+        assert ld.feature_missing("memory.honcho") == ("honcho-ai==2.2.0",)
+        assert ld._is_satisfied("honcho-ai==2.2.0") is False
+
+    def test_floor_pinned_feature_newer_is_strict_satisfied(self, monkeypatch):
+        # A floor pin (>=) expresses "any newer is acceptable" — even the
+        # strict predicate accepts 0.8.6, so no downgrade signal exists on
+        # ANY path for this feature (issue #80390, suggestion #4).
         self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
-        # Default (strict) predicate is the update path's detector.
-        assert ld.feature_missing("memory.hindsight") == (self._PIN,)
-        assert ld._is_satisfied(self._PIN) is False
+        assert ld._is_satisfied(self._PIN) is True
+        assert ld.feature_missing("memory.hindsight") == ()
+
+    def test_exclusive_floor_bound_is_honoured(self, monkeypatch):
+        # ``>1.0`` with exactly 1.0.0 installed is a genuine runtime
+        # mismatch (satisfying it is an upgrade, never a downgrade);
+        # one patch release past the bound is satisfied.
+        self._patch_env(monkeypatch, {"pkg-x": "1.0.0"})
+        assert ld._is_satisfied_runtime("pkg-x>1.0") is False
+        self._patch_env(monkeypatch, {"pkg-x": "1.0.1"})
+        assert ld._is_satisfied_runtime("pkg-x>1.0") is True
 
     def test_refresh_active_features_never_downgrades(self, monkeypatch):
-        fake = self._patch_env(monkeypatch, {self._PKG: "0.8.6"})
-        monkeypatch.setattr(ld, "active_features", lambda: ["memory.hindsight"])
+        fake = self._patch_env(monkeypatch, {"honcho-ai": "2.3.0"})
+        monkeypatch.setattr(ld, "active_features", lambda: ["memory.honcho"])
         result = ld.refresh_active_features(prompt=False)
         # ensure() (the only installer) no-ops on newer — nothing downgraded.
         assert fake.installed == []
         # Strict pre-check still classifies the feature as needing a refresh
         # (acceptance (c)); the refresh itself is a no-op thanks to ensure().
-        assert result["memory.hindsight"] == "refreshed"
+        assert result["memory.honcho"] == "refreshed"

--- a/tests/tools/test_lazy_deps_managed.py
+++ b/tests/tools/test_lazy_deps_managed.py
@@ -24,7 +24,12 @@ def _missing_and_installable(monkeypatch):
     ``allow_lazy_installs: false`` otherwise short-circuits with a different
     rejection reason).
     """
-    monkeypatch.setattr(lazy_deps, "feature_missing", lambda _f: ("some-pkg==1.0",))
+    monkeypatch.setattr(
+        lazy_deps, "feature_missing",
+        # ensure() passes the ``runtime`` flag (added for #80390) — the mock
+        # must tolerate it to keep forcing the "missing" state.
+        lambda _f, **kw: ("some-pkg==1.0",),
+    )
     monkeypatch.setattr(lazy_deps, "_allow_lazy_installs", lambda: True)
     monkeypatch.setattr(lazy_deps, "_lazy_install_target", lambda: None)
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -599,9 +599,12 @@ def _is_satisfied(spec: str) -> bool:
 
     Checks both presence AND version. If the package is installed at a
     version outside the spec's range, returns False so the caller will
-    upgrade/downgrade to the pinned version. This is what makes
-    ``hermes update`` propagate pin bumps in :data:`LAZY_DEPS` to already-
-    installed backends instead of silently leaving stale versions in place.
+    upgrade/downgrade to the pinned version. This is the STRICT predicate
+    — exact-pin enforcement for callers that want it (e.g. the matrix
+    adapter's check, or any caller using :func:`feature_missing` with its
+    strict default). The runtime paths (:func:`ensure`, the ``hermes
+    update`` refresh pass) use :func:`_is_satisfied_runtime` instead, so a
+    newer-than-pin install is never downgraded (#80390).
 
     If ``packaging`` is unavailable for any reason (it's a transitive of
     pip so this should never happen), we fall back to a presence-only check
@@ -688,10 +691,11 @@ def _is_satisfied_runtime(spec: str) -> bool:
     pin back down). Only a genuinely absent package, or one installed BELOW
     the pin's floor, is treated as missing by the runtime install path.
 
-    Strict pin semantics stay the job of :func:`_is_satisfied` / the
-    ``hermes update`` propagation pass (:func:`refresh_active_features`),
-    which intentionally flag any version mismatch so stale installs get
-    upgraded to the pin.
+    Strict pin semantics stay the job of :func:`_is_satisfied` for callers
+    that explicitly ask for them (``feature_missing`` strict default);
+    the ``hermes update`` propagation pass (:func:`refresh_active_features`)
+    uses runtime semantics too, so it flags only genuinely-missing or
+    below-pin installs and upgrades those to the pin.
     """
     if _is_satisfied(spec):
         return True
@@ -938,8 +942,7 @@ def feature_missing(feature: str, *, runtime: bool = False) -> tuple[str, ...]:
     an installed version NEWER than the spec's pin counts as satisfied, so
     the runtime ``ensure`` path never downgrades an operator-installed newer
     backend (#80390). Strict pin semantics — the default — flag any version
-    mismatch so the ``hermes update`` propagation pass
-    (:func:`refresh_active_features`) can upgrade stale installs to the pin.
+    mismatch for callers that still want exact-pin enforcement.
     """
     check = _is_satisfied_runtime if runtime else _is_satisfied
     return tuple(s for s in feature_specs(feature) if not check(s))
@@ -1231,12 +1234,19 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
                                   whether to surface it (we don't raise)
         ``"skipped: <reason>"`` — gated off (config flag, user decline)
 
+    Uses the same runtime semantics as :func:`ensure` for the pre-check
+    (:func:`feature_missing` with ``runtime=True``): an installed version
+    NEWER than the pin counts as satisfied and is reported ``"current"``
+    — never "refreshed", which would claim a reinstall that never ran
+    (#80390). A version BELOW the pin is still missing and gets upgraded,
+    so pin-bump propagation is preserved.
+
     Intended for ``hermes update``. Never raises; lazy-install failures
     here must not block the rest of the update flow.
     """
     results: dict[str, str] = {}
     for feature in active_features():
-        missing = feature_missing(feature)
+        missing = feature_missing(feature, runtime=True)
         if not missing:
             results[feature] = "current"
             continue

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -630,6 +630,71 @@ def _is_satisfied(spec: str) -> bool:
         return True
 
 
+def _spec_floor_version(spec: str):
+    """Return the lowest acceptable version implied by ``spec``, or None.
+
+    The floor is the max of the versions contributed by the spec's lower
+    bound operators (``==``, ``>=``, ``>``, ``~=``) — e.g. ``==0.6.1`` →
+    ``0.6.1``, ``>=0.20,<1`` → ``0.20``. Ceiling-only specs (``<2``) and
+    unparseable specs have no floor and return None.
+    """
+    spec_tail = _specifier_from_spec(spec)
+    if not spec_tail:
+        return None
+    try:
+        from packaging.specifiers import InvalidSpecifier, SpecifierSet
+        from packaging.version import InvalidVersion, Version
+        specifiers = SpecifierSet(spec_tail)
+    except (ImportError, InvalidSpecifier):
+        return None
+    floors = []
+    for specifier in specifiers:
+        if specifier.operator in ("==", ">=", ">", "~="):
+            try:
+                floors.append(Version(specifier.version))
+            except InvalidVersion:
+                continue
+    return max(floors) if floors else None
+
+
+def _is_satisfied_runtime(spec: str) -> bool:
+    """Is ``spec`` satisfied for the RUNTIME (``ensure``) path?
+
+    Delegates to the strict :func:`_is_satisfied` first — same cost on the
+    already-satisfied hot path. When the strict check fails, applies floor
+    semantics instead of giving up: an installed version NEWER than the
+    spec's pin still counts as satisfied, so ``ensure()`` never implicitly
+    DOWNGRADES a backend the operator installed at a newer version
+    (upstream issue #80390 — a data-ratcheted backend's DB can't follow a
+    pin back down). Only a genuinely absent package, or one installed BELOW
+    the pin's floor, is treated as missing by the runtime install path.
+
+    Strict pin semantics stay the job of :func:`_is_satisfied` / the
+    ``hermes update`` propagation pass (:func:`refresh_active_features`),
+    which intentionally flag any version mismatch so stale installs get
+    upgraded to the pin.
+    """
+    if _is_satisfied(spec):
+        return True
+    pkg = _pkg_name_from_spec(spec)
+    try:
+        from importlib.metadata import version as _md_version
+        installed = _md_version(pkg)
+    except Exception:
+        return False  # absent (or metadata broken) — genuinely missing
+    floor = _spec_floor_version(spec)
+    if floor is None:
+        # No parseable floor (ceiling-only / malformed): the package IS
+        # installed, so never churn it — treat as satisfied.
+        return True
+    try:
+        from packaging.version import Version
+        return Version(installed) >= floor
+    except Exception:
+        # Unparseable installed version — err on "don't churn".
+        return True
+
+
 def _is_present(spec: str) -> bool:
     """Cheap presence-only check (package name installed at any version).
 
@@ -826,9 +891,34 @@ def feature_specs(feature: str) -> tuple[str, ...]:
     return LAZY_DEPS[feature]
 
 
-def feature_missing(feature: str) -> tuple[str, ...]:
-    """Return the subset of specs for ``feature`` not currently installed."""
-    return tuple(s for s in feature_specs(feature) if not _is_satisfied(s))
+def _describe_missing(spec: str) -> str:
+    """Render a missing spec for messages, noting an off-pin installed version.
+
+    Distinguishes "absent" (plain spec) from "version mismatch" (spec plus
+    the installed version that failed the pin check) so the user isn't told
+    a package is missing when it's actually installed at the wrong version.
+    """
+    pkg = _pkg_name_from_spec(spec)
+    try:
+        from importlib.metadata import version as _md_version
+        installed = _md_version(pkg)
+    except Exception:
+        return spec  # genuinely absent
+    return f"{spec} (installed: {installed} — version mismatch)"
+
+
+def feature_missing(feature: str, *, runtime: bool = False) -> tuple[str, ...]:
+    """Return the subset of specs for ``feature`` not currently installed.
+
+    ``runtime=True`` applies runtime semantics (:func:`_is_satisfied_runtime`):
+    an installed version NEWER than the spec's pin counts as satisfied, so
+    the runtime ``ensure`` path never downgrades an operator-installed newer
+    backend (#80390). Strict pin semantics — the default — flag any version
+    mismatch so the ``hermes update`` propagation pass
+    (:func:`refresh_active_features`) can upgrade stale installs to the pin.
+    """
+    check = _is_satisfied_runtime if runtime else _is_satisfied
+    return tuple(s for s in feature_specs(feature) if not check(s))
 
 
 def ensure(feature: str, *, prompt: bool = True) -> None:
@@ -848,7 +938,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             feature, (), f"feature {feature!r} not in LAZY_DEPS allowlist"
         )
 
-    missing = feature_missing(feature)
+    missing = feature_missing(feature, runtime=True)
     if not missing:
         return
 
@@ -917,7 +1007,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             _pt_active = False
 
     if prompt and not _pt_active and sys.stdin.isatty() and sys.stdout.isatty():
-        spec_list = ", ".join(missing)
+        spec_list = ", ".join(_describe_missing(s) for s in missing)
         try:
             answer = input(
                 f"\nFeature {feature!r} requires: {spec_list}\n"
@@ -953,7 +1043,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     except Exception:
         pass
 
-    still_missing = feature_missing(feature)
+    still_missing = feature_missing(feature, runtime=True)
     if still_missing:
         raise FeatureUnavailable(
             feature, still_missing,
@@ -965,10 +1055,18 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
 
 def is_available(feature: str) -> bool:
-    """Return True if the feature's deps are already satisfied."""
+    """Return True if the runtime can use this feature right now.
+
+    Uses runtime semantics: an installed version NEWER than the pinned floor
+    counts as available (never-downgrade, #80390), so this predicate agrees
+    with what :func:`ensure` would do — it never reports "not available" for
+    a working newer install (the wake_word readiness path depends on this).
+    Strict pin semantics remain the job of :func:`feature_missing` and the
+    ``hermes update`` refresh pass (:func:`refresh_active_features`).
+    """
     if feature not in LAZY_DEPS:
         return False
-    return not feature_missing(feature)
+    return not feature_missing(feature, runtime=True)
 
 
 def feature_install_command(feature: str) -> Optional[str]:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,15 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    # Floor-pinned on purpose (issue #80390, suggestion #4, reporter-validated):
+    # the embedded hindsight stack is operator-installed from a MOVING PyPI
+    # train (hindsight-all resolves to 0.8.x today) outside the image's
+    # lockfile, and the backend's data dir ratchets forward with each release —
+    # the client must be allowed to ride that train. A bare floor still flags
+    # absent/below-pin installs; every other lazy feature stays exactly pinned
+    # (==) for deterministic installs. The `hindsight` extra in pyproject.toml
+    # keeps its == pin: that is the deterministic CI surface.
+    "memory.hindsight": ("hindsight-client>=0.6.1",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the
@@ -631,12 +639,18 @@ def _is_satisfied(spec: str) -> bool:
 
 
 def _spec_floor_version(spec: str):
-    """Return the lowest acceptable version implied by ``spec``, or None.
+    """Return ``(floor, exclusive)`` — the lowest acceptable version implied
+    by ``spec`` and whether that bound is exclusive (``>``) — or None when the
+    spec has no usable lower bound.
 
     The floor is the max of the versions contributed by the spec's lower
-    bound operators (``==``, ``>=``, ``>``, ``~=``) — e.g. ``==0.6.1`` →
-    ``0.6.1``, ``>=0.20,<1`` → ``0.20``. Ceiling-only specs (``<2``) and
-    unparseable specs have no floor and return None.
+    bound operators (``==``, ``>=``, ``>``, ``~=``) — e.g. ``>=0.6.1`` →
+    ``(0.6.1, False)``, ``>1.0`` → ``(1.0, True)``, ``>=0.20,<1`` →
+    ``(0.20, False)``. ``exclusive`` is True when the max floor came from a
+    ``>`` operator (a strict ``>`` wins a same-version tie with ``>=``/``==``),
+    so the runtime can treat ``>1.0`` with 1.0.0 installed as a genuine
+    mismatch — satisfying it is an upgrade, never a downgrade. Ceiling-only
+    specs (``<2``) and unparseable specs have no floor and return None.
     """
     spec_tail = _specifier_from_spec(spec)
     if not spec_tail:
@@ -651,10 +665,15 @@ def _spec_floor_version(spec: str):
     for specifier in specifiers:
         if specifier.operator in ("==", ">=", ">", "~="):
             try:
-                floors.append(Version(specifier.version))
+                floors.append(
+                    (Version(specifier.version), specifier.operator == ">")
+                )
             except InvalidVersion:
                 continue
-    return max(floors) if floors else None
+    if not floors:
+        return None
+    # (Version, bool) tuples: an exclusive ">" wins a same-version tie.
+    return max(floors)
 
 
 def _is_satisfied_runtime(spec: str) -> bool:
@@ -689,7 +708,12 @@ def _is_satisfied_runtime(spec: str) -> bool:
         return True
     try:
         from packaging.version import Version
-        return Version(installed) >= floor
+        floor_ver, exclusive = floor
+        if exclusive:
+            # ``>1.0`` with 1.0.0 installed is a genuine mismatch — fixing
+            # it is an upgrade, never a downgrade.
+            return Version(installed) > floor_ver
+        return Version(installed) >= floor_ver
     except Exception:
         # Unparseable installed version — err on "don't churn".
         return True


### PR DESCRIPTION
## What does this PR do?

Fixes two related defects in the lazy-deps / memory-status path — #80390 is the root cause, #80388 its visible symptom:

**#80390 — auto-downgrade on every retain.** `tools/lazy_deps.py` pinned `hindsight-client==0.6.1` and the strict `_is_satisfied()` treated any off-pin install as missing. An operator-installed, working, NEWER hindsight stack was reported missing, and `ensure()` attempted an unattended downgrade to the pin on every retain. This is destructive: the embedded hindsight stack migrates its Postgres (pg0) data directory forward with each release — once 0.8.x has run, the DB cannot go back to 0.6.1. The `==` pin was also the wrong shape for this backend (reporter suggestion #4, validated by the reporter on 0.8.6): hindsight ships outside the image's lockfile on a moving PyPI train, so the pin is now a floor (`hindsight-client>=0.6.1`) — absent/below-pin installs stay flagged, but `ensure()` installs the current train instead of stale 0.6.1, and the status hint no longer coaches toward the broken state.

**#80388 — dishonest status.** `hermes memory status` checked only the provider's static config, so it printed `available ✓` while every retain was dropped on a version/install check the runtime enforces.

**Approach — explicit runtime semantics, strict preserved.** Rather than rewriting the strict predicate globally, this PR opts specific runtime paths into never-downgrade behavior:

- `feature_missing(feature, *, runtime=False)` — **strict by default**: byte-identical behavior for every caller that doesn't opt in (matrix adapter, doctor). `runtime=True` applies floor semantics via `_is_satisfied_runtime`: strict check first (same cost on the hot path), then installed ≥ floor (exclusive `>` bounds are honored — `>1.0` with 1.0.0 installed is a genuine mismatch, an upgrade never a downgrade); a spec with no parseable floor means "installed ⇒ satisfied" (don't churn).
- `ensure()` uses `runtime=True` for the pre-check AND post-install verify — newer installs are never touched, below-pin installs still upgrade (pin propagation intact), absent packages still install, install failure still raises `FeatureUnavailable`.
- `refresh_active_features()` pre-checks with the same runtime semantics as `ensure()` (`feature_missing(feature, runtime=True)`): a newer-than-pin install is reported `"current"` — never `"refreshed"`, which would claim a reinstall that never ran — while a genuinely below-pin install is still flagged and upgraded, so pin-bump propagation is preserved. **A downgrade is impossible anywhere**.
- `is_available()` becomes a runtime-readiness predicate — the wake_word readiness path (`tools/wake_word.py:851/877/901`) never disables a working newer install in a sealed env.
- `_describe_missing()` — prompts distinguish "absent" from "installed at a different version".
- `hermes memory status` now uses the exact runtime predicate (`_runtime_lazy_missing` → `feature_missing(f"memory.{provider}", runtime=True)`), so status and runtime **cannot disagree by construction**. Healthy line byte-identical; env-var checklist only on static failure. Missing deps are listed with the canonical install hint from `feature_install_command()`.

**Note on competing PR #80496:** @webtecnica's `fix(memory): never auto-downgrade installed hindsight; honest status predicate` fixed the same two issues with a different approach — rewriting `_is_satisfied()` globally so newer-than-pin counts as satisfied, plus changing the hindsight pin to `>=0.6.1`. That fix was valid and its tests passed. I tested both trees head-to-head (identical suite + behavioral probes, same venv) before filing: this PR preserves the strict/update-path contract for all existing callers (their version silently makes `feature_missing("platform.matrix")` and the `hermes update` refresh pre-check newer-tolerant at the check level), renders an actionable install command in status, and adds tests for the refresh-never-downgrades contract their PR doesn't cover. The final commit adopts their hindsight pin shape (`>=0.6.1`) — it implements the reporter's own suggestion #4 and was validated by the reporter on 0.8.6 — while every other lazy feature stays exactly pinned (`==`) and the CI `hindsight` extra is untouched. The difference that remains is architectural: ours keeps strict pin semantics for every existing caller by default, with runtime paths opting in. @webtecnica closed #80496 in favor of this PR after filing.

## Related Issue

Fixes #80390, Fixes #80388

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py` — `_spec_floor_version` (floor + exclusive `>` bounds), `_is_satisfied_runtime`, `feature_missing(runtime=)`, `ensure()` runtime semantics, `is_available()` runtime, `_describe_missing`, hindsight floor pin (+140)
- `tests/tools/test_lazy_deps.py` — `TestRuntimeNeverDowngrade`, 14 tests (+162)
- `tests/tools/test_lazy_deps_managed.py` — fixture compat for the new kwarg (+7)
- `hermes_cli/memory_setup.py` — `_runtime_lazy_missing` + truthful status block (+66)
- `tests/hermes_cli/test_memory_status.py` — `TestStatusUsesRuntimePredicate`, 6 tests (+93)

## How to Test

1. **Reproduce #80390:** with hindsight-client installed NEWER than the floor pin (e.g. 0.8.6 vs `>=0.6.1`), the old code treated it as missing and `ensure()` attempted to install the pin (a downgrade). Now: `feature_missing("memory.hindsight", runtime=True)` → `()`, `ensure()` no-ops, `is_available()` → True.
2. **Reproduce #80388:** with lazy deps below the pin or absent, `hermes memory status` now prints `not available ✗` + `Missing runtime deps:` + the specs + the canonical `uv pip install 'hindsight-client>=0.6.1'` hint (current train, not stale 0.6.1) — instead of `available ✓`.
3. **Targeted suite** (change surface + integration):
   `python scripts/run_tests_parallel.py -j 8 tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_managed.py tests/plugins/memory/test_memory_lazy_install.py tests/hermes_cli/test_memory_status.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_memory_setup_provider_arg.py tests/hermes_cli/test_lazy_refresh_venv_repair.py tests/tools/test_wake_word.py`
   → **135 passed, 0 failed** (1 skip: `importorskip("numpy")` — numpy absent from the dev venv).
4. **Behavior probes** (never-downgrade / below-pin upgrade / absent install / strict-default preservation / status-runtime agreement): 9/9 PASS.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `fix(tools): …`, `fix(cli): …`
- [x] I searched for existing PRs — issues #80390/#80388 were open and unassigned at filing; the competing PR #80496 is disclosed above (closed in favor of this one since); two later PRs, #80559 and #80555, were filed against these issues after this PR and remain open at the time of writing
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Tests added for my changes (required for bug fixes) — 20 new tests
- [x] I've tested on my platform: **Windows 11** (x64)

### Documentation & Housekeeping

- [x] Docstrings updated on all changed functions — or N/A
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture or workflow changes)
- [x] Cross-platform impact considered — `scripts/check-windows-footguns.py` clean on the diff (5 files); no new POSIX-only calls; Linux/macOS not tested locally (CI covers Ubuntu/Python 3.11)
- [x] Tool descriptions/schemas — N/A (no model-tool schema changes)

**Full-suite caveat:** on this Windows 11 box the full suite has pre-existing environmental failures unrelated to this change — temp-dir symlink fixtures fail with `WinError 1314` (Windows symlink privilege, the documented AGENTS.md §3.4 footgun), optional-SDK tests fail on packages CI installs via extras (e.g. `hindsight_client_api` via `--extra hindsight`), and `test_npm_engine` trips warnings-as-errors. The targeted suite above plus CI (Linux) are the authoritative gates.

## Security impact

- **Shell execution:** no change to command construction. The existing `uv pip install` path runs specs from `LAZY_DEPS` constants (maintainer-controlled) via subprocess list-form; no user input reaches a shell. `_describe_missing` renders spec strings into a prompt message only.
- **File/path handling:** none added.
- **Credentials:** none touched; status output prints package specs only, never secrets.
- **Network/telemetry:** none added.
- **Cross-platform:** no new POSIX-only syscalls; footguns clean; tested Windows 11 only.

## Screenshots / Logs

Behavior probe output and repro scripts available on request.
