### PR TITLE
fix(cli): resolve the desktop-entry Exec independently of argv[0]

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,16 +57,48 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
-def resolve_exec_command() -> str:
+def _is_inside_checkout(path: Optional[str], project_root: Optional[Path]) -> bool:
+    """True when ``path`` lives inside the source checkout.
+
+    An entry point inside the checkout is the bare ``hermes`` launcher
+    script, not an installed wrapper. It runs under ``/usr/bin/env
+    python3`` and leans on the caller's interpreter and ``sys.path`` to
+    import ``hermes_cli``; a cold desktop-menu launch supplies neither.
+    """
+    if not path or project_root is None:
+        return False
+    try:
+        Path(path).resolve().relative_to(Path(project_root).resolve())
+    except (ValueError, OSError):
+        return False
+    return True
+
+
+def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
     Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
     runs as a module with no launcher installed, use the current
     interpreter, also absolute.
+
+    ``resolve_hermes_bin()`` ranks ``sys.argv[0]`` first. That is right
+    for re-exec'ing *this* process, where argv[0] is runnable by
+    construction, and wrong for a value written to disk and run later by
+    the desktop environment. When this entry is what launched us, argv[0]
+    is the checkout's bare ``hermes`` script, so baking it back into
+    ``Exec`` breaks every later menu launch and never heals. It also makes
+    the rendered contents alternate between the wrapper and the script,
+    which defeats the unchanged-contents check below and rewrites the
+    entry on every other launch (#80439). Discard a checkout-internal
+    entry point and fall through to PATH, then to the interpreter.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
+    if _is_inside_checkout(bin_path, project_root):
+        bin_path = shutil.which("hermes")
+        if _is_inside_checkout(bin_path, project_root):
+            bin_path = None
     if bin_path:
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
@@ -154,7 +186,10 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
     # Use the themed name when the checkout has no icon (a lite or
     # packaged install). A broken absolute path renders as no icon.
     icon_value = str(icon) if icon.is_file() else "hermes"
-    contents = render_desktop_entry(resolve_exec_command(), icon_value)
+    contents = render_desktop_entry(resolve_exec_command(project_root), icon_value)
+    # Imported inside the function so the module stays import-light for
+    # the uninstaller and the Electron main process.
+    from utils import atomic_write_text
 
     try:
         entry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -162,9 +197,15 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
         # churn the menu caches.
         if entry_path.is_file() and entry_path.read_text(encoding="utf-8") == contents:
             return entry_path
-        entry_path.write_text(contents, encoding="utf-8")
+        # Publish through the shared atomic writer: a truncate-then-write
+        # leaves a zero-length entry when the write is interrupted, which
+        # drops Hermes out of the menu and kills the taskbar pin for good.
+        # ``preserve_mode`` chmods the temp file before the replace, so an
+        # entry that is already 0o755 never transits mkstemp's 0o600.
+        atomic_write_text(entry_path, contents, preserve_mode=True, create_mode=0o755)
         # Some launchers (and older Plasma) offer the entry only when it
-        # is executable.
+        # is executable. Still forced here: preserve_mode carries over a
+        # mode the user (or an older Hermes) may have left non-executable.
         entry_path.chmod(0o755)
     except OSError:
         return None

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -9,7 +9,8 @@ Two values must be absolute for the entry to work:
 
   - ``Exec`` — the launcher runs without shell ``PATH`` customizations, so
     a bare ``hermes desktop`` fails when hermes lives in ``~/.local/bin``
-    or a venv. Resolve the real binary and write its full path.
+    or a venv. Write a full path, and one that does not itself go looking
+    for an interpreter on the session's ``PATH``.
   - ``Icon`` — an unqualified icon name needs an indexed icon theme. The
     spec allows an absolute path instead, so point at the app icon in the
     checkout. Do not copy the icon: ``Exec`` already depends on that tree.
@@ -74,6 +75,58 @@ def _is_inside_checkout(path: Optional[str], project_root: Optional[Path]) -> bo
     return True
 
 
+def _is_env_python_wrapper(path: str) -> bool:
+    """True when ``path`` picks its interpreter off ``PATH`` at exec time.
+
+    A ``#!/usr/bin/env python3`` shebang defers the interpreter choice to
+    whatever ``PATH`` holds when the script runs. The desktop session's
+    ``PATH`` is not the shell's, so such a wrapper can land on a system
+    interpreter with no Hermes venv on ``sys.path`` — the same stranded
+    entry ``_is_inside_checkout`` guards against, reached by shebang
+    instead of by location. A hand-written ``~/bin/hermes``, or a console
+    script from a non-venv editable install, fails that way while sitting
+    outside the checkout. An installed console script instead names its
+    own interpreter absolutely and carries no such dependency.
+
+    Require the shebang's program *basename* to be exactly ``env``, so a
+    hardcoded interpreter under a directory named ``envs`` does not match,
+    and require the command it runs to be a ``python*`` binary.
+    """
+    try:
+        with open(path, "rb") as handle:
+            shebang = handle.readline(256)
+    except OSError:
+        return False
+    if not shebang.startswith(b"#!"):
+        return False
+    tokens = shebang[2:].split()
+    if not tokens:
+        return False
+    if os.path.basename(tokens[0].decode("utf-8", "replace")) != "env":
+        return False
+    args = tokens[1:]
+    if args[:1] == [b"-S"]:
+        args = args[1:]
+    if not args:
+        return False
+    return os.path.basename(args[0].decode("utf-8", "replace")).startswith("python")
+
+
+def _is_durable_entry_point(path: Optional[str], project_root: Optional[Path]) -> bool:
+    """True when ``path`` is worth persisting into ``Exec=``.
+
+    Durable means it still starts Hermes months later from a cold menu
+    click, under the desktop session's own environment. Two ways to fail
+    that: living inside the checkout, and resolving ``python`` through
+    ``PATH``.
+    """
+    if not path:
+        return False
+    if _is_inside_checkout(path, project_root):
+        return False
+    return not _is_env_python_wrapper(path)
+
+
 def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
@@ -89,20 +142,32 @@ def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     ``Exec`` breaks every later menu launch and never heals. It also makes
     the rendered contents alternate between the wrapper and the script,
     which defeats the unchanged-contents check below and rewrites the
-    entry on every other launch (#80439). Discard a checkout-internal
-    entry point and fall through to PATH, then to the interpreter.
+    entry on every other launch (#80439). Discard a candidate that is not
+    durable and fall through to PATH, then to the interpreter.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
-    if _is_inside_checkout(bin_path, project_root):
+    if bin_path and not _is_durable_entry_point(bin_path, project_root):
+        # ``resolve_hermes_bin()`` already consulted PATH last, so only
+        # retry it when the candidate it returned came from argv[0].
         bin_path = shutil.which("hermes")
-        if _is_inside_checkout(bin_path, project_root):
+        if not _is_durable_entry_point(bin_path, project_root):
             bin_path = None
     if bin_path:
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        # Absolute, but NOT symlink-resolved. A venv's ``bin/python`` is a
+        # symlink to the base interpreter, and CPython decides it is inside
+        # a venv by looking for ``pyvenv.cfg`` beside the path it was
+        # *invoked* through. Dereferencing that symlink lands on the base
+        # interpreter — for a uv-created venv, under
+        # ``~/.local/share/uv/python/``, outside the venv entirely — so the
+        # venv's ``site-packages`` drops off ``sys.path`` and the persisted
+        # command cannot import ``hermes_cli`` at all. Every other site
+        # that spawns this same module keeps the invocation path:
+        # ``relaunch.py``, ``uninstall.py``, ``kanban_db.py``.
+        argv = [os.path.abspath(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import stat
 from pathlib import Path
 
 import pytest
 
+import utils
 from hermes_cli import linux_desktop_entry as lde
 
 
@@ -24,6 +26,25 @@ def _make_project(tmp_path: Path) -> Path:
     icon.parent.mkdir(parents=True)
     icon.write_bytes(b"\x89PNG fake")
     return root
+
+
+def _make_executable(path: Path) -> Path:
+    """Create an executable stand-in for a hermes entry point."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _fake_which(monkeypatch, hermes: "str | None") -> None:
+    """Pin ``shutil.which("hermes")``.
+
+    ``relaunch`` and this module share the one ``shutil`` module, so a
+    single patch covers both lookups.
+    """
+    monkeypatch.setattr(
+        lde.shutil, "which", lambda name: hermes if name == "hermes" else None
+    )
 
 
 def _parse(entry_text: str) -> dict:
@@ -88,6 +109,87 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+# ---------------------------------------------------------------------------
+# Exec must not depend on what launched this process (#80439)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
+    # The desktop entry launched us, so argv[0] is the checkout script.
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    _fake_which(monkeypatch, str(wrapper))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    expected = lde._quote_exec_arg(str(wrapper.resolve()))
+    assert exec_line == f"{expected} desktop"
+    assert str(checkout_script) not in exec_line
+
+
+def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The checkout's bare launcher runs under `/usr/bin/env python3` with
+    # no venv shim, so a cold menu launch cannot import hermes_cli through
+    # it. Persisting it strands the entry permanently.
+    assert str(checkout_script) not in exec_line
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+    assert Path(exec_line.split(" ")[0]).is_absolute()
+
+
+def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(tmp_path / "opt" / "bin" / "hermes")
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Only checkout-internal entry points are rejected. An installed
+    # wrapper reached through argv[0] is still the best value to persist.
+    expected = lde._quote_exec_arg(str(wrapper.resolve()))
+    assert exec_line == f"{expected} desktop"
+
+
+def test_entry_is_stable_across_a_relaunch_through_itself(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
+    _fake_which(monkeypatch, str(wrapper))
+    refreshes: list[Path] = []
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda d: refreshes.append(d) or [])
+
+    # Launch one: from a terminal, through the installed wrapper.
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    entry = lde.install_desktop_entry(root)
+    first = entry.read_text(encoding="utf-8")
+    assert len(refreshes) == 1
+
+    # Launch two: the menu runs the entry, so argv[0] is now whatever the
+    # entry pointed at. Feed back the worst case.
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    lde.install_desktop_entry(root)
+
+    assert entry.read_text(encoding="utf-8") == first
+    # No rewrite means no menu-cache churn, so Plasma keeps the taskbar
+    # pin associated with this entry instead of spawning a second window.
+    assert len(refreshes) == 1
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
@@ -100,6 +202,43 @@ def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monke
     # Unchanged content → no rewrite, no menu-cache churn on every launch.
     lde.install_desktop_entry(root)
     assert len(calls) == 1
+
+
+def test_install_publishes_atomically_and_leaves_no_temp(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+    entry = lde.install_desktop_entry(root)
+    # Change the rendered contents so this is a real overwrite, not the
+    # unchanged-contents fast path.
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/opt/hermes/bin/hermes")
+    assert lde.install_desktop_entry(root) == entry
+
+    assert list(entry.parent.iterdir()) == [entry]
+    assert _parse(entry.read_text(encoding="utf-8"))["Exec"] == "/opt/hermes/bin/hermes desktop"
+    assert stat.S_IMODE(entry.stat().st_mode) == 0o755
+
+
+def test_failed_publish_leaves_the_existing_entry_intact(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+
+    entry = lde.install_desktop_entry(root)
+    published = entry.read_text(encoding="utf-8")
+
+    def boom(_tmp, _target):
+        raise OSError(errno.EIO, "the disk went away mid-publish")
+
+    monkeypatch.setattr(utils, "atomic_replace", boom)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/opt/hermes/bin/hermes")
+
+    assert lde.install_desktop_entry(root) is None
+    # A truncate-then-write would have left a partial or zero-length
+    # entry here, dropping Hermes out of the menu and killing the pin.
+    assert entry.read_text(encoding="utf-8") == published
+    assert list(entry.parent.iterdir()) == [entry]
 
 
 def test_install_without_source_icon_uses_themed_name(tmp_path, xdg_home, monkeypatch):

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import os
 import stat
 from pathlib import Path
 
@@ -28,10 +29,18 @@ def _make_project(tmp_path: Path) -> Path:
     return root
 
 
-def _make_executable(path: Path) -> Path:
+#: What an installed console script's shebang looks like: its own
+#: interpreter, hardcoded absolute, with no ``PATH`` lookup at exec time.
+INSTALLED_SHEBANG = "#!/opt/hermes/venv/bin/python3\n"
+#: What the checkout's bare ``hermes`` launcher looks like: the
+#: interpreter is whatever ``PATH`` yields when the script runs.
+ENV_PYTHON_SHEBANG = "#!/usr/bin/env python3\n"
+
+
+def _make_executable(path: Path, shebang: str = INSTALLED_SHEBANG) -> Path:
     """Create an executable stand-in for a hermes entry point."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    path.write_text(shebang, encoding="utf-8")
     path.chmod(0o755)
     return path
 
@@ -116,7 +125,7 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 
 def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
     # The desktop entry launched us, so argv[0] is the checkout script.
     monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
@@ -133,7 +142,7 @@ def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monke
 
 def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
     _fake_which(monkeypatch, None)
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
@@ -149,6 +158,122 @@ def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home,
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation needs privileges on Windows")
+def test_exec_keeps_the_lexical_venv_interpreter_path(tmp_path, xdg_home, monkeypatch):
+    """The interpreter fallback persists the path Python was invoked
+    through, not the symlink target behind it.
+
+    A venv's ``bin/python`` is a symlink to a base interpreter, and CPython
+    decides it is inside a venv by finding ``pyvenv.cfg`` beside the
+    *invocation* path. A uv-created venv points that symlink at
+    ``~/.local/share/uv/python/...``, outside the venv, so a dereferenced
+    Exec starts an interpreter that has never heard of the venv's
+    ``site-packages`` and cannot import ``hermes_cli`` at all. Absolute is
+    not enough — the entry has to stay inside the venv.
+    """
+    root = _make_project(tmp_path)
+    base = tmp_path / "uv" / "python" / "cpython-3.11" / "bin" / "python3.11"
+    base.parent.mkdir(parents=True)
+    base.write_bytes(b"")
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base)
+    (venv_python.parent.parent / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Guard the fixture: this asserts nothing unless the interpreter really
+    # is a symlink pointing somewhere else.
+    assert venv_python.is_symlink()
+    assert os.path.realpath(venv_python) != str(venv_python)
+
+    assert exec_line == f"{lde._quote_exec_arg(str(venv_python))} -m hermes_cli.main desktop"
+    assert str(base) not in exec_line
+    # The reason the lexical path matters: pyvenv.cfg is beside it, so
+    # CPython still finds the venv. Beside the resolved target it is not.
+    persisted = Path(exec_line.split(" ", 1)[0])
+    assert (persisted.parent.parent / "pyvenv.cfg").is_file()
+
+
+def test_exec_rejects_env_python_wrapper_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
+    """A ``#!/usr/bin/env python3`` wrapper is not durable wherever it lives.
+
+    A hand-rolled ``~/bin/hermes``, or a console script from a non-venv
+    editable install, sits outside the checkout and so survives
+    ``_is_inside_checkout`` — yet it still looks up ``python3`` on ``PATH``
+    when it runs. A cold menu launch supplies the desktop session's
+    ``PATH``, not the shell's, and the interpreter it lands on need not
+    have Hermes on ``sys.path``. Rejecting by location alone is not enough.
+    """
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(tmp_path / "home" / "bin" / "hermes", ENV_PYTHON_SHEBANG)
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, str(wrapper))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert str(wrapper) not in exec_line
+    expected = lde._quote_exec_arg(os.path.abspath(lde.sys.executable))
+    assert exec_line == f"{expected} -m hermes_cli.main desktop"
+
+
+def test_exec_keeps_an_interpreter_under_a_directory_named_envs(tmp_path, xdg_home, monkeypatch):
+    """The shebang check keys off the program's basename, not a substring.
+
+    ``#!/home/u/envs/hermes/bin/python3`` hardcodes its interpreter — that
+    is what an installed console script looks like. Matching ``env``
+    loosely would discard it and drop back to the ambient interpreter for
+    no reason.
+    """
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(
+        tmp_path / "envs" / "hermes" / "bin" / "hermes",
+        "#!/home/u/envs/hermes/bin/python3\n",
+    )
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{lde._quote_exec_arg(str(wrapper.resolve()))} desktop"
+
+
+@pytest.mark.parametrize(
+    "first_bytes,expected",
+    [
+        (b"#!/usr/bin/env python3\n", True),
+        (b"#!/usr/bin/env python\n", True),
+        (b"#!/usr/bin/env -S python3 -u\n", True),
+        (b"#!/opt/hermes/venv/bin/python3\n", False),
+        (b"#!/home/u/envs/hermes/bin/python3\n", False),
+        (b"#!/usr/bin/env node\n", False),
+        (b"#!/bin/sh\n", False),
+        (b"#!/usr/bin/env\n", False),
+        (b"\x7fELF\x02\x01\x01\x00", False),
+        (b"", False),
+    ],
+)
+def test_env_python_wrapper_detection(tmp_path, first_bytes, expected):
+    candidate = tmp_path / "hermes"
+    candidate.write_bytes(first_bytes)
+    assert lde._is_env_python_wrapper(str(candidate)) is expected
+
+
+def test_env_python_wrapper_detection_tolerates_an_unreadable_candidate(tmp_path):
+    # An unreadable candidate is not evidence of a PATH dependency, and it
+    # must not raise on the launch path either.
+    assert lde._is_env_python_wrapper(str(tmp_path / "does-not-exist")) is False
+
+
 def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     wrapper = _make_executable(tmp_path / "opt" / "bin" / "hermes")
@@ -159,15 +284,16 @@ def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    # Only checkout-internal entry points are rejected. An installed
-    # wrapper reached through argv[0] is still the best value to persist.
+    # Only non-durable entry points are rejected. An installed wrapper
+    # that names its own interpreter is still the best value to persist,
+    # even when argv[0] is how we found it.
     expected = lde._quote_exec_arg(str(wrapper.resolve()))
     assert exec_line == f"{expected} desktop"
 
 
 def test_entry_is_stable_across_a_relaunch_through_itself(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
     _fake_which(monkeypatch, str(wrapper))
     refreshes: list[Path] = []


### PR DESCRIPTION
## This is a sibling follow-up to #76456 (commit `eea6044`)

- **What #76456 covered:** it introduced `hermes_cli/linux_desktop_entry.py`, giving `hermes desktop` a real XDG launcher presence — absolute `Exec`, absolute `Icon`, tool-gated menu-cache refresh, and an unchanged-contents guard so a launch does not churn the caches. All of that is right and stays.
- **What #76456 did not touch:** *which* absolute path gets persisted. It reuses `relaunch.resolve_hermes_bin()`, whose priority order was designed for re-exec, not for a value written to disk.
- **What this adds:** a durability filter on the persisted `Exec` — by location, by shebang, and by keeping the interpreter path lexical — plus an atomic publish of the entry file. Additive only: no restructuring of the module, and all 14 of its original tests still pass (two fixture shebangs were made explicit; no assertion was changed).

## What does this PR do?

Fixes both symptoms in #80439. They are one root cause, not two bugs.

`resolve_exec_command()` delegated to `relaunch.resolve_hermes_bin()`, which documents its own priority as **1.** `sys.argv[0]` if it resolves to a real executable, **2.** `shutil.which("hermes")`, **3.** `None`. That order is correct for `resolve_hermes_bin`'s actual job — re-exec'ing *this* process, where argv[0] is runnable by construction — and wrong as the source of a value baked into `~/.local/share/applications/hermes.desktop`, which the desktop environment executes later from a process that shares nothing with this one.

**Symptom 1 — the launcher goes permanently dead.** When the entry itself launches Hermes, argv[0] is the checkout's bare `hermes` script. That script is:

```python
#!/usr/bin/env python3
if __name__ == "__main__":
    from hermes_cli.main import main
```

— system `python3`, no venv shim, `hermes_cli` imported from the caller's `sys.path`. A terminal launch supplies that; a cold KDE/GNOME menu launch does not. `install_desktop_entry()` rewrites `Exec` to that path, and every subsequent menu launch dies at import. The entry never heals, because the failing launch never reaches the code that would rewrite it.

**Symptom 2 — the KDE taskbar pin breaks.** This falls out of symptom 1. `Exec` alternates between the installed wrapper (terminal launch) and the checkout script (menu launch), so the "skip the rewrite when contents are identical" guard never holds across alternating launches. The entry is rewritten and `kbuildsycoca6 --noincremental` re-run every other launch; Plasma drops the pin's association with the entry and the pinned icon opens a second window instead of focusing the first.

Fixing the `Exec` derivation makes the rendered contents converge to one stable value, which restores the idempotence guard and therefore fixes the pin. One change, both symptoms.

**Symptom 3 — the interpreter fallback lands outside its own venv.** Reported against this branch by @magicJie on a uv-created venv, and the same root cause one level down: a *per-invocation* fact being replaced by a *resolved* one. The fallback wrote `str(Path(sys.executable).resolve())`. `sys.executable` is `<venv>/bin/python`, a symlink into uv's standalone Python; CPython decides it is inside a venv by looking for `pyvenv.cfg` beside the path it was **invoked** through, not beside the symlink target. Dereferencing it produces

```text
/home/jay/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/bin/python3.11 -m hermes_cli.main desktop
```

— outside the venv, so `site-packages` is gone and the persisted command fails with `ModuleNotFoundError: No module named 'hermes_cli'`. Absolute was necessary but not sufficient; the path also has to stay *inside* the venv. Now `os.path.abspath(sys.executable)`. This module was the only production site in the repo dereferencing the interpreter — `relaunch.build_relaunch_argv`, `uninstall.py`'s per-profile invocation and `kanban_db.py`'s module-invocation helper all build this exact `-m hermes_cli.main` argv from a bare `sys.executable`, so the fix restores the module to the codebase's own convention.

**Also durable-but-not-checkout-internal: the `env python` shebang.** `_is_inside_checkout` rejects a candidate by *where it lives*. A hand-rolled `~/bin/hermes`, or a console script from a non-venv editable install, sits outside the checkout and was kept — yet it still resolves `python3` off `PATH` when the launcher runs it, which is symptom 1 reached by a different route (a cold menu launch supplies the desktop session's `PATH`, not the shell's). A candidate whose shebang program is `env` invoking a `python*` command is now rejected too. The check compares the shebang program's *basename* against `env` rather than substring-matching, so a real hardcoded interpreter under a directory named `envs` is still kept.

**Second, unrelated-to-argv0 but same durable artifact:** the entry was published with a bare `entry_path.write_text(...)`, a truncate-then-write. An interruption between truncate and write leaves a zero-length `hermes.desktop` — Hermes disappears from the menu and the pin dies for good. `utils.atomic_write_text`'s own docstring states it exists so "every destructive file rewrite in the codebase shares one implementation", so this call site was a deviation. It is now routed through the shared helper (same precedent as #79137 and #79746). `preserve_mode=True` keeps an already-`0o755` entry from transiting `mkstemp`'s `0o600`, and preserves the owner when a privileged process rewrites a user-owned file; the unconditional `chmod(0o755)` afterwards is retained because the module requires the entry to be executable regardless of the mode it previously had.

### Resolution precedence now persisted

1. `resolve_hermes_bin()` — unchanged, still argv[0] then PATH.
2. **If** that candidate is not durable — it lives inside `project_root`, or its shebang is `env` dispatching a `python*` — discard it and take `shutil.which("hermes")` instead; if that is also not durable, discard that too. (`resolve_hermes_bin()` already consults PATH last, so the retry only fires when the candidate came from argv[0].)
3. `os.path.abspath(sys.executable) -m hermes_cli.main desktop` — absolute, but **not** symlink-resolved, so a venv interpreter stays in its venv.

An installed wrapper reached *through* argv[0] (`~/.local/bin/hermes`, a venv shim, a nix store path) is still preferred — only the candidates that cannot start Hermes from a cold session are rejected. `tests/hermes_cli/test_relaunch.py` and `resolve_hermes_bin` itself are deliberately untouched: their argv[0]-first order is correct for re-exec and is pinned by 12 tests. The defect is persistence, not the helper.

## Related Issue

Fixes #80439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/linux_desktop_entry.py`

- New private `_is_inside_checkout(path, project_root)` — resolves both sides and reports whether an entry point lives inside the source tree. Returns `False` for `None`/empty and swallows only `ValueError`/`OSError` from `resolve()`/`relative_to()`.
- New private `_is_env_python_wrapper(path)` — reads at most 256 bytes, requires a `#!`, requires the program's *basename* to be exactly `env`, tolerates `env -S`, and requires the command it runs to start with `python`. An unreadable candidate returns `False`: absence of evidence is not evidence of a `PATH` dependency, and this runs on the launch path, so it must not raise.
- New private `_is_durable_entry_point(path, project_root)` — the two rejection clauses behind one name, so `resolve_exec_command` reads as one question asked twice.
- `resolve_exec_command()` takes an optional `project_root` and discards a non-durable candidate, falling through to PATH and then to the interpreter. Default stays `None`, so calling it with no argument preserves the old behaviour exactly.
- The interpreter fallback is `os.path.abspath(sys.executable)` rather than `str(Path(sys.executable).resolve())`. `os` is already imported at module scope.
- `install_desktop_entry()` passes its `project_root` through, and publishes via `utils.atomic_write_text(..., preserve_mode=True, create_mode=0o755)`. The `utils` import is function-local, matching the module's existing lazy-import idiom (`from hermes_cli.relaunch import ...`) so the module stays import-light for the uninstaller and the Electron main process, as its docstring promises.

`tests/hermes_cli/test_linux_desktop_entry.py` — 11 new tests (20 cases with parametrisation), placed beside the existing `test_exec_*` and install clusters. Helpers `_make_executable` and `_fake_which` added next to the existing `_make_project`/`_stub_tools`; `_make_executable` now takes the shebang so a test can say which kind of entry point it is standing up (`INSTALLED_SHEBANG` for a console script, `ENV_PYTHON_SHEBANG` for the checkout's launcher). No pre-existing assertion was changed.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_linux_desktop_entry.py -v
```

**Before → after, verified in both directions.** Applying the new test file to clean `main` (prod file untouched, run in a detached worktree) fails exactly the four regression tests, and passes on this branch:

| Test | On clean `main` | On this branch | Pins |
| --- | --- | --- | --- |
| `test_exec_prefers_path_wrapper_over_checkout_argv0` | ❌ `Exec` = checkout script | ✅ `Exec` = PATH wrapper | symptom 1 |
| `test_exec_rejects_checkout_argv0_when_no_wrapper_on_path` | ❌ `Exec` = checkout script | ✅ `Exec` = `<python> -m hermes_cli.main desktop` | symptom 1, the reporter's case |
| `test_entry_is_stable_across_a_relaunch_through_itself` | ❌ contents differ, cache refresh runs twice | ✅ byte-identical, refresh runs once | symptom 2 (the pin) |
| `test_failed_publish_leaves_the_existing_entry_intact` | ❌ returns the path; a real failure would truncate | ✅ returns `None`, prior entry byte-identical, no temp residue | atomic publish |
| `test_exec_accepts_argv0_outside_the_checkout` | ✅ | ✅ | guard: argv[0] was narrowed, not deleted |
| `test_install_publishes_atomically_and_leaves_no_temp` | ✅ | ✅ | guard: no `.tmp` residue, mode `0o755` |

The last two pass on both sides by design — they are guards against over-correcting, not regression proofs.

**Second round — symptom 3 and the shebang clause**, verified against the previous head of this branch (`38e94f0`) rather than clean `main`, since they regress code this PR itself introduced:

| Test | On `38e94f0` | On this branch | Pins |
| --- | --- | --- | --- |
| `test_exec_keeps_the_lexical_venv_interpreter_path` | ❌ `Exec` = the base interpreter behind the venv symlink | ✅ `Exec` = the venv's own `bin/python`, `pyvenv.cfg` still beside it | symptom 3 |
| `test_exec_rejects_env_python_wrapper_outside_the_checkout` | ❌ `Exec` = the `env python` wrapper | ✅ `Exec` = `<python> -m hermes_cli.main desktop` | symptom 1, reached by shebang |
| `test_exec_keeps_an_interpreter_under_a_directory_named_envs` | ✅ | ✅ | guard: `env` is matched as a basename, not a substring |
| `test_env_python_wrapper_detection` (10 cases) | n/a — new predicate | ✅ | `env -S python3 -u`, `env node`, `#!/bin/sh`, bare `env`, a non-shebang ELF header, an empty file |

Each clause was reverted in isolation to confirm it is the one doing the work: with `os.path.abspath` reverted, `test_exec_keeps_the_lexical_venv_interpreter_path` fails; with the shebang clause reverted and `abspath` kept, only `test_exec_rejects_env_python_wrapper_outside_the_checkout` fails.

Full run on this branch: **34 passed** in `test_linux_desktop_entry.py` (14 pre-existing + 20 new cases; no pre-existing test was modified). Adjacent suites also green: `tests/hermes_cli/test_gui_command.py`, `tests/hermes_cli/test_gui_uninstall.py`, `tests/hermes_cli/test_relaunch.py` — 34 passed, 68 combined.

**Manual, on the reporter's setup (Linux):**

1. `hermes desktop` from a terminal via `~/.local/bin/hermes` → `grep Exec ~/.local/share/applications/hermes.desktop` shows the wrapper.
2. Launch Hermes from the KDE application menu.
3. `grep Exec` again → **unchanged** (before this PR it flipped to `.../hermes-agent/hermes desktop`).
4. `stat -c %Y ~/.local/share/applications/hermes.desktop` before and after step 2 → unchanged, so no `kbuildsycoca6` run and the taskbar pin keeps focusing the existing window.

## Root-cause coverage (sibling-site sweep)

The concern is **a per-invocation path baked into a durable, later-executed artifact**. `grep -rn --include='*.py' 'resolve_hermes_bin'` plus a sweep for `Exec=` / `.desktop` writers enumerates every site:

| Site | Disposition |
| --- | --- |
| `linux_desktop_entry.resolve_exec_command` | **Covered** — the only place an argv[0]-derived path is persisted, and (per `git grep -n 'sys\.executable' -- '*.py' \| grep -E 'resolve\(\)\|realpath'`) the only production site in the repo that dereferenced the interpreter. |
| `linux_desktop_entry.render_desktop_entry` (`Exec=`) | **Covered** via its input. |
| `linux_desktop_entry.install_desktop_entry` (`write_text`) | **Covered** — atomic publish. |
| `relaunch.resolve_hermes_bin` / `build_relaunch_argv` | Excluded — transient re-exec of the current process. argv[0]-first is deliberate there and pinned by its own tests. Nothing is persisted. Already passes a bare `sys.executable`. |
| `linux_desktop_entry.resolve_exec_command`, binary branch (`str(Path(bin_path).resolve())`) | **Deliberately unchanged** — resolving is load-bearing for `_is_inside_checkout`, and for a wrapper the two choices trade off in opposite directions (lexical survives the target being replaced by an upgrade; resolved survives the symlink being removed). Neither can produce an import failure, so it reads as a maintainer's call rather than a bug. |
| `uninstall.py` per-profile invocation, `kanban_db.py` module-invocation helper | Excluded — already bare `sys.executable`; they are the convention symptom 3 restores. |
| `gateway/run.py::_resolve_hermes_bin` | Excluded — `shutil.which` first, and the result feeds a `Popen` within the same process lifetime, never a file. |
| `hermes_cli/kanban_db.py` | Excluded — documented mirror of `gateway.run._resolve_hermes_bin`; same transient use. |
| `tools/environments/local.py::_resolve_hermes_bin_dir` | Excluded — builds a `PATH` prefix for a child environment; not argv[0]-derived, not persisted. |
| systemd unit / launchd plist `ExecStart` (`hermes_cli/gateway.py`) | Excluded — generated from the venv interpreter path; `grep resolve_hermes_bin hermes_cli/gateway.py` → 0 hits. |
| `hermes_cli/gui_uninstall.py` | Excluded — reads `desktop_entry_path()` for removal only; no `Exec` derivation, no write. |

`resolve_exec_command` has exactly one call site, so the signature change is fully covered.

## Deliberately not included

The issue also raises four items that are maintainer calls rather than bug fixes, so they are left out to keep this reviewable as one concern. Happy to follow up on any of them:

- **"Don't rewrite if a user-customized version exists."** This needs a policy decision about how to distinguish a user edit from a stale entry (marker comment? checksum sidecar?). With `Exec` stabilised, the entry stops churning on its own, which is the part that actually broke the pin.
- **`--skip-build` in the generated `Exec`.** Changes what a menu launch does, not whether it works.
- **NVIDIA + Wayland `ELECTRON_OZONE_PLATFORM_HINT=x11` autodetection.** New runtime detection with its own compatibility surface.
- **A `Path=` key pointing at the checkout.** Would let the `sys.executable -m hermes_cli.main` fallback work from a bare, uninstalled checkout, but it is a different concern (working directory, not path durability) and a bad `Path=` makes some launchers refuse the entry outright.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused suite plus the adjacent CLI suites listed above, not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (the suite is platform-gated via `monkeypatch` on `sys.platform`, exactly as the existing tests in this file are, so it runs headlessly off-Linux). The manual KDE/Plasma steps above are not something I can verify first-hand.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `resolve_exec_command` and the new helper explain the durability requirement and why `resolve_hermes_bin`'s order is right for its own caller
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `install_desktop_entry` is already a no-op off Linux/BSD via `is_supported()`; `_is_inside_checkout` is pure `pathlib`, `_is_env_python_wrapper` reads bytes and never executes the candidate (a Windows `.exe` has no `#!` and is simply kept), the one symlink-creating test is `skipif os.name == "nt"`, and the atomic writer is the one the rest of the codebase already uses on every platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Three open PRs touch `resolve_exec_command()`. To be explicit about the overlap:

- **#82040** (@darzi-admin) independently reached the same `os.path.abspath(sys.executable)` conclusion for the interpreter fallback, with the same `pyvenv.cfg` reasoning, a few hours before symptom 3 was reported here — that change is *not* an original finding of this PR and I am not claiming it as one. #82040 also carries an unrelated `hermes_cli/main.py` change moving launcher registration past the `--build-only` return, which this PR does not touch. What this PR carries that #82040 does not: the location filter and the PATH-preference fall-through (so an installed `bash` wrapper is still preferred over dropping straight to the interpreter — the case in the Deepin 25 report above), and the atomic publish of the entry file.
- **#80563** (@patil2001) adds a shebang classifier but keeps `Path(sys.executable).resolve()`, so it does not address symptom 3.
- **#81899** (@snkosi-dev) changes `resolve_hermes_bin()` in `hermes_cli/relaunch.py`, upstream of this module and deliberately out of scope here.

Happy to defer on any overlapping hunk, or to rebase onto whichever of these lands first.

## Screenshots / Logs

Focused suite on this branch:

```
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_prefers_path_wrapper_over_checkout_argv0 PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_rejects_checkout_argv0_when_no_wrapper_on_path PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_keeps_the_lexical_venv_interpreter_path PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_rejects_env_python_wrapper_outside_the_checkout PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_keeps_an_interpreter_under_a_directory_named_envs PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_exec_accepts_argv0_outside_the_checkout PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_entry_is_stable_across_a_relaunch_through_itself PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_install_publishes_atomically_and_leaves_no_temp PASSED
tests/hermes_cli/test_linux_desktop_entry.py::test_failed_publish_leaves_the_existing_entry_intact PASSED
============================== 34 passed in 0.31s ==============================
```

First-round tests against clean `main` (production file unmodified):

```
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_exec_prefers_path_wrapper_over_checkout_argv0
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_exec_rejects_checkout_argv0_when_no_wrapper_on_path
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_entry_is_stable_across_a_relaunch_through_itself
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_failed_publish_leaves_the_existing_entry_intact
========================= 4 failed, 16 passed in 0.94s =========================
```

Second-round tests against the previous head of this branch (`38e94f0`), each clause reverted on its own:

```
# os.path.abspath reverted to Path(...).resolve()
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_exec_keeps_the_lexical_venv_interpreter_path
E   - <venv>/bin/python3 -m hermes_cli.main desktop
E   + <uv standalone build>/cpython-3.11.15-.../bin/python3.11 -m hermes_cli.main desktop

# shebang clause reverted, abspath kept
FAILED tests/hermes_cli/test_linux_desktop_entry.py::test_exec_rejects_env_python_wrapper_outside_the_checkout
E   assert '<tmp>/home/bin/hermes' not in '<tmp>/home/bin/hermes desktop'
========================= 1 failed, 3 passed in 0.16s ==========================
```

