### PR TITLE
fix(cli): sanitize lone surrogates before writing oneshot output

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -28,6 +28,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
 
+from agent.message_sanitization import _sanitize_surrogates
+
 from gateway.session_context import declare_stateless_channel
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -278,6 +280,10 @@ def run_oneshot(
     _write_usage_file(usage_file, result)
 
     if response:
+        # A lone surrogate (U+D800..U+DFFF) from an OpenAI-compatible provider
+        # crashes real_stdout.write on a strict UTF-8 stream (#80366). Replace
+        # them before printing so the run completes with exit code 0.
+        response = _sanitize_surrogates(response)
         real_stdout.write(response)
         if not response.endswith("\n"):
             real_stdout.write("\n")

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -286,3 +286,33 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
 
 
 
+
+def test_oneshot_sanitizes_lone_surrogates_before_stdout():
+    program = textwrap.dedent(
+        """
+        import sys
+        import hermes_cli.oneshot as oneshot
+
+        def _fake_agent(*args, **kwargs):
+            return ("answer " + chr(0xD800) + " boom", {})
+
+        oneshot._run_agent = _fake_agent
+        sys.exit(oneshot.run_oneshot("hello"))
+        """
+    )
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        timeout=10,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ("answer " + chr(0xFFFD) + " boom" + os.linesep).encode("utf-8")
+    assert b"Traceback" not in result.stderr


### PR DESCRIPTION
## What
`hermes -z` / oneshot mode could crash after the agent finished: an OpenAI-compatible provider occasionally returns a response containing a lone surrogate code point (U+D800..U+DFFF), and writing it to a strict UTF-8 stdout stream raises `UnicodeEncodeError` inside `real_stdout.write`. The response is now passed through `_sanitize_surrogates` (the same helper `run_agent` already uses for JSON payloads) right before printing, replacing any lone surrogates with U+FFFD.

## Why
The process died with a traceback immediately after the agent completed, so pipelines got no clean exit code and no output for a valid run. Surrogates are invalid in UTF-8 and never representable on a strict stream; sanitizing at the write boundary fixes the whole class of lone-surrogate responses in oneshot mode.

## How to test
Run the new regression test:
```
bash scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -q -k test_oneshot_sanitizes_lone_surrogates_before_stdout
```
It spawns a child process that stubs `_run_agent` to return `"answer " + chr(0xD800) + " boom"`, then asserts the process exits 0 and stdout equals the UTF-8 bytes of the sanitized `"answer <U+FFFD> boom"` output.

## Platforms
Tested on native Windows via the hermetic runner (`scripts/run_tests.sh`). The expected-bytes assertion uses `os.linesep` so it holds on both Windows and POSIX.

Fixes #80366