### PR TITLE
feat(kanban): let an agent-session CLI create subscribe its origin chat

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2257,6 +2257,15 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Auto-subscribe the originating chat when ``hermes kanban create``
+        # is run from the CLI *inside an agent session* (the gateway bridges
+        # HERMES_SESSION_PLATFORM / HERMES_SESSION_CHAT_ID into terminal
+        # subprocess envs). Default False: auto-subscribing every CLI call
+        # was over-eager (PR #19718, reverted in #19721) because scripts and
+        # cron jobs also drive the CLI. With no session identity present the
+        # CLI create stays silent regardless of this knob, so enabling it
+        # only affects agent-session creates that have a delivery channel.
+        "cli_auto_subscribe": False,
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1472,6 +1472,35 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
     return 0
 
 
+def _maybe_cli_auto_subscribe(conn, task_id: str) -> bool:
+    """Subscribe the originating chat to ``task_id`` when configured.
+
+    Gated by ``kanban.cli_auto_subscribe`` (default False). ``hermes kanban
+    create`` deliberately does not auto-subscribe by default — subscribing
+    every CLI call was reverted upstream (#19718 / #19721) because scripts
+    and cron jobs also drive the CLI. When the knob is on, only a create
+    carrying a full gateway session identity (HERMES_SESSION_PLATFORM +
+    HERMES_SESSION_CHAT_ID, read via the stale-safe
+    ``gateway.session_context.get_session_env``) subscribes; bare CLI /
+    cron / script creates stay silent regardless of the knob.
+
+    Returns True when a subscription row was written. Never raises — a
+    notification bookkeeping failure must not fail the create.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        if not cfg_get(load_config(), "kanban", "cli_auto_subscribe", default=False):
+            return False
+        from tools.kanban_tools import subscribe_calling_session
+
+        return subscribe_calling_session(
+            conn, task_id, require_platform_identity=True
+        )
+    except Exception:
+        return False
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
@@ -1521,10 +1550,16 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+        auto_subscribed = _maybe_cli_auto_subscribe(conn, task_id)
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
         print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+        if auto_subscribed:
+            print(
+                "Subscribed the calling session for finish notifications "
+                "(kanban.cli_auto_subscribe)."
+            )
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are
@@ -2481,6 +2516,18 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
+        # Spawned cards nobody is watching will finish silently — surface
+        # that at the point of confusion (every dispatch run) instead of
+        # relying on the operator remembering to notify-subscribe. Computed
+        # regardless of kanban.cli_auto_subscribe; best-effort so a
+        # notification bookkeeping failure never fails the dispatch.
+        spawned_unwatched: list[str] = []
+        for _tid, _who, _ws in res.spawned:
+            try:
+                if not kb.list_notify_subs(conn, _tid):
+                    spawned_unwatched.append(_tid)
+            except Exception:
+                pass
     if getattr(args, "json", False):
         print(json.dumps({
             "reclaimed": res.reclaimed,
@@ -2493,6 +2540,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "workspace": ws}
                 for (tid, who, ws) in res.spawned
             ],
+            "spawned_unwatched": spawned_unwatched,
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
             "skipped_per_profile_capped": [
@@ -2520,6 +2568,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     for tid, who, ws in res.spawned:
         tag = " (dry)" if args.dry_run else ""
         print(f"  - {tid}  ->  {who}  @ {ws or '-'}{tag}")
+    if spawned_unwatched:
+        print(
+            f"{len(spawned_unwatched)} spawned card(s) have no notify "
+            "subscription — finishes will be silent "
+            "(kanban.cli_auto_subscribe or notify-subscribe)"
+        )
     if res.auto_assigned_default:
         print(
             f"Auto-assigned to kanban.default_assignee={default_assignee!r}: "

--- a/tests/hermes_cli/test_kanban_cli_auto_subscribe.py
+++ b/tests/hermes_cli/test_kanban_cli_auto_subscribe.py
@@ -1,0 +1,322 @@
+"""Tests for the ``kanban.cli_auto_subscribe`` knob and the dispatch-time
+unwatched-card warning.
+
+``hermes kanban create`` deliberately does NOT auto-subscribe by default —
+auto-subscribing every CLI call was reverted upstream (#19718 / #19721)
+because scripts and cron jobs also drive the CLI. But a CLI create issued
+from inside an agent session (the gateway bridges HERMES_SESSION_PLATFORM /
+HERMES_SESSION_CHAT_ID into terminal subprocess envs) is exactly the case
+where the origin chat SHOULD hear about the card's terminal events; the
+in-process tool path already does this via
+``tools.kanban_tools._maybe_auto_subscribe``.
+
+Two halves under test:
+
+1. ``kanban.cli_auto_subscribe`` (default False). When true AND the session
+   identity is present via ``gateway.session_context.get_session_env`` (the
+   same stale-identity-safe accessor the tool path uses), ``hermes kanban
+   create`` writes the same ``kanban_notify_subs`` row the tool path would.
+   No identity -> no subscription, preserving the #19718 rationale for
+   cron/script creates regardless of the knob.
+
+2. ``hermes kanban dispatch`` appends a one-line warning when spawned cards
+   have zero notify subscriptions, regardless of the knob — visibility at
+   the point of confusion instead of a silent finish.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # A prior test in this process may have engaged the session-context
+    # machinery and left the ContextVars explicitly cleared (""), which
+    # would suppress the os.environ fallback these tests rely on. Restore
+    # the "never bound" sentinel for order-independence.
+    from gateway.session_context import reset_session_vars
+
+    reset_session_vars()
+    kb.init_db()
+    return home
+
+
+def _enable_knob(home: Path) -> None:
+    (home / "config.yaml").write_text("kanban:\n  cli_auto_subscribe: true\n")
+
+
+def _set_session_env(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat1")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_TYPE", "dm")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "topic1")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "user1")
+    monkeypatch.setenv("HERMES_SESSION_MESSAGE_ID", "462")
+
+
+def _create_and_get_task_id(title: str = "hello") -> tuple[str, str]:
+    out = kc.run_slash(f'create "{title}" --assignee worker1')
+    m = re.search(r"Created\s+(t_[0-9a-f]+)\b", out)
+    assert m, f"create output did not include a task id: {out!r}"
+    return m.group(1), out
+
+
+def _subs_for(task_id: str) -> list[dict]:
+    conn = kb.connect()
+    try:
+        return kb.list_notify_subs(conn, task_id)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Half 1 — the config knob
+# ---------------------------------------------------------------------------
+
+
+def test_knob_on_with_session_env_subscribes_origin_chat(kanban_home, monkeypatch):
+    """knob=true + session identity present -> the CLI create writes the
+    same notify-sub row the tool path (`_maybe_auto_subscribe`) would,
+    delivery metadata included."""
+    _enable_knob(kanban_home)
+    _set_session_env(monkeypatch)
+
+    task_id, out = _create_and_get_task_id()
+
+    subs = _subs_for(task_id)
+    assert len(subs) == 1
+    sub = subs[0]
+    assert sub["platform"] == "telegram"
+    assert sub["chat_id"] == "chat1"
+    assert sub["thread_id"] == "topic1"
+    assert sub["user_id"] == "user1"
+    assert sub["chat_type"] == "dm"
+    assert sub["delivery_metadata"] == {
+        "chat_type": "dm",
+        "direct_messages_topic_id": "topic1",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "462",
+        "thread_id": "topic1",
+    }
+    # Text output tells the operator the subscription happened.
+    assert "cli_auto_subscribe" in out
+
+
+def test_knob_defaults_off_no_subscription(kanban_home, monkeypatch):
+    """CONTROL: with no config at all (knob default False), a CLI create
+    with full session identity present must NOT subscribe — this pins the
+    #19718 default. Passes on the pre-change tree by construction."""
+    _set_session_env(monkeypatch)
+
+    task_id, out = _create_and_get_task_id("default off")
+
+    assert _subs_for(task_id) == []
+    assert "cli_auto_subscribe" not in out
+
+
+def test_knob_explicitly_false_no_subscription(kanban_home, monkeypatch):
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  cli_auto_subscribe: false\n"
+    )
+    _set_session_env(monkeypatch)
+
+    task_id, _ = _create_and_get_task_id("explicit false")
+
+    assert _subs_for(task_id) == []
+
+
+def test_knob_on_without_session_env_no_subscription(kanban_home, monkeypatch):
+    """knob=true but no session identity (cron / bare script) -> silent,
+    preserving the upstream #19718 revert rationale."""
+    _enable_knob(kanban_home)
+    for var in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_CHAT_TYPE",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_MESSAGE_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    task_id, out = _create_and_get_task_id("no env")
+
+    assert _subs_for(task_id) == []
+    assert "cli_auto_subscribe" not in out
+
+
+def test_knob_on_half_identity_no_subscription(kanban_home, monkeypatch):
+    """Platform without chat id is not a routable identity."""
+    _enable_knob(kanban_home)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+
+    task_id, _ = _create_and_get_task_id("half identity")
+
+    assert _subs_for(task_id) == []
+
+
+def test_stale_cleared_context_rejects_env_chat_id(kanban_home, monkeypatch):
+    """Stale-identity rejection, same semantics as the tool path: when the
+    session-context machinery was engaged and then explicitly cleared
+    (handler exited), ``get_session_env`` returns "" and must NOT fall back
+    to a stale os.environ mirror — so no subscription is written even
+    though the env vars are present."""
+    from gateway.session_context import (
+        clear_session_vars,
+        reset_session_vars,
+        set_session_vars,
+    )
+
+    _enable_knob(kanban_home)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "stale-chat")
+
+    tokens = set_session_vars(platform="telegram", chat_id="live-chat")
+    try:
+        clear_session_vars(tokens)  # identity explicitly cleared -> "" wins
+        task_id, _ = _create_and_get_task_id("stale identity")
+        assert _subs_for(task_id) == []
+    finally:
+        reset_session_vars()
+
+
+def test_add_notify_sub_failure_does_not_fail_create(kanban_home, monkeypatch):
+    """A notification bookkeeping failure must never fail the create."""
+    _enable_knob(kanban_home)
+    _set_session_env(monkeypatch)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(kb, "add_notify_sub", _boom)
+
+    task_id, out = _create_and_get_task_id("sub failure tolerated")
+    assert task_id
+    assert "cli_auto_subscribe" not in out  # did not claim success
+
+
+# ---------------------------------------------------------------------------
+# Half 2 — dispatch-time unwatched-card warning
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_args(**overrides) -> argparse.Namespace:
+    base = dict(dry_run=False, max=None, failure_limit=2, json=False)
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _fake_dispatch(monkeypatch, spawned):
+    res = kb.DispatchResult(spawned=spawned)
+    monkeypatch.setattr(kb, "dispatch_once", lambda conn, **kw: res)
+
+
+def test_dispatch_warns_on_spawned_cards_with_zero_subs(
+    kanban_home, monkeypatch, capsys
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="unwatched", assignee="worker1")
+    finally:
+        conn.close()
+    _fake_dispatch(monkeypatch, [(tid, "worker1", "/tmp/ws")])
+
+    rc = kc._cmd_dispatch(_dispatch_args())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert (
+        "1 spawned card(s) have no notify subscription — finishes will be "
+        "silent (kanban.cli_auto_subscribe or notify-subscribe)"
+    ) in out
+
+
+def test_dispatch_warning_suppressed_when_spawned_cards_are_watched(
+    kanban_home, monkeypatch, capsys
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="watched", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat1"
+        )
+    finally:
+        conn.close()
+    _fake_dispatch(monkeypatch, [(tid, "worker1", "/tmp/ws")])
+
+    rc = kc._cmd_dispatch(_dispatch_args())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "no notify subscription" not in out
+
+
+def test_dispatch_warning_absent_when_nothing_spawned(
+    kanban_home, monkeypatch, capsys
+):
+    _fake_dispatch(monkeypatch, [])
+
+    rc = kc._cmd_dispatch(_dispatch_args())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "no notify subscription" not in out
+
+
+def test_dispatch_warning_counts_only_unwatched(kanban_home, monkeypatch, capsys):
+    conn = kb.connect()
+    try:
+        tid_watched = kb.create_task(conn, title="w", assignee="worker1")
+        tid_silent_a = kb.create_task(conn, title="a", assignee="worker1")
+        tid_silent_b = kb.create_task(conn, title="b", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid_watched, platform="telegram", chat_id="chat1"
+        )
+    finally:
+        conn.close()
+    _fake_dispatch(
+        monkeypatch,
+        [
+            (tid_watched, "worker1", ""),
+            (tid_silent_a, "worker1", ""),
+            (tid_silent_b, "worker1", ""),
+        ],
+    )
+
+    rc = kc._cmd_dispatch(_dispatch_args())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "2 spawned card(s) have no notify subscription" in out
+
+
+def test_dispatch_json_carries_spawned_unwatched_without_text_warning(
+    kanban_home, monkeypatch, capsys
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="json unwatched", assignee="worker1")
+    finally:
+        conn.close()
+    _fake_dispatch(monkeypatch, [(tid, "worker1", "")])
+
+    rc = kc._cmd_dispatch(_dispatch_args(json=True))
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    payload = json.loads(out)  # stdout must stay strictly machine-parseable
+    assert payload["spawned_unwatched"] == [tid]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1397,6 +1397,30 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         # user-friendly behaviour that mirrors the pre-gate implementation.
         pass
 
