### PR TITLE
nix: auto-substitute Python packages from nixpkgs via intersectAttrs

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -20,25 +20,93 @@ let
     sourcePreference = "wheel";
   };
 
-  isAarch64Darwin = stdenv.hostPlatform.system == "aarch64-darwin";
-
-  # Keep the workspace locked through uv2nix, but supply the local voice stack
-  # from nixpkgs so wheel-only transitive artifacts do not break evaluation.
-  mkPrebuiltPassthru = dependencies: {
-    inherit dependencies;
-    optional-dependencies = { };
-    dependency-groups = { };
-  };
-
+  # Substitute a uv2nix-built package with the equivalent nixpkgs prebuilt
+  # version.  nixpkgs builds are cached on cache.nixos.org, so this avoids
+  # hundreds of local compilations — many of which are native (C/Rust/Cython)
+  # and slow to build from source.
+  #
+  # The uv2nix overlay populates `passthru.dependencies` from uv.lock.  We
+  # preserve that passthru so the venv resolver still sees the correct
+  # dependency graph — no manual dependency lists needed.
+  #
+  # nixpkgsPrebuilt searches `prev.nativeBuildInputs` for `pyproject-hook` to
+  # determine the Python version for ABI compatibility checks.  The uv2nix
+  # package may use `pyprojectWheelHook` instead (wheel-only packages), so we
+  # always inject `pyprojectHook` to satisfy that lookup.
   mkPrebuiltOverride =
-    final: from: dependencies:
+    final: from: prevPkg:
     hacks.nixpkgsPrebuilt {
       inherit from;
       prev = {
         nativeBuildInputs = [ final.pyprojectHook ];
-        passthru = mkPrebuiltPassthru dependencies;
+        passthru = prevPkg.passthru;
       };
     };
+
+  # Auto-substitute every package that exists in both the uv2nix overlay and
+  # nixpkgs.  We build a set of nixpkgs Python package names (without evaluating
+  # their values) and intersect it with the uv2nix package names.
+  #
+  # Packages not in nixpkgs (e.g. ruamel-yaml, some alibabacloud SDKs) fall
+  # through to the normal uv2nix build automatically.  When a new dep is added
+  # to hermes-agent that already exists in nixpkgs, it's auto-substituted —
+  # no manual list to maintain.
+  #
+  # Packages that throw on evaluation (e.g. olm marked insecure) are excluded
+  # via tryEval on .pname — they fall through to the normal uv2nix build.
+  # Note: tryEval catches `throw` but NOT `assert` failures.  nixpkgs'
+  # insecure-package checks use `assert`, so packages with `assert`-based
+  # guards need an explicit denylist entry.
+  wellKnown = [
+    "python"
+    "pkgs"
+    "stdenv"
+    "pythonPkgsBuildHost"
+    "resolveBuildSystem"
+    "resolveVirtualEnv"
+    "mkVirtualEnv"
+    "hooks"
+    "callPackage"
+  ];
+
+  # Packages that can't be safely evaluated from nixpkgs (assert-based guards
+  # that tryEval can't catch).  They fall through to the uv2nix build.
+  denylist = [
+    "python-olm"  # olm marked insecure via assert, not throw
+  ];
+
+  # Build a set of nixpkgs Python package names without evaluating values.
+  # hasAttr does not force the attribute's value, so this is safe for packages
+  # that would throw/assert on evaluation.
+  nixpkgsNames = builtins.attrNames python312.pkgs;
+
+  prebuiltOverrides =
+    final: prev:
+    builtins.listToAttrs (
+      builtins.filter
+        (s: s != null)
+        (map
+          (name:
+            if builtins.elem name wellKnown
+              || builtins.elem name denylist
+              || !(builtins.elem name nixpkgsNames)
+            then null
+            else
+              let
+                # tryEval catches packages that throw on evaluation (e.g.
+                # broken/unfree via throw).  assert-based guards (e.g. insecure)
+                # are handled by the denylist above.
+                evaled = builtins.tryEval python312.pkgs.${name}.pname;
+              in
+              if !evaled.success
+              then null
+              else {
+                inherit name;
+                value = mkPrebuiltOverride final python312.pkgs.${name} prev.${name};
+              })
+          (builtins.attrNames prev)
+        )
+    );
 
   # Legacy alibabacloud packages ship only sdists with setup.py/setup.cfg
   # and no pyproject.toml, so setuptools isn't declared as a build dep.
@@ -61,44 +129,7 @@ let
         ] (_: null)
       );
 
