### PR TITLE
fix(mcp): preserve repeated env flags

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -196,10 +196,13 @@ def _save_bearer_auth_token(name: str, token: str) -> Dict[str, str]:
     return _bearer_auth_headers(name)
 
 
-def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
-    """Parse ``KEY=VALUE`` strings from CLI args into an env dict."""
+def _parse_env_assignments(raw_env: Optional[List[Any]]) -> Dict[str, str]:
+    """Parse and flatten grouped ``KEY=VALUE`` CLI args into an env dict."""
     parsed: Dict[str, str] = {}
     for item in raw_env or []:
+        if isinstance(item, (list, tuple)):
+            parsed.update(_parse_env_assignments(list(item)))
+            continue
         text = str(item or "").strip()
         if not text:
             continue

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -67,9 +67,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     )
     mcp_add_p.add_argument(
         "--env",
-        nargs="*",
+        action="append",
+        nargs="+",
         default=[],
-        help="Environment variables for stdio servers (KEY=VALUE)",
+        metavar="KEY=VALUE",
+        help=(
+            "Environment variables for stdio servers; accepts multiple values "
+            "and may be repeated"
+        ),
     )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")

--- a/tests/hermes_cli/test_mcp_add_env_parser.py
+++ b/tests/hermes_cli/test_mcp_add_env_parser.py
@@ -1,0 +1,34 @@
+"""Production-parser regressions for ``hermes mcp add --env``."""
+
+import argparse
+
+from hermes_cli.subcommands.mcp import build_mcp_parser
+
+
+def _parse_mcp_add(*argv: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_mcp_parser(subparsers, cmd_mcp=lambda _args: None)
+    return parser.parse_args(["mcp", "add", "demo", "--command", "demo-mcp", *argv])
+
+
+def test_repeated_env_flags_accumulate_groups() -> None:
+    args = _parse_mcp_add(
+        "--env",
+        "FIRST=1",
+        "SECOND=two",
+        "--env",
+        "THIRD=3",
+        "FOURTH=four",
+    )
+
+    assert args.env == [
+        ["FIRST=1", "SECOND=two"],
+        ["THIRD=3", "FOURTH=four"],
+    ]
+
+
+def test_single_env_flag_keeps_grouped_assignments() -> None:
+    args = _parse_mcp_add("--env", "FIRST=1", "SECOND=two")
+
+    assert args.env == [["FIRST=1", "SECOND=two"]]

--- a/tests/hermes_cli/test_mcp_add_env_parser.py
+++ b/tests/hermes_cli/test_mcp_add_env_parser.py
@@ -32,3 +32,19 @@ def test_single_env_flag_keeps_grouped_assignments() -> None:
     args = _parse_mcp_add("--env", "FIRST=1", "SECOND=two")
 
     assert args.env == [["FIRST=1", "SECOND=two"]]
+
+
+def test_env_flags_before_args_preserve_command_remainder() -> None:
+    args = _parse_mcp_add(
+        "--env",
+        "FIRST=1",
+        "--args",
+        "mcp",
+        "gateway",
+        "run",
+        "--profile",
+        "research",
+    )
+
+    assert args.env == [["FIRST=1"]]
+    assert args.args == ["mcp", "gateway", "run", "--profile", "research"]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -243,6 +243,38 @@ class TestMcpAdd:
             "DEBUG": "true",
         }
 
+    def test_add_stdio_server_flattens_repeated_env_groups(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Every assignment from repeated grouped --env flags is persisted."""
+        expected_env = {
+            "FIRST": "1",
+            "SECOND": "two",
+            "THIRD": "3",
+        }
+
+        def mock_probe(name, config, **kw):
+            assert config["env"] == expected_env
+            return [("search", "Search repos")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="grouped-env",
+            mcp_command="demo-mcp",
+            env=[["FIRST=1", "SECOND=two"], ["THIRD=3"]],
+        ))
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        assert config["mcp_servers"]["grouped-env"]["env"] == expected_env
+
 
     def test_add_preset_fills_transport(self, tmp_path, capsys, monkeypatch):
         """A preset fills in command/args when no explicit transport given."""


### PR DESCRIPTION
## Summary

- make `hermes mcp add --env` safely repeatable
- preserve the existing grouped form (`--env A=1 B=2`)
- flatten repeated parser groups before validation and persistence
- test the production `build_mcp_parser()` rather than a parser replica

Fixes #37501.
Fixes #45672.

## Maintainer consolidation note

This PR is the current-`main` consolidation requested by the review on #45703 and the cross-PR triage on #37501/#45672:

| Merge criterion | #45703 | This PR |
| --- | --- | --- |
| Changes the live `hermes_cli/subcommands/mcp.py` builder | Yes | Yes |
| Repeated `--env A=1 --env B=2` | Yes | Yes |
| Existing grouped `--env A=1 B=2` remains valid | No | Yes |
| Exercises the real `build_mcp_parser()` | No | Yes |
| Covers grouped/repeated flattening through persistence | No | Yes |
| Covers required `--env` before `--args` ordering through the real parser | No | Yes |

- #45703's [review](https://github.com/NousResearch/hermes-agent/pull/45703#pullrequestreview-4694847440) asks for both accepted forms and production-parser regressions; both are covered here.
- The [issue-level consolidation review](https://github.com/NousResearch/hermes-agent/issues/45672#issuecomment-5165385701) recommends a current-main salvage of #40084; that is this PR's implementation and attribution basis.
- Thanks to @EdderTalmor for #45703's current-parser diagnosis and regression attempt. This PR incorporates the compatibility and test requirements surfaced by its review rather than competing with that work.

## Root cause

The live MCP parser used `nargs="*"` without an accumulating action. Argparse therefore replaced earlier values each time `--env` appeared, silently retaining only the final group.

Using `action="append", nargs="+"` preserves both accepted forms:

```console
hermes mcp add demo --command demo-mcp --env A=1 B=2
hermes mcp add demo --command demo-mcp --env A=1 --env B=2
```

`cmd_mcp_add()` then recursively flattens those groups before applying the existing environment-name validation and persistence logic.

## Attribution and consolidation

This is a current-`main` salvage of Kevin Yin's focused implementation in #40084 / commit `3ace69fabe9eb6552fa23547a3025ae601c49921`, relocated from the obsolete inlined parser to `hermes_cli/subcommands/mcp.py` and updated with production-parser coverage as requested by the issue triage.

The commit preserves Kevin's authorship. This PR is intended to consolidate the duplicate chain discussed on #37501 and #45672, not compete with the partial stale-parser variants.

## Verification

- RED on upstream `main`: 3 new regressions failed, proving repeated groups were dropped/rejected
- GREEN: `scripts/run_tests.sh tests/hermes_cli/test_mcp_add_env_parser.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_config.py` — 36 passed
- `python -m ruff check .` — passed (one unrelated pre-existing malformed `# noqa` warning)
- `python -m py_compile` on changed Python files — passed
- `git diff --check` — passed
- Ty: no new diagnostics; the four whole-file diagnostics in `hermes_cli/mcp_config.py` reproduce unchanged on `origin/main`
- real CLI smoke: repeated and grouped `--env` flags launched the local Gas City stdio MCP, discovered 22 tools, and persisted all three requested variables under a temporary `HERMES_HOME`
- full `scripts/run_tests.sh` with `.[all,dev]`: completed non-green in 28 unrelated files (69 failures), concentrated in optional/lazy provider and macOS-specific tests; the focused MCP files remained green

## Scope

No Gas City source or runtime configuration changes are included. This only fixes generic Hermes MCP CLI argument handling.