+    return subscribe_calling_session(conn, task_id)
+
+
+def subscribe_calling_session(
+    conn: Any, task_id: str, *, require_platform_identity: bool = False
+) -> bool:
+    """Resolve the calling session's delivery identity and write a notify sub.
+
+    Shared by the agent-tool auto-subscribe path (:func:`_maybe_auto_subscribe`,
+    gated by ``kanban.auto_subscribe_on_create``) and the CLI create path
+    (``hermes kanban create``, gated by ``kanban.cli_auto_subscribe`` in
+    ``hermes_cli.kanban._cmd_create``). Identity is read through
+    ``gateway.session_context.get_session_env`` so an explicitly cleared
+    session context ("" ContextVar) suppresses a stale ``os.environ``
+    mirror instead of subscribing a foreign chat.
+
+    ``require_platform_identity=True`` (the CLI path) accepts only a full
+    gateway identity (platform + chat id) and skips the TUI
+    ``HERMES_SESSION_KEY`` fallback below: a bare CLI/cron/script create
+    has no delivery channel and must stay silent (#19718).
+
+    Returns True if a subscription row was written; any exception is
+    logged at WARNING and swallowed (returns False).
+    """
     platform = ""
     chat_id = ""
     try:
@@ -1404,6 +1428,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         platform = get_session_env("HERMES_SESSION_PLATFORM", "")
         chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
         if not platform or not chat_id:
