### PR TITLE
feat(discord): implement delete_message for progress-bubble cleanup

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3420,6 +3420,36 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a previously sent Discord message.
+
+        Overrides :meth:`BasePlatformAdapter.delete_message` (which returns
+        ``False`` = unsupported) so the gateway's ``cleanup_progress`` path
+        can remove temporary tool-progress bubbles after the final response
+        is delivered.  Local Novacom patch pending upstream inclusion.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = channel.get_partial_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:
+            # Best-effort: already-deleted (404/10008) or missing permission
+            # must never break final delivery.
+            logger.debug(
+                "[%s] Failed to delete Discord message %s in %s: %s",
+                self.name, message_id, chat_id, e,
+            )
+            return False
+
     @staticmethod
     def _is_length_overflow_error(err: Exception) -> bool:
         """True when a Discord edit/send failed because text exceeded 2,000.


### PR DESCRIPTION
## Summary

The gateway's `cleanup_progress` feature (`display.platforms.<platform>.cleanup_progress`) collects the message IDs of temporary tool-progress bubbles and deletes them after the final response is delivered. The gateway guard in `gateway/run.py` silently disables this when the platform adapter does not override `BasePlatformAdapter.delete_message`:

```python
if _cleanup_adapter is not None and (
    _cleanup_delete is None
    or _cleanup_delete is BasePlatformAdapter.delete_message
):
    # Adapter doesn't support deletion — silently disable.
```

Telegram, Slack, and Google Chat adapters implement `delete_message`; **Discord never did**, so `cleanup_progress: true` has been a silent no-op on Discord even though Discord's REST API fully supports message deletion (bots can always delete their own messages).

## Change

Adds `DiscordAdapter.delete_message` using `channel.get_partial_message(id).delete()`, mirroring the channel-resolution pattern already used by `edit_message` (cache first, `fetch_channel` fallback).

Best-effort semantics per the base-class contract: returns `False` on any failure (already-deleted 10008, missing permission, disconnected client) and logs at debug level so final delivery is never affected.

## Testing

- `scripts/run_tests.sh tests/gateway/test_discord_send.py` passes
- Deployed on a 15-profile production fleet (Novacom Building Partners): progress bubbles are deleted after the final message lands, with `streaming: true` + `cleanup_progress: true` + `tool_progress: all/verbose`