### PR TITLE
fix(model-metadata): scale per-1M-token relay prices correctly

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1120,6 +1120,23 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
             result["cache_read"] = str(float(deepinfra_pricing["cache_read_tokens"]) / 1_000_000)
         return result
 
+    # Some relays quote token prices per 1M tokens via a ``unit`` field
+    # (e.g. ``unit: "per_1m_tokens"``) instead of per token. Detect it and
+    # scale the generic token prices by 1e6 so the cost machinery
+    # (usage_pricing.py) sees the same per-token convention Novita/DeepInfra
+    # already map into above.
+    def _unit_is_per_1m(raw: Any) -> bool:
+        if not isinstance(raw, str):
+            return False
+        unit = raw.strip().lower().replace("_", "").replace("-", "").replace(" ", "")
+        return "per1m" in unit or "permillion" in unit or unit in ("1m", "1mtokens")
+
+    per_1m_tokens = any(
+        str(key).lower() == "unit" and _unit_is_per_1m(value)
+        for mapping in _iter_nested_dicts(payload)
+        for key, value in mapping.items()
+    )
+
     alias_map = {
         "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),
         "completion": ("completion", "output", "output_cost_per_token", "completion_token_cost"),
@@ -1135,7 +1152,10 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         for target, aliases in alias_map.items():
             for alias in aliases:
                 if alias in normalized and normalized[alias] not in {None, ""}:
-                    pricing[target] = normalized[alias]
+                    price = normalized[alias]
+                    if per_1m_tokens and target in ("prompt", "completion", "cache_read", "cache_write"):
+                        price = str(float(price) / 1_000_000)
+                    pricing[target] = price
                     break
         if pricing:
             return pricing

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -562,6 +562,24 @@ class TestFetchEndpointModelMetadata:
         success.close.assert_called_once()
 
 
+class TestExtractPricing:
+    def test_per_1m_tokens_unit_is_scaled(self):
+        """Relays quoting per-1M-token prices must be scaled to per-token."""
+        import agent.model_metadata as mm
+
+        payload = {
+            "id": "vendor/model",
+            "pricing": {
+                "unit": "per_1m_tokens",
+                "prompt": "3.0",
+                "completion": "15.0",
+            },
+        }
+        result = mm._extract_pricing(payload)
+        assert float(result["prompt"]) == pytest.approx(3.0 / 1_000_000)
+        assert float(result["completion"]) == pytest.approx(15.0 / 1_000_000)
+
+
 # =========================================================================
 # Nous Portal context-window resolution (provider="nous")
 # =========================================================================


### PR DESCRIPTION
## What
`_extract_pricing()` in `agent/model_metadata.py` now honors a `unit` field on OpenAI-compatible relay model metadata. When a relay declares `unit: "per_1m_tokens"` (or equivalent like `per_million_tokens`), the generic pricing branch divides `prompt` / `completion` / cache prices by `1_000_000` to produce per-token values — the same convention the existing Novita/DeepInfra branches already map into. Per-request (`request`) costs are flat fees and are left unscaled. Values that are already per-token (no per-1M unit) pass through unchanged, so nothing is double-scaled.

## Why
Issue #80431: relays that quote price per 1M tokens had those prices taken verbatim by the generic alias-mapping branch. Downstream cost math (`usage_pricing.py::_pricing_entry_from_metadata`) treats these as per-token and multiplies by 1e6, so reported cost was inflated by 1e6 for such relays.

## How to test
- New regression test: `tests/agent/test_model_metadata.py::TestExtractPricing::test_per_1m_tokens_unit_is_scaled` — feeds a generic relay payload with `unit: "per_1m_tokens"`, `prompt: "3.0"`, `completion: "15.0"` and asserts the parsed per-token values are `3e-6` / `1.5e-5`.
- Run: `bash scripts/run_tests.sh tests/agent/test_model_metadata.py -q`
  - Baseline (clean tree): 20 failed / 43 passed (pre-existing, unrelated `agent.models_dev` resolution issues).
  - With fix: 20 failed / 44 passed — the new test passes and no existing test regressed.

## Platforms
- Windows (worktree tested). Pure-python logic; no platform-specific code paths.

Fixes #80431