### PR TITLE
fix(gateway): classify provider-resolution failures instead of always labeling them auth

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6292,15 +6292,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     # all (raw aiohttp 500, no JSON body).  Handling it
                     # here, once, covers every _run_agent() caller;
                     # /v1/runs has its own branch in its executor.
-                    logger.warning("Provider authentication failed for session=%s: %s",
+                    # Not necessarily an auth problem: _resolve_runtime_agent_kwargs()
+                    # raises the same RuntimeError for a rate-limited AuthError, so
+                    # labeling every one of these "authentication failed" sent
+                    # operators to re-authenticate credentials that were fine.
+                    # Classify off the wrapped AuthError instead — reachable via
+                    # __cause__ because both raise sites use `raise ... from exc`.
+                    from gateway.run import _gateway_runtime_failure_response
+
+                    logger.warning("Provider runtime resolution failed for session=%s: %s",
                                    session_id or "", exc)
                     return (
-                        {
-                            "final_response": f"⚠️ Provider authentication failed: {exc}",
-                            "messages": [],
-                            "api_calls": 0,
-                            "tools": [],
-                        },
+                        _gateway_runtime_failure_response(exc, "api_server"),
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
                 finally:
@@ -6773,8 +6776,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 # message the other endpoints give a provider auth/credential
                 # failure, instead of falling through to the generic
                 # except-Exception branch below.
-                logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-                error_msg = f"⚠️ Provider authentication failed: {exc}"
+                # Same classification as the _run_agent() branch above: a quota
+                # cap must not be reported to /v1/runs as an auth failure.
+                from gateway.run import _gateway_runtime_failure_text
+
+                logger.warning("Provider runtime resolution failed for run=%s: %s", run_id, exc)
+                error_msg = _gateway_runtime_failure_text(exc, "api_server")
                 self._set_run_status(
                     run_id,
                     "failed",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,24 +644,135 @@ def _format_exec_approval_fallback(
     )
 
 
+# Shared reply copy so the text- and exception-based classifiers cannot drift.
+_GATEWAY_REPLY_AUTH = (
+    "⚠️ Provider authentication failed. Check the configured credentials; "
+    "raw provider details are in the gateway logs."
+)
+_GATEWAY_REPLY_POLICY = (
+    "⚠️ The model provider rejected the request. I kept the raw provider "
+    "error out of chat; check gateway logs for details or try rephrasing."
+)
+_GATEWAY_REPLY_RATE_LIMIT = (
+    "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+)
+_GATEWAY_REPLY_TEMPORARY = (
+    "⚠️ The model provider is temporarily unavailable. Please retry in a few seconds."
+)
+_GATEWAY_REPLY_GENERIC = (
+    "⚠️ The model provider failed after retries. I kept raw provider details "
+    "out of chat; check gateway logs for diagnostics."
+)
+
+# Entitlement failures are neither bad credentials nor rate limits: the operator
+# has to top up or renew, so AuthError's own actionable wording is the useful
+# reply and must not be flattened into the generic category.
+_GATEWAY_ENTITLEMENT_CODES = frozenset({
+    "subscription_required",
+    "insufficient_credits",
+    "subscription_expired",
+    "no_usable_credits",
+    "account_missing",
+})
+
+# AuthError codes that report a provider-side fault rather than anything wrong
+# with the operator's credentials — e.g. auth.py raises code="server_error" for
+# "Failed to resolve a Nous inference API key". Telling the operator to check
+# credentials there is exactly the mislabel this change removes.
+_GATEWAY_NON_CREDENTIAL_CODES = frozenset({"server_error"})
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
+        return _GATEWAY_REPLY_AUTH
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
-        )
+        return _GATEWAY_REPLY_POLICY
     if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
-    )
+        return _GATEWAY_REPLY_RATE_LIMIT
+    return _GATEWAY_REPLY_GENERIC
+
+
+def _gateway_provider_exception_reply(exc: BaseException) -> str:
+    """Classify a provider-resolution failure, preferring structured error data.
+
+    Callers used to hard-label every runtime-resolution failure "Provider
+    authentication failed". A provider quota cap therefore reached chat as a
+    credentials problem, sending the operator to re-authenticate credentials
+    that were valid the whole time (#32790 reports the same confusion).
+
+    ``AuthError`` already distinguishes quota, entitlement and credential
+    failures, so consult it before falling back to matching the rendered
+    string. The original ``AuthError`` arrives wrapped —
+    ``_resolve_runtime_agent_kwargs`` re-raises it as
+    ``RuntimeError(format_runtime_provider_error(exc)) from exc``, and
+    ``api_server`` adds a ``_ProviderAuthResolutionError`` layer on top — so
+    walk the ``__cause__`` chain rather than inspecting only the outermost
+    exception.
+    """
+    try:
+        from hermes_cli.auth import AuthError, format_auth_error, is_rate_limited_auth_error
+    except Exception:  # pragma: no cover - fall back to text classification
+        return _gateway_provider_error_reply(str(exc))
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, AuthError):
+            if is_rate_limited_auth_error(current):
+                return _GATEWAY_REPLY_RATE_LIMIT
+            code = getattr(current, "code", None)
+            if code in _GATEWAY_ENTITLEMENT_CODES:
+                # Already actionable ("top up/renew credits, then retry"), and
+                # safe for chat: entitlement wording carries no raw provider
+                # payload or credentials.
+                return f"⚠️ {format_auth_error(current)}"
+            if code == "temporarily_unavailable":
+                return _GATEWAY_REPLY_TEMPORARY
+            if code in _GATEWAY_NON_CREDENTIAL_CODES:
+                return _GATEWAY_REPLY_GENERIC
+            # Every other AuthError code in the tree is credential-shaped
+            # (not_logged_in, invalid_token, codex_auth_missing, refresh_failed,
+            # token_exchange_failed, …). Deliberately not gated on
+            # relogin_required: genuine credential errors such as "No Anthropic
+            # credentials found" (code="missing_api_key") leave it False.
+            return _GATEWAY_REPLY_AUTH
+        current = current.__cause__
+
+    return _gateway_provider_error_reply(str(exc))
+
+
+def _gateway_runtime_failure_text(exc: BaseException, platform: Any) -> str:
+    """Reply text for a provider-runtime resolution failure on ``platform``.
+
+    Programmatic surfaces (CLI/TUI ``local``, ``api_server``, webhooks) keep the
+    raw exception; chat surfaces get the short classified category. Either way
+    the old unconditional "Provider authentication failed" label is gone — it
+    described a quota cap as a credentials problem.
+
+    Shared with ``gateway.platforms.api_server``, which has its own
+    ``_ProviderAuthResolutionError`` handlers and does not route through
+    ``_sanitize_gateway_final_response``.
+    """
+    if _gateway_surface_passes_raw_text(platform):
+        return f"⚠️ Provider runtime resolution failed: {exc}"
+    return _gateway_provider_exception_reply(exc)
+
+
+def _gateway_runtime_failure_response(exc: BaseException, platform: Any) -> dict:
+    """Build the turn result for a provider-runtime resolution failure.
+
+    ``api_calls`` is 0 because the failure happens while resolving credentials,
+    before any request is issued — that zero is the tell in the gateway log when
+    diagnosing one of these.
+    """
+    return {
+        "final_response": _gateway_runtime_failure_text(exc, platform),
+        "messages": [],
+        "api_calls": 0,
+        "tools": [],
+    }
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
@@ -4500,12 +4611,7 @@ class TurnRunner:
                 model, runtime_kwargs.get("provider"), ctx.session_key or "",
             )
         except Exception as exc:
-            return {
-                "final_response": f"⚠️ Provider authentication failed: {exc}",
-                "messages": [],
-                "api_calls": 0,
-                "tools": [],
-            }
+            return _gateway_runtime_failure_response(exc, getattr(ctx.source, "platform", None))
 
         pr = self._runner._provider_routing
         reasoning_config = self._runner._resolve_session_reasoning_config(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -355,6 +355,72 @@ def auth_adapter():
 # ---------------------------------------------------------------------------
 
 
+class TestRunAgentProviderResolutionFailure:
+    """_run_agent()'s _ProviderAuthResolutionError branch serves session
+    chat/stream, chat completions and Responses. It used to hard-label every
+    provider-runtime resolution failure "Provider authentication failed", so a
+    quota cap told operators to re-authenticate valid credentials.
+
+    These drive the real handler (not the shared helper) so the wiring is
+    covered: reverting the branch fails them.
+    """
+
+    @staticmethod
+    def _production_wrapped(auth_error):
+        """Reproduce the chain _run_agent() sees: AuthError -> RuntimeError
+        (from _resolve_runtime_agent_kwargs) -> _ProviderAuthResolutionError
+        (from _create_agent)."""
+        from gateway.platforms.api_server import _ProviderAuthResolutionError
+
+        try:
+            raise RuntimeError(str(auth_error)) from auth_error
+        except RuntimeError as inner:
+            try:
+                raise _ProviderAuthResolutionError(str(inner)) from inner
+            except _ProviderAuthResolutionError as outer:
+                return outer
+
+    async def _final_response(self, adapter, side_effect):
+        with patch.object(adapter, "_create_agent", side_effect=side_effect):
+            result, usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+        assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        assert result["api_calls"] == 0
+        return result["final_response"]
+
+    @pytest.mark.asyncio
+    async def test_quota_cap_is_not_labeled_authentication_failure(self, adapter):
+        from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
+
+        quota = AuthError(
+            "Codex provider quota exhausted (429); retry after 160602s. "
+            "Credentials are still valid.",
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
+            relogin_required=False,
+        )
+        text = await self._final_response(adapter, self._production_wrapped(quota))
+        assert "authentication failed" not in text.lower()
+        # api_server is a programmatic surface, so raw detail is preserved.
+        assert "quota exhausted" in text
+
+    @pytest.mark.asyncio
+    async def test_credential_failure_still_surfaces_its_detail(self, adapter):
+        from gateway.platforms.api_server import _ProviderAuthResolutionError
+
+        text = await self._final_response(
+            adapter,
+            _ProviderAuthResolutionError("No credentials found for provider 'nous'"),
+        )
+        assert text == (
+            "⚠️ Provider runtime resolution failed: "
+            "No credentials found for provider 'nous'"
+        )
+
+
 class TestAgentExecution:
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -605,27 +605,34 @@ class TestStopRun:
 
 
 class TestRunsProviderAuthFailure:
-    @pytest.mark.asyncio
-    async def test_status_reports_provider_auth_failure_distinctly(self, adapter):
-        """/v1/runs builds its own agent via _create_agent() and does not
-        route through _run_agent(), so the controlled "Provider
-        authentication failed" message added there does not cover this
-        endpoint. _handle_runs()'s own _ProviderAuthResolutionError branch
-        must give the same distinguished message instead of the generic
-        except-Exception "run failed" text."""
+    @staticmethod
+    def _production_wrapped(auth_error):
+        """Reproduce the exact chain /v1/runs sees in production.
+
+        _resolve_runtime_agent_kwargs() re-raises the AuthError as a
+        RuntimeError, and _create_agent() then wraps that in
+        _ProviderAuthResolutionError — so the AuthError is two __cause__ levels
+        down, not one.
+        """
         from gateway.platforms.api_server import _ProviderAuthResolutionError
 
+        try:
+            raise RuntimeError(str(auth_error)) from auth_error
+        except RuntimeError as inner:
+            try:
+                raise _ProviderAuthResolutionError(str(inner)) from inner
+            except _ProviderAuthResolutionError as outer:
+                return outer
+
+    async def _failed_run_status(self, adapter, side_effect):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_create_agent") as mock_create:
-                mock_create.side_effect = _ProviderAuthResolutionError(
-                    "No credentials found for provider 'nous'"
-                )
+                mock_create.side_effect = side_effect
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
                 assert resp.status == 202
-                data = await resp.json()
-                run_id = data["run_id"]
+                run_id = (await resp.json())["run_id"]
 
                 for _ in range(40):
                     status_resp = await cli.get(f"/v1/runs/{run_id}")
@@ -633,7 +640,46 @@ class TestRunsProviderAuthFailure:
                     if status["status"] == "failed":
                         break
                     await asyncio.sleep(0.05)
+        return status
 
-                assert status["status"] == "failed"
-                assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
-                assert status["last_event"] == "run.failed"
+    @pytest.mark.asyncio
+    async def test_status_reports_provider_resolution_failure_distinctly(self, adapter):
+        """/v1/runs builds its own agent via _create_agent() and does not route
+        through _run_agent(), so _handle_runs()'s own
+        _ProviderAuthResolutionError branch must give a distinguished message
+        instead of the generic except-Exception "run failed" text.
+
+        /v1/runs is a programmatic surface, so it keeps the raw provider text —
+        only the inaccurate "authentication failed" label is gone.
+        """
+        from gateway.platforms.api_server import _ProviderAuthResolutionError
+
+        status = await self._failed_run_status(
+            adapter,
+            _ProviderAuthResolutionError("No credentials found for provider 'nous'"),
+        )
+        assert status["status"] == "failed"
+        assert status["last_event"] == "run.failed"
+        assert status["error"] == (
+            "⚠️ Provider runtime resolution failed: "
+            "No credentials found for provider 'nous'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_quota_cap_is_not_reported_as_authentication_failure(self, adapter):
+        """A rate-limited AuthError reaches this branch through the same wrapper
+        as a credential failure. Reporting it as "authentication failed" sends
+        the operator to re-authenticate credentials that are valid."""
+        from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
+
+        quota = AuthError(
+            "Codex provider quota exhausted (429); retry after 160602s. "
+            "Credentials are still valid.",
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
+            relogin_required=False,
+        )
+        status = await self._failed_run_status(adapter, self._production_wrapped(quota))
+        assert status["status"] == "failed"
+        assert "authentication failed" not in status["error"].lower()
+        assert "quota exhausted" in status["error"]

--- a/tests/gateway/test_provider_error_classification.py
+++ b/tests/gateway/test_provider_error_classification.py
@@ -1,0 +1,175 @@
+"""A quota cap must not be reported to chat as an authentication failure.
+
+Regression test for the gateway path that hard-labeled every
+provider-resolution failure "Provider authentication failed". A provider usage
+cap (HTTP 429) reached users as a credentials error, sending operators to
+re-authenticate credentials that were valid the whole time.
+"""
+
+import pytest
+
+from gateway.platforms.api_server import _ProviderAuthResolutionError
+from gateway.run import (
+    _GATEWAY_REPLY_AUTH,
+    _GATEWAY_REPLY_GENERIC,
+    _GATEWAY_REPLY_RATE_LIMIT,
+    _GATEWAY_REPLY_TEMPORARY,
+    _gateway_provider_exception_reply,
+    _gateway_runtime_failure_response,
+    _gateway_runtime_failure_text,
+)
+from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
+
+
+def _wrapped(exc: Exception) -> RuntimeError:
+    """Mirror how _resolve_runtime_agent_kwargs re-raises resolution failures."""
+    try:
+        raise RuntimeError(str(exc)) from exc
+    except RuntimeError as wrapper:
+        return wrapper
+
+
+def _api_server_wrapped(exc: Exception) -> _ProviderAuthResolutionError:
+    """Mirror api_server's extra wrapping layer.
+
+    _create_agent() catches the RuntimeError from _resolve_runtime_agent_kwargs()
+    and re-raises it as _ProviderAuthResolutionError, so the AuthError sits two
+    levels down the __cause__ chain on that path.
+    """
+    inner = _wrapped(exc)
+    try:
+        raise _ProviderAuthResolutionError(str(inner)) from inner
+    except _ProviderAuthResolutionError as wrapper:
+        return wrapper
+
+
+def _quota_error() -> AuthError:
+    return AuthError(
+        "Codex provider quota exhausted (429); retry after 160602s. "
+        "Credentials are still valid.",
+        provider="openai-codex",
+        code=CODEX_RATE_LIMITED_CODE,
+        relogin_required=False,
+    )
+
+
+class TestRateLimitNotMislabeled:
+    def test_quota_exhaustion_reports_as_rate_limit(self):
+        reply = _gateway_provider_exception_reply(_wrapped(_quota_error()))
+        assert reply == _GATEWAY_REPLY_RATE_LIMIT
+        assert "authentication failed" not in reply.lower()
+
+    def test_unwrapped_quota_error_also_classified(self):
+        assert _gateway_provider_exception_reply(_quota_error()) == _GATEWAY_REPLY_RATE_LIMIT
+
+
+class TestCredentialFailuresStillReportAsAuth:
+    @pytest.mark.parametrize("relogin_required", [True, False])
+    def test_missing_credentials_report_as_auth(self, relogin_required):
+        """Many genuine credential errors leave relogin_required False, so the
+        classification must not be gated on that flag."""
+        exc = AuthError(
+            "No Anthropic credentials found. Set ANTHROPIC_API_KEY.",
+            provider="anthropic",
+            code="missing_api_key",
+            relogin_required=relogin_required,
+        )
+        assert _gateway_provider_exception_reply(_wrapped(exc)) == _GATEWAY_REPLY_AUTH
+
+
+class TestEntitlementAndTemporary:
+    def test_entitlement_error_keeps_actionable_wording(self):
+        exc = AuthError(
+            "Subscription credits are exhausted.",
+            provider="nous",
+            code="insufficient_credits",
+            relogin_required=False,
+        )
+        reply = _gateway_provider_exception_reply(_wrapped(exc))
+        # Neither a credentials problem nor a rate limit.
+        assert reply not in (_GATEWAY_REPLY_AUTH, _GATEWAY_REPLY_RATE_LIMIT)
+        assert "credits" in reply.lower()
+
+    def test_temporarily_unavailable_is_its_own_category(self):
+        exc = AuthError(
+            "Provider is warming up.",
+            provider="nous",
+            code="temporarily_unavailable",
+            relogin_required=False,
+        )
+        assert _gateway_provider_exception_reply(_wrapped(exc)) == _GATEWAY_REPLY_TEMPORARY
+
+    def test_provider_side_server_error_is_not_a_credentials_problem(self):
+        """auth.py raises code="server_error" when Nous cannot resolve an
+        inference key. Nothing is wrong with the operator's credentials, so
+        telling them to check credentials is the same class of mislabel."""
+        exc = AuthError(
+            "Failed to resolve a Nous inference API key",
+            provider="nous",
+            code="server_error",
+        )
+        assert _gateway_provider_exception_reply(_wrapped(exc)) == _GATEWAY_REPLY_GENERIC
+
+
+class TestNonAuthErrors:
+    @pytest.mark.parametrize(
+        "message, expected",
+        [
+            ("Error code: 401 - invalid api key", _GATEWAY_REPLY_AUTH),
+            ("Rate limited after 3 retries", _GATEWAY_REPLY_RATE_LIMIT),
+            ("connection reset by peer", _GATEWAY_REPLY_GENERIC),
+        ],
+    )
+    def test_plain_exceptions_fall_back_to_text_classification(self, message, expected):
+        assert _gateway_provider_exception_reply(RuntimeError(message)) == expected
+
+
+class TestTurnResponseShape:
+    """Covers the value the gateway turn actually returns, not just the classifier."""
+
+    def test_chat_surface_gets_classified_category(self):
+        result = _gateway_runtime_failure_response(_wrapped(_quota_error()), "slack")
+        assert result["final_response"] == _GATEWAY_REPLY_RATE_LIMIT
+        assert result["api_calls"] == 0
+        assert result["messages"] == [] and result["tools"] == []
+
+    def test_programmatic_surface_keeps_raw_detail(self):
+        """CLI/API/webhook callers are promised raw diagnostics."""
+        result = _gateway_runtime_failure_response(_wrapped(_quota_error()), "local")
+        assert "quota exhausted" in result["final_response"]
+        assert result["final_response"] != _GATEWAY_REPLY_RATE_LIMIT
+
+
+class TestApiServerSurface:
+    """api_server has its own _ProviderAuthResolutionError handlers and never
+    calls _sanitize_gateway_final_response, so it needs its own coverage."""
+
+    @pytest.mark.parametrize("surface", ["api_server", "webhook"])
+    def test_quota_not_labeled_as_auth(self, surface):
+        text = _gateway_runtime_failure_text(_api_server_wrapped(_quota_error()), surface)
+        assert "authentication failed" not in text.lower()
+        # Raw diagnostics preserved for these programmatic surfaces.
+        assert "quota exhausted" in text
+
+    def test_session_chat_response_shape(self):
+        result = _gateway_runtime_failure_response(
+            _api_server_wrapped(_quota_error()), "api_server")
+        assert "authentication failed" not in result["final_response"].lower()
+        assert result["api_calls"] == 0
+        assert result["messages"] == [] and result["tools"] == []
+
+    def test_double_wrapped_auth_error_still_classified_for_chat(self):
+        """The AuthError sits two __cause__ levels down on the api_server path;
+        a chat surface must still get the rate-limit category, not auth."""
+        assert _gateway_runtime_failure_text(
+            _api_server_wrapped(_quota_error()), "slack") == _GATEWAY_REPLY_RATE_LIMIT
+
+    def test_genuine_credential_failure_still_reads_as_auth_on_chat(self):
+        exc = AuthError(
+            "No Anthropic credentials found. Set ANTHROPIC_API_KEY.",
+            provider="anthropic",
+            code="missing_api_key",
+            relogin_required=False,
+        )
+        assert _gateway_runtime_failure_text(
+            _api_server_wrapped(exc), "slack") == _GATEWAY_REPLY_AUTH


### PR DESCRIPTION
## Problem

A provider usage cap reaches users as **"⚠️ Provider authentication failed"**, which sends the operator off to re-authenticate credentials that were valid the whole time.

Observed on a Slack gateway: the primary provider (`openai-codex`) hit its usage cap, so `resolve_runtime_provider()` raised an `AuthError` with `code="codex_rate_limited"` and the message *"Codex provider quota exhausted (429); retry after 160602s. Credentials are still valid."* Chat showed an authentication failure.

The tell in the gateway log is `api_calls=0` — the turn failed while resolving credentials, before any request went out:

```
WARNING gateway.run: Primary provider rate-limited (429): Codex provider quota exhausted (429);
        retry after 160602s. Credentials are still valid. — trying fallback
INFO    gateway.run: response ready: platform=slack chat=… time=1.2s api_calls=0 response=122 chars
```

## Cause

Two blanket handlers hard-labeled *every* runtime-resolution failure as auth:

- `gateway/run.py` — the `run_agent` path
- `gateway/platforms/api_server.py` — its own `_ProviderAuthResolutionError` handlers, covering session chat/stream, chat completions, Responses, and `/v1/runs`

```python
except Exception as exc:
    return {"final_response": f"⚠️ Provider authentication failed: {exc}", ...}
```

On the chat path, `_sanitize_gateway_final_response` → `_gateway_provider_error_reply` then matched `_GATEWAY_AUTH_ERROR_RE` against that self-inflicted label and returned the auth category, so the rate-limit branch was unreachable — even though `format_auth_error` had already produced the bare quota string that `_GATEWAY_RATE_LIMIT_RE` would have classified correctly.

## Fix

Classify on the structured `AuthError` before falling back to text matching. The error arrives wrapped — `_resolve_runtime_agent_kwargs` re-raises as `RuntimeError(...) from exc`, and `api_server._create_agent` adds a `_ProviderAuthResolutionError` layer — so the `__cause__` chain is walked (bounded, with an identity guard against cycles).

| Case | Reply |
|---|---|
| `is_rate_limited_auth_error()` | rate-limit category |
| entitlement codes (`subscription_required`, `insufficient_credits`, `subscription_expired`, `no_usable_credits`, `account_missing`) | `format_auth_error()`'s own actionable wording |
| `temporarily_unavailable` | its own category |
| `server_error` | generic — a provider-side fault, not a credentials problem |
| any other `AuthError` | authentication category |
| non-`AuthError` | existing text-based classification, unchanged |

Three details worth reviewer attention:

- **Not gated on `relogin_required`.** Plenty of genuine credential failures leave it `False` — e.g. *"No Anthropic credentials found"* (`runtime_provider.py`) and `code="missing_api_key"` — so gating on it would downgrade real auth failures to the generic category.
- **`server_error` is carved out.** `auth.py` raises it for *"Failed to resolve a Nous inference API key"*. Nothing is wrong with the operator's credentials there, so it would be the same class of mislabel.
- **Programmatic surfaces keep raw text.** `local`, `api_server` and webhooks stay in `_GATEWAY_RAW_TEXT_PLATFORMS`; only chat surfaces get the short category. `api_server.py` never calls `_sanitize_gateway_final_response`, so it now uses the shared `_gateway_runtime_failure_text()` directly.

Reply strings are shared constants so the text- and exception-based classifiers can't drift apart.

## Compatibility

This is an observable text change, not a schema change. Anything matching the literal prefix `"⚠️ Provider authentication failed: "` will need updating:

- `/v1/runs` — poll status `error` and the `run.failed` SSE payload
- every `_run_agent()` caller — session chat/stream, chat completions, Responses

Those now read `"⚠️ Provider runtime resolution failed: <raw provider error>"`, preserving the raw diagnostic detail these programmatic surfaces already carried.

## Tests

`tests/gateway/test_provider_error_classification.py` (new, 17 cases): quota wrapped/unwrapped, credential failures with `relogin_required` both `True` and `False`, entitlement, `temporarily_unavailable`, `server_error`, non-`AuthError` fallback, the returned turn dict for chat vs programmatic surfaces, and the double-wrapped `api_server` chain.

Endpoint-level wiring coverage (these drive the real handlers, not the shared helper — reverting either handler fails them):
- `tests/gateway/test_api_server.py::TestRunAgentProviderResolutionFailure`
- `tests/gateway/test_api_server_runs.py::TestRunsProviderAuthFailure`

The existing `test_status_reports_provider_auth_failure_distinctly` asserted the old literal string. It is renamed to `..._provider_resolution_failure_distinctly` with its intent and assertions intact — `/v1/runs` must still give a distinguished message rather than the generic "run failed" text — plus a new quota case reproducing the full production wrapper chain.

`tests/gateway/` — 5057 passed. The 7 failures in that directory are pre-existing on this machine (Discord attachments, systemd, session-store paths) and reproduce unchanged with this patch stashed.

Refs #32790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QndRT2g1YntvwYMTech8aQ
