### PR TITLE
fix(gateway): write systemd units and launchd plists without a truncation window

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3110,6 +3110,29 @@ def _refuse_temp_home_service_write(definition: str, kind: str) -> bool:
     return True
 
 
+def _write_service_definition(path: "Path", definition: str) -> None:
+    """Write a systemd unit / launchd plist without a truncation window.
+
+    A bare ``write_text`` empties the file before the new definition lands,
+    and every caller hands the result straight to the service manager
+    (``systemctl daemon-reload``, ``launchctl bootstrap``), so a half-written
+    file is parsed immediately. The refresh paths make that concrete: they
+    rewrite a definition that is already installed and running, and the
+    launchd refresh can be executing inside the gateway's own process tree —
+    the bootout below it tears that tree down, this CLI included.
+
+    A unit the manager cannot parse means the gateway simply stops coming
+    back at login, with nothing to point at.
+
+    ``preserve_mode`` keeps an already-installed definition's bits;
+    ``create_mode`` lands a new one at 0644, which is what the umask gave
+    before and what systemd and launchd expect to be able to read.
+    """
+    from utils import atomic_write_text
+
+    atomic_write_text(path, definition, preserve_mode=True, create_mode=0o644)
+
+
 def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     """Rewrite the installed systemd unit when the generated definition has changed."""
     unit_path = get_systemd_unit_path(system=system)
@@ -3153,7 +3176,7 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     if _refuse_temp_home_service_write(new_unit, "systemd unit"):
         return False
 
