### PR TITLE
fix(file_ops): ignore trailing U+FFFD from UTF-8 byte-sample boundary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,13 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_utf8_character_split_at_sample_boundary_not_flagged(self, tmp_path):
+        """A byte-limited sample may end halfway through valid UTF-8 text."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # The production terminal decoder uses errors="replace".  If
+        # ``head -c 1000`` ends halfway through a UTF-8 character, that produces
+        # one trailing replacement marker even though the source file is text.
+        boundary_sample = "a" * 999 + "\ufffd"
+
+        assert ops._is_likely_binary("architecture.md", boundary_sample) is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -908,9 +908,15 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # ``head -c 1000`` may cut a valid multi-byte UTF-8 character at
+            # the sample boundary.  The terminal decoder then appends one
+            # U+FFFD even though the file itself is valid text.  Ignore only
+            # that boundary marker; replacement chars anywhere else still
+            # prove that the sampled bytes were not valid UTF-8.
+            sampled = content_sample[:1000]
+            if "\ufffd" in sampled.rstrip("\ufffd"):
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sampled
                                if ord(c) < 32 and c not in '\n\r\t')
             return non_printable / min(len(content_sample), 1000) > 0.30
         


### PR DESCRIPTION
## Problem

`read_file` uses `head -c 1000` to sample file content for binary detection. When the 1000-byte boundary falls in the middle of a valid multi-byte UTF-8 character, the subprocess decoder (with `errors="replace"`) appends one `U+FFFD` replacement character for the incomplete byte sequence.

`_is_likely_binary` treated **any** `U+FFFD` in the sample as proof of non-UTF-8 content, so legitimate text files (e.g. a large Markdown file with Cyrillic/CJK characters near byte offset 1000) were incorrectly flagged as binary. This blocked `read_file` and `patch` operations with:

```
Binary file — cannot display as text.
```

## Root Cause

`tools/file_operations.py`:
```python
if "\ufffd" in content_sample[:1000]:
    return True
```

This check correctly catches genuinely non-UTF-8 content (where the decoder inserts replacement characters throughout). But it also fires on the **single boundary marker** produced when `head -c 1000` truncates a valid UTF-8 character.

## Fix

Ignore only a **trailing run** of `U+FFFD` at the end of the sample — that is the decoder's boundary artifact. Interior replacement characters still prove the sampled bytes were not valid UTF-8 and are flagged as binary.

```python
sampled = content_sample[:1000]
if "\ufffd" in sampled.rstrip("\ufffd"):
    return True
```

## Test

New regression test: `TestReadNonUtf8IsBinary::test_utf8_character_split_at_sample_boundary_not_flagged`

Verifies that a sample ending with a boundary `U+FFFD` is **not** flagged as binary, while existing tests confirm genuine non-UTF-8 content is still detected.