+            if require_platform_identity:
+                return False
             # TUI / desktop fallback: platform/chat_id ContextVars are
             # cleared for TUI sessions, but the parent process exports
             # HERMES_SESSION_KEY into the subprocess env. Treat that
@@ -1468,7 +1494,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         return True
     except Exception as _exc:
         logger.warning(
-            "_maybe_auto_subscribe failed: %r (platform=%r key_set=%r)",
+            "subscribe_calling_session failed: %r (platform=%r key_set=%r)",
             _exc, platform, bool(chat_id),
         )
         return False

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -584,6 +584,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `cli_auto_subscribe` | `false` | Same auto-subscribe, but for `hermes kanban create` run on the CLI. Off by default because scripts and cron jobs also drive the CLI. When on, only a create carrying a full gateway session identity (`HERMES_SESSION_PLATFORM` + `HERMES_SESSION_CHAT_ID`, which the gateway exports into terminal subprocesses) subscribes; a bare CLI/cron/script create stays silent either way. |
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
`hermes kanban create` never registers a notify subscription, so a card
created from a terminal inside an agent session finishes silently — the
chat that asked for the work is not watching. The in-process tool path
already handles this (`_maybe_auto_subscribe`, gated by
`kanban.auto_subscribe_on_create`); the CLI path never got the equivalent.

