### PR TITLE
fix(tools): cache default-profile tool defs in multiplex gateways (#79047)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -356,6 +356,13 @@ def get_tool_definitions(
                 _is_dispatcher_owned_worker(),
                 profile_scope,
             )
+        else:
+            # Issue #79047: make cache bypass observable. The only normal
+            # quiet-mode bypass is an unresolved multiplex profile identity.
+            logger.info(
+                "tool_definitions cache bypassed: profile cache scope unresolved "
+                "(multiplex active but hermes_home identity could not be resolved)"
+            )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -205,36 +205,109 @@ class TestCheckFnTransientFailureSuppression:
             reg.invalidate_check_fn_cache()
             _clear_tool_defs_cache()
 
-    def test_unscoped_multiplex_request_bypasses_cache(self, monkeypatch):
-        """An unknown profile must never share another request's cache entry."""
+    def test_unscoped_multiplex_default_profile_uses_cache(self, monkeypatch):
+        """The default profile in a multiplex gateway has no hermes_home
+        override, but it is still a valid, stable scope: the process Hermes
+        home.  It must share tool-def/check_fn cache across repeated turns
+        (#79047), not recompute every request."""
         import model_tools
         import tools.registry as reg
         from agent.secret_scope import set_multiplex_active
 
-        values = iter([True, False])
         definition_calls = {"n": 0}
 
-        def probe():
-            return next(values)
+        def available():
+            return True
 
         def compute_definitions(*_args, **_kwargs):
             definition_calls["n"] += 1
             return []
 
         set_multiplex_active(True)
+        # Ensure no per-turn profile override is in context.
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home_override", lambda: None
+        )
         monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute_definitions)
         try:
-            assert reg._check_fn_cached(probe) is True
-            assert reg._check_fn_cached(probe) is False
-            assert not reg._check_fn_cache
+            assert reg._check_fn_cached(available) is True
+            assert reg._check_fn_cached(available) is True
+            assert len(reg._check_fn_cache) == 1
 
             model_tools.get_tool_definitions(quiet_mode=True)
             model_tools.get_tool_definitions(quiet_mode=True)
-            assert definition_calls["n"] == 2
-            assert not model_tools._tool_defs_cache
+            assert definition_calls["n"] == 1
+            assert len(model_tools._tool_defs_cache) == 1
         finally:
             set_multiplex_active(False)
             reg.invalidate_check_fn_cache()
+            model_tools._clear_tool_defs_cache()
+
+    def test_multiplex_profiles_do_not_share_tool_def_cache(self, monkeypatch, tmp_path):
+        """The default profile and an explicit profile override must keep
+        separate tool-def cache entries so a per-profile toolset does not leak
+        into another profile (#79047)."""
+        import model_tools
+        import tools.registry as reg
+        from agent.secret_scope import set_multiplex_active
+
+        seen = []
+
+        def compute_definitions(enabled_toolsets, disabled_toolsets, quiet_mode, **kwargs):
+            seen.append(enabled_toolsets)
+            return []
+
+        set_multiplex_active(True)
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute_definitions)
+
+        default_home = tmp_path / "default"
+        default_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+        profile_a = tmp_path / "profiles" / "a"
+        profile_a.mkdir(parents=True)
+
+        try:
+            # Default profile call.
+            monkeypatch.setattr(
+                "hermes_constants.get_hermes_home_override", lambda: None
+            )
+            model_tools.get_tool_definitions(quiet_mode=True)
+
+            # Explicit profile override call.
+            monkeypatch.setattr(
+                "hermes_constants.get_hermes_home_override", lambda: str(profile_a)
+            )
+            model_tools.get_tool_definitions(quiet_mode=True)
+
+            assert len(model_tools._tool_defs_cache) == 2, (
+                "default profile and profile A must not share the same cache entry"
+            )
+        finally:
+            set_multiplex_active(False)
+            reg.invalidate_check_fn_cache()
+            model_tools._clear_tool_defs_cache()
+
+    def test_multiplex_bypass_logs_unresolved_scope(self, monkeypatch, caplog):
+        """When the cache is bypassed because the multiplex profile scope
+        could not be resolved, get_tool_definitions logs the exact reason
+        (#79047)."""
+        import logging
+        import model_tools
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        monkeypatch.setattr(
+            model_tools, "check_fn_cache_scope", lambda: model_tools.CHECK_FN_CACHE_BYPASS
+        )
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", lambda *_a, **_kw: [])
+        try:
+            with caplog.at_level(logging.INFO, logger="model_tools"):
+                model_tools.get_tool_definitions(quiet_mode=True)
+            assert "tool_definitions cache bypassed" in caplog.text
+            assert "profile cache scope unresolved" in caplog.text
+        finally:
+            set_multiplex_active(False)
             model_tools._clear_tool_defs_cache()
 
     def test_profile_scoped_check_cache_is_bounded(self, monkeypatch):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -250,18 +250,27 @@ def check_fn_cache_scope() -> Optional[str]:
     cache. A multiplex gateway installs a Hermes-home override for every
     profile turn, so the canonical profile key is the stable isolation
     boundary across repeated turns for that profile.
