### PR TITLE
fix: unique suffixes for same-second recordings and saves

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8379,7 +8379,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception as e:
             print(f"(x_x) Failed to create save directory {saved_dir}: {e}")
             return
-        path = saved_dir / f"hermes_conversation_{timestamp}.json"
+        # Unique suffix keeps same-second saves distinct.
+        path = saved_dir / f"hermes_conversation_{timestamp}_{uuid.uuid4().hex[:8]}.json"
 
         try:
             with open(path, "w", encoding="utf-8") as f:

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -331,7 +331,6 @@ class TestCreateAudioRecorder:
 class TestTermuxAudioRecorder:
     def test_start_and_stop_use_termux_microphone_commands(self, monkeypatch, temp_voice_dir):
         command_calls = []
-        output_path = Path(temp_voice_dir) / "recording_20260409_120000.aac"
 
         def fake_run(cmd, **kwargs):
             command_calls.append(cmd)
@@ -352,16 +351,21 @@ class TestTermuxAudioRecorder:
         recorder._start_time = time.monotonic() - 1.0
         result = recorder.stop()
 
-        assert result == str(output_path)
+        # Filename is the timestamp plus a unique suffix.
+        assert result == command_calls[0][2]
+        assert Path(result).name.startswith("recording_20260409_120000_")
+        assert Path(result).suffix == ".aac"
         assert command_calls[0][:2] == ["/data/data/com.termux/files/usr/bin/termux-microphone-record", "-f"]
         assert command_calls[1] == ["/data/data/com.termux/files/usr/bin/termux-microphone-record", "-q"]
 
     def test_cancel_removes_partial_termux_recording(self, monkeypatch, temp_voice_dir):
-        output_path = Path(temp_voice_dir) / "recording_20260409_120000.aac"
+        created = []
 
         def fake_run(cmd, **kwargs):
             if cmd[1] == "-f":
-                Path(cmd[2]).write_bytes(b"aac-bytes")
+                path = Path(cmd[2])
+                path.write_bytes(b"aac-bytes")
+                created.append(path)
             return MagicMock(returncode=0, stdout="", stderr="")
 
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
@@ -376,7 +380,7 @@ class TestTermuxAudioRecorder:
         recorder.start()
         recorder.cancel()
 
-        assert output_path.exists() is False
+        assert created and created[0].exists() is False
         assert recorder.is_recording is False
 
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import tempfile
 import threading
 import time
+import uuid
 import wave
 from typing import Any, Callable, Dict, List, Optional
 
@@ -726,7 +727,10 @@ class TermuxAudioRecorder:
                 return
             os.makedirs(_TEMP_DIR, exist_ok=True)
             timestamp = time.strftime("%Y%m%d_%H%M%S")
-            self._recording_path = os.path.join(_TEMP_DIR, f"recording_{timestamp}.aac")
+            # Unique suffix keeps same-second recordings distinct.
+            self._recording_path = os.path.join(
+                _TEMP_DIR, f"recording_{timestamp}_{uuid.uuid4().hex[:8]}.aac"
+            )
 
         command = [
             mic_cmd,
@@ -1183,8 +1187,11 @@ class AudioRecorder:
         Returns the file path.
         """
         os.makedirs(_TEMP_DIR, exist_ok=True)
+        # Unique suffix keeps same-second recordings distinct.
         timestamp = time.strftime("%Y%m%d_%H%M%S")
-        wav_path = os.path.join(_TEMP_DIR, f"recording_{timestamp}.wav")
+        wav_path = os.path.join(
+            _TEMP_DIR, f"recording_{timestamp}_{uuid.uuid4().hex[:8]}.wav"
+        )
 
         with wave.open(wav_path, "wb") as wf:
             wf.setnchannels(CHANNELS)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2619,7 +2619,8 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5011, f"failed to create save directory {saved_dir}: {e}")
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    path = saved_dir / f"hermes_conversation_{timestamp}.json"
+    # Unique suffix keeps same-second saves distinct.
+    path = saved_dir / f"hermes_conversation_{timestamp}_{uuid.uuid4().hex[:8]}.json"
 
     with session["history_lock"]:
         messages = list(session.get("history", []))


### PR DESCRIPTION
Recording and /save snapshot filenames used second-resolution timestamps, so two writes in the same second collided and silently overwrote each other.

- tools/voice_mode.py: WAV and Termux AAC recordings now carry a uuid suffix, so concurrent same-second writes from the recorder and the barge-in/full-duplex listeners can't overwrite each other.
- cli.py / tui_gateway/methods_session.py: hermes_conversation_*.json saves carry a uuid suffix, so back-to-back /save calls don't silently overwrite the previous snapshot.
- tests/tools/test_voice_mode.py: Termux tests updated for the new filename format.
