### PR TITLE
fix(update): honor explicit --branch instead of restoring current

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9162,7 +9162,11 @@ def cmd_update(args):
         sys.exit(UPDATE_EXIT_CONCURRENT)
 
     try:
-        _cmd_update_impl(args, gateway_mode=gateway_mode)
+        _cmd_update_impl(
+            args,
+            gateway_mode=gateway_mode,
+            branch_explicit=bool(getattr(args, "branch", None)),
+        )
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3561,7 +3561,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
         # Never let line-ending cleanup block an update.
         pass
 
-def _cmd_update_impl(args, gateway_mode: bool):
+def _cmd_update_impl(args, gateway_mode: bool, *, branch_explicit: bool = False):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
     # In gateway mode, use file-based IPC for prompts instead of stdin
@@ -3859,7 +3859,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in {branch, "HEAD"}:
+            # An explicit --branch must be retained: don't silently switch
+            # back to the previous branch when there is nothing to pull.
+            if not branch_explicit and current_branch not in {branch, "HEAD"}:
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=_m().PROJECT_ROOT,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -504,6 +504,34 @@ class TestCmdUpdateBranchFlag:
         assert "nonexistent" in out
 
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_branch_flag_retains_requested_branch_when_up_to_date(
+        self, mock_run, _mock_which, capsys
+    ):
+        """Regression #80412: an explicit ``--branch`` is retained on the
+        no-new-commits path instead of being overridden by a restore to the
+        branch the user was on before the update."""
+        mock_run.side_effect = self._branch_side_effect(
+            current_branch="main", target_branch="bb/gui", commit_count="0"
+        )
+        args = SimpleNamespace(branch="bb/gui")
+
+        cmd_update(args)
+
+        commands = [
+            " ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list
+        ]
+        checkout_cmds = [c for c in commands if "checkout" in c and "-B" not in c]
+        # We switched to the requested branch...
+        assert any("bb/gui" in c for c in checkout_cmds), checkout_cmds
+        # ...and never restored the previous branch.
+        assert not any("main" in c for c in checkout_cmds), checkout_cmds
+
+        out = capsys.readouterr().out
+        assert "Already up to date!" in out
+
+
 class TestCmdUpdateCheckBranchFlag:
     """``hermes update --check --branch <name>`` honors the branch override.
 


### PR DESCRIPTION
## What
- Threads an explicit-branch flag from the CLI layer into `_cmd_update_impl`.
- When `hermes update --branch B` is invoked and the target branch has no new commits to pull, the requested branch `B` is now retained instead of being silently overridden by a restore to the branch the user was on before the update.

## Why
Fixes #80412. Previously, on the no-new-commits path, `_cmd_update_impl` unconditionally restored `current_branch`, discarding an explicit `--branch` choice even when the checkout to `B` had just succeeded.

## How to test
```bash
bash scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -q
```
New regression test: `test_branch_flag_retains_requested_branch_when_up_to_date` — 22/22 tests pass.

## Platforms
- Windows (CRLF preserved; no whole-file reformatting)

Fixes #80412