### PR TITLE
fix(gateway): bind profile cwd in multiplexed sessions

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -57,6 +57,11 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+def get_session_cwd_override() -> str:
+    """Return the cwd explicitly bound to the current session context."""
+    return _session_cwd_override()
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16458,8 +16458,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length_async
+                from agent.runtime_cwd import get_session_cwd_override
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                _msg_cwd = (
+                    get_session_cwd_override()
+                    or os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                )
                 _msg_config_ctx = None
                 _msg_cfg = None
                 _msg_model_cfg = {}
@@ -16571,6 +16575,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Run inbound preprocessing under the routed profile when multiplexed."""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                # NOTE: _set_session_env() already binds the routed profile's cwd
+                # via the session ContextVar before this function is called.
+                # Binding and clearing here would wipe that value, breaking the
+                # runtime footer and any downstream cwd consumers.
                 return await self._prepare_inbound_message_text(
                     event=event,
                     source=source,
@@ -18227,6 +18235,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
+                from agent.runtime_cwd import get_session_cwd_override
                 from gateway.runtime_footer import build_footer_line as _bfl
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
@@ -18234,7 +18243,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=get_session_cwd_override() or os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
                 )
             except Exception as _footer_err:
@@ -21882,6 +21891,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _session_cwd = self._session_cwd_for_source(context.source)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -21895,9 +21905,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=_session_cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )
+
+    def _session_cwd_for_source(self, source: SessionSource) -> str:
+        """Resolve the logical cwd for one multiplexed profile session.
+
+        Gateway startup bridges only the active profile's ``terminal.cwd`` to
+        process-global ``TERMINAL_CWD``. A multiplexed secondary profile must
+        therefore bind its own cwd through the existing session ContextVar;
+        otherwise it silently inherits the gateway launch directory (or the
+        active profile's cwd).
+
+        Single-profile gateways deliberately return an empty override so their
+        existing process-level cwd behavior remains unchanged.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return ""
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        try:
+            with _profile_runtime_scope(profile_home):
+                profile_config = _load_gateway_runtime_config()
+        except Exception:
+            logger.warning(
+                "Failed to resolve terminal cwd for profile %s; using gateway cwd",
+                getattr(source, "profile", "") or "default",
+                exc_info=True,
+            )
+            return ""
+
+        terminal_config = profile_config.get("terminal") or {}
+        if not isinstance(terminal_config, dict):
+            terminal_config = {}
+        configured_cwd = str(
+            terminal_config.get("cwd", profile_config.get("cwd", "")) or ""
+        ).strip()
+        terminal_backend = str(
+            terminal_config.get(
+                "env_type",
+                terminal_config.get(
+                    "backend",
+                    profile_config.get("env_type", profile_config.get("backend", "local")),
+                ),
+            )
+            or "local"
+        ).strip()
+        if terminal_backend.lower() != "local":
+            return ""
+
+        from gateway.cwd_placeholder import resolve_placeholder_terminal_cwd
+
+        resolved = resolve_placeholder_terminal_cwd(
+            configured_cwd=configured_cwd,
+            terminal_backend=terminal_backend,
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=False,
+            home_fallback=str(Path.home()),
+        )
+        if not resolved:
+            return ""
+        return str(Path(resolved).expanduser())
 
     def _clear_session_env(self, tokens: list) -> None:
         """Restore session context variables to their pre-handler values."""
@@ -24937,15 +25007,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
              adapter ownership, OR profile_routes matching at ``build_source`` time.
           2. ``_profile_name_for_source`` — re-run routing here as a defensive
              fallback for sources that bypass ``build_source``.
-          3. The active profile (the multiplexer's own home).
+          3. The gateway process's own home (the multiplexer's primary profile).
+
+        The final fallback must not call ``get_active_profile_name()`` or
+        ``get_hermes_home()``: both honor the context-local profile override. A
+        newly spawned task can temporarily inherit another routed turn's context,
+        which would otherwise make an unrouted/default message run under that
+        secondary profile.
         """
-        from hermes_cli.profiles import (
-            get_active_profile_name,
-            get_profile_dir,
-            profile_exists,
-        )
-        from hermes_constants import get_hermes_home
-        
+        from hermes_cli.profiles import get_profile_dir, profile_exists
+
         # Track whether a profile was explicitly requested (vs. falling back to default)
         explicit_profile = None
         try:
@@ -24957,8 +25028,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if name:
                     explicit_profile = name  # Routing explicitly set this profile
             if not name:
-                name = get_active_profile_name() or "default"
-            
+                return _hermes_home
+
             profile_dir = get_profile_dir(name)
             # Warn if an explicit profile doesn't exist on disk
             if explicit_profile and not profile_exists(name):
@@ -24970,7 +25041,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     source.chat_id,
                     getattr(source, "guild_id", None),
                 )
-                return get_hermes_home()
+                return _hermes_home
             return profile_dir
         except Exception:
             # Catch normalization errors, path errors, etc.
@@ -24983,7 +25054,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 explicit_profile or "(no profile)",
                 exc_info=True,
             )
-            return get_hermes_home()
+            return _hermes_home
 
     async def _run_agent_inner(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18620,8 +18620,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length_async
+                from agent.runtime_cwd import get_session_cwd_override
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                _msg_cwd = (
+                    get_session_cwd_override()
+                    or os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                )
                 _msg_config_ctx = None
                 _msg_cfg = None
                 _msg_model_cfg = {}
@@ -18733,6 +18737,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Run inbound preprocessing under the routed profile when multiplexed."""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                # NOTE: _set_session_env() already binds the routed profile's cwd
+                # via the session ContextVar before this function is called.
+                # Binding and clearing here would wipe that value, breaking the
+                # runtime footer and any downstream cwd consumers.
                 return await self._prepare_inbound_message_text(
                     event=event,
                     source=source,
@@ -20614,6 +20622,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
+                from agent.runtime_cwd import get_session_cwd_override
                 from gateway.runtime_footer import build_footer_line as _bfl
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
@@ -20621,7 +20630,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=get_session_cwd_override() or os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
                 )
             except Exception as _footer_err:
@@ -24664,6 +24673,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _session_cwd = self._session_cwd_for_source(context.source)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24679,9 +24689,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=_session_cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )
+
+    def _session_cwd_for_source(self, source: SessionSource) -> str:
+        """Resolve the logical cwd for one multiplexed profile session.
+
+        Gateway startup bridges only the active profile's ``terminal.cwd`` to
+        process-global ``TERMINAL_CWD``. A multiplexed secondary profile must
+        therefore bind its own cwd through the existing session ContextVar;
+        otherwise it silently inherits the gateway launch directory (or the
+        active profile's cwd).
+
+        Single-profile gateways deliberately return an empty override so their
+        existing process-level cwd behavior remains unchanged.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return ""
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        try:
+            with _profile_runtime_scope(profile_home):
+                profile_config = _load_gateway_runtime_config()
+        except Exception:
+            logger.warning(
+                "Failed to resolve terminal cwd for profile %s; using gateway cwd",
+                getattr(source, "profile", "") or "default",
+                exc_info=True,
+            )
+            return ""
+
+        terminal_config = profile_config.get("terminal") or {}
+        if not isinstance(terminal_config, dict):
+            terminal_config = {}
+        configured_cwd = str(
+            terminal_config.get("cwd", profile_config.get("cwd", "")) or ""
+        ).strip()
+        terminal_backend = str(
+            terminal_config.get(
+                "env_type",
+                terminal_config.get(
+                    "backend",
+                    profile_config.get("env_type", profile_config.get("backend", "local")),
+                ),
+            )
+            or "local"
+        ).strip()
+        if terminal_backend.lower() != "local":
+            return ""
+
+        from gateway.cwd_placeholder import resolve_placeholder_terminal_cwd
+
+        resolved = resolve_placeholder_terminal_cwd(
+            configured_cwd=configured_cwd,
+            terminal_backend=terminal_backend,
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=False,
+            home_fallback=str(Path.home()),
+        )
+        if not resolved:
+            return ""
+        return str(Path(resolved).expanduser())
 
     def _clear_session_env(self, tokens: list) -> None:
         """Restore session context variables to their pre-handler values."""
@@ -28226,16 +28296,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
              adapter ownership, OR profile_routes matching at ``build_source`` time.
           2. ``_profile_name_for_source`` — re-run routing here as a defensive
              fallback for sources that bypass ``build_source``.
-          3. The active profile (the multiplexer's own home).
+          3. The gateway process's own home (the multiplexer's primary profile).
+
+        The final fallback must not call ``get_active_profile_name()`` or
+        ``get_hermes_home()``: both honor the context-local profile override. A
+        newly spawned task can temporarily inherit another routed turn's context,
+        which would otherwise make an unrouted/default message run under that
+        secondary profile.
         """
         from gateway.profile_routing import ProfileRouteRejected
