### PR TITLE
feat(delegation): bounded resource-aware background admission queue

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1470,11 +1470,17 @@ code_execution:
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.
-# Supports single tasks and batch mode (default 3 parallel, configurable).
+# Supports single tasks and batch mode with a shared child-slot budget.
 delegation:
   max_iterations: 250                         # Max tool-calling turns per child (default: 250)
-  # max_concurrent_children: 10               # Max parallel child agents per batch (default: 10, floor: 1, no ceiling).
-                                              # WARNING: values above 10 multiply API cost linearly.
+  # max_concurrent_children: 10               # Total running child slots across background singles/batches (default: 10, floor: 1, no ceiling).
+                                               # WARNING: values above 10 multiply API cost linearly.
+  # max_queued_delegations: 8                 # Maximum pending background calls; 0 rejects work that cannot start.
+  # queue_timeout_seconds: 3600               # Maximum seconds a call may remain queued; 0 disables expiry.
+  # min_available_memory_mb: 0                # Host/cgroup memory headroom stop floor; 0 disables gating.
+  # resume_available_memory_mb: 0             # Higher recovery floor after a block; 0 follows stop floor.
+  # max_memory_psi_avg10: 0                   # Linux PSI some/avg10 stop ceiling; 0 disables PSI gating.
+  # resume_memory_psi_avg10: 0                # Lower recovery ceiling; 0 follows stop ceiling.
   # max_spawn_depth: 1                        # Delegation tree depth cap (range: 1-3, default: 1 = flat).
                                               # Raise to 2 to allow workers to spawn their own subagents.
                                               # Requires role="orchestrator" on intermediate agents.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1285,11 +1285,17 @@ code_execution:
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.
-# Supports single tasks and batch mode (default 3 parallel, configurable).
+# Supports single tasks and batch mode with a shared child-slot budget.
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
-  # max_concurrent_children: 3                # Max parallel child agents per batch (default: 3, floor: 1, no ceiling).
-                                              # WARNING: values above 10 multiply API cost linearly.
+  # max_concurrent_children: 3                # Total running child slots across background singles/batches (floor: 1).
+                                               # WARNING: values above 10 multiply API cost linearly.
+  # max_queued_delegations: 8                 # Maximum pending background calls; 0 rejects work that cannot start.
+  # queue_timeout_seconds: 3600               # Maximum seconds a call may remain queued; 0 disables expiry.
+  # min_available_memory_mb: 0                # Host/cgroup memory headroom stop floor; 0 disables gating.
+  # resume_available_memory_mb: 0             # Higher recovery floor after a block; 0 follows stop floor.
+  # max_memory_psi_avg10: 0                   # Linux PSI some/avg10 stop ceiling; 0 disables PSI gating.
+  # resume_memory_psi_avg10: 0                # Lower recovery ceiling; 0 follows stop ceiling.
   # max_spawn_depth: 1                        # Delegation tree depth cap (range: 1-3, default: 1 = flat).
                                               # Raise to 2 to allow workers to spawn their own subagents.
                                               # Requires role="orchestrator" on intermediate agents.

--- a/cli.py
+++ b/cli.py
@@ -1213,8 +1213,8 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
         except Exception:
             pass
         try:
-            from tools.async_delegation import interrupt_all as _interrupt_async_delegations
-            _interrupt_async_delegations(reason="CLI shutdown")
+            from tools.async_delegation import begin_shutdown as _shutdown_async_delegations
+            _shutdown_async_delegations(reason="CLI shutdown")
         except Exception:
             pass
         try:

--- a/cli.py
+++ b/cli.py
@@ -1199,8 +1199,8 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     except Exception:
         pass
     try:
-        from tools.async_delegation import interrupt_all as _interrupt_async_delegations
-        _interrupt_async_delegations(reason="CLI shutdown")
+        from tools.async_delegation import begin_shutdown as _shutdown_async_delegations
+        _shutdown_async_delegations(reason="CLI shutdown")
     except Exception:
         pass
     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14466,8 +14466,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _e:
                     logger.debug("mark_running_jobs_interrupted (%s) error: %s", phase, _e)
                 try:
-                    from tools.async_delegation import interrupt_all as _interrupt_async
-                    _async_n = _interrupt_async(reason=f"gateway shutdown ({phase})")
+                    from tools.async_delegation import begin_shutdown as _shutdown_async
+                    _async_n = _shutdown_async(reason=f"gateway shutdown ({phase})")
                     if _async_n:
                         logger.info(
                             "Shutdown (%s): interrupted %d background delegation(s)",
@@ -26563,6 +26563,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 name=f"gateway-turn-reaper-{_process_task_id[:12]}",
                 daemon=True,
             ).start()
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            interrupt_for_session(
+                session_key=session_key,
+                parent_session_id=str(
+                    getattr(running_agent, "session_id", "") or ""
+                ),
+                reason=invalidation_reason,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to interrupt background delegations for %s",
+                session_key,
+                exc_info=True,
+            )
         adapter = self._adapter_for_source(source)
         interrupt_session_activity = getattr(
             type(adapter), "interrupt_session_activity", None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12723,8 +12723,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _e:
                     logger.debug("mark_running_jobs_interrupted (%s) error: %s", phase, _e)
                 try:
-                    from tools.async_delegation import interrupt_all as _interrupt_async
-                    _async_n = _interrupt_async(reason=f"gateway shutdown ({phase})")
+                    from tools.async_delegation import begin_shutdown as _shutdown_async
+                    _async_n = _shutdown_async(reason=f"gateway shutdown ({phase})")
                     if _async_n:
                         logger.info(
                             "Shutdown (%s): interrupted %d background delegation(s)",
@@ -23109,6 +23109,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 name=f"gateway-turn-reaper-{_process_task_id[:12]}",
                 daemon=True,
             ).start()
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            interrupt_for_session(
+                session_key=session_key,
+                parent_session_id=str(
+                    getattr(running_agent, "session_id", "") or ""
+                ),
+                reason=invalidation_reason,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to interrupt background delegations for %s",
+                session_key,
+                exc_info=True,
+            )
         adapter = self._adapter_for_source(source)
         interrupt_session_activity = getattr(
             type(adapter), "interrupt_session_activity", None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1365,7 +1365,7 @@ class GatewaySlashCommandsMixin:
             from tools.async_delegation import list_async_delegations
             delegations = [
                 d for d in list_async_delegations()
-                if d.get("status") in ("running", "stalling", "finalizing")
+                if d.get("status") in ("queued", "running", "stalling", "finalizing")
             ]
         except Exception:
             delegations = []
@@ -1385,7 +1385,9 @@ class GatewaySlashCommandsMixin:
                     goal = goal[:67] + "..."
                 status = d.get("status", "?")
                 row = f"- `{d.get('delegation_id', '?')}` · {status}"
-                if status == "stalling":
+                if status == "queued":
+                    row += f" · {d.get('queue_reason', 'capacity')}"
+                elif status == "stalling":
                     quiet = d.get("stalled_after_quiet_seconds")
                     if quiet is not None:
                         row += f" · no progress {quiet:.0f}s"
@@ -1459,6 +1461,26 @@ class GatewaySlashCommandsMixin:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_handler",
             )
+            return EphemeralReply(t("gateway.stop.stopped"))
+
+        # Detached delegations outlive the foreground turn, so an otherwise
+        # idle session can still own queued/running work. /stop must cancel it.
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            _async_stopped = interrupt_for_session(
+                session_key=session_key,
+                parent_session_id=str(getattr(session_entry, "session_id", "") or ""),
+                reason="stop_command_idle",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to interrupt idle-session delegations for %s",
+                session_key,
+                exc_info=True,
+            )
+            _async_stopped = 0
+        if _async_stopped:
             return EphemeralReply(t("gateway.stop.stopped"))
 
         # No run under the caller's own session key.  In a per-user thread

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1383,6 +1383,26 @@ class GatewaySlashCommandsMixin:
             )
             return EphemeralReply(t("gateway.stop.stopped"))
 
+        # Detached delegations outlive the foreground turn, so an otherwise
+        # idle session can still own queued/running work. /stop must cancel it.
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            _async_stopped = interrupt_for_session(
+                session_key=session_key,
+                parent_session_id=str(getattr(session_entry, "session_id", "") or ""),
+                reason="stop_command_idle",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to interrupt idle-session delegations for %s",
+                session_key,
+                exc_info=True,
+            )
+            _async_stopped = 0
+        if _async_stopped:
+            return EphemeralReply(t("gateway.stop.stopped"))
+
         # No run under the caller's own session key.  In a per-user thread
         # (thread_sessions_per_user=True) each participant is isolated even
         # inside one shared thread, so a run another user started lives under

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -529,10 +529,14 @@ class CLICommandsMixin:
             delegations = []
         running_d = [
             d for d in delegations
-            if d.get("status") in ("running", "stalling")
+            if d.get("status") in ("running", "stalling", "finalizing")
         ]
+        queued_d = [d for d in delegations if d.get("status") == "queued"]
         if delegations:
-            _cprint(f"  Background delegations: {len(running_d)} running")
+            _cprint(
+                "  Background delegations: "
+                f"{len(running_d)} running, {len(queued_d)} queued"
+            )
             for d in delegations:
                 goal = (d.get("goal") or "")[:60]
                 status = d.get("status", "?")
@@ -540,8 +544,10 @@ class CLICommandsMixin:
                     f"    {d.get('delegation_id', '?')} · "
                     f"{status} · {goal}"
                 )
-                # Live-status detail for in-flight delegations (#51690).
-                if status == "stalling":
+                # Live-status detail for queued/in-flight delegations (#51690).
+                if status == "queued":
+                    line += f" · {d.get('queue_reason', 'capacity')}"
+                elif status == "stalling":
                     quiet = d.get("stalled_after_quiet_seconds")
                     if quiet is not None:
                         line += (

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1932,11 +1932,21 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # subagent effort: "ultra", "max", "xhigh", "high",
                                  # "medium", "low", "minimal", "none" (empty = inherit)
-        "max_concurrent_children": 10,  # unified concurrency cap: max parallel children per batch
-                                       # AND max concurrent background (background=true)
-                                       # delegation units. New async dispatches beyond the cap
-                                       # fall back to synchronous execution. Floor of 1, no ceiling.
-                                       # (Replaces the deprecated max_async_children.)
+        "max_concurrent_children": 10,  # total child-agent slots shared by running
+                                        # background singles and batches. New async
+                                        # work queues when all required slots are busy.
+                                        # Floor of 1, no ceiling.
+                                        # (Replaces the deprecated max_async_children.)
+        "max_queued_delegations": 8,   # bounded FIFO backlog of background calls;
+                                       # 0 rejects work that cannot start immediately
+        "queue_timeout_seconds": 3600, # max FIFO wait; 0 disables queue expiry
+        "min_available_memory_mb": 0,  # optional admission floor based on host and
+                                       # cgroup memory headroom; 0 disables it
+        "resume_available_memory_mb": 0,  # higher recovery floor after a memory block;
+                                          # 0 follows min_available_memory_mb
+        "max_memory_psi_avg10": 0,  # Linux PSI some/avg10 stop ceiling; 0 disables
+        "resume_memory_psi_avg10": 0,  # lower PSI recovery ceiling after a block;
+                                        # 0 follows max_memory_psi_avg10
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1706,11 +1706,21 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # subagent effort: "ultra", "max", "xhigh", "high",
                                  # "medium", "low", "minimal", "none" (empty = inherit)
-        "max_concurrent_children": 3,  # unified concurrency cap: max parallel children per batch
-                                       # AND max concurrent background (background=true)
-                                       # delegation units. New async dispatches beyond the cap
-                                       # fall back to synchronous execution. Floor of 1, no ceiling.
+        "max_concurrent_children": 3,  # total child-agent slots shared by running
+                                       # background singles and batches. New async
+                                       # work queues when all required slots are busy.
+                                       # Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        "max_queued_delegations": 8,   # bounded FIFO backlog of background calls;
+                                       # 0 rejects work that cannot start immediately
+        "queue_timeout_seconds": 3600, # max FIFO wait; 0 disables queue expiry
+        "min_available_memory_mb": 0,  # optional admission floor based on host and
+                                       # cgroup memory headroom; 0 disables it
+        "resume_available_memory_mb": 0,  # higher recovery floor after a memory block;
+                                          # 0 follows min_available_memory_mb
+        "max_memory_psi_avg10": 0,  # Linux PSI some/avg10 stop ceiling; 0 disables
+        "resume_memory_psi_avg10": 0,  # lower PSI recovery ceiling after a block;
+                                        # 0 follows max_memory_psi_avg10
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -153,8 +153,8 @@ def _cleanup_oneshot_runtime() -> None:
     except Exception:
         pass
     try:
-        from tools.async_delegation import interrupt_all
-        interrupt_all(reason="oneshot shutdown")
+        from tools.async_delegation import begin_shutdown
+        begin_shutdown(reason="oneshot shutdown")
     except Exception:
         pass
     try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -152,8 +152,8 @@ def _cleanup_oneshot_runtime() -> None:
     except Exception:
         pass
     try:
-        from tools.async_delegation import interrupt_all
-        interrupt_all(reason="oneshot shutdown")
+        from tools.async_delegation import begin_shutdown
+        begin_shutdown(reason="oneshot shutdown")
     except Exception:
         pass
     try:

--- a/tests/gateway/test_agents_command_delegations.py
+++ b/tests/gateway/test_agents_command_delegations.py
@@ -84,3 +84,30 @@ async def test_agents_command_marks_stalling_delegation(monkeypatch):
     assert "no progress" in out
 
 
+@pytest.mark.asyncio
+async def test_agents_command_surfaces_queued_delegation_reason():
+    gate = threading.Event()
+    running = ad.dispatch_async_delegation(
+        goal="slot holder", context=None, toolsets=None, role="leaf",
+        model="m", session_key="agent:main:test:dm:1", max_async_children=1,
+        runner=lambda: {} if gate.wait(timeout=10) else {},
+    )
+    queued = ad.dispatch_async_delegation(
+        goal="waiting child", context=None, toolsets=None, role="leaf",
+        model="m", session_key="agent:main:test:dm:1", max_async_children=1,
+        max_queued_delegations=1,
+        runner=lambda: {},
+    )
+    assert running["status"] == "dispatched"
+    assert queued["status"] == "queued"
+
+    try:
+        out = await _make_runner()._handle_agents_command(_Event())  # type: ignore[arg-type]
+    finally:
+        gate.set()
+
+    assert queued["delegation_id"] in out
+    assert "queued" in out
+    assert "capacity" in out
+
+

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -99,6 +99,37 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
     assert "no active" in str(getattr(result, "text", result)).lower()
 
 
+@pytest.mark.asyncio
+async def test_stop_idle_session_interrupts_detached_delegation(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    key = _per_user_key("userA")
+    runner._running_agents = {}
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+
+    interrupted = []
+
+    def _interrupt_for_session(**kwargs):
+        interrupted.append(kwargs)
+        return 1
+
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", _interrupt_for_session
+    )
+
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+    result = await runner._handle_stop_command(event)
+
+    assert interrupted == [{
+        "session_key": key,
+        "parent_session_id": "",
+        "reason": "stop_command_idle",
+    }]
+    assert "stopped" in str(getattr(result, "text", result)).lower()
+
+
 # ---------------------------------------------------------------------------
 # /stop with no active agent still clears a stuck platform status (#32295)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import threading
 import time
+from concurrent.futures import Future
+from types import SimpleNamespace
 
 import pytest
 
@@ -69,6 +71,11 @@ def test_active_for_session_counts_every_live_delegation_state():
     with ad._records_lock:
         ad._records.update(
             {
+                "queued": {
+                    "delegation_id": "queued",
+                    "status": "queued",
+                    "origin_ui_session_id": "desktop-sid",
+                },
                 "running": {
                     "status": "running",
                     "origin_ui_session_id": "desktop-sid",
@@ -92,9 +99,12 @@ def test_active_for_session_counts_every_live_delegation_state():
             }
         )
 
-    assert ad.active_for_session("desktop-sid") == 3
+    assert ad.active_for_session("desktop-sid") == 4
     assert ad.active_for_session("other-sid") == 1
     assert ad.active_for_session("") == 0
+    assert ad.has_live_for_session(origin_ui_session_id="desktop-sid") is True
+    with ad._records_lock:
+        ad._records.pop("queued", None)
 
 
 def test_dispatch_returns_immediately_without_blocking():
@@ -202,27 +212,1047 @@ def test_rich_reinjection_block_is_self_contained():
         assert needle in text, f"missing {needle!r}"
 
 
-def test_dispatch_rejected_at_capacity():
-    ev = threading.Event()
+def test_dispatch_queues_at_capacity_and_starts_after_slot_frees():
+    first_gate = threading.Event()
+    second_started = threading.Event()
+
+    def first_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "first"}
+
+    def second_runner():
+        second_started.set()
+        return {"status": "completed", "summary": "second"}
+
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=first_runner, max_async_children=1,
+    )
+    assert first["status"] == "dispatched"
+
+    second = ad.dispatch_async_delegation(
+        goal="second", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=second_runner, max_async_children=1,
+    )
+    assert second["status"] == "queued"
+    assert second["delegation_id"].startswith("deleg_")
+    assert second_started.wait(timeout=0.1) is False
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert second_started.wait(timeout=2)
+    assert _drain_for(second["delegation_id"]) is not None
+
+
+def test_batch_queues_until_all_child_slots_are_available():
+    first_gate = threading.Event()
+    batch_started = threading.Event()
+
+    def first_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "first"}
+
+    def batch_runner():
+        batch_started.set()
+        return {
+            "results": [
+                {"status": "completed", "summary": "a"},
+                {"status": "completed", "summary": "b"},
+            ]
+        }
+
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=first_runner, max_async_children=2,
+    )
+    assert first["status"] == "dispatched"
+
+    batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=batch_runner, max_async_children=2,
+    )
+    assert batch["status"] == "queued"
+    assert batch_started.wait(timeout=0.1) is False
+    assert ad.active_task_count() == 1
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert batch_started.wait(timeout=2)
+    assert _drain_for(batch["delegation_id"]) is not None
+
+
+def test_pending_queue_is_bounded_and_overflow_never_runs():
+    first_gate = threading.Event()
+    overflow_started = threading.Event()
 
     def blocker():
-        ev.wait(timeout=60)
-        return {"status": "completed", "summary": "x"}
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "done"}
 
-    for i in range(2):
-        r = ad.dispatch_async_delegation(
-            goal=f"task{i}", context=None, toolsets=None, role="leaf",
-            model="m", session_key="", runner=blocker, max_async_children=2,
-        )
-        assert r["status"] == "dispatched"
-
-    r3 = ad.dispatch_async_delegation(
-        goal="task3", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=blocker, max_async_children=2,
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=blocker, max_async_children=1,
+        max_queued_delegations=1,
     )
