### PR TITLE
test(tui): shard tui gateway test suite s3 clusters (tests/test_tui_gateway_server.py, tracker #78647)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6579,54 +6579,6 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     assert cfg_clamp["display"]["sections"]["thinking"] == "collapsed"
 
 
-def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
-    monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
-    agent = types.SimpleNamespace(reasoning_config=None)
-    server._sessions["sid"] = _session(agent=agent)
-    server._sessions["sid"]["create_reasoning_override"] = {"enabled": True, "effort": "low"}
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "reasoning",
-                "value": "high",
-                "scope": "global",
-            },
-        }
-    )
-
-    assert resp["result"]["value"] == "high"
-    assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
-    assert "create_reasoning_override" not in server._sessions["sid"]
-
-    status = server.handle_request(
-        {"id": "2", "method": "config.get", "params": {"session_id": "sid", "key": "reasoning"}}
-    )
-    assert status["result"]["value"] == "high"
-
-
-def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch):
-    monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    agent = types.SimpleNamespace(verbose_logging=False)
-    server._sessions["sid"] = _session(agent=agent)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
-        }
-    )
-
-    assert resp["result"]["value"] == "verbose"
-    assert server._sessions["sid"]["tool_progress_mode"] == "verbose"
-    assert agent.verbose_logging is True
-
-
 
 def test_config_set_model_waits_for_lazy_agent_before_switch(monkeypatch):
     """A model switch against a lazy-created live session must apply to the
@@ -7300,70 +7252,6 @@ def test_restore_agent_model_runtime_falls_back_to_switch_model():
     assert agent.model == "old/model"
     assert agent.provider == "openrouter"
     assert agent.base_url == "https://openrouter.ai/api/v1"
-
-
-def test_config_set_personality_rejects_unknown_name(monkeypatch):
-    monkeypatch.setattr(
-        server,
-        "_available_personalities",
-        lambda cfg=None: {"helpful": "You are helpful."},
-    )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "personality", "value": "bogus"},
-        }
-    )
-
-    assert "error" in resp
-    assert "Unknown personality" in resp["error"]["message"]
-
-
-def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
-    agent = types.SimpleNamespace(
-        ephemeral_system_prompt=None, _cached_system_prompt="old"
-    )
-    session = _session(
-        agent=agent,
-        history=[{"role": "user", "text": "hi"}],
-        history_version=4,
-    )
-    emits = []
-
-    server._sessions["sid"] = session
-    monkeypatch.setattr(
-        server,
-        "_available_personalities",
-        lambda cfg=None: {"helpful": "You are helpful."},
-    )
-    monkeypatch.setattr(
-        server, "_session_info", lambda agent, *a: {"model": getattr(agent, "model", "?")}
-    )
-    monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
-    monkeypatch.setattr(server, "_write_config_key", lambda path, value: None)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
-        }
-    )
-
-    assert resp["result"]["history_reset"] is False
-    assert resp["result"]["info"] == {"model": "?"}
-    # History is preserved with a pivot marker appended
-    assert len(session["history"]) == 2
-    assert session["history"][0] == {"role": "user", "text": "hi"}
-    assert session["history"][1]["role"] == "user"
-    assert "personality" in session["history"][1]["content"].lower()
-    assert "You are helpful." in session["history"][1]["content"]
-    assert session["history_version"] == 5
-    # Agent's system prompt was updated in-place; cached prompt untouched
-    assert agent.ephemeral_system_prompt == "You are helpful."
-    assert agent._cached_system_prompt == "old"
-    assert ("session.info", "sid", {"model": "?"}) in emits
 
 
 def test_compress_session_history_passes_force():

--- a/tests/tui_gateway/test_config_set_personality.py
+++ b/tests/tui_gateway/test_config_set_personality.py
@@ -1,0 +1,108 @@
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _neuter_agent_prewarm_timer(request, monkeypatch):
+    """Stub the deferred agent pre-warm timer for every test in this module.
+
+    ``session.create`` and non-eager ``session.resume`` fire a 50 ms
+    background ``threading.Timer`` (``_schedule_agent_build``) that calls
+    whatever ``server._make_agent`` is patched in AT FIRE TIME. Left live,
+    a timer armed by one test outlives it and lands in the NEXT test's
+    ``_make_agent`` mock, racily corrupting its captured state (the
+    ``'tip' == 'cont_tip'`` flakes in the session_resume tests). Tests that
+    exercise the deferred build itself opt back in with
+    ``@pytest.mark.real_agent_prewarm``.
+    """
+    if request.node.get_closest_marker("real_agent_prewarm"):
+        yield
+        return
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    yield
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        **extra,
+    }
+
+
+def test_config_set_personality_rejects_unknown_name(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_available_personalities",
+        lambda cfg=None: {"helpful": "You are helpful."},
+    )
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "personality", "value": "bogus"},
+        }
+    )
+
+    assert "error" in resp
+    assert "Unknown personality" in resp["error"]["message"]
+
+
+def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
+    agent = types.SimpleNamespace(
+        ephemeral_system_prompt=None, _cached_system_prompt="old"
+    )
+    session = _session(
+        agent=agent,
+        history=[{"role": "user", "text": "hi"}],
+        history_version=4,
+    )
+    emits = []
+
+    server._sessions["sid"] = session
+    monkeypatch.setattr(
+        server,
+        "_available_personalities",
+        lambda cfg=None: {"helpful": "You are helpful."},
+    )
+    monkeypatch.setattr(
+        server, "_session_info", lambda agent, *a: {"model": getattr(agent, "model", "?")}
+    )
+    monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
+    monkeypatch.setattr(server, "_write_config_key", lambda path, value: None)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
+        }
+    )
+
+    assert resp["result"]["history_reset"] is False
+    assert resp["result"]["info"] == {"model": "?"}
+    # History is preserved with a pivot marker appended
+    assert len(session["history"]) == 2
+    assert session["history"][0] == {"role": "user", "text": "hi"}
+    assert session["history"][1]["role"] == "user"
+    assert "personality" in session["history"][1]["content"].lower()
+    assert "You are helpful." in session["history"][1]["content"]
+    assert session["history_version"] == 5
+    # Agent's system prompt was updated in-place; cached prompt untouched
+    assert agent.ephemeral_system_prompt == "You are helpful."
+    assert agent._cached_system_prompt == "old"
+    assert ("session.info", "sid", {"model": "?"}) in emits

--- a/tests/tui_gateway/test_config_set_reasoning_verbose.py
+++ b/tests/tui_gateway/test_config_set_reasoning_verbose.py
@@ -1,0 +1,92 @@
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _neuter_agent_prewarm_timer(request, monkeypatch):
+    """Stub the deferred agent pre-warm timer for every test in this module.
+
+    ``session.create`` and non-eager ``session.resume`` fire a 50 ms
+    background ``threading.Timer`` (``_schedule_agent_build``) that calls
+    whatever ``server._make_agent`` is patched in AT FIRE TIME. Left live,
+    a timer armed by one test outlives it and lands in the NEXT test's
+    ``_make_agent`` mock, racily corrupting its captured state (the
+    ``'tip' == 'cont_tip'`` flakes in the session_resume tests). Tests that
+    exercise the deferred build itself opt back in with
+    ``@pytest.mark.real_agent_prewarm``.
+    """
+    if request.node.get_closest_marker("real_agent_prewarm"):
+        yield
+        return
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    yield
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        **extra,
+    }
+
+
+def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    agent = types.SimpleNamespace(reasoning_config=None)
+    server._sessions["sid"] = _session(agent=agent)
+    server._sessions["sid"]["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "reasoning",
+                "value": "high",
+                "scope": "global",
+            },
+        }
+    )
+
+    assert resp["result"]["value"] == "high"
+    assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
+    assert "create_reasoning_override" not in server._sessions["sid"]
+
+    status = server.handle_request(
+        {"id": "2", "method": "config.get", "params": {"session_id": "sid", "key": "reasoning"}}
+    )
+    assert status["result"]["value"] == "high"
+
+
+def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    agent = types.SimpleNamespace(verbose_logging=False)
+    server._sessions["sid"] = _session(agent=agent)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
+        }
+    )
+
+    assert resp["result"]["value"] == "verbose"
+    assert server._sessions["sid"]["tool_progress_mode"] == "verbose"
+    assert agent.verbose_logging is True


### PR DESCRIPTION
## What changed and why

Shard slice for the `tests/test_tui_gateway_server.py` large-file decomposition (tracker #78647, tracker #78629). This is region **s3** of the 5×2×3 double-blind decomposition: the config-set-reasoning-verbose and config-set-personality test families move verbatim into focused observable modules.

- **Moved (4 tests, byte-verbatim):**
  - `test_config_set_reasoning_global_scope_clears_session_override`, `test_config_set_verbose_updates_session_mode_and_agent` → `tests/tui_gateway/test_config_set_reasoning_verbose.py`
  - `test_config_set_personality_rejects_unknown_name`, `test_config_set_personality_preserves_history_and_returns_info` → `tests/tui_gateway/test_config_set_personality.py`
- Zero behavior change: pure test refactor (test-file godfile — no runtime code touched). Local seams preserved: `_neuter_agent_prewarm_timer` autouse fixture and `_session` helper copied verbatim into both modules.

## How to test

```bash
HERMES_PYTHON="C:/Users/andre/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe" scripts/run_tests.sh tests/tui_gateway/test_config_set_reasoning_verbose.py tests/tui_gateway/test_config_set_personality.py
# expected: 4 passed, 0 failed
```


## Footgun Gate

`git diff --check` is clean on each branch. The newly added modules each scan clean (`check-windows-footguns.py`: 0 findings). The retained godfile carries 10 pre-existing bare `Path.read_text/write_text` encoding findings; a pristine pin scan reproduced the same 10 findings. No slice-introduced footgun exists; the retained-godfile baseline debt is outside these extracted test windows and remains staged for a later test-hygiene class fix.

## Verification (blind, 5×2×3)

Double-blind witnesses **w2a + w2b** (independent, forbidden from each other's outputs and from W1 artifacts) both VERIFIED:
- Byte-fidelity: all 4 moved defs AST-slice-identical to pin `9d4ef04ed00` source
- Orphan gate: 0 moved defs remain in the godfile; each exists exactly once in its module
- Seam check: PASS (autouse fixture + `_session` helper preserved verbatim)
- Focused suite: 4 passed / 0 failed (both witnesses)
- `git diff --check` clean; `py_compile` clean

Witness verdicts: `C:/tmp/tg-campaign/godfile/tui_test/extraction/ew2/s3-w2a.json`, `s3-w2b.json` (schema `tui-test-extraction-w2-witness/1.0`, both VERIFIED).

## Platforms tested

Windows (git-bash host), repo main venv python 3.11.

## Why this matters to users

No user-visible change — large-file decomposition: the 16,245-line test monolith shrinks, each focused module is independently runnable and debuggable, and the 2K-law kill track advances. Test-file slices are behavior-neutral by construction (epic method 3).

Part of #78647
Part of #78629

## Links

- This PR: https://github.com/NousResearch/hermes-agent/pull/80539
- God-file tracker: https://github.com/NousResearch/hermes-agent/issues/78629
- Kill-All-Gods epic: https://github.com/NousResearch/hermes-agent/issues/78647
- KILL LOCK comment: https://github.com/NousResearch/hermes-agent/issues/78629#issuecomment-5208459782
- Scoreboard comment: https://github.com/NousResearch/hermes-agent/issues/78629#issuecomment-5208455466
- Slice PR #80537: https://github.com/NousResearch/hermes-agent/pull/80537
- Slice PR #80538: https://github.com/NousResearch/hermes-agent/pull/80538
- Slice PR #80539: https://github.com/NousResearch/hermes-agent/pull/80539
- Slice PR #80540: https://github.com/NousResearch/hermes-agent/pull/80540
- Slice PR #80541: https://github.com/NousResearch/hermes-agent/pull/80541