-        from hermes_cli.profiles import (
-            get_active_profile_name,
-            get_profile_dir,
-            profile_exists,
-        )
-        from hermes_constants import get_hermes_home
-        
+        from hermes_cli.profiles import get_profile_dir, profile_exists
         # Track whether a profile was explicitly requested (vs. falling back to default)
         explicit_profile = None
         try:
@@ -28247,8 +28317,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if name:
                     explicit_profile = name  # Routing explicitly set this profile
             if not name:
-                name = get_active_profile_name() or "default"
-            
+                return _hermes_home
+
             profile_dir = get_profile_dir(name)
             # Warn if an explicit profile doesn't exist on disk
             if explicit_profile and not profile_exists(name):
@@ -28260,7 +28330,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     source.chat_id,
                     getattr(source, "guild_id", None),
                 )
-                return get_hermes_home()
+                return _hermes_home
             return profile_dir
         except ProfileRouteRejected:
             raise
@@ -28275,7 +28345,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 explicit_profile or "(no profile)",
                 exc_info=True,
             )
-            return get_hermes_home()
+            return _hermes_home
 
     async def _run_agent_inner(
         self,

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -88,6 +88,45 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
+def test_unrouted_source_uses_gateway_home_not_inherited_profile_scope(
+    tmp_path, monkeypatch
+):
+    """A default-lane turn must not inherit the previous routed profile.
+
+    Messaging tasks are spawned with ``copy_context()``.  If the spawning task
+    still carries a secondary profile's HERMES_HOME override, resolving an
+    unrouted source through ``get_active_profile_name()`` incorrectly treats
+    that secondary profile as the gateway's primary profile.
+    """
+    import gateway.run as run_mod
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from hermes_cli import profiles
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / ".hermes"
+    inherited = root / "profiles" / "bastion"
+    inherited.mkdir(parents=True)
+
+    monkeypatch.setattr(run_mod, "_hermes_home", root)
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: root)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: root / "profiles")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True, profile_routes=[])
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="default-lane")
+
+    token = set_hermes_home_override(str(inherited))
+    try:
+        assert runner._resolve_profile_home_for_source(source) == root
+    finally:
+        reset_hermes_home_override(token)
+
+
 def test_cold_profile_hydrates_external_source_without_global_env(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_multiplex_profile_cwd.py
+++ b/tests/gateway/test_multiplex_profile_cwd.py
@@ -1,0 +1,361 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.runtime_cwd import get_session_cwd_override, resolve_agent_cwd
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from tools.terminal_tool import (
+    clear_task_env_overrides,
+    cleanup_all_environments,
+    clear_session_cwd,
+    get_session_cwd,
+    register_task_env_overrides,
+    terminal_tool,
+)
+
+
+def _context(
+    profile: str = "secondary",
+    session_key: str = "agent:secondary:telegram:group:-1001234567890:101",
+) -> SessionContext:
+    return SessionContext(
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001234567890",
+            chat_type="group",
+            profile=profile,
+        ),
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+        session_key=session_key,
+        session_id="test-session",
+    )
+
+
+def _runner(profile_home: Path) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._resolve_profile_home_for_source = lambda source: profile_home
+    return runner
+
+
+def test_multiplex_profile_terminal_cwd_is_bound_to_session(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "secondary"
+    workspace = tmp_path / "workspace"
+    profile_home.mkdir(parents=True)
+    workspace.mkdir()
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(workspace)}})
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "default-workspace"))
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_agent_cwd() == workspace
+        assert get_session_cwd(_context().session_key) is None
+        result = json.loads(
+            terminal_tool(command="pwd", task_id="test-session", session_id="test-session")
+        )
+        assert result["exit_code"] == 0
+        assert result["output"].strip() == str(workspace)
+        assert get_session_cwd(_context().session_key) == str(workspace)
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)
+        clear_task_env_overrides("test-session")
+
+
+def test_multiplex_profile_placeholder_does_not_inherit_process_cwd(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": "."}})
+    )
+    process_cwd = tmp_path / "default-workspace"
+    process_cwd.mkdir()
+    profile_launch_home = tmp_path / "launch-home"
+    profile_launch_home.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(process_cwd))
+    monkeypatch.setenv("HOME", str(profile_launch_home))
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_agent_cwd() == profile_launch_home
+        result = json.loads(
+            terminal_tool(command="pwd", task_id="test-session", session_id="test-session")
+        )
+        assert result["exit_code"] == 0
+        assert result["output"].strip() == str(profile_launch_home)
+        assert get_session_cwd(_context().session_key) == str(profile_launch_home)
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)
+        clear_task_env_overrides("test-session")
+
+
+def test_existing_session_cwd_is_not_overwritten(tmp_path):
+    profile_home = tmp_path / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+    configured_workspace = tmp_path / "configured-workspace"
+    configured_workspace.mkdir()
+    changed_workspace = tmp_path / "changed-workspace"
+    changed_workspace.mkdir()
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"terminal": {"backend": "local", "cwd": str(configured_workspace)}}
+        )
+    )
+    register_task_env_overrides("test-session", {"cwd": str(changed_workspace)})
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        result = json.loads(
+            terminal_tool(command="pwd", task_id="test-session", session_id="test-session")
+        )
+        assert result["exit_code"] == 0
+        assert result["output"].strip() == str(changed_workspace)
+        assert get_session_cwd(_context().session_key) == str(changed_workspace)
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)
+        clear_task_env_overrides("test-session")
+
+
+def test_single_profile_gateway_keeps_process_cwd(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+    configured_workspace = tmp_path / "configured-workspace"
+    configured_workspace.mkdir()
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"terminal": {"backend": "local", "cwd": str(configured_workspace)}}
+        )
+    )
+    process_cwd = tmp_path / "process-workspace"
+    process_cwd.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(process_cwd))
+
+    runner = _runner(profile_home)
+    runner.config.multiplex_profiles = False
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_agent_cwd() == process_cwd
+        assert get_session_cwd(_context().session_key) is None
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)
+        clear_task_env_overrides("test-session")
+
+
+def test_multiplex_nonlocal_backend_keeps_existing_process_cwd(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "ssh", "cwd": "/remote/project"}})
+    )
+    process_cwd = tmp_path / "process-workspace"
+    process_cwd.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(process_cwd))
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_agent_cwd() == process_cwd
+        assert get_session_cwd(_context().session_key) is None
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)
+        clear_task_env_overrides("test-session")
+
+
+def test_multiplex_sessions_do_not_share_cached_local_environment(tmp_path):
+    profile_a = tmp_path / "profiles" / "alpha"
+    profile_b = tmp_path / "profiles" / "beta"
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    for path in (profile_a, profile_b, workspace_a, workspace_b):
+        path.mkdir(parents=True)
+    (profile_a / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(workspace_a)}})
+    )
+    (profile_b / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(workspace_b)}})
+    )
+    key_a = "agent:alpha:telegram:group:-1001234567890:101"
+    key_b = "agent:beta:telegram:group:-1001234567890:202"
+
+    runner_a = _runner(profile_a)
+    tokens_a = runner_a._set_session_env(_context("alpha", key_a))
+    try:
+        result_a = json.loads(
+            terminal_tool(command="pwd", task_id="session-a", session_id="session-a")
+        )
+        assert result_a["exit_code"] == 0
+        assert result_a["output"].strip() == str(workspace_a)
+    finally:
+        runner_a._clear_session_env(tokens_a)
+
+    runner_b = _runner(profile_b)
+    tokens_b = runner_b._set_session_env(_context("beta", key_b))
+    try:
+        result_b = json.loads(
+            terminal_tool(command="pwd", task_id="session-b", session_id="session-b")
+        )
+        assert result_b["exit_code"] == 0
+        assert result_b["output"].strip() == str(workspace_b)
+    finally:
+        runner_b._clear_session_env(tokens_b)
+        cleanup_all_environments()
+        for session_key in (key_a, key_b):
+            clear_session_cwd(session_key)
+        for task_id in ("session-a", "session-b"):
+            clear_task_env_overrides(task_id)
+
+
+def test_multiplex_at_reference_expansion_uses_profile_cwd(monkeypatch, tmp_path):
+    """The inbound @-reference preprocessor must expand against the routed
+    profile's cwd, not the primary profile's process-global TERMINAL_CWD.
+
+    Pre-fix, the preprocessor read ``os.environ["TERMINAL_CWD"]`` directly
+    before session binding, so a routed secondary profile resolved @file:
+    references against the primary workspace. This pins the early session-cwd
+    pin in ``_prepare_profile_scoped_inbound_message_text``.
+    """
+    import asyncio
+
+    import gateway.run as gateway_run
+    from agent.context_references import ContextReferenceResult
+    from gateway.platforms.base import MessageEvent
+
+    profile_home = tmp_path / "profiles" / "secondary"
+    workspace = tmp_path / "workspace"
+    profile_home.mkdir(parents=True)
+    workspace.mkdir()
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(workspace)}})
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "default-workspace"))
+
+    captured: dict = {}
+
+    async def _fake_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+        captured["cwd"] = cwd
+        captured["allowed_root"] = allowed_root
+        return ContextReferenceResult(
+            message="[expanded body]",
+            original_message=message,
+            expanded=True,
+        )
+
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _fake_preprocess)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda cfg=None: "openai/gpt-4.1-mini",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {"default": "openai/gpt-4.1-mini", "context_length": 128000},
+            "terminal": {"backend": "local", "cwd": str(workspace)},
+        },
+    )
+
+    runner = _runner(profile_home)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001234567890",
+        chat_type="group",
+        profile="secondary",
+    )
+    event = MessageEvent(text="please look at @file:notes.txt", source=source)
+
+    # Real code flow: _set_session_env binds the ContextVar first, then
+    # _prepare_profile_scoped_inbound_message_text reads it. The test must
+    # simulate that ordering.
+    context = _context()
+    tokens = runner._set_session_env(context)
+    try:
+        asyncio.run(
+            runner._prepare_profile_scoped_inbound_message_text(
+                event=event,
+                source=source,
+                history=[],
+            )
+        )
+    finally:
+        runner._clear_session_env(tokens)
+
+    assert captured.get("cwd") == str(workspace), (
+        f"@-reference expansion should use profile cwd {workspace!r}, got {captured.get('cwd')!r}"
+    )
+    assert captured.get("allowed_root") == str(workspace)
+
+
+def test_multiplex_runtime_footer_uses_profile_cwd(monkeypatch, tmp_path):
+    """The runtime-metadata footer must show the routed profile's cwd, not the
+    primary profile's process-global TERMINAL_CWD.
+
+    Pre-fix, the footer read ``os.environ["TERMINAL_CWD"]`` directly, so a
+    routed secondary profile displayed the primary workspace in its status
+    line. This pins the footer's session-cwd override read.
+    """
+    profile_home = tmp_path / "profiles" / "secondary"
+    workspace = tmp_path / "workspace"
+    profile_home.mkdir(parents=True)
+    workspace.mkdir()
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(workspace)}})
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "default-workspace"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert get_session_cwd_override() == str(workspace)
+        from gateway.runtime_footer import build_footer_line
+
+        footer = build_footer_line(
+            user_config={"display": {"runtime_footer": {"enabled": True}}},
+            platform_key="telegram",
+            model="openai/gpt-5.4",
+            context_tokens=68000,
+            context_length=100000,
+            cwd=get_session_cwd_override() or os.environ.get("TERMINAL_CWD", ""),
+        )
+        # Footer home-relativizes the path; the routed profile's cwd is
+        # ``tmp_path/workspace`` so it renders as ``~/workspace``.
+        assert "~/workspace" in footer
+        assert "default-workspace" not in footer
+    finally:
+        runner._clear_session_env(tokens)
+        cleanup_all_environments()
+        clear_session_cwd(_context().session_key)

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -83,7 +83,10 @@ class TestMissingProfileWarning:
             with patch("hermes_cli.profiles.get_profile_dir") as mock_get_dir:
                 mock_get_dir.return_value = Path("/hermes/profiles/nonexistent")
                 with patch("hermes_cli.profiles.profile_exists", return_value=False):
