### PR TITLE
docs: use canonical TUI workspace commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,16 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run the TUI workspace scripts from the repository root; their definitions live
+in `ui-tui/package.json`.
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm install                              # first time
+npm --workspace ui-tui run dev           # watch mode (rebuilds hermes-ink + tsx --watch)
+npm --workspace ui-tui start             # production
+npm --workspace ui-tui run build         # bundle ui-tui/dist/entry.js with esbuild
+npm --workspace ui-tui run check         # build hermes-ink, typecheck, test, and lint
+npm --workspace ui-tui run fix           # eslint --fix and prettier
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary
- run TUI development commands unambiguously from the repository root by targeting the `ui-tui` workspace
- replace separate stale typecheck/lint/format examples with the package-defined `check` and `fix` aggregators
- correct the build description to match the esbuild bundle written to `ui-tui/dist/entry.js`

## Validation
- `npm install` — passed
- manifest/documentation command mapping check — passed (`dev`, `start`, `build`, `check`, and `fix` all resolve in `ui-tui/package.json`; no stale unqualified commands remain)
- `npm --workspace ui-tui run dev` — built `@hermes/ink` and entered watch mode; intentionally stopped after startup
- `npm --workspace ui-tui start` — resolved and exited cleanly in the non-TTY worker
- `npm --workspace ui-tui run build` — passed
- `npm --workspace ui-tui run fix` — passed with one existing ESLint warning and no file changes
- `npm --workspace ui-tui run check` — command resolved and ran all four stages; the Windows run ended with 9 failures, 1,515 passes, and 8 skips. An `origin/main` baseline run in the same environment ended with the same 8 Windows path-specific failures, 1,516 passes, and 8 skips; the branch-only extra was a timer flake. Linux CI remains authoritative.
- `npm run verify` — unavailable because the repository defines no `verify` script
- `git diff --check origin/main...HEAD` — passed

## Scope
Docs-only. `AGENTS.md` is the only changed file.

## Base freshness
- base: `0957277f2f468bac22bbfcfa7c43029858c9597e`
- final distance behind `origin/main`: 0 commits
