### PR TITLE
fix(memory): status reflects runtime lazy_deps predicate

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -528,7 +528,23 @@ def cmd_status(args) -> None:
 
         if provider:
             print("\n  Plugin:    installed ✓")
-            if provider.is_available():
+            runtime_available = provider.is_available()
+            # The runtime retain path decides availability via the
+            # lazy-deps predicate ensure("memory.<provider>") — e.g.
+            # hindsight's cloud client SDK — not provider config alone.
+            # Mirror the same predicate here with the check-only
+            # is_available() so status never triggers an install;
+            # providers without a registered lazy feature pass through.
+            from tools.lazy_deps import feature_specs
+            from tools.lazy_deps import is_available as _lazy_feature_available
+            lazy_feature = f"memory.{provider_name}"
+            try:
+                feature_specs(lazy_feature)
+            except KeyError:
+                pass
+            else:
+                runtime_available = runtime_available and _lazy_feature_available(lazy_feature)
+            if runtime_available:
                 print("  Status:    available ✓")
             else:
                 print("  Status:    not available ✗")

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -54,4 +54,46 @@ class TestMemoryStatusLabels:
         assert "disabled ✗" in out
 
 
+class TestMemoryStatusLazyPredicate:
+    """Status must agree with the runtime retain path's lazy-deps
+    predicate, not just provider.is_available() — e.g. hindsight reports
+    "available" from config alone, but retain gates on
+    ensure("memory.hindsight")."""
+
+    def test_status_not_available_when_lazy_deps_unsatisfied(self, capfd, monkeypatch):
+        """provider.is_available() True but lazy-deps unsatisfied
+        must still print "not available" (mirrors the runtime predicate)."""
+        from hermes_cli.memory_setup import cmd_status
+
+        class ProviderAvailableNoDeps:
+            def is_available(self):
+                return True
+
+            def get_config_schema(self):
+                return []
+
+        provider = ProviderAvailableNoDeps()
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"memory": {"provider": "hindsight"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._get_available_providers",
+            lambda: [("hindsight", "Hindsight memory", provider)],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *args, **kwargs: {"memory"},
+        )
+        monkeypatch.setattr("tools.lazy_deps.is_available", lambda feature: False)
+
+        cmd_status(args=None)
+        out = capfd.readouterr().out
+
+        assert "Status:    available ✓" not in out
+        assert "Status:    not available ✗" in out
+
+
+
 


### PR DESCRIPTION
## What
`hermes memory status` now reports a provider as installed/available using the same lazy-deps predicate the runtime retain path uses (`ensure("memory.hindsight")` / `lazy_deps.is_available`), instead of relying only on `provider.is_available()`.

## Why
The status check in `hermes_cli/memory_setup.py` decided `installed ✓ / available ✓` purely from `provider.is_available()` (which checks config/credentials only, e.g. hindsight's API key). The actual runtime retain path gates availability on the lazy-deps predicate `ensure("memory.hindsight")` (the `hindsight-client` SDK). The two disagreed, so status could print `available ✓` while retain would trigger an install or fail at runtime.

## How to test
- `bash scripts/run_tests.sh tests/hermes_cli/test_memory_status.py -q` — new regression test `test_status_not_available_when_lazy_deps_unsatisfied` asserts that when `provider.is_available()` returns True but the lazy-deps predicate is unsatisfied, status prints `not available ✗`.
- Manually: configure `memory.provider: hindsight` with a key but no `hindsight-client` package installed; `hermes memory status` now reports `not available ✗`, matching what retain will actually do.

## Platforms
Windows (hermetic test runner, CI-parity env).
Fixes #80388