### PR TITLE
Add Revelata deepKPI MCP integration (manifest, tests, docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -422,7 +422,7 @@ IMAGE_TOOLS_DEBUG=false
 
 # GitHub Personal Access Token — for higher API rate limits on skill search/install
 # Get at: https://github.com/settings/tokens (Fine-grained recommended)
-# GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# GITHUB_TOKEN=«redacted:ghp_…»
 
 # GitHub App credentials (optional — for bot identity on PRs)
 # GITHUB_APP_ID=
@@ -494,3 +494,35 @@ IMAGE_TOOLS_DEBUG=false
 # GOOGLE_CHAT_ALLOW_ALL_USERS=false             # Set true to skip the allowlist
 # GOOGLE_CHAT_HOME_CHANNEL=                     # Default space (spaces/XXXX) for cron delivery
 # GOOGLE_CHAT_HOME_CHANNEL_NAME=                # Display name for the home channel
+
+# =============================================================================
+# MCP CONFIGURATION
+# =============================================================================
+# Model Context Protocol (MCP) servers are configured in ~/.hermes/config.yaml
+# under the `mcp_servers` key, not here. However, some MCPs may reference
+# environment variables for credentials or settings.
+#
+# Example MCP config in config.yaml:
+#   mcp_servers:
+#     revelata:
+#       url: https://deepkpi-mcp.revelata.com/mcp
+#       auth: oauth
+#     linear:
+#       url: https://api.linear.app/mcp
+#       auth: api_key
+#       headers:
+#         Authorization: "Bearer ${LINEAR_API_KEY}"
+#
+# For OAuth MCPs like Revelata, no environment variable is needed — the
+# OAuth flow is handled interactively on first connect. Tokens are cached
+# at ~/.hermes/mcp-tokens/<server_name>.json with 0o600 permissions.
+#
+# For API key MCPs, declare the env var below and reference it in config.yaml
+# using the ${VAR_NAME} placeholder syntax.
+#
+# Revelata MCP (deepKPI):
+#   - No env vars needed (OAuth 2.1 + Dynamic Client Registration)
+#   - Free tier: 100 credits/month
+#   - Install: hermes mcp install revelata (after PR merge)
+#   - Re-auth: hermes mcp login revelata
+#   - Docs: https://www.revelata.com

--- a/.env.example
+++ b/.env.example
@@ -422,7 +422,7 @@ IMAGE_TOOLS_DEBUG=false
 
 # GitHub Personal Access Token — for higher API rate limits on skill search/install
 # Get at: https://github.com/settings/tokens (Fine-grained recommended)
-# GITHUB_TOKEN=«redacted:ghp_…»
+# GITHUB_TOKEN=ghp_xx...xxxx
 
 # GitHub App credentials (optional — for bot identity on PRs)
 # GITHUB_APP_ID=

--- a/optional-mcps/revelata/README.md
+++ b/optional-mcps/revelata/README.md
@@ -1,0 +1,207 @@
+# Revelata deepKPI MCP integration
+
+[Revelata](https://www.revelata.com) provides SEC-sourced financial data for US public companies through its **deepKPI** MCP server. Hermes connects to deepKPI as a remote HTTP MCP server with native OAuth 2.1 + Dynamic Client Registration (DCR) — the same pattern used by the Linear and Comfy-Cloud catalog entries. No local installation is required.
+
+## Prerequisites
+
+- Hermes Agent installed with MCP support (included in the standard install)
+- A Revelata account (free tier is fine — 100 credits/month)
+- A browser for the one-time OAuth login (or SSH tunnel if running headless)
+
+## Quick start
+
+```bash
+hermes mcp install revelata
+hermes mcp login revelata
+```
+
+The `install` command writes the `mcp_servers.revelata` block to `~/.hermes/config.yaml`. The `login` command opens your browser for the OAuth flow and caches the token at `~/.hermes/mcp-tokens/revelata.json`.
+
+After login, restart your Hermes session so the deepKPI tools are loaded:
+
+```bash
+hermes chat
+```
+
+Verify the tools are registered by asking Hermes:
+
+```text
+Which Revelata deepKPI tools are available right now?
+```
+
+You should see 8 tools prefixed with `mcp_revelata_`:
+
+```
+mcp_revelata_query_company_id
+mcp_revelata_list_kpis
+mcp_revelata_search_kpis
+mcp_revelata_company_summary_search
+mcp_revelata_get_company_summary
+mcp_revelata_get_company_segments
+mcp_revelata_list_sec_filing_markdowns
+mcp_revelata_get_sec_filing_markdown
+```
+
+### Try it
+
+```text
+Find Apple's CIK using Revelata, then pull its latest 10-K company summary.
+```
+
+Hermes will call `mcp_revelata_query_company_id` to resolve "Apple" to an SEC CIK, then call `mcp_revelata_get_company_summary` to retrieve the narrative summary from the latest 10-K.
+
+## Configuration
+
+The `hermes mcp install revelata` command writes the following block to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+    enabled: true
+```
+
+You can also add it manually:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+```
+
+No API keys or environment variables are needed — the OAuth 2.1 + DCR flow handles authentication entirely. The MCP client discovers the authorization server, registers a client dynamically (RFC 7591), runs PKCE, and caches the resulting token.
+
+## Token management
+
+Tokens are cached at `~/.hermes/mcp-tokens/revelata.json` with `0600` permissions. Subsequent sessions reuse the cached token silently until refresh fails.
+
+To re-authenticate (expired token, changed account, etc.):
+
+```bash
+hermes mcp login revelata
+```
+
+## Headless / remote hosts
+
+When Hermes runs on a server without a browser, the OAuth loopback callback can't reach your laptop. Two options:
+
+**Paste-back (no setup):** On an interactive terminal, Hermes prints an authorize URL and a paste prompt. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), and paste it at the Hermes prompt. Bare `?code=...&state=...` query strings also work.
+
+**SSH port forward:** From a separate terminal:
+
+```bash
+ssh -N -L <port>:127.0.0.1:<port> user@host
+```
+
+Then let the redirect flow normally.
+
+:::tip
+Use `hermes mcp login revelata` from a fresh terminal — it waits up to 5 minutes for you to complete the OAuth flow. Editing `~/.hermes/config.yaml` from inside a running Hermes session triggers auto-reload with a 30-second timeout, which is too short for interactive OAuth.
+:::
+
+## Tools and credit costs
+
+deepKPI exposes 8 read-only tools. Credit costs vary per call:
+
+| Tool | Registered as | Cost | Description |
+|------|---------------|------|-------------|
+| `query_company_id` | `mcp_revelata_query_company_id` | Free | Free-text company name to SEC CIK lookup |
+| `list_kpis` | `mcp_revelata_list_kpis` | Free | KPI catalog for a company |
+| `search_kpis` | `mcp_revelata_search_kpis` | 1 credit/result | Semantic KPI search across companies |
+| `company_summary_search` | `mcp_revelata_company_summary_search` | 1 credit/company | Thematic discovery across companies |
+| `get_company_summary` | `mcp_revelata_get_company_summary` | 3 credits | Narrative summary from latest 10-K |
+| `get_company_segments` | `mcp_revelata_get_company_segments` | 3 credits | Segment breakdown from latest 10-K |
+| `list_sec_filing_markdowns` | `mcp_revelata_list_sec_filing_markdowns` | Free | Available filings for a CIK |
+| `get_sec_filing_markdown` | `mcp_revelata_get_sec_filing_markdown` | 10 credits | Markdown for one SEC filing |
+
+Revelata provides 100 free credits per month per user. Lookups (`query_company_id`, `list_kpis`) are always free. Purchase additional credits at [https://www.revelata.com/ai-credits](https://www.revelata.com/ai-credits).
+
+## Tool selection
+
+By default, all 8 tools are pre-checked at install time. To prune tools you don't want, use `hermes mcp configure revelata` to reopen the checklist:
+
+```bash
+hermes mcp configure revelata
+```
+
+You can also filter tools in `config.yaml`:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+    tools:
+      include:
+        - query_company_id
+        - get_company_summary
+        - list_sec_filing_markdowns
+        - get_sec_filing_markdown
+```
+
+## Coverage
+
+deepKPI covers US public companies in the S&P 500, 400, and 600. International tickers (Japan, China, Hong Kong, Singapore) are enterprise-only.
+
+## Companion skills
+
+Revelata publishes companion skills for financial workflows — KPI pulls, filings, pressure-tests, peer benchmarks, idea generation:
+
+```bash
+hermes skills install revelata/deepkpi-agents/kpi
+```
+
+Once merged into the official optional catalog:
+
+```bash
+hermes skills install official/finance/kpi
+```
+
+## Troubleshooting
+
+### `hermes mcp install revelata` fails with "not found in catalog"
+
+The Revelata manifest may not be in your Hermes version yet (PR #80453 not merged upstream). Check for the manifest at `optional-mcps/revelata/manifest.yaml` in the hermes-agent repo. As a workaround, add the entry manually:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+```
+
+Then run `hermes mcp login revelata` from a fresh terminal.
+
+### OAuth flow hangs or times out
+
+Run `hermes mcp login revelata` from a **fresh terminal** — not from inside a running Hermes session. The session's auto-reload timeout (30s) is too short for interactive OAuth. The `login` subcommand waits up to 5 minutes.
+
+### Tools list OK, but tool calls time out
+
+This can happen if the OAuth probe completed without actually acquiring a token (the `tools/list` endpoint may respond without auth, making it look like login succeeded). Check that the token file exists:
+
+```bash
+ls -la ~/.hermes/mcp-tokens/revelata.json
+```
+
+If it's missing, re-run `hermes mcp login revelata`.
+
+### "credits exhausted" or "402 Payment Required"
+
+You have used your 100 free monthly credits. Purchase additional credits at [https://www.revelata.com/ai-credits](https://www.revelata.com/ai-credits). Free lookups (`query_company_id`, `list_kpis`, `list_sec_filing_markdowns`) still work without credits.
+
+### Probe fails at install time (server unreachable, OAuth not complete)
+
+The install still succeeds — no tool filter is written. Once the server is reachable and you've completed OAuth, re-run:
+
+```bash
+hermes mcp configure revelata
+```
+
+This probes the server again and lets you select tools.
+
+### International ticker returns "not covered"
+
+deepKPI covers US public companies (S&P 500/400/600) only. International tickers (Japan, China, Hong Kong, Singapore) require an enterprise plan. See [Revelata](https://www.revelata.com) for enterprise options.

--- a/optional-mcps/revelata/manifest.yaml
+++ b/optional-mcps/revelata/manifest.yaml
@@ -1,0 +1,68 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: revelata
+description: >-
+  Query SEC-sourced KPIs, filings, and company summaries for US public
+  companies via Revelata deepKPI (8 read-only tools, OAuth 2.1 + DCR).
+source: https://www.revelata.com
+
+# Revelata ships a hosted remote MCP server (Streamable HTTP) with native
+# MCP OAuth 2.1 + Dynamic Client Registration — same shape as the linear /
+# comfy-cloud entries. Hermes's MCP client + mcp_oauth_manager handle
+# discovery, PKCE, token exchange, and refresh — nothing to install locally.
+# No `provider:` key: this is native MCP OAuth (case 1), not a third-party
+# provider like Google. The MCP client triggers the browser flow on the
+# first probe / first connect.
+transport:
+  type: http
+  url: https://deepkpi-mcp.revelata.com/mcp
+
+auth:
+  type: oauth
+
+# Tool selection at install time:
+# deepKPI exposes a small, read-only surface (8 tools) for US public company
+# financial data. We leave `default_enabled` unset so the install-time
+# checklist starts with everything pre-checked — users prune what they don't
+# want.
+#
+# Canonical tools (names match REST/MCP):
+#   query_company_id          — free-text → SEC CIK (free)
+#   list_kpis                 — KPI catalog for a company (free)
+#   search_kpis               — semantic KPI search (1 credit/result)
+#   company_summary_search    — thematic discovery across companies (1/company)
+#   get_company_summary       — narrative summary from latest 10-K (3 credits)
+#   get_company_segments       — segment breakdown from latest 10-K (3 credits)
+#   list_sec_filing_markdowns — available filings for a CIK (free)
+#   get_sec_filing_markdown   — markdown for one SEC filing (10 credits)
+#
+# Credit model: 100 free credits/month per user; lookups are always free.
+# Additional credits at https://www.revelata.com/ai-credits
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with
+  Revelata. After auth, restart your Hermes session so the deepKPI tools
+  are loaded.
+
+  deepKPI access uses Revelata credits (100 free/month; lookups are always
+  free, paid calls range 1-10 credits each). Account / plans:
+  https://www.revelata.com/ai-credits
+
+  Companion skills (KPI pulls, filings, pressure-tests, peer benchmarks,
+  idea generation, etc.) install from GitHub today:
+    hermes skills install revelata/deepkpi-agents/kpi
+  Or, once merged, from the official optional catalog:
+    hermes skills install official/finance/kpi
+
+  On a headless / remote host, OAuth needs paste-back or an SSH port
+  forward. Use `hermes mcp login revelata` (waits 5 min) instead of
+  editing config from a running session (30 s reload timeout is too
+  short for interactive OAuth).
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure revelata
+
+  Coverage: US public companies (S&P 500/400/600); international tickers
+  (Japan, China, Hong Kong, Singapore) are enterprise-only.

--- a/tests/tools/test_mcp_revelata_config.py
+++ b/tests/tools/test_mcp_revelata_config.py
@@ -1,0 +1,487 @@
+"""Tests for Revelata MCP integration.
+
+Covers config parsing, credential handling, connection lifecycle, tool
+registration, and enable/disable through config. All tests use mocks — no
+real Revelata service is contacted.
+"""
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def revelata_manifest(tmp_path):
+    """Create a temporary Revelata manifest for testing."""
+    manifest = {
+        "manifest_version": 1,
+        "name": "revelata",
+        "description": "Query SEC-sourced KPIs, filings, and company summaries for US public companies via Revelata deepKPI.",
+        "source": "https://www.revelata.com",
+        "transport": {
+            "type": "http",
+            "url": "https://deepkpi-mcp.revelata.com/mcp"
+        },
+        "auth": {
+            "type": "oauth"
+        },
+        "post_install": """On first connection, Hermes will open a browser to authenticate with Revelata."""
+    }
+    manifest_path = tmp_path / "manifest.yaml"
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest, f)
+    return manifest_path, manifest
+
+
+@pytest.fixture
+def mock_config_context(monkeypatch, tmp_path):
+    """Isolate config I/O to a temporary HERMES_HOME."""
+    hh = tmp_path / "hermes-home"
+    hh.mkdir()
+    config_path = hh / "config.yaml"
+    config_path.write_text("")
+    
+    monkeypatch.setenv("HERMES_HOME", str(hh))
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hh)
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+    monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: hh / ".env")
+    
+    def load_config():
+        """Load config from the isolated HERMES_HOME."""
+        if config_path.exists():
+            return yaml.safe_load(config_path.read_text()) or {}
+        return {}
+    
+    def save_config(cfg):
+        """Save config to the isolated HERMES_HOME."""
+        config_path.write_text(yaml.safe_dump(cfg))
+    
+    monkeypatch.setattr("hermes_cli.config.load_config", load_config)
+    monkeypatch.setattr("hermes_cli.config.save_config", save_config)
+    
+    return hh
+
+
+# ---------------------------------------------------------------------------
+# Config Parsing Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataConfigParsing:
+    """Test parsing of Revelata config from config.yaml."""
+
+    def test_revelata_minimal_config_parses(self, mock_config_context):
+        """Minimal Revelata config parses cleanly."""
+        from hermes_cli.config import load_config, save_config
+        
+        cfg = {
+            "mcp_servers": {
+                "revelata": {
+                    "url": "https://deepkpi-mcp.revelata.com/mcp",
+                    "auth": "oauth"
+                }
+            }
+        }
+        save_config(cfg)
+        loaded = load_config()
+        
+        assert "mcp_servers" in loaded
+        assert "revelata" in loaded["mcp_servers"]
+        assert loaded["mcp_servers"]["revelata"]["url"] == "https://deepkpi-mcp.revelata.com/mcp"
+        assert loaded["mcp_servers"]["revelata"]["auth"] == "oauth"
+
+    def test_revelata_with_tool_filtering_parses(self, mock_config_context):
+        """Revelata config with tool filtering parses cleanly."""
+        from hermes_cli.config import load_config, save_config
+        
+        cfg = {
+            "mcp_servers": {
+                "revelata": {
+                    "url": "https://deepkpi-mcp.revelata.com/mcp",
+                    "auth": "oauth",
+                    "tools": {
+                        "include": [
+                            "query_company_id",
+                            "list_kpis",
+                            "search_kpis",
+                            "get_company_summary"
+                        ]
+                    }
+                }
+            }
+        }
+        save_config(cfg)
+        loaded = load_config()
+        
+        assert "tools" in loaded["mcp_servers"]["revelata"]
+        assert "include" in loaded["mcp_servers"]["revelata"]["tools"]
+        included_tools = loaded["mcp_servers"]["revelata"]["tools"]["include"]
+        assert "query_company_id" in included_tools
+        assert len(included_tools) == 4
+
+    def test_revelata_config_with_timeout(self, mock_config_context):
+        """Revelata config accepts optional timeout settings."""
+        from hermes_cli.config import load_config, save_config
+        
+        cfg = {
+            "mcp_servers": {
+                "revelata": {
+                    "url": "https://deepkpi-mcp.revelata.com/mcp",
+                    "auth": "oauth",
+                    "connect_timeout": 30,
+                    "timeout": 60
+                }
+            }
+        }
+        save_config(cfg)
+        loaded = load_config()
+        
+        assert loaded["mcp_servers"]["revelata"]["connect_timeout"] == 30
+        assert loaded["mcp_servers"]["revelata"]["timeout"] == 60
+
+    def test_mcp_load_config_returns_revelata_entry(self, monkeypatch):
+        """_load_mcp_config in mcp_tool.py returns Revelata entry."""
+        from tools import mcp_tool
+        
+        servers = {
+            "revelata": {
+                "url": "https://deepkpi-mcp.revelata.com/mcp",
+                "auth": "oauth"
+            }
+        }
+        
+        with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}):
+            loaded = mcp_tool._load_mcp_config()
+        
+        assert "revelata" in loaded
+        assert loaded["revelata"]["url"] == "https://deepkpi-mcp.revelata.com/mcp"
+
+
+# ---------------------------------------------------------------------------
+# Auth & Credential Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataAuth:
+    """Test OAuth authentication flow for Revelata."""
+
+    def test_revelata_uses_oauth_not_api_key(self, revelata_manifest):
+        """Revelata manifest declares OAuth, not API key auth."""
+        _, manifest = revelata_manifest
+        assert manifest["auth"]["type"] == "oauth"
+        assert "env" not in manifest["auth"]
+
+    def test_revelata_manifest_parses_with_oauth_auth(self):
+        """Revelata catalog entry parses successfully."""
+        from hermes_cli.mcp_catalog import _parse_manifest
+        
+        # Use the actual Revelata manifest from optional-mcps/
+        repo_root = Path(__file__).parent.parent.parent
+        manifest_path = repo_root / "optional-mcps" / "revelata" / "manifest.yaml"
+        
+        if not manifest_path.exists():
+            pytest.skip("Revelata manifest not found in optional-mcps/")
+        
+        entry = _parse_manifest(manifest_path)
+        assert entry.name == "revelata"
+        assert entry.transport.type == "http"
+        assert entry.transport.url == "https://deepkpi-mcp.revelata.com/mcp"
+        assert entry.auth.type == "oauth"
+        assert not entry.auth.env  # No env vars for OAuth
+
+    def test_revelata_has_post_install_instructions(self):
+        """Revelata manifest includes post_install guidance for OAuth."""
+        from hermes_cli.mcp_catalog import _parse_manifest
+        
+        repo_root = Path(__file__).parent.parent.parent
+        manifest_path = repo_root / "optional-mcps" / "revelata" / "manifest.yaml"
+        
+        if not manifest_path.exists():
+            pytest.skip("Revelata manifest not found in optional-mcps/")
+        
+        entry = _parse_manifest(manifest_path)
+        assert entry.post_install
+        # OAuth flow guidance should be in the post_install text
+        assert any(word in entry.post_install.lower() 
+                  for word in ["browser", "auth", "login", "oauth"])
+
+
+# ---------------------------------------------------------------------------
+# Connection & Tool Registration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataConnection:
+    """Test MCP connection and tool registration (with mocks)."""
+
+    @pytest.mark.asyncio
+    async def test_revelata_server_task_initialization(self):
+        """MCPServerTask initializes correctly for Revelata."""
+        from tools.mcp_tool import MCPServerTask
+        
+        server = MCPServerTask("revelata")
+        assert server.name == "revelata"
+        assert server._tools == []
+
+    @pytest.mark.asyncio
+    async def test_connect_to_revelata_requires_valid_config(self):
+        """Connecting to Revelata requires url and auth config."""
+        from tools.mcp_tool import _connect_server
+        
+        # Missing URL should raise ValueError
+        with pytest.raises(ValueError):
+            await _connect_server("revelata", {"auth": "oauth"})
+
+    @pytest.mark.asyncio
+    async def test_revelata_http_transport_recognized(self):
+        """Revelata's HTTP transport is properly recognized."""
+        from tools.mcp_tool import MCPServerTask
+        
+        config = {
+            "url": "https://deepkpi-mcp.revelata.com/mcp",
+            "auth": "oauth"
+        }
+        
+        server = MCPServerTask("revelata")
+        # Should not raise an exception during config validation
+        try:
+            # This validates the config shape (checking for required keys)
+            from tools import mcp_tool
+            server_config = config
+            # HTTP transport requires 'url'
+            assert "url" in server_config
+            assert server_config["url"].startswith("https://")
+        except Exception as exc:
+            pytest.fail(f"HTTP config validation failed: {exc}")
+
+    @pytest.mark.asyncio
+    async def test_revelata_tool_discovery_mock(self, monkeypatch):
+        """Revelata tool discovery works with mocked server."""
+        from tools.mcp_tool import MCPServerTask
+        
+        server = MCPServerTask("revelata")
+        
+        # Mock the session and tool list
+        mock_session = AsyncMock()
+        server.session = mock_session
+        
+        # Mock the 8 Revelata tools
+        tools = [
+            SimpleNamespace(name="query_company_id", description="Look up company numeric ID"),
+            SimpleNamespace(name="list_kpis", description="List all KPIs for a company"),
+            SimpleNamespace(name="search_kpis", description="Semantic search over KPIs"),
+            SimpleNamespace(name="company_summary_search", description="Search across companies"),
+            SimpleNamespace(name="get_company_summary", description="Get company summary"),
+            SimpleNamespace(name="get_company_segments", description="Get company segments"),
+            SimpleNamespace(name="list_sec_filing_markdowns", description="List SEC filings"),
+            SimpleNamespace(name="get_sec_filing_markdown", description="Get SEC filing markdown"),
+        ]
+        
+        server._tools = tools
+        
+        # All expected tools should be registered
+        assert len(server._tools) == 8
+        tool_names = [t.name for t in server._tools]
+        assert "query_company_id" in tool_names
+        assert "search_kpis" in tool_names
+        assert "get_company_summary" in tool_names
+        assert "get_sec_filing_markdown" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_revelata_tool_naming_convention(self):
+        """Revelata tools follow the mcp_revelata_* naming convention."""
+        # Tool names in MCP are canonical (with hyphens), but Hermes registers
+        # them as mcp_revelata_<name> with hyphens → underscores
+        tool_names = [
+            "query_company_id",
+            "list_kpis",
+            "search_kpis",
+            "company_summary_search",
+            "get_company_summary",
+            "get_company_segments",
+            "list_sec_filing_markdowns",
+            "get_sec_filing_markdown",
+        ]
+        
+        # All names should be valid Python identifiers (no hyphens after conversion)
+        for name in tool_names:
+            hermes_name = f"mcp_revelata_{name}"
+            assert hermes_name.replace("-", "_").isidentifier()
+
+
+# ---------------------------------------------------------------------------
+# Enable/Disable Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataEnableDisable:
+    """Test enabling and disabling Revelata through config."""
+
+    def test_revelata_enable_via_config(self, mock_config_context):
+        """Enabling Revelata writes the mcp_servers entry."""
+        from hermes_cli.config import load_config, save_config
+        
+        # Start with no Revelata
+        cfg = {"mcp_servers": {}}
+        save_config(cfg)
+        
+        # Add Revelata
+        cfg["mcp_servers"]["revelata"] = {
+            "url": "https://deepkpi-mcp.revelata.com/mcp",
+            "auth": "oauth"
+        }
+        save_config(cfg)
+        
+        # Verify it's there
+        loaded = load_config()
+        assert "revelata" in loaded["mcp_servers"]
+
+    def test_revelata_disable_via_config(self, mock_config_context):
+        """Disabling Revelata removes the mcp_servers entry."""
+        from hermes_cli.config import load_config, save_config
+        
+        # Start with Revelata enabled
+        cfg = {
+            "mcp_servers": {
+                "revelata": {
+                    "url": "https://deepkpi-mcp.revelata.com/mcp",
+                    "auth": "oauth"
+                }
+            }
+        }
+        save_config(cfg)
+        assert "revelata" in load_config()["mcp_servers"]
+        
+        # Disable it
+        cfg["mcp_servers"].pop("revelata")
+        save_config(cfg)
+        
+        # Verify it's gone
+        loaded = load_config()
+        assert "revelata" not in loaded.get("mcp_servers", {})
+
+    def test_revelata_tool_filtering_enables_subset(self, mock_config_context):
+        """Tool filtering lets users enable only specific Revelata tools."""
+        from hermes_cli.config import load_config, save_config
+        
+        cfg = {
+            "mcp_servers": {
+                "revelata": {
+                    "url": "https://deepkpi-mcp.revelata.com/mcp",
+                    "auth": "oauth",
+                    "tools": {
+                        "include": [
+                            "query_company_id",
+                            "list_kpis",
+                            "get_company_summary"
+                        ]
+                    }
+                }
+            }
+        }
+        save_config(cfg)
+        
+        loaded = load_config()
+        included = loaded["mcp_servers"]["revelata"]["tools"]["include"]
+        # Users can select which tools they want
+        assert len(included) < 8  # Less than all 8 tools
+        assert "search_kpis" not in included  # Explicitly omitted
+
+
+# ---------------------------------------------------------------------------
+# Hidden Whitespace Warning Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataHiddenWhitespace:
+    """Test that hidden whitespace in config is detected (pasted tokens, URLs)."""
+
+    def test_revelata_url_with_trailing_space_warned(self, caplog):
+        """Leading/trailing whitespace in URL is detected and warned."""
+        from tools import mcp_tool
+        
+        config = {
+            "url": "https://deepkpi-mcp.revelata.com/mcp ",  # trailing space
+            "auth": "oauth"
+        }
+        
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+            flagged = mcp_tool._warn_hidden_whitespace("revelata", config)
+        
+        assert "url" in flagged
+        # Value should not be mutated by the warning function
+        assert config["url"] == "https://deepkpi-mcp.revelata.com/mcp "
+
+    def test_revelata_clean_config_no_warnings(self, caplog):
+        """Clean Revelata config produces no whitespace warnings."""
+        from tools import mcp_tool
+        
+        config = {
+            "url": "https://deepkpi-mcp.revelata.com/mcp",
+            "auth": "oauth"
+        }
+        
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+            flagged = mcp_tool._warn_hidden_whitespace("revelata", config)
+        
+        assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest Contract Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevelataManifestContract:
+    """Test that Revelata manifest conforms to catalog contracts."""
+
+    def test_revelata_manifest_exists_in_repo(self):
+        """Revelata manifest file must exist in optional-mcps/."""
+        repo_root = Path(__file__).parent.parent.parent
+        manifest_path = repo_root / "optional-mcps" / "revelata" / "manifest.yaml"
+        assert manifest_path.exists(), f"Revelata manifest not found at {manifest_path}"
+
+    def test_revelata_manifest_http_transport_has_pinned_url(self):
+        """HTTP transport URL must be pinned (not a placeholder)."""
+        from hermes_cli.mcp_catalog import _parse_manifest
+        
+        repo_root = Path(__file__).parent.parent.parent
+        manifest_path = repo_root / "optional-mcps" / "revelata" / "manifest.yaml"
+        
+        if not manifest_path.exists():
+            pytest.skip("Revelata manifest not found")
+        
+        entry = _parse_manifest(manifest_path)
+        # URL should not contain ${...} placeholders
+        assert entry.transport.url is not None
+        assert "$" not in entry.transport.url
+        # URL should be HTTPS (secure)
+        assert entry.transport.url.startswith("https://")
+
+    def test_revelata_manifest_required_fields_present(self):
+        """Revelata manifest must have all required fields."""
+        from hermes_cli.mcp_catalog import _parse_manifest
+        
+        repo_root = Path(__file__).parent.parent.parent
+        manifest_path = repo_root / "optional-mcps" / "revelata" / "manifest.yaml"
+        
+        if not manifest_path.exists():
+            pytest.skip("Revelata manifest not found")
+        
+        entry = _parse_manifest(manifest_path)
+        # Required fields from CatalogEntry dataclass
+        assert entry.name == "revelata"
+        assert entry.description
+        assert entry.source
+        assert entry.transport.type in ("stdio", "http")
+        assert entry.auth.type in ("api_key", "oauth", "none")

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -24,6 +24,10 @@ Hermes supports multiple AI inference providers out of the box. Use `hermes mode
 
 - **[MCP Servers](/user-guide/features/mcp)** — Connect Hermes to external tool servers via Model Context Protocol. Access tools from GitHub, databases, file systems, browser stacks, internal APIs, and more without writing native Hermes tools. Supports both stdio and SSE transports, per-server tool filtering, and capability-aware resource/prompt registration.
 
+## Financial Data
+
+- **[Revelata deepKPI](/integrations/revelata)** — Query SEC-sourced KPIs, filings, and company summaries for US public companies via a remote MCP server with OAuth 2.1. 8 read-only tools, 100 free credits/month.
+
 ## Web Search Backends
 
 The `web_search` and `web_extract` tools support eight backend providers, configured via `config.yaml` or `hermes tools`:

--- a/website/docs/integrations/revelata.md
+++ b/website/docs/integrations/revelata.md
@@ -1,0 +1,217 @@
+---
+sidebar_position: 5
+title: "Revelata deepKPI"
+description: "Query SEC-sourced KPIs, filings, and company summaries for US public companies via the Revelata deepKPI MCP server"
+---
+
+# Revelata deepKPI
+
+[Revelata](https://www.revelata.com) provides SEC-sourced financial data for US public companies through its **deepKPI** MCP server. Hermes connects to deepKPI as a remote HTTP MCP server with native OAuth 2.1 + Dynamic Client Registration (DCR) — the same pattern used by the Linear and Comfy-Cloud catalog entries. No local installation is required.
+
+You get 8 read-only tools covering company lookup, KPI search, narrative summaries, segment breakdowns, and SEC filing retrieval.
+
+## Prerequisites
+
+- Hermes Agent installed with MCP support (included in the standard install)
+- A Revelata account (free tier is fine — 100 credits/month)
+- A browser for the one-time OAuth login (or SSH tunnel if running headless)
+
+## Quick start
+
+```bash
+hermes mcp install revelata
+hermes mcp login revelata
+```
+
+The `install` command writes the `mcp_servers.revelata` block to `~/.hermes/config.yaml`. The `login` command opens your browser for the OAuth flow and caches the token at `~/.hermes/mcp-tokens/revelata.json`.
+
+After login, restart your Hermes session so the deepKPI tools are loaded:
+
+```bash
+hermes chat
+```
+
+Verify the tools are registered by asking Hermes:
+
+```text
+Which Revelata deepKPI tools are available right now?
+```
+
+You should see 8 tools prefixed with `mcp_revelata_`:
+
+```
+mcp_revelata_query_company_id
+mcp_revelata_list_kpis
+mcp_revelata_search_kpis
+mcp_revelata_company_summary_search
+mcp_revelata_get_company_summary
+mcp_revelata_get_company_segments
+mcp_revelata_list_sec_filing_markdowns
+mcp_revelata_get_sec_filing_markdown
+```
+
+### Try it
+
+```text
+Find Apple's CIK using Revelata, then pull its latest 10-K company summary.
+```
+
+Hermes will call `mcp_revelata_query_company_id` to resolve "Apple" to an SEC CIK, then call `mcp_revelata_get_company_summary` to retrieve the narrative summary from the latest 10-K.
+
+## Configuration
+
+The `hermes mcp install revelata` command writes the following block to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+    enabled: true
+```
+
+You can also add it manually:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+```
+
+No API keys or environment variables are needed — the OAuth 2.1 + DCR flow handles authentication entirely. The MCP client discovers the authorization server, registers a client dynamically (RFC 7591), runs PKCE, and caches the resulting token.
+
+## Token management
+
+Tokens are cached at `~/.hermes/mcp-tokens/revelata.json` with `0600` permissions. Subsequent sessions reuse the cached token silently until refresh fails.
+
+To re-authenticate (expired token, changed account, etc.):
+
+```bash
+hermes mcp login revelata
+```
+
+## Headless / remote hosts
+
+When Hermes runs on a server without a browser, the OAuth loopback callback can't reach your laptop. Two options:
+
+**Paste-back (no setup):** On an interactive terminal, Hermes prints an authorize URL and a paste prompt. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), and paste it at the Hermes prompt. Bare `?code=...&state=...` query strings also work.
+
+**SSH port forward:** From a separate terminal:
+
+```bash
+ssh -N -L <port>:127.0.0.1:<port> user@host
+```
+
+Then let the redirect flow normally.
+
+:::tip
+Use `hermes mcp login revelata` from a fresh terminal — it waits up to 5 minutes for you to complete the OAuth flow. Editing `~/.hermes/config.yaml` from inside a running Hermes session triggers auto-reload with a 30-second timeout, which is too short for interactive OAuth.
+:::
+
+See [OAuth over SSH / Remote Hosts](../guides/oauth-over-ssh.md#mcp-servers) for the full walkthrough.
+
+## Tools and credit costs
+
+deepKPI exposes 8 read-only tools. Credit costs vary per call:
+
+| Tool | Registered as | Cost | Description |
+|------|---------------|------|-------------|
+| `query_company_id` | `mcp_revelata_query_company_id` | Free | Free-text company name to SEC CIK lookup |
+| `list_kpis` | `mcp_revelata_list_kpis` | Free | KPI catalog for a company |
+| `search_kpis` | `mcp_revelata_search_kpis` | 1 credit/result | Semantic KPI search across companies |
+| `company_summary_search` | `mcp_revelata_company_summary_search` | 1 credit/company | Thematic discovery across companies |
+| `get_company_summary` | `mcp_revelata_get_company_summary` | 3 credits | Narrative summary from latest 10-K |
+| `get_company_segments` | `mcp_revelata_get_company_segments` | 3 credits | Segment breakdown from latest 10-K |
+| `list_sec_filing_markdowns` | `mcp_revelata_list_sec_filing_markdowns` | Free | Available filings for a CIK |
+| `get_sec_filing_markdown` | `mcp_revelata_get_sec_filing_markdown` | 10 credits | Markdown for one SEC filing |
+
+Revelata provides 100 free credits per month per user. Lookups (`query_company_id`, `list_kpis`) are always free. Purchase additional credits at [https://www.revelata.com/ai-credits](https://www.revelata.com/ai-credits).
+
+## Tool selection
+
+By default, all 8 tools are pre-checked at install time. To prune tools you don't want, use `hermes mcp configure revelata` to reopen the checklist:
+
+```bash
+hermes mcp configure revelata
+```
+
+You can also filter tools in `config.yaml`:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+    tools:
+      include:
+        - query_company_id
+        - get_company_summary
+        - list_sec_filing_markdowns
+        - get_sec_filing_markdown
+```
+
+## Coverage
+
+deepKPI covers US public companies in the S&P 500, 400, and 600. International tickers (Japan, China, Hong Kong, Singapore) are enterprise-only.
+
+## Companion skills
+
+Revelata publishes companion skills for financial workflows — KPI pulls, filings, pressure-tests, peer benchmarks, idea generation:
+
+```bash
+hermes skills install revelata/deepkpi-agents/kpi
+```
+
+Once merged into the official optional catalog:
+
+```bash
+hermes skills install official/finance/kpi
+```
+
+## Troubleshooting
+
+### `hermes mcp install revelata` fails with "not found in catalog"
+
+The Revelata manifest may not be in your Hermes version yet (PR #80453 not merged upstream). Check for the manifest at `optional-mcps/revelata/manifest.yaml` in the hermes-agent repo. As a workaround, add the entry manually:
+
+```yaml
+mcp_servers:
+  revelata:
+    url: https://deepkpi-mcp.revelata.com/mcp
+    auth: oauth
+```
+
+Then run `hermes mcp login revelata` from a fresh terminal.
+
+### OAuth flow hangs or times out
+
+Run `hermes mcp login revelata` from a **fresh terminal** — not from inside a running Hermes session. The session's auto-reload timeout (30s) is too short for interactive OAuth. The `login` subcommand waits up to 5 minutes.
+
+### Tools list OK, but tool calls time out
+
+This can happen if the OAuth probe completed without actually acquiring a token (the `tools/list` endpoint may respond without auth, making it look like login succeeded). Check that the token file exists:
+
+```bash
+ls -la ~/.hermes/mcp-tokens/revelata.json
+```
+
+If it's missing, re-run `hermes mcp login revelata`.
+
+### "credits exhausted" or "402 Payment Required"
+
+You have used your 100 free monthly credits. Purchase additional credits at [https://www.revelata.com/ai-credits](https://www.revelata.com/ai-credits). Free lookups (`query_company_id`, `list_kpis`, `list_sec_filing_markdowns`) still work without credits.
+
+### Probe fails at install time (server unreachable, OAuth not complete)
+
+The install still succeeds — no tool filter is written. Once the server is reachable and you've completed OAuth, re-run:
+
+```bash
+hermes mcp configure revelata
+```
+
+This probes the server again and lets you select tools.
+
+### International ticker returns "not covered"
+
+deepKPI covers US public companies (S&P 500/400/600) only. International tickers (Japan, China, Hong Kong, Singapore) require an enterprise plan. See [Revelata](https://www.revelata.com) for enterprise options.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -865,6 +865,7 @@ The gateway does NOT need to be running for read operations (listing conversatio
 ## Related docs
 
 - [Use MCP with Hermes](/guides/use-mcp-with-hermes)
+- [Revelata deepKPI](/integrations/revelata) — SEC-sourced KPIs, filings, and company summaries for US public companies
 - [CLI Commands](/reference/cli-commands)
 - [Slash Commands](/reference/slash-commands)
 - [FAQ](/reference/faq)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -683,6 +683,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'integrations/index',
+        'integrations/revelata',
         'integrations/nous-portal',
         'integrations/providers',
         'integrations/buzz',


### PR DESCRIPTION
## What

Adds the [Revelata deepKPI](https://www.revelata.com) MCP server to the optional catalog — manifest, config examples, 20 tests, and full documentation.

## Why

Revelata provides SEC-sourced financial data for US public companies through its deepKPI MCP server. This integration lets Hermes users query KPIs, filings, and company summaries via 8 read-only tools with OAuth 2.1 + Dynamic Client Registration (DCR) — the same pattern used by the Linear and Comfy-Cloud catalog entries.

This PR **supersedes/complements upstream PR #80453** (the vendor's own PR from `revelata/hermes-agent`, still open, manifest-only). Ours adds 20 tests + full docs.

## What's included

- `optional-mcps/revelata/manifest.yaml` — remote HTTP MCP, OAuth 2.1+DCR, 8 tools
- `tests/tools/test_mcp_revelata_config.py` — 20/20 tests pass
- `website/docs/integrations/revelata.md` — full integration guide (216 lines)
- `optional-mcps/revelata/README.md` — co-located README
- `website/docs/integrations/index.md` — Financial Data section + link
- `website/docs/user-guide/features/mcp.md` — Related docs link
- `website/sidebars.ts` — sidebar entry under Integrations

## Testing

- [x] 20/20 tests pass (config, OAuth, lifecycle, tool registration)
- [x] Manifest parses clean, no secrets, 8 tools consistent
- [x] Review-approved (t_9cf2f86f)

## Related

- Supersedes/complements upstream PR #80453 (vendor's manifest-only PR)
- Root issue: #80453