### PR TITLE
fix(honcho): fingerprint config content for cache busting

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -22525,7 +22526,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, str | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -22533,16 +22534,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json content."""
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                content_digest = hashlib.sha256(path.read_bytes()).hexdigest()
             except OSError:
-                mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                content_digest = None
+            memo_key = (str(path), content_digest)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -16,6 +16,7 @@ chosen ``user_peer_id`` can be asserted without touching the network.
 
 import hashlib
 import json
+import os
 from unittest.mock import MagicMock
 
 
@@ -515,16 +516,18 @@ class TestPinTransition:
         )
 
     def test_cache_busting_signature_reflects_pin_peer_name(self, tmp_path, monkeypatch):
-        """Gateway agent cache must bust when honcho.json's pinPeerName flips."""
+        """Gateway cache must bust even when honcho.json's mtime is unchanged."""
         from gateway.run import GatewayRunner
 
         cfg_path = tmp_path / "honcho.json"
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": True}))
+        original_stat = cfg_path.stat()
         sig_pinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": False}))
+        os.utime(cfg_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
         sig_unpinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_pinned["honcho.pin_peer_name"] != sig_unpinned["honcho.pin_peer_name"]


### PR DESCRIPTION
## Summary

- fingerprint the active `honcho.json` contents instead of relying only on file mtime
- invalidate the cached gateway agent when Honcho identity settings change but the timestamp is preserved
- make the existing `pinPeerName` cache-busting regression deterministic by explicitly restoring the original mtime

## Problem

`GatewayRunner._extract_honcho_cache_busting_config()` memoized parsed Honcho identity settings by `(path, st_mtime_ns)`. A rewrite that preserves the same mtime reuses stale settings, so the gateway agent cache does not rebuild after an identity mapping change.

The deterministic regression reproduces this on current `main`: after `pinPeerName` changes from `true` to `false` with the same mtime, the unpatched code returns `true` for both signatures.

## Fix

Use a SHA-256 digest of the file contents in the memo key. This keeps the memoization but ties invalidation to the data being parsed rather than filesystem timestamp behavior.

## Tests

- regression test against unmodified `main` gateway code: **1 failed, 24 passed** (`assert True != True`, expected reproduction)
- `scripts/run_tests.sh tests/honcho_plugin/test_pin_peer_name.py`: **25 passed**
- `ruff 0.15.10 check gateway/run.py tests/honcho_plugin/test_pin_peer_name.py`: **passed**

Related but distinct from #33440, which expands the set of manager-scoped fields included in the signature; this PR fixes invalidation when the config content changes without an mtime change.