+
+    The default profile in a multiplex gateway has no context-local override
+    (it runs under the process's own HERMES_HOME). That is a stable, valid
+    scope: the default profile is the process Hermes home, not an unknown
+    profile that must bypass both cache layers (#79047).
     """
     try:
         from agent.secret_scope import is_multiplex_active
 
         if not is_multiplex_active():
             return None
-        from hermes_constants import get_hermes_home_override
+        from hermes_constants import get_hermes_home_override, get_process_hermes_home
 
         override = get_hermes_home_override()
-        if not override:
-            return CHECK_FN_CACHE_BYPASS
-        return str(Path(override).expanduser().resolve())
+        if override:
+            return str(Path(override).expanduser().resolve())
+        # Multiplex active, but this request is the default profile. Use the
+        # process home so tool-def and check_fn caches are shared across
+        # repeated default-profile turns rather than recomputing every turn
+        # (regression #79047).
+        return str(get_process_hermes_home().expanduser().resolve())
     except Exception:
         # Fail closed: bypass both cache layers rather than aliasing requests
         # whose multiplex profile identity could not be resolved.


### PR DESCRIPTION
## What does this PR do?

Fixes a `api_server` latency regression where `get_tool_definitions()` recomputed tool schemas on every request in multiplex mode, adding ~3.3 s to agent creation.

In a multiplex gateway (`gateway.multiplex_profiles=true`), `tools.registry.check_fn_cache_scope()` is supposed to use the active profile's `HERMES_HOME` as the cache-isolation key. For the default profile there is no per-turn `hermes_home_override`, so the function returned `CHECK_FN_CACHE_BYPASS` and disabled both the `get_tool_definitions` memoization and the `check_fn` availability cache. Every `api_server` request to the default route therefore paid the full tool-discovery cost on every turn.

This change treats the default profile in a multiplex gateway as the process `HERMES_HOME` (the stable key it already was), so repeated default-profile requests share the same cache entry while explicit profile overrides still get their own isolated entry.

It also adds a single observable log line in `model_tools.get_tool_definitions()` when the cache is bypassed because the profile scope is unresolved, making future regressions of this shape trivial to diagnose.

## Related Issue

Fixes #79047

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Changes Made

- `tools/registry.py` — `check_fn_cache_scope()` now falls back to `get_process_hermes_home()` when multiplex is active but no per-turn `hermes_home_override` is installed, instead of returning `CHECK_FN_CACHE_BYPASS`.
- `model_tools.py` — `get_tool_definitions()` logs the reason when the quiet-mode cache is bypassed due to an unresolved multiplex profile scope.
- `tests/tools/test_terminal_tool_requirements.py` — replaced the old `test_unscoped_multiplex_request_bypasses_cache` with three regression tests:
  - `test_unscoped_multiplex_default_profile_uses_cache`: the default profile in multiplex now hits both `check_fn` and `tool_definitions` caches on the second call.
  - `test_multiplex_profiles_do_not_share_tool_def_cache`: the default profile and an explicit override still produce distinct cache entries.
  - `test_multiplex_bypass_logs_unresolved_scope`: when `check_fn_cache_scope()` does return `CHECK_FN_CACHE_BYPASS`, the bypass is logged.

## How to Test

1. The new regression tests fail on `main` and pass on this branch:

```bash
uv run pytest tests/tools/test_terminal_tool_requirements.py::TestCheckFnTransientFailureSuppression::test_unscoped_multiplex_default_profile_uses_cache -q
uv run pytest tests/tools/test_terminal_tool_requirements.py::TestCheckFnTransientFailureSuppression::test_multiplex_profiles_do_not_share_tool_def_cache -q
uv run pytest tests/tools/test_terminal_tool_requirements.py::TestCheckFnTransientFailureSuppression::test_multiplex_bypass_logs_unresolved_scope -q
```

2. To reproduce manually against a live `api_server`:
   - Start the gateway with `gateway.multiplex_profiles=true` and a configured default API server.
   - Send two sequential `POST /v1/responses` requests to the default (non-prefixed) route.
   - On `main` the logs show `tool_definitions.compute ... cache_key=False` and ~3.3 s `init.tool_definitions` for both requests.
   - On this branch the second request shows a cache hit and the `init.tool_definitions` cost disappears.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and this issue was clean
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all related tests pass
- [x] I've added regression tests that fail on base
- [x] I've tested on my platform: macOS 15, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no user-facing docs beyond this body
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: changes use existing `hermes_constants` helpers