-    assert r3["status"] == "rejected"
-    assert "capacity reached" in r3["error"]
-    ev.set()
+    queued = ad.dispatch_async_delegation(
+        goal="queued", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=blocker, max_async_children=1,
+        max_queued_delegations=1,
+    )
+    overflow = ad.dispatch_async_delegation(
+        goal="overflow", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: overflow_started.set() or {},
+        max_async_children=1, max_queued_delegations=1,
+    )
+
+    assert first["status"] == "dispatched"
+    assert queued["status"] == "queued"
+    assert overflow["status"] == "rejected"
+    assert "queue" in overflow["error"].lower()
+    assert overflow_started.wait(timeout=0.1) is False
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_queue_is_fifo_when_head_batch_needs_more_slots():
+    first_gate = threading.Event()
+    order = []
+
+    def active_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "active"}
+
+    first = ad.dispatch_async_delegation(
+        goal="active", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=active_runner,
+        max_async_children=3,
+    )
+    batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b", "c"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: order.append("batch") or {"results": []},
+        max_async_children=3,
+    )
+    later = ad.dispatch_async_delegation(
+        goal="later", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: order.append("later") or {
+            "status": "completed", "summary": "later"
+        },
+        max_async_children=3,
+    )
+
+    assert first["status"] == "dispatched"
+    assert batch["status"] == "queued"
+    assert later["status"] == "queued"
+    assert order == []
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert _drain_for(batch["delegation_id"]) is not None
+    assert _drain_for(later["delegation_id"]) is not None
+    assert order == ["batch", "later"]
+
+
+def test_dispatch_waits_for_memory_floor_before_starting(monkeypatch):
+    available = {"bytes": 100}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+
+    result = ad.dispatch_async_delegation(
+        goal="memory gated", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {
+            "status": "completed", "summary": "done"
+        },
+        max_async_children=1,
+        min_available_memory_bytes=200,
+    )
+
+    assert result["status"] == "queued"
+    assert result["queue_reason"] == "resources"
+    assert started.wait(timeout=0.1) is False
+
+    available["bytes"] = 300
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_effective_memory_uses_tightest_cgroup_limit(monkeypatch, tmp_path):
+    import psutil
+
+    cgroup = tmp_path / "delegation.slice"
+    cgroup.mkdir()
+    (cgroup / "memory.current").write_text("100\n", encoding="utf-8")
+    (cgroup / "memory.high").write_text("700\n", encoding="utf-8")
+    (cgroup / "memory.max").write_text("900\n", encoding="utf-8")
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: SimpleNamespace(available=1000)
+    )
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: str(cgroup))
+
+    assert ad._effective_available_memory_bytes() == 600
+
+
+def test_memory_probe_failure_fails_closed_when_floor_configured(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: None)
+    record = {
+        "min_available_memory_bytes": 100,
+        "resume_available_memory_bytes": 100,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is False
+    assert record["_resource_blocked"] is True
+
+
+def test_memory_probe_failure_without_floor_allows_admission(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: None)
+    record = {
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is True
+
+
+def test_psi_unavailable_falls_back_to_memory_gate(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 500)
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: None)
+    record = {
+        "min_available_memory_bytes": 100,
+        "resume_available_memory_bytes": 100,
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 50.0,
+        "_resource_blocked": False,
+    }
+    # PSI unavailable is NOT a block; memory gate decides.
+    assert ad._resources_available(record) is True
+
+
+def test_psi_over_ceiling_blocks_until_recovery(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 500)
+    pressure = {"avg10": 70.0}
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: pressure["avg10"])
+    record = {
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 10.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is False
+    # Still over the stop ceiling.
+    pressure["avg10"] = 60.0
+    assert ad._resources_available(record) is False
+    # Dropped below the resume ceiling -> admitted again.
+    pressure["avg10"] = 5.0
+    assert ad._resources_available(record) is True
+
+
+def test_non_posix_returns_host_availability_only(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    # On non-POSIX the cgroup probe is skipped entirely.
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: None)
+    import psutil
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: SimpleNamespace(available=1234))
+    assert ad._effective_available_memory_bytes() == 1234
+    assert ad._memory_psi_avg10() is None
+    monkeypatch.setattr(os, "name", "posix")
+
+
+def test_missing_cgroup_falls_back_to_host_availability(monkeypatch):
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: None)
+    import psutil
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: SimpleNamespace(available=777))
+    assert ad._effective_available_memory_bytes() == 777
+
+
+def test_memory_hysteresis_requires_resume_floor(monkeypatch):
+    available = {"bytes": 50}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+
+    result = ad.dispatch_async_delegation(
+        goal="memory hysteresis", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+        min_available_memory_bytes=100,
+        resume_available_memory_bytes=200,
+    )
+    assert result["status"] == "queued"
+
+    available["bytes"] = 150
+    assert started.wait(timeout=0.1) is False
+    available["bytes"] = 200
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_memory_psi_gate_uses_lower_resume_threshold(monkeypatch):
+    pressure = {"avg10": 20.0}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 10_000)
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: pressure["avg10"])
+
+    result = ad.dispatch_async_delegation(
+        goal="psi gated", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+        max_memory_psi_avg10=10.0,
+        resume_memory_psi_avg10=5.0,
+    )
+    assert result["status"] == "queued"
+
+    pressure["avg10"] = 8.0
+    assert started.wait(timeout=0.1) is False
+    pressure["avg10"] = 4.0
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_batch_larger_than_slot_limit_is_rejected_without_runner():
+    started = threading.Event()
+    result = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {"results": []},
+        max_async_children=1,
+    )
+    assert result["status"] == "rejected"
+    assert "requires 2 child slots" in result["error"]
+    assert started.is_set() is False
+
+
+def test_dispatch_persistence_failure_releases_reservation(monkeypatch):
+    started = threading.Event()
+
+    def fail_persistence(_record):
+        raise OSError("state db unavailable")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persistence)
+    result = ad.dispatch_async_delegation(
+        goal="must persist", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+    )
+
+    assert result["status"] == "rejected"
+    assert "persist" in result["error"].lower()
+    assert ad.active_count() == 0
+    assert ad.list_async_delegations() == []
+    assert started.is_set() is False
+
+
+def test_concurrent_queue_overflow_never_exceeds_bound():
+    active_started = threading.Event()
+    release_active = threading.Event()
+
+    first = ad.dispatch_async_delegation(
+        goal="active", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1, max_queued_delegations=3,
+        runner=lambda: (
+            active_started.set(), release_active.wait(timeout=2),
+            {"status": "completed", "summary": "active"},
+        )[-1],
+    )
+    assert first["status"] == "dispatched"
+    assert active_started.wait(timeout=1)
+
+    barrier = threading.Barrier(11)
+    results = []
+    result_lock = threading.Lock()
+
+    def submit(index):
+        barrier.wait()
+        outcome = ad.dispatch_async_delegation(
+            goal=f"queued-{index}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", max_async_children=1, max_queued_delegations=3,
+            runner=lambda: {"status": "completed", "summary": str(index)},
+        )
+        with result_lock:
+            results.append(outcome)
+
+    threads = [threading.Thread(target=submit, args=(i,)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert sum(result["status"] == "queued" for result in results) == 3
+    assert sum(result["status"] == "rejected" for result in results) == 7
+    assert sum(
+        record["status"] == "queued" for record in ad.list_async_delegations()
+    ) == 3
+
+    release_active.set()
+    completion_ids = {first["delegation_id"]}
+    completion_ids.update(
+        result["delegation_id"] for result in results if result["status"] == "queued"
+    )
+    seen = set()
+    deadline = time.monotonic() + 3
+    while completion_ids - seen and time.monotonic() < deadline:
+        try:
+            event = process_registry.completion_queue.get(timeout=0.1)
+        except queue.Empty:
+            continue
+        seen.add(event.get("delegation_id"))
+    assert completion_ids <= seen
+
+
+def test_interrupt_all_cancels_queued_work_without_starting_it(monkeypatch):
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    result = ad.dispatch_async_delegation(
+        goal="queued cancel", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+
+    assert ad.interrupt_all(reason="test shutdown") == 1
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+    assert started.wait(timeout=0.1) is False
+
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 100)
+    time.sleep(0.1)
+    assert started.is_set() is False
+
+
+def test_queued_work_times_out_without_starting(monkeypatch):
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.01)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    result = ad.dispatch_async_delegation(
+        goal="queued timeout", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+        queue_timeout_seconds=0.05,
+    )
+    assert result["status"] == "queued"
+
+    event = _drain_for(result["delegation_id"], timeout=2)
+    assert event is not None
+    assert event["status"] == "timeout"
+    assert "queue" in event["error"].lower()
+    assert started.is_set() is False
+
+
+def test_capacity_queued_timeout_fires_while_worker_slot_is_busy():
+    gate = threading.Event()
+    queued_started = threading.Event()
+
+    def busy_runner():
+        gate.wait(timeout=60)
+        return {"status": "completed", "summary": "busy"}
+
+    first = ad.dispatch_async_delegation(
+        goal="busy", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=busy_runner,
+        max_async_children=1,
+    )
+    queued = ad.dispatch_async_delegation(
+        goal="capacity timeout", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: queued_started.set() or {},
+        max_async_children=1, queue_timeout_seconds=0.05,
+    )
+    assert first["status"] == "dispatched"
+    assert queued["status"] == "queued"
+
+    event = _drain_for(queued["delegation_id"], timeout=1)
+    assert event is not None
+    assert event["status"] == "timeout"
+    assert queued_started.is_set() is False
+
+    gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+
+
+def test_lingering_timed_out_child_retains_slot_until_future_exits():
+    lingering = Future()
+    next_started = threading.Event()
+
+    timed_out = ad.dispatch_async_delegation(
+        goal="timed out but alive", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: {
+            "status": "error",
+            "summary": None,
+            "error": "timed out",
+            "_lingering_futures": [lingering],
+        },
+    )
+    assert timed_out["status"] == "dispatched"
+    event = _drain_for(timed_out["delegation_id"])
+    assert event is not None
+    assert event["status"] == "error"
+
+    queued = ad.dispatch_async_delegation(
+        goal="must wait for actual exit", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: next_started.set() or {"status": "completed"},
+    )
+    assert queued["status"] == "queued"
+    assert next_started.wait(timeout=0.1) is False
+
+    lingering.set_result(None)
+    assert next_started.wait(timeout=1)
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_batch_lingering_futures_retain_slots_until_they_exit():
+    lingering_a = Future()
+    next_started = threading.Event()
+
+    timed_out_batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=2,
+        runner=lambda: {
+            "status": "completed",
+            "results": [
+                {"task_index": 0, "status": "timeout", "summary": None},
+                {"task_index": 1, "status": "completed", "summary": "ok"},
+            ],
+            "_lingering_futures": [lingering_a],
+        },
+    )
+    assert timed_out_batch["status"] == "dispatched"
+    event = _drain_for(timed_out_batch["delegation_id"])
+    assert event is not None
+    assert event["status"] == "completed"
+
+    queued = ad.dispatch_async_delegation_batch(
+        goals=["c", "d"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=2,
+        runner=lambda: next_started.set() or {"status": "completed", "results": []},
+    )
+    assert queued["status"] == "queued"
+    assert next_started.wait(timeout=0.1) is False
+
+    lingering_a.set_result(None)
+    assert next_started.wait(timeout=1)
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_reset_for_tests_clears_lingering_slots():
+    lingering = Future()
+    result = ad.dispatch_async_delegation(
+        goal="reset clears slots", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: {
+            "status": "error", "summary": None, "error": "timed out",
+            "_lingering_futures": [lingering],
+        },
+    )
+    assert result["status"] == "dispatched"
+    assert _drain_for(result["delegation_id"]) is not None
+    assert sum(ad._lingering_resource_slots.values()) >= 1
+
+    ad._reset_for_tests()
+    assert ad._lingering_resource_slots == {}
+
+
+def test_stale_generation_worker_cannot_push_completion_after_reset():
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    stale = {
+        "delegation_id": "deleg_stale_generation",
+        "session_key": "session-stale",
+        "status": "finalizing",
+        "dispatched_at": time.time(),
+        "completed_at": time.time(),
+        "goal": "stale generation",
+        # Captured before the reset that bumped the generation.
+        "_generation": ad._manager_generation - 1,
+    }
+    with ad._records_lock:
+        ad._records[stale["delegation_id"]] = stale
+
+    ad._push_completion_event(
+        stale, {"status": "completed", "summary": "must not leak"}, "completed"
+    )
+
+    assert process_registry.completion_queue.empty()
+    assert ad.get_durable_delegation("deleg_stale_generation") is None
+    ad._reset_for_tests()
+
+
+def test_late_worker_after_reset_does_not_leak_completion():
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    started = threading.Event()
+    release = threading.Event()
+
+    result = ad.dispatch_async_delegation(
+        goal="late worker", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: (
+            started.set(), release.wait(timeout=5),
+            {"status": "completed", "summary": "late"},
+        )[-1],
+    )
+    assert result["status"] == "dispatched"
+    assert started.wait(timeout=1)
+
+    ad._reset_for_tests()
+    release.set()
+    time.sleep(0.3)
+
+    assert process_registry.completion_queue.empty()
+    assert ad.list_async_delegations() == []
+
+
+def test_queued_interruption_falls_back_to_interrupt_fn_after_promotion():
+    """C1: interrupt racing promotion must not terminalize a promoted record."""
+    ad._reset_for_tests()
+    interrupt_calls = []
+
+    def interrupt_fn():
+        interrupt_calls.append(True)
+
+    record = {
+        "delegation_id": "deleg_promote_race",
+        "session_key": "session-c1",
+        "status": "queued",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "goal": "promotion race",
+        "is_batch": False,
+        "interrupt_fn": interrupt_fn,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": None,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    # Admission thread wins the race: record is promoted to running before
+    # the interrupt path claims it.
+    with ad._records_lock:
+        ad._records[record["delegation_id"]]["status"] = "running"
+
+    result = ad._finalize_queued_interruption(record["delegation_id"], "race test")
+    assert result is True
+    assert interrupt_calls == [True]
+    # Record must NOT be terminalized by the queued path.
+    assert ad._records[record["delegation_id"]]["status"] == "running"
+    from tools.process_registry import process_registry
+
+    assert process_registry.completion_queue.empty()
+    ad._reset_for_tests()
+
+
+def test_queued_interruption_after_promotion_delivers_one_interrupted(monkeypatch):
+    """End-to-end C1: interrupt during admission -> exactly one interrupted event."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    started = threading.Event()
+    gate = threading.Event()
+
+    def runner():
+        started.set()
+        gate.wait(timeout=2)
+        return {"status": "completed", "summary": "should not complete"}
+
+    # Capacity-freeze the slot so the second dispatch queues.
+    blocker = ad.dispatch_async_delegation(
+        goal="blocker", context=None, toolsets=None, role="leaf", model="m",
+        session_key="c1-e2e", runner=lambda: (
+            gate.wait(timeout=2), {"status": "completed"},
+        )[-1],
+        max_async_children=1, min_available_memory_bytes=0,
+    )
+    assert blocker["status"] == "dispatched"
+    # Queue a second one behind it, then interrupt the session immediately.
+    queued = ad.dispatch_async_delegation(
+        goal="raced", context=None, toolsets=None, role="leaf", model="m",
+        session_key="c1-e2e", runner=runner,
+        max_async_children=1, min_available_memory_bytes=0,
+    )
+    assert queued["status"] == "queued"
+    assert ad.interrupt_for_session(session_key="c1-e2e", reason="race") >= 1
+
+    gate.set()  # let the blocker finish so the queue drains
+    deadline = time.monotonic() + 3
+    events = []
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            events.append(process_registry.completion_queue.get_nowait())
+        time.sleep(0.02)
+    ids = [e.get("delegation_id") for e in events]
+    # Both delegations must resolve exactly once; the raced one must be
+    # interrupted (via interrupt_fn fallback), never completed.
+    assert blocker["delegation_id"] in ids
+    raced_events = [e for e in events if e.get("delegation_id") == queued["delegation_id"]]
+    assert len(raced_events) == 1
+    assert raced_events[0]["status"] == "interrupted"
+    ad._reset_for_tests()
+
+
+def test_persist_state_failure_during_admission_still_submits_worker(monkeypatch):
+    """M2: a _persist_state failure must not kill the admission thread."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    available = {"bytes": 0}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    real_persist = ad._persist_state
+    fail_next = {"fail": True}
+
+    def flaky_persist(delegation_id, state):
+        if fail_next["fail"] and state == "running":
+            fail_next["fail"] = False
+            raise OSError("simulated disk full")
+        return real_persist(delegation_id, state)
+
+    monkeypatch.setattr(ad, "_persist_state", flaky_persist)
+    started = threading.Event()
+
+    result = ad.dispatch_async_delegation(
+        goal="persist-fail", context=None, toolsets=None, role="leaf", model="m",
+        session_key="m2", runner=lambda: started.set() or {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+    available["bytes"] = 100  # memory recovers -> admission proceeds
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    assert event["status"] == "completed"
+    assert started.is_set()
+    ad._reset_for_tests()
+
+
+def test_stale_monitor_restarts_when_queued_record_admitted(monkeypatch):
+    """M1: admission must re-ensure the stale monitor if it exited."""
+    ad._reset_for_tests()
+    calls = {"ensure": 0}
+    real_ensure = ad._ensure_stale_monitor
+
+    def counting_ensure():
+        calls["ensure"] += 1
+        return real_ensure()
+
+    monkeypatch.setattr(ad, "_ensure_stale_monitor", counting_ensure)
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    available = {"bytes": 0}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    before = calls["ensure"]
+
+    result = ad.dispatch_async_delegation(
+        goal="m1", context=None, toolsets=None, role="leaf", model="m",
+        session_key="m1", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+    available["bytes"] = 100  # memory recovers -> admission proceeds
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    # Admission path must have re-ensured the monitor even though dispatch
+    # was blocked (no progress_fn -> monitor exited during queued period).
+    assert calls["ensure"] > before
+    ad._reset_for_tests()
+
+
+def test_queued_persist_failure_releases_slot_and_does_not_abort_sweep(monkeypatch):
+    """MAJOR: a persist failure in queued finalization must not strand it."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    real_push = ad._push_completion_event
+    fail_next = {"fail": True}
+
+    def flaky_push(record, result, status):
+        if fail_next["fail"]:
+            fail_next["fail"] = False
+            raise OSError("simulated DB full")
+        return real_push(record, result, status)
+
+    monkeypatch.setattr(ad, "_push_completion_event", flaky_push)
+
+    # Two memory-gated queued records in different sessions. Strict FIFO
+    # means the second queues behind the first; both are never-started.
+    first = ad.dispatch_async_delegation(
+        goal="maj-first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj1", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert first["status"] == "queued"
+    second = ad.dispatch_async_delegation(
+        goal="maj-second", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj2", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert second["status"] == "queued"
+
+    # interrupt_all must NOT abort mid-sweep when the first record's
+    # completion persist raises: both records get a terminal state, and no
+    # exception escapes the sweep.
+    count = ad.interrupt_all(reason="maj test")
+    assert count == 2
+    with ad._records_lock:
+        assert ad._records[first["delegation_id"]]["status"] == "interrupted"
+        assert ad._records[second["delegation_id"]]["status"] == "interrupted"
+    # Exactly one event delivered (the failing record's push was skipped;
+    # the second record's succeeded).
+    delivered = []
+    while not process_registry.completion_queue.empty():
+        delivered.append(process_registry.completion_queue.get_nowait())
+    assert len(delivered) == 1
+    assert delivered[0]["delegation_id"] == second["delegation_id"]
+    # The slot is released: a fresh dispatch with memory available starts.
+    available = {"bytes": 100}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    fresh = ad.dispatch_async_delegation(
+        goal="maj-fresh", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj3", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert fresh["status"] == "dispatched"
+    ad._reset_for_tests()
+
+
+def test_queued_interruption_skips_terminal_record(monkeypatch):
+    """MINOR: fallback must not over-report interrupted for completed work."""
+    ad._reset_for_tests()
+    interrupt_calls = []
+
+    def interrupt_fn():
+        interrupt_calls.append(True)
+
+    record = {
+        "delegation_id": "deleg_terminal_skip",
+        "session_key": "session-minor1",
+        "status": "completed",  # worker already won the race and finished
+        "dispatched_at": time.time(),
+        "completed_at": time.time(),
+        "goal": "terminal skip",
+        "is_batch": False,
+        "interrupt_fn": interrupt_fn,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": None,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    result = ad._finalize_queued_interruption(record["delegation_id"], "skip test")
+    assert result is False
+    assert interrupt_calls == []
+    ad._reset_for_tests()
+
+
+def test_stalled_finalize_persist_failure_still_releases_slot(monkeypatch):
+    """Cycle-3 MAJOR: _finalize_stalled must not strand on persist failure."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    real_push = ad._push_completion_event
+
+    def flaky_push(record, result, status):
+        raise OSError("simulated DB full")
+
+    monkeypatch.setattr(ad, "_push_completion_event", flaky_push)
+    record = {
+        "delegation_id": "deleg_stalled_persist",
+        "session_key": "c3-major",
+        "status": "stalling",
+        "dispatched_at": time.time() - 60,
+        "completed_at": None,
+        "goal": "stalled persist",
+        "is_batch": False,
+        "interrupt_fn": None,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": time.time(),
+        "_stall_quiet_seconds": 5.0,
+        "_stall_threshold_seconds": 5.0,
+        "_stall_in_tool": False,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    ad._finalize_stalled(record["delegation_id"])
+    # Record must be terminalized (slot released) despite the persist failure.
+    with ad._records_lock:
+        assert ad._records[record["delegation_id"]]["status"] == "stalled"
+    assert process_registry.completion_queue.empty()
+    ad._reset_for_tests()
+
+
+def test_psi_resume_zero_follows_stop_ceiling():
+    """Cycle-3 MINOR: resume PSI 0 must mean 'follow stop ceiling'."""
+    ad._reset_for_tests()
+    record = {
+        "delegation_id": "deleg_psi_normalize",
+        "session_key": "c3-minor2",
+        "status": "queued",
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 0.0,  # direct caller passes 0 explicitly
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+    }
+    # Not blocked: stop ceiling (50) applies.
+    assert ad._resources_available(record) is True
+    # Blocked once: resume ceiling must follow stop ceiling (50), not clamp to 0.
+    record["_resource_blocked"] = True
+    assert ad._resources_available(record) is True
+    ad._reset_for_tests()
+
+
+def test_prune_durable_records_preserves_live_queued_rows(monkeypatch, tmp_path):
+    """M3: durable pruning must never delete a live queued row."""
+    import gateway.status as gateway_status
+
+    ad._db_path = lambda: tmp_path / "state.db"
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: False)
+    now = time.time()
+    # A live queued row with a frozen updated_at (oldest pending row).
+    ad._persist_dispatch({
+        "delegation_id": "deleg_live_queued",
+        "session_key": "m3",
+        "status": "queued",
+        "dispatched_at": now - 1000,
+        "goal": "live queued",
+        "is_batch": False,
+    })
+    # A terminal delivered row (candidate for pruning).
+    ad._persist_dispatch({
+        "delegation_id": "deleg_terminal_1",
+        "session_key": "m3",
+        "status": "completed",
+        "dispatched_at": now - 1000,
+        "goal": "terminal",
+        "is_batch": False,
+    })
+    ad._persist_completion(
+        {"delegation_id": "deleg_terminal_1", "session_key": "m3",
+         "status": "completed", "dispatched_at": now - 1000,
+         "completed_at": now - 500},
+        {"status": "completed"},
+    )
+    ad.mark_completion_delivered("deleg_terminal_1")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET updated_at=? WHERE delegation_id='deleg_terminal_1'",
+            (now - 500,),
+        )
+
+    ad._prune_durable_records()
+
+    durable = ad.get_durable_delegation("deleg_live_queued")
+    assert durable is not None
+    assert durable["state"] == "queued"
+
+
+def test_interrupt_for_session_cancels_only_matching_queued_work(monkeypatch):
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    target = ad.dispatch_async_delegation(
+        goal="target", context=None, toolsets=None, role="leaf", model="m",
+        session_key="session-a", runner=lambda: {}, max_async_children=1,
+        min_available_memory_bytes=1,
+    )
+    other = ad.dispatch_async_delegation(
+        goal="other", context=None, toolsets=None, role="leaf", model="m",
+        session_key="session-b", runner=lambda: {}, max_async_children=1,
+        min_available_memory_bytes=1,
+    )
+
+    assert ad.interrupt_for_session(session_key="session-a") == 1
+    event = _drain_for(target["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+    other_items = [
+        item for item in ad.list_async_delegations()
+        if item["delegation_id"] == other["delegation_id"]
+    ]
+    assert other_items[0]["status"] == "queued"
+
+    assert ad.interrupt_all(reason="test cleanup") == 1
+    assert _drain_for(other["delegation_id"]) is not None
+
+
+def test_begin_shutdown_cancels_queue_and_rejects_new_work(monkeypatch):
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    started = threading.Event()
+
+    queued = ad.dispatch_async_delegation(
+        goal="queued at shutdown", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert queued["status"] == "queued"
+
+    assert ad.begin_shutdown(reason="test shutdown") == 1
+    event = _drain_for(queued["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+
+    rejected = ad.dispatch_async_delegation(
+        goal="too late", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+    )
+    assert rejected["status"] == "rejected"
+    assert "shutting down" in rejected["error"].lower()
+    assert started.is_set() is False
 
 
 def test_interrupt_all_signals_running_children():
@@ -686,8 +1716,7 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
 
 
 def test_concurrent_dispatch_respects_capacity():
-    """Two threads racing dispatch with cap=1 must yield exactly one accept
-    (capacity check and record insert are atomic under the records lock)."""
+    """Two racing dispatches with cap=1 produce one runner and one queued job."""
     gate = threading.Event()
 
     def blocker():
@@ -713,8 +1742,16 @@ def test_concurrent_dispatch_respects_capacity():
     for t in threads:
         t.join(timeout=10)
     statuses = sorted(r["status"] for r in results)
-    assert statuses == ["dispatched", "rejected"]
+    assert statuses == ["dispatched", "queued"]
     gate.set()
+    expected_ids = {result["delegation_id"] for result in results}
+    seen_ids = set()
+    deadline = time.monotonic() + 5
+    while seen_ids != expected_ids and time.monotonic() < deadline:
+        event = _drain_one(timeout=0.2)
+        if event and event.get("delegation_id") in expected_ids:
+            seen_ids.add(event["delegation_id"])
+    assert seen_ids == expected_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import threading
 import time
+from concurrent.futures import Future
+from types import SimpleNamespace
 
 import pytest
 
@@ -202,27 +204,1047 @@ def test_rich_reinjection_block_is_self_contained():
         assert needle in text, f"missing {needle!r}"
 
 
-def test_dispatch_rejected_at_capacity():
-    ev = threading.Event()
+def test_dispatch_queues_at_capacity_and_starts_after_slot_frees():
+    first_gate = threading.Event()
+    second_started = threading.Event()
+
+    def first_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "first"}
+
+    def second_runner():
+        second_started.set()
+        return {"status": "completed", "summary": "second"}
+
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=first_runner, max_async_children=1,
+    )
+    assert first["status"] == "dispatched"
+
+    second = ad.dispatch_async_delegation(
+        goal="second", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=second_runner, max_async_children=1,
+    )
+    assert second["status"] == "queued"
+    assert second["delegation_id"].startswith("deleg_")
+    assert second_started.wait(timeout=0.1) is False
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert second_started.wait(timeout=2)
+    assert _drain_for(second["delegation_id"]) is not None
+
+
+def test_batch_queues_until_all_child_slots_are_available():
+    first_gate = threading.Event()
+    batch_started = threading.Event()
+
+    def first_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "first"}
+
+    def batch_runner():
+        batch_started.set()
+        return {
+            "results": [
+                {"status": "completed", "summary": "a"},
+                {"status": "completed", "summary": "b"},
+            ]
+        }
+
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=first_runner, max_async_children=2,
+    )
+    assert first["status"] == "dispatched"
+
+    batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=batch_runner, max_async_children=2,
+    )
+    assert batch["status"] == "queued"
+    assert batch_started.wait(timeout=0.1) is False
+    assert ad.active_task_count() == 1
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert batch_started.wait(timeout=2)
+    assert _drain_for(batch["delegation_id"]) is not None
+
+
+def test_pending_queue_is_bounded_and_overflow_never_runs():
+    first_gate = threading.Event()
+    overflow_started = threading.Event()
 
     def blocker():
-        ev.wait(timeout=60)
-        return {"status": "completed", "summary": "x"}
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "done"}
 
-    for i in range(2):
-        r = ad.dispatch_async_delegation(
-            goal=f"task{i}", context=None, toolsets=None, role="leaf",
-            model="m", session_key="", runner=blocker, max_async_children=2,
-        )
-        assert r["status"] == "dispatched"
-
-    r3 = ad.dispatch_async_delegation(
-        goal="task3", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=blocker, max_async_children=2,
+    first = ad.dispatch_async_delegation(
+        goal="first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=blocker, max_async_children=1,
+        max_queued_delegations=1,
     )
-    assert r3["status"] == "rejected"
-    assert "capacity reached" in r3["error"]
-    ev.set()
+    queued = ad.dispatch_async_delegation(
+        goal="queued", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=blocker, max_async_children=1,
+        max_queued_delegations=1,
+    )
+    overflow = ad.dispatch_async_delegation(
+        goal="overflow", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: overflow_started.set() or {},
+        max_async_children=1, max_queued_delegations=1,
+    )
+
+    assert first["status"] == "dispatched"
+    assert queued["status"] == "queued"
+    assert overflow["status"] == "rejected"
+    assert "queue" in overflow["error"].lower()
+    assert overflow_started.wait(timeout=0.1) is False
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_queue_is_fifo_when_head_batch_needs_more_slots():
+    first_gate = threading.Event()
+    order = []
+
+    def active_runner():
+        first_gate.wait(timeout=60)
+        return {"status": "completed", "summary": "active"}
+
+    first = ad.dispatch_async_delegation(
+        goal="active", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=active_runner,
+        max_async_children=3,
+    )
+    batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b", "c"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: order.append("batch") or {"results": []},
+        max_async_children=3,
+    )
+    later = ad.dispatch_async_delegation(
+        goal="later", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: order.append("later") or {
+            "status": "completed", "summary": "later"
+        },
+        max_async_children=3,
+    )
+
+    assert first["status"] == "dispatched"
+    assert batch["status"] == "queued"
+    assert later["status"] == "queued"
+    assert order == []
+
+    first_gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+    assert _drain_for(batch["delegation_id"]) is not None
+    assert _drain_for(later["delegation_id"]) is not None
+    assert order == ["batch", "later"]
+
+
+def test_dispatch_waits_for_memory_floor_before_starting(monkeypatch):
+    available = {"bytes": 100}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+
+    result = ad.dispatch_async_delegation(
+        goal="memory gated", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {
+            "status": "completed", "summary": "done"
+        },
+        max_async_children=1,
+        min_available_memory_bytes=200,
+    )
+
+    assert result["status"] == "queued"
+    assert result["queue_reason"] == "resources"
+    assert started.wait(timeout=0.1) is False
+
+    available["bytes"] = 300
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_effective_memory_uses_tightest_cgroup_limit(monkeypatch, tmp_path):
+    import psutil
+
+    cgroup = tmp_path / "delegation.slice"
+    cgroup.mkdir()
+    (cgroup / "memory.current").write_text("100\n", encoding="utf-8")
+    (cgroup / "memory.high").write_text("700\n", encoding="utf-8")
+    (cgroup / "memory.max").write_text("900\n", encoding="utf-8")
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: SimpleNamespace(available=1000)
+    )
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: str(cgroup))
+
+    assert ad._effective_available_memory_bytes() == 600
+
+
+def test_memory_probe_failure_fails_closed_when_floor_configured(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: None)
+    record = {
+        "min_available_memory_bytes": 100,
+        "resume_available_memory_bytes": 100,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is False
+    assert record["_resource_blocked"] is True
+
+
+def test_memory_probe_failure_without_floor_allows_admission(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: None)
+    record = {
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is True
+
+
+def test_psi_unavailable_falls_back_to_memory_gate(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 500)
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: None)
+    record = {
+        "min_available_memory_bytes": 100,
+        "resume_available_memory_bytes": 100,
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 50.0,
+        "_resource_blocked": False,
+    }
+    # PSI unavailable is NOT a block; memory gate decides.
+    assert ad._resources_available(record) is True
+
+
+def test_psi_over_ceiling_blocks_until_recovery(monkeypatch):
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 500)
+    pressure = {"avg10": 70.0}
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: pressure["avg10"])
+    record = {
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 10.0,
+        "_resource_blocked": False,
+    }
+    assert ad._resources_available(record) is False
+    # Still over the stop ceiling.
+    pressure["avg10"] = 60.0
+    assert ad._resources_available(record) is False
+    # Dropped below the resume ceiling -> admitted again.
+    pressure["avg10"] = 5.0
+    assert ad._resources_available(record) is True
+
+
+def test_non_posix_returns_host_availability_only(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    # On non-POSIX the cgroup probe is skipped entirely.
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: None)
+    import psutil
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: SimpleNamespace(available=1234))
+    assert ad._effective_available_memory_bytes() == 1234
+    assert ad._memory_psi_avg10() is None
+    monkeypatch.setattr(os, "name", "posix")
+
+
+def test_missing_cgroup_falls_back_to_host_availability(monkeypatch):
+    monkeypatch.setattr(ad, "_current_cgroup_v2_path", lambda: None)
+    import psutil
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: SimpleNamespace(available=777))
+    assert ad._effective_available_memory_bytes() == 777
+
+
+def test_memory_hysteresis_requires_resume_floor(monkeypatch):
+    available = {"bytes": 50}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+
+    result = ad.dispatch_async_delegation(
+        goal="memory hysteresis", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+        min_available_memory_bytes=100,
+        resume_available_memory_bytes=200,
+    )
+    assert result["status"] == "queued"
+
+    available["bytes"] = 150
+    assert started.wait(timeout=0.1) is False
+    available["bytes"] = 200
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_memory_psi_gate_uses_lower_resume_threshold(monkeypatch):
+    pressure = {"avg10": 20.0}
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 10_000)
+    monkeypatch.setattr(ad, "_memory_psi_avg10", lambda: pressure["avg10"])
+
+    result = ad.dispatch_async_delegation(
+        goal="psi gated", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+        max_memory_psi_avg10=10.0,
+        resume_memory_psi_avg10=5.0,
+    )
+    assert result["status"] == "queued"
+
+    pressure["avg10"] = 8.0
+    assert started.wait(timeout=0.1) is False
+    pressure["avg10"] = 4.0
+    assert started.wait(timeout=1)
+    assert _drain_for(result["delegation_id"]) is not None
+
+
+def test_batch_larger_than_slot_limit_is_rejected_without_runner():
+    started = threading.Event()
+    result = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {"results": []},
+        max_async_children=1,
+    )
+    assert result["status"] == "rejected"
+    assert "requires 2 child slots" in result["error"]
+    assert started.is_set() is False
+
+
+def test_dispatch_persistence_failure_releases_reservation(monkeypatch):
+    started = threading.Event()
+
+    def fail_persistence(_record):
+        raise OSError("state db unavailable")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persistence)
+    result = ad.dispatch_async_delegation(
+        goal="must persist", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+    )
+
+    assert result["status"] == "rejected"
+    assert "persist" in result["error"].lower()
+    assert ad.active_count() == 0
+    assert ad.list_async_delegations() == []
+    assert started.is_set() is False
+
+
+def test_concurrent_queue_overflow_never_exceeds_bound():
+    active_started = threading.Event()
+    release_active = threading.Event()
+
+    first = ad.dispatch_async_delegation(
+        goal="active", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1, max_queued_delegations=3,
+        runner=lambda: (
+            active_started.set(), release_active.wait(timeout=2),
+            {"status": "completed", "summary": "active"},
+        )[-1],
+    )
+    assert first["status"] == "dispatched"
+    assert active_started.wait(timeout=1)
+
+    barrier = threading.Barrier(11)
+    results = []
+    result_lock = threading.Lock()
+
+    def submit(index):
+        barrier.wait()
+        outcome = ad.dispatch_async_delegation(
+            goal=f"queued-{index}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", max_async_children=1, max_queued_delegations=3,
+            runner=lambda: {"status": "completed", "summary": str(index)},
+        )
+        with result_lock:
+            results.append(outcome)
+
+    threads = [threading.Thread(target=submit, args=(i,)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert sum(result["status"] == "queued" for result in results) == 3
+    assert sum(result["status"] == "rejected" for result in results) == 7
+    assert sum(
+        record["status"] == "queued" for record in ad.list_async_delegations()
+    ) == 3
+
+    release_active.set()
+    completion_ids = {first["delegation_id"]}
+    completion_ids.update(
+        result["delegation_id"] for result in results if result["status"] == "queued"
+    )
+    seen = set()
+    deadline = time.monotonic() + 3
+    while completion_ids - seen and time.monotonic() < deadline:
+        try:
+            event = process_registry.completion_queue.get(timeout=0.1)
+        except queue.Empty:
+            continue
+        seen.add(event.get("delegation_id"))
+    assert completion_ids <= seen
+
+
+def test_interrupt_all_cancels_queued_work_without_starting_it(monkeypatch):
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    result = ad.dispatch_async_delegation(
+        goal="queued cancel", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+
+    assert ad.interrupt_all(reason="test shutdown") == 1
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+    assert started.wait(timeout=0.1) is False
+
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 100)
+    time.sleep(0.1)
+    assert started.is_set() is False
+
+
+def test_queued_work_times_out_without_starting(monkeypatch):
+    started = threading.Event()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.01)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    result = ad.dispatch_async_delegation(
+        goal="queued timeout", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+        queue_timeout_seconds=0.05,
+    )
+    assert result["status"] == "queued"
+
+    event = _drain_for(result["delegation_id"], timeout=2)
+    assert event is not None
+    assert event["status"] == "timeout"
+    assert "queue" in event["error"].lower()
+    assert started.is_set() is False
+
+
+def test_capacity_queued_timeout_fires_while_worker_slot_is_busy():
+    gate = threading.Event()
+    queued_started = threading.Event()
+
+    def busy_runner():
+        gate.wait(timeout=60)
+        return {"status": "completed", "summary": "busy"}
+
+    first = ad.dispatch_async_delegation(
+        goal="busy", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=busy_runner,
+        max_async_children=1,
+    )
+    queued = ad.dispatch_async_delegation(
+        goal="capacity timeout", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: queued_started.set() or {},
+        max_async_children=1, queue_timeout_seconds=0.05,
+    )
+    assert first["status"] == "dispatched"
+    assert queued["status"] == "queued"
+
+    event = _drain_for(queued["delegation_id"], timeout=1)
+    assert event is not None
+    assert event["status"] == "timeout"
+    assert queued_started.is_set() is False
+
+    gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+
+
+def test_lingering_timed_out_child_retains_slot_until_future_exits():
+    lingering = Future()
+    next_started = threading.Event()
+
+    timed_out = ad.dispatch_async_delegation(
+        goal="timed out but alive", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: {
+            "status": "error",
+            "summary": None,
+            "error": "timed out",
+            "_lingering_futures": [lingering],
+        },
+    )
+    assert timed_out["status"] == "dispatched"
+    event = _drain_for(timed_out["delegation_id"])
+    assert event is not None
+    assert event["status"] == "error"
+
+    queued = ad.dispatch_async_delegation(
+        goal="must wait for actual exit", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: next_started.set() or {"status": "completed"},
+    )
+    assert queued["status"] == "queued"
+    assert next_started.wait(timeout=0.1) is False
+
+    lingering.set_result(None)
+    assert next_started.wait(timeout=1)
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_batch_lingering_futures_retain_slots_until_they_exit():
+    lingering_a = Future()
+    next_started = threading.Event()
+
+    timed_out_batch = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=2,
+        runner=lambda: {
+            "status": "completed",
+            "results": [
+                {"task_index": 0, "status": "timeout", "summary": None},
+                {"task_index": 1, "status": "completed", "summary": "ok"},
+            ],
+            "_lingering_futures": [lingering_a],
+        },
+    )
+    assert timed_out_batch["status"] == "dispatched"
+    event = _drain_for(timed_out_batch["delegation_id"])
+    assert event is not None
+    assert event["status"] == "completed"
+
+    queued = ad.dispatch_async_delegation_batch(
+        goals=["c", "d"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=2,
+        runner=lambda: next_started.set() or {"status": "completed", "results": []},
+    )
+    assert queued["status"] == "queued"
+    assert next_started.wait(timeout=0.1) is False
+
+    lingering_a.set_result(None)
+    assert next_started.wait(timeout=1)
+    assert _drain_for(queued["delegation_id"]) is not None
+
+
+def test_reset_for_tests_clears_lingering_slots():
+    lingering = Future()
+    result = ad.dispatch_async_delegation(
+        goal="reset clears slots", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: {
+            "status": "error", "summary": None, "error": "timed out",
+            "_lingering_futures": [lingering],
+        },
+    )
+    assert result["status"] == "dispatched"
+    assert _drain_for(result["delegation_id"]) is not None
+    assert sum(ad._lingering_resource_slots.values()) >= 1
+
+    ad._reset_for_tests()
+    assert ad._lingering_resource_slots == {}
+
+
+def test_stale_generation_worker_cannot_push_completion_after_reset():
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    stale = {
+        "delegation_id": "deleg_stale_generation",
+        "session_key": "session-stale",
+        "status": "finalizing",
+        "dispatched_at": time.time(),
+        "completed_at": time.time(),
+        "goal": "stale generation",
+        # Captured before the reset that bumped the generation.
+        "_generation": ad._manager_generation - 1,
+    }
+    with ad._records_lock:
+        ad._records[stale["delegation_id"]] = stale
+
+    ad._push_completion_event(
+        stale, {"status": "completed", "summary": "must not leak"}, "completed"
+    )
+
+    assert process_registry.completion_queue.empty()
+    assert ad.get_durable_delegation("deleg_stale_generation") is None
+    ad._reset_for_tests()
+
+
+def test_late_worker_after_reset_does_not_leak_completion():
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    started = threading.Event()
+    release = threading.Event()
+
+    result = ad.dispatch_async_delegation(
+        goal="late worker", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", max_async_children=1,
+        runner=lambda: (
+            started.set(), release.wait(timeout=5),
+            {"status": "completed", "summary": "late"},
+        )[-1],
+    )
+    assert result["status"] == "dispatched"
+    assert started.wait(timeout=1)
+
+    ad._reset_for_tests()
+    release.set()
+    time.sleep(0.3)
+
+    assert process_registry.completion_queue.empty()
+    assert ad.list_async_delegations() == []
+
+
+def test_queued_interruption_falls_back_to_interrupt_fn_after_promotion():
+    """C1: interrupt racing promotion must not terminalize a promoted record."""
+    ad._reset_for_tests()
+    interrupt_calls = []
+
+    def interrupt_fn():
+        interrupt_calls.append(True)
+
+    record = {
+        "delegation_id": "deleg_promote_race",
+        "session_key": "session-c1",
+        "status": "queued",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "goal": "promotion race",
+        "is_batch": False,
+        "interrupt_fn": interrupt_fn,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": None,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    # Admission thread wins the race: record is promoted to running before
+    # the interrupt path claims it.
+    with ad._records_lock:
+        ad._records[record["delegation_id"]]["status"] = "running"
+
+    result = ad._finalize_queued_interruption(record["delegation_id"], "race test")
+    assert result is True
+    assert interrupt_calls == [True]
+    # Record must NOT be terminalized by the queued path.
+    assert ad._records[record["delegation_id"]]["status"] == "running"
+    from tools.process_registry import process_registry
+
+    assert process_registry.completion_queue.empty()
+    ad._reset_for_tests()
+
+
+def test_queued_interruption_after_promotion_delivers_one_interrupted(monkeypatch):
+    """End-to-end C1: interrupt during admission -> exactly one interrupted event."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    started = threading.Event()
+    gate = threading.Event()
+
+    def runner():
+        started.set()
+        gate.wait(timeout=2)
+        return {"status": "completed", "summary": "should not complete"}
+
+    # Capacity-freeze the slot so the second dispatch queues.
+    blocker = ad.dispatch_async_delegation(
+        goal="blocker", context=None, toolsets=None, role="leaf", model="m",
+        session_key="c1-e2e", runner=lambda: (
+            gate.wait(timeout=2), {"status": "completed"},
+        )[-1],
+        max_async_children=1, min_available_memory_bytes=0,
+    )
+    assert blocker["status"] == "dispatched"
+    # Queue a second one behind it, then interrupt the session immediately.
+    queued = ad.dispatch_async_delegation(
+        goal="raced", context=None, toolsets=None, role="leaf", model="m",
+        session_key="c1-e2e", runner=runner,
+        max_async_children=1, min_available_memory_bytes=0,
+    )
+    assert queued["status"] == "queued"
+    assert ad.interrupt_for_session(session_key="c1-e2e", reason="race") >= 1
+
+    gate.set()  # let the blocker finish so the queue drains
+    deadline = time.monotonic() + 3
+    events = []
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            events.append(process_registry.completion_queue.get_nowait())
+        time.sleep(0.02)
+    ids = [e.get("delegation_id") for e in events]
+    # Both delegations must resolve exactly once; the raced one must be
+    # interrupted (via interrupt_fn fallback), never completed.
+    assert blocker["delegation_id"] in ids
+    raced_events = [e for e in events if e.get("delegation_id") == queued["delegation_id"]]
+    assert len(raced_events) == 1
+    assert raced_events[0]["status"] == "interrupted"
+    ad._reset_for_tests()
+
+
+def test_persist_state_failure_during_admission_still_submits_worker(monkeypatch):
+    """M2: a _persist_state failure must not kill the admission thread."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    available = {"bytes": 0}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    real_persist = ad._persist_state
+    fail_next = {"fail": True}
+
+    def flaky_persist(delegation_id, state):
+        if fail_next["fail"] and state == "running":
+            fail_next["fail"] = False
+            raise OSError("simulated disk full")
+        return real_persist(delegation_id, state)
+
+    monkeypatch.setattr(ad, "_persist_state", flaky_persist)
+    started = threading.Event()
+
+    result = ad.dispatch_async_delegation(
+        goal="persist-fail", context=None, toolsets=None, role="leaf", model="m",
+        session_key="m2", runner=lambda: started.set() or {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+    available["bytes"] = 100  # memory recovers -> admission proceeds
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    assert event["status"] == "completed"
+    assert started.is_set()
+    ad._reset_for_tests()
+
+
+def test_stale_monitor_restarts_when_queued_record_admitted(monkeypatch):
+    """M1: admission must re-ensure the stale monitor if it exited."""
+    ad._reset_for_tests()
+    calls = {"ensure": 0}
+    real_ensure = ad._ensure_stale_monitor
+
+    def counting_ensure():
+        calls["ensure"] += 1
+        return real_ensure()
+
+    monkeypatch.setattr(ad, "_ensure_stale_monitor", counting_ensure)
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    available = {"bytes": 0}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    before = calls["ensure"]
+
+    result = ad.dispatch_async_delegation(
+        goal="m1", context=None, toolsets=None, role="leaf", model="m",
+        session_key="m1", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert result["status"] == "queued"
+    available["bytes"] = 100  # memory recovers -> admission proceeds
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    # Admission path must have re-ensured the monitor even though dispatch
+    # was blocked (no progress_fn -> monitor exited during queued period).
+    assert calls["ensure"] > before
+    ad._reset_for_tests()
+
+
+def test_queued_persist_failure_releases_slot_and_does_not_abort_sweep(monkeypatch):
+    """MAJOR: a persist failure in queued finalization must not strand it."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    real_push = ad._push_completion_event
+    fail_next = {"fail": True}
+
+    def flaky_push(record, result, status):
+        if fail_next["fail"]:
+            fail_next["fail"] = False
+            raise OSError("simulated DB full")
+        return real_push(record, result, status)
+
+    monkeypatch.setattr(ad, "_push_completion_event", flaky_push)
+
+    # Two memory-gated queued records in different sessions. Strict FIFO
+    # means the second queues behind the first; both are never-started.
+    first = ad.dispatch_async_delegation(
+        goal="maj-first", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj1", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert first["status"] == "queued"
+    second = ad.dispatch_async_delegation(
+        goal="maj-second", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj2", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert second["status"] == "queued"
+
+    # interrupt_all must NOT abort mid-sweep when the first record's
+    # completion persist raises: both records get a terminal state, and no
+    # exception escapes the sweep.
+    count = ad.interrupt_all(reason="maj test")
+    assert count == 2
+    with ad._records_lock:
+        assert ad._records[first["delegation_id"]]["status"] == "interrupted"
+        assert ad._records[second["delegation_id"]]["status"] == "interrupted"
+    # Exactly one event delivered (the failing record's push was skipped;
+    # the second record's succeeded).
+    delivered = []
+    while not process_registry.completion_queue.empty():
+        delivered.append(process_registry.completion_queue.get_nowait())
+    assert len(delivered) == 1
+    assert delivered[0]["delegation_id"] == second["delegation_id"]
+    # The slot is released: a fresh dispatch with memory available starts.
+    available = {"bytes": 100}
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: available["bytes"])
+    fresh = ad.dispatch_async_delegation(
+        goal="maj-fresh", context=None, toolsets=None, role="leaf", model="m",
+        session_key="maj3", runner=lambda: {"status": "completed"},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert fresh["status"] == "dispatched"
+    ad._reset_for_tests()
+
+
+def test_queued_interruption_skips_terminal_record(monkeypatch):
+    """MINOR: fallback must not over-report interrupted for completed work."""
+    ad._reset_for_tests()
+    interrupt_calls = []
+
+    def interrupt_fn():
+        interrupt_calls.append(True)
+
+    record = {
+        "delegation_id": "deleg_terminal_skip",
+        "session_key": "session-minor1",
+        "status": "completed",  # worker already won the race and finished
+        "dispatched_at": time.time(),
+        "completed_at": time.time(),
+        "goal": "terminal skip",
+        "is_batch": False,
+        "interrupt_fn": interrupt_fn,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": None,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    result = ad._finalize_queued_interruption(record["delegation_id"], "skip test")
+    assert result is False
+    assert interrupt_calls == []
+    ad._reset_for_tests()
+
+
+def test_stalled_finalize_persist_failure_still_releases_slot(monkeypatch):
+    """Cycle-3 MAJOR: _finalize_stalled must not strand on persist failure."""
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    real_push = ad._push_completion_event
+
+    def flaky_push(record, result, status):
+        raise OSError("simulated DB full")
+
+    monkeypatch.setattr(ad, "_push_completion_event", flaky_push)
+    record = {
+        "delegation_id": "deleg_stalled_persist",
+        "session_key": "c3-major",
+        "status": "stalling",
+        "dispatched_at": time.time() - 60,
+        "completed_at": None,
+        "goal": "stalled persist",
+        "is_batch": False,
+        "interrupt_fn": None,
+        "progress_fn": None,
+        "required_slots": 1,
+        "max_async_children": 1,
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+        "max_memory_psi_avg10": 0.0,
+        "resume_memory_psi_avg10": 0.0,
+        "queue_timeout_seconds": 0.0,
+        "_queued_monotonic": time.monotonic(),
+        "_progress_token": None,
+        "_progress_ts": time.time(),
+        "_interrupted_at": time.time(),
+        "_stall_quiet_seconds": 5.0,
+        "_stall_threshold_seconds": 5.0,
+        "_stall_in_tool": False,
+        "_generation": ad._manager_generation,
+    }
+    with ad._records_lock:
+        ad._records[record["delegation_id"]] = record
+
+    ad._finalize_stalled(record["delegation_id"])
+    # Record must be terminalized (slot released) despite the persist failure.
+    with ad._records_lock:
+        assert ad._records[record["delegation_id"]]["status"] == "stalled"
+    assert process_registry.completion_queue.empty()
+    ad._reset_for_tests()
+
+
+def test_psi_resume_zero_follows_stop_ceiling():
+    """Cycle-3 MINOR: resume PSI 0 must mean 'follow stop ceiling'."""
+    ad._reset_for_tests()
+    record = {
+        "delegation_id": "deleg_psi_normalize",
+        "session_key": "c3-minor2",
+        "status": "queued",
+        "max_memory_psi_avg10": 50.0,
+        "resume_memory_psi_avg10": 0.0,  # direct caller passes 0 explicitly
+        "min_available_memory_bytes": 0,
+        "resume_available_memory_bytes": 0,
+    }
+    # Not blocked: stop ceiling (50) applies.
+    assert ad._resources_available(record) is True
+    # Blocked once: resume ceiling must follow stop ceiling (50), not clamp to 0.
+    record["_resource_blocked"] = True
+    assert ad._resources_available(record) is True
+    ad._reset_for_tests()
+
+
+def test_prune_durable_records_preserves_live_queued_rows(monkeypatch, tmp_path):
+    """M3: durable pruning must never delete a live queued row."""
+    import gateway.status as gateway_status
+
+    ad._db_path = lambda: tmp_path / "state.db"
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: False)
+    now = time.time()
+    # A live queued row with a frozen updated_at (oldest pending row).
+    ad._persist_dispatch({
+        "delegation_id": "deleg_live_queued",
+        "session_key": "m3",
+        "status": "queued",
+        "dispatched_at": now - 1000,
+        "goal": "live queued",
+        "is_batch": False,
+    })
+    # A terminal delivered row (candidate for pruning).
+    ad._persist_dispatch({
+        "delegation_id": "deleg_terminal_1",
+        "session_key": "m3",
+        "status": "completed",
+        "dispatched_at": now - 1000,
+        "goal": "terminal",
+        "is_batch": False,
+    })
+    ad._persist_completion(
+        {"delegation_id": "deleg_terminal_1", "session_key": "m3",
+         "status": "completed", "dispatched_at": now - 1000,
+         "completed_at": now - 500},
+        {"status": "completed"},
+    )
+    ad.mark_completion_delivered("deleg_terminal_1")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET updated_at=? WHERE delegation_id='deleg_terminal_1'",
+            (now - 500,),
+        )
+
+    ad._prune_durable_records()
+
+    durable = ad.get_durable_delegation("deleg_live_queued")
+    assert durable is not None
+    assert durable["state"] == "queued"
+
+
+def test_interrupt_for_session_cancels_only_matching_queued_work(monkeypatch):
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+
+    target = ad.dispatch_async_delegation(
+        goal="target", context=None, toolsets=None, role="leaf", model="m",
+        session_key="session-a", runner=lambda: {}, max_async_children=1,
+        min_available_memory_bytes=1,
+    )
+    other = ad.dispatch_async_delegation(
+        goal="other", context=None, toolsets=None, role="leaf", model="m",
+        session_key="session-b", runner=lambda: {}, max_async_children=1,
+        min_available_memory_bytes=1,
+    )
+
+    assert ad.interrupt_for_session(session_key="session-a") == 1
+    event = _drain_for(target["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+    other_items = [
+        item for item in ad.list_async_delegations()
+        if item["delegation_id"] == other["delegation_id"]
+    ]
+    assert other_items[0]["status"] == "queued"
+
+    assert ad.interrupt_all(reason="test cleanup") == 1
+    assert _drain_for(other["delegation_id"]) is not None
+
+
+def test_begin_shutdown_cancels_queue_and_rejects_new_work(monkeypatch):
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(ad, "_effective_available_memory_bytes", lambda: 0)
+    started = threading.Event()
+
+    queued = ad.dispatch_async_delegation(
+        goal="queued at shutdown", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1, min_available_memory_bytes=1,
+    )
+    assert queued["status"] == "queued"
+
+    assert ad.begin_shutdown(reason="test shutdown") == 1
+    event = _drain_for(queued["delegation_id"])
+    assert event is not None
+    assert event["status"] == "interrupted"
+
+    rejected = ad.dispatch_async_delegation(
+        goal="too late", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=lambda: started.set() or {},
+        max_async_children=1,
+    )
+    assert rejected["status"] == "rejected"
+    assert "shutting down" in rejected["error"].lower()
+    assert started.is_set() is False
 
 
 def test_interrupt_all_signals_running_children():
@@ -686,8 +1708,7 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
 
 
 def test_concurrent_dispatch_respects_capacity():
-    """Two threads racing dispatch with cap=1 must yield exactly one accept
-    (capacity check and record insert are atomic under the records lock)."""
+    """Two racing dispatches with cap=1 produce one runner and one queued job."""
     gate = threading.Event()
 
     def blocker():
@@ -713,8 +1734,16 @@ def test_concurrent_dispatch_respects_capacity():
     for t in threads:
         t.join(timeout=10)
     statuses = sorted(r["status"] for r in results)
-    assert statuses == ["dispatched", "rejected"]
+    assert statuses == ["dispatched", "queued"]
     gate.set()
+    expected_ids = {result["delegation_id"] for result in results}
+    seen_ids = set()
+    deadline = time.monotonic() + 5
+    while seen_ids != expected_ids and time.monotonic() < deadline:
+        event = _drain_one(timeout=0.2)
+        if event and event.get("delegation_id") in expected_ids:
+            seen_ids.add(event["delegation_id"])
+    assert seen_ids == expected_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_async_delegation_fd_leak.py
+++ b/tests/tools/test_async_delegation_fd_leak.py
@@ -79,6 +79,29 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     assert set(opened) == set(closed)
 
 
+def test_recovery_reports_abandoned_queue_as_never_started(monkeypatch, tmp_path):
+    import time
+    import gateway.status as gateway_status
+
+    _point_ledger(monkeypatch, tmp_path)
+    ad._persist_dispatch({
+        "delegation_id": "deleg_abandoned_queue",
+        "session_key": "session-a",
+        "status": "queued",
+        "dispatched_at": time.time(),
+        "goal": "never started",
+        "is_batch": False,
+    })
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: False)
+
+    assert ad.recover_abandoned_delegations() == 1
+    durable = ad.get_durable_delegation("deleg_abandoned_queue")
+    assert durable is not None
+    assert durable["state"] == "interrupted"
+    assert durable["result"]["status"] == "interrupted"
+    assert "before start" in durable["result"]["error"]
+
+
 def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
     """A PRAGMA/DDL failure after connect() must still close the connection."""
     _point_ledger(monkeypatch, tmp_path)

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -10,7 +10,7 @@ conversation as a type='async_delegation' completion event.
 Sync fallbacks preserved:
   - no routable session (direct Python callers, `hermes cron run`)
   - async delivery unsupported (one-shot runners, cron child sessions)
-  - dispatch pool at capacity (claim already taken — must not strand it)
+  - dispatch rejection/submission failure (claim already taken — run inline once)
 """
 import json
 import threading
@@ -180,7 +180,7 @@ class TestSyncFallbacks:
                 res = _try_dispatch_background_run(_job('job-bg-06'))
         assert res is None
 
-    def test_pool_at_capacity_runs_inline(self):
+    def test_rejected_dispatch_runs_inline(self):
         """A rejected dispatch must not strand the already-taken claim."""
         with _bound_session_key():
             with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
@@ -193,6 +193,31 @@ class TestSyncFallbacks:
         assert res["dispatched"] is False
         assert res["success"] is True
         m_run.assert_called_once()   # ran inline on this thread
+
+    def test_queued_dispatch_is_accepted_without_inline_duplicate(self):
+        """A queued runner owns the claim and must be allowed to execute once."""
+        claimed = {**_job("job-bg-queued"), "fire_claim": {"by": "bg-owner"}}
+        with _bound_session_key():
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                return_value={
+                    "status": "queued",
+                    "delegation_id": "deleg_cron_queued",
+                    "queue_reason": "capacity",
+                },
+            ), patch("cron.scheduler.run_one_job") as m_run:
+                res = _try_dispatch_background_run(_job("job-bg-queued"))
+
+        assert res == {
+            "claimed": True,
+            "dispatched": True,
+            "status": "queued",
+            "delegation_id": "deleg_cron_queued",
+            "queue_reason": "capacity",
+        }
+        m_run.assert_not_called()
 
 
 class TestInFlightDedupe:

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -15,6 +15,7 @@ dispatch code reads it — the fake child build below reproduces that clobber.
 """
 
 import json
+import threading
 import time
 from unittest.mock import MagicMock
 
@@ -146,9 +147,31 @@ def test_apiserver_session_with_id_dispatches_background(monkeypatch):
 
 
 def test_apiserver_session_without_id_stays_synchronous(monkeypatch):
-    """No session id to wake → keep the sync fallback (a detached result
-    would never re-enter any conversation)."""
+    """No session id to wake → keep the sync fallback and parent ownership."""
     dt = _patch_delegate(monkeypatch)
+    parent = _fake_parent()
+    child = MagicMock()
+    child._delegate_role = "leaf"
+    child._subagent_id = "sync-child"
+
+    def build_parent_owned_child(**kwargs):
+        kwargs["parent_agent"]._active_children.append(child)
+        return child
+
+    def assert_parent_owned_while_running(*_args, **_kwargs):
+        assert child in parent._active_children
+        return {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done synchronously",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    monkeypatch.setattr(dt, "_build_child_agent", build_parent_owned_child)
+    monkeypatch.setattr(dt, "_run_single_child", assert_parent_owned_while_running)
     set_session_vars(
         platform="api_server",
         chat_id="",
@@ -159,9 +182,226 @@ def test_apiserver_session_without_id_stays_synchronous(monkeypatch):
 
     out = dt.delegate_task(
         goal="one-shot", context="ctx",
-        background=True, parent_agent=_fake_parent(),
+        background=True, parent_agent=parent,
     )
     parsed = json.loads(out)
     assert parsed.get("status") != "dispatched", parsed
     assert "SYNCHRONOUSLY" in parsed.get("note", "")
     assert process_registry.completion_queue.empty()
+
+
+def test_capacity_queue_never_falls_back_to_synchronous_execution(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-queued",
+        session_key="raw-sid-queued",
+        session_id="raw-sid-queued",
+        async_delivery=False,
+    )
+
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda **_kwargs: {
+            "status": "queued",
+            "delegation_id": "deleg_queued1",
+            "queue_reason": "capacity",
+        },
+    )
+    monkeypatch.setattr(
+        dt,
+        "_run_single_child",
+        lambda *_args, **_kwargs: pytest.fail("queued work ran synchronously"),
+    )
+
+    parsed = json.loads(dt.delegate_task(
+        goal="queue me", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "queued"
+    assert parsed["mode"] == "background"
+    assert parsed["delegation_id"] == "deleg_queued1"
+    assert parsed["queue_reason"] == "capacity"
+    assert "queued" in parsed["note"].lower()
+    assert "subagent_ids" not in parsed
+    assert "action='list'" in parsed["control_hint"]
+
+
+def test_capacity_queue_defers_child_construction_until_admitted(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-lazy",
+        session_key="raw-sid-lazy",
+        session_id="raw-sid-lazy",
+        async_delivery=False,
+    )
+    build_calls = []
+
+    def build_child(**kwargs):
+        build_calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(dt, "_build_child_agent", build_child)
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda **_kwargs: {
+            "status": "queued",
+            "delegation_id": "deleg_lazy1",
+            "queue_reason": "capacity",
+        },
+    )
+
+    parsed = json.loads(dt.delegate_task(
+        goal="build me later", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "queued"
+    assert build_calls == []
+
+
+def test_resource_queue_builds_child_only_after_promotion(monkeypatch):
+    from tools import async_delegation as ad
+
+    ad._reset_for_tests()
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-promote",
+        session_key="raw-sid-promote",
+        session_id="raw-sid-promote",
+        async_delivery=False,
+    )
+    available = {"bytes": 0}
+    build_calls = []
+    built_children = []
+    original_build = dt._build_child_agent
+
+    def counted_build(**kwargs):
+        build_calls.append(kwargs)
+        child = original_build(**kwargs)
+        built_children.append(child)
+        return child
+
+    monkeypatch.setattr(dt, "_build_child_agent", counted_build)
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+    monkeypatch.setattr(dt, "_get_max_async_children", lambda: 1)
+    monkeypatch.setattr(dt, "_get_min_available_memory_bytes", lambda: 100)
+    monkeypatch.setattr(dt, "_get_resume_available_memory_bytes", lambda: 200)
+
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    parsed = json.loads(dt.delegate_task(
+        goal="promote later", context="ctx", background=True,
+        output_schema=schema,
+        parent_agent=_fake_parent(),
+    ))
+    assert parsed["status"] == "queued"
+    assert build_calls == []
+
+    available["bytes"] = 150
+    time.sleep(0.1)
+    assert build_calls == []
+    available["bytes"] = 250
+    event = _drain_one()
+    assert event is not None
+    assert event["status"] == "completed"
+    assert len(build_calls) == 1
+    assert "OUTPUT CONTRACT" in build_calls[0]["context"]
+    assert built_children[0]._delegate_output_schema == schema
+    ad._reset_for_tests()
+
+
+def test_cancel_during_lazy_child_build_is_nonblocking_and_cleans_up(monkeypatch):
+    from tools import async_delegation as ad
+
+    ad._reset_for_tests()
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-cancel-build",
+        session_key="raw-sid-cancel-build",
+        session_id="raw-sid-cancel-build",
+        async_delivery=False,
+    )
+    build_started = threading.Event()
+    release_build = threading.Event()
+    child = MagicMock()
+    child.run.return_value = "must not run"
+
+    def blocking_build(**_kwargs):
+        build_started.set()
+        assert release_build.wait(timeout=2)
+        return child
+
+    monkeypatch.setattr(dt, "_build_child_agent", blocking_build)
+    monkeypatch.setattr(dt, "_get_max_async_children", lambda: 1)
+    parent = _fake_parent()
+    parsed = json.loads(dt.delegate_task(
+        goal="cancel during build", context=None, background=True,
+        parent_agent=parent,
+    ))
+    assert parsed["status"] == "dispatched"
+    assert build_started.wait(timeout=1)
+
+    started = time.monotonic()
+    assert ad.interrupt_for_session(
+        "raw-sid-cancel-build", parent_session_id=parent.session_id,
+        reason="test cancellation",
+    ) == 1
+    assert time.monotonic() - started < 0.5
+    release_build.set()
+
+    event = _drain_one()
+    assert event is not None
+    assert event["status"] == "interrupted"
+    child.run.assert_not_called()
+    child.close.assert_called_once()
+    ad._reset_for_tests()
+
+
+def test_queue_configuration_is_forwarded_to_async_admission(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-config",
+        session_key="raw-sid-config",
+        session_id="raw-sid-config",
+        async_delivery=False,
+    )
+    captured = {}
+
+    def fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"status": "dispatched", "delegation_id": "deleg_config1"}
+
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch", fake_dispatch
+    )
+    monkeypatch.setattr(dt, "_get_max_queued_delegations", lambda: 5)
+    monkeypatch.setattr(dt, "_get_min_available_memory_bytes", lambda: 4096)
+    monkeypatch.setattr(dt, "_get_resume_available_memory_bytes", lambda: 8192)
+    monkeypatch.setattr(dt, "_get_max_memory_psi_avg10", lambda: 12.0)
+    monkeypatch.setattr(dt, "_get_resume_memory_psi_avg10", lambda: 5.0)
+    monkeypatch.setattr(dt, "_get_queue_timeout_seconds", lambda: 123.0)
+
+    parsed = json.loads(dt.delegate_task(
+        goal="configured", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "dispatched"
+    assert captured["max_queued_delegations"] == 5
+    assert captured["min_available_memory_bytes"] == 4096
+    assert captured["resume_available_memory_bytes"] == 8192
+    assert captured["max_memory_psi_avg10"] == 12.0
+    assert captured["resume_memory_psi_avg10"] == 5.0
+    assert captured["queue_timeout_seconds"] == 123.0

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -15,6 +15,7 @@ dispatch code reads it — the fake child build below reproduces that clobber.
 """
 
 import json
+import threading
 import time
 from unittest.mock import MagicMock
 
@@ -165,3 +166,207 @@ def test_apiserver_session_without_id_stays_synchronous(monkeypatch):
     assert parsed.get("status") != "dispatched", parsed
     assert "SYNCHRONOUSLY" in parsed.get("note", "")
     assert process_registry.completion_queue.empty()
+
+
+def test_capacity_queue_never_falls_back_to_synchronous_execution(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-queued",
+        session_key="raw-sid-queued",
+        session_id="raw-sid-queued",
+        async_delivery=False,
+    )
+
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda **_kwargs: {
+            "status": "queued",
+            "delegation_id": "deleg_queued1",
+            "queue_reason": "capacity",
+        },
+    )
+    monkeypatch.setattr(
+        dt,
+        "_run_single_child",
+        lambda *_args, **_kwargs: pytest.fail("queued work ran synchronously"),
+    )
+
+    parsed = json.loads(dt.delegate_task(
+        goal="queue me", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "queued"
+    assert parsed["mode"] == "background"
+    assert parsed["delegation_id"] == "deleg_queued1"
+    assert parsed["queue_reason"] == "capacity"
+    assert "queued" in parsed["note"].lower()
+
+
+def test_capacity_queue_defers_child_construction_until_admitted(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-lazy",
+        session_key="raw-sid-lazy",
+        session_id="raw-sid-lazy",
+        async_delivery=False,
+    )
+    build_calls = []
+
+    def build_child(**kwargs):
+        build_calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(dt, "_build_child_agent", build_child)
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda **_kwargs: {
+            "status": "queued",
+            "delegation_id": "deleg_lazy1",
+            "queue_reason": "capacity",
+        },
+    )
+
+    parsed = json.loads(dt.delegate_task(
+        goal="build me later", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "queued"
+    assert build_calls == []
+
+
+def test_resource_queue_builds_child_only_after_promotion(monkeypatch):
+    from tools import async_delegation as ad
+
+    ad._reset_for_tests()
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-promote",
+        session_key="raw-sid-promote",
+        session_id="raw-sid-promote",
+        async_delivery=False,
+    )
+    available = {"bytes": 0}
+    build_calls = []
+    original_build = dt._build_child_agent
+
+    def counted_build(**kwargs):
+        build_calls.append(kwargs)
+        return original_build(**kwargs)
+
+    monkeypatch.setattr(dt, "_build_child_agent", counted_build)
+    monkeypatch.setattr(ad, "_ADMISSION_RECHECK_SECONDS", 0.02)
+    monkeypatch.setattr(
+        ad, "_effective_available_memory_bytes", lambda: available["bytes"]
+    )
+    monkeypatch.setattr(dt, "_get_max_async_children", lambda: 1)
+    monkeypatch.setattr(dt, "_get_min_available_memory_bytes", lambda: 100)
+    monkeypatch.setattr(dt, "_get_resume_available_memory_bytes", lambda: 200)
+
+    parsed = json.loads(dt.delegate_task(
+        goal="promote later", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+    assert parsed["status"] == "queued"
+    assert build_calls == []
+
+    available["bytes"] = 150
+    time.sleep(0.1)
+    assert build_calls == []
+    available["bytes"] = 250
+    event = _drain_one()
+    assert event is not None
+    assert event["status"] == "completed"
+    assert len(build_calls) == 1
+    ad._reset_for_tests()
+
+
+def test_cancel_during_lazy_child_build_is_nonblocking_and_cleans_up(monkeypatch):
+    from tools import async_delegation as ad
+
+    ad._reset_for_tests()
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-cancel-build",
+        session_key="raw-sid-cancel-build",
+        session_id="raw-sid-cancel-build",
+        async_delivery=False,
+    )
+    build_started = threading.Event()
+    release_build = threading.Event()
+    child = MagicMock()
+    child.run.return_value = "must not run"
+
+    def blocking_build(**_kwargs):
+        build_started.set()
+        assert release_build.wait(timeout=2)
+        return child
+
+    monkeypatch.setattr(dt, "_build_child_agent", blocking_build)
+    monkeypatch.setattr(dt, "_get_max_async_children", lambda: 1)
+    parent = _fake_parent()
+    parsed = json.loads(dt.delegate_task(
+        goal="cancel during build", context=None, background=True,
+        parent_agent=parent,
+    ))
+    assert parsed["status"] == "dispatched"
+    assert build_started.wait(timeout=1)
+
+    started = time.monotonic()
+    assert ad.interrupt_for_session(
+        "raw-sid-cancel-build", parent_session_id=parent.session_id,
+        reason="test cancellation",
+    ) == 1
+    assert time.monotonic() - started < 0.5
+    release_build.set()
+
+    event = _drain_one()
+    assert event is not None
+    assert event["status"] == "interrupted"
+    child.run.assert_not_called()
+    child.close.assert_called_once()
+    ad._reset_for_tests()
+
+
+def test_queue_configuration_is_forwarded_to_async_admission(monkeypatch):
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-config",
+        session_key="raw-sid-config",
+        session_id="raw-sid-config",
+        async_delivery=False,
+    )
+    captured = {}
+
+    def fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"status": "dispatched", "delegation_id": "deleg_config1"}
+
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch", fake_dispatch
+    )
+    monkeypatch.setattr(dt, "_get_max_queued_delegations", lambda: 5)
+    monkeypatch.setattr(dt, "_get_min_available_memory_bytes", lambda: 4096)
+    monkeypatch.setattr(dt, "_get_resume_available_memory_bytes", lambda: 8192)
+    monkeypatch.setattr(dt, "_get_max_memory_psi_avg10", lambda: 12.0)
+    monkeypatch.setattr(dt, "_get_resume_memory_psi_avg10", lambda: 5.0)
+    monkeypatch.setattr(dt, "_get_queue_timeout_seconds", lambda: 123.0)
+
+    parsed = json.loads(dt.delegate_task(
+        goal="configured", context="ctx", background=True,
+        parent_agent=_fake_parent(),
+    ))
+
+    assert parsed["status"] == "dispatched"
+    assert captured["max_queued_delegations"] == 5
+    assert captured["min_available_memory_bytes"] == 4096
+    assert captured["resume_available_memory_bytes"] == 8192
+    assert captured["max_memory_psi_avg10"] == 12.0
+    assert captured["resume_memory_psi_avg10"] == 5.0
+    assert captured["queue_timeout_seconds"] == 123.0

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -69,11 +70,21 @@ _executor_lock = threading.Lock()
 _executor_max_workers: int = 0
 
 _records_lock = threading.Lock()
+_admission_condition = threading.Condition(_records_lock)
 # delegation_id -> record dict. Kept for the lifetime of the run plus a short
 # tail after completion so `list_async_delegations()` can show recent results.
 _records: Dict[str, Dict[str, Any]] = {}
+_lingering_resource_slots: Dict[str, int] = {}
+_shutdown_event = threading.Event()
+# Manager generation: bumped on test reset / shutdown so workers that captured
+# a record from an earlier generation cannot push completions into the shared
+# queue after the manager has been torn down (see _push_completion_event).
+_manager_generation = 0
 
-_DEFAULT_MAX_ASYNC_CHILDREN = 3
+_DEFAULT_MAX_ASYNC_CHILDREN = 10
+_DEFAULT_MAX_QUEUED_DELEGATIONS = 8
+_DEFAULT_QUEUE_TIMEOUT_SECONDS = 3600.0
+_ADMISSION_RECHECK_SECONDS = 1.0
 # How many completed records to retain for status queries before pruning.
 _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
@@ -258,11 +269,11 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
                 owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
-             record["dispatched_at"], now, __import__("os").getpid(),
-             owner_started_at, json.dumps(task_payload),
+             record.get("status", "running"), record["dispatched_at"], now,
+             __import__("os").getpid(), owner_started_at, json.dumps(task_payload),
              record.get("origin_session_id", "")),
         )
     _prune_durable_records()
@@ -274,7 +285,12 @@ def _delete_durable_delegation(delegation_id: str) -> None:
 
 
 def _prune_durable_records() -> None:
-    """Bound terminal history, preferring delivered records for deletion."""
+    """Bound terminal history, preferring delivered records for deletion.
+
+    Live non-terminal states are ``('running','finalizing','queued')`` — a
+    queued row is still pending admission and must never be pruned: its
+    terminal outcome (timeout/cancel/start) has not been recorded yet.
+    """
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _transaction() as conn:
@@ -283,14 +299,14 @@ def _prune_durable_records() -> None:
             (cutoff,),
         )
         terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing','queued')"
         ).fetchone()[0]
         excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
