### PR TITLE
fix(lazy-deps): cache install failures to stop per-message retries

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -144,6 +144,43 @@ class TestEnsure:
 
 
 # ---------------------------------------------------------------------------
+# Failed-install negative cache (#80468)
+# ---------------------------------------------------------------------------
+#
+# A failed lazy install (e.g. STT backend offline, PyPI 404/quarantine) must
+# not be re-attempted on every call - each STT message previously re-ran the
+# whole slow uv -> pip fallback. ensure() records the failure for the session
+# and short-circuits later calls to the recorded error, while the first call
+# still surfaces the real pip error to the caller.
+# ---------------------------------------------------------------------------
+
+
+class TestFailedInstallNegativeCache:
+    def test_failed_install_is_not_retried_within_session(self, monkeypatch):
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.stt_retry", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        # Fresh per-test cache - the module-level dict is process-global.
+        monkeypatch.setattr(ld, "_failed_installs", {})
+        attempts = []
+
+        def failing_install(specs, **kw):
+            attempts.append(specs)
+            return ld._InstallResult(False, "", "network unreachable")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", failing_install)
+
+        # First call surfaces the real install error...
+        with pytest.raises(ld.FeatureUnavailable, match="network unreachable"):
+            ld.ensure("test.stt_retry", prompt=False)
+        # ...but the second call short-circuits without re-running pip.
+        with pytest.raises(ld.FeatureUnavailable, match="network unreachable"):
+            ld.ensure("test.stt_retry", prompt=False)
+
+        assert attempts == [("zzzfake>=1",)]
+
+
+# ---------------------------------------------------------------------------
 # is_available
 # ---------------------------------------------------------------------------
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -55,7 +55,8 @@ Security model:
 * **Offline detection.** If the install fails (offline, mirror down,
   PyPI 404 / quarantine), we surface the failure as
   :class:`FeatureUnavailable` with the actual pip stderr — no silent
-  retries, no caching of bad state.
+  retries; a session-scoped negative cache stops the doomed install from
+  being re-run on every call.
 
 Adding a new backend:
 
@@ -382,6 +383,16 @@ _LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
 # incompatible; we detect the mismatch and wipe the store so packages get
 # re-resolved against the new interpreter rather than importing a stale .so.
 _TARGET_STAMP_NAME = ".python-abi"
+
+# Session-scoped negative cache for lazy installs. Keys are feature names;
+# values are the failure reason recorded when an install attempt failed this
+# process. A failed install is NOT re-attempted for the rest of the session:
+# every ensure() call for that feature short-circuits to the recorded error
+# instead of re-running the slow uv -> pip fallback (the reported bug: each
+# STT message retried a doomed install). The cache clears naturally when the
+# deps become available - ensure() returns early once feature_missing() is
+# empty - and is process-scoped, so a fresh run retries fresh.
+_failed_installs: dict[str, str] = {}
 
 
 def _python_abi_tag() -> str:
@@ -900,6 +911,14 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             "lazy installs disabled (security.allow_lazy_installs=false)"
         )
 
+    # A previous install attempt for this feature failed earlier in this
+    # process. Don't re-run the slow uv -> pip fallback on every subsequent
+    # call - e.g. each STT message would otherwise retry the whole doomed
+    # install. Report the recorded failure until the deps become available.
+    cached_failure = _failed_installs.get(feature)
+    if cached_failure:
+        raise FeatureUnavailable(feature, missing, cached_failure)
+
     # Only show the interactive confirmation when we own a TTY and
     # prompt_toolkit isn't running.  A bare input() deadlocks when a
     # prompt_toolkit app owns the terminal because keystrokes route to
@@ -939,10 +958,9 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
         if snippet:
             # Clip to a readable size — pip can dump pages of resolution traces.
             snippet = snippet[-2000:]
-        raise FeatureUnavailable(
-            feature, missing,
-            f"pip install failed: {snippet or 'no error output'}"
-        )
+        reason = f"pip install failed: {snippet or 'no error output'}"
+        _failed_installs[feature] = reason
+        raise FeatureUnavailable(feature, missing, reason)
 
     # Verify post-install. importlib.metadata caches per-process, so if we
     # just installed something the cache may not see it without a refresh.
@@ -955,11 +973,12 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
     still_missing = feature_missing(feature)
     if still_missing:
-        raise FeatureUnavailable(
-            feature, still_missing,
+        reason = (
             "install reported success but packages still not importable "
             "(may require Python restart)"
         )
+        _failed_installs[feature] = reason
+        raise FeatureUnavailable(feature, still_missing, reason)
 
     logger.info("Lazy install complete for feature %r", feature)
 


### PR DESCRIPTION
## What
Adds a session-scoped negative cache to `tools/lazy_deps.py::ensure()`. When an install attempt fails for a lazy feature (e.g. an STT backend), the failure reason is recorded in a module-level `_failed_installs` dict keyed by feature name. Subsequent `ensure()` calls for the same feature while the deps are still missing short-circuit to the recorded `FeatureUnavailable` error instead of re-running the slow `uv` -> `pip` fallback install.

## Why
Issue #80468: an STT-related lazy dependency that fails to install was retried on every call, so each STT message re-ran the whole slow install attempt (uv -> pip -> ensurepip ladder) against a known-bad state. The fix memoizes the failure for the session so a failed install is attempted at most once per process.

## How to test
```bash
bash scripts/run_tests.sh tests/tools/test_lazy_deps.py -q
```
New regression test `TestFailedInstallNegativeCache::test_failed_install_is_not_retried_within_session` forces an install failure via a monkeypatched `_venv_pip_install`, calls `ensure()` twice, and asserts the installer is invoked only once (the second call short-circuits via the cache). All 58 tests in the file pass, including the pre-existing ensure()/refresh/install_specs suites.

## Platforms
Tested on Windows (the suite's one durable-target chmod test failure is a pre-existing NTFS-only issue, reproduced identically on the base commit).

Fixes #80468