-    unit_path.write_text(new_unit, encoding="utf-8")
+    _write_service_definition(unit_path, new_unit)
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     print(
         f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install"
@@ -3355,7 +3378,7 @@ def systemd_install(
     if _refuse_temp_home_service_write(new_unit, "systemd unit"):
         return
     print(f"Installing {_service_scope_label(system)} systemd service to: {unit_path}")
-    unit_path.write_text(new_unit, encoding="utf-8")
+    _write_service_definition(unit_path, new_unit)
 
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     if enable_on_startup:
@@ -4181,7 +4204,7 @@ def refresh_launchd_plist_if_needed() -> bool:
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return False
 
-    plist_path.write_text(new_plist, encoding="utf-8")
+    _write_service_definition(plist_path, new_plist)
     label = get_launchd_label()
     domain = _launchd_domain()
     target = f"{domain}/{label}"
@@ -4350,7 +4373,7 @@ def launchd_install(force: bool = False):
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(new_plist, encoding="utf-8")
+    _write_service_definition(plist_path, new_plist)
 
     try:
         _launchctl_bootstrap(
@@ -4400,7 +4423,7 @@ def launchd_start():
             sys.exit(1)
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
-        plist_path.write_text(new_plist, encoding="utf-8")
+        _write_service_definition(plist_path, new_plist)
         try:
             _launchctl_bootstrap(_launchd_domain(), plist_path, label, timeout=30)
             subprocess.run(

--- a/tests/hermes_cli/test_gateway_service_definition_write.py
+++ b/tests/hermes_cli/test_gateway_service_definition_write.py
@@ -1,0 +1,112 @@
+"""A service definition must never be left half-written.
+
+Every caller hands the file straight to the service manager
+(``systemctl daemon-reload`` / ``launchctl bootstrap``), so a truncated unit
+or plist is parsed immediately — and the refresh paths rewrite a definition
+that is already installed and running. The launchd refresh can even be
+running inside the gateway's own process tree, which the bootout below it
+tears down.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+
+INSTALLED = "[Unit]\nDescription=Hermes Gateway (installed)\n"
+REPLACEMENT = "[Unit]\nDescription=Hermes Gateway (updated)\n"
+
+
+def test_existing_definition_survives_an_interrupted_write(tmp_path, monkeypatch):
+    path = tmp_path / "hermes-gateway.service"
+    path.write_text(INSTALLED, encoding="utf-8")
+    original = path.read_bytes()
+
+    def boom(fd):
+        raise OSError("simulated crash mid-write")
+
+    monkeypatch.setattr(os, "fsync", boom)
+    try:
+        gateway_cli._write_service_definition(path, REPLACEMENT)
+    except OSError:
+        pass  # the durable path refuses to swap in a half-written file
+
+    assert path.read_bytes() == original, (
+        "the installed service definition was destroyed; the service manager "
+        "would load an empty unit on the next reload"
+    )
+
+
+def test_normal_write_replaces_the_definition(tmp_path):
+    path = tmp_path / "hermes-gateway.service"
+    path.write_text(INSTALLED, encoding="utf-8")
+
+    gateway_cli._write_service_definition(path, REPLACEMENT)
+
+    assert path.read_text(encoding="utf-8") == REPLACEMENT
+
+
+def test_write_creates_a_missing_definition(tmp_path):
+    path = tmp_path / "nested" / "com.hermes.gateway.plist"
+
+    gateway_cli._write_service_definition(path, REPLACEMENT)
+
+    assert path.read_text(encoding="utf-8") == REPLACEMENT
+
+
+def test_new_definition_is_manager_readable(tmp_path):
+    """systemd and launchd both need to read the file; 0600 would hide it."""
+    if os.name == "nt":
+        pytest.skip("POSIX permission bits")
+    import stat
+
+    path = tmp_path / "hermes-gateway.service"
+    gateway_cli._write_service_definition(path, REPLACEMENT)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o644
+
+
+def test_existing_definition_keeps_its_mode(tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX permission bits")
+    import stat
+
+    path = tmp_path / "hermes-gateway.service"
+    path.write_text(INSTALLED, encoding="utf-8")
+    os.chmod(path, 0o640)
+
+    gateway_cli._write_service_definition(path, REPLACEMENT)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+class _Stop(Exception):
+    """Halt the refresh right after the write, before any launchctl work."""
+
+
+def test_launchd_refresh_writes_through_the_durable_path(tmp_path, monkeypatch):
+    """Pins the wiring — a correct helper is worthless if a caller skips it."""
+    plist = tmp_path / "com.hermes.gateway.plist"
+    plist.write_text(INSTALLED, encoding="utf-8")
+
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist)
+    monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: REPLACEMENT)
+
+    seen: dict = {}
+
+    def spy(path, definition):
+        seen["path"] = path
+        seen["definition"] = definition
+        raise _Stop
+
+    monkeypatch.setattr(gateway_cli, "_write_service_definition", spy)
+
+    with pytest.raises(_Stop):
+        gateway_cli.refresh_launchd_plist_if_needed()
+
+    assert seen["path"] == plist
+    assert seen["definition"] == REPLACEMENT


### PR DESCRIPTION
## What

`utils.atomic_write_text`'s docstring states the invariant plainly: it exists "so that every destructive file rewrite in the codebase shares one implementation." 67827dd99 swept four rewrites that still bypassed it. The five service-definition writes in `hermes_cli/gateway.py` are the same shape and were not reached:

```
3179  systemd_service_refresh   unit_path.write_text(new_unit, ...)
3381  systemd_install           unit_path.write_text(new_unit, ...)
4207  refresh_launchd_plist_if_needed   plist_path.write_text(new_plist, ...)
4376  launchd_install           plist_path.write_text(new_plist, ...)
4426  launchd_start (self-heal) plist_path.write_text(new_plist, ...)
```

Every one of them hands the file straight to the service manager on the next line — `systemctl daemon-reload`, `launchctl bootstrap` — so a half-written unit or plist is parsed immediately rather than sitting on disk until the next boot. Two of the five rewrite a definition that is already installed and running; `refresh_launchd_plist_if_needed` is guarded by `plist_path.exists()`, so it is a rewrite by construction.

The interruption is not hypothetical in this file. The comment directly below the launchd refresh documents the exact window:

> If this refresh is running INSIDE the gateway's own launchd process tree (e.g. the agent triggered a self-update via its terminal tool), a direct `launchctl bootout` tears down the service's process group — which includes THIS CLI — before the follow-up `bootstrap` can run. (#43842)

Truncate-then-die is precisely the situation that path already knows it is in, and an agent self-update is a routine action.

The read half degrades silently, like the four cases in the sweep: a unit the manager cannot parse means the gateway just stops coming back at login, with nothing to point at. Driving the two writers under the same interruption:

```
bare write_text   -> unit after interruption: ''
atomic_write_text -> unit after interruption: '[Unit]\nDescription=Hermes Gateway (installed)\n'
```

## The fix

One `_write_service_definition` helper, and all five sites route through it. The mode arguments matter here rather than being incidental: `atomic_write_text` swaps in mkstemp's 0600 temp file, and a 0600 unit is one neither systemd nor launchd can read. `preserve_mode=True` keeps an installed definition's existing bits; `create_mode=0o644` lands a new one where the umask used to put it.

The `_refuse_temp_home_service_write` guard in front of each call is untouched — this only changes how the bytes land.

## Tests and results

New file `tests/hermes_cli/test_gateway_service_definition_write.py` (kept separate from `test_gateway_service.py`, which is gated behind `importorskip("pwd")` and so never runs off POSIX):

- an interrupted write leaves an installed definition byte-identical, with the failure message naming what the service manager would otherwise load
- a normal write replaces the definition, and a missing one is created
- a new definition lands at 0644, and an existing 0640 keeps its mode — POSIX-only, skipped elsewhere
- the launchd refresh is driven for real, with its collaborators stubbed, to pin that the call site goes through the durable path rather than only the helper being correct

Six tests: 4 pass, 2 skip on this platform.

For regressions I ran the gateway and systemd suites (`tests/hermes_cli/*gateway*`, `*systemd*` — 182 passed) before and after. Excluding the new file, the failure lists are byte-identical: 11 failures, all pre-existing on `main`. `scripts/check-windows-footguns.py` is clean on both changed files.