### PR TITLE
fix(linux-desktop): correct Exec path and stop rewriting entry each launch

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -60,18 +60,42 @@ def icon_path(project_root: Path) -> Path:
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
-    Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
-    runs as a module with no launcher installed, use the current
-    interpreter, also absolute.
+    Mirror how the running process was launched: prefer the ``hermes``
+    entry point resolved from argv[0]/PATH. When that is a bare Python
+    script (a ``#!/usr/bin/env python`` launcher that cannot put the
+    ``hermes_cli`` package on ``sys.path`` in the desktop's stripped
+    environment) or is missing, fall back to the current interpreter as
+    ``python -m hermes_cli.main`` — which provably imports ``hermes_cli``
+    because this process is running inside it.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
-    if bin_path:
+    if bin_path and _bin_puts_hermes_cli_on_syspath(bin_path):
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
         argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _bin_puts_hermes_cli_on_syspath(bin_path: str) -> bool:
+    """Whether running ``bin_path`` guarantees ``hermes_cli`` is importable.
+
+    The desktop launcher runs with a stripped environment (no ``PATH`` or
+    ``PYTHONPATH``), so a portable launcher whose shebang routes through
+    ``/usr/bin/env`` cannot resolve its interpreter or its imports. A venv
+    console-script wrapper names its interpreter in an absolute shebang, so
+    that interpreter's site-packages — which contains ``hermes_cli``, since
+    the running process imported it — is on ``sys.path``. Missing or
+    unreadable paths fall through to the caller's resolution; only a
+    provably bare script is rejected.
+    """
+    try:
+        with open(bin_path, encoding="utf-8") as fh:
+            shebang = fh.readline().strip()
+    except (OSError, UnicodeDecodeError):
+        return True
+    return not shebang.startswith("#!/usr/bin/env")
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -88,6 +88,34 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+def test_exec_rejects_bare_env_script_for_module_launch(
+    tmp_path, xdg_home, monkeypatch
+):
+    # A bare launcher such as the repo-root ``hermes`` script shebangs
+    # through /usr/bin/env, so it cannot put ``hermes_cli`` on sys.path in
+    # the desktop's stripped environment. The Exec line must launch via the
+    # current interpreter instead, mirroring how the running process was
+    # launched.
+    root = _make_project(tmp_path)
+    bare_script = tmp_path / "bin" / "hermes"
+    bare_script.parent.mkdir()
+    bare_script.write_text(
+        "#!/usr/bin/env python3\nfrom hermes_cli.main import main\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(bare_script)
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The bare env-shebang launcher must not be the Exec target; the entry
+    # launches hermes_cli as a module, which provably imports the package.
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+    assert str(bare_script) not in exec_line
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")


### PR DESCRIPTION
## What
The generated Linux `hermes.desktop` entry used whatever `resolve_hermes_bin()` returned for its `Exec=` line. When that resolved to a bare Python launcher — e.g. the repo-root `hermes` script, whose `#!/usr/bin/env python3` shebang cannot put the `hermes_cli` package on `sys.path` in the desktop launcher's stripped environment — the entry failed to launch at all.

`resolve_exec_command()` in `hermes_cli/linux_desktop_entry.py` now rejects provably-bare scripts (env-shebang launchers) and falls back to the current interpreter as `python -m hermes_cli.main`, mirroring how the running process was launched. That form provably imports `hermes_cli` because the process writing the entry is running inside it. A venv console-script wrapper resolved from argv[0]/PATH is still preferred.

Rejecting the unreliable bin also makes the rendered entry byte-stable across launches, so the existing compare-before-write in `install_desktop_entry()` skips the rewrite — KDE pinned-window tracking (which keys on the `.desktop` file's identity) survives.

## Why
Fixes issue #80439: the `Exec=` path was wrong (bare script instead of an entry point with `hermes_cli` importable), and the entry was rewritten every launch.

## How to test
- `bash scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_entry.py -q`
- New regression test `test_exec_rejects_bare_env_script_for_module_launch` mocks `resolve_hermes_bin` to return a bare `#!/usr/bin/env python3` script and asserts the rendered `Exec=` launches via `-m hermes_cli.main` (it fails against the old code).
- Existing `test_install_is_idempotent_and_skips_cache_refresh` confirms a second install with unchanged content does not rewrite the entry or churn menu caches.

## Platforms
Linux (the module is Linux/BSD-only and gated by `is_supported()`).
Fixes #80439