### PR TITLE
fix(streaming): accept usage-only terminal chunks without finish_reason

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3073,6 +3073,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         role = "assistant"
         reasoning_parts: list = []
         usage_obj = None
+        # Some OpenAI-compatible gateways (e.g. opencode.ai/zen/go with
+        # gpt-5.6-luna) end the stream with a usage-only chunk but never
+        # send finish_reason or [DONE].  A usage-only chunk is the spec'd
+        # terminal chunk, so record it to distinguish a graceful end from
+        # a genuine mid-stream drop.
+        _graceful_usage_end = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -3247,6 +3253,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Usage comes in the final chunk with empty choices
                 if hasattr(chunk, "usage") and chunk.usage:
                     usage_obj = chunk.usage
+                    _graceful_usage_end = True
                 continue
 
             delta = chunk.choices[0].delta
@@ -3506,6 +3513,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             finish_reason is None
             and content_parts
             and not tool_calls_acc
+            # A usage-only terminal chunk means the provider finished the
+            # response normally but omitted finish_reason (opencode.ai/zen/go
+            # with gpt-5.6-luna does this) — that is NOT a mid-stream drop.
+            and not _graceful_usage_end
         )
         if _text_only_dropped_no_finish:
             logger.warning(


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where Hermes incorrectly treated OpenCode streaming responses as incomplete when the stream ended with a usage-only chunk but without a finish_reason.

This caused unnecessary retries, repeated responses, and duplicated context for models such as gpt-5.6-luna.

The fix recognizes a usage-only terminal chunk as a successful completion when no finish_reason is provided.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated agent/chat_completion_helpers.py
- Treat usage-only terminal chunks as normal stream completion signals
- Prevented unnecessary mid-stream retries when finish_reason is omitted
- Prevented repeated or concatenated responses caused by those retries

## How to Test

1. Configure Hermes to use the OpenCode gateway with gpt-5.6-luna.
2. Send a prompt that requires a normal tool-enabled response.
3. Confirm that the request completes successfully without repeated retries or duplicated output.
4. Verify that the response completes with a single API call and is processed as a normal completion.
5. Run the test suite with:
   ```bash
   pytest tests/ -q
   ```

Manual verification confirmed that the request completed with:
- api_calls=1
- finish_reason=stop

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Manual test result:

```text
api_calls=1
finish_reason=stop
```

Before this fix, the same response could trigger multiple retries and repeated output because the upstream gateway omitted finish_reason.