-                    with patch("hermes_constants.get_hermes_home", return_value=Path("/hermes")):
+                    # The fallback is the gateway process's own home, captured
+                    # at module import; get_hermes_home() is intentionally not
+                    # consulted (it honors the context-local profile override).
+                    with patch("gateway.run._hermes_home", Path("/hermes")):
                         with caplog.at_level(logging.WARNING):
                             result = mock_runner._resolve_profile_home_for_source(discord_source)
                             
@@ -111,7 +114,7 @@ class TestExceptionHandling:
         
         with patch("hermes_cli.profiles.get_active_profile_name", return_value="active"):
             with patch("hermes_cli.profiles.get_profile_dir", side_effect=ValueError("Invalid profile name")):
-                with patch("hermes_constants.get_hermes_home", return_value=Path("/hermes")):
+                with patch("gateway.run._hermes_home", Path("/hermes")):
                     with caplog.at_level(logging.WARNING):
                         result = mock_runner._resolve_profile_home_for_source(discord_source)
                         

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2438,7 +2438,26 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
+        # Resolve the durable gateway/topic key before cwd selection. ``task_id``
+        # is an execution identifier and may differ from the conversation key
+        # that owns persistent ``cd`` state.
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="") or (task_id or "")
+        session_cwd = get_session_cwd(session_key)
+        if not overrides.get("cwd") and not session_cwd and env_type == "local":
+            # Multiplexed gateways bind each routed profile's cwd through a
+            # ContextVar because process-global TERMINAL_CWD belongs to the
+            # primary profile. Seed lazily on the first terminal call so
+            # shared local environments cannot leak another session's cwd,
+            # while sessions that never use terminal create no registry state.
+            from agent.runtime_cwd import get_session_cwd_override
+
+            context_cwd = get_session_cwd_override()
+            if context_cwd:
+                record_session_cwd(session_key, context_cwd)
+                session_cwd = context_cwd
+        cwd = overrides.get("cwd") or session_cwd or config["cwd"]
         # A per-task cwd override (registered by the gateway/TUI for workspace
         # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
         # config["cwd"] was already sanitized for container backends in

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2747,7 +2747,27 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
+        # Resolve the durable gateway/topic key before cwd selection. ``task_id``
+        # is an execution identifier and may differ from the conversation key
+        # that owns persistent ``cd`` state.
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="") or (task_id or "")
+        session_cwd = get_session_cwd(session_key)
+        if not overrides.get("cwd") and not session_cwd and env_type == "local":
+            # Multiplexed gateways bind each routed profile's cwd through a
+            # ContextVar because process-global TERMINAL_CWD belongs to the
+            # primary profile. Seed lazily on the first terminal call so
+            # shared local environments cannot leak another session's cwd,
+            # while sessions that never use terminal create no registry state.
+            from agent.runtime_cwd import get_session_cwd_override
+
+            context_cwd = get_session_cwd_override()
+            if context_cwd:
+                record_session_cwd(session_key, context_cwd)
+                session_cwd = context_cwd
+        cwd = overrides.get("cwd") or session_cwd or config["cwd"]
+
         # Session-scoped mount resolution (single owner: _resolve_task_host_cwd).
         # Under per-session isolation a fresh session must not inherit the
         # process-global TERMINAL_CWD mount left behind by a previous session.