+                     WHERE state NOT IN ('running','finalizing','queued')
                      ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
                               updated_at ASC LIMIT ?
                    )""",
@@ -298,14 +314,14 @@ def _prune_durable_records() -> None:
             )
         pending_count = conn.execute(
             """SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'"""
+              WHERE state NOT IN ('running','finalizing','queued') AND delivery_state='pending'"""
         ).fetchone()[0]
         overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
         if overflow:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                     WHERE state NOT IN ('running','finalizing','queued') AND delivery_state='pending'
                      ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (overflow,),
@@ -324,6 +340,15 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def _persist_state(delegation_id: str, state: str) -> None:
+    """Durably mirror an in-memory lifecycle transition."""
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state=?, updated_at=? WHERE delegation_id=?",
+            (state, time.time(), delegation_id),
+        )
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -333,7 +358,11 @@ def _note_delivery_attempt(delegation_id: str) -> None:
 
 
 def recover_abandoned_delegations() -> int:
-    """Classify records whose owning process disappeared as outcome unknown."""
+    """Terminalize durable records whose owning process disappeared.
+
+    A dead-owner queued record provably never began and is reported interrupted;
+    running/finalizing records remain unknown because side effects may have begun.
+    """
     try:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
@@ -344,12 +373,13 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
-               FROM async_delegations WHERE state IN ('running','finalizing')"""
+                      owner_started_at, task_json, origin_session_id, state
+               FROM async_delegations
+               WHERE state IN ('queued','running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, prior_state) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -358,6 +388,12 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            terminal_status = "interrupted" if prior_state == "queued" else "unknown"
+            terminal_error = (
+                "Queued delegation was cancelled before start because its owner exited."
+                if prior_state == "queued"
+                else "Delegation owner exited before recording a terminal result; outcome unknown."
+            )
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -368,8 +404,8 @@ def recover_abandoned_delegations() -> int:
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "status": terminal_status, "summary": None,
+                "error": terminal_error,
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
             # Routing origin persisted at dispatch (see _capture_routing_origin):
@@ -378,12 +414,17 @@ def recover_abandoned_delegations() -> int:
             for _k in ("scope_id", "user_id", "user_name"):
                 if task.get(_k):
                     event[_k] = task[_k]
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
+            result = {
+                "status": terminal_status, "summary": None, "error": terminal_error
+            }
             conn.execute(
-                """UPDATE async_delegations SET state='unknown', completed_at=?,
+                """UPDATE async_delegations SET state=?, completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
                    WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+                (
+                    terminal_status, now, now, json.dumps(event), json.dumps(result),
+                    delegation_id,
+                ),
             )
             recovered += 1
     return recovered
@@ -611,11 +652,10 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
 def active_count() -> int:
     """Number of async delegation UNITS currently running.
 
-    A unit is one dispatch: a single subagent OR a whole fan-out batch. A batch
-    counts as ONE here because it occupies one async-pool slot (the capacity
-    semantics ``dispatch_async_delegation_batch`` relies on). For the count of
-    actual concurrent child subagents (batch expanded), use
-    ``active_task_count()``.
+    A unit is one dispatch: a single subagent or one fan-out batch. This is an
+    observability count of dispatch records, not slot accounting; a running batch
+    reserves one child slot per goal. Use ``active_task_count()`` for the expanded
+    child count.
     """
     with _records_lock:
         return sum(
@@ -625,14 +665,14 @@ def active_count() -> int:
 
 
 def active_for_session(origin_ui_session_id: str) -> int:
-    """Number of live async delegations owned by one UI session."""
+    """Number of live queued or running delegations owned by one UI session."""
     if not origin_ui_session_id:
         return 0
     with _records_lock:
         return sum(
             1
             for r in _records.values()
-            if r.get("status") in {"running", "stalling", "finalizing"}
+            if r.get("status") in {"queued", "running", "stalling", "finalizing"}
             and str(r.get("origin_ui_session_id") or "")
             == origin_ui_session_id
         )
@@ -682,14 +722,14 @@ def has_live_for_session(
 ) -> bool:
     """Whether a session still owns any live async delegation.
 
-    Live = running / stalling / finalizing — the same states the reapers'
-    keepalive treats as active work.
+    Live = queued / running / stalling / finalizing — the states whose owner
+    must be kept routable until the work is cancelled or reaches a terminal state.
     """
     if not session_key and not origin_ui_session_id and not parent_session_id:
         return False
     with _records_lock:
         return any(
-            r.get("status") in {"running", "stalling", "finalizing"}
+            r.get("status") in {"queued", "running", "stalling", "finalizing"}
             and _matches_session_selectors(
                 r,
                 session_key=session_key,
@@ -698,6 +738,217 @@ def has_live_for_session(
             )
             for r in _records.values()
         )
+
+
+def _current_cgroup_v2_path() -> Optional[str]:
+    """Return this process's cgroup-v2 directory, if mounted conventionally."""
+    if os.name != "posix":
+        return None
+    try:
+        with open("/proc/self/cgroup", encoding="utf-8") as handle:
+            for line in handle:
+                hierarchy, _controllers, path = line.rstrip("\n").split(":", 2)
+                if hierarchy == "0":
+                    return os.path.join("/sys/fs/cgroup", path.lstrip("/"))
+    except (OSError, ValueError):
+        logger.debug("Cgroup v2 path probe failed", exc_info=True)
+    return None
+
+
+def _effective_available_memory_bytes() -> Optional[int]:
+    """Return host availability capped by this process's cgroup headroom."""
+    try:
+        import psutil
+
+        available = int(psutil.virtual_memory().available)
+    except Exception:
+        logger.debug("Available-memory probe failed", exc_info=True)
+        return None
+
+    cgroup_dir = _current_cgroup_v2_path()
+    if cgroup_dir is None:
+        return available
+    try:
+        with open(
+            os.path.join(cgroup_dir, "memory.current"), encoding="utf-8"
+        ) as handle:
+            current = int(handle.read().strip())
+        for filename in ("memory.high", "memory.max"):
+            with open(
+                os.path.join(cgroup_dir, filename), encoding="utf-8"
+            ) as handle:
+                raw = handle.read().strip()
+            if raw != "max":
+                available = min(available, max(0, int(raw) - current))
+    except (OSError, ValueError):
+        # No cgroup v2 limit (or a transient read race): host availability is
+        # still a valid cross-platform admission signal.
+        pass
+    return available
+
+
+def _memory_psi_avg10() -> Optional[float]:
+    """Return Linux memory-pressure ``some avg10`` or ``None`` if unavailable."""
+    if os.name != "posix":
+        return None
+    try:
+        with open("/proc/pressure/memory", encoding="utf-8") as handle:
+            for line in handle:
+                fields = line.split()
+                if fields and fields[0] == "some":
+                    for field in fields[1:]:
+                        if field.startswith("avg10="):
+                            return float(field.split("=", 1)[1])
+    except (OSError, ValueError):
+        logger.debug("Memory PSI probe failed", exc_info=True)
+    return None
+
+
+def _resources_available(record: Dict[str, Any]) -> bool:
+    was_blocked = bool(record.get("_resource_blocked", False))
+    minimum = max(0, int(record.get("min_available_memory_bytes", 0)))
+    resume_minimum = max(
+        minimum, int(record.get("resume_available_memory_bytes", minimum))
+    )
+    memory_floor = resume_minimum if was_blocked else minimum
+
+    max_psi = max(0.0, float(record.get("max_memory_psi_avg10", 0.0)))
+    resume_value = float(record.get("resume_memory_psi_avg10", max_psi))
+    # Defense-in-depth: a non-positive explicit resume ceiling must follow the
+    # stop ceiling (same convention as delegate_tool's getter). Without this,
+    # a direct dispatch_async_delegation* caller passing 0 with max_psi > 0
+    # would clamp the resume ceiling to 0 and stay blocked until PSI is
+    # exactly 0.
+    if resume_value <= 0.0:
+        resume_value = max_psi
+    resume_psi = max(0.0, min(max_psi, resume_value))
+    psi_ceiling = resume_psi if was_blocked else max_psi
+
+    memory_ready = True
+    if memory_floor:
+        available = _effective_available_memory_bytes()
+        # An explicitly configured memory floor is fail-closed when the probe
+        # is unavailable; otherwise the safety control would silently vanish.
+        memory_ready = available is not None and available >= memory_floor
+
+    pressure_ready = True
+    if max_psi:
+        pressure = _memory_psi_avg10()
+        # PSI is Linux-only and optional; unavailable PSI falls back to the
+        # memory-headroom gate for cross-platform compatibility.
+        pressure_ready = pressure is None or pressure <= psi_ceiling
+
+    ready = memory_ready and pressure_ready
+    record["_resource_blocked"] = not ready
+    return ready
+
+
+def _queue_head_locked() -> Optional[str]:
+    """Return the oldest queued delegation id. Caller holds ``_records_lock``."""
+    for record in _records.values():
+        if record.get("status") == "queued":
+            return record.get("delegation_id")
+    return None
+
+
+def _running_task_slots_locked() -> int:
+    """Return admitted and still-live child slots. Caller holds record lock."""
+    running = sum(
+        max(1, int(record.get("required_slots", 1)))
+        for record in _records.values()
+        if record.get("status") in {"running", "stalling", "finalizing"}
+    )
+    return running + sum(_lingering_resource_slots.values())
+
+
+def _register_lingering_resources(
+    delegation_id: str, futures: List[Any]
+) -> None:
+    """Retain slots for timed-out child threads until their futures truly exit."""
+    live = [future for future in futures if future is not None and not future.done()]
+    if not live:
+        return
+    with _admission_condition:
+        _lingering_resource_slots[delegation_id] = len(live)
+        _admission_condition.notify_all()
+
+    def _release_one(_future: Any) -> None:
+        with _admission_condition:
+            remaining = _lingering_resource_slots.get(delegation_id, 0) - 1
+            if remaining > 0:
+                _lingering_resource_slots[delegation_id] = remaining
+            else:
+                _lingering_resource_slots.pop(delegation_id, None)
+            _admission_condition.notify_all()
+
+    for future in live:
+        future.add_done_callback(_release_one)
+
+
+def _wait_for_admission(delegation_id: str) -> bool:
+    """Block a daemon worker until its FIFO position can claim all child slots."""
+    admitted = False
+    expired = False
+    with _admission_condition:
+        while True:
+            record = _records.get(delegation_id)
+            if record is None:
+                return False
+            if record.get("status") == "running":
+                return True
+            if record.get("status") != "queued":
+                return False
+            queue_timeout = max(0.0, float(record.get("queue_timeout_seconds", 0)))
+            queued_at = float(record.get("_queued_monotonic", time.monotonic()))
+            if queue_timeout and time.monotonic() - queued_at >= queue_timeout:
+                expired = True
+                break
+            required = max(1, int(record.get("required_slots", 1)))
+            limit = max(1, int(record.get("max_async_children", 1)))
+            is_head = _queue_head_locked() == delegation_id
+            slots_ready = _running_task_slots_locked() + required <= limit
+            resources_ready = is_head and slots_ready and _resources_available(record)
+            if not is_head:
+                record["queue_reason"] = "fifo"
+            elif not slots_ready:
+                record["queue_reason"] = "capacity"
+            elif not resources_ready:
+                record["queue_reason"] = "resources"
+            if is_head and slots_ready and resources_ready:
+                record["status"] = "running"
+                admitted = True
+                _admission_condition.notify_all()
+                break
+            wait_for = _ADMISSION_RECHECK_SECONDS
+            if queue_timeout:
+                remaining = queue_timeout - (time.monotonic() - queued_at)
+                wait_for = min(wait_for, max(0.001, remaining))
+            _admission_condition.wait(timeout=wait_for)
+    if expired:
+        _finalize_queued_terminal(
+            delegation_id,
+            "timeout",
+            "Queued delegation timed out before resources became available.",
+        )
+        return False
+    if admitted:
+        # The stale monitor may have exited while this record sat queued (its
+        # sweeps only monitor running work). Restart it so an admitted-then-
+        # wedged child is still force-finalized instead of leaking its slot.
+        _ensure_stale_monitor()
+        try:
+            _persist_state(delegation_id, "running")
+        except Exception:
+            # Best-effort mirror: the durable row already exists from
+            # _persist_dispatch, and the terminal completion persist will
+            # overwrite state. A failure here must NOT kill the admission
+            # thread — the worker still needs to be submitted or the slot
+            # leaks with a record stuck "running" and no runner.
+            logger.exception(
+                "Failed to persist running state for admitted delegation %s",
+                delegation_id,
+            )
+    return admitted
 
 
 def _new_delegation_id() -> str:
@@ -712,7 +963,7 @@ def _prune_completed_locked() -> None:
     completed = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running"
+        if r.get("status") not in {"queued", "running", "stalling", "finalizing"}
     ]
     if len(completed) <= _MAX_RETAINED_COMPLETED:
         return
@@ -764,6 +1015,12 @@ def dispatch_async_delegation(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    max_queued_delegations: int = _DEFAULT_MAX_QUEUED_DELEGATIONS,
+    min_available_memory_bytes: int = 0,
+    resume_available_memory_bytes: int = 0,
+    max_memory_psi_avg10: float = 0.0,
+    resume_memory_psi_avg10: float = 0.0,
+    queue_timeout_seconds: float = _DEFAULT_QUEUE_TIMEOUT_SECONDS,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
@@ -798,15 +1055,13 @@ def dispatch_async_delegation(
         stale-detection block at the top of this module). When omitted, the
         delegation is not monitored.
     max_async_children
-        Concurrency cap. When at capacity the dispatch is REJECTED (the caller
-        should fall back to sync or tell the user) rather than queued, so a
-        runaway model can't pile up unbounded background work.
+        Global child-slot cap. Work that cannot claim all required slots enters
+        the bounded FIFO; queue overflow is rejected without synchronous fallback.
 
     Returns
     -------
     dict
-        ``{"status": "dispatched", "delegation_id": ...}`` on success, or
-        ``{"status": "rejected", "error": ...}`` when at capacity.
+        A ``dispatched`` or ``queued`` handle, or an explicit ``rejected`` error.
     """
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
@@ -827,41 +1082,92 @@ def dispatch_async_delegation(
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
         "progress_fn": progress_fn,
+        "required_slots": 1,
+        "max_async_children": max_async_children,
+        "min_available_memory_bytes": min_available_memory_bytes,
+        "resume_available_memory_bytes": max(
+            min_available_memory_bytes, resume_available_memory_bytes
+        ),
+        "max_memory_psi_avg10": max_memory_psi_avg10,
+        "resume_memory_psi_avg10": resume_memory_psi_avg10,
+        "queue_timeout_seconds": queue_timeout_seconds,
+        "_queued_monotonic": time.monotonic(),
         # Stale-monitor bookkeeping (see _stale_monitor_loop).
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "_generation": _manager_generation,
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
     # from different gateway sessions) both pass the check and exceed the cap.
     with _records_lock:
-        running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
-        )
-        if running >= max_async_children:
+        if _shutdown_event.is_set():
             return {
                 "status": "rejected",
-                "error": (
-                    f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
-                    f"the chat), or run this task synchronously "
-                    f"(background=false). Raise delegation.max_concurrent_children in "
-                    f"config.yaml to allow more concurrent background subagents."
-                ),
+                "error": "Async delegation manager is shutting down.",
             }
+        capacity_ready = (
+            _queue_head_locked() is None
+            and _running_task_slots_locked() + record["required_slots"]
+            <= max_async_children
+        )
+        resources_ready = _resources_available(record)
+        queued = not (capacity_ready and resources_ready)
+        queue_reason = "capacity" if not capacity_ready else "resources"
+        if queued:
+            pending = sum(1 for r in _records.values() if r.get("status") == "queued")
+            queue_limit = max(0, int(max_queued_delegations))
+            if pending >= queue_limit:
+                return {
+                    "status": "rejected",
+                    "error": f"Async delegation queue is full ({queue_limit} pending).",
+                }
+            record["status"] = "queued"
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:
+        logger.exception("Failed to persist async delegation %s", delegation_id)
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation: {exc}",
+        }
+    try:
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        _delete_durable_delegation(delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to initialize async delegation executor: {exc}",
+        }
 
     def _worker() -> None:
         result: Dict[str, Any] = {}
         status = "error"
         try:
             result = runner() or {}
+            lingering = result.pop("_lingering_futures", [])
+            if isinstance(lingering, list):
+                _register_lingering_resources(delegation_id, lingering)
             status = result.get("status") or "completed"
+        except InterruptedError as exc:
+            result = {
+                "status": "interrupted",
+                "summary": None,
+                "error": str(exc),
+                "api_calls": 0,
+                "duration_seconds": round(time.time() - dispatched_at, 2),
+                "exit_reason": "interrupted",
+            }
+            status = "interrupted"
         except Exception as exc:  # noqa: BLE001 — must never crash the worker
             logger.exception("Async delegation %s crashed", delegation_id)
             result = {
@@ -875,11 +1181,32 @@ def dispatch_async_delegation(
         finally:
             _finalize(delegation_id, result, status)
 
+    # Capture the request/profile context now; queued launchers may run much later.
+    worker_with_context = propagate_context_to_thread(_worker)
+
+    def _launch_when_admitted() -> None:
+        if not _wait_for_admission(delegation_id):
+            return
+        try:
+            executor.submit(worker_with_context)
+        except Exception as exc:  # executor may be shutting down
+            logger.exception("Failed to launch queued delegation %s", delegation_id)
+            _finalize_queued_terminal(
+                delegation_id,
+                "error",
+                f"Failed to launch queued delegation: {exc}",
+            )
+
     try:
-        # Propagate the dispatching profile so the detached child resolves
-        # get_hermes_home() under the right profile.
-        executor.submit(propagate_context_to_thread(_worker))
-    except Exception as exc:  # pragma: no cover — pool submit failure is rare
+        if queued:
+            threading.Thread(
+                target=propagate_context_to_thread(_launch_when_admitted),
+                name=f"async-delegate-admission-{delegation_id}",
+                daemon=True,
+            ).start()
+        else:
+            executor.submit(worker_with_context)
+    except Exception as exc:  # pragma: no cover — thread/pool start failure is rare
         with _records_lock:
             _records.pop(delegation_id, None)
         _delete_durable_delegation(delegation_id)
@@ -891,10 +1218,15 @@ def dispatch_async_delegation(
         _ensure_stale_monitor()
 
     logger.info(
-        "Dispatched async delegation %s (session_key=%s): %s",
+        "%s async delegation %s (session_key=%s): %s",
+        "Queued" if queued else "Dispatched",
         delegation_id, session_key or "<cli>", (goal or "")[:80],
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    return {
+        "status": "queued" if queued else "dispatched",
+        "delegation_id": delegation_id,
+        **({"queue_reason": queue_reason} if queued else {}),
+    }
 
 
 def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
@@ -904,17 +1236,35 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         return
     event_record, _interrupt_fn = claimed
 
-    _push_completion_event(event_record, result, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_completion_event(event_record, result, status)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async delegation %s (%s): failed to publish completion event; "
+            "releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
 
 
 def _begin_finalization(
     delegation_id: str,
+    allowed_statuses: Optional[tuple] = None,
 ) -> Optional[tuple[Dict[str, Any], Optional[Callable[[], None]]]]:
-    """Atomically claim terminal delivery while keeping the record active."""
+    """Atomically claim terminal delivery while keeping the record active.
+
+    ``allowed_statuses`` restricts which in-flight states may be claimed. The
+    queued-interruption path passes ``("queued",)`` so a record that was
+    promoted to ``running`` between the caller's snapshot and this claim is
+    NOT terminalized here — the caller must instead fall back to
+    ``interrupt_fn`` so the worker self-cancels before starting.
+    """
+    if allowed_statuses is None:
+        allowed_statuses = ("queued", "running", "stalling")
     with _records_lock:
         record = _records.get(delegation_id)
-        if record is None or record.get("status") not in ("running", "stalling"):
+        if record is None or record.get("status") not in allowed_statuses:
             return
         # Stay active until durable persistence and queue publication finish;
         # otherwise process shutdown can kill this daemon worker in the narrow
@@ -930,11 +1280,12 @@ def _begin_finalization(
 
 
 def _finish_finalization(delegation_id: str, status: str) -> None:
-    with _records_lock:
+    with _admission_condition:
         record = _records.get(delegation_id)
         if record is not None:
             record["status"] = status
         _prune_completed_locked()
+        _admission_condition.notify_all()
 
 
 def _push_completion_event(
@@ -944,7 +1295,21 @@ def _push_completion_event(
 
     Best-effort: a failure here must not crash the worker, but it WOULD mean a
     silently-lost result, so we log loudly.
+
+    Generation guard: the record was captured by the worker thread at
+    finalization time. If the manager was torn down (test reset or process
+    shutdown) since dispatch, ``_manager_generation`` has moved on and the
+    completion must be dropped — a late worker from a previous generation
+    must never contaminate the shared queue or the durable ledger.
     """
+    if record.get("_generation", _manager_generation) != _manager_generation:
+        logger.info(
+            "Dropping stale-generation completion for %s (generation %s != %s)",
+            record.get("delegation_id"),
+            record.get("_generation"),
+            _manager_generation,
+        )
+        return
     try:
         from tools.process_registry import process_registry
     except Exception as exc:  # pragma: no cover
@@ -1026,6 +1391,12 @@ def dispatch_async_delegation_batch(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    max_queued_delegations: int = _DEFAULT_MAX_QUEUED_DELEGATIONS,
+    min_available_memory_bytes: int = 0,
+    resume_available_memory_bytes: int = 0,
+    max_memory_psi_avg10: float = 0.0,
+    resume_memory_psi_avg10: float = 0.0,
+    queue_timeout_seconds: float = _DEFAULT_QUEUE_TIMEOUT_SECONDS,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
@@ -1035,9 +1406,8 @@ def dispatch_async_delegation_batch(
     ``runner`` here runs the entire batch — it builds and joins on every child
     in parallel and returns the combined ``{"results": [...],
     "total_duration_seconds": N}`` dict that the synchronous path would have
-    returned. We occupy ONE async slot for the whole batch (the in-batch
-    parallelism is bounded separately by ``max_concurrent_children``), so a
-    single ``delegate_task`` fan-out never exhausts the async pool by itself.
+    returned. The batch reserves one admission slot per child, so concurrent
+    singles and batches together never exceed ``max_async_children``.
 
     When the batch finishes, a SINGLE completion event is pushed onto the
     shared ``process_registry.completion_queue`` carrying the full per-task
@@ -1045,13 +1415,24 @@ def dispatch_async_delegation_batch(
     as one message once every child is done — the chat is never blocked while
     they run.
 
-    Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
-    ``{"status": "rejected", "error": ...}`` when the async pool is at
-    capacity.
+    Returns ``{"status": "dispatched", "delegation_id": ...}`` when started,
+    ``status="queued"`` when admitted to the bounded FIFO, or
+    ``status="rejected"`` when the FIFO is full.
     """
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)
+    slot_limit = max(1, int(max_async_children))
+    if n == 0:
+        return {"status": "rejected", "error": "Delegation batch is empty."}
+    if n > slot_limit:
+        return {
+            "status": "rejected",
+            "error": (
+                f"Delegation batch requires {n} child slots, but "
+                f"max_concurrent_children is {slot_limit}."
+            ),
+        }
     # A combined goal label for status listings / the completion header.
     combined_goal = (
         goals[0] if n == 1 else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
@@ -1075,44 +1456,98 @@ def dispatch_async_delegation_batch(
         "interrupt_fn": interrupt_fn,
         "is_batch": True,
         "progress_fn": progress_fn,
+        "required_slots": n,
+        "max_async_children": max_async_children,
+        "min_available_memory_bytes": min_available_memory_bytes,
+        "resume_available_memory_bytes": max(
+            min_available_memory_bytes, resume_available_memory_bytes
+        ),
+        "max_memory_psi_avg10": max_memory_psi_avg10,
+        "resume_memory_psi_avg10": resume_memory_psi_avg10,
+        "queue_timeout_seconds": queue_timeout_seconds,
+        "_queued_monotonic": time.monotonic(),
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "_generation": _manager_generation,
     }
     with _records_lock:
-        running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
-        )
-        if running >= max_async_children:
+        if _shutdown_event.is_set():
             return {
                 "status": "rejected",
-                "error": (
-                    f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
-                    f"the chat), or raise delegation.max_concurrent_children in "
-                    f"config.yaml to allow more concurrent background units."
-                ),
+                "error": "Async delegation manager is shutting down.",
             }
+        capacity_ready = (
+            _queue_head_locked() is None
+            and _running_task_slots_locked() + record["required_slots"]
+            <= max_async_children
+        )
+        resources_ready = _resources_available(record)
+        queued = not (capacity_ready and resources_ready)
+        queue_reason = "capacity" if not capacity_ready else "resources"
+        if queued:
+            pending = sum(1 for r in _records.values() if r.get("status") == "queued")
+            queue_limit = max(0, int(max_queued_delegations))
+            if pending >= queue_limit:
+                return {
+                    "status": "rejected",
+                    "error": f"Async delegation queue is full ({queue_limit} pending).",
+                }
+            record["status"] = "queued"
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:
+        logger.exception("Failed to persist async delegation %s", delegation_id)
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation: {exc}",
+        }
+    try:
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        _delete_durable_delegation(delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to initialize async delegation executor: {exc}",
+        }
 
     def _worker() -> None:
         combined: Dict[str, Any] = {}
         status = "error"
         try:
             combined = runner() or {}
-            # Batch status: completed unless every child errored/was interrupted.
-            child_results = combined.get("results") or []
-            if child_results and all(
-                (r.get("status") not in ("completed", "success"))
-                for r in child_results
-            ):
-                status = "error"
+            lingering = combined.pop("_lingering_futures", [])
+            if isinstance(lingering, list):
+                _register_lingering_resources(delegation_id, lingering)
+            requested_status = combined.get("status")
+            if requested_status in {"interrupted", "timeout", "error"}:
+                status = requested_status
             else:
-                status = "completed"
+                # Batch status: completed unless every child errored/interrupted.
+                child_results = combined.get("results") or []
+                if child_results and all(
+                    (r.get("status") not in ("completed", "success"))
+                    for r in child_results
+                ):
+                    status = "error"
+                else:
+                    status = "completed"
+        except InterruptedError as exc:
+            combined = {
+                "status": "interrupted",
+                "results": [],
+                "error": str(exc),
+                "total_duration_seconds": round(time.time() - dispatched_at, 2),
+            }
+            status = "interrupted"
         except Exception as exc:  # noqa: BLE001 — must never crash the worker
             logger.exception("Async delegation batch %s crashed", delegation_id)
             combined = {
@@ -1124,9 +1559,30 @@ def dispatch_async_delegation_batch(
         finally:
             _finalize_batch(delegation_id, combined, status)
 
+    worker_with_context = propagate_context_to_thread(_worker)
+
+    def _launch_when_admitted() -> None:
+        if not _wait_for_admission(delegation_id):
+            return
+        try:
+            executor.submit(worker_with_context)
+        except Exception as exc:  # executor may be shutting down
+            logger.exception("Failed to launch queued batch %s", delegation_id)
+            _finalize_queued_terminal(
+                delegation_id,
+                "error",
+                f"Failed to launch queued delegation batch: {exc}",
+            )
+
     try:
-        # Propagate the dispatching profile to the detached batch children.
-        executor.submit(propagate_context_to_thread(_worker))
+        if queued:
+            threading.Thread(
+                target=propagate_context_to_thread(_launch_when_admitted),
+                name=f"async-delegate-admission-{delegation_id}",
+                daemon=True,
+            ).start()
+        else:
+            executor.submit(worker_with_context)
     except Exception as exc:  # pragma: no cover
         with _records_lock:
             _records.pop(delegation_id, None)
@@ -1139,10 +1595,15 @@ def dispatch_async_delegation_batch(
         _ensure_stale_monitor()
 
     logger.info(
-        "Dispatched async delegation batch %s (%d task(s), session_key=%s)",
+        "%s async delegation batch %s (%d task(s), session_key=%s)",
+        "Queued" if queued else "Dispatched",
         delegation_id, n, session_key or "<cli>",
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    return {
+        "status": "queued" if queued else "dispatched",
+        "delegation_id": delegation_id,
+        **({"queue_reason": queue_reason} if queued else {}),
+    }
 
 
 def _finalize_batch(
@@ -1154,14 +1615,33 @@ def _finalize_batch(
         return
     event_record, _interrupt_fn = claimed
 
-    _push_batch_completion_event(event_record, combined, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_batch_completion_event(event_record, combined, status)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async batch delegation %s (%s): failed to publish completion "
+            "event; releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
 
 
 def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
     """Push a combined async-delegation batch completion event."""
+    if (
+        event_record.get("_generation", _manager_generation)
+        != _manager_generation
+    ):
+        logger.info(
+            "Dropping stale-generation batch completion for %s (generation %s != %s)",
+            event_record.get("delegation_id"),
+            event_record.get("_generation"),
+            _manager_generation,
+        )
+        return
     try:
         from tools.process_registry import process_registry
     except Exception as exc:  # pragma: no cover
@@ -1380,32 +1860,40 @@ def _finalize_stalled(delegation_id: str) -> None:
         ),
         "stall_grace_seconds": _STALL_GRACE_SECONDS,
     }
-    if event_record.get("is_batch"):
-        _push_batch_completion_event(
-            event_record,
-            {
-                "results": [],
-                "error": error,
-                "total_duration_seconds": duration,
-                **stall_meta,
-            },
-            "stalled",
+    try:
+        if event_record.get("is_batch"):
+            _push_batch_completion_event(
+                event_record,
+                {
+                    "results": [],
+                    "error": error,
+                    "total_duration_seconds": duration,
+                    **stall_meta,
+                },
+                "stalled",
+            )
+        else:
+            _push_completion_event(
+                event_record,
+                {
+                    "status": "stalled",
+                    "summary": None,
+                    "error": error,
+                    "api_calls": 0,
+                    "duration_seconds": duration,
+                    "exit_reason": "stalled",
+                    **stall_meta,
+                },
+                "stalled",
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async delegation %s (stalled): failed to publish completion "
+            "event; releasing slot (%s)",
+            delegation_id, exc,
         )
-    else:
-        _push_completion_event(
-            event_record,
-            {
-                "status": "stalled",
-                "summary": None,
-                "error": error,
-                "api_calls": 0,
-                "duration_seconds": duration,
-                "exit_reason": "stalled",
-                **stall_meta,
-            },
-            "stalled",
-        )
-    _finish_finalization(delegation_id, "stalled")
+    finally:
+        _finish_finalization(delegation_id, "stalled")
 
 
 def _children_activity_from_token(token: Any, now: float) -> Optional[List]:
@@ -1499,6 +1987,101 @@ def list_async_delegations() -> List[Dict[str, Any]]:
     return items
 
 
+def _finalize_queued_terminal(
+    delegation_id: str,
+    status: str,
+    error: str,
+) -> bool:
+    """Publish one terminal event for a delegation that never started.
+
+    Only a record still in ``queued`` may be terminalized here. If the record
+    was promoted to ``running`` between the caller's snapshot and this claim
+    (interrupt racing admission), fall back to ``interrupt_fn`` so the worker
+    observes the cancellation and self-cancels — terminalizing it here would
+    let the worker run the delegation un-cancelled while the completion is
+    silently dropped (see _begin_finalization).
+    """
+    claimed = _begin_finalization(delegation_id, allowed_statuses=("queued",))
+    if claimed is None:
+        # Either the record no longer exists (already terminal) or it was
+        # promoted. Deliver the cancellation through the runner's interrupt
+        # hook; the not-yet-started worker then finalizes itself with
+        # exactly-once delivery. If the worker already completed (record is
+        # terminal or being finalized), there is nothing left to cancel —
+        # report False so callers don't over-count an interruption.
+        with _records_lock:
+            record = _records.get(delegation_id)
+            if record is None or record.get("status") not in ("running", "stalling"):
+                return False
+            interrupt_fn = record.get("interrupt_fn")
+        if callable(interrupt_fn):
+            try:
+                interrupt_fn()
+                return True
+            except Exception as exc:
+                logger.debug(
+                    "Queued interruption fallback for %s failed: %s",
+                    delegation_id, exc,
+                )
+        return False
+    event_record, _interrupt_fn = claimed
+    try:
+        if event_record.get("is_batch"):
+            _push_batch_completion_event(
+                event_record,
+                {"results": [], "error": error, "total_duration_seconds": 0.0},
+                status,
+            )
+        else:
+            _push_completion_event(
+                event_record,
+                {
+                    "status": status,
+                    "summary": None,
+                    "error": error,
+                    "api_calls": 0,
+                    "duration_seconds": 0.0,
+                    "exit_reason": status,
+                },
+                status,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # A durable-persist failure must not strand this record in
+        # "finalizing" with no actor to retry it: queued work never started,
+        # so no runner thread will ever finalize it and its slot would leak
+        # for the process lifetime. Log loudly, then the finally below
+        # releases the slot; restart recovery re-classifies the durable row
+        # conservatively (queued -> interrupted).
+        logger.exception(
+            "Queued delegation %s (%s): failed to publish terminal event; "
+            "releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
+    return True
+
+
+def _finalize_queued_interruption(delegation_id: str, reason: str) -> bool:
+    return _finalize_queued_terminal(
+        delegation_id,
+        "interrupted",
+        f"Queued delegation cancelled before start ({reason}).",
+    )
+
+
+def begin_shutdown(reason: str = "shutdown") -> int:
+    """Stop new admission and cancel every queued/running delegation.
+
+    This is process-lifecycle cleanup. Session-scoped ``/stop`` must use
+    ``interrupt_for_session`` instead.
+    """
+    with _admission_condition:
+        _shutdown_event.set()
+        _admission_condition.notify_all()
+    return interrupt_all(reason=reason)
+
+
 def interrupt_all(reason: str = "shutdown") -> int:
     """Signal every running async delegation to stop. Returns how many.
 
@@ -1510,9 +2093,13 @@ def interrupt_all(reason: str = "shutdown") -> int:
     with _records_lock:
         targets = [
             r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            if r.get("status") in ("queued", "running", "stalling")
         ]
     for r in targets:
+        if r.get("status") == "queued":
+            if _finalize_queued_interruption(r["delegation_id"], reason):
+                count += 1
+            continue
         fn = r.get("interrupt_fn")
         if callable(fn):
             try:
@@ -1558,7 +2145,7 @@ def interrupt_for_session(
     with _records_lock:
         targets = [
             r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            if r.get("status") in ("queued", "running", "stalling")
             and _matches_session_selectors(
                 r,
                 session_key=session_key,
@@ -1567,6 +2154,10 @@ def interrupt_for_session(
             )
         ]
     for r in targets:
+        if r.get("status") == "queued":
+            if _finalize_queued_interruption(r["delegation_id"], reason):
+                count += 1
+            continue
         fn = r.get("interrupt_fn")
         if callable(fn):
             try:
@@ -1587,7 +2178,15 @@ def interrupt_for_session(
 
 def _reset_for_tests() -> None:
     """Test-only: clear all state and tear down the executor + monitor."""
-    global _executor, _executor_max_workers, _monitor_thread
+    global _executor, _executor_max_workers, _monitor_thread, _manager_generation
+    with _admission_condition:
+        _shutdown_event.set()
+        # Bump the generation BEFORE canceling so any worker that already
+        # captured its record cannot push a completion into the shared queue
+        # once we clear state below.
+        _manager_generation += 1
+        _admission_condition.notify_all()
+    interrupt_all(reason="test reset")
     with _executor_lock:
         if _executor is not None:
             _executor.shutdown(wait=False)
@@ -1599,5 +2198,8 @@ def _reset_for_tests() -> None:
         _monitor_thread = None
     if thread is not None and thread.is_alive():
         thread.join(timeout=2)
-    with _records_lock:
+    with _admission_condition:
         _records.clear()
+        _lingering_resource_slots.clear()
+        _shutdown_event.clear()
+        _admission_condition.notify_all()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -69,11 +70,21 @@ _executor_lock = threading.Lock()
 _executor_max_workers: int = 0
 
 _records_lock = threading.Lock()
+_admission_condition = threading.Condition(_records_lock)
 # delegation_id -> record dict. Kept for the lifetime of the run plus a short
 # tail after completion so `list_async_delegations()` can show recent results.
 _records: Dict[str, Dict[str, Any]] = {}
+_lingering_resource_slots: Dict[str, int] = {}
+_shutdown_event = threading.Event()
+# Manager generation: bumped on test reset / shutdown so workers that captured
+# a record from an earlier generation cannot push completions into the shared
+# queue after the manager has been torn down (see _push_completion_event).
+_manager_generation = 0
 
 _DEFAULT_MAX_ASYNC_CHILDREN = 3
+_DEFAULT_MAX_QUEUED_DELEGATIONS = 8
+_DEFAULT_QUEUE_TIMEOUT_SECONDS = 3600.0
+_ADMISSION_RECHECK_SECONDS = 1.0
 # How many completed records to retain for status queries before pruning.
 _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
@@ -216,11 +227,11 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
                 owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
-             record["dispatched_at"], now, __import__("os").getpid(),
-             owner_started_at, json.dumps(task_payload),
+             record.get("status", "running"), record["dispatched_at"], now,
+             __import__("os").getpid(), owner_started_at, json.dumps(task_payload),
              record.get("origin_session_id", "")),
         )
     _prune_durable_records()
@@ -232,7 +243,12 @@ def _delete_durable_delegation(delegation_id: str) -> None:
 
 
 def _prune_durable_records() -> None:
-    """Bound terminal history, preferring delivered records for deletion."""
+    """Bound terminal history, preferring delivered records for deletion.
+
+    Live non-terminal states are ``('running','finalizing','queued')`` — a
+    queued row is still pending admission and must never be pruned: its
+    terminal outcome (timeout/cancel/start) has not been recorded yet.
+    """
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _transaction() as conn:
@@ -241,14 +257,14 @@ def _prune_durable_records() -> None:
             (cutoff,),
         )
         terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing','queued')"
         ).fetchone()[0]
         excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
+                     WHERE state NOT IN ('running','finalizing','queued')
                      ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
                               updated_at ASC LIMIT ?
                    )""",
@@ -256,14 +272,14 @@ def _prune_durable_records() -> None:
             )
         pending_count = conn.execute(
             """SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'"""
+              WHERE state NOT IN ('running','finalizing','queued') AND delivery_state='pending'"""
         ).fetchone()[0]
         overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
         if overflow:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                     WHERE state NOT IN ('running','finalizing','queued') AND delivery_state='pending'
                      ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (overflow,),
@@ -282,6 +298,15 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def _persist_state(delegation_id: str, state: str) -> None:
+    """Durably mirror an in-memory lifecycle transition."""
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state=?, updated_at=? WHERE delegation_id=?",
+            (state, time.time(), delegation_id),
+        )
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -291,7 +316,11 @@ def _note_delivery_attempt(delegation_id: str) -> None:
 
 
 def recover_abandoned_delegations() -> int:
-    """Classify records whose owning process disappeared as outcome unknown."""
+    """Terminalize durable records whose owning process disappeared.
+
+    A dead-owner queued record provably never began and is reported interrupted;
+    running/finalizing records remain unknown because side effects may have begun.
+    """
     try:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
@@ -302,12 +331,13 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
-               FROM async_delegations WHERE state IN ('running','finalizing')"""
+                      owner_started_at, task_json, origin_session_id, state
+               FROM async_delegations
+               WHERE state IN ('queued','running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, prior_state) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -316,6 +346,12 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            terminal_status = "interrupted" if prior_state == "queued" else "unknown"
+            terminal_error = (
+                "Queued delegation was cancelled before start because its owner exited."
+                if prior_state == "queued"
+                else "Delegation owner exited before recording a terminal result; outcome unknown."
+            )
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -326,16 +362,21 @@ def recover_abandoned_delegations() -> int:
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "status": terminal_status, "summary": None,
+                "error": terminal_error,
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
+            result = {
+                "status": terminal_status, "summary": None, "error": terminal_error
+            }
             conn.execute(
-                """UPDATE async_delegations SET state='unknown', completed_at=?,
+                """UPDATE async_delegations SET state=?, completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
                    WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+                (
+                    terminal_status, now, now, json.dumps(event), json.dumps(result),
+                    delegation_id,
+                ),
             )
             recovered += 1
     return recovered
@@ -535,11 +576,10 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
 def active_count() -> int:
     """Number of async delegation UNITS currently running.
 
-    A unit is one dispatch: a single subagent OR a whole fan-out batch. A batch
-    counts as ONE here because it occupies one async-pool slot (the capacity
-    semantics ``dispatch_async_delegation_batch`` relies on). For the count of
-    actual concurrent child subagents (batch expanded), use
-    ``active_task_count()``.
+    A unit is one dispatch: a single subagent or one fan-out batch. This is an
+    observability count of dispatch records, not slot accounting; a running batch
+    reserves one child slot per goal. Use ``active_task_count()`` for the expanded
+    child count.
     """
     with _records_lock:
         return sum(
@@ -624,6 +664,217 @@ def has_live_for_session(
         )
 
 
+def _current_cgroup_v2_path() -> Optional[str]:
+    """Return this process's cgroup-v2 directory, if mounted conventionally."""
+    if os.name != "posix":
+        return None
+    try:
+        with open("/proc/self/cgroup", encoding="utf-8") as handle:
+            for line in handle:
+                hierarchy, _controllers, path = line.rstrip("\n").split(":", 2)
+                if hierarchy == "0":
+                    return os.path.join("/sys/fs/cgroup", path.lstrip("/"))
+    except (OSError, ValueError):
+        logger.debug("Cgroup v2 path probe failed", exc_info=True)
+    return None
+
+
+def _effective_available_memory_bytes() -> Optional[int]:
+    """Return host availability capped by this process's cgroup headroom."""
+    try:
+        import psutil
+
+        available = int(psutil.virtual_memory().available)
+    except Exception:
+        logger.debug("Available-memory probe failed", exc_info=True)
+        return None
+
+    cgroup_dir = _current_cgroup_v2_path()
+    if cgroup_dir is None:
+        return available
+    try:
+        with open(
+            os.path.join(cgroup_dir, "memory.current"), encoding="utf-8"
+        ) as handle:
+            current = int(handle.read().strip())
+        for filename in ("memory.high", "memory.max"):
+            with open(
+                os.path.join(cgroup_dir, filename), encoding="utf-8"
+            ) as handle:
+                raw = handle.read().strip()
+            if raw != "max":
+                available = min(available, max(0, int(raw) - current))
+    except (OSError, ValueError):
+        # No cgroup v2 limit (or a transient read race): host availability is
+        # still a valid cross-platform admission signal.
+        pass
+    return available
+
+
+def _memory_psi_avg10() -> Optional[float]:
+    """Return Linux memory-pressure ``some avg10`` or ``None`` if unavailable."""
+    if os.name != "posix":
+        return None
+    try:
+        with open("/proc/pressure/memory", encoding="utf-8") as handle:
+            for line in handle:
+                fields = line.split()
+                if fields and fields[0] == "some":
+                    for field in fields[1:]:
+                        if field.startswith("avg10="):
+                            return float(field.split("=", 1)[1])
+    except (OSError, ValueError):
+        logger.debug("Memory PSI probe failed", exc_info=True)
+    return None
+
+
+def _resources_available(record: Dict[str, Any]) -> bool:
+    was_blocked = bool(record.get("_resource_blocked", False))
+    minimum = max(0, int(record.get("min_available_memory_bytes", 0)))
+    resume_minimum = max(
+        minimum, int(record.get("resume_available_memory_bytes", minimum))
+    )
+    memory_floor = resume_minimum if was_blocked else minimum
+
+    max_psi = max(0.0, float(record.get("max_memory_psi_avg10", 0.0)))
+    resume_value = float(record.get("resume_memory_psi_avg10", max_psi))
+    # Defense-in-depth: a non-positive explicit resume ceiling must follow the
+    # stop ceiling (same convention as delegate_tool's getter). Without this,
+    # a direct dispatch_async_delegation* caller passing 0 with max_psi > 0
+    # would clamp the resume ceiling to 0 and stay blocked until PSI is
+    # exactly 0.
+    if resume_value <= 0.0:
+        resume_value = max_psi
+    resume_psi = max(0.0, min(max_psi, resume_value))
+    psi_ceiling = resume_psi if was_blocked else max_psi
+
+    memory_ready = True
+    if memory_floor:
+        available = _effective_available_memory_bytes()
+        # An explicitly configured memory floor is fail-closed when the probe
+        # is unavailable; otherwise the safety control would silently vanish.
+        memory_ready = available is not None and available >= memory_floor
+
+    pressure_ready = True
+    if max_psi:
+        pressure = _memory_psi_avg10()
+        # PSI is Linux-only and optional; unavailable PSI falls back to the
+        # memory-headroom gate for cross-platform compatibility.
+        pressure_ready = pressure is None or pressure <= psi_ceiling
+
+    ready = memory_ready and pressure_ready
+    record["_resource_blocked"] = not ready
+    return ready
+
+
+def _queue_head_locked() -> Optional[str]:
+    """Return the oldest queued delegation id. Caller holds ``_records_lock``."""
+    for record in _records.values():
+        if record.get("status") == "queued":
+            return record.get("delegation_id")
+    return None
+
+
+def _running_task_slots_locked() -> int:
+    """Return admitted and still-live child slots. Caller holds record lock."""
+    running = sum(
+        max(1, int(record.get("required_slots", 1)))
+        for record in _records.values()
+        if record.get("status") in {"running", "stalling", "finalizing"}
+    )
+    return running + sum(_lingering_resource_slots.values())
+
+
+def _register_lingering_resources(
+    delegation_id: str, futures: List[Any]
+) -> None:
+    """Retain slots for timed-out child threads until their futures truly exit."""
+    live = [future for future in futures if future is not None and not future.done()]
+    if not live:
+        return
+    with _admission_condition:
+        _lingering_resource_slots[delegation_id] = len(live)
+        _admission_condition.notify_all()
+
+    def _release_one(_future: Any) -> None:
+        with _admission_condition:
+            remaining = _lingering_resource_slots.get(delegation_id, 0) - 1
+            if remaining > 0:
+                _lingering_resource_slots[delegation_id] = remaining
+            else:
+                _lingering_resource_slots.pop(delegation_id, None)
+            _admission_condition.notify_all()
+
+    for future in live:
+        future.add_done_callback(_release_one)
+
+
+def _wait_for_admission(delegation_id: str) -> bool:
+    """Block a daemon worker until its FIFO position can claim all child slots."""
+    admitted = False
+    expired = False
+    with _admission_condition:
+        while True:
+            record = _records.get(delegation_id)
+            if record is None:
+                return False
+            if record.get("status") == "running":
+                return True
+            if record.get("status") != "queued":
+                return False
+            queue_timeout = max(0.0, float(record.get("queue_timeout_seconds", 0)))
+            queued_at = float(record.get("_queued_monotonic", time.monotonic()))
+            if queue_timeout and time.monotonic() - queued_at >= queue_timeout:
+                expired = True
+                break
+            required = max(1, int(record.get("required_slots", 1)))
+            limit = max(1, int(record.get("max_async_children", 1)))
+            is_head = _queue_head_locked() == delegation_id
+            slots_ready = _running_task_slots_locked() + required <= limit
+            resources_ready = is_head and slots_ready and _resources_available(record)
+            if not is_head:
+                record["queue_reason"] = "fifo"
+            elif not slots_ready:
+                record["queue_reason"] = "capacity"
+            elif not resources_ready:
+                record["queue_reason"] = "resources"
+            if is_head and slots_ready and resources_ready:
+                record["status"] = "running"
+                admitted = True
+                _admission_condition.notify_all()
+                break
+            wait_for = _ADMISSION_RECHECK_SECONDS
+            if queue_timeout:
+                remaining = queue_timeout - (time.monotonic() - queued_at)
+                wait_for = min(wait_for, max(0.001, remaining))
+            _admission_condition.wait(timeout=wait_for)
+    if expired:
+        _finalize_queued_terminal(
+            delegation_id,
+            "timeout",
+            "Queued delegation timed out before resources became available.",
+        )
+        return False
+    if admitted:
+        # The stale monitor may have exited while this record sat queued (its
+        # sweeps only monitor running work). Restart it so an admitted-then-
+        # wedged child is still force-finalized instead of leaking its slot.
+        _ensure_stale_monitor()
+        try:
+            _persist_state(delegation_id, "running")
+        except Exception:
+            # Best-effort mirror: the durable row already exists from
+            # _persist_dispatch, and the terminal completion persist will
+            # overwrite state. A failure here must NOT kill the admission
+            # thread — the worker still needs to be submitted or the slot
+            # leaks with a record stuck "running" and no runner.
+            logger.exception(
+                "Failed to persist running state for admitted delegation %s",
+                delegation_id,
+            )
+    return admitted
+
+
 def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
 
@@ -636,7 +887,7 @@ def _prune_completed_locked() -> None:
     completed = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running"
+        if r.get("status") not in {"queued", "running", "stalling", "finalizing"}
     ]
     if len(completed) <= _MAX_RETAINED_COMPLETED:
         return
@@ -688,6 +939,12 @@ def dispatch_async_delegation(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    max_queued_delegations: int = _DEFAULT_MAX_QUEUED_DELEGATIONS,
+    min_available_memory_bytes: int = 0,
+    resume_available_memory_bytes: int = 0,
+    max_memory_psi_avg10: float = 0.0,
+    resume_memory_psi_avg10: float = 0.0,
+    queue_timeout_seconds: float = _DEFAULT_QUEUE_TIMEOUT_SECONDS,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
@@ -722,15 +979,13 @@ def dispatch_async_delegation(
         stale-detection block at the top of this module). When omitted, the
         delegation is not monitored.
     max_async_children
-        Concurrency cap. When at capacity the dispatch is REJECTED (the caller
-        should fall back to sync or tell the user) rather than queued, so a
-        runaway model can't pile up unbounded background work.
+        Global child-slot cap. Work that cannot claim all required slots enters
+        the bounded FIFO; queue overflow is rejected without synchronous fallback.
 
     Returns
     -------
     dict
-        ``{"status": "dispatched", "delegation_id": ...}`` on success, or
-        ``{"status": "rejected", "error": ...}`` when at capacity.
+        A ``dispatched`` or ``queued`` handle, or an explicit ``rejected`` error.
     """
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
@@ -750,41 +1005,92 @@ def dispatch_async_delegation(
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
         "progress_fn": progress_fn,
+        "required_slots": 1,
+        "max_async_children": max_async_children,
+        "min_available_memory_bytes": min_available_memory_bytes,
+        "resume_available_memory_bytes": max(
+            min_available_memory_bytes, resume_available_memory_bytes
+        ),
+        "max_memory_psi_avg10": max_memory_psi_avg10,
+        "resume_memory_psi_avg10": resume_memory_psi_avg10,
+        "queue_timeout_seconds": queue_timeout_seconds,
+        "_queued_monotonic": time.monotonic(),
         # Stale-monitor bookkeeping (see _stale_monitor_loop).
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "_generation": _manager_generation,
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
     # from different gateway sessions) both pass the check and exceed the cap.
     with _records_lock:
-        running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
-        )
-        if running >= max_async_children:
+        if _shutdown_event.is_set():
             return {
                 "status": "rejected",
-                "error": (
-                    f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
-                    f"the chat), or run this task synchronously "
-                    f"(background=false). Raise delegation.max_concurrent_children in "
-                    f"config.yaml to allow more concurrent background subagents."
-                ),
+                "error": "Async delegation manager is shutting down.",
             }
+        capacity_ready = (
+            _queue_head_locked() is None
+            and _running_task_slots_locked() + record["required_slots"]
+            <= max_async_children
+        )
+        resources_ready = _resources_available(record)
+        queued = not (capacity_ready and resources_ready)
+        queue_reason = "capacity" if not capacity_ready else "resources"
+        if queued:
+            pending = sum(1 for r in _records.values() if r.get("status") == "queued")
+            queue_limit = max(0, int(max_queued_delegations))
+            if pending >= queue_limit:
+                return {
+                    "status": "rejected",
+                    "error": f"Async delegation queue is full ({queue_limit} pending).",
+                }
+            record["status"] = "queued"
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:
+        logger.exception("Failed to persist async delegation %s", delegation_id)
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation: {exc}",
+        }
+    try:
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        _delete_durable_delegation(delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to initialize async delegation executor: {exc}",
+        }
 
     def _worker() -> None:
         result: Dict[str, Any] = {}
         status = "error"
         try:
             result = runner() or {}
+            lingering = result.pop("_lingering_futures", [])
+            if isinstance(lingering, list):
+                _register_lingering_resources(delegation_id, lingering)
             status = result.get("status") or "completed"
+        except InterruptedError as exc:
+            result = {
+                "status": "interrupted",
+                "summary": None,
+                "error": str(exc),
+                "api_calls": 0,
+                "duration_seconds": round(time.time() - dispatched_at, 2),
+                "exit_reason": "interrupted",
+            }
+            status = "interrupted"
         except Exception as exc:  # noqa: BLE001 — must never crash the worker
             logger.exception("Async delegation %s crashed", delegation_id)
             result = {
@@ -798,11 +1104,32 @@ def dispatch_async_delegation(
         finally:
             _finalize(delegation_id, result, status)
 
+    # Capture the request/profile context now; queued launchers may run much later.
+    worker_with_context = propagate_context_to_thread(_worker)
+
+    def _launch_when_admitted() -> None:
+        if not _wait_for_admission(delegation_id):
+            return
+        try:
+            executor.submit(worker_with_context)
+        except Exception as exc:  # executor may be shutting down
+            logger.exception("Failed to launch queued delegation %s", delegation_id)
+            _finalize_queued_terminal(
+                delegation_id,
+                "error",
+                f"Failed to launch queued delegation: {exc}",
+            )
+
     try:
-        # Propagate the dispatching profile so the detached child resolves
-        # get_hermes_home() under the right profile.
-        executor.submit(propagate_context_to_thread(_worker))
-    except Exception as exc:  # pragma: no cover — pool submit failure is rare
+        if queued:
+            threading.Thread(
+                target=propagate_context_to_thread(_launch_when_admitted),
+                name=f"async-delegate-admission-{delegation_id}",
+                daemon=True,
+            ).start()
+        else:
+            executor.submit(worker_with_context)
+    except Exception as exc:  # pragma: no cover — thread/pool start failure is rare
         with _records_lock:
             _records.pop(delegation_id, None)
         _delete_durable_delegation(delegation_id)
@@ -814,10 +1141,15 @@ def dispatch_async_delegation(
         _ensure_stale_monitor()
 
     logger.info(
-        "Dispatched async delegation %s (session_key=%s): %s",
+        "%s async delegation %s (session_key=%s): %s",
+        "Queued" if queued else "Dispatched",
         delegation_id, session_key or "<cli>", (goal or "")[:80],
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    return {
+        "status": "queued" if queued else "dispatched",
+        "delegation_id": delegation_id,
+        **({"queue_reason": queue_reason} if queued else {}),
+    }
 
 
 def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
@@ -827,17 +1159,35 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         return
     event_record, _interrupt_fn = claimed
 
-    _push_completion_event(event_record, result, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_completion_event(event_record, result, status)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async delegation %s (%s): failed to publish completion event; "
+            "releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
 
 
 def _begin_finalization(
     delegation_id: str,
+    allowed_statuses: Optional[tuple] = None,
 ) -> Optional[tuple[Dict[str, Any], Optional[Callable[[], None]]]]:
-    """Atomically claim terminal delivery while keeping the record active."""
+    """Atomically claim terminal delivery while keeping the record active.
+
+    ``allowed_statuses`` restricts which in-flight states may be claimed. The
+    queued-interruption path passes ``("queued",)`` so a record that was
+    promoted to ``running`` between the caller's snapshot and this claim is
+    NOT terminalized here — the caller must instead fall back to
+    ``interrupt_fn`` so the worker self-cancels before starting.
+    """
+    if allowed_statuses is None:
+        allowed_statuses = ("queued", "running", "stalling")
     with _records_lock:
         record = _records.get(delegation_id)
-        if record is None or record.get("status") not in ("running", "stalling"):
+        if record is None or record.get("status") not in allowed_statuses:
             return
         # Stay active until durable persistence and queue publication finish;
         # otherwise process shutdown can kill this daemon worker in the narrow
@@ -853,11 +1203,12 @@ def _begin_finalization(
 
 
 def _finish_finalization(delegation_id: str, status: str) -> None:
-    with _records_lock:
+    with _admission_condition:
         record = _records.get(delegation_id)
         if record is not None:
             record["status"] = status
         _prune_completed_locked()
+        _admission_condition.notify_all()
 
 
 def _push_completion_event(
@@ -867,7 +1218,21 @@ def _push_completion_event(
 
     Best-effort: a failure here must not crash the worker, but it WOULD mean a
     silently-lost result, so we log loudly.
+
+    Generation guard: the record was captured by the worker thread at
+    finalization time. If the manager was torn down (test reset or process
+    shutdown) since dispatch, ``_manager_generation`` has moved on and the
+    completion must be dropped — a late worker from a previous generation
+    must never contaminate the shared queue or the durable ledger.
     """
+    if record.get("_generation", _manager_generation) != _manager_generation:
+        logger.info(
+            "Dropping stale-generation completion for %s (generation %s != %s)",
+            record.get("delegation_id"),
+            record.get("_generation"),
+            _manager_generation,
+        )
+        return
     try:
         from tools.process_registry import process_registry
     except Exception as exc:  # pragma: no cover
@@ -943,6 +1308,12 @@ def dispatch_async_delegation_batch(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    max_queued_delegations: int = _DEFAULT_MAX_QUEUED_DELEGATIONS,
+    min_available_memory_bytes: int = 0,
+    resume_available_memory_bytes: int = 0,
+    max_memory_psi_avg10: float = 0.0,
+    resume_memory_psi_avg10: float = 0.0,
+    queue_timeout_seconds: float = _DEFAULT_QUEUE_TIMEOUT_SECONDS,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
@@ -952,9 +1323,8 @@ def dispatch_async_delegation_batch(
     ``runner`` here runs the entire batch — it builds and joins on every child
     in parallel and returns the combined ``{"results": [...],
     "total_duration_seconds": N}`` dict that the synchronous path would have
-    returned. We occupy ONE async slot for the whole batch (the in-batch
-    parallelism is bounded separately by ``max_concurrent_children``), so a
-    single ``delegate_task`` fan-out never exhausts the async pool by itself.
+    returned. The batch reserves one admission slot per child, so concurrent
+    singles and batches together never exceed ``max_async_children``.
 
     When the batch finishes, a SINGLE completion event is pushed onto the
     shared ``process_registry.completion_queue`` carrying the full per-task
@@ -962,13 +1332,24 @@ def dispatch_async_delegation_batch(
     as one message once every child is done — the chat is never blocked while
     they run.
 
-    Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
-    ``{"status": "rejected", "error": ...}`` when the async pool is at
-    capacity.
+    Returns ``{"status": "dispatched", "delegation_id": ...}`` when started,
+    ``status="queued"`` when admitted to the bounded FIFO, or
+    ``status="rejected"`` when the FIFO is full.
     """
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)
+    slot_limit = max(1, int(max_async_children))
+    if n == 0:
+        return {"status": "rejected", "error": "Delegation batch is empty."}
+    if n > slot_limit:
+        return {
+            "status": "rejected",
+            "error": (
+                f"Delegation batch requires {n} child slots, but "
+                f"max_concurrent_children is {slot_limit}."
+            ),
+        }
     # A combined goal label for status listings / the completion header.
     combined_goal = (
         goals[0] if n == 1 else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
@@ -991,44 +1372,98 @@ def dispatch_async_delegation_batch(
         "interrupt_fn": interrupt_fn,
         "is_batch": True,
         "progress_fn": progress_fn,
+        "required_slots": n,
+        "max_async_children": max_async_children,
+        "min_available_memory_bytes": min_available_memory_bytes,
+        "resume_available_memory_bytes": max(
+            min_available_memory_bytes, resume_available_memory_bytes
+        ),
+        "max_memory_psi_avg10": max_memory_psi_avg10,
+        "resume_memory_psi_avg10": resume_memory_psi_avg10,
+        "queue_timeout_seconds": queue_timeout_seconds,
+        "_queued_monotonic": time.monotonic(),
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "_generation": _manager_generation,
     }
     with _records_lock:
-        running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
-        )
-        if running >= max_async_children:
+        if _shutdown_event.is_set():
             return {
                 "status": "rejected",
-                "error": (
-                    f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
-                    f"the chat), or raise delegation.max_concurrent_children in "
-                    f"config.yaml to allow more concurrent background units."
-                ),
+                "error": "Async delegation manager is shutting down.",
             }
+        capacity_ready = (
+            _queue_head_locked() is None
+            and _running_task_slots_locked() + record["required_slots"]
+            <= max_async_children
+        )
+        resources_ready = _resources_available(record)
+        queued = not (capacity_ready and resources_ready)
+        queue_reason = "capacity" if not capacity_ready else "resources"
+        if queued:
+            pending = sum(1 for r in _records.values() if r.get("status") == "queued")
+            queue_limit = max(0, int(max_queued_delegations))
+            if pending >= queue_limit:
+                return {
+                    "status": "rejected",
+                    "error": f"Async delegation queue is full ({queue_limit} pending).",
+                }
+            record["status"] = "queued"
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:
+        logger.exception("Failed to persist async delegation %s", delegation_id)
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation: {exc}",
+        }
+    try:
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        with _admission_condition:
+            _records.pop(delegation_id, None)
+            _admission_condition.notify_all()
+        _delete_durable_delegation(delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to initialize async delegation executor: {exc}",
+        }
 
     def _worker() -> None:
         combined: Dict[str, Any] = {}
         status = "error"
         try:
             combined = runner() or {}
-            # Batch status: completed unless every child errored/was interrupted.
-            child_results = combined.get("results") or []
-            if child_results and all(
-                (r.get("status") not in ("completed", "success"))
-                for r in child_results
-            ):
-                status = "error"
+            lingering = combined.pop("_lingering_futures", [])
+            if isinstance(lingering, list):
+                _register_lingering_resources(delegation_id, lingering)
+            requested_status = combined.get("status")
+            if requested_status in {"interrupted", "timeout", "error"}:
+                status = requested_status
             else:
-                status = "completed"
+                # Batch status: completed unless every child errored/interrupted.
+                child_results = combined.get("results") or []
+                if child_results and all(
+                    (r.get("status") not in ("completed", "success"))
+                    for r in child_results
+                ):
+                    status = "error"
+                else:
+                    status = "completed"
+        except InterruptedError as exc:
+            combined = {
+                "status": "interrupted",
+                "results": [],
+                "error": str(exc),
+                "total_duration_seconds": round(time.time() - dispatched_at, 2),
+            }
+            status = "interrupted"
         except Exception as exc:  # noqa: BLE001 — must never crash the worker
             logger.exception("Async delegation batch %s crashed", delegation_id)
             combined = {
@@ -1040,9 +1475,30 @@ def dispatch_async_delegation_batch(
         finally:
             _finalize_batch(delegation_id, combined, status)
 
+    worker_with_context = propagate_context_to_thread(_worker)
+
+    def _launch_when_admitted() -> None:
+        if not _wait_for_admission(delegation_id):
+            return
+        try:
+            executor.submit(worker_with_context)
+        except Exception as exc:  # executor may be shutting down
+            logger.exception("Failed to launch queued batch %s", delegation_id)
+            _finalize_queued_terminal(
+                delegation_id,
+                "error",
+                f"Failed to launch queued delegation batch: {exc}",
+            )
+
     try:
-        # Propagate the dispatching profile to the detached batch children.
-        executor.submit(propagate_context_to_thread(_worker))
+        if queued:
+            threading.Thread(
+                target=propagate_context_to_thread(_launch_when_admitted),
+                name=f"async-delegate-admission-{delegation_id}",
+                daemon=True,
+            ).start()
+        else:
+            executor.submit(worker_with_context)
     except Exception as exc:  # pragma: no cover
         with _records_lock:
             _records.pop(delegation_id, None)
@@ -1055,10 +1511,15 @@ def dispatch_async_delegation_batch(
         _ensure_stale_monitor()
 
     logger.info(
-        "Dispatched async delegation batch %s (%d task(s), session_key=%s)",
+        "%s async delegation batch %s (%d task(s), session_key=%s)",
+        "Queued" if queued else "Dispatched",
         delegation_id, n, session_key or "<cli>",
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    return {
+        "status": "queued" if queued else "dispatched",
+        "delegation_id": delegation_id,
+        **({"queue_reason": queue_reason} if queued else {}),
+    }
 
 
 def _finalize_batch(
@@ -1070,14 +1531,33 @@ def _finalize_batch(
         return
     event_record, _interrupt_fn = claimed
 
-    _push_batch_completion_event(event_record, combined, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_batch_completion_event(event_record, combined, status)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async batch delegation %s (%s): failed to publish completion "
+            "event; releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
 
 
 def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
     """Push a combined async-delegation batch completion event."""
+    if (
+        event_record.get("_generation", _manager_generation)
+        != _manager_generation
+    ):
+        logger.info(
+            "Dropping stale-generation batch completion for %s (generation %s != %s)",
+            event_record.get("delegation_id"),
+            event_record.get("_generation"),
+            _manager_generation,
+        )
+        return
     try:
         from tools.process_registry import process_registry
     except Exception as exc:  # pragma: no cover
@@ -1292,32 +1772,40 @@ def _finalize_stalled(delegation_id: str) -> None:
         ),
         "stall_grace_seconds": _STALL_GRACE_SECONDS,
     }
-    if event_record.get("is_batch"):
-        _push_batch_completion_event(
-            event_record,
-            {
-                "results": [],
-                "error": error,
-                "total_duration_seconds": duration,
-                **stall_meta,
-            },
-            "stalled",
+    try:
+        if event_record.get("is_batch"):
+            _push_batch_completion_event(
+                event_record,
+                {
+                    "results": [],
+                    "error": error,
+                    "total_duration_seconds": duration,
+                    **stall_meta,
+                },
+                "stalled",
+            )
+        else:
+            _push_completion_event(
+                event_record,
+                {
+                    "status": "stalled",
+                    "summary": None,
+                    "error": error,
+                    "api_calls": 0,
+                    "duration_seconds": duration,
+                    "exit_reason": "stalled",
+                    **stall_meta,
+                },
+                "stalled",
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Async delegation %s (stalled): failed to publish completion "
+            "event; releasing slot (%s)",
+            delegation_id, exc,
         )
-    else:
-        _push_completion_event(
-            event_record,
-            {
-                "status": "stalled",
-                "summary": None,
-                "error": error,
-                "api_calls": 0,
-                "duration_seconds": duration,
-                "exit_reason": "stalled",
-                **stall_meta,
-            },
-            "stalled",
-        )
-    _finish_finalization(delegation_id, "stalled")
+    finally:
+        _finish_finalization(delegation_id, "stalled")
 
 
 def _children_activity_from_token(token: Any, now: float) -> Optional[List]:
@@ -1411,6 +1899,101 @@ def list_async_delegations() -> List[Dict[str, Any]]:
     return items
 
 
+def _finalize_queued_terminal(
+    delegation_id: str,
+    status: str,
+    error: str,
+) -> bool:
+    """Publish one terminal event for a delegation that never started.
+
+    Only a record still in ``queued`` may be terminalized here. If the record
+    was promoted to ``running`` between the caller's snapshot and this claim
+    (interrupt racing admission), fall back to ``interrupt_fn`` so the worker
+    observes the cancellation and self-cancels — terminalizing it here would
+    let the worker run the delegation un-cancelled while the completion is
+    silently dropped (see _begin_finalization).
+    """
+    claimed = _begin_finalization(delegation_id, allowed_statuses=("queued",))
+    if claimed is None:
+        # Either the record no longer exists (already terminal) or it was
+        # promoted. Deliver the cancellation through the runner's interrupt
+        # hook; the not-yet-started worker then finalizes itself with
+        # exactly-once delivery. If the worker already completed (record is
+        # terminal or being finalized), there is nothing left to cancel —
+        # report False so callers don't over-count an interruption.
+        with _records_lock:
+            record = _records.get(delegation_id)
+            if record is None or record.get("status") not in ("running", "stalling"):
+                return False
+            interrupt_fn = record.get("interrupt_fn")
+        if callable(interrupt_fn):
+            try:
+                interrupt_fn()
+                return True
+            except Exception as exc:
+                logger.debug(
+                    "Queued interruption fallback for %s failed: %s",
+                    delegation_id, exc,
+                )
+        return False
+    event_record, _interrupt_fn = claimed
+    try:
+        if event_record.get("is_batch"):
+            _push_batch_completion_event(
+                event_record,
+                {"results": [], "error": error, "total_duration_seconds": 0.0},
+                status,
+            )
+        else:
+            _push_completion_event(
+                event_record,
+                {
+                    "status": status,
+                    "summary": None,
+                    "error": error,
+                    "api_calls": 0,
+                    "duration_seconds": 0.0,
+                    "exit_reason": status,
+                },
+                status,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # A durable-persist failure must not strand this record in
+        # "finalizing" with no actor to retry it: queued work never started,
+        # so no runner thread will ever finalize it and its slot would leak
+        # for the process lifetime. Log loudly, then the finally below
+        # releases the slot; restart recovery re-classifies the durable row
+        # conservatively (queued -> interrupted).
+        logger.exception(
+            "Queued delegation %s (%s): failed to publish terminal event; "
+            "releasing slot (%s)",
+            delegation_id, status, exc,
+        )
+    finally:
+        _finish_finalization(delegation_id, status)
+    return True
+
+
+def _finalize_queued_interruption(delegation_id: str, reason: str) -> bool:
+    return _finalize_queued_terminal(
+        delegation_id,
+        "interrupted",
+        f"Queued delegation cancelled before start ({reason}).",
+    )
+
+
+def begin_shutdown(reason: str = "shutdown") -> int:
+    """Stop new admission and cancel every queued/running delegation.
+
+    This is process-lifecycle cleanup. Session-scoped ``/stop`` must use
+    ``interrupt_for_session`` instead.
+    """
+    with _admission_condition:
+        _shutdown_event.set()
+        _admission_condition.notify_all()
+    return interrupt_all(reason=reason)
+
+
 def interrupt_all(reason: str = "shutdown") -> int:
     """Signal every running async delegation to stop. Returns how many.
 
@@ -1422,9 +2005,13 @@ def interrupt_all(reason: str = "shutdown") -> int:
     with _records_lock:
         targets = [
             r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            if r.get("status") in ("queued", "running", "stalling")
         ]
     for r in targets:
+        if r.get("status") == "queued":
+            if _finalize_queued_interruption(r["delegation_id"], reason):
+                count += 1
+            continue
         fn = r.get("interrupt_fn")
         if callable(fn):
             try:
@@ -1470,7 +2057,7 @@ def interrupt_for_session(
     with _records_lock:
         targets = [
             r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            if r.get("status") in ("queued", "running", "stalling")
             and _matches_session_selectors(
                 r,
                 session_key=session_key,
@@ -1479,6 +2066,10 @@ def interrupt_for_session(
             )
         ]
     for r in targets:
+        if r.get("status") == "queued":
+            if _finalize_queued_interruption(r["delegation_id"], reason):
+                count += 1
+            continue
         fn = r.get("interrupt_fn")
         if callable(fn):
             try:
@@ -1499,7 +2090,15 @@ def interrupt_for_session(
 
 def _reset_for_tests() -> None:
     """Test-only: clear all state and tear down the executor + monitor."""
-    global _executor, _executor_max_workers, _monitor_thread
+    global _executor, _executor_max_workers, _monitor_thread, _manager_generation
+    with _admission_condition:
+        _shutdown_event.set()
+        # Bump the generation BEFORE canceling so any worker that already
+        # captured its record cannot push a completion into the shared queue
+        # once we clear state below.
+        _manager_generation += 1
+        _admission_condition.notify_all()
+    interrupt_all(reason="test reset")
     with _executor_lock:
         if _executor is not None:
             _executor.shutdown(wait=False)
@@ -1511,5 +2110,8 @@ def _reset_for_tests() -> None:
         _monitor_thread = None
     if thread is not None and thread.is_alive():
         thread.join(timeout=2)
-    with _records_lock:
+    with _admission_condition:
         _records.clear()
+        _lingering_resource_slots.clear()
+        _shutdown_event.clear()
+        _admission_condition.notify_all()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1094,7 +1094,7 @@ def _try_dispatch_background_run(
 
         max_async = _get_max_async_children()
     except Exception:
-        max_async = 3
+        max_async = 10
 
     started_at = time.time()
     deliver = job.get("deliver", "local")
@@ -1145,20 +1145,26 @@ def _try_dispatch_background_run(
         max_async_children=max_async,
     )
 
-    if dispatch.get("status") == "dispatched":
-        return {
+    dispatch_status = dispatch.get("status")
+    if dispatch_status in {"dispatched", "queued"}:
+        payload = {
             "claimed": True,
             "dispatched": True,
+            "status": dispatch_status,
             "delegation_id": dispatch.get("delegation_id"),
         }
+        if dispatch_status == "queued":
+            payload["queue_reason"] = dispatch.get("queue_reason", "capacity")
+        return payload
 
-    # Pool at capacity (or submit failure): the claim is already taken and
-    # must not be stranded — run inline exactly as the legacy path did.
+    # Rejected submission: the claim is already taken and must not be stranded.
+    # Only this terminal rejection falls back inline; an accepted queued runner
+    # owns the claim and will execute it exactly once after admission.
     logger.info(
-        "cronjob run: background pool unavailable (%s); running job '%s' inline.",
+        "cronjob run: background dispatch rejected (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -905,11 +905,11 @@ def _get_max_async_children() -> int:
     """Concurrency cap for background (``background=true``) delegations.
 
     DEPRECATED KNOB: ``delegation.max_async_children`` has been unified into
-    ``delegation.max_concurrent_children`` — one cap governs both a single
-    synchronous batch's parallelism and how many background delegation units
-    may run at once. When at capacity, a new async dispatch is REJECTED (not
-    queued) so a runaway model can't pile up unbounded background work; the
-    caller falls back to running the work synchronously.
+    ``delegation.max_concurrent_children`` — one cap governs both synchronous
+    batch parallelism and total running background child slots. Work that
+    cannot reserve its slots enters the bounded FIFO; only queue overflow or
+    submission failure is rejected. A rejected async dispatch does not create
+    unbounded background work.
 
     A leftover ``max_async_children`` in config.yaml is ignored (the config
     migration removes it, folding a raised value into
@@ -926,6 +926,95 @@ def _get_max_async_children() -> int:
             "delegations too. Remove the stale key from config.yaml."
         )
     return _get_max_concurrent_children()
+
+
+def _get_max_queued_delegations() -> int:
+    """Maximum bounded backlog of background delegation units."""
+    value = _load_config().get("max_queued_delegations", 8)
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.max_queued_delegations=%r is invalid; using default 8",
+            value,
+        )
+        return 8
+
+
+def _get_min_available_memory_bytes() -> int:
+    """Configured memory headroom required before queued work may start."""
+    value = _load_config().get("min_available_memory_mb", 0)
+    try:
+        return max(0, int(float(value) * 1024 * 1024))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.min_available_memory_mb=%r is invalid; disabling the floor",
+            value,
+        )
+        return 0
+
+
+def _get_resume_available_memory_bytes() -> int:
+    """Higher memory headroom required after admission has been blocked."""
+    cfg = _load_config()
+    minimum = cfg.get("min_available_memory_mb", 0)
+    value = cfg.get("resume_available_memory_mb", minimum)
+    try:
+        return max(
+            max(0, int(float(minimum) * 1024 * 1024)),
+            int(float(value) * 1024 * 1024),
+        )
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.resume_available_memory_mb=%r is invalid; using the stop floor",
+            value,
+        )
+        return _get_min_available_memory_bytes()
+
+
+def _get_max_memory_psi_avg10() -> float:
+    """PSI some/avg10 ceiling for starting new background work; 0 disables."""
+    value = _load_config().get("max_memory_psi_avg10", 0)
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.max_memory_psi_avg10=%r is invalid; disabling PSI gating",
+            value,
+        )
+        return 0.0
+
+
+def _get_resume_memory_psi_avg10() -> float:
+    """Lower PSI ceiling required to resume after pressure blocked admission."""
+    cfg = _load_config()
+    maximum = cfg.get("max_memory_psi_avg10", 0)
+    value = cfg.get("resume_memory_psi_avg10", maximum)
+    try:
+        stop_ceiling = max(0.0, float(maximum))
+        resume_ceiling = float(value)
+        if resume_ceiling <= 0.0:
+            resume_ceiling = stop_ceiling
+        return max(0.0, min(stop_ceiling, resume_ceiling))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.resume_memory_psi_avg10=%r is invalid; using the stop ceiling",
+            value,
+        )
+        return _get_max_memory_psi_avg10()
+
+
+def _get_queue_timeout_seconds() -> float:
+    """Maximum time a background delegation may remain queued."""
+    value = _load_config().get("queue_timeout_seconds", 3600)
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.queue_timeout_seconds=%r is invalid; using 3600",
+            value,
+        )
+        return 3600.0
 
 
 def _get_child_timeout() -> Optional[float]:
@@ -1734,7 +1823,7 @@ def _build_child_agent(
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
-    # (configurable via delegation.max_iterations, default 50).  This means
+    # (configurable via delegation.max_iterations, default 250).  This means
     # total iterations across parent + subagents can exceed the parent's
     # max_iterations.  The user controls the per-subagent cap in config.yaml.
 
@@ -2908,6 +2997,14 @@ def _run_single_child(
                 ),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
+                # A timed-out child thread can keep running after we abandon
+                # the wait. Carry its live future upward so the async manager
+                # retains the resource slot until the thread ACTUALLY exits
+                # instead of oversubscribing the process the moment the
+                # timeout result is finalized (see _register_lingering_resources).
+                "_lingering_futures": (
+                    [_child_future] if is_timeout and not _child_future.done() else []
+                ),
             }
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
@@ -3819,75 +3916,145 @@ def delegate_task(
         _capture_gateway_steer_authority(_origin_ui_session_id)
     )
 
-    # Build all child agents on the main thread (thread-safe construction).
-    # _build_child_preserving_parent_tools saves/restores the parent's
-    # resolved tool names around each construction under a lock, so child
-    # toolset resolution never leaks into the parent (shared with the plugin
-    # subagent-lifecycle API).
-    children = []
-    for i, t in enumerate(task_list):
-        # Per-task role beats top-level; normalise again so unknown
-        # per-task values warn and degrade to leaf uniformly.
-        effective_role = _normalize_role(t.get("role") or top_role)
-        # T1-24: schema'd tasks get the contract appended to their context
-        # so the child knows the expected output shape before it starts.
-        _task_schema = task_schemas[i] if i < len(task_schemas) else None
-        _child_context = t.get("context")
-        if _task_schema is not None:
-            from tools.delegation_output_schema import append_output_contract
+    # Child construction is intentionally lazy. A capacity- or memory-queued
+    # delegation retains only lightweight task/routing state; model clients,
+    # tool registries, and child sessions are allocated only after admission.
+    children: List[tuple[int, Dict[str, Any], Any]] = []
+    _child_agents: List[Any] = []
+    _children_lock = threading.RLock()
+    _cancel_before_build = threading.Event()
 
-            _child_context = append_output_contract(_child_context, _task_schema)
+    def _detach_child_from_parent(child: Any) -> None:
+        if not hasattr(parent_agent, "_active_children"):
+            return
+        _ac_lock = getattr(parent_agent, "_active_children_lock", None)
         try:
-            child = _build_child_preserving_parent_tools(
-                task_index=i,
-                goal=t["goal"],
-                context=_child_context,
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
-                role=effective_role,
-            )
-        except ValueError as exc:
-            # Explicit-pin preflight failures (e.g. pinned delegation.command
-            # missing from PATH) refuse the spawn loudly (#80450).
-            return tool_error(str(exc))
-        # Attach the validated schema for the completion-side validation
-        # hook in _run_single_child. Absent (None) on schema-less tasks.
-        if _task_schema is not None:
-            try:
-                child._delegate_output_schema = _task_schema
-            except Exception:
-                logger.debug("Could not attach output schema to child %d", i)
-        # Tee the child's progress events into its live transcript log.
-        # wrap_progress_callback preserves the inner callback contract
-        # (including the _flush attribute) and never lets writer failures
-        # reach the agent loop. When no parent display exists the inner
-        # callback is None and the wrapper still records events.
-        _writer = live_writers[i] if i < len(live_writers) else None
-        if _writer is not None:
-            child.tool_progress_callback = wrap_progress_callback(
-                getattr(child, "tool_progress_callback", None), _writer
-            )
-            child._live_transcript_path = str(_writer.path)
-        # Delegation identity for the live registry + process-notification
-        # attribution (child-started background processes report under it).
-        if live_deleg_id:
-            setattr(child, "_delegation_id", live_deleg_id)
-        children.append((i, t, child))
+            if _ac_lock:
+                with _ac_lock:
+                    parent_agent._active_children.remove(child)
+            else:
+                parent_agent._active_children.remove(child)
+        except ValueError:
+            pass
 
-    def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
+    def _interrupt_built_children(reason: str) -> None:
+        _cancel_before_build.set()
+        # Child construction holds this lock. Cancellation must never wait for
+        # potentially slow provider/tool initialization; the builder observes
+        # the event and cleans up any partially built children itself.
+        if not _children_lock.acquire(blocking=False):
+            return
+        try:
+            snapshot = list(_child_agents)
+        finally:
+            _children_lock.release()
+        for child in snapshot:
+            try:
+                interrupted = request_hard_interrupt(child, reason)
+                if not interrupted and hasattr(child, "_interrupt_requested"):
+                    child._interrupt_requested = True
+            except Exception:
+                pass
+
+    def _discard_unstarted_children_locked(reason: str) -> None:
+        """Interrupt and close children that were built but never entered a runner."""
+        for child in list(_child_agents):
+            try:
+                if hasattr(child, "interrupt"):
+                    child.interrupt(reason)
+                elif hasattr(child, "_interrupt_requested"):
+                    child._interrupt_requested = True
+            except Exception:
+                pass
+            try:
+                close_fn = getattr(child, "close", None)
+                if callable(close_fn):
+                    close_fn()
+            except Exception:
+                logger.debug("Failed to close unstarted delegation child", exc_info=True)
+        children.clear()
+        _child_agents.clear()
+
+    def _build_children_if_needed(*, detach_from_parent: bool = False) -> bool:
+        with _children_lock:
+            if children:
+                return True
+            if _cancel_before_build.is_set():
+                return False
+            try:
+                for i, t in enumerate(task_list):
+                    if _cancel_before_build.is_set():
+                        break
+                    # Per-task role beats top-level; normalise again so unknown
+                    # values warn and degrade to leaf uniformly.
+                    effective_role = _normalize_role(t.get("role") or top_role)
+                    # Schema'd tasks get the contract appended to their context
+                    # before the lazily admitted child is constructed.
+                    _task_schema = task_schemas[i] if i < len(task_schemas) else None
+                    _child_context = t.get("context")
+                    if _task_schema is not None:
+                        from tools.delegation_output_schema import append_output_contract
+
+                        _child_context = append_output_contract(
+                            _child_context, _task_schema
+                        )
+                    child: Any = _build_child_preserving_parent_tools(
+                        task_index=i,
+                        goal=t["goal"],
+                        context=_child_context,
+                        # Subagents inherit the parent's toolsets; the model
+                        # cannot choose or narrow them.
+                        toolsets=None,
+                        model=creds["model"],
+                        max_iterations=effective_max_iter,
+                        task_count=n_tasks,
+                        parent_agent=parent_agent,
+                        override_provider=creds["provider"],
+                        override_base_url=creds["base_url"],
+                        override_api_key=creds["api_key"],
+                        override_api_mode=creds["api_mode"],
+                        override_request_overrides=creds.get("request_overrides"),
+                        override_max_tokens=creds.get("max_output_tokens"),
+                        override_acp_command=creds.get("command"),
+                        override_acp_args=creds.get("args"),
+                        role=effective_role,
+                    )
+                    if _task_schema is not None:
+                        try:
+                            child._delegate_output_schema = _task_schema
+                        except Exception:
+                            logger.debug("Could not attach output schema to child %d", i)
+                    children.append((i, t, child))
+                    _child_agents.append(child)
+                    if detach_from_parent:
+                        _detach_child_from_parent(child)
+                    _writer = live_writers[i] if i < len(live_writers) else None
+                    if _writer is not None:
+                        child.tool_progress_callback = wrap_progress_callback(
+                            getattr(child, "tool_progress_callback", None), _writer
+                        )
+                        child._live_transcript_path = str(_writer.path)
+                    if live_deleg_id:
+                        setattr(child, "_delegation_id", live_deleg_id)
+            except Exception:
+                _cancel_before_build.set()
+                _discard_unstarted_children_locked(
+                    "Delegation child construction failed"
+                )
+                raise
+
+            if _cancel_before_build.is_set():
+                _discard_unstarted_children_locked(
+                    "Async delegation cancelled during startup"
+                )
+                return False
+            return len(children) == n_tasks
+
+    def _execute_and_aggregate(
+        *,
+        honor_parent_interrupt: bool = True,
+        detach_from_parent: bool = False,
+    ) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
         dict. Used by BOTH the synchronous path and the background runner. In
@@ -3897,6 +4064,8 @@ def delegate_task(
         results block. That is the contract: fan-out runs in the background,
         waits on each other, and returns together.
         """
+        if not _build_children_if_needed(detach_from_parent=detach_from_parent):
+            raise InterruptedError("Async delegation cancelled before child startup")
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
@@ -4075,6 +4244,18 @@ def delegate_task(
         }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
+        # Aggregate any still-running timed-out child futures upward so the
+        # async manager can retain their resource slots (see
+        # _register_lingering_resources in tools/async_delegation.py). The
+        # per-child entries must NOT carry the futures themselves: the result
+        # dicts reach the completion event and are JSON-serialized.
+        lingering: List[Any] = []
+        for entry in results:
+            futures = entry.pop("_lingering_futures", None)
+            if isinstance(futures, list):
+                lingering.extend(f for f in futures if f is not None)
+        if lingering:
+            combined["_lingering_futures"] = lingering
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
@@ -4130,6 +4311,10 @@ def delegate_task(
             )
             _sync_result = _execute_and_aggregate()
             if isinstance(_sync_result, dict):
+                # Daemon threads keep running after a timeout even in the sync
+                # path, but there is no async registry here to hold their slots
+                # — the key is a Future and must never reach json.dumps.
+                _sync_result.pop("_lingering_futures", None)
                 _sync_result["note"] = (
                     "background=true is not available in this session — it cannot "
                     "receive a detached subagent result after the turn ends (a "
@@ -4177,36 +4362,17 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
-        _child_agents = [c for (_, _, c) in children]
-
-        # Detach every child from the parent's interrupt-propagation list — the
-        # batch's lifecycle is owned by the async registry now, not the parent
-        # turn. _build_child_agent attached them (correct for sync runs).
-        if hasattr(parent_agent, "_active_children"):
-            _ac_lock = getattr(parent_agent, "_active_children_lock", None)
-            for _c in _child_agents:
-                try:
-                    if _ac_lock:
-                        with _ac_lock:
-                            parent_agent._active_children.remove(_c)
-                    else:
-                        parent_agent._active_children.remove(_c)
-                except ValueError:
-                    pass
 
         def _batch_runner():
             # This batch is detached from the foreground turn. Its lifecycle is
             # owned by the async registry and cancelled only via _batch_interrupt.
-            return _execute_and_aggregate(honor_parent_interrupt=False)
+            return _execute_and_aggregate(
+                honor_parent_interrupt=False,
+                detach_from_parent=True,
+            )
 
         def _batch_interrupt():
-            for _c in _child_agents:
-                try:
-                    interrupted = request_hard_interrupt(_c, "Async delegation cancelled")
-                    if not interrupted and hasattr(_c, "_interrupt_requested"):
-                        _c._interrupt_requested = True
-                except Exception:
-                    pass
+            _interrupt_built_children("Async delegation cancelled")
 
         def _batch_progress():
             # Progress token for the async registry's stale monitor: the
@@ -4256,46 +4422,57 @@ def delegate_task(
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),
+            max_queued_delegations=_get_max_queued_delegations(),
+            min_available_memory_bytes=_get_min_available_memory_bytes(),
+            resume_available_memory_bytes=_get_resume_available_memory_bytes(),
+            max_memory_psi_avg10=_get_max_memory_psi_avg10(),
+            resume_memory_psi_avg10=_get_resume_memory_psi_avg10(),
+            queue_timeout_seconds=_get_queue_timeout_seconds(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
             delegation_id=live_deleg_id,
             progress_fn=_batch_progress,
         )
 
-        if dispatch.get("status") == "dispatched":
+        dispatch_status = dispatch.get("status")
+        if dispatch_status in {"dispatched", "queued"}:
             n = len(_goals)
-            note = (
-                "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
-                if n == 1 else
-                f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
-            )
+            if dispatch_status == "queued":
+                reason = dispatch.get("queue_reason", "capacity")
+                note = (
+                    f"The delegation is queued because {reason} limits do not "
+                    "currently allow it to start. It will run automatically when "
+                    "resources are available, and its result will re-enter the "
+                    "conversation as a new message. Do not poll or re-dispatch it."
+                )
+            else:
+                note = (
+                    "Subagent is running in the background. You and the user can "
+                    "keep working; its full result re-enters the conversation as a "
+                    "new message when it finishes. Do not wait or poll — just "
+                    "continue."
+                    if n == 1 else
+                    f"{n} subagents are running in parallel in the background. You "
+                    f"and the user can keep working; they wait on each other and "
+                    f"their consolidated results re-enter the conversation as a "
+                    f"single message once ALL of them finish. Do not wait or poll "
+                    f"— just continue."
+                )
             payload = {
-                "status": "dispatched",
+                "status": dispatch_status,
                 "mode": "background",
                 "count": n,
                 "delegation_id": dispatch["delegation_id"],
                 "goals": _goals,
                 "note": note,
             }
-            _sids = [
-                getattr(_c, "_subagent_id", None) for _c in _child_agents
-            ]
-            if any(isinstance(s, str) and s for s in _sids):
-                payload["subagent_ids"] = _sids
-                payload["control_hint"] = (
-                    "While a child runs you can orchestrate it live with this "
-                    "same tool: delegate_task(action='list') to see live "
-                    "children, action='steer' with subagent_id + message to "
-                    "redirect one, action='stop' with subagent_id to end one "
-                    "early."
-                )
+            payload["control_hint"] = (
+                "Use delegate_task(action='list') after children start to see their "
+                "subagent_ids; then use action='steer' or action='stop' with a "
+                "subagent_id for live control."
+            )
+            if dispatch_status == "queued":
+                payload["queue_reason"] = dispatch.get("queue_reason", "capacity")
             if live_paths:
                 payload["live_transcripts"] = list(live_paths)
                 payload["live_transcripts_hint"] = (
@@ -4306,24 +4483,13 @@ def delegate_task(
                 )
             return json.dumps(payload, ensure_ascii=False)
 
-        # Pool at capacity / schedule failure — children are still attached
-        # (we detach above only on the parent list, but the async unit was
-        # never accepted, so re-attaching isn't needed: we just run inline).
-        logger.info(
-            "delegate_task: async pool at capacity (%s); running the whole "
-            "batch synchronously instead.",
+        logger.warning(
+            "delegate_task: async dispatch rejected without synchronous fallback: %s",
             dispatch.get("error", "rejected"),
         )
-        _cap_result = _execute_and_aggregate()
-        if isinstance(_cap_result, dict):
-            _cap_result["note"] = (
-                "The background delegation pool was at capacity "
-                "(delegation.max_concurrent_children), so the subagent(s) ran "
-                "SYNCHRONOUSLY and the result is included above. Raise "
-                "delegation.max_concurrent_children in config.yaml to allow "
-                "more concurrent background delegations."
-            )
-        return json.dumps(_cap_result, ensure_ascii=False)
+        return tool_error(
+            dispatch.get("error", "Async delegation could not be scheduled.")
+        )
 
     # ----- Synchronous path -----
     return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
@@ -4793,7 +4959,7 @@ DELEGATE_TASK_SCHEMA = {
                     "required": ["goal"],
                 },
                 # No maxItems — the runtime limit is configurable via
-                # delegation.max_concurrent_children (default 3) and
+                # delegation.max_concurrent_children (default 10) and
                 # enforced with a clear error in delegate_task().
                 "description": "(rebuilt at get_definitions() time)",
             },

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -654,6 +654,95 @@ def _get_max_async_children() -> int:
     return _get_max_concurrent_children()
 
 
+def _get_max_queued_delegations() -> int:
+    """Maximum bounded backlog of background delegation units."""
+    value = _load_config().get("max_queued_delegations", 8)
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.max_queued_delegations=%r is invalid; using default 8",
+            value,
+        )
+        return 8
+
+
+def _get_min_available_memory_bytes() -> int:
+    """Configured memory headroom required before queued work may start."""
+    value = _load_config().get("min_available_memory_mb", 0)
+    try:
+        return max(0, int(float(value) * 1024 * 1024))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.min_available_memory_mb=%r is invalid; disabling the floor",
+            value,
+        )
+        return 0
+
+
+def _get_resume_available_memory_bytes() -> int:
+    """Higher memory headroom required after admission has been blocked."""
+    cfg = _load_config()
+    minimum = cfg.get("min_available_memory_mb", 0)
+    value = cfg.get("resume_available_memory_mb", minimum)
+    try:
+        return max(
+            max(0, int(float(minimum) * 1024 * 1024)),
+            int(float(value) * 1024 * 1024),
+        )
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.resume_available_memory_mb=%r is invalid; using the stop floor",
+            value,
+        )
+        return _get_min_available_memory_bytes()
+
+
+def _get_max_memory_psi_avg10() -> float:
+    """PSI some/avg10 ceiling for starting new background work; 0 disables."""
+    value = _load_config().get("max_memory_psi_avg10", 0)
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.max_memory_psi_avg10=%r is invalid; disabling PSI gating",
+            value,
+        )
+        return 0.0
+
+
+def _get_resume_memory_psi_avg10() -> float:
+    """Lower PSI ceiling required to resume after pressure blocked admission."""
+    cfg = _load_config()
+    maximum = cfg.get("max_memory_psi_avg10", 0)
+    value = cfg.get("resume_memory_psi_avg10", maximum)
+    try:
+        stop_ceiling = max(0.0, float(maximum))
+        resume_ceiling = float(value)
+        if resume_ceiling <= 0.0:
+            resume_ceiling = stop_ceiling
+        return max(0.0, min(stop_ceiling, resume_ceiling))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.resume_memory_psi_avg10=%r is invalid; using the stop ceiling",
+            value,
+        )
+        return _get_max_memory_psi_avg10()
+
+
+def _get_queue_timeout_seconds() -> float:
+    """Maximum time a background delegation may remain queued."""
+    value = _load_config().get("queue_timeout_seconds", 3600)
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.queue_timeout_seconds=%r is invalid; using 3600",
+            value,
+        )
+        return 3600.0
+
+
 def _get_child_timeout() -> Optional[float]:
     """Read delegation.child_timeout_seconds from config.
 
@@ -2444,6 +2533,14 @@ def _run_single_child(
                 ),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
+                # A timed-out child thread can keep running after we abandon
+                # the wait. Carry its live future upward so the async manager
+                # retains the resource slot until the thread ACTUALLY exits
+                # instead of oversubscribing the process the moment the
+                # timeout result is finalized (see _register_lingering_resources).
+                "_lingering_futures": (
+                    [_child_future] if is_timeout and not _child_future.done() else []
+                ),
             }
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
@@ -3138,49 +3235,121 @@ def delegate_task(
         _capture_gateway_steer_authority(_origin_ui_session_id)
     )
 
-    # Build all child agents on the main thread (thread-safe construction).
-    # _build_child_preserving_parent_tools saves/restores the parent's
-    # resolved tool names around each construction under a lock, so child
-    # toolset resolution never leaks into the parent (shared with the plugin
-    # subagent-lifecycle API).
-    children = []
-    for i, t in enumerate(task_list):
-        # Per-task role beats top-level; normalise again so unknown
-        # per-task values warn and degrade to leaf uniformly.
-        effective_role = _normalize_role(t.get("role") or top_role)
-        child = _build_child_preserving_parent_tools(
-            task_index=i,
-            goal=t["goal"],
-            context=t.get("context"),
-            # Subagents always inherit the parent's toolsets; the model
-            # cannot choose or narrow them (no model-facing toolsets arg).
-            toolsets=None,
-            model=creds["model"],
-            max_iterations=effective_max_iter,
-            task_count=n_tasks,
-            parent_agent=parent_agent,
-            override_provider=creds["provider"],
-            override_base_url=creds["base_url"],
-            override_api_key=creds["api_key"],
-            override_api_mode=creds["api_mode"],
-            override_request_overrides=creds.get("request_overrides"),
-            override_max_tokens=creds.get("max_output_tokens"),
-            override_acp_command=creds.get("command"),
-            override_acp_args=creds.get("args"),
-            role=effective_role,
-        )
-        # Tee the child's progress events into its live transcript log.
-        # wrap_progress_callback preserves the inner callback contract
-        # (including the _flush attribute) and never lets writer failures
-        # reach the agent loop. When no parent display exists the inner
-        # callback is None and the wrapper still records events.
-        _writer = live_writers[i] if i < len(live_writers) else None
-        if _writer is not None:
-            child.tool_progress_callback = wrap_progress_callback(
-                getattr(child, "tool_progress_callback", None), _writer
-            )
-            child._live_transcript_path = str(_writer.path)
-        children.append((i, t, child))
+    # Child construction is intentionally lazy. A capacity- or memory-queued
+    # delegation retains only lightweight task/routing state; model clients,
+    # tool registries, and child sessions are allocated only after admission.
+    children: List[tuple[int, Dict[str, Any], Any]] = []
+    _child_agents: List[Any] = []
+    _children_lock = threading.RLock()
+    _cancel_before_build = threading.Event()
+
+    def _detach_child_from_parent(child: Any) -> None:
+        if not background or not hasattr(parent_agent, "_active_children"):
+            return
+        _ac_lock = getattr(parent_agent, "_active_children_lock", None)
+        try:
+            if _ac_lock:
+                with _ac_lock:
+                    parent_agent._active_children.remove(child)
+            else:
+                parent_agent._active_children.remove(child)
+        except ValueError:
+            pass
+
+    def _interrupt_built_children(reason: str) -> None:
+        _cancel_before_build.set()
+        # Child construction holds this lock. Cancellation must never wait for
+        # potentially slow provider/tool initialization; the builder observes
+        # the event and cleans up any partially built children itself.
+        if not _children_lock.acquire(blocking=False):
+            return
+        try:
+            snapshot = list(_child_agents)
+        finally:
+            _children_lock.release()
+        for child in snapshot:
+            try:
+                interrupted = request_hard_interrupt(child, reason)
+                if not interrupted and hasattr(child, "_interrupt_requested"):
+                    child._interrupt_requested = True
+            except Exception:
+                pass
+
+    def _discard_unstarted_children_locked(reason: str) -> None:
+        """Interrupt and close children that were built but never entered a runner."""
+        for child in list(_child_agents):
+            try:
+                if hasattr(child, "interrupt"):
+                    child.interrupt(reason)
+                elif hasattr(child, "_interrupt_requested"):
+                    child._interrupt_requested = True
+            except Exception:
+                pass
+            try:
+                close_fn = getattr(child, "close", None)
+                if callable(close_fn):
+                    close_fn()
+            except Exception:
+                logger.debug("Failed to close unstarted delegation child", exc_info=True)
+        children.clear()
+        _child_agents.clear()
+
+    def _build_children_if_needed() -> bool:
+        with _children_lock:
+            if children:
+                return True
+            if _cancel_before_build.is_set():
+                return False
+            try:
+                for i, t in enumerate(task_list):
+                    if _cancel_before_build.is_set():
+                        break
+                    # Per-task role beats top-level; normalise again so unknown
+                    # values warn and degrade to leaf uniformly.
+                    effective_role = _normalize_role(t.get("role") or top_role)
+                    child: Any = _build_child_preserving_parent_tools(
+                        task_index=i,
+                        goal=t["goal"],
+                        context=t.get("context"),
+                        # Subagents inherit the parent's toolsets; the model
+                        # cannot choose or narrow them.
+                        toolsets=None,
+                        model=creds["model"],
+                        max_iterations=effective_max_iter,
+                        task_count=n_tasks,
+                        parent_agent=parent_agent,
+                        override_provider=creds["provider"],
+                        override_base_url=creds["base_url"],
+                        override_api_key=creds["api_key"],
+                        override_api_mode=creds["api_mode"],
+                        override_request_overrides=creds.get("request_overrides"),
+                        override_max_tokens=creds.get("max_output_tokens"),
+                        override_acp_command=creds.get("command"),
+                        override_acp_args=creds.get("args"),
+                        role=effective_role,
+                    )
+                    children.append((i, t, child))
+                    _child_agents.append(child)
+                    _detach_child_from_parent(child)
+                    _writer = live_writers[i] if i < len(live_writers) else None
+                    if _writer is not None:
+                        child.tool_progress_callback = wrap_progress_callback(
+                            getattr(child, "tool_progress_callback", None), _writer
+                        )
+                        child._live_transcript_path = str(_writer.path)
+            except Exception:
+                _cancel_before_build.set()
+                _discard_unstarted_children_locked(
+                    "Delegation child construction failed"
+                )
+                raise
+
+            if _cancel_before_build.is_set():
+                _discard_unstarted_children_locked(
+                    "Async delegation cancelled during startup"
+                )
+                return False
+            return len(children) == n_tasks
 
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
@@ -3192,6 +3361,8 @@ def delegate_task(
         results block. That is the contract: fan-out runs in the background,
         waits on each other, and returns together.
         """
+        if not _build_children_if_needed():
+            raise InterruptedError("Async delegation cancelled before child startup")
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
@@ -3370,6 +3541,18 @@ def delegate_task(
         }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
+        # Aggregate any still-running timed-out child futures upward so the
+        # async manager can retain their resource slots (see
+        # _register_lingering_resources in tools/async_delegation.py). The
+        # per-child entries must NOT carry the futures themselves: the result
+        # dicts reach the completion event and are JSON-serialized.
+        lingering: List[Any] = []
+        for entry in results:
+            futures = entry.pop("_lingering_futures", None)
+            if isinstance(futures, list):
+                lingering.extend(f for f in futures if f is not None)
+        if lingering:
+            combined["_lingering_futures"] = lingering
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
@@ -3425,6 +3608,10 @@ def delegate_task(
             )
             _sync_result = _execute_and_aggregate()
             if isinstance(_sync_result, dict):
+                # Daemon threads keep running after a timeout even in the sync
+                # path, but there is no async registry here to hold their slots
+                # — the key is a Future and must never reach json.dumps.
+                _sync_result.pop("_lingering_futures", None)
                 _sync_result["note"] = (
                     "background=true is not available in this session — it cannot "
                     "receive a detached subagent result after the turn ends (a "
@@ -3472,22 +3659,6 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
-        _child_agents = [c for (_, _, c) in children]
-
-        # Detach every child from the parent's interrupt-propagation list — the
-        # batch's lifecycle is owned by the async registry now, not the parent
-        # turn. _build_child_agent attached them (correct for sync runs).
-        if hasattr(parent_agent, "_active_children"):
-            _ac_lock = getattr(parent_agent, "_active_children_lock", None)
-            for _c in _child_agents:
-                try:
-                    if _ac_lock:
-                        with _ac_lock:
-                            parent_agent._active_children.remove(_c)
-                    else:
-                        parent_agent._active_children.remove(_c)
-                except ValueError:
-                    pass
 
         def _batch_runner():
             # This batch is detached from the foreground turn. Its lifecycle is
@@ -3495,13 +3666,7 @@ def delegate_task(
             return _execute_and_aggregate(honor_parent_interrupt=False)
 
         def _batch_interrupt():
-            for _c in _child_agents:
-                try:
-                    interrupted = request_hard_interrupt(_c, "Async delegation cancelled")
-                    if not interrupted and hasattr(_c, "_interrupt_requested"):
-                        _c._interrupt_requested = True
-                except Exception:
-                    pass
+            _interrupt_built_children("Async delegation cancelled")
 
         def _batch_progress():
             # Progress token for the async registry's stale monitor: the
@@ -3551,34 +3716,52 @@ def delegate_task(
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),
+            max_queued_delegations=_get_max_queued_delegations(),
+            min_available_memory_bytes=_get_min_available_memory_bytes(),
+            resume_available_memory_bytes=_get_resume_available_memory_bytes(),
+            max_memory_psi_avg10=_get_max_memory_psi_avg10(),
+            resume_memory_psi_avg10=_get_resume_memory_psi_avg10(),
+            queue_timeout_seconds=_get_queue_timeout_seconds(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
             delegation_id=live_deleg_id,
             progress_fn=_batch_progress,
         )
 
-        if dispatch.get("status") == "dispatched":
+        dispatch_status = dispatch.get("status")
+        if dispatch_status in {"dispatched", "queued"}:
             n = len(_goals)
-            note = (
-                "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
-                if n == 1 else
-                f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
-            )
+            if dispatch_status == "queued":
+                reason = dispatch.get("queue_reason", "capacity")
+                note = (
+                    f"The delegation is queued because {reason} limits do not "
+                    "currently allow it to start. It will run automatically when "
+                    "resources are available, and its result will re-enter the "
+                    "conversation as a new message. Do not poll or re-dispatch it."
+                )
+            else:
+                note = (
+                    "Subagent is running in the background. You and the user can "
+                    "keep working; its full result re-enters the conversation as a "
+                    "new message when it finishes. Do not wait or poll — just "
+                    "continue."
+                    if n == 1 else
+                    f"{n} subagents are running in parallel in the background. You "
+                    f"and the user can keep working; they wait on each other and "
+                    f"their consolidated results re-enter the conversation as a "
+                    f"single message once ALL of them finish. Do not wait or poll "
+                    f"— just continue."
+                )
             payload = {
-                "status": "dispatched",
+                "status": dispatch_status,
                 "mode": "background",
                 "count": n,
                 "delegation_id": dispatch["delegation_id"],
                 "goals": _goals,
                 "note": note,
             }
+            if dispatch_status == "queued":
+                payload["queue_reason"] = dispatch.get("queue_reason", "capacity")
             if live_paths:
                 payload["live_transcripts"] = list(live_paths)
                 payload["live_transcripts_hint"] = (
@@ -3589,24 +3772,13 @@ def delegate_task(
                 )
             return json.dumps(payload, ensure_ascii=False)
 
-        # Pool at capacity / schedule failure — children are still attached
-        # (we detach above only on the parent list, but the async unit was
-        # never accepted, so re-attaching isn't needed: we just run inline).
-        logger.info(
-            "delegate_task: async pool at capacity (%s); running the whole "
-            "batch synchronously instead.",
+        logger.warning(
+            "delegate_task: async dispatch rejected without synchronous fallback: %s",
             dispatch.get("error", "rejected"),
         )
-        _cap_result = _execute_and_aggregate()
-        if isinstance(_cap_result, dict):
-            _cap_result["note"] = (
-                "The background delegation pool was at capacity "
-                "(delegation.max_concurrent_children), so the subagent(s) ran "
-                "SYNCHRONOUSLY and the result is included above. Raise "
-                "delegation.max_concurrent_children in config.yaml to allow "
-                "more concurrent background delegations."
-            )
-        return json.dumps(_cap_result, ensure_ascii=False)
+        return tool_error(
+            dispatch.get("error", "Async delegation could not be scheduled.")
+        )
 
     # ----- Synchronous path -----
     return json.dumps(_execute_and_aggregate(), ensure_ascii=False)

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -200,14 +200,21 @@ Subagents inherit the parent's enabled toolsets. `delegate_task` does not accept
 
 ## Constraints
 
-- **Default 3 parallel tasks**: batches default to 3 concurrent subagents (configurable via `delegation.max_concurrent_children` in config.yaml, no hard ceiling, only a floor of 1)
+- **Default 10 child slots**: all running background singles and batch children share `delegation.max_concurrent_children` (floor 1, no hard ceiling). Work that cannot reserve its slots enters a bounded FIFO.
+- **Bounded admission**: `max_queued_delegations` limits FIFO length, `queue_timeout_seconds` bounds its wait, and optional `min_available_memory_mb` holds work until host/cgroup headroom recovers. Queue overflow is rejected without synchronous fallback.
 - **Nested delegation is opt-in**: leaf subagents (default) cannot call `delegate_task`, `clarify`, `memory`, or `execute_code`. Orchestrator subagents (`role="orchestrator"`) retain `delegate_task` for further delegation, but only when `delegation.max_spawn_depth` is raised above the default of 1 (floor 1, no ceiling); the other three remain blocked. Disable globally via `delegation.orchestrator_enabled: false`.
 
 ### Tuning Concurrency and Depth
 
 | Config | Default | Range | Effect |
 |--------|---------|-------|--------|
-| `max_concurrent_children` | 3 | >=1 | Parallel batch size per `delegate_task` call |
+| `max_concurrent_children` | 10 | >=1 | Total running child slots across background singles and batches |
+| `max_queued_delegations` | 8 | >=0 | Maximum pending background calls; 0 disables waiting |
+| `queue_timeout_seconds` | 3600 | >=0 | Maximum FIFO wait; 0 disables expiry |
+| `min_available_memory_mb` | 0 | >=0 | Host/cgroup headroom stop floor; 0 disables the memory gate |
+| `resume_available_memory_mb` | 0 | >= stop floor | Higher recovery floor after a block; 0 follows stop floor |
+| `max_memory_psi_avg10` | 0 | >=0 | Linux PSI some/avg10 stop ceiling; 0 disables PSI gating |
+| `resume_memory_psi_avg10` | 0 | 0..stop ceiling | Lower recovery ceiling; 0 follows stop ceiling |
 | `max_spawn_depth` | 1 | >=1 | How many delegation levels can spawn further |
 
 Example: running 30 parallel workers with nested subagents:
@@ -220,7 +227,7 @@ delegation:
 
 - **Separate terminals** — each subagent gets its own terminal session with separate working directory and state
 - **No conversation history** — subagents see only the `goal` and `context` the parent agent passes when calling `delegate_task`
-- **Default 50 iterations** — set `max_iterations` lower for simple tasks to save cost
+- **Default 250 iterations** — set `max_iterations` lower for simple tasks to save cost
 - **Not durable** — top-level delegation runs in the background and posts its result back later, but it remains tied to the owning session and Hermes process. Session closure, `/stop`, `/new`, or a process restart can cancel or strand in-progress work. Use `cronjob` or `terminal(background=True, notify_on_complete=True)` for work that must survive those boundaries.
 
 ---

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -200,14 +200,21 @@ Subagents inherit the parent's enabled toolsets. `delegate_task` does not accept
 
 ## Constraints
 
-- **Default 3 parallel tasks**: batches default to 3 concurrent subagents (configurable via `delegation.max_concurrent_children` in config.yaml, no hard ceiling, only a floor of 1)
+- **Default 3 child slots**: all running background singles and batch children share `delegation.max_concurrent_children` (floor 1, no hard ceiling). Work that cannot reserve its slots enters a bounded FIFO.
+- **Bounded admission**: `max_queued_delegations` limits FIFO length, `queue_timeout_seconds` bounds its wait, and optional `min_available_memory_mb` holds work until host/cgroup headroom recovers. Queue overflow is rejected without synchronous fallback.
 - **Nested delegation is opt-in**: leaf subagents (default) cannot call `delegate_task`, `clarify`, `memory`, or `execute_code`. Orchestrator subagents (`role="orchestrator"`) retain `delegate_task` for further delegation, but only when `delegation.max_spawn_depth` is raised above the default of 1 (floor 1, no ceiling); the other three remain blocked. Disable globally via `delegation.orchestrator_enabled: false`.
 
 ### Tuning Concurrency and Depth
 
 | Config | Default | Range | Effect |
 |--------|---------|-------|--------|
-| `max_concurrent_children` | 3 | >=1 | Parallel batch size per `delegate_task` call |
+| `max_concurrent_children` | 3 | >=1 | Total running child slots across background singles and batches |
+| `max_queued_delegations` | 8 | >=0 | Maximum pending background calls; 0 disables waiting |
+| `queue_timeout_seconds` | 3600 | >=0 | Maximum FIFO wait; 0 disables expiry |
+| `min_available_memory_mb` | 0 | >=0 | Host/cgroup headroom stop floor; 0 disables the memory gate |
+| `resume_available_memory_mb` | 0 | >= stop floor | Higher recovery floor after a block; 0 follows stop floor |
+| `max_memory_psi_avg10` | 0 | >=0 | Linux PSI some/avg10 stop ceiling; 0 disables PSI gating |
+| `resume_memory_psi_avg10` | 0 | 0..stop ceiling | Lower recovery ceiling; 0 follows stop ceiling |
 | `max_spawn_depth` | 1 | >=1 | How many delegation levels can spawn further |
 
 Example: running 30 parallel workers with nested subagents:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -21,7 +21,7 @@ delegate_task(
 
 ## Parallel Batch
 
-Up to 3 concurrent subagents by default (configurable, no hard ceiling):
+Up to 10 concurrent subagents by default (configurable, no hard ceiling):
 
 ```python
 delegate_task(tasks=[
@@ -117,11 +117,11 @@ delegate_task(
 
 When a top-level agent provides a `tasks` array, Hermes returns one background handle, runs the subagents in parallel, and posts one consolidated result after every child finishes. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
 
-- **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
+- **Maximum concurrency:** 10 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
-- **Cancellation:** Follow-up messages do not cancel a top-level background batch. `/stop` or closing/resetting the owning session cancels its active children. Synchronous orchestrator children still follow their parent's interrupt state
+- **Cancellation:** Follow-up messages do not cancel a top-level background batch. `/stop` or closing/resetting the owning session cancels queued work and active children. Synchronous orchestrator children still follow their parent's interrupt state
 
 Synchronous single-task delegation from an orchestrator runs directly without thread pool overhead.
 
@@ -137,7 +137,9 @@ retry.
 
 This does not resume child execution after a crash. A delegation whose owner
 process disappears while it is still running is recorded as `unknown`, because
-Hermes cannot prove whether its external side effects happened. Pending and
+Hermes cannot prove whether its external side effects happened. A delegation
+that was still `queued` (never started) is recorded as `interrupted` —
+"cancelled before start" — since Hermes can prove it never ran. Pending and
 delivered records are bounded and profile-local.
 
 ## Model Override
@@ -223,6 +225,28 @@ non-timeout errors.
 With a hard cap configured, if a subagent times out having made **zero** API calls (usually: provider unreachable, auth failure, or tool-schema rejection), `delegate_task` writes a structured diagnostic to `~/.hermes/logs/subagent-timeout-<session>-<timestamp>.log` containing the subagent's config snapshot, credential-resolution trace, any early error messages, and stack traces for **all** live threads (not just the child's own) — a child parked waiting on a nested helper thread is indistinguishable from a slow provider without the full picture.
 :::
 
+## Background Admission Queue
+
+Background delegations share a process-wide child-slot budget. A batch reserves
+one slot per child; when it cannot reserve every required slot immediately, the
+whole call enters a bounded FIFO rather than running synchronously and bypassing
+the limit. Optional memory-headroom and Linux memory-PSI gates can also hold
+work in the same queue. On Linux, the headroom probe uses the smaller of host
+`MemAvailable` and the current cgroup's `memory.high`/`memory.max` headroom.
+Separate stop and resume thresholds provide hysteresis after resource pressure.
+
+Queued work starts automatically when it reaches the head, all required child
+slots are free, and the configured resource gates are satisfied. `/stop`, session reset, and
+gateway shutdown cancel matching queued work before its runner starts. Queue
+expiry produces a terminal `timeout` completion. A full queue rejects new work;
+it never falls back to synchronous execution.
+
+The queue is process-local execution state, not a durable job runner. After a
+process restart, a queued-but-never-started entry is reported as `interrupted`
+("cancelled before start"), while a running one is reported with an `unknown`
+outcome. Use `cronjob` or a bounded background terminal process for work that
+must survive process restarts.
+
 ## Stall Detection for Background Subagents
 
 Background delegations (`delegate_task(background=true)`) are watched by a
@@ -300,7 +324,7 @@ The parent agent orchestrates its own running children with the same `delegate_t
 {"action": "stop",  "subagent_id": "sa-0-1a2b3c4d"}
 ```
 
-- **`list`** returns the conversation's live children: `subagent_id`, goal, status, `running_seconds`, `accepting_steer`, and the live transcript path. Ids also come back in the spawn dispatch response as `subagent_ids`.
+- **`list`** returns the conversation's live children: `subagent_id`, goal, status, `running_seconds`, `accepting_steer`, and the live transcript path. Because queued children are constructed only after admission, the initial spawn response directs callers to `list` rather than timing-dependently returning ids.
 - **`steer`** queues a course correction into a running child without stopping it (delivery semantics below).
 - **`stop`** ends a child early at its next iteration boundary; the partial result still re-enters the conversation as a normal completion message.
 
@@ -365,9 +389,9 @@ delegate_task(
 :::warning Background completion durability is not durable execution
 Top-level model-facing `delegate_task` calls run in the background automatically where the session supports later delivery. Hermes returns a handle immediately, and the result re-enters the conversation after the child or batch finishes. Orchestrator subagents wait for their workers in the current turn because they must synthesize those results before returning. Stateless request/response endpoints fall back to synchronous execution when they cannot deliver a detached result later.
 
-- Normal follow-up messages do not cancel background children. `/stop` cancels running background delegations, and closing or resetting the owning session discards its active children.
+- Normal follow-up messages do not cancel background children. `/stop` cancels queued and running background delegations, and closing or resetting the owning session discards queued work and active children.
 - Explicit session close/reset interrupts that session's background children. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.
-- A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened.
+- A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened. A child that was still queued (never started) becomes `interrupted` — "cancelled before start".
 - A child that completed before restart but whose result was not delivered is restored and routed back through the owning session's normal checks.
 - Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the parent was interrupted too, that result often never makes it into a user-visible reply.
 
@@ -442,8 +466,14 @@ error.
 ```yaml
 # In ~/.hermes/config.yaml
 delegation:
-  max_iterations: 50                        # Max turns per child (default: 50)
-  # max_concurrent_children: 3              # Parallel children per batch (default: 3)
+  max_iterations: 250                       # Max turns per child (default: 250)
+  # max_concurrent_children: 10             # Total running child slots shared by singles and batches
+  # max_queued_delegations: 8               # Bounded FIFO length; 0 rejects when work cannot start
+  # queue_timeout_seconds: 3600             # Maximum FIFO wait; 0 disables expiry
+  # min_available_memory_mb: 0              # Host/cgroup headroom stop floor; 0 disables
+  # resume_available_memory_mb: 0           # Higher recovery floor after blocking; 0 follows stop floor
+  # max_memory_psi_avg10: 0                 # Linux PSI some/avg10 stop ceiling; 0 disables
+  # resume_memory_psi_avg10: 0              # Lower recovery ceiling; 0 follows stop ceiling
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -137,7 +137,9 @@ retry.
 
 This does not resume child execution after a crash. A delegation whose owner
 process disappears while it is still running is recorded as `unknown`, because
-Hermes cannot prove whether its external side effects happened. Pending and
+Hermes cannot prove whether its external side effects happened. A delegation
+that was still `queued` (never started) is recorded as `interrupted` —
+"cancelled before start" — since Hermes can prove it never ran. Pending and
 delivered records are bounded and profile-local.
 
 ## Model Override
@@ -205,6 +207,28 @@ non-timeout errors.
 :::tip Diagnostic dump on zero-call timeout
 With a hard cap configured, if a subagent times out having made **zero** API calls (usually: provider unreachable, auth failure, or tool-schema rejection), `delegate_task` writes a structured diagnostic to `~/.hermes/logs/subagent-timeout-<session>-<timestamp>.log` containing the subagent's config snapshot, credential-resolution trace, any early error messages, and stack traces for **all** live threads (not just the child's own) — a child parked waiting on a nested helper thread is indistinguishable from a slow provider without the full picture.
 :::
+
+## Background Admission Queue
+
+Background delegations share a process-wide child-slot budget. A batch reserves
+one slot per child; when it cannot reserve every required slot immediately, the
+whole call enters a bounded FIFO rather than running synchronously and bypassing
+the limit. Optional memory-headroom and Linux memory-PSI gates can also hold
+work in the same queue. On Linux, the headroom probe uses the smaller of host
+`MemAvailable` and the current cgroup's `memory.high`/`memory.max` headroom.
+Separate stop and resume thresholds provide hysteresis after resource pressure.
+
+Queued work starts automatically when it reaches the head, all required child
+slots are free, and the configured resource gates are satisfied. `/stop`, session reset, and
+gateway shutdown cancel matching queued work before its runner starts. Queue
+expiry produces a terminal `timeout` completion. A full queue rejects new work;
+it never falls back to synchronous execution.
+
+The queue is process-local execution state, not a durable job runner. After a
+process restart, a queued-but-never-started entry is reported as `interrupted`
+("cancelled before start"), while a running one is reported with an `unknown`
+outcome. Use `cronjob` or a bounded background terminal process for work that
+must survive process restarts.
 
 ## Stall Detection for Background Subagents
 
@@ -330,7 +354,7 @@ Top-level model-facing `delegate_task` calls run in the background automatically
 
 - Normal follow-up messages do not cancel background children. `/stop` cancels running background delegations, and closing or resetting the owning session discards its active children.
 - Explicit session close/reset interrupts that session's background children. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.
-- A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened.
+- A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened. A child that was still queued (never started) becomes `interrupted` — "cancelled before start".
 - A child that completed before restart but whose result was not delivered is restored and routed back through the owning session's normal checks.
 - Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the parent was interrupted too, that result often never makes it into a user-visible reply.
 
@@ -370,7 +394,13 @@ For **durable execution** that must survive session closure or process restart, 
 # In ~/.hermes/config.yaml
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
-  # max_concurrent_children: 3              # Parallel children per batch (default: 3)
+  # max_concurrent_children: 3              # Total running child slots shared by singles and batches
+  # max_queued_delegations: 8               # Bounded FIFO length; 0 rejects when work cannot start
+  # queue_timeout_seconds: 3600             # Maximum FIFO wait; 0 disables expiry
+  # min_available_memory_mb: 0              # Host/cgroup headroom stop floor; 0 disables
+  # resume_available_memory_mb: 0           # Higher recovery floor after blocking; 0 follows stop floor
+  # max_memory_psi_avg10: 0                 # Linux PSI some/avg10 stop ceiling; 0 disables
+  # resume_memory_psi_avg10: 0              # Lower recovery ceiling; 0 follows stop ceiling
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override


### PR DESCRIPTION
## What

When the background delegation pool is at capacity (or host/cgroup memory is insufficient), async delegations now **wait in a bounded FIFO admission queue** instead of being rejected — and capacity pressure **never falls through to synchronous execution** (the old behavior bypassed `max_concurrent_children` entirely).

## Changes

- `tools/async_delegation.py`
  - FIFO admission queue with per-child slot reservation (one slot per batch child)
  - Configurable maximum pending count (`max_queued_delegations`, default 8) and queue timeout (`queue_timeout_seconds`, default 3600)
  - Memory gating: host `MemAvailable` capped by cgroup-v2 headroom (`min_available_memory_mb` / `resume_available_memory_mb`), plus optional Linux memory-PSI ceiling with stop/resume hysteresis (`max_memory_psi_avg10` / `resume_memory_psi_avg10`)
  - Queued records: persisted, user-visible `queued` status, interruptible (global + per-session), timeout-finalizable without invoking the runner, included in abandoned-owner recovery
  - Admission waiting runs **outside** the worker executor (no executor starvation), with daemon launcher threads and shutdown cleanup
  - Stale-monitor restart, lingering-slot retention, manager-generation guard
- `tools/delegate_tool.py` — treats `queued` as accepted background dispatch (no synchronous fallback on capacity); forwards the new settings
- `gateway/run.py`, `gateway/slash_commands.py`, `cli.py`, `hermes_cli/main.py` — `begin_shutdown` wiring, queued status display
- Config defaults (`hermes_cli/config_defaults.py`, `cli-config.yaml.example`) + docs (`delegation.md`, `delegation-patterns.md`)

## Tests

- Queue: capacity queueing, batch slot accounting, FIFO ordering, bounds/overflow, memory+PSI gating, timeout, cancellation (global + per-session), concurrency, no synchronous fallback, config forwarding, fd-leak, executor-starvation, persistence-failure slot release, stalled-finalize hardening
- Local results: **69 passed** (delegation + gateway suites on current `main`), plus 90 in the integration branch; ruff + `py_compile` + `git diff --check` clean; 3 independent review cycles passed

Draft while live-testing in the user's own environment; not ready for merge yet.