### PR TITLE
fix(gateway): preserve declared plugin media attachments

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1568,6 +1568,51 @@ _TOOL_MEDIA_RE = re.compile(
     r'txt|csv|apk|ipa))',
     re.IGNORECASE,
 )
+_MEDIA_TAG_RESULT_CONTRACT = "media_tag_v1"
+
+
+def _typed_tool_result_media_tags(tool_name: str, content: str) -> tuple[List[str], bool]:
+    """Extract an explicit media contract from a successful plugin result.
+
+    Plugin tools are not part of the core producer allowlist, but they can
+    declare a deliverable attachment without relying on prose by returning
+    ``data.media_tag`` in their success envelope. Restricting this path to the
+    named field avoids treating MEDIA examples elsewhere in arbitrary tool
+    output as outbound attachments.
+    """
+    if not tool_name or '"media_tag"' not in content or "MEDIA:" not in content:
+        return [], False
+    try:
+        from tools.registry import registry
+
+        declared = registry.has_result_contract(
+            tool_name,
+            _MEDIA_TAG_RESULT_CONTRACT,
+        )
+    except Exception:
+        declared = False
+    if not declared:
+        return [], False
+    try:
+        payload = json.loads(content)
+    except Exception:
+        return [], False
+    if not isinstance(payload, dict) or not (
+        payload.get("ok") is True or payload.get("success") is True
+    ):
+        return [], False
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return [], False
+    media_tag = data.get("media_tag")
+    if not isinstance(media_tag, str):
+        return [], False
+
+    media_files, remainder = BasePlatformAdapter.extract_media(media_tag)
+    if len(media_files) != 1 or remainder.strip():
+        return [], False
+    path, is_voice = media_files[0]
+    return [f"MEDIA:{path}"], is_voice
 
 
 def _collect_auto_append_media_tags(
@@ -1577,13 +1622,16 @@ def _collect_auto_append_media_tags(
 ) -> tuple[List[str], bool]:
     """Collect real media tags from current-turn producer-tool results only.
 
-    Two layered guards keep stale/example MEDIA: strings out of the reply:
+    Three layered guards keep stale/example MEDIA: strings out of the reply:
 
-    1. Producer-tool allowlist: only tools that intentionally emit deliverable
-       artifacts (TTS) are eligible. Documentation, logs, and search results can
-       contain example strings such as MEDIA:/absolute/path/to/file, which must
-       never be delivered as attachments. (Fixes the original report behind #16721.)
-    2. Current-turn isolation: only messages produced this turn are scanned, so a
+    1. Explicit plugin contract: a successful tool result may declare an exact
+       ``data.media_tag`` field. MEDIA examples elsewhere in its output are ignored.
+    2. Producer-tool allowlist: legacy built-ins that intentionally emit
+       deliverable artifacts (TTS/image generation) remain eligible.
+       Documentation, logs, and search results can contain example strings such
+       as MEDIA:/absolute/path/to/file, which must never be delivered as
+       attachments. (Fixes the original report behind #16721.)
+    3. Current-turn isolation: only messages produced this turn are scanned, so a
        tool result from an earlier turn (still present in the full message list)
        cannot leak onto a later text-only reply (#34608).
 
@@ -1596,7 +1644,8 @@ def _collect_auto_append_media_tags(
     history_media_paths = history_media_paths or set()
     # Only trust the slice boundary when the message list still contains the
     # full history prefix. Otherwise scan everything (compression-safe fallback).
-    if history_offset and len(messages) >= history_offset:
+    slice_trusted = not history_offset or len(messages) >= history_offset
+    if history_offset and slice_trusted:
         new_messages = messages[history_offset:]
     else:
         new_messages = messages
@@ -1618,10 +1667,22 @@ def _collect_auto_append_media_tags(
         if msg.get("role") not in ("tool", "function"):
             continue
         call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(call_id) not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
-            continue
         content = str(msg.get("content") or "")
-        tool_name = tool_name_by_call_id.get(call_id)
+        tool_name = tool_name_by_call_id.get(call_id) or ""
+        typed_tags, typed_voice = (
+            _typed_tool_result_media_tags(tool_name, content)
+            if slice_trusted
+            else ([], False)
+        )
+        if typed_tags:
+            media_tags.extend(
+                tag for tag in typed_tags
+                if tag.removeprefix("MEDIA:") not in history_media_paths
+            )
+            has_voice_directive = has_voice_directive or typed_voice
+            continue
+        if tool_name not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
+            continue
         # JSON-payload tools (image_generate) return a local-file path in a
         # known field rather than a MEDIA: tag. Extract it so delivery is
         # deterministic even when the model omits the path from its reply.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -345,6 +345,7 @@ class PluginContext:
     def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
         self.manifest = manifest
         self._manager = manager
+        self._registered_tool_names: Set[str] = set()
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
@@ -461,11 +462,25 @@ class PluginContext:
             emoji=emoji,
             override=override,
         )
+        entry = registry.get_entry(name)
+        if entry is not None and entry.handler is handler:
+            self._registered_tool_names.add(name)
         self._manager._plugin_tool_names.add(name)
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
         )
+
+    def declare_tool_result_contract(self, name: str, contract: str) -> None:
+        """Opt one tool from this plugin into a host-consumed result contract."""
+        if name not in self._registered_tool_names:
+            raise ValueError(
+                f"Plugin {self.manifest.name!r} cannot declare a result contract "
+                f"for unowned tool {name!r}"
+            )
+        from tools.registry import registry
+
+        registry.declare_result_contract(name, contract)
 
     # -- override trust gate ------------------------------------------------
 

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -11,6 +11,7 @@ make_image tool several turns earlier must not leak onto a later
 text-only reply, even when the path-based dedup set fails to capture it.
 """
 
+import json
 import re
 from unittest.mock import MagicMock
 
@@ -137,6 +138,211 @@ caption
         tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
         assert tags == []
         assert voice is False
+
+    def test_gateway_auto_append_keeps_typed_plugin_media_tag(self):
+        """A successful plugin media result survives later housekeeping calls."""
+        from gateway.run import _collect_auto_append_media_tags
+        from tools.registry import registry
+
+        messages = [
+            {"role": "user", "content": "Make and send the video"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_video", "function": {"name": "plugin_video_status"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_video",
+                "content": (
+                    '{"ok": true, "data": {'
+                    '"media_tag": "MEDIA:/opt/data/videos/generated/result.mp4"}}'
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "Logging the completed render.",
+                "tool_calls": [
+                    {"id": "call_log", "function": {"name": "plugin_log_event"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_log",
+                "content": '{"success": true}',
+            },
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        registry.register(
+            name="plugin_video_status",
+            toolset="test_plugin_media",
+            schema={"description": "test", "parameters": {"type": "object"}},
+            handler=lambda _args: "",
+            result_contracts={"media_tag_v1"},
+        )
+        try:
+            tags, voice = _collect_auto_append_media_tags(messages, history_offset=1)
+        finally:
+            registry.deregister("plugin_video_status")
+
+        assert tags == ["MEDIA:/opt/data/videos/generated/result.mp4"]
+        assert voice is False
+
+    def test_gateway_auto_append_rejects_untrusted_plugin_media_text(self):
+        """Plugin MEDIA text needs a successful, explicit data.media_tag contract."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        for content in (
+            '{"ok": false, "data": {"media_tag": "MEDIA:/tmp/failed.mp4"}}',
+            '{"ok": true, "data": {"note": "MEDIA:/tmp/example.mp4"}}',
+            '{"ok": true, "data": {"media_tag": "MEDIA:/tmp/no-extension"}}',
+        ):
+            messages = [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "call_plugin", "function": {"name": "plugin_tool"}}
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_plugin",
+                    "content": content,
+                },
+            ]
+
+            tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+
+            assert tags == []
+            assert voice is False
+
+    def test_gateway_auto_append_uses_delivery_grammar_for_typed_plugin_media(self):
+        """Typed plugin media accepts the same quoted paths as native delivery."""
+        from gateway.run import _collect_auto_append_media_tags
+        from tools.registry import registry
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_plugin", "function": {"name": "plugin_media_tool"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_plugin",
+                "content": (
+                    '{"success": true, "data": {'
+                    '"media_tag": "MEDIA:\\\"/tmp/rendered clips/final cut.mp4\\\""}}'
+                ),
+            },
+        ]
+
+        registry.register(
+            name="plugin_media_tool",
+            toolset="test_plugin_media",
+            schema={"description": "test", "parameters": {"type": "object"}},
+            handler=lambda _args: "",
+            result_contracts={"media_tag_v1"},
+        )
+        try:
+            tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        finally:
+            registry.deregister("plugin_media_tool")
+
+        assert tags == ['MEDIA:/tmp/rendered clips/final cut.mp4']
+        assert voice is False
+
+    def test_gateway_auto_append_rejects_undeclared_or_ambiguous_media_contracts(self):
+        """Only declared producers with one exact media tag can auto-attach."""
+        from gateway.run import _collect_auto_append_media_tags
+        from tools.registry import registry
+
+        registry.register(
+            name="declared_media_tool",
+            toolset="test_plugin_media",
+            schema={"description": "test", "parameters": {"type": "object"}},
+            handler=lambda _args: "",
+            result_contracts={"media_tag_v1"},
+        )
+        try:
+            for tool_name, media_tag in (
+                ("undeclared_tool", "MEDIA:/tmp/private.pdf"),
+                (
+                    "declared_media_tool",
+                    "MEDIA:/tmp/render.mp4 MEDIA:/tmp/private.pdf",
+                ),
+                ("declared_media_tool", "MEDIA:/tmp/render.mp4 finished"),
+            ):
+                messages = [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {"id": "call_plugin", "function": {"name": tool_name}}
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_plugin",
+                        "content": (
+                            '{"success": true, "data": {'
+                            f'"media_tag": {json.dumps(media_tag)}' + "}}"
+                        ),
+                    },
+                ]
+
+                tags, voice = _collect_auto_append_media_tags(messages)
+
+                assert tags == []
+                assert voice is False
+        finally:
+            registry.deregister("declared_media_tool")
+
+    def test_gateway_auto_append_does_not_replay_typed_media_from_history(self):
+        """Declared plugin media is limited to a trusted current-turn slice."""
+        from gateway.run import _collect_auto_append_media_tags
+        from tools.registry import registry
+
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "old_call", "function": {"name": "declared_media_tool"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "old_call",
+                "content": (
+                    '{"success": true, "data": {'
+                    '"media_tag": "MEDIA:/tmp/old-render.mp4"}}'
+                ),
+            },
+        ]
+        messages = [*history, {"role": "assistant", "content": "Done."}]
+        registry.register(
+            name="declared_media_tool",
+            toolset="test_plugin_media",
+            schema={"description": "test", "parameters": {"type": "object"}},
+            handler=lambda _args: "",
+            result_contracts={"media_tag_v1"},
+        )
+        try:
+            sliced_tags, _ = _collect_auto_append_media_tags(
+                messages,
+                history_offset=len(history),
+            )
+            fallback_tags, _ = _collect_auto_append_media_tags(
+                messages,
+                history_offset=9999,
+            )
+        finally:
+            registry.deregister("declared_media_tool")
+
+        assert sliced_tags == []
+        assert fallback_tags == []
 
 
     def test_collect_history_media_paths_includes_image_generate_json(self):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -960,6 +960,40 @@ class TestPreLlmCallTargetRouting:
         assert "plain text C" in _plugin_user_context
 
 
+class TestPluginToolResultContracts:
+    def test_plugin_can_declare_contract_only_for_its_registered_tool(self):
+        from tools.registry import registry
+
+        manager = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="test-plugin", source="user"),
+            manager,
+        )
+        ctx.register_tool(
+            name="test_media_result_tool",
+            toolset="test_plugin",
+            schema={
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda _args: "",
+        )
+        try:
+            ctx.declare_tool_result_contract(
+                "test_media_result_tool",
+                "media_tag_v1",
+            )
+
+            assert registry.has_result_contract(
+                "test_media_result_tool",
+                "media_tag_v1",
+            )
+            with pytest.raises(ValueError, match="unowned tool"):
+                ctx.declare_tool_result_contract("shell_exec", "media_tag_v1")
+        finally:
+            registry.deregister("test_media_result_tool")
+
+
 # ── TestPluginCommands ────────────────────────────────────────────────────
 
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -163,12 +163,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "result_contracts",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 result_contracts=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -187,6 +188,7 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.result_contracts = frozenset(result_contracts or ())
 
 
 # ---------------------------------------------------------------------------
@@ -531,6 +533,7 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        result_contracts: Set[str] | None = None,
         override: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
@@ -591,6 +594,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                result_contracts=result_contracts,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -820,6 +824,20 @@ class ToolRegistry:
         """Return the toolset a tool belongs to, or None."""
         entry = self.get_entry(name)
         return entry.toolset if entry else None
+
+    def declare_result_contract(self, name: str, contract: str) -> None:
+        """Declare one host-consumed result contract for a registered tool."""
+        with self._lock:
+            entry = self._tools.get(name)
+            if entry is None:
+                raise KeyError(f"Tool is not registered: {name}")
+            entry.result_contracts = frozenset((*entry.result_contracts, contract))
+            self._generation += 1
+
+    def has_result_contract(self, name: str, contract: str) -> bool:
+        """Return whether a tool explicitly opted into a host result contract."""
+        entry = self.get_entry(name)
+        return bool(entry and contract in entry.result_contracts)
 
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -586,6 +586,21 @@ auditable in `~/.hermes/logs/agent.log`. Plugins load after built-in
 tools, so the registration order is correct: your handler replaces the
 built-in one.
 
+### Declaring a media result
+
+A plugin tool that intentionally returns one native attachment can opt into
+Hermes' final-response recovery after it registers the tool:
+
+```python
+ctx.declare_tool_result_contract("render_status", "media_tag_v1")
+```
+
+On success, return exactly one deliverable tag in `data.media_tag`, such as
+`{"ok": true, "data": {"media_tag": "MEDIA:/absolute/result.mp4"}}`.
+Hermes ignores this field for undeclared tools, failed results, ambiguous
+multi-tag values, and stale history. This prevents arbitrary tool output from
+being interpreted as an outbound local-file attachment.
+
 ### Register multiple hooks
 
 ```python


### PR DESCRIPTION
## Summary

Plugin-generated video and audio attachments now survive later housekeeping tool calls in the same agent turn. Before this change, a valid `MEDIA:` tag could appear in an intermediate tool result and disappear when the model finished with prose after a logging call.

This adds an opt-in `media_tag_v1` result contract for plugin tools. The gateway recovers one exact `data.media_tag` from a successful, declared producer and appends it to the final response. It uses the canonical media parser, keeps current-turn isolation, and disables the new path when compression makes the history boundary uncertain.

The declaration is ownership-bound through `PluginContext`. Undeclared tools, failed results, ambiguous multi-tag values, trailing prose, and stale history cannot trigger attachment delivery. This is security-sensitive because arbitrary tool output must not become a local-file upload.

## How to test

- `scripts/run_tests.sh tests/gateway/test_media_extraction.py tests/hermes_cli/test_plugins.py -q` - 53 passed
- `git diff --check`
- Tested on macOS. No live messaging credentials or paid media generation were used.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