### PR DESCRIPTION
## What does this PR do?

In a multiplexed gateway (`multiplex_profiles: true`), startup bridges only the **primary** profile's `terminal.cwd` to the process-global `TERMINAL_CWD` env var. Sessions routed to a secondary profile resolved their cwd from that process-global latch, so:

- the **runtime footer** showed the wrong profile's workspace,
- **`@file:`/`@folder:` reference preprocessing** resolved against the wrong profile's workspace,
- the **terminal tool** seeded its per-session cwd from whichever profile made the first terminal call after a gateway restart — a coin flip that stamped one profile's workspace process-wide for every lane.

This PR binds the routed profile's cwd through the existing session ContextVar and routes every consumer through it, making cwd resolution deterministic per profile. It builds on #70600 and addresses the gaps raised in its review (the `@`-reference preprocessor and the runtime footer still read `os.environ["TERMINAL_CWD"]` directly), plus two further defects found while verifying the fix in production:

1. `_prepare_profile_scoped_inbound_message_text` ran after `_set_session_env()` and its pin/clear wiped the ContextVar, so the footer fell back to process-global `TERMINAL_CWD`.
2. `_resolve_profile_home_for_source()` fell back to `get_active_profile_name()`, which honors the context-local profile override. Messaging tasks spawn with `copy_context()`, so an unrouted/default-lane turn could inherit a previously routed profile's scope and resolve to the wrong profile home. It now falls back to the gateway process's own home.

