### PR TITLE
fix(backup): restore import members atomically so a failed import can't erase config

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import threading
@@ -918,6 +919,15 @@ def _extract_member_atomically(
     delegate to the shared ``utils`` helpers rather than being re-derived here.
     The temp file is removed on any failure so a partial import leaves no
     residue.
+
+    The one bit of the old file *not* carried across is setuid/setgid.  The
+    replacement bytes come out of the zip, so preserving those would let an
+    archive take over the identity an existing privileged file executes as —
+    and unlike the other ``utils`` writers, which re-serialize content this
+    process produced, the trust boundary here is an untrusted archive.  The
+    mask is applied once, before the temp file is chmod'd, so neither the
+    pre-replace ``fchmod`` nor the post-replace restore can re-elevate the
+    target.
     """
     # ``_preserve_file_mode`` returns None when the target does not exist (or
     # cannot be stat'd), in which case the umask-derived create-mode applies —
@@ -926,6 +936,17 @@ def _extract_member_atomically(
     owner = _preserve_file_owner(target)
     if mode is None:
         mode = new_file_mode
+    else:
+        # Deliberately NOT a faithful mode copy: setuid/setgid are dropped.
+        # ``_preserve_file_mode`` returns ``stat.S_IMODE``, i.e. all twelve
+        # bits, and the content replacing this file comes from the archive.
+        # Carrying the elevated bits across would let archive-controlled bytes
+        # take over an existing setuid/setgid file, so ``hermes import`` would
+        # hand whoever produced the zip the identity that file runs as.  Nothing
+        # constrains that to Hermes' own state either: the ``_external/`` branch
+        # of ``run_import`` publishes members anywhere under ``$HOME``.  The
+        # sticky bit is kept — it is inert on a regular file.
+        mode &= ~(stat.S_ISUID | stat.S_ISGID)
 
     # Truncate the stem: mkstemp adds ~16 characters, and a member already near
     # NAME_MAX would otherwise fail here on a write that used to succeed.
@@ -951,8 +972,10 @@ def _extract_member_atomically(
             dst.flush()
             os.fsync(dst.fileno())
         real_path = Path(atomic_replace(tmp_name, target))
-        # Owner first: chown clears setuid/setgid, so the mode restore below is
-        # what puts those bits back.  Ordering mirrors ``atomic_yaml_write``.
+        # Owner first, mode second — the ordering ``atomic_yaml_write`` uses,
+        # because chown drops setuid/setgid and a mode restore that ran first
+        # would be partly undone.  Here ``mode`` no longer carries those bits,
+        # so the two agree: neither step can re-elevate the restored file.
         _restore_file_owner(real_path, owner)
         _restore_file_mode(real_path, mode)
     except BaseException:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import threading
@@ -24,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -854,6 +856,93 @@ def _detect_prefix(zf: zipfile.ZipFile) -> str:
     return ""
 
 
+def _default_new_file_mode() -> Optional[int]:
+    """Return the mode ``open(path, "wb")`` gives a file it has to create.
+
+    ``tempfile.mkstemp`` always creates at 0600, so staging an import through a
+    temp file would tighten every *newly created* file to owner-only — the same
+    hazard ``utils._restore_file_mode`` documents for Docker/NAS volume mounts
+    that rely on broader permissions.  The umask can only be read by setting it,
+    so this is resolved once per import rather than once per member.  The probe
+    installs a *restrictive* mask rather than 0 so that anything another thread
+    creates inside the two-syscall window is owner-only, never world-writable.
+    Returns ``None`` if the umask cannot be read, in which case the caller
+    leaves mkstemp's mode alone.
+    """
+    try:
+        current = os.umask(0o077)
+        os.umask(current)
+    except OSError:
+        return None
+    return 0o666 & ~current
+
+
+def _extract_member_atomically(
+    zf: zipfile.ZipFile,
+    member: str,
+    target: Path,
+    new_file_mode: Optional[int] = None,
+) -> None:
+    """Restore one zip member onto *target* with no truncation window.
+
+    ``open(target, "wb")`` truncates the user's existing file to zero *before*
+    any replacement bytes exist.  A Ctrl-C, an ENOSPC, a corrupt member, or a
+    crash between the truncate and the write therefore leaves that file empty
+    with nothing behind it — during ``hermes import``, which is the
+    disaster-recovery path a user reaches for *because* they already lost
+    something.  Staging into the target's own directory and publishing with a
+    rename means the target only ever moves from its old contents to the
+    complete new contents.
+
+    ``atomic_replace`` rather than a bare ``os.replace``: it resolves a
+    symlinked target first, so a deployment that links ``config.yaml`` into a
+    dotfiles repo keeps the link instead of having it silently swapped for a
+    regular file (GitHub #16743), and it falls back to copy/fsync/unlink on
+    ``EXDEV``/``EBUSY`` for cross-device and bind-mount installs.
+
+    Permission bits are carried across the replace so routing through mkstemp
+    does not change the mode the caller would otherwise have produced.  The
+    temp file is removed on any failure so a partial import leaves no residue.
+    """
+    mode = new_file_mode
+    try:
+        mode = stat.S_IMODE(target.stat().st_mode)
+    except OSError:
+        # Target does not exist (or cannot be stat'd) — keep the create-mode.
+        pass
+
+    # Truncate the stem: mkstemp adds ~16 characters, and a member already near
+    # NAME_MAX would otherwise fail here on a write that used to succeed.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name[:80]}.", suffix=".partial"
+    )
+    try:
+        with os.fdopen(fd, "wb") as dst:
+            if mode is not None and hasattr(os, "fchmod"):
+                # Apply before the replace so the target never transits through
+                # mkstemp's 0600.  fchmod is Unix-only; Windows uses the
+                # post-replace chmod below.
+                os.fchmod(dst.fileno(), mode)
+            # Stream instead of ``src.read()``: a multi-gigabyte state.db member
+            # must not be held in memory in one piece.
+            with zf.open(member) as src:
+                shutil.copyfileobj(src, dst)
+            dst.flush()
+            os.fsync(dst.fileno())
+        real_path = atomic_replace(tmp_name, target)
+        if mode is not None and not hasattr(os, "fchmod"):
+            try:
+                os.chmod(real_path, mode)
+            except OSError:
+                pass
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
 def run_import(args) -> None:
     """Restore a Hermes backup from a zip file."""
     zip_path = Path(args.zipfile).expanduser().resolve()
@@ -912,6 +1001,9 @@ def run_import(args) -> None:
         restored_external = 0
         skipped_runtime: list[str] = []
         home_dir = Path.home().resolve()
+        # Resolved once: every member is published via a temp file, and mkstemp
+        # would otherwise create newly restored files as 0600.
+        new_file_mode = _default_new_file_mode()
         t0 = time.monotonic()
 
         for member in members:
@@ -931,8 +1023,7 @@ def run_import(args) -> None:
                     continue
                 try:
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    with zf.open(member) as src, open(target, "wb") as dst:
-                        dst.write(src.read())
+                    _extract_member_atomically(zf, member, target, new_file_mode)
                     # External provider configs commonly hold credentials.
                     if target.suffix in {".json", ".env", ".conf"} or target.name in _SECRET_FILE_NAMES:
                         try:
@@ -977,8 +1068,7 @@ def run_import(args) -> None:
 
             try:
                 target.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(member) as src, open(target, "wb") as dst:
-                    dst.write(src.read())
+                _extract_member_atomically(zf, member, target, new_file_mode)
                 if target.name in _SECRET_FILE_NAMES:
                     os.chmod(target, 0o600)
                 restored += 1

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -903,7 +903,11 @@ def _extract_member_atomically(
     symlinked target first, so a deployment that links ``config.yaml`` into a
     dotfiles repo keeps the link instead of having it silently swapped for a
     regular file (GitHub #16743), and it falls back to copy/fsync/unlink on
-    ``EXDEV``/``EBUSY`` for cross-device and bind-mount installs.
+    ``EXDEV``/``EBUSY`` for cross-device and bind-mount installs.  That
+    fallback uses ``shutil.copyfile``, which does truncate in place, so on the
+    cross-device path the guarantee above degrades to today's behaviour rather
+    than improving on it; closing that belongs in ``utils.atomic_replace``,
+    where every atomic writer in the repo would benefit, not here.
 
     Permission bits *and* ownership are carried across the replace so routing
     through mkstemp does not change the file the caller would otherwise have

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,7 +13,6 @@ import logging
 import os
 import shutil
 import sqlite3
-import stat
 import sys
 import tempfile
 import threading
@@ -25,7 +24,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
-from utils import atomic_replace
+from utils import (
+    _preserve_file_mode,
+    _preserve_file_owner,
+    _restore_file_mode,
+    _restore_file_owner,
+    atomic_replace,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -900,16 +905,23 @@ def _extract_member_atomically(
     regular file (GitHub #16743), and it falls back to copy/fsync/unlink on
     ``EXDEV``/``EBUSY`` for cross-device and bind-mount installs.
 
-    Permission bits are carried across the replace so routing through mkstemp
-    does not change the mode the caller would otherwise have produced.  The
-    temp file is removed on any failure so a partial import leaves no residue.
+    Permission bits *and* ownership are carried across the replace so routing
+    through mkstemp does not change the file the caller would otherwise have
+    produced.  ``os.replace`` swaps in a temp file owned by the *writing* user,
+    so without the chown a ``sudo hermes import`` would silently re-own every
+    restored file to root — on the disaster-recovery path, and on exactly the
+    Docker/NAS installs ``utils._restore_file_owner`` documents.  Both concerns
+    delegate to the shared ``utils`` helpers rather than being re-derived here.
+    The temp file is removed on any failure so a partial import leaves no
+    residue.
     """
-    mode = new_file_mode
-    try:
-        mode = stat.S_IMODE(target.stat().st_mode)
-    except OSError:
-        # Target does not exist (or cannot be stat'd) — keep the create-mode.
-        pass
+    # ``_preserve_file_mode`` returns None when the target does not exist (or
+    # cannot be stat'd), in which case the umask-derived create-mode applies —
+    # the same shape as ``atomic_yaml_write``'s ``create_mode`` fallback.
+    mode = _preserve_file_mode(target)
+    owner = _preserve_file_owner(target)
+    if mode is None:
+        mode = new_file_mode
 
     # Truncate the stem: mkstemp adds ~16 characters, and a member already near
     # NAME_MAX would otherwise fail here on a write that used to succeed.
@@ -918,23 +930,27 @@ def _extract_member_atomically(
     )
     try:
         with os.fdopen(fd, "wb") as dst:
-            if mode is not None and hasattr(os, "fchmod"):
-                # Apply before the replace so the target never transits through
-                # mkstemp's 0600.  fchmod is Unix-only; Windows uses the
-                # post-replace chmod below.
-                os.fchmod(dst.fileno(), mode)
+            if mode is not None:
+                # Apply the mode to the temp file BEFORE the replace so the
+                # target never transits through mkstemp's 0600, and so
+                # ``atomic_replace``'s EXDEV/EBUSY ``shutil.copystat`` fallback
+                # copies the intended bits rather than 0600.  fchmod is
+                # Unix-only; Windows takes the path-based chmod.
+                if hasattr(os, "fchmod"):
+                    os.fchmod(dst.fileno(), mode)
+                else:
+                    os.chmod(tmp_name, mode)
             # Stream instead of ``src.read()``: a multi-gigabyte state.db member
             # must not be held in memory in one piece.
             with zf.open(member) as src:
                 shutil.copyfileobj(src, dst)
             dst.flush()
             os.fsync(dst.fileno())
-        real_path = atomic_replace(tmp_name, target)
-        if mode is not None and not hasattr(os, "fchmod"):
-            try:
-                os.chmod(real_path, mode)
-            except OSError:
-                pass
+        real_path = Path(atomic_replace(tmp_name, target))
+        # Owner first: chown clears setuid/setgid, so the mode restore below is
+        # what puts those bits back.  Ordering mirrors ``atomic_yaml_write``.
+        _restore_file_owner(real_path, owner)
+        _restore_file_mode(real_path, mode)
     except BaseException:
         try:
             os.unlink(tmp_name)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -748,6 +748,84 @@ class TestImportAtomicWrites:
         assert target.read_text() == "model: restored\n"
         assert (target.stat().st_mode & 0o777) == 0o644
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership")
+    def test_restore_preserves_existing_file_owner(self, tmp_path, monkeypatch):
+        """A root-run import must not re-own the user's files to root.
+
+        ``os.replace`` swaps in a temp file owned by the *writing* user, so a
+        ``sudo hermes import`` onto a user-owned (or Docker/NAS volume-owned)
+        HERMES_HOME would hand every restored file to root. The uid/gid is
+        forced so the assertion does not require running as root.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        target = hermes_home / "config.yaml"
+        target.write_text("model: original\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {"config.yaml": "model: restored\n", "state.db": ""})
+
+        chown_calls: list[tuple[Path, int, int]] = []
+        monkeypatch.setattr(
+            "hermes_cli.backup._preserve_file_owner",
+            lambda p: (123, 456) if Path(p).exists() else None,
+        )
+        monkeypatch.setattr(
+            "utils.os.chown",
+            lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+        )
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert target.read_text() == "model: restored\n"
+        # config.yaml pre-existed, so its owner is captured and re-applied;
+        # state.db is newly created, so there is no prior owner to restore.
+        assert chown_calls == [(target, 123, 456)]
+
+    @pytest.mark.skipif(not hasattr(os, "fchmod"), reason="needs fchmod present to remove it")
+    def test_mode_is_applied_before_the_replace_without_fchmod(self, tmp_path, monkeypatch):
+        """Covers the Windows branch: no ``fchmod``, so ``chmod`` the temp path.
+
+        Applying the mode only *after* ``atomic_replace`` leaves the published
+        file at mkstemp's 0600 until that chmod lands (and permanently if the
+        process dies in between), and ``atomic_replace``'s EXDEV/EBUSY
+        ``shutil.copystat`` fallback would copy 0600 onto the target. Mirrors
+        the transit-window fix ``atomic_yaml_write`` already carries.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        target = hermes_home / "config.yaml"
+        target.write_text("model: original\n")
+        os.chmod(target, 0o644)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {"config.yaml": "model: restored\n", "state.db": ""})
+
+        import hermes_cli.backup as backup_mod
+
+        real_replace = backup_mod.atomic_replace
+        staged_modes: list[int] = []
+
+        def spying_replace(tmp, dst):
+            if Path(dst).name == "config.yaml":
+                staged_modes.append(os.stat(tmp).st_mode & 0o777)
+            return real_replace(tmp, dst)
+
+        monkeypatch.delattr(os, "fchmod")
+        monkeypatch.setattr(backup_mod, "atomic_replace", spying_replace)
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        # Without the pre-replace chmod this reads 0o600 (mkstemp's mode).
+        assert staged_modes == [0o644]
+        assert (target.stat().st_mode & 0o777) == 0o644
+
 
 # ---------------------------------------------------------------------------
 # Profile restoration tests

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -566,6 +566,189 @@ class TestImportEdgeCases:
         assert (hermes_home / "sessions" / "s0599.json").exists()
 
 
