### PR TITLE
fix(backup): recognise SQLite stores whose filename isn't .db

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -70,18 +70,37 @@ _EXCLUDED_DIRS = {
     ".ruff_cache",
 }
 
+# Extensions Hermes uses for its SQLite stores. Almost every one is ``.db``,
+# but the observability metrics store is ``metrics.sqlite3``; keyed off ``.db``
+# alone it was neither snapshotted nor had its sidecars dropped — the exact
+# pairing the sidecar comment below warns about.
+_SQLITE_DB_SUFFIXES = (".db", ".sqlite", ".sqlite3")
+
+# SQLite derives sidecar names from the FULL database filename
+# (``state.db`` -> ``state.db-wal``), so the skip list needs every database
+# extension rather than a bare ``-wal``/``-shm`` match, which would also drop
+# unrelated user files.
+_SQLITE_SIDECAR_SUFFIXES = tuple(
+    f"{_db}{_sidecar}"
+    for _db in _SQLITE_DB_SUFFIXES
+    for _sidecar in ("-wal", "-shm", "-journal")
+)
+
+def _is_sqlite_db_path(path: "Path") -> bool:
+    """True when *path* names one of Hermes' SQLite stores."""
+    return path.suffix.lower() in _SQLITE_DB_SUFFIXES
+
+
 # File-name suffixes to skip
 _EXCLUDED_SUFFIXES = (
     ".pyc",
     ".pyo",
-    # SQLite sidecar files — the backup takes a consistent snapshot of ``*.db``
-    # via ``sqlite3.backup()``, so shipping the live WAL / shared-memory /
-    # rollback-journal alongside would pair a fresh snapshot with stale sidecar
-    # state and produce a torn restore on the next open. They're transient and
-    # regenerated on first connection anyway.
-    ".db-wal",
-    ".db-shm",
-    ".db-journal",
+    # SQLite sidecar files — the backup takes a consistent snapshot of the
+    # database via ``sqlite3.backup()``, so shipping the live WAL /
+    # shared-memory / rollback-journal alongside would pair a fresh snapshot
+    # with stale sidecar state and produce a torn restore on the next open.
+    # They're transient and regenerated on first connection anyway.
+    *_SQLITE_SIDECAR_SUFFIXES,
 )
 
 # File names to skip (runtime state that's meaningless on another machine)
@@ -704,7 +723,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)
-                if abs_path.suffix == ".db":
+                if _is_sqlite_db_path(abs_path):
                     # Stage the snapshot alongside the output zip so that the
                     # temp file lives on the same filesystem.  The system
                     # default (/tmp) may be a small tmpfs that cannot hold