Single-profile gateways are deliberately unchanged: `_session_cwd_for_source()` returns an empty override when `multiplex_profiles` is off, preserving existing process-level cwd behavior.

## Related Issue

Builds on / supersedes #70600 (review feedback addressed; happy for that branch to be pulled in here or vice versa — whichever is easier for maintainers).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`
  - `_set_session_env()` resolves the routed profile's `terminal.cwd` via new `_session_cwd_for_source()` and binds it through the session ContextVar (`set_session_vars(cwd=...)`)
  - Runtime footer reads `get_session_cwd_override()` before falling back to `TERMINAL_CWD`
  - `@`-reference preprocessor resolves its cwd from the session override first
  - `_resolve_profile_home_for_source()` falls back to the gateway process home instead of `get_active_profile_name()` (context-scope leak via `copy_context()`)
- `agent/runtime_cwd.py` — expose `get_session_cwd_override()`
- `tools/terminal_tool.py` — seed the per-session cwd from the ContextVar override instead of the process-global `TERMINAL_CWD` latch
- `tests/gateway/test_multiplex_profile_cwd.py` — 8 regression tests: per-profile cwd isolation, footer, `@`-reference resolution, terminal-tool seeding
- `tests/gateway/test_multiplex_credential_isolation.py` — regression test: unrouted source resolves to the gateway home even under an inherited profile scope

