### PR TITLE
fix(model-picker): honor discover_models=false in all sections

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2233,24 +2233,33 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Unified pathway: route through cached_provider_model_ids() so the
-        # /model picker sees the SAME list `hermes model` would build, with
-        # disk caching to keep the picker open snappy. Falls back to the
-        # curated static list when the live fetcher returns nothing.
-        model_ids = cached_provider_model_ids(hermes_id)
-        if not model_ids:
-            model_ids = curated.get(hermes_id, [])
-            if hermes_id in _MODELS_DEV_PREFERRED:
-                model_ids = _merge_with_models_dev(hermes_id, model_ids)
         # A providers.<built-in>.models block extends the provider's discovered
         # catalog. Section 3 cannot emit it later because this built-in row owns
         # the slug, so merge declarations here before applying max_models.
         configured_models: list[str] = []
+        configured: dict = {}
         if isinstance(user_providers, dict):
             configured = user_providers.get(hermes_id)
             if isinstance(configured, dict):
                 configured_models = _declared_model_ids(configured.get("models"))
-        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
+        # Honor ``providers.<built-in>.discover_models: false``: skip the live
+        # /v1/models merge and surface only the declared ``models:`` list.
+        discover = configured.get("discover_models", True) if isinstance(configured, dict) else True
+        if isinstance(discover, str):
+            discover = discover.lower() not in {"false", "no", "0"}
+        if discover:
+            # Unified pathway: route through cached_provider_model_ids() so the
+            # /model picker sees the SAME list `hermes model` would build, with
+            # disk caching to keep the picker open snappy. Falls back to the
+            # curated static list when the live fetcher returns nothing.
+            model_ids = cached_provider_model_ids(hermes_id)
+            if not model_ids:
+                model_ids = curated.get(hermes_id, [])
+                if hermes_id in _MODELS_DEV_PREFERRED:
+                    model_ids = _merge_with_models_dev(hermes_id, model_ids)
+            model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
+        else:
+            model_ids = list(configured_models)
         total = len(model_ids)
         if hermes_id in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models
@@ -2380,7 +2389,20 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        # Honor ``providers.<slug>.discover_models: false``: skip the live
+        # /v1/models merge and surface only the declared ``models:`` list.
+        configured_models: list[str] = []
+        configured: dict = {}
+        if isinstance(user_providers, dict):
+            configured = user_providers.get(hermes_slug)
+            if isinstance(configured, dict):
+                configured_models = _declared_model_ids(configured.get("models"))
+        discover = configured.get("discover_models", True) if isinstance(configured, dict) else True
+        if isinstance(discover, str):
+            discover = discover.lower() not in {"false", "no", "0"}
+        if not discover:
+            model_ids = list(configured_models)
+        elif hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs
@@ -2508,9 +2530,22 @@ def list_authenticated_providers(
         if not _cp_has_creds:
             continue
 
+        # Honor ``providers.<slug>.discover_models: false``: skip the live
+        # /v1/models merge and surface only the declared ``models:`` list.
+        _cp_configured_models: list[str] = []
+        _cp_configured: dict = {}
+        if isinstance(user_providers, dict):
+            _cp_configured = user_providers.get(_cp.slug)
+            if isinstance(_cp_configured, dict):
+                _cp_configured_models = _declared_model_ids(_cp_configured.get("models"))
+        _cp_discover = _cp_configured.get("discover_models", True) if isinstance(_cp_configured, dict) else True
+        if isinstance(_cp_discover, str):
+            _cp_discover = _cp_discover.lower() not in {"false", "no", "0"}
         # For bedrock, use live discovery so the list reflects the active
         # region (eu.*, us.*, ap.*) instead of the hardcoded us.* static list.
-        if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
+        if not _cp_discover:
+            _cp_model_ids = list(_cp_configured_models)
+        elif _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
             try:
                 _ids = cached_provider_model_ids(_cp.slug)
                 _cp_model_ids = _ids if _ids else curated.get(_cp.slug, [])

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -608,3 +608,45 @@ def test_current_custom_model_not_leaked_into_other_provider_rows(monkeypatch):
     for row in providers:
         if row["slug"] != "openrouter" and not row.get("is_current"):
             assert custom not in row.get("models", []), f"leaked into {row['slug']}"
+
+
+def test_list_authenticated_providers_discover_models_false_keeps_declared_only(monkeypatch):
+    """``providers.<built-in>.discover_models: false`` must skip the live
+    /v1/models merge and surface ONLY the declared ``models:`` list.
+
+    Regression for #80536: section 1 of list_authenticated_providers merged
+    the live catalog via ``cached_provider_model_ids()`` even when config
+    pinned ``discover_models: false``, so the /model picker showed models the
+    user never declared.
+    """
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"deepseek": {"name": "DeepSeek"}},
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+
+    def _boom(slug, *args, **kwargs):
+        if slug == "deepseek":
+            raise AssertionError("live /v1/models catalog must not be fetched")
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", _boom)
+
+    user_providers = {
+        "deepseek": {
+            "discover_models": False,
+            "models": ["deepseek-chat", "deepseek-reasoner"],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="deepseek",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    row = next(p for p in providers if p["slug"] == "deepseek")
+    assert row["models"] == ["deepseek-chat", "deepseek-reasoner"]
+    assert row["total_models"] == 2


### PR DESCRIPTION
## What

`list_authenticated_providers()` in `hermes_cli/model_switch.py` merges the live provider `/v1/models` catalog into the /model picker even when the provider config sets `discover_models: false`.

Custom providers (sections 3 & 4) already gated discovery on `discover_models` via `should_probe`. But three built-in paths always called `cached_provider_model_ids()` (or its AWS/curated equivalent) regardless of the flag:

- Section 1 — `PROVIDER_TO_MODELS_DEV` loop
- Section 2 — `HERMES_OVERLAYS` loop (incl. `openai-codex` / `copilot` / `copilot-acp`)
- Section 2b — `CANONICAL_PROVIDERS` loop (incl. `aws_sdk`/bedrock)

Each path now reads `providers.<slug>.discover_models` and, when falsy, surfaces **only** the declared `models:` list and skips any live-catalog fetch. String flags (`"false"` / `"no"` / `"0"`) are honored to match the existing sections 3/4 normalization.

## Why

Fixes #80536 — the picker showed models the user never declared, defeating `discover_models: false`.

## How to test

```
bash scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py -q
# 13 passed, 0 failed
```

Broader related run (7 files: `test_model_switch_custom_providers.py`, `test_vertex_model_picker.py`, `test_provider_section3_grouping.py`, `test_overlay_slug_resolution.py`, `test_opencode_go_in_model_list.py`, `test_ollama_cloud_provider.py`, `test_user_providers_model_switch.py`) → 82 passed, 1 failed. The single failure is pre-existing and unrelated (missing `concurrent_log_handler` in the hermetic venv; verified failing on baseline too).

The new regression test asserts that with `discover_models: False`, only the declared models are listed and `cached_provider_model_ids()` raises if called (i.e., no live fetch happens).

## Platforms

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [x] Linux (POSIX-compatible logic; runs under the hermetic test venv)

Fixes #80536