### PR TITLE
feat(mattermost): isolate DM sessions per top-level message (Slack parity)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -146,6 +146,20 @@ class MattermostAdapter(BasePlatformAdapter):
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
+    def _dm_top_level_threads_as_sessions(self) -> bool:
+        """Whether top-level Mattermost DMs get per-message session threads.
+
+        Defaults to ``True`` so each top-level DM message is isolated as its
+        own Hermes session — matching Slack's ``dm_top_level_threads_as_sessions``
+        behavior.  Set ``platforms.mattermost.extra.dm_top_level_threads_as_sessions``
+        to ``false`` in config.yaml to revert to the legacy behavior where all
+        top-level DMs share one continuous session.
+        """
+        raw = self.config.extra.get("dm_top_level_threads_as_sessions") if self.config.extra else None
+        if raw is None:
+            return True  # default: each DM top-level message is its own session
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
     # ------------------------------------------------------------------
     # HTTP helpers
     # ------------------------------------------------------------------
@@ -911,9 +925,21 @@ class MattermostAdapter(BasePlatformAdapter):
         thread_id = post.get("root_id") or None
         if (
             not thread_id
-            and self._reply_mode == "thread"
             and channel_type_raw != "D"
+            and self._reply_mode == "thread"
             and post_id
+        ):
+            thread_id = post_id
+
+        # DM session isolation: stamp each top-level DM message with its own
+        # post_id as thread_id so each root message becomes its own session,
+        # matching Slack's dm_top_level_threads_as_sessions behavior. Replies
+        # in a thread keep the thread's root_id as their session key.
+        if (
+            not thread_id
+            and channel_type_raw == "D"
+            and post_id
+            and self._dm_top_level_threads_as_sessions()
         ):
             thread_id = post_id
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -594,3 +594,145 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.message_id == "top_post_123"
 
 
+# ---------------------------------------------------------------------------
+# DM session isolation (Slack-compatible dm_top_level_threads_as_sessions)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dm_top_level_post_gets_own_thread_id_by_default():
+    """A top-level DM message (no root_id) is stamped with its own post_id as
+    thread_id, giving each DM root its own session — matching Slack behavior."""
+    adapter = _make_adapter()
+    adapter._reply_mode = "off"
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+    post_data = {
+        "id": "dm_post_123",
+        "user_id": "user_123",
+        "channel_id": "chan_dm",
+        "message": "hello",
+        "root_id": "",
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "D",
+            "sender_name": "@alice",
+        },
+    }
+    await adapter._handle_ws_event(event)
+    msg_event = adapter.handle_message.call_args[0][0]
+    assert msg_event.source.thread_id == "dm_post_123"
+
+
+@pytest.mark.asyncio
+async def test_dm_reply_in_thread_keeps_root_id():
+    """A reply inside a DM thread keeps the thread's root_id, not its own id,
+    so it continues the same session as the root message."""
+    adapter = _make_adapter()
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+    post_data = {
+        "id": "reply_456",
+        "user_id": "user_123",
+        "channel_id": "chan_dm",
+        "message": "follow-up",
+        "root_id": "dm_post_123",
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "D",
+            "sender_name": "@alice",
+        },
+    }
+    await adapter._handle_ws_event(event)
+    msg_event = adapter.handle_message.call_args[0][0]
+    assert msg_event.source.thread_id == "dm_post_123"
+
+
+@pytest.mark.asyncio
+async def test_dm_top_level_disabled_when_config_false():
+    """When dm_top_level_threads_as_sessions is false, top-level DM messages
+    do NOT get a synthetic thread_id — reverting to legacy single-session."""
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+    config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"url": "https://mm.example.com", "dm_top_level_threads_as_sessions": False},
+    )
+    adapter = MattermostAdapter(config)
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+    post_data = {
+        "id": "dm_post_789",
+        "user_id": "user_123",
+        "channel_id": "chan_dm",
+        "message": "hello",
+        "root_id": "",
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "D",
+            "sender_name": "@alice",
+        },
+    }
+    await adapter._handle_ws_event(event)
+    msg_event = adapter.handle_message.call_args[0][0]
+    assert msg_event.source.thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_dm_root_and_reply_share_session_key():
+    """End-to-end: a DM root message and its thread reply produce the same
+    session key — the core invariant of DM session isolation."""
+    from gateway.session import SessionSource, build_session_key
+    adapter = _make_adapter()
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+
+    async def _send(post_id, root_id=""):
+        adapter.handle_message.reset_mock()
+        post_data = {
+            "id": post_id,
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": "msg",
+        }
+        if root_id:
+            post_data["root_id"] = root_id
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+        await adapter._handle_ws_event(event)
+        return adapter.handle_message.call_args[0][0].source.thread_id
+
+    root_tid = await _send("root_123")
+    reply_tid = await _send("reply_456", root_id="root_123")
+
+    def session_key(thread_id):
+        src = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="chan_dm",
+            chat_type="dm",
+            user_id="user_123",
+            thread_id=thread_id,
+        )
+        return build_session_key(src)
+
+    assert session_key(root_tid) == session_key(reply_tid)
+
+


