### PR TITLE
fix(win): probe npm.cmd shims with nbsp in path

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -349,8 +349,17 @@ def node_tool_runnable(path: str | None) -> bool:
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        if sys.platform == "win32" and candidate.suffix.lower() in (".cmd", ".bat"):
+            # A .cmd/.bat shim runs through cmd.exe, whose tokenizer treats
+            # U+00A0 (nbsp) as a plain space. subprocess only auto-quotes args
+            # for ASCII whitespace, so an nbsp in the shim path (e.g. under
+            # %LOCALAPPDATA%) would split the path mid-way. Hand cmd.exe a
+            # pre-quoted command line so the nbsp stays inside a quoted argument.
+            probe = f'"{path}" --version'
+        else:
+            probe = [path, "--version"]
         result = subprocess.run(
-            [path, "--version"],
+            probe,
             capture_output=True,
             timeout=10,
             env=with_hermes_node_path(),

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -280,6 +280,43 @@ class TestNodeToolRunnable:
 
 
 
+class TestNodeToolRunnableWindowsNbsp:
+    """Regression for #80499 — cmd.exe tokenizes U+00A0 (nbsp) as a space.
+
+    A .cmd/.bat shim is probed through cmd.exe. When the shim path contains a
+    U+00A0 (e.g. a Hermes-managed Node tree under %LOCALAPPDATA%), subprocess's
+    argv quoting does not protect the nbsp, so cmd.exe splits the path mid-way
+    and a healthy shim reports as not runnable. The probe must hand cmd.exe a
+    pre-quoted command line, keeping the nbsp inside a quoted argument.
+    """
+
+    def test_cmd_shim_with_nbsp_probe_is_pre_quoted(self, tmp_path, monkeypatch):
+        nbsp = chr(0x00A0)
+        shim_dir = tmp_path / ("LocalAppData" + nbsp + "dir")
+        shim_dir.mkdir(parents=True)
+        shim = shim_dir / "npm.cmd"
+        shim.write_text("@echo off\nnode --version\n", encoding="utf-8")
+
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return SimpleNamespace(returncode=0)
+
+        import subprocess as subprocess_mod
+        import hermes_cli._subprocess_compat as subprocess_compat
+
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setattr(subprocess_compat, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(subprocess_mod, "run", fake_run)
+
+        assert node_tool_runnable(str(shim)) is True
+        (probe,) = captured
+        assert probe == f'"{shim}" --version'
+        # The nbsp must sit inside the quoted command token, not split from it.
+        assert nbsp in probe[1:probe.rindex('"')]
+
+
 class TestIsContainer:
     """Tests for is_container() — Docker/Podman detection."""
 


### PR DESCRIPTION
## What
On Windows, `hermes_constants.node_tool_runnable()` probes a resolved `node`/`npm`/`npx` binary with `subprocess.run([path, "--version"], ...)`. For a `.cmd`/`.bat` shim the probe is routed through `cmd.exe`, and a U+00A0 (non-breaking space) in the path — e.g. a Hermes-managed Node tree under `%LOCALAPPDATA%` with an nbsp in a directory name — is treated by cmd.exe's tokenizer as a plain space. Python's argv quoting only protects ASCII whitespace, so the path is split mid-way, the probe fails, and a healthy shim reports as *not runnable*.

Fix: on the Windows `.cmd`/`.bat` branch, hand cmd.exe a pre-quoted command line (`'"<path>" --version'` as a single string, passed verbatim to `CreateProcess`), so the nbsp stays inside a quoted argument. POSIX probing and the `.exe`/bare-file path are unchanged (still the original `[path, "--version"]` list).

## Why
A healthy `npm.cmd` under an nbsp-containing path is falsely reported as broken, so `find_hermes_node_executable("npm")` (and the Node refresh / web UI build that depends on it) skips or heals a working tool. Reproduced on native Windows with a shim at `<tmp>/dir\xa0name/npm.cmd`: before the fix the probe exits 1 with `'...\dir' is not recognized as an internal or external command`; after the fix it returns 0.

## How to test
```bash
scripts/run_tests.sh tests/test_hermes_constants.py -q
```
New test `tests/test_hermes_constants.py::TestNodeToolRunnableWindowsNbsp::test_cmd_shim_with_nbsp_probe_is_pre_quoted` builds a `npm.cmd` under a path containing `chr(0x00A0)`, mocks `subprocess.run`, and asserts the probe is the pre-quoted command line `'"<path>" --version'` with the nbsp inside the quoted token. It passes on Windows (the live branch) and on POSIX CI (platform is forced via `sys.platform` monkeypatch, subprocess is mocked).

## Platforms
- Windows (native) — fixed and covered by the new regression test; full `tests/test_hermes_constants.py` run locally.
- Linux/macOS — code path untouched (probe branch gated on `sys.platform == "win32"` and `.cmd`/`.bat` suffix).