### PR TITLE
fix(mcp): tolerate null args in stdio bridge watchdog

### DIFF
--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -38,3 +38,16 @@ def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
         *command_args,
     ]
     assert "--create-time" not in wrapped_args
+
+@pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
+def test_wrap_command_tolerates_null_args():
+    command = "/opt/hermes/bin/mcp-server"
+
+    wrapped_command, wrapped_args = mcp_tool._wrap_command_with_watchdog(
+        command,
+        None,
+    )
+
+    assert wrapped_command == sys.executable
+    assert wrapped_args[-2:] == ["--", command]
+    assert "--create-time" not in wrapped_args

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -722,7 +722,7 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         "--ppid", str(my_pid),
         "--",
         command,
-        *args,
+        *(args or []),
     ]
     return sys.executable, watchdog_args
 


### PR DESCRIPTION
## What

`_wrap_command_with_watchdog` in `tools/mcp_tool.py` unpacked `*args` directly. When an MCP server config declares `args: null` (an explicit null value, not an absent key), the resolved argument list is `None`, and the unpacking raised `TypeError: 'NoneType' object is not iterable` during the stdio connection handshake, making the server unusable.

Treat a missing or null argument list as empty: `*(args or [])`.

## Why

Issue #80437: a user-defined MCP server with `args: null` in `config.yaml` fails to connect at all. This is the whole bug class — any null `args` now connects normally while preserving existing behavior for absent keys and non-empty lists.

## How to test

1. Add an MCP server entry with an explicit `args: null` to `~/.hermes/config.yaml`.
2. Start Hermes and issue any prompt that would call the MCP tool — previously the stdio handshake crashes with `TypeError`; now the server connects and the tool works.
3. Regression test included: `tests/tools/test_mcp_stdio_watchdog.py::test_wrap_command_tolerates_null_args` exercises the POSIX watchdog-wrapping path with a `None` argument list.

## Platforms

POSIX (watchdog wrapping is POSIX-only; the non-POSIX early return was already safe).

Fixes #80437