Auto-subscribing every CLI call is not the answer — that was #19718 and it
was reverted, correctly: scripts and cron jobs drive the same CLI and have
no delivery channel. So this is two narrower pieces:

1. `kanban.cli_auto_subscribe`, default **false**. When enabled, a CLI
   create subscribes the origin chat only if it carries a full gateway
   session identity (HERMES_SESSION_PLATFORM + HERMES_SESSION_CHAT_ID,
   which the gateway exports into terminal subprocesses). Identity is read
   through `gateway.session_context.get_session_env`, so an explicitly
   cleared session context suppresses a stale `os.environ` mirror instead
   of subscribing a foreign chat. No identity -> no subscription,
   regardless of the knob, preserving the #19718 rationale.

   The identity resolution + notify-sub write is factored out of
   `_maybe_auto_subscribe` into `subscribe_calling_session(...)` so both
   callers share one implementation. `require_platform_identity=True` (the
   CLI path) additionally skips the TUI `HERMES_SESSION_KEY` fallback.

2. `hermes kanban dispatch` now prints one line when spawned cards have
   zero notify subscriptions, regardless of the knob:

     N spawned card(s) have no notify subscription - finishes will be
     silent (kanban.cli_auto_subscribe or notify-subscribe)

   JSON output carries the same fact as `spawned_unwatched` so stdout stays
   machine-parseable. This is the discoverable half: the operator learns
   about the silence at the moment it is created, not after the cards
   finish. Both paths are best-effort — a notification bookkeeping failure
   never fails a create or a dispatch.

