### PR TITLE
docs(google-workspace): clarify headless token recovery flow

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -159,6 +159,7 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 
 ### Notes
 
+- Headless recovery: if a previously-authorized token is lost, deleted, or expired, Steps 2-5 above are the full fix — this flow requires no local webserver and no browser on the Hermes host itself. Don't fall back to the raw Python API or a CLI's own local-callback auth flow; they aren't designed for headless environments and will fail.
 - Token is stored at `~/.hermes/google_token.json` and auto-refreshes.
 - Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
 - If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.


### PR DESCRIPTION
## What
Adds a note to the google-workspace skill's Notes section clarifying that the existing OAuth setup flow (Steps 2-5) works fully headless — no local webserver or browser needed on the Hermes host.

## Why
Closes #80364. The issue reporter lost a previously-authorized token and tried several non-functional workarounds (raw Python API, CLI's local-webserver auth) before discovering that the existing setup.py flow already handles this correctly. This note prevents others from hitting the same dead ends.

## Change
One line added to ## Notes in skills/productivity/google-workspace/SKILL.md. No code changes.