+class _ExplodingMember:
+    """Zip member whose stream dies mid-restore (ENOSPC / corrupt member).
+
+    Both the pre-fix ``dst.write(src.read())`` and the atomic
+    ``shutil.copyfileobj`` path pull bytes through ``read()``, so injecting
+    here exercises whichever implementation is in the tree.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def read(self, *args):
+        raise OSError(28, "No space left on device")
+
+    def close(self):
+        pass
+
+
+def _break_member(monkeypatch, failing_member: str) -> None:
+    """Make ``ZipFile.open`` hand back a dying stream for one member only."""
+    real_open = zipfile.ZipFile.open
+
+    def _patched(self, name, *args, **kwargs):
+        filename = name.filename if isinstance(name, zipfile.ZipInfo) else name
+        if filename == failing_member:
+            return _ExplodingMember()
+        return real_open(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _patched)
+
+
+class TestImportAtomicWrites:
+    """`hermes import` must never leave a user's file truncated.
+
+    The pre-fix code did ``open(target, "wb")`` then ``dst.write(src.read())``,
+    which zeroes the existing file *before* any replacement bytes exist. These
+    tests pin the invariant for both restore branches: the HERMES_HOME branch
+    and the ``_external/`` branch that writes into third-party configs under
+    the user's home.
+    """
+
+    def _zip(self, zip_path: Path, files: dict) -> None:
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for name, content in files.items():
+                zf.writestr(name, content)
+
+    def test_failed_member_leaves_existing_file_intact(self, tmp_path, monkeypatch):
+        """A dying member must not destroy the file it was replacing."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        original = "model: original\napi_key: keep-me\n"
+        (hermes_home / "config.yaml").write_text(original)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {"config.yaml": "model: replacement\n", "state.db": ""})
+        _break_member(monkeypatch, "config.yaml")
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        # Pre-fix this file is 0 bytes: the truncate landed, the write did not.
+        assert (hermes_home / "config.yaml").read_text() == original
+        # And the aborted write must not litter the directory it staged in.
+        assert list(hermes_home.glob(".config.yaml.*")) == []
+
+    def test_failed_external_member_leaves_existing_file_intact(self, tmp_path, monkeypatch):
+        """Same invariant on the `_external/` branch, which writes outside HERMES_HOME."""
+        dst_home = tmp_path / "dst"
+        dst_home.mkdir()
+        hermes_home = dst_home / ".hermes"
+        hermes_home.mkdir()
+        honcho = dst_home / ".honcho"
+        honcho.mkdir()
+        original = '{"peer":"original"}'
+        (honcho / "config.json").write_text(original)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {
+            "config.yaml": "model: {}\n",
+            "_external/.honcho/config.json": '{"peer":"replacement"}',
+        })
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: dst_home)
+        _break_member(monkeypatch, "_external/.honcho/config.json")
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert (honcho / "config.json").read_text() == original
+        assert list(honcho.glob(".config.json.*")) == []
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX symlinks")
+    def test_symlinked_target_keeps_its_symlink(self, tmp_path, monkeypatch):
+        """A symlinked target is written through, not replaced by a regular file.
+
+        Guards the atomic rewrite against a naive ``os.replace``, which would
+        detach dotfiles-managed deployments (GitHub #16743). ``atomic_replace``
+        resolves the link first.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        store = hermes_home / "store"
+        store.mkdir()
+        real = store / "config.yaml"
+        real.write_text("model: original\n")
+        link = hermes_home / "config.yaml"
+        link.symlink_to(real)
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {"config.yaml": "model: restored\n", "state.db": ""})
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert link.is_symlink(), "import replaced the symlink with a regular file"
+        assert real.read_text() == "model: restored\n"
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX symlinks")
+    def test_symlinked_external_target_keeps_its_symlink(self, tmp_path, monkeypatch):
+        """Same guard on the `_external/` branch — the realistic dotfiles case."""
+        dst_home = tmp_path / "dst"
+        dst_home.mkdir()
+        hermes_home = dst_home / ".hermes"
+        hermes_home.mkdir()
+        dotfiles = dst_home / "dotfiles"
+        dotfiles.mkdir()
+        real = dotfiles / "honcho.json"
+        real.write_text('{"peer":"original"}')
+        honcho = dst_home / ".honcho"
+        honcho.mkdir()
+        link = honcho / "config.json"
+        link.symlink_to(real)
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: dst_home)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {
+            "config.yaml": "model: {}\n",
+            "_external/.honcho/config.json": '{"peer":"restored"}',
+        })
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert link.is_symlink(), "import replaced the symlink with a regular file"
+        assert real.read_text() == '{"peer":"restored"}'
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file modes")
+    def test_restore_preserves_existing_file_mode(self, tmp_path, monkeypatch):
+        """Staging through mkstemp must not silently tighten restored files to 0600.
+
+        ``tempfile.mkstemp`` creates at 0600; the mode of the file being
+        replaced has to survive the publish, or Docker/NAS installs that rely
+        on broader permissions break on restore.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        target = hermes_home / "config.yaml"
+        target.write_text("model: original\n")
+        os.chmod(target, 0o644)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(zip_path, {"config.yaml": "model: restored\n", "state.db": ""})
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert target.read_text() == "model: restored\n"
+        assert (target.stat().st_mode & 0o777) == 0o644
+
+
 # ---------------------------------------------------------------------------
 # Profile restoration tests
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import stat
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -825,6 +826,73 @@ class TestImportAtomicWrites:
         # Without the pre-replace chmod this reads 0o600 (mkstemp's mode).
         assert staged_modes == [0o644]
         assert (target.stat().st_mode & 0o777) == 0o644
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX setuid/setgid bits")
+    def test_restore_does_not_carry_setuid_onto_archive_content(
+        self, tmp_path, monkeypatch
+    ):
+        """An imported member must not inherit a privileged target's identity.
+
+        ``_preserve_file_mode`` returns ``stat.S_IMODE``, i.e. all twelve bits,
+        so a target sitting at 0o6755 hands setuid/setgid straight back to a
+        file whose contents now come from the zip.  Whoever produced the
+        archive would then get whatever that file executes as.  The other
+        ``utils`` writers can preserve the full mode safely because they
+        re-serialize content this process produced; ``hermes import`` is the
+        one write path where the bytes are untrusted, and it is also the path
+        that documents ``sudo`` use for owner preservation.
+
+        The sibling assertions in this class mask with ``& 0o777``, which
+        discards exactly the bits at issue, so this failure is invisible to
+        them.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        target = hermes_home / "helper.sh"
+        target.write_text("#!/bin/sh\necho original\n")
+        os.chmod(target, 0o6755)
+        if stat.S_IMODE(target.stat().st_mode) != 0o6755:
+            pytest.skip("filesystem refuses setuid/setgid on a user-owned file")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._zip(
+            zip_path,
+            {"helper.sh": "#!/bin/sh\necho attacker\n", "state.db": ""},
+        )
+
+        import hermes_cli.backup as backup_mod
+
+        real_replace = backup_mod.atomic_replace
+        staged_modes: list[int] = []
+
+        def spying_replace(tmp, dst):
+            if Path(dst).name == "helper.sh":
+                staged_modes.append(stat.S_IMODE(os.stat(tmp).st_mode))
+            return real_replace(tmp, dst)
+
+        monkeypatch.setattr(backup_mod, "atomic_replace", spying_replace)
+
+        from hermes_cli.backup import run_import
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        published = stat.S_IMODE(target.stat().st_mode)
+        assert target.read_text() == "#!/bin/sh\necho attacker\n"
+        assert not published & stat.S_ISUID, (
+            f"archive content kept the target's setuid bit (mode 0o{published:o})"
+        )
+        assert not published & stat.S_ISGID, (
+            f"archive content kept the target's setgid bit (mode 0o{published:o})"
+        )
+        # The ordinary permission bits are still preserved — this drops the
+        # elevated bits, it does not fall back to mkstemp's 0600.
+        assert published == 0o755
+        # And there must be no transient elevation either: the temp file is
+        # chmod'd before the replace, so it must never carry the bits.
+        assert staged_modes == [0o755], (
+            f"the staged temp file was elevated before publish: {staged_modes}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`hermes import` could destroy the file it was restoring.

Both restore sites in `run_import` wrote each zip member like this:

```python
with zf.open(member) as src, open(target, "wb") as dst:
    dst.write(src.read())
```

`open(target, "wb")` truncates the user's existing file to zero **before any replacement bytes exist**. There is no `os.replace`, no fsync, and no backup. A Ctrl-C, an ENOSPC, a corrupt or truncated zip member, or a crash between the truncate and the write leaves `config.yaml`, `.env`, or an external provider config **empty, with nothing behind it** — during `hermes import`, which is the documented disaster-recovery path. The user is running it *because* they already lost something.

Two things make this worse than a normal non-atomic write:

- **Site 1 writes outside HERMES_HOME.** The `_external/` branch restores memory-provider state to its original home-relative location (e.g. `~/.honcho/config.json`), so a failed import can zero a third-party config the user never associated with Hermes.
- **It is the normal path, not a rare state.** Every member of every import goes through it.

Both sites now stage the member into the target's own directory, fsync, and publish with `utils.atomic_replace`. The target only ever moves from its old contents to the complete new contents.

**This extends the module's own established idiom rather than introducing one.** `hermes_cli/backup.py` already publishes atomically twice — `os.replace(partial_path, final_path)` in `_atomic_output_path` (`:211`) and `os.replace(staging_dir, snap_dir)` in the snapshot writer (`:1337`, from the recently landed `aad8f741` *"serialize and atomically publish snapshots"*). `run_import` was the one path left overwriting user files in place. `utils.atomic_write_text` states the invariant directly in its docstring: it exists so that *"every destructive file rewrite in the codebase shares one implementation."*

**Why `utils.atomic_replace` and not a bare `os.replace`** — this is load-bearing. `open(target, "wb")` writes *through* a symlink, so a user who links `~/.hermes/config.yaml` into a dotfiles repo keeps that link today. A naive `mkstemp` + `os.replace` would replace the symlink with a regular file and silently detach the deployment — that is #16743, a bug this repo has already been bitten by. `atomic_replace` resolves the link first, and falls back to copy/fsync/unlink on `EXDEV`/`EBUSY` for cross-device and bind-mount installs. Two of the added tests pin this; both go red if the helper is swapped for a raw `os.replace`.

## Related Issue

No filed issue — found by inspection of the restore path. Refs #16743 (the symlink-detach hazard the helper is chosen to avoid).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/backup.py`

- Added `_extract_member_atomically()`: `mkstemp` in the **target's own directory** (never `/tmp`, so the `EXDEV` fallback stays the exception) → stream the member → `fsync` → `atomic_replace`. The temp file is unlinked on any failure, including `KeyboardInterrupt`, so a partial import leaves no residue.
- Streams with `shutil.copyfileobj` instead of `src.read()`, which also stops a multi-gigabyte `state.db` member being held in memory in one piece.
- Added `_default_new_file_mode()`: `mkstemp` creates at 0600, so without this every *newly created* file would be tightened to owner-only, breaking Docker/NAS installs that rely on broader permissions — the same hazard `utils._restore_file_mode` documents. Existing files keep their own mode (captured and applied to the temp fd *before* the replace, so the target never transits 0600). Resolved once per import, and the probe installs a restrictive mask rather than 0 so nothing created by another thread in that two-syscall window is world-writable.
- Both `run_import` write sites call the helper. **The `os.chmod(...)` calls at both sites are untouched** — permission behaviour is byte-for-byte what it was.

`tests/hermes_cli/test_backup.py`

- New `TestImportAtomicWrites`, 5 tests, covering **both** restore branches:
  - `test_failed_member_leaves_existing_file_intact` — a member whose stream dies mid-restore must not destroy the file it was replacing, and must leave no `.config.yaml.*` temp behind.
  - `test_failed_external_member_leaves_existing_file_intact` — same invariant on the `_external/` branch.
  - `test_symlinked_target_keeps_its_symlink` / `test_symlinked_external_target_keeps_its_symlink` — the target keeps its symlink and the real file receives the content.
  - `test_restore_preserves_existing_file_mode` — staging through `mkstemp` does not tighten a 0644 file to 0600.

Acceptance criteria, all covered: (1) no window in which the target exists truncated or partially written; (2) a symlinked target survives; (3) a mid-write failure leaves the original intact with no stray temp; (4) existing permission behaviour unchanged.

## How to Test

Reproduce the bug on `main`:

1. `printf 'model: keep-me\n' > $HERMES_HOME/config.yaml`
2. Build a backup zip whose `config.yaml` member is truncated/corrupt (or `^C` during `hermes import` on a large archive).
3. `hermes import backup.zip --force` → `config.yaml` is now **0 bytes**. The original is gone.

With this PR, the same run reports the member in the warnings block and `config.yaml` still holds `model: keep-me`.

Automated, with the injected-failure direction verified in both directions:

```
pytest tests/hermes_cli/test_backup.py -q                      # 45 passed (40 existing + 5 new)
pytest tests/hermes_cli/test_backup.py::TestImportAtomicWrites # 5 passed
```

Regression guard, run explicitly:

- Reverting **only** `hermes_cli/backup.py` to `main` and re-running: the two data-loss tests **fail** (the file is 0 bytes — the truncate landed, the write did not), the 3 guards pass. Restoring the fix: 5 passed.
- Swapping `atomic_replace` for a bare `os.replace`: the two symlink tests **fail**. The guards are not vacuous.

Adjacent suites touching the same primitive, all green:

```
pytest tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py \
       tests/hermes_cli/test_update_zip_atomic_replace.py tests/hermes_cli/test_update_zip_symlink_reject.py \
       tests/test_stale_utils_module_import.py -q               # 12 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see Related / Positioning below
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** Ran `tests/hermes_cli/test_backup.py` (45 passed) plus the five adjacent atomic-write/utils-import suites listed above (12 passed). Exact commands and counts are in "How to Test".
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — behaviour is documented in the new helpers' docstrings; no user-facing docs change, the CLI contract is unchanged
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — `os.fchmod` is Unix-only, so where it is absent the mode is applied to the temp file with a path-based `os.chmod` before the replace, with `utils._restore_file_mode` kept afterwards as the belt-and-braces path (mirrors `utils.atomic_yaml_write` after `43fc86562`); `_preserve_file_owner` is a no-op off POSIX; `atomic_replace` already handles the Windows/bind-mount `EBUSY` path; the symlink, mode, and owner tests are `skipif(os.name != "posix")` and the no-`fchmod` test uses `monkeypatch.delattr` so the Windows branch is covered on CI
- [x] N/A — no tool descriptions or schemas changed

## Related / Positioning

I checked the open queue by symbol and by changed path before opening this. Several PRs are adjacent; I want to be precise about which are disjoint and which is not, rather than claim a clean field.

**Complementary, content-disjoint — no action needed:**

- **#56946** (`guard os.chmod on Windows where it is a no-op`) and **#56949** (`use Windows ACLs for credential file permissions`) both edit *only* the `os.chmod(...)` lines at these two sites, leaving the write statements as unchanged context. I deliberately did not touch those lines, so both remain applicable on top of this.
- **#37989** (embedded Hindsight archives) adds bookkeeping *after* the write; **#11224** (`_detect_prefix`), **#9839** (profile resolution), and **#46765** (`restore_quick_snapshot` / `restore_cron_jobs_if_emptied`) are elsewhere in the file.

**Genuinely overlapping, and it does *not* fix this bug:**

- **#61881** (`harden backup import and OOXML extraction`, currently `CONFLICTING`) replaces these same two statements with a `_copy_zip_member()` helper. That helper is:

  ```python
  with zf.open(member) as src, open(target, "wb") as dst:
      shutil.copyfileobj(src, dst, length=_IMPORT_COPY_CHUNK_BYTES)
  ```

  It is **still truncate-then-write** — no temp file, no `os.replace`, no fsync, no symlink handling. It fixes the whole-member-in-memory problem (which this PR also fixes) but the data-loss window survives it unchanged. Its real value is elsewhere in its diff: zip-bomb limits, member-count/size/ratio caps, and an external-target allowlist, none of which this PR touches.

  So the two are not duplicates and neither is a subset of the other in intent — but they do collide textually on these two lines, and whichever lands second will need a trivial rebase. On the write statements themselves this PR is the superset: it carries #61881's streaming change and adds the atomicity, symlink preservation, and temp cleanup that it lacks. Happy to rebase onto it, or to fold the atomic helper into `_copy_zip_member` if you would rather take that one first — just say which.

I did not extend this to `restore_quick_snapshot`, which has the same class of non-atomic `shutil.copy2` overwrite: it is a different entry point (`/snapshot` restore, not `hermes import`) and it is the function #46765 is actively editing. Happy to file it separately.

## Follow-up commit

`dfda12ea3` addresses the three inline findings on `hermes_cli/backup.py`; each thread has a reply with the reasoning. Two of them changed code. `dc051c497` (current head) then scopes the helper's docstring to what it actually guarantees — see the triage-comment reply below on `atomic_replace`'s cross-device fallback.

**Owner preservation was missing, and that is the substantive one.** `tempfile.mkstemp` + `atomic_replace` publishes a temp file owned by the *writing* user, so `sudo hermes import` was re-owning every restored file to root — on the disaster-recovery path, and on exactly the Docker/NAS volume-mounted installs `utils._restore_file_owner` was added for (`551e5af50`, *"preserve owner on atomic writes (#56644)"*). `_extract_member_atomically` now captures `_preserve_file_owner(target)` before staging and calls `_restore_file_owner` after the replace, ahead of the mode restore — `chown` clears setuid/setgid, so the mode has to go back last. This is the ordering `atomic_yaml_write` and `atomic_json_write` already use.

**The mode was only applied before the replace on the `os.fchmod` branch.** Platforms without `fchmod` fell through to a best-effort post-replace `chmod`, which left the published file at `mkstemp`'s 0600 until that call landed — permanently if the process died in between — and made `atomic_replace`'s `EXDEV`/`EBUSY` `shutil.copystat` fallback copy 0600 onto the target. The mode is now applied to the temp file on both branches, with the post-replace restore kept as belt-and-braces.

**Both concerns now delegate to the shared `utils` helpers rather than being re-derived here** — `_preserve_file_mode` / `_preserve_file_owner` / `_restore_file_mode` / `_restore_file_owner`, the same set `atomic_write_text` and `atomic_yaml_write` use after `3556728a5` (*"move mode+owner preservation into atomic_write_text"*) and `43fc86562` (*"close the yaml 0600 transit window"*). They are underscore-private, and I took importing them over re-implementing deliberately: same repo, `backup.py` already imports `atomic_replace` from `utils`, and a second copy of chown-then-chmod ordering is exactly the divergence those commits consolidated. If you would rather they were public, say the word and I will add a thin public wrapper in `utils.py` in this PR. The local `import stat` is gone as a result.

The third finding — `os.umask` mutating process-global state — I declined, with reasoning in the thread: CPython has no portable read-only umask query, the probe deliberately installs the restrictive `0o077` so anything a racing thread creates is owner-only rather than widened, the window is two syscalls, and it is resolved **once per import** rather than per member. The suggested alternative (create a throwaway file and `stat` it) adds I/O in the user's config directory on a recovery path and has its own race without removing the process-global one.

Two tests added to `TestImportAtomicWrites`, both mutation-checked in the final file location:

| Test | Red before | Green after |
| --- | --- | --- |
| `test_restore_preserves_existing_file_owner` | `chown_calls == []` | `[(config.yaml, 123, 456)]` |
| `test_mode_is_applied_before_the_replace_without_fchmod` | staged mode `0o600` | staged mode `0o644` |

The owner test forces a uid/gid so it does not need root, and asserts the chown fires **once** — on the pre-existing file, not on the newly created member, which pins that the owner is genuinely captured rather than invented. The mode test uses `monkeypatch.delattr(os, "fchmod")` (the convention `43fc86562` established for this branch) and spies the temp file's mode at `atomic_replace` time rather than after, so a post-replace `chmod` cannot make it pass. Deleting only the `_restore_file_owner` call reds the first; deleting only the `os.chmod(tmp_name, mode)` line reds the second.

```
pytest tests/hermes_cli/test_backup.py                                        # 47 passed
pytest tests/hermes_cli/test_backup.py tests/test_atomic_replace_symlinks.py \
       tests/test_atomic_write_text_metadata.py                               # 67 passed, 1 skipped
```