### PR DESCRIPTION
## What does this PR do?

Ports Slack's `dm_top_level_threads_as_sessions` session isolation to the Mattermost adapter. Each top-level DM message now gets its own session (stamped with its own `post_id` as `thread_id`), while threaded replies continue the root's session — matching the behavior Slack has had since `dm_top_level_threads_as_sessions` was introduced there.

**Problem:** Mattermost top-level DM messages shared one continuous session. The channel stamping fix (#18279) explicitly excluded DMs (`channel_type_raw != "D"`), so every top-level DM in the same channel collapsed into `session_key = platform:dm:{chat_id}` — no thread suffix. This blocks parallel DM conversations and mixes unrelated topics into one context window.

**Fix:** Stamp top-level DM messages with their own `post_id` as `thread_id`, gated by a new `_dm_top_level_threads_as_sessions()` config method that mirrors Slack's exactly.

## Related Issue

Closes #18279 (the DM portion — the channel portion was already fixed; this completes the parity).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`:
  - New method `_dm_top_level_threads_as_sessions()` — reads `platforms.mattermost.extra.dm_top_level_threads_as_sessions`, defaults to `true` (mirrors Slack's default)
  - New DM stamping block: top-level DM messages (`channel_type == "D"`, no `root_id`) get `thread_id = post_id` when the feature is enabled
  - Channel stamping logic unchanged — only the DM exclusion from the existing block is preserved (it's now handled by the separate DM block)

- `tests/gateway/test_mattermost.py`:
  - `test_dm_top_level_post_gets_own_thread_id_by_default` — top-level DM gets its own thread_id
  - `test_dm_reply_in_thread_keeps_root_id` — threaded reply keeps root_id (continues session)
  - `test_dm_top_level_disabled_when_config_false` — config false → no stamping (legacy behavior)
  - `test_dm_root_and_reply_share_session_key` — end-to-end: root + reply produce same `build_session_key()`

## How to Test

```bash
pytest tests/gateway/test_mattermost.py -v
```

All 27 tests pass (23 existing + 4 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(mattermost): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #37144 addresses thread root/reply continuity but does not add DM session isolation or a config gate; this PR is complementary
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_mattermost.py -v` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings added inline (matching Slack's pattern; `dm_top_level_threads_as_sessions` is an `extra` key not documented in `cli-config.yaml.example`, consistent with Slack's treatment)
- [x] I've updated `cli-config.yaml.example` — N/A (extra key, matches Slack convention)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (platform-agnostic session-key logic)
- [x] I've updated tool descriptions/schemas — N/A

## Design Notes

**Why gate with a config option instead of always-on?** Slack uses the same pattern — default `true` with an escape hatch. Some deployments may rely on the legacy single-session-per-DM behavior (e.g., a DM channel used as a persistent command surface). The config gate lets them revert without a code change.

**Why independent of `reply_mode`?** DM session isolation is orthogonal to reply placement. Whether the bot replies in threads or flat, each top-level DM message should still get its own session. The `reply_mode` flag controls *outbound* formatting; session keying is *inbound* routing.