@@ -1233,7 +1252,7 @@ def _create_quick_snapshot_locked(
                 if "/workspaces/" in f"/{sub_rel}/" or "/attachments/" in f"/{sub_rel}/":
                     continue
                 if _too_large(sub, sub_rel):
-                    if sub.suffix == ".db":
+                    if _is_sqlite_db_path(sub):
                         oversized_skipped.append(sub_rel)
                     continue
                 dst = staging_dir / sub_rel
@@ -1242,7 +1261,7 @@ def _create_quick_snapshot_locked(
                     # Route SQLite DBs through the WAL-safe backup() path so a
                     # board DB with an open WAL (the gateway may hold it at
                     # snapshot time) is captured consistently.
-                    if sub.suffix == ".db":
+                    if _is_sqlite_db_path(sub):
                         if not _safe_copy_db(sub, dst):
                             failed_dbs.append(sub_rel)
                             print(
@@ -1266,7 +1285,7 @@ def _create_quick_snapshot_locked(
             continue
 
         if _too_large(src, rel):
-            if src.suffix == ".db":
+            if _is_sqlite_db_path(src):
                 oversized_skipped.append(rel)
             continue
 
@@ -1274,7 +1293,7 @@ def _create_quick_snapshot_locked(
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            if src.suffix == ".db":
+            if _is_sqlite_db_path(src):
                 if not _safe_copy_db(src, dst):
                     failed_dbs.append(rel)
                     print(
@@ -1457,7 +1476,7 @@ def restore_quick_snapshot(
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            if dst.suffix == ".db":
+            if _is_sqlite_db_path(dst):
                 # Atomic-ish replace for databases
                 tmp = dst.parent / f".{dst.name}.snap_restore"
                 shutil.copy2(src, tmp)
@@ -1693,7 +1712,7 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
         ) as zf:
             for index, (abs_path, rel_path) in enumerate(files_to_add, 1):
                 try:
-                    if abs_path.suffix == ".db":
+                    if _is_sqlite_db_path(abs_path):
                         # Stage the snapshot alongside the output zip so that the
                         # temp file lives on the same filesystem.  The system
                         # default (/tmp) may be a small tmpfs that cannot hold

--- a/tests/hermes_cli/test_backup_sqlite_sidecars.py
+++ b/tests/hermes_cli/test_backup_sqlite_sidecars.py
@@ -1,0 +1,65 @@
+"""A SQLite store whose filename isn't ``.db`` must not be backed up raw.
+
+The backup takes a consistent ``sqlite3.backup()`` snapshot of each database
+and drops the live WAL / shared-memory / rollback-journal, because — as the
+skip list's own comment puts it — shipping them together "would pair a fresh
+snapshot with stale sidecar state and produce a torn restore on the next
+open".
+
+Both halves were keyed on the ``.db`` extension, so the observability metrics
+store (``metrics.sqlite3``) fell through both: copied byte-for-byte while its
+sidecars rode along.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.backup as backup
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "state.db-wal",
+        "state.db-shm",
+        "state.db-journal",
+        "metrics.sqlite3-wal",
+        "metrics.sqlite3-shm",
+        "metrics.sqlite3-journal",
+        "board.sqlite-wal",
+    ],
+)
+def test_sidecars_are_excluded_for_every_database_extension(name):
+    assert backup._should_exclude(Path(name)) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["state.db", "metrics.sqlite3", "board.sqlite", "config.yaml", "SOUL.md"],
+)
+def test_databases_and_ordinary_files_are_kept(name):
+    assert backup._should_exclude(Path(name)) is False
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("state.db", True),
+        ("metrics.sqlite3", True),
+        ("board.sqlite", True),
+        ("notes.md", False),
+        ("archive.tar.gz", False),
+    ],
+)
+def test_snapshot_covers_every_database_extension(name, expected):
+    """The consistent-snapshot path must recognise the same set."""
+    assert backup._is_sqlite_db_path(Path(name)) is expected
+
+
+def test_sidecar_skip_does_not_swallow_unrelated_files():
+    """The match is anchored on a database extension, not a bare ``-wal``."""
+    for name in ("notes-wal", "report-shm", "daily-journal", "my-wal.txt"):
+        assert backup._should_exclude(Path(name)) is False


### PR DESCRIPTION
## What

The backup routes each database through a consistent `sqlite3.backup()` snapshot and drops the live sidecars. The skip list says why:

> shipping the live WAL / shared-memory / rollback-journal alongside would pair a fresh snapshot with stale sidecar state and produce a torn restore on the next open

Both halves are keyed on the `.db` extension:

```python
if abs_path.suffix == ".db":                                  # snapshot
_EXCLUDED_SUFFIXES = (..., ".db-wal", ".db-shm", ".db-journal")  # sidecars
```

Every Hermes store matches that — `state.db`, `kanban.db`, `projects.db`, `executions.db`, `response_store.db`, `memory_store.db`, `verification_evidence.db`, `discord_message_recovery.db` — except one. The observability metrics store is `metrics.sqlite3`, so it falls through **both** halves at once. Running the real predicate against the real filenames:

```
state.db                  excluded=False   snapshotted=True
state.db-wal              excluded=True    (dropped, correct)
state.db-shm              excluded=True    (dropped, correct)
metrics.sqlite3           excluded=False   snapshotted=False
metrics.sqlite3-wal       excluded=False   (shipped)
metrics.sqlite3-shm       excluded=False   (shipped)
metrics.sqlite3-journal   excluded=False   (shipped)
```

So the one store that misses the snapshot is also the one store whose sidecars ride along — a raw byte copy of a database that may have an open WAL, packed together with that WAL. That is precisely the combination the comment describes as a torn restore, and a plain copy of a live WAL-mode database is not a consistent copy even on its own.

`sqlite3` is not an exotic spelling here: it is what the metrics store already uses on disk today, and the sidecar names SQLite derives (`metrics.sqlite3-wal`) simply do not end in `.db-wal`.

## The fix

Name the database extensions once and derive both halves from that list, so a store added under any of them is covered by construction rather than by remembering to update two places.

Sidecars are matched as `<db-ext>-wal` / `-shm` / `-journal` rather than a bare `-wal`, so an unrelated file called `notes-wal` or `daily-journal` is still backed up. The five `.db`-keyed call sites (full backup, quick snapshot, oversize reporting, snapshot restore) all go through the same predicate.

## Tests and results

`tests/hermes_cli/test_backup_sqlite_sidecars.py`:

- sidecars are excluded for every database extension — `state.db-*` (already worked, kept as a non-regression pin) and `metrics.sqlite3-*` / `board.sqlite-wal` (the bug)
- databases themselves and ordinary files are kept
- the snapshot predicate recognises the same set it excludes sidecars for
- the anchored match does not swallow `notes-wal`, `report-shm`, `daily-journal`, `my-wal.txt`

18 pass with the fix. On `main` the `metrics.sqlite3-*` and `board.sqlite-wal` cases fail behaviourally while the `state.db-*` cases pass, which is the split you'd want from a non-regression pin.

Backup, snapshot, import and export suites (15 files) run to 145 passed. I ran them before and after and diffed the failure lists: excluding the new file they are byte-identical — 2 failures, both pre-existing on `main` (`test_quick_snapshot_is_published_with_manifest`, `test_import_guard_flags_missing_first_party_module`). `scripts/check-windows-footguns.py` is clean on both changed files.