-  pythonPackageOverrides =
-    final: _prev:
-    if isAarch64Darwin then
-      {
-        numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
-
-        pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
-
-        av = mkPrebuiltOverride final python312.pkgs.av { };
-
-        humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
-
-        coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
-          humanfriendly = [ ];
-        };
-
-        onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
-          coloredlogs = [ ];
-          numpy = [ ];
-          packaging = [ ];
-        };
-
-        ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
-          numpy = [ ];
-          pyyaml = [ ];
-        };
-
-        faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
-          av = [ ];
-          ctranslate2 = [ ];
-          huggingface-hub = [ ];
-          onnxruntime = [ ];
-          tokenizers = [ ];
-          tqdm = [ ];
-        };
-      }
-    else
-      { };
+  pythonPackageOverrides = prebuiltOverrides;
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {


### PR DESCRIPTION
## Summary

Replaces the manual `mkPrebuiltOverride` list (aarch64-darwin only, 8 packages) with an automatic approach that discovers all matching packages between the uv2nix overlay and nixpkgs. This eliminates 154 derivations and substitutes 552 more paths from `cache.nixos.org` on a fresh install.

## Problem

The uv2nix build creates ~296 Python-related derivations (148 wheel fetches + 148 install builds) even though most packages already exist in `nixpkgs.python312.pkgs` with identical upstream versions. The existing `mkPrebuiltOverride` pattern only covered 8 packages on aarch64-darwin — on Linux, `pythonPackageOverrides` was empty, meaning all 148 packages were built from scratch by uv2nix.

## Changes

### mkPrebuiltOverride API change

The function signature changes from `(final, from, dependencies)` to `(final, from, prevPkg)`:

**Before:** manual dependency list, passthru replaced with stub

    mkPrebuiltOverride = final: from: dependencies:
      hacks.nixpkgsPrebuilt {
        inherit from;
        prev = {
          nativeBuildInputs = [ final.pyprojectHook ];
          passthru = mkPrebuiltPassthru dependencies;  # manual deps
        };
      };

**After:** preserve passthru from the uv2nix overlay (deps from uv.lock)

    mkPrebuiltOverride = final: from: prevPkg:
      hacks.nixpkgsPrebuilt {
        inherit from;
        prev = {
          nativeBuildInputs = [ final.pyprojectHook ];
          passthru = prevPkg.passthru;  # deps from uv.lock
        };
      };

This is an internal `let`-binding — not exported, not part of any public API. Zero impact on downstream users.

### prebuiltOverrides — automatic discovery

Instead of a manual list of packages, `prebuiltOverrides` auto-discovers all matching packages by iterating over uv2nix package names and checking against nixpkgs:

- **wellKnown**: infrastructure attributes (python, pkgs, stdenv, hooks, resolvers) — excluded to avoid infinite recursion
- **denylist**: packages with `assert`-based guards that `tryEval` can't catch (currently just `python-olm` — olm marked insecure)
- **nixpkgsNames**: `builtins.attrNames python312.pkgs` — built once, used for name-only filtering (no value evaluation)
- **tryEval**: catches packages that `throw` on evaluation (broken/unfree). `assert`-based guards need explicit denylist entries

Packages not in nixpkgs (e.g. `ruamel-yaml`, some alibabacloud SDKs) fall through to the normal uv2nix build automatically.

### Removed

- `mkPrebuiltPassthru` — no longer needed (passthru comes from the uv2nix package)
- `isAarch64Darwin` guard — overrides now apply on all platforms
- Manual dependency lists for onnxruntime, ctranslate2, faster-whisper, coloredlogs — deps come from uv.lock via passthru

## Impact

Measured on x86_64-linux with the `full` package (all optional dependency groups):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Derivations to build | 1115 | 961 | **-154 (14%)** |
| Paths fetched from cache | 209 | 761 | **+552 (substituted from cache.nixos.org)** |

The approach is **self-maintaining**: when hermes-agent adds a new Python dep that already exists in nixpkgs, it's auto-substituted — no manual list to update. When nixpkgs removes a package, it falls back to uv2nix automatically.

## Testing

- [x] `nix eval .#packages.x86_64-linux.default.outPath` — evaluates cleanly
- [x] `nix build .#packages.x86_64-linux.default --dry-run` — 961 derivations (down from 1115)
- [ ] `nix flake check` — needs full build (left for CI)
- [ ] aarch64-darwin evaluation — left for CI cross-eval check

## Notes for reviewers

- The `denylist` currently contains only `python-olm`. If nixpkgs adds more `assert`-based insecure packages in the future, they would need to be added here. An alternative would be to evaluate with `NIXPKGS_ALLOW_INSECURE=1` but that changes the semantics for all packages.
- The `nixpkgsNames = builtins.attrNames python312.pkgs` line evaluates the full nixpkgs Python package set's attribute names. This is a one-time cost at evaluation time and doesn't trigger value evaluation (just name enumeration).