### PR TITLE
feat(desktop): close-to-tray option with persistent tray icon

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -187,6 +187,7 @@ import {
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { destroyTray, isTrayEnabled, loadTrayPrefs, setTrayEnabled } from './tray'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
@@ -2610,6 +2611,10 @@ let updateInFlight = false
 // set, window-all-closed calls app.quit() on every platform so the process
 // actually dies and the hand-off script can proceed immediately.
 let isQuittingForHandoff = false
+// Set once a real quit is underway (tray Quit, Cmd-Q, taskbar close). The
+// main window's close handler steps aside when this is true so the window
+// actually closes instead of hiding to the tray.
+let isReallyQuitting = false
 
 // Quit-guard latches: one while the confirmation is on screen (a second
 // Cmd-Q must not stack dialogs), one after the user has said "quit anyway"
@@ -9349,6 +9354,17 @@ function createWindow() {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
 
+  // Close → tray: when enabled, the X button hides the window and keeps the
+  // backend alive behind a tray icon instead of tearing the app down. Real
+  // quits (before-quit handler, tray Quit item) set isReallyQuitting first
+  // so this handler steps aside.
+  mainWindow.on('close', event => {
+    if (isTrayEnabled() && !isReallyQuitting) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
+
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
   mainWindow.on('closed', () => {
@@ -10326,6 +10342,42 @@ const claimedAmbientCue = createEventDeduper()
 // A window asks "do I own this ambient cue (turn-end sound / spoken reply)?".
 // The first caller within the window gets true; peers get false and stay quiet.
 ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
+
+ipcMain.handle('hermes:tray:get', () => isTrayEnabled())
+
+ipcMain.handle('hermes:tray:set', (_event, enabled) => {
+  return setTrayEnabled(Boolean(enabled), {
+    onShow: () => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.show()
+        focusWindow(mainWindow)
+      }
+    },
+    onQuit: () => {
+      app.quit()
+    }
+  })
+})
+
+// Restore the persisted choice on startup so the tray icon appears even
+// before the window first closes. Tray creation requires the app to be
+// ready — deferring via whenReady() avoids "Cannot create Tray before app
+// is ready" crashing the main process at module scope.
+if (loadTrayPrefs()) {
+  app.whenReady().then(() => {
+    setTrayEnabled(true, {
+      onShow: () => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.show()
+          focusWindow(mainWindow)
+        }
+      },
+      onQuit: () => {
+        app.quit()
+      }
+    })
+  })
+}
 
 ipcMain.handle('hermes:notify', (_event, payload) => {
   if (!Notification.isSupported()) {
@@ -11959,6 +12011,11 @@ app.on('before-quit', event => {
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  // Real quit (tray Quit, Cmd-Q, taskbar close): let window close events
+  // pass through, and drop the tray icon so it doesn't linger after exit.
+  isReallyQuitting = true
+  destroyTray()
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()

--- a/apps/desktop/electron/tray.test.ts
+++ b/apps/desktop/electron/tray.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for electron/tray.ts — the close-to-tray prefs + tray lifecycle.
+ *
+ * Run with: npx vitest run --project electron electron/tray.test.ts
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { destroyTray, isTrayEnabled, loadTrayPrefs, setTrayEnabled } from './tray'
+
+// --- electron mock ---------------------------------------------------------
+
+const electronMock = vi.hoisted(() => {
+  let userDataPath = ''
+
+  class FakeTray {
+    destroyed = false
+    toolTip: string | null = null
+    contextMenu: unknown = null
+    clickHandlers: Array<() => void> = []
+
+    constructor() {
+      instances.push(this)
+    }
+
+    setToolTip(text: string) {
+      this.toolTip = text
+    }
+
+    setContextMenu(menu: unknown) {
+      this.contextMenu = menu
+    }
+
+    on(event: string, handler: () => void) {
+      if (event === 'click') {
+        this.clickHandlers.push(handler)
+      }
+
+      return this
+    }
+
+    destroy() {
+      this.destroyed = true
+    }
+  }
+
+  const instances: FakeTray[] = []
+
+  return {
+    app: {
+      isReady: () => true,
+      getAppPath: () => '/fake/app-path',
+      getPath: (name: string) => {
+        if (name === 'userData') {
+          return userDataPath
+        }
+
+        throw new Error(`unexpected getPath(${name})`)
+      },
+      __setUserDataPath(p: string) {
+        userDataPath = p
+      }
+    },
+    Menu: {
+      buildFromTemplate: (template: unknown) => template
+    },
+    nativeImage: {
+      createFromPath: () => ({ isEmpty: () => false })
+    },
+    Tray: FakeTray,
+    __instances: instances
+  }
+})
+
+vi.mock('electron', () => ({
+  app: electronMock.app,
+  Menu: electronMock.Menu,
+  nativeImage: electronMock.nativeImage,
+  Tray: electronMock.Tray
+}))
+
+// --- tests -----------------------------------------------------------------
+
+describe('tray prefs', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tray-test-'))
+    electronMock.app.__setUserDataPath(dir)
+    // Module-level `tray` state survives across tests in one file; reset it
+    // so each test starts with no tray instance.
+    destroyTray()
+    electronMock.__instances.length = 0
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('defaults to enabled when no prefs file exists', () => {
+    expect(loadTrayPrefs()).toBe(true)
+  })
+
+  it('persists and reloads the choice', () => {
+    setTrayEnabled(false, { onShow: () => {}, onQuit: () => {} })
+    expect(loadTrayPrefs()).toBe(false)
+    setTrayEnabled(true, { onShow: () => {}, onQuit: () => {} })
+    expect(loadTrayPrefs()).toBe(true)
+    expect(isTrayEnabled()).toBe(true)
+  })
+
+  it('reads an existing prefs file with closeToTray: false', () => {
+    fs.writeFileSync(path.join(dir, 'tray-prefs.json'), JSON.stringify({ closeToTray: false }))
+    expect(loadTrayPrefs()).toBe(false)
+  })
+
+  it('creates a tray with tooltip and context menu when enabled', () => {
+    setTrayEnabled(true, { onShow: () => {}, onQuit: () => {} })
+    expect(electronMock.__instances.length).toBe(1)
+    const tray = electronMock.__instances[0]
+    expect(tray.destroyed).toBe(false)
+    expect(tray.toolTip).toBe('Hermes')
+    expect(tray.contextMenu).toBeTruthy()
+    expect(tray.clickHandlers.length).toBe(1)
+  })
+
+  it('destroys the tray on destroyTray', () => {
+    setTrayEnabled(true, { onShow: () => {}, onQuit: () => {} })
+    destroyTray()
+    expect(electronMock.__instances[0].destroyed).toBe(true)
+  })
+})

--- a/apps/desktop/electron/tray.ts
+++ b/apps/desktop/electron/tray.ts
@@ -1,0 +1,113 @@
+// System-tray support: keep Hermes alive in the tray when the main window
+// closes, instead of quitting. The enabled flag persists to a tiny JSON file
+// in userData so the choice survives restarts; the module is pure state +
+// Electron calls so main.ts only wires IPC and the close handler.
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { app, Menu, nativeImage, Tray } from 'electron'
+
+let tray: Tray | null = null
+let enabled = false
+let onShow: (() => void) | null = null
+let onQuit: (() => void) | null = null
+
+function prefsPath(): string {
+  return path.join(app.getPath('userData'), 'tray-prefs.json')
+}
+
+export function loadTrayPrefs(): boolean {
+  try {
+    const raw = fs.readFileSync(prefsPath(), 'utf8')
+    const parsed = JSON.parse(raw)
+    enabled = parsed?.closeToTray === true
+  } catch {
+    // No prefs file yet: default ON (close-to-tray), matching the user's
+    // "closing the window must not kill the process" requirement.
+    enabled = true
+  }
+
+  return enabled
+}
+
+function persist(): void {
+  try {
+    fs.writeFileSync(prefsPath(), JSON.stringify({ closeToTray: enabled }))
+  } catch {
+    // non-fatal: tray just won't remember the choice this run
+  }
+}
+
+export function isTrayEnabled(): boolean {
+  return enabled
+}
+
+function iconPath(): string {
+  // Packaged: resources/icon.ico (extraResources); dev: apps/desktop/assets.
+  const candidates = [
+    path.join(process.resourcesPath ?? '', 'icon.ico'),
+    path.join(process.resourcesPath ?? '', 'assets', 'icon.png'),
+    path.join(app.getAppPath(), 'assets', 'icon.png'),
+    path.join(app.getAppPath(), '..', 'assets', 'icon.png')
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return candidates[2]
+}
+
+function ensureTray(): void {
+  if (tray) {
+    return
+  }
+
+  if (!app.isReady()) {
+    // Tray before app-ready throws and would take down the main process;
+    // callers on startup paths must defer via app.whenReady().
+    throw new Error('ensureTray called before app ready')
+  }
+
+  const image = nativeImage.createFromPath(iconPath())
+  tray = new Tray(image.isEmpty() ? nativeImage.createEmpty() : image)
+  tray.setToolTip('Hermes')
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: 'Open Hermes', click: () => onShow?.() },
+      { type: 'separator' },
+      { label: 'Quit', click: () => onQuit?.() }
+    ])
+  )
+  tray.on('click', () => onShow?.())
+}
+
+export function setTrayEnabled(
+  next: boolean,
+  callbacks: { onShow: () => void; onQuit: () => void }
+): boolean {
+  enabled = next
+  onShow = callbacks.onShow
+  onQuit = callbacks.onQuit
+  persist()
+
+  if (enabled) {
+    ensureTray()
+  } else if (tray) {
+    tray.destroy()
+    tray = null
+  }
+
+  return enabled
+}
+
+/** Call on app quit so the icon doesn't linger after the process exits. */
+export function destroyTray(): void {
+  if (tray) {
+    tray.destroy()
+    tray = null
+  }
+}

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -108,11 +108,22 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
       markRightPanePerf('terminal-measure', reason)
       const r = slot.getBoundingClientRect()
+      // A kept-alive pane hidden as an inactive tab keeps its layout box
+      // (visibility:hidden — see pane-shell/pane-visibility.ts), so its rect is
+      // indistinguishable from the active tab's. The ancestor marker is the
+      // only reliable signal: treat a hidden slot as 0×0 so the fixed overlay
+      // can't keep painting over the pane that replaced it.
+      const paneHidden = slot.closest('[data-pane-hidden]') !== null
       // floor top/left + ceil right/bottom: overlay always covers the slot's
       // full pixel footprint, so half-pixel rects can't leak page bg through.
       const top = Math.floor(r.top)
       const left = Math.floor(r.left)
-      const next: Rect = { top, left, width: Math.ceil(r.right) - left, height: Math.ceil(r.bottom) - top }
+      const next: Rect = {
+        top,
+        left,
+        width: paneHidden ? 0 : Math.ceil(r.right) - left,
+        height: paneHidden ? 0 : Math.ceil(r.bottom) - top
+      }
 
       if (!sameRect(prev, next)) {
         prev = next


### PR DESCRIPTION
## Summary

Two desktop changes that have been running locally on Windows:

### 1. Close-to-tray option with persistent tray icon
Closing the main window now hides it behind a system-tray icon instead of quitting, keeping the backend alive. The choice persists to `userData/tray-prefs.json` (default on) and is restored on startup; real quits via the tray **Quit** item, Cmd-Q, or the taskbar still tear the app down and drop the tray icon.

- `electron/tray.ts` — tray lifecycle + prefs persistence (new)
- `electron/main.ts` — close handler, `hermes:tray:get/set` IPC, startup restore, `before-quit` teardown
- `electron/tray.test.ts` — unit tests for prefs + tray lifecycle (new)

### 2. Terminal overlay no longer covers hidden panes
A keep-alive terminal hidden as an inactive tab keeps its layout box (`visibility: hidden`), so its measured rect was indistinguishable from the active tab's and the fixed overlay kept painting over the pane that replaced it. The overlay now detects the `[data-pane-hidden]` ancestor marker and reports a 0×0 rect so it retreats. Addresses #73385.

## Test Plan
- `vitest run --project electron electron/tray.test.ts` — 5/5 pass
- `tsc --noEmit` (electron + renderer projects) — clean
- Manually verified on Windows: close → window hides, process stays alive with tray icon; tray click restores; tray **Quit** exits and removes the icon

## Notes
- Tray is **default-on** (no prefs file yet → enabled), matching the "closing the window must not kill the process" requirement; a prefs toggle is wired via `hermes:tray:set` for a future settings entry.
- Tray creation requires the app to be ready; startup restore defers via `app.whenReady()`.