Tests: tests/hermes_cli/test_kanban_cli_auto_subscribe.py (12 cases) —
knob on/off/default, identity present/absent/half, stale-cleared context
rejected, add_notify_sub failure tolerated, warning renders/suppresses/
counts-only-unwatched, JSON field. RED-proven: 4 of the 12 fail on the
parent commit; the other 8 pin the pre-existing default-off behaviour.

---

**Why default-false:** #19718 auto-subscribed every CLI `create` and was reverted
for good reason — scripts and cron jobs drive the same CLI and have no delivery
channel. This lands the capability behind an opt-in knob and, separately, makes
the silence *visible* at dispatch time whether or not the knob is on.

**Verification**

- `pytest tests/hermes_cli/test_kanban_cli_auto_subscribe.py -q` -> `12 passed`
  (also green across 10 `--randomly-seed` orderings).
- RED proof: the same file copied onto a detached `origin/main` worktree ->
  `4 failed, 8 passed`. The 4 that fail are the new behaviour; the 8 that pass
  pin the pre-existing default-off/no-identity semantics.
- `pytest tests/hermes_cli/ -k kanban -p no:randomly` -> `177 passed, 7 failed`;
  the same 7 fail on unmodified `origin/main` (pre-existing, order-sensitive:
  `test_kanban_write_guard`, `test_kanban_db`, `test_kanban_decompose`,
  `test_kanban_lifecycle_hooks`). No new failures attributable to this change.