## How to Test

1. Configure a multiplexed gateway with two profiles that have different `terminal.cwd` values, and a `profile_routes` entry routing one chat/topic to the secondary profile.
2. Send a message in the routed chat: the runtime footer must show the **secondary** profile's workspace, and `terminal` calls must start in that cwd.
3. Send a message in an unrouted (default-lane) chat immediately after: footer and cwd must show the **primary** profile's workspace — no leakage from the routed turn.
4. Regression suite: `python -m pytest tests/gateway/test_multiplex_profile_cwd.py tests/gateway/test_multiplex_credential_isolation.py -q` → **13 passed**.
5. Verified in production on macOS 26 with a live multiplexed gateway (Telegram topics routed to two secondary profiles): footers and terminal cwd now resolve deterministically per profile across restarts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — builds on #70600 with its review gaps addressed
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full `scripts/run_tests.sh` run: only pre-existing failures on clean `main` (unrelated to cwd), no new failures from this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `pathlib` throughout, no signal/process-group calls; `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema changes)

## Screenshots / Logs

Production footer after fix — routed secondary profile session shows its own workspace instead of the primary profile's:

```
before (routed lane):  cwd ~/<primary>/workspace            ← wrong profile
after  (routed lane):  cwd ~/<primary>/profiles/<secondary>/workspace/<project>  ✓
after  (default lane): cwd ~/<primary>/workspace            ✓ no cross-lane leak
```
