### PR TITLE
fix(lazy-deps): stop auto-downgrading newer hindsight-client

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -225,6 +225,25 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied(spec) is True
         assert ld.feature_missing("tool.trace_upload") == ()
 
+    def test_newer_than_exact_pin_counts_as_satisfied(self, monkeypatch):
+        """#80390: an installed version NEWER than an exact pin satisfies the
+        pin-as-floor, so ensure() must not force-downgrade a working newer
+        hindsight-client back to the pinned 0.6.1."""
+        monkeypatch.setitem(
+            ld.LAZY_DEPS, "memory.hindsight", ("hindsight-client==0.6.1",)
+        )
+        self._fake_version(monkeypatch, {"hindsight-client": "0.8.3"})
+        assert ld._is_satisfied("hindsight-client==0.6.1") is True
+        assert ld.feature_missing("memory.hindsight") == ()
+        assert ld.is_available("memory.hindsight") is True
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail(
+                "pip must not be called: newer hindsight-client satisfies the pin"
+            ),
+        )
+        ld.ensure("memory.hindsight", prompt=False)  # no exception, no pip
+
     @pytest.mark.parametrize(
         ("feature", "installed_versions", "expected_repairs"),
         [

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -591,9 +591,11 @@ def _is_satisfied(spec: str) -> bool:
 
     Checks both presence AND version. If the package is installed at a
     version outside the spec's range, returns False so the caller will
-    upgrade/downgrade to the pinned version. This is what makes
-    ``hermes update`` propagate pin bumps in :data:`LAZY_DEPS` to already-
-    installed backends instead of silently leaving stale versions in place.
+    upgrade to the pinned version. This is what makes ``hermes update``
+    propagate pin bumps in :data:`LAZY_DEPS` to already-installed backends
+    instead of silently leaving stale versions in place. An installed
+    version NEWER than an exact pin counts as satisfied — the pin is a
+    floor, and we never force-downgrade a working newer client (#80390).
 
     If ``packaging`` is unavailable for any reason (it's a transitive of
     pip so this should never happen), we fall back to a presence-only check
@@ -624,10 +626,27 @@ def _is_satisfied(spec: str) -> bool:
         return True
 
     try:
-        return Version(installed) in SpecifierSet(spec_tail)
+        installed_v = Version(installed)
+        if installed_v in SpecifierSet(spec_tail):
+            return True
     except (InvalidSpecifier, InvalidVersion, Exception):
         # Malformed spec or installed version we can't parse — don't churn.
         return True
+
+    # An exact pin is a floor, not a ceiling. If the installed version is
+    # NEWER than the pinned version it is importable and satisfies the pin
+    # as a minimum, so do not force-downgrade it back to the pin on every
+    # retain. Pin bumps still propagate: an installed version BELOW the pin
+    # is not satisfied and gets upgraded. (#80390: hindsight-client pinned
+    # ==0.6.1 was re-installed as a downgrade on every retain because the
+    # user had a newer, working 0.8.x client installed.)
+    if spec_tail.startswith("=="):
+        try:
+            return installed_v > Version(spec_tail[2:])
+        except (InvalidVersion, Exception):
+            return True
+
+    return False
 
 
 def _is_present(spec: str) -> bool:


### PR DESCRIPTION
## What
`tools/lazy_deps.py` pins `memory.hindsight` to `hindsight-client==0.6.1`, and `_is_satisfied()` treated that exact pin as a strict match. If the user had a newer, working `hindsight-client` installed (e.g. 0.8.x), `_is_satisfied()` returned `False`, so `ensure()` / `refresh_active_features()` re-ran pip and **downgraded** the working client back to `0.6.1` — on every retain.

The fix treats an exact pin as a **floor**: an installed version *newer* than the pin now counts as satisfied (no install, no downgrade). Pin bumps still propagate — an installed version *below* the pin is still unsatisfied and gets upgraded, preserving the `hermes update` lazy-refresh behavior. Exact pins that are security minima (e.g. `aiohttp==3.14.1`, `anthropic==0.87.0`) are unaffected: an installed version equal to or newer than the pin remains safe/satisfied, while older vulnerable versions still get upgraded to the pinned floor.

## Why
Fixes #80390 — Hermes auto-downgrades a working newer `hindsight-client` to the pinned `0.6.1` on every retain, breaking the user's working memory setup.

## How to test
1. Install a `hindsight-client` newer than `0.6.1` (e.g. `uv pip install 'hindsight-client>=0.7'`).
2. Run `hermes update` (or trigger the lazy-refresh pass) / start a retain.
3. Before: pip re-installs/downgrades to `hindsight-client==0.6.1` every time.
4. After: the newer client is reported satisfied; no install runs.
5. Regression test:
   `bash scripts/run_tests.sh tests/tools/test_lazy_deps.py -q` (58 passed; includes the new `test_newer_than_exact_pin_counts_as_satisfied`).

## Platforms
Tested on native Windows (via `scripts/run_tests.sh`). The change is platform-independent logic in `_is_satisfied()`.

Fixes #80390