### PR TITLE
fix(honcho): recover memory from mid-session OAuth 401s

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -522,7 +522,7 @@ class HonchoMemoryProvider(MemoryProvider):
                         )
                     except Exception as exc:
                         logger.debug("Honcho dialectic prewarm failed: %s", exc)
-                        self._dialectic_empty_streak += 1
+                        self._note_dialectic_failure(exc)
                         return
                     if r and r.strip():
                         with self._prefetch_lock:
@@ -715,6 +715,11 @@ class HonchoMemoryProvider(MemoryProvider):
 
         parts = []
 
+        # One-time notice, relayed by the model, that auth is dead and memory is paused.
+        auth_notice = self._pop_auth_notice()
+        if auth_notice:
+            parts.append(auth_notice)
+
         # ----- Layer 1: Base context (representation + card) -----
         if not _skip_base:
             # The first base fetch gets the remaining turn-1 budget. Later
@@ -804,7 +809,7 @@ class HonchoMemoryProvider(MemoryProvider):
                         r = self._run_dialectic_depth(query)
                     except Exception as exc:
                         logger.debug("Honcho first-turn dialectic failed: %s", exc)
-                        self._dialectic_empty_streak += 1
+                        self._note_dialectic_failure(exc)
                         return
                     if r and r.strip():
                         with self._prefetch_lock:
@@ -844,6 +849,25 @@ class HonchoMemoryProvider(MemoryProvider):
         result = self._truncate_to_budget(result)
 
         return result
+
+    def _pop_auth_notice(self) -> str:
+        """One-time model-facing notice that Honcho auth expired and memory is paused."""
+        pop = getattr(self._manager, "pop_auth_notice", None)
+        if not callable(pop):
+            return ""
+        try:
+            msg = pop()
+        except Exception:
+            return ""
+        if not isinstance(msg, str) or not msg:
+            return ""
+        return (
+            "[Honcho memory status] Authentication with the Honcho memory backend "
+            "has expired and automatic token refresh failed, so memory sync and "
+            f"recall are paused. Reason: {msg}\n"
+            "Tell the user (once) that Honcho memory is paused and that running "
+            "'hermes honcho setup' to re-authenticate will restore it."
+        )
 
     def _consume_pending_dialectic(self) -> str:
         """Pop any pending dialectic result, applying the stale-discard guard.
@@ -941,7 +965,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 result = self._run_dialectic_depth(query)
             except Exception as e:
                 logger.debug("Honcho prefetch failed: %s", e)
-                self._dialectic_empty_streak += 1
+                self._note_dialectic_failure(e)
                 return
             if result and result.strip():
                 with self._prefetch_lock:
@@ -1019,6 +1043,22 @@ class HonchoMemoryProvider(MemoryProvider):
         widened = self._dialectic_cadence + self._dialectic_empty_streak
         ceiling = self._dialectic_cadence * self._BACKOFF_MAX
         return min(widened, ceiling)
+
+    def _note_dialectic_failure(self, exc: BaseException) -> None:
+        """Widen the empty-streak backoff after a failed dialectic cycle.
+
+        Auth failures are exempt: waiting cannot fix a dead token, and backoff
+        would delay recovery after the user re-authenticates.
+        """
+        from plugins.memory.honcho.session import HonchoAuthError
+
+        if isinstance(exc, HonchoAuthError):
+            logger.warning(
+                "Honcho dialectic auth failure (not counted toward cadence backoff): %s",
+                exc,
+            )
+            return
+        self._dialectic_empty_streak += 1
 
     def liveness_snapshot(self) -> dict:
         """In-process snapshot of dialectic liveness state for diagnostics.

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -292,6 +292,10 @@ class HonchoMemoryProvider(MemoryProvider):
         self._init_lock = threading.Lock()
         self._init_error = ""
 
+        # Init auth failures live here because the failed manager is discarded.
+        self._init_auth_failure: Optional[str] = None
+        self._init_auth_notice_emitted = False
+
         # Cron and flush contexts disable the plugin entirely.
         self._cron_skipped = False
 
@@ -445,11 +449,19 @@ class HonchoMemoryProvider(MemoryProvider):
             init_session_id = self._lazy_init_session_id or "hermes-default"
 
             def _run() -> None:
+                from plugins.memory.honcho.session import HonchoAuthError
+
                 try:
                     self._do_session_init(cfg, init_session_id, **init_kwargs)
                     self._lazy_init_kwargs = None
                     self._lazy_init_session_id = None
                     self._init_error = ""
+                    self._clear_init_auth_failure()
+                except HonchoAuthError as e:
+                    self._init_error = str(e)
+                    self._record_init_auth_failure(e)
+                    self._manager = None
+                    logger.warning("Honcho background session init failed: authentication rejected")
                 except Exception as e:
                     self._init_error = str(e)
                     self._manager = None
@@ -563,6 +575,8 @@ class HonchoMemoryProvider(MemoryProvider):
         if not self._config or self._lazy_init_kwargs is None:
             return False
 
+        from plugins.memory.honcho.session import HonchoAuthError
+
         try:
             self._do_session_init(
                 self._config,
@@ -572,12 +586,28 @@ class HonchoMemoryProvider(MemoryProvider):
             # Clear lazy refs
             self._lazy_init_kwargs = None
             self._lazy_init_session_id = None
+            self._clear_init_auth_failure()
             return self._manager is not None
+        except HonchoAuthError as e:
+            self._record_init_auth_failure(e)
+            self._manager = None
+            self._session_initialized = False
+            logger.warning("Honcho lazy session init failed: authentication rejected")
+            return False
         except Exception as e:
             self._manager = None
             self._session_initialized = False
             logger.warning("Honcho lazy session init failed: %s", e)
             return False
+
+    def _record_init_auth_failure(self, exc: BaseException) -> None:
+        """Keep the auth detail so the one-time notice survives the manager discard."""
+        self._init_auth_failure = str(exc)
+
+    def _clear_init_auth_failure(self) -> None:
+        if self._init_auth_failure is not None:
+            self._init_auth_failure = None
+            self._init_auth_notice_emitted = False
 
     def _session_ready(self) -> bool:
         """Return whether a manager/session key can be used safely.
@@ -701,7 +731,8 @@ class HonchoMemoryProvider(MemoryProvider):
                         timeout=max(0.0, first_turn_base_deadline - time.monotonic())
                     )
             if not self._session_ready():
-                return ""
+                # A failed auth init still owes the user the one-time notice.
+                return self._pop_auth_notice()
 
         # First-turn mode suppresses only the base layer; dialectic is independent.
         _skip_base = (
@@ -852,15 +883,19 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def _pop_auth_notice(self) -> str:
         """One-time model-facing notice that Honcho auth expired and memory is paused."""
+        msg = None
         pop = getattr(self._manager, "pop_auth_notice", None)
-        if not callable(pop):
-            return ""
-        try:
-            msg = pop()
-        except Exception:
-            return ""
+        if callable(pop):
+            try:
+                msg = pop()
+            except Exception:
+                msg = None
         if not isinstance(msg, str) or not msg:
-            return ""
+            # Init failures discard the manager; the provider kept the detail.
+            if self._init_auth_failure is None or self._init_auth_notice_emitted:
+                return ""
+            self._init_auth_notice_emitted = True
+            msg = self._init_auth_failure
         return (
             "[Honcho memory status] Authentication with the Honcho memory backend "
             "has expired and automatic token refresh failed, so memory sync and "
@@ -1460,6 +1495,10 @@ class HonchoMemoryProvider(MemoryProvider):
             if self._init_thread and self._init_thread.is_alive():
                 return tool_error("Honcho session is still initializing; try again shortly.")
             if not self._ensure_session():
+                if self._init_auth_failure:
+                    return tool_error(
+                        f"Honcho memory authentication failed: {self._init_auth_failure}"
+                    )
                 return tool_error("Honcho session could not be initialized.")
 
         if not self._manager or not self._session_key:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1047,8 +1047,7 @@ class HonchoMemoryProvider(MemoryProvider):
     def _note_dialectic_failure(self, exc: BaseException) -> None:
         """Widen the empty-streak backoff after a failed dialectic cycle.
 
-        Auth failures are exempt: waiting cannot fix a dead token, and backoff
-        would delay recovery after the user re-authenticates.
+        Auth failures are exempt because waiting cannot fix a dead token.
         """
         from plugins.memory.honcho.session import HonchoAuthError
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1451,6 +1451,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         """Handle a Honcho tool call, with lazy session init for tools-only mode."""
+        from plugins.memory.honcho.session import HonchoAuthError
+
         if self._cron_skipped:
             return tool_error("Honcho is not active (cron context).")
 
@@ -1560,6 +1562,10 @@ class HonchoMemoryProvider(MemoryProvider):
 
             return tool_error(f"Unknown tool: {tool_name}")
 
+        except HonchoAuthError as e:
+            # Never report an auth failure as an empty result; the model would read it as "no memory".
+            logger.error("Honcho tool %s failed: authentication rejected", tool_name)
+            return tool_error(f"Honcho memory authentication failed: {e}")
         except Exception as e:
             logger.error("Honcho tool %s failed: %s", tool_name, e)
             return tool_error(f"Honcho {tool_name} failed: {e}")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1541,8 +1541,15 @@ def cmd_identity(args) -> None:
         return
 
     if show:
+        from plugins.memory.honcho.session import HonchoAuthError
+        try:
+            user_card = mgr.get_peer_card(session_key)
+            ai_rep = mgr.get_ai_representation(session_key)
+        except HonchoAuthError as e:
+            print(f"  Honcho authentication failed: {e}\n")
+            return
+
         # ── User peer ────────────────────────────────────────────────────────
-        user_card = mgr.get_peer_card(session_key)
         print(f"\nUser peer ({hcfg.peer_name or 'not set'})\n" + "─" * 40)
         if user_card:
             for fact in user_card:
@@ -1551,7 +1558,6 @@ def cmd_identity(args) -> None:
             print("  No user peer card yet. Send a few messages to build one.")
 
         # ── AI peer ──────────────────────────────────────────────────────────
-        ai_rep = mgr.get_ai_representation(session_key)
         print(f"\nAI peer ({hcfg.ai_peer})\n" + "─" * 40)
         if ai_rep.get("representation"):
             print(ai_rep["representation"])

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -934,8 +934,9 @@ def _resolve_timeout_from_sources(config: HonchoClientConfig | None) -> float:
 def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
     """Refresh a near-expiry OAuth grant and point ``config.api_key`` at it.
 
-    No-op for static API keys or when refresh fails (fail-open: the stale token
-    is left in place and the existing 401 handling degrades gracefully).
+    No-op for static API keys or when refresh fails: the stale token stays in
+    place and the first rejected call triggers the post-401 recovery in
+    session.py (forced rotation, one retry).
     """
     try:
         from plugins.memory.honcho import oauth

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -6,15 +6,22 @@ expiry to keep it live.
 
 Refresh tokens rotate with single-use reuse detection: a replayed stale token
 revokes the whole grant. So every refresh must persist the rotated token
-atomically and be serialized — and a failed refresh never raises into the
-agent (stale token stays; the fail-open path absorbs the eventual 401).
+atomically and be serialized. A failed exchange never raises into the agent:
+transient failures retry once immediately (the server re-rotates a replayed
+refresh token only within a short grace window, so waiting for the next
+memory call is too late), and a permanent OAuth error such as invalid_grant
+marks the grant dead so nothing keeps hitting the token endpoint — callers
+surface a re-login prompt instead. A server-side 401 on a locally-valid
+token is recovered via ``force_refresh_token``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 from contextlib import contextmanager
@@ -34,6 +41,29 @@ _REFRESH_SKEW_SECONDS = 120
 # Default HTTP timeout for the token exchange. Kept short — the refresh happens
 # on the path to a memory call, and a stalled auth server must not hang it.
 _REFRESH_TIMEOUT_SECONDS = 15.0
+
+# Retry pause, kept short: the server honors a replayed refresh token only briefly after rotating it.
+_REFRESH_RETRY_DELAY_SECONDS = 2.0
+
+# OAuth error codes that a retry can never fix — the grant itself is dead.
+_PERMANENT_OAUTH_ERRORS = frozenset({"invalid_grant", "invalid_client", "unauthorized_client"})
+
+# Token values are secret even though their prefixes are not; redact before logging.
+_TOKEN_VALUE_RE = re.compile(r"hch-(at|rt)-[A-Za-z0-9._~+/=-]+")
+
+
+def _redact_tokens(text: str) -> str:
+    """Replace any embedded token values with their prefix plus a placeholder."""
+    return _TOKEN_VALUE_RE.sub(lambda m: f"hch-{m.group(1)}-[redacted]", text)
+
+
+class OAuthRefreshError(Exception):
+    """Token endpoint rejected the refresh. ``permanent`` means re-login is required."""
+
+    def __init__(self, message: str, *, error: str = "", permanent: bool = False):
+        super().__init__(message)
+        self.error = error
+        self.permanent = permanent
 
 # Serializes refresh across threads sharing one process's config. Re-checked
 # under the lock (double-checked) so racing callers don't replay a rotated
@@ -98,6 +128,31 @@ def _config_refresh_lock(path: Path):
 # cache entry can't break auth — it just defers picking up external changes
 # until the token nears expiry and disk is read again.
 _expiry_cache: dict[tuple[str, str], tuple[float, str]] = {}
+
+# Permanently rejected grants: (config path, host) → sha256 of the dead refresh token; a re-login rotates the token, so the digest check self-clears.
+_dead_grants: dict[tuple[str, str], str] = {}
+
+
+def _refresh_token_digest(cred: OAuthCredential) -> str:
+    return hashlib.sha256(cred.refresh_token.encode("utf-8")).hexdigest()
+
+
+def _grant_is_dead(key: tuple[str, str], cred: OAuthCredential) -> bool:
+    return _dead_grants.get(key) == _refresh_token_digest(cred)
+
+
+def _mark_grant_dead(key: tuple[str, str], cred: OAuthCredential) -> None:
+    _dead_grants[key] = _refresh_token_digest(cred)
+
+
+def reauth_required(path: Path, host: str) -> bool:
+    """True when ``host``'s OAuth grant is dead and only a new login fixes it."""
+    key = (str(path), host)
+    if key not in _dead_grants:
+        return False
+    block = (_read_config(path).get("hosts") or {}).get(host) or {}
+    cred = OAuthCredential.from_host_block(block)
+    return cred is not None and _grant_is_dead(key, cred)
 
 
 def is_oauth_access_token(value: str | None) -> bool:
@@ -208,9 +263,10 @@ def _http_get_json(url: str, timeout: float) -> dict[str, Any]:
 def _exchange_refresh_token(cred: OAuthCredential, *, now: float) -> OAuthCredential:
     """Run the refresh_token grant and return the rotated credential.
 
-    Raises on any transport/protocol failure; callers fail open.
+    Raises ``OAuthRefreshError`` (with the endpoint's error body) on an error
+    response, transport errors as-is; callers fail open.
     """
-    body = _http_post_form(
+    status, body = _http_post_form_status(
         cred.token_endpoint,
         {
             "grant_type": "refresh_token",
@@ -219,6 +275,15 @@ def _exchange_refresh_token(cred: OAuthCredential, *, now: float) -> OAuthCreden
         },
         _REFRESH_TIMEOUT_SECONDS,
     )
+    if status >= 400:
+        error = str(body.get("error") or "")
+        description = str(body.get("error_description") or "")
+        detail = " — ".join(p for p in (error, description) if p) or "no error body"
+        raise OAuthRefreshError(
+            _redact_tokens(f"token endpoint returned HTTP {status}: {detail}"),
+            error=error,
+            permanent=error in _PERMANENT_OAUTH_ERRORS,
+        )
     access = body.get("access_token")
     refresh = body.get("refresh_token")
     if not is_oauth_access_token(access) or not refresh:
@@ -236,6 +301,29 @@ def _exchange_refresh_token(cred: OAuthCredential, *, now: float) -> OAuthCreden
         scope=str(body.get("scope", cred.scope)),
         token_type=str(body.get("token_type", cred.token_type)),
     )
+
+
+def _exchange_with_retry(cred: OAuthCredential, *, now: float) -> OAuthCredential:
+    """Exchange the refresh token, retrying once immediately on transient failure.
+
+    The server honors a replayed refresh token only within a short grace
+    window after rotating it, so the retry must happen now — deferring to the
+    next memory call lands outside the window and revokes the grant.
+    """
+    try:
+        return _exchange_refresh_token(cred, now=now)
+    except OAuthRefreshError as exc:
+        if exc.permanent:
+            raise
+        first: Exception = exc
+    except Exception as exc:
+        first = exc
+    logger.warning(
+        "Honcho OAuth token exchange failed, retrying once: %s",
+        _redact_tokens(str(first)),
+    )
+    time.sleep(_REFRESH_RETRY_DELAY_SECONDS)
+    return _exchange_refresh_token(cred, now=now)
 
 
 def _read_config(path: Path) -> dict[str, Any]:
@@ -279,6 +367,7 @@ def _persist_credential(path: Path, host: str, cred: OAuthCredential) -> None:
     block["oauth"] = cred.oauth_block()
     _atomic_write_config(path, raw)
     _expiry_cache[(str(path), host)] = (cred.expires_at, cred.access_token)
+    _dead_grants.pop((str(path), host), None)
 
 
 def ensure_fresh_token(
@@ -293,7 +382,9 @@ def ensure_fresh_token(
     Returns ``(None, False)`` when the host has no OAuth credential (e.g. a plain
     API key) so callers leave the existing token untouched. Refresh failures are
     swallowed: the current (possibly stale) token is returned with
-    ``refreshed=False`` and the fail-open path handles any resulting 401.
+    ``refreshed=False``, transient failures retry once immediately, and a
+    permanently rejected grant is marked dead so later calls skip the endpoint.
+    The 401 recovery in session.py escalates dead grants to the user.
     """
     now = time.time() if now is None else now
     key = (str(path), host)
@@ -323,14 +414,76 @@ def ensure_fresh_token(
         current = OAuthCredential.from_host_block(fresh_block) or cred
         if not current.is_expired(now=now):
             return current.access_token, current.access_token != cred.access_token
+        if _grant_is_dead(key, current):
+            return current.access_token, False
         try:
-            rotated = _exchange_refresh_token(current, now=now)
+            rotated = _exchange_with_retry(current, now=now)
+        except OAuthRefreshError as exc:
+            if exc.permanent:
+                _mark_grant_dead(key, current)
+                logger.error(
+                    "Honcho OAuth grant for host %s is no longer valid (%s); "
+                    "run 'hermes honcho setup' to re-authenticate", host, exc,
+                )
+            else:
+                logger.warning("Honcho OAuth refresh failed for host %s: %s", host, exc)
+            return current.access_token, False
         except Exception as exc:
-            logger.warning("Honcho OAuth refresh failed for host %s: %s", host, exc)
+            logger.warning(
+                "Honcho OAuth refresh failed for host %s: %s",
+                host, _redact_tokens(str(exc)),
+            )
             return current.access_token, False
         _persist_credential(path, host, rotated)
         logger.info("Honcho OAuth token refreshed for host %s", host)
         return rotated.access_token, True
+
+
+def force_refresh_token(path: Path, host: str) -> str | None:
+    """Rotate ``host``'s access token now, ignoring local expiry math.
+
+    Recovery path for a server-side 401 on a token the local clock still
+    considers valid (clock skew, server-side rotation, revocation). Returns
+    the new access token, or ``None`` when the host has no OAuth credential,
+    the grant is dead, or the exchange fails — callers surface the original
+    auth error in that case.
+    """
+    now = time.time()
+    key = (str(path), host)
+    with _refresh_lock, _config_refresh_lock(path):
+        block = (_read_config(path).get("hosts") or {}).get(host) or {}
+        cred = OAuthCredential.from_host_block(block)
+        if cred is None:
+            _expiry_cache.pop(key, None)
+            return None
+        if _grant_is_dead(key, cred):
+            return None
+        cached = _expiry_cache.get(key)
+        # Another thread or process already rotated: adopt the newer on-disk token.
+        if cached is not None and cred.access_token != cached[1] and not cred.is_expired(now=now):
+            _expiry_cache[key] = (cred.expires_at, cred.access_token)
+            return cred.access_token
+        try:
+            rotated = _exchange_with_retry(cred, now=now)
+        except OAuthRefreshError as exc:
+            if exc.permanent:
+                _mark_grant_dead(key, cred)
+                logger.error(
+                    "Honcho OAuth grant for host %s is no longer valid (%s); "
+                    "run 'hermes honcho setup' to re-authenticate", host, exc,
+                )
+            else:
+                logger.warning("Honcho OAuth forced refresh failed for host %s: %s", host, exc)
+            return None
+        except Exception as exc:
+            logger.warning(
+                "Honcho OAuth forced refresh failed for host %s: %s",
+                host, _redact_tokens(str(exc)),
+            )
+            return None
+        _persist_credential(path, host, rotated)
+        logger.info("Honcho OAuth token force-refreshed for host %s after an auth failure", host)
+        return rotated.access_token
 
 
 def install_grant(
@@ -378,6 +531,7 @@ def install_grant(
         if apply_config:
             _deep_merge(raw, granted_config)
     _expiry_cache[(str(path), host)] = (cred.expires_at, cred.access_token)
+    _dead_grants.pop((str(path), host), None)
     hosts = raw.setdefault("hosts", {})
     block = hosts.setdefault(host, {})
     block["apiKey"] = cred.access_token

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -304,11 +304,9 @@ def _exchange_refresh_token(cred: OAuthCredential, *, now: float) -> OAuthCreden
 
 
 def _exchange_with_retry(cred: OAuthCredential, *, now: float) -> OAuthCredential:
-    """Exchange the refresh token, retrying once immediately on transient failure.
+    """Exchange the refresh token, retrying once on transient failure.
 
-    The server honors a replayed refresh token only within a short grace
-    window after rotating it, so the retry must happen now — deferring to the
-    next memory call lands outside the window and revokes the grant.
+    The server accepts a replayed token only briefly after rotating it, so the retry cannot wait.
     """
     try:
         return _exchange_refresh_token(cred, now=now)
@@ -440,13 +438,9 @@ def ensure_fresh_token(
 
 
 def force_refresh_token(path: Path, host: str) -> str | None:
-    """Rotate ``host``'s access token now, ignoring local expiry math.
+    """Rotate ``host``'s access token now, ignoring local expiry.
 
-    Recovery path for a server-side 401 on a token the local clock still
-    considers valid (clock skew, server-side rotation, revocation). Returns
-    the new access token, or ``None`` when the host has no OAuth credential,
-    the grant is dead, or the exchange fails — callers surface the original
-    auth error in that case.
+    Recovers a 401 on a token the local clock still thinks is valid.
     """
     now = time.time()
     key = (str(path), host)

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -26,18 +26,13 @@ _PEER_ID_HASH_ESCALATION_LENGTHS = (_PEER_ID_HASH_LEN, 12, 16, 24, 32, 64)
 
 
 class HonchoAuthError(RuntimeError):
-    """Auth failure that survived a forced token refresh and one retry.
+    """Auth failure that survived a forced refresh and one retry.
 
-    Raised instead of swallowed so callers can tell a rejected credential
-    apart from an empty result; cadence backoff must not count it as empty.
+    Raised, not swallowed, so callers can tell a rejected credential from an empty result.
     """
 
 
-# Text fallback for transports without a status attribute. Conservative on
-# purpose: a false positive spends a refresh-token rotation, and a lost
-# rotation response can permanently revoke the grant. A missed auth error
-# only costs one un-recovered call. "authentication failed" (not bare
-# "authentication") so auth-infrastructure outage messages stay transient.
+# Matched narrowly: a false positive spends a token rotation, and a lost rotation revokes the grant.
 _AUTH_ERROR_MARKERS = (
     "invalid or expired access token",
     "authentication failed",
@@ -240,10 +235,9 @@ class HonchoSessionManager:
         return self._auth_failure
 
     def _reauth_required(self) -> bool:
-        """True when the OAuth grant is dead and only a new login can fix it.
+        """True when the grant is dead and only a new login can fix it.
 
-        Reads the config and compares the refresh-token digest, so a re-login
-        flips this back to False with no network call — recovery is immediate.
+        Compares the on-disk refresh-token digest, so a new login clears it with no network call.
         """
         try:
             from plugins.memory.honcho import oauth
@@ -257,11 +251,9 @@ class HonchoSessionManager:
             return False
 
     def _force_reauth(self) -> bool:
-        """Rotate the OAuth token after a server-side 401 and rebind the client.
+        """Rotate the token after a 401 and rebind the client.
 
-        Returns True when a fresh token was obtained and applied. False for
-        static API keys (no OAuth credential), a dead grant, or a failed
-        exchange — callers surface the original auth error in that case.
+        False for a static API key, a dead grant, or a failed exchange.
         """
         try:
             from plugins.memory.honcho import oauth

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -56,6 +56,12 @@ def _auth_error_message(exc: BaseException) -> str:
     )
 
 
+_REAUTH_REQUIRED_MESSAGE = (
+    "Honcho OAuth grant is revoked and cannot be refreshed; "
+    "re-authenticate with 'hermes honcho setup'."
+)
+
+
 @dataclass
 class HonchoSession:
     """
@@ -218,6 +224,23 @@ class HonchoSessionManager:
             return None
         self._auth_notice_emitted = True
         return self._auth_failure
+
+    def _reauth_required(self) -> bool:
+        """True when the OAuth grant is dead and only a new login can fix it.
+
+        Reads the config and compares the refresh-token digest, so a re-login
+        flips this back to False with no network call — recovery is immediate.
+        """
+        try:
+            from plugins.memory.honcho import oauth
+            from plugins.memory.honcho.client import resolve_config_path
+
+            host = getattr(self._config, "host", "") or ""
+            if not host:
+                return False
+            return oauth.reauth_required(resolve_config_path(), host)
+        except Exception:
+            return False
 
     def _force_reauth(self) -> bool:
         """Rotate the OAuth token after a server-side 401 and rebind the client.
@@ -512,6 +535,15 @@ class HonchoSessionManager:
         if not session.messages:
             return True
 
+        new_messages = [m for m in session.messages if not m.get("_synced")]
+        if not new_messages:
+            return True
+
+        # A dead grant cannot authenticate; skip the call until re-login.
+        if self._reauth_required():
+            self._record_auth_failure(HonchoAuthError(_REAUTH_REQUIRED_MESSAGE))
+            return False
+
         user_peer = self._get_or_create_peer(session.user_peer_id)
         assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
         honcho_session = self._sessions_cache.get(session.honcho_session_id)
@@ -520,10 +552,6 @@ class HonchoSessionManager:
             honcho_session, _ = self._get_or_create_honcho_session(
                 session.honcho_session_id, user_peer, assistant_peer
             )
-
-        new_messages = [m for m in session.messages if not m.get("_synced")]
-        if not new_messages:
-            return True
 
         honcho_messages = []
         for msg in new_messages:
@@ -749,6 +777,12 @@ class HonchoSessionManager:
         session = self._cache.get(session_key)
         if not session:
             return ""
+
+        # A dead grant cannot authenticate; skip the call until re-login.
+        if self._reauth_required():
+            exc = HonchoAuthError(_REAUTH_REQUIRED_MESSAGE)
+            self._record_auth_failure(exc)
+            raise exc
 
         target_peer_id = self._resolve_peer_id(session, peer)
         if target_peer_id is None:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -9,7 +9,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
 from plugins.memory.honcho.oauth import _redact_tokens
@@ -279,18 +279,58 @@ class HonchoSessionManager:
             logger.warning("Honcho post-401 token refresh failed", exc_info=True)
             return False
 
-    def _get_or_create_peer(self, peer_id: str) -> Any:
-        """
-        Get or create a Honcho peer.
+    def _authed_call(self, op_name: str, operation: Callable[[], Any]) -> Any:
+        """Run an authenticated SDK operation, forcing one token refresh on a 401.
 
-        Peers are lazy -- no API call until first use.
-        Observation settings are controlled per-session via SessionPeerConfig.
+        ``operation`` must re-resolve peer/session objects itself: a failed
+        in-place refresh rebuilds the client, orphaning objects captured earlier.
         """
+        if self._reauth_required():
+            exc = HonchoAuthError(_REAUTH_REQUIRED_MESSAGE)
+            self._record_auth_failure(exc)
+            raise exc
+        try:
+            result = operation()
+        except HonchoAuthError:
+            raise
+        except Exception as e:
+            if not _is_auth_error(e):
+                raise
+            logger.warning(
+                "Honcho %s hit an auth error; forcing token refresh and "
+                "retrying once: %s", op_name, _redact_tokens(str(e)),
+            )
+            if not self._force_reauth():
+                self._record_auth_failure(e)
+                raise HonchoAuthError(_auth_error_message(e)) from e
+            try:
+                result = operation()
+            except Exception as retry_exc:
+                if _is_auth_error(retry_exc):
+                    self._record_auth_failure(retry_exc)
+                    raise HonchoAuthError(_auth_error_message(retry_exc)) from retry_exc
+                raise
+        self._clear_auth_failure()
+        return result
+
+    def _sdk_session(self, session_id: str) -> Any:
+        """Get or create the SDK session; a client rebuild clears the cache, so re-fetch."""
+        with self._cache_lock:
+            cached = self._sessions_cache.get(session_id)
+        if cached is not None:
+            return cached
+        sdk_session = self.honcho.session(session_id)
+        with self._cache_lock:
+            self._sessions_cache[session_id] = sdk_session
+        return sdk_session
+
+    def _get_or_create_peer(self, peer_id: str) -> Any:
+        """Get or create a Honcho peer (one get-or-create API call, then cached)."""
         with self._cache_lock:
             if peer_id in self._peers_cache:
                 return self._peers_cache[peer_id]
 
-        peer = self.honcho.peer(peer_id)
+        peer = self._authed_call("peer setup", lambda: self.honcho.peer(peer_id))
         with self._cache_lock:
             self._peers_cache[peer_id] = peer
         return peer
@@ -309,10 +349,11 @@ class HonchoSessionManager:
                 logger.debug("Honcho session '%s' retrieved from cache", session_id)
                 return self._sessions_cache[session_id], []
 
-        session = self.honcho.session(session_id)
+        self._authed_call("session setup", lambda: self._sdk_session(session_id))
 
         # Configure per-peer observation from granular booleans.
         # These map 1:1 to Honcho's SessionPeerConfig toggles.
+        auth_dead = False
         try:
             from honcho.session import SessionPeerConfig
             user_config = SessionPeerConfig(
@@ -323,16 +364,28 @@ class HonchoSessionManager:
                 observe_me=self._ai_observe_me,
                 observe_others=self._ai_observe_others,
             )
+            peer_entries = [(user_peer, user_config), (assistant_peer, ai_config)]
 
-            session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
+            self._authed_call(
+                "session peer setup",
+                lambda: self._sdk_session(session_id).add_peers(peer_entries),
+            )
 
             # Sync back: server-side config (set via Honcho UI) wins over
             # local defaults. Read the effective config after add_peers.
             # Note: observation booleans are manager-scoped, not per-session.
             # Last session init wins. Fine for CLI; gateway should scope per-session.
             try:
-                server_user = session.get_peer_configuration(user_peer)
-                server_ai = session.get_peer_configuration(assistant_peer)
+                def _read_server_configs() -> tuple[Any, Any]:
+                    sdk_session = self._sdk_session(session_id)
+                    return (
+                        sdk_session.get_peer_configuration(user_peer),
+                        sdk_session.get_peer_configuration(assistant_peer),
+                    )
+
+                server_user, server_ai = self._authed_call(
+                    "peer configuration read", _read_server_configs
+                )
                 if server_user.observe_me is not None:
                     self._user_observe_me = server_user.observe_me
                 if server_user.observe_others is not None:
@@ -346,8 +399,13 @@ class HonchoSessionManager:
                     self._user_observe_me, self._user_observe_others,
                     self._ai_observe_me, self._ai_observe_others,
                 )
+            except HonchoAuthError:
+                raise
             except Exception as e:
                 logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
+        except HonchoAuthError:
+            # Already recorded by _authed_call; skip the remaining init calls.
+            auth_dead = True
         except Exception as e:
             logger.warning(
                 "Honcho session '%s' add_peers failed (non-fatal): %s",
@@ -356,38 +414,55 @@ class HonchoSessionManager:
 
         # Load existing messages via context() - single call for messages + metadata
         existing_messages = []
-        try:
-            ctx = session.context(summary=True, tokens=self._context_tokens)
-            existing_messages = ctx.messages or []
-
-            # Verify chronological ordering
-            if existing_messages and len(existing_messages) > 1:
-                timestamps = [m.created_at for m in existing_messages if m.created_at]
-                if timestamps and timestamps != sorted(timestamps):
-                    logger.warning(
-                        "Honcho messages not chronologically ordered for session '%s', sorting",
-                        session_id,
-                    )
-                    existing_messages = sorted(
-                        existing_messages,
-                        key=lambda m: m.created_at or datetime.min,
-                    )
-
-            if existing_messages:
-                logger.info(
-                    "Honcho session '%s' retrieved (%d existing messages)",
-                    session_id, len(existing_messages),
+        if not auth_dead:
+            try:
+                ctx = self._authed_call(
+                    "session context load",
+                    lambda: self._sdk_session(session_id).context(
+                        summary=True, tokens=self._context_tokens
+                    ),
                 )
-            else:
-                logger.info("Honcho session '%s' created (new)", session_id)
-        except Exception as e:
-            logger.warning(
-                "Honcho session '%s' loaded (failed to fetch context: %s)",
-                session_id, e,
-            )
+                existing_messages = ctx.messages or []
 
-        self._sessions_cache[session_id] = session
-        return session, existing_messages
+                # Verify chronological ordering
+                if existing_messages and len(existing_messages) > 1:
+                    timestamps = [m.created_at for m in existing_messages if m.created_at]
+                    if timestamps and timestamps != sorted(timestamps):
+                        logger.warning(
+                            "Honcho messages not chronologically ordered for session '%s', sorting",
+                            session_id,
+                        )
+                        existing_messages = sorted(
+                            existing_messages,
+                            key=lambda m: m.created_at or datetime.min,
+                        )
+
+                if existing_messages:
+                    logger.info(
+                        "Honcho session '%s' retrieved (%d existing messages)",
+                        session_id, len(existing_messages),
+                    )
+                else:
+                    logger.info("Honcho session '%s' created (new)", session_id)
+            except HonchoAuthError:
+                logger.warning(
+                    "Honcho session '%s' loaded without server context: auth failed",
+                    session_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Honcho session '%s' loaded (failed to fetch context: %s)",
+                    session_id, e,
+                )
+
+        with self._cache_lock:
+            honcho_session = self._sessions_cache.get(session_id)
+        if honcho_session is None:
+            # A mid-init client rebuild dropped the cached session; resolve a fresh one.
+            honcho_session = self._authed_call(
+                "session setup", lambda: self._sdk_session(session_id)
+            )
+        return honcho_session, existing_messages
 
     def _sanitize_id(self, id_str: str) -> str:
         """Sanitize an ID to match Honcho's pattern: ^[a-zA-Z0-9_-]+"""
@@ -545,48 +620,31 @@ class HonchoSessionManager:
         if not new_messages:
             return True
 
-        # A dead grant cannot authenticate; skip the call until re-login.
-        if self._reauth_required():
-            self._record_auth_failure(HonchoAuthError(_REAUTH_REQUIRED_MESSAGE))
-            return False
-
-        user_peer = self._get_or_create_peer(session.user_peer_id)
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-
-        if not honcho_session:
-            honcho_session, _ = self._get_or_create_honcho_session(
-                session.honcho_session_id, user_peer, assistant_peer
-            )
-
-        honcho_messages = []
-        for msg in new_messages:
-            peer = user_peer if msg["role"] == "user" else assistant_peer
-            honcho_messages.append(peer.message(msg["content"]))
+        # Resolved inside the operation so a retry after a client rebuild gets fresh objects.
+        def _sync_messages() -> int:
+            user_peer = self._get_or_create_peer(session.user_peer_id)
+            assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+            honcho_session = self._sessions_cache.get(session.honcho_session_id)
+            if honcho_session is None:
+                honcho_session, _ = self._get_or_create_honcho_session(
+                    session.honcho_session_id, user_peer, assistant_peer
+                )
+            honcho_messages = [
+                (user_peer if m["role"] == "user" else assistant_peer).message(m["content"])
+                for m in new_messages
+            ]
+            honcho_session.add_messages(honcho_messages)
+            return len(honcho_messages)
 
         try:
-            try:
-                honcho_session.add_messages(honcho_messages)
-            except Exception as e:
-                if not _is_auth_error(e):
-                    raise
-                logger.warning(
-                    "Honcho message sync hit an auth error; forcing token "
-                    "refresh and retrying once: %s", _redact_tokens(str(e)),
-                )
-                if not self._force_reauth():
-                    raise
-                honcho_session.add_messages(honcho_messages)
-            self._clear_auth_failure()
+            synced = self._authed_call("message sync", _sync_messages)
             for msg in new_messages:
                 msg["_synced"] = True
-            logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
+            logger.debug("Synced %d messages to Honcho for %s", synced, session.key)
             with self._cache_lock:
                 self._cache[session.key] = session
             return True
         except Exception as e:
-            if _is_auth_error(e):
-                self._record_auth_failure(e)
             for msg in new_messages:
                 msg["_synced"] = False
             logger.error("Failed to sync messages to Honcho: %s", e)
@@ -784,12 +842,6 @@ class HonchoSessionManager:
         if not session:
             return ""
 
-        # A dead grant cannot authenticate; skip the call until re-login.
-        if self._reauth_required():
-            exc = HonchoAuthError(_REAUTH_REQUIRED_MESSAGE)
-            self._record_auth_failure(exc)
-            raise exc
-
         target_peer_id = self._resolve_peer_id(session, peer)
         if target_peer_id is None:
             return ""
@@ -819,27 +871,7 @@ class HonchoSessionManager:
             return target_peer.chat(query, reasoning_level=level) or ""
 
         try:
-            try:
-                result = _chat_once()
-            except Exception as e:
-                if not _is_auth_error(e):
-                    raise
-                logger.warning(
-                    "Honcho dialectic query hit an auth error; forcing token "
-                    "refresh and retrying once: %s", _redact_tokens(str(e)),
-                )
-                if not self._force_reauth():
-                    self._record_auth_failure(e)
-                    raise HonchoAuthError(_auth_error_message(e)) from e
-                try:
-                    result = _chat_once()
-                except Exception as retry_exc:
-                    if _is_auth_error(retry_exc):
-                        self._record_auth_failure(retry_exc)
-                        raise HonchoAuthError(_auth_error_message(retry_exc)) from retry_exc
-                    raise
-
-            self._clear_auth_failure()
+            result = self._authed_call("dialectic query", _chat_once)
             # Only automatic injection uses the Hermes-side character cap.
             if (
                 apply_injection_cap
@@ -916,11 +948,16 @@ class HonchoSessionManager:
         # return null summary — the guard below handles that gracefully.
         # Per-directory returning sessions get their accumulated summary.
         try:
-            honcho_session = self._sessions_cache.get(session.honcho_session_id)
-            if honcho_session:
-                ctx = honcho_session.context(summary=True)
+            if session.honcho_session_id in self._sessions_cache:
+                ctx = self._authed_call(
+                    "session summary fetch",
+                    lambda: self._sdk_session(session.honcho_session_id).context(summary=True),
+                )
                 if ctx.summary and getattr(ctx.summary, "content", None):
                     result["summary"] = ctx.summary.content
+        except HonchoAuthError:
+            # Auth is dead; the pop_auth_notice path tells the model why context is missing.
+            return result
         except Exception as e:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
@@ -929,6 +966,8 @@ class HonchoSessionManager:
             user_ctx = self._fetch_peer_context(observer_peer_id, search_query=user_message or None, target=target_peer_id or session.user_peer_id)
             result["representation"] = user_ctx["representation"]
             result["card"] = "\n".join(user_ctx["card"])
+        except HonchoAuthError:
+            return result
         except Exception as e:
             logger.warning("Failed to fetch user context from Honcho: %s", e)
 
@@ -937,6 +976,8 @@ class HonchoSessionManager:
             ai_ctx = self._fetch_peer_context(session.assistant_peer_id, target=session.assistant_peer_id)
             result["ai_representation"] = ai_ctx["representation"]
             result["ai_card"] = "\n".join(ai_ctx["card"])
+        except HonchoAuthError:
+            return result
         except Exception as e:
             logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
 
@@ -960,23 +1001,24 @@ class HonchoSessionManager:
             logger.warning("No local session cached for '%s', skipping migration", session_key)
             return False
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
+        if session.honcho_session_id not in self._sessions_cache:
             logger.warning("No Honcho session cached for '%s', skipping migration", session_key)
             return False
-
-        user_peer = self._get_or_create_peer(session.user_peer_id)
 
         content_bytes = self._format_migration_transcript(session_key, messages)
         first_ts = messages[0].get("timestamp") if messages else None
 
         try:
-            honcho_session.upload_file(
-                file=("prior_history.txt", content_bytes, "text/plain"),
-                peer=user_peer,
-                metadata={"source": "local_jsonl", "count": len(messages)},
-                created_at=first_ts,
-            )
+            def _upload() -> None:
+                user_peer = self._get_or_create_peer(session.user_peer_id)
+                self._sdk_session(session.honcho_session_id).upload_file(
+                    file=("prior_history.txt", content_bytes, "text/plain"),
+                    peer=user_peer,
+                    metadata={"source": "local_jsonl", "count": len(messages)},
+                    created_at=first_ts,
+                )
+
+            self._authed_call("history migration upload", _upload)
             logger.info("Migrated %d local messages to Honcho for %s", len(messages), session_key)
             return True
         except Exception as e:
@@ -1039,13 +1081,9 @@ class HonchoSessionManager:
             logger.warning("No local session cached for '%s', skipping memory migration", session_key)
             return False
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
+        if session.honcho_session_id not in self._sessions_cache:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
-
-        user_peer = self._get_or_create_peer(session.user_peer_id)
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
 
         uploaded = False
         files = [
@@ -1053,26 +1091,26 @@ class HonchoSessionManager:
                 "MEMORY.md",
                 "consolidated_memory.md",
                 "Long-term agent notes and preferences",
-                user_peer,
+                session.user_peer_id,
                 "user",
             ),
             (
                 "USER.md",
                 "user_profile.md",
                 "User profile and preferences",
-                user_peer,
+                session.user_peer_id,
                 "user",
             ),
             (
                 "SOUL.md",
                 "agent_soul.md",
                 "Agent persona and identity configuration",
-                assistant_peer,
+                session.assistant_peer_id,
                 "ai",
             ),
         ]
 
-        for filename, upload_name, description, target_peer, target_kind in files:
+        for filename, upload_name, description, target_peer_id, target_kind in files:
             filepath = memory_path / filename
             if not filepath.exists():
                 continue
@@ -1092,15 +1130,18 @@ class HonchoSessionManager:
             )
 
             try:
-                honcho_session.upload_file(
-                    file=(upload_name, wrapped.encode("utf-8"), "text/plain"),
-                    peer=target_peer,
-                    metadata={
-                        "source": "local_memory",
-                        "original_file": filename,
-                        "target_peer": target_kind,
-                    },
-                )
+                def _upload() -> None:
+                    self._sdk_session(session.honcho_session_id).upload_file(
+                        file=(upload_name, wrapped.encode("utf-8"), "text/plain"),
+                        peer=self._get_or_create_peer(target_peer_id),
+                        metadata={
+                            "source": "local_memory",
+                            "original_file": filename,
+                            "target_peer": target_kind,
+                        },
+                    )
+
+                self._authed_call("memory migration upload", _upload)
                 logger.info(
                     "Uploaded %s to Honcho for %s (%s peer)",
                     filename,
@@ -1108,6 +1149,9 @@ class HonchoSessionManager:
                     target_kind,
                 )
                 uploaded = True
+            except HonchoAuthError:
+                logger.error("Honcho memory migration stopped after %s: auth failed", filename)
+                break
             except Exception as e:
                 logger.error("Failed to upload %s to Honcho: %s", filename, e)
 
@@ -1129,16 +1173,17 @@ class HonchoSessionManager:
         peer_card for per-session messaging sessions even when the peer itself
         has a populated card.
         """
-        peer = self._get_or_create_peer(peer_id)
-        getter = getattr(peer, "get_card", None)
-        if callable(getter):
-            return self._normalize_card(getter(target=target) if target is not None else getter())
+        def _get_card() -> Any:
+            peer = self._get_or_create_peer(peer_id)
+            getter = getattr(peer, "get_card", None)
+            if callable(getter):
+                return getter(target=target) if target is not None else getter()
+            legacy_getter = getattr(peer, "card", None)
+            if callable(legacy_getter):
+                return legacy_getter(target=target) if target is not None else legacy_getter()
+            return None
 
-        legacy_getter = getattr(peer, "card", None)
-        if callable(legacy_getter):
-            return self._normalize_card(legacy_getter(target=target) if target is not None else legacy_getter())
-
-        return []
+        return self._normalize_card(self._authed_call("peer card fetch", _get_card))
 
     def _fetch_peer_context(
         self,
@@ -1147,8 +1192,11 @@ class HonchoSessionManager:
         *,
         target: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch representation + peer card directly from a peer object."""
-        peer = self._get_or_create_peer(peer_id)
+        """Fetch representation + peer card directly from a peer object.
+
+        Raises HonchoAuthError when auth is dead or a 401 survives the forced
+        refresh; the non-auth fallback chain would just repeat the failure.
+        """
         representation = ""
         card: list[str] = []
 
@@ -1158,27 +1206,42 @@ class HonchoSessionManager:
                 context_kwargs["target"] = target
             if search_query is not None:
                 context_kwargs["search_query"] = search_query
-            ctx = peer.context(**context_kwargs) if context_kwargs else peer.context()
+
+            def _peer_context() -> Any:
+                peer = self._get_or_create_peer(peer_id)
+                return peer.context(**context_kwargs) if context_kwargs else peer.context()
+
+            ctx = self._authed_call("peer context fetch", _peer_context)
             representation = (
                 getattr(ctx, "representation", None)
                 or getattr(ctx, "peer_representation", None)
                 or ""
             )
             card = self._normalize_card(getattr(ctx, "peer_card", None))
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Direct peer.context() failed for '%s': %s", peer_id, e)
 
         if not representation:
             try:
-                representation = (
-                    peer.representation(target=target) if target is not None else peer.representation()
+                def _peer_representation() -> Any:
+                    peer = self._get_or_create_peer(peer_id)
+                    return peer.representation(target=target) if target is not None else peer.representation()
+
+                representation = self._authed_call(
+                    "peer representation fetch", _peer_representation
                 ) or ""
+            except HonchoAuthError:
+                raise
             except Exception as e:
                 logger.debug("Direct peer.representation() failed for '%s': %s", peer_id, e)
 
         if not card:
             try:
                 card = self._fetch_peer_card(peer_id, target=target)
+            except HonchoAuthError:
+                raise
             except Exception as e:
                 logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
 
@@ -1189,13 +1252,13 @@ class HonchoSessionManager:
 
         Uses the session-level context() API which returns summary,
         peer_representation, peer_card, and messages.
+        Raises HonchoAuthError so callers can tell rejected credentials from no context.
         """
         session = self._cache.get(session_key)
         if not session:
             return {}
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
+        if session.honcho_session_id not in self._sessions_cache:
             # Fall back to peer-level context, respecting the requested peer
             peer_id = self._resolve_peer_id(session, peer)
             if peer_id is None:
@@ -1204,10 +1267,13 @@ class HonchoSessionManager:
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
-            ctx = honcho_session.context(
-                summary=True,
-                peer_target=target_peer_id or observer_peer_id,
-                peer_perspective=observer_peer_id,
+            ctx = self._authed_call(
+                "session context fetch",
+                lambda: self._sdk_session(session.honcho_session_id).context(
+                    summary=True,
+                    peer_target=target_peer_id or observer_peer_id,
+                    peer_perspective=observer_peer_id,
+                ),
             )
 
             result: dict[str, Any] = {}
@@ -1231,6 +1297,8 @@ class HonchoSessionManager:
                 ]
 
             return result
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Session context fetch failed: %s", e)
             return {}
@@ -1275,7 +1343,7 @@ class HonchoSessionManager:
 
         Fast, no LLM reasoning. Returns raw structured facts Honcho has
         inferred about the target peer (name, role, preferences, patterns).
-        Empty list if unavailable.
+        Empty list if unavailable; raises HonchoAuthError on rejected credentials.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -1291,6 +1359,8 @@ class HonchoSessionManager:
             if target_peer_id:
                 return self._fetch_peer_card(target_peer_id)
             return []
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
@@ -1317,6 +1387,9 @@ class HonchoSessionManager:
         Returns:
             Ranked message excerpts as a formatted string, or empty string
             if none found.
+
+        Raises:
+            HonchoAuthError: rejected credentials, so no-results is not implied.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -1337,18 +1410,27 @@ class HonchoSessionManager:
         limit = max(3, min(20, char_budget // 300))
 
         try:
-            messages = self.honcho.search(
-                q,
-                filters={"peer_perspective": peer_id},
-                limit=limit,
+            messages = self._authed_call(
+                "message search",
+                lambda: self.honcho.search(
+                    q,
+                    filters={"peer_perspective": peer_id},
+                    limit=limit,
+                ),
             )
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Honcho message search failed (peer_perspective=%s): %s", peer_id, e)
             # Fall back to peer-authored search if the perspective filter is
             # unsupported by the running Honcho version.
             try:
-                peer_obj = self._get_or_create_peer(peer_id)
-                messages = peer_obj.search(q, limit=limit)
+                messages = self._authed_call(
+                    "peer search",
+                    lambda: self._get_or_create_peer(peer_id).search(q, limit=limit),
+                )
+            except HonchoAuthError:
+                raise
             except Exception as e2:
                 logger.debug("Honcho peer search fallback also failed: %s", e2)
                 return ""
@@ -1431,13 +1513,17 @@ class HonchoSessionManager:
                 logger.warning("Could not resolve conclusion peer '%s' for session '%s'", peer, session_key)
                 return False
 
-            conclusions_scope = self._conclusions_scope(session, target_peer_id)
-            conclusions_scope.create([{
-                "content": content.strip(),
-                "session_id": session.honcho_session_id,
-            }])
+            self._authed_call(
+                "conclusion create",
+                lambda: self._conclusions_scope(session, target_peer_id).create([{
+                    "content": content.strip(),
+                    "session_id": session.honcho_session_id,
+                }]),
+            )
             logger.info("Created conclusion about %s for %s: %s", target_peer_id, session_key, content[:80])
             return True
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.error("Failed to create conclusion: %s", e)
             return False
@@ -1458,10 +1544,14 @@ class HonchoSessionManager:
             return False
         try:
             target_peer_id = self._resolve_peer_id(session, peer)
-            scope = self._conclusions_scope(session, target_peer_id)
-            scope.delete(conclusion_id)
+            self._authed_call(
+                "conclusion delete",
+                lambda: self._conclusions_scope(session, target_peer_id).delete(conclusion_id),
+            )
             logger.info("Deleted conclusion %s for %s", conclusion_id, session_key)
             return True
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.error("Failed to delete conclusion %s: %s", conclusion_id, e)
             return False
@@ -1491,12 +1581,17 @@ class HonchoSessionManager:
             target_peer_id = self._resolve_peer_id(session, peer)
             if target_peer_id is None:
                 return []
-            scope = self._conclusions_scope(session, target_peer_id)
-            if query:
-                conclusions = scope.query(query, top_k=limit)
-            else:
-                conclusions = scope.list(size=limit).items
+
+            def _list() -> Any:
+                scope = self._conclusions_scope(session, target_peer_id)
+                if query:
+                    return scope.query(query, top_k=limit)
+                return scope.list(size=limit).items
+
+            conclusions = self._authed_call("conclusion list", _list)
             return [{"id": c.id, "content": c.content} for c in conclusions]
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Honcho list_conclusions failed: %s", e)
             return []
@@ -1520,12 +1615,14 @@ class HonchoSessionManager:
             if observer_peer_id is None:
                 logger.warning("Could not resolve peer '%s' for set_peer_card in session '%s'", peer, session_key)
                 return None
-            peer_obj = self._get_or_create_peer(observer_peer_id)
-            result = (
-                peer_obj.set_card(card, target=target_peer_id)
-                if target_peer_id is not None
-                else peer_obj.set_card(card)
-            )
+
+            def _set_card() -> Any:
+                peer_obj = self._get_or_create_peer(observer_peer_id)
+                if target_peer_id is not None:
+                    return peer_obj.set_card(card, target=target_peer_id)
+                return peer_obj.set_card(card)
+
+            result = self._authed_call("peer card update", _set_card)
             logger.info(
                 "Updated peer card observer=%s target=%s (%d facts)",
                 observer_peer_id,
@@ -1533,6 +1630,8 @@ class HonchoSessionManager:
                 len(card),
             )
             return result
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.error("Failed to set peer card: %s", e)
             return None
@@ -1561,9 +1660,7 @@ class HonchoSessionManager:
             logger.warning("No session cached for '%s', skipping AI seed", session_key)
             return False
 
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
+        if session.honcho_session_id not in self._sessions_cache:
             logger.warning("No Honcho session cached for '%s', skipping AI seed", session_key)
             return False
 
@@ -1575,7 +1672,14 @@ class HonchoSessionManager:
                 f"{content.strip()}\n"
                 f"</ai_identity_seed>"
             )
-            honcho_session.add_messages([assistant_peer.message(wrapped)])
+
+            def _seed() -> None:
+                assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+                self._sdk_session(session.honcho_session_id).add_messages(
+                    [assistant_peer.message(wrapped)]
+                )
+
+            self._authed_call("identity seed", _seed)
             logger.info("Seeded AI identity from '%s' into %s", source, session_key)
             return True
         except Exception as e:
@@ -1599,6 +1703,8 @@ class HonchoSessionManager:
                 "representation": ctx["representation"] or "",
                 "card": "\n".join(ctx["card"]),
             }
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.debug("Failed to fetch AI representation: %s", e)
             return {"representation": "", "card": ""}

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
+from plugins.memory.honcho.oauth import _redact_tokens
 
 if TYPE_CHECKING:
     from honcho import Honcho
@@ -32,26 +33,38 @@ class HonchoAuthError(RuntimeError):
     """
 
 
-# The SDK raises different exception classes per transport, but an auth failure always carries one of these markers.
+# Text fallback for transports without a status attribute. Conservative on
+# purpose: a false positive spends a refresh-token rotation, and a lost
+# rotation response can permanently revoke the grant. A missed auth error
+# only costs one un-recovered call. "authentication failed" (not bare
+# "authentication") so auth-infrastructure outage messages stay transient.
 _AUTH_ERROR_MARKERS = (
     "invalid or expired access token",
-    "authentication",
+    "authentication failed",
     "unauthorized",
-    "401",
 )
+
+# A 401 in text counts only with HTTP context ("HTTP 401", "status 401"), never as a bare number.
+_HTTP_401_RE = re.compile(r"\b(?:http|status(?:[ _]code)?\s*[:=]?)\s*401\b")
 
 
 def _is_auth_error(exc: BaseException) -> bool:
     status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
     if status == 401:
         return True
+    # The transport reported a concrete non-auth status; trust it over text.
+    if isinstance(status, int) and status not in (0, 401):
+        return False
     text = str(exc).lower()
+    if _HTTP_401_RE.search(text):
+        return True
     return any(marker in text for marker in _AUTH_ERROR_MARKERS)
 
 
 def _auth_error_message(exc: BaseException) -> str:
     return (
-        f"Honcho rejected our credentials and a forced token refresh did not recover: {exc}. "
+        "Honcho rejected our credentials and a forced token refresh did not "
+        f"recover: {_redact_tokens(str(exc))}. "
         "Re-authenticate with 'hermes honcho setup'."
     )
 
@@ -204,13 +217,14 @@ class HonchoSessionManager:
         return self._honcho
 
     def _record_auth_failure(self, exc: BaseException) -> None:
+        detail = _redact_tokens(str(exc))
         if self._auth_failure is None:
             logger.error(
                 "Honcho authentication failed and token refresh did not recover; "
                 "memory sync and recall are paused until the user re-authenticates: %s",
-                exc,
+                detail,
             )
-        self._auth_failure = str(exc)
+        self._auth_failure = detail
 
     def _clear_auth_failure(self) -> None:
         if self._auth_failure is not None:
@@ -566,7 +580,7 @@ class HonchoSessionManager:
                     raise
                 logger.warning(
                     "Honcho message sync hit an auth error; forcing token "
-                    "refresh and retrying once: %s", e,
+                    "refresh and retrying once: %s", _redact_tokens(str(e)),
                 )
                 if not self._force_reauth():
                     raise
@@ -820,7 +834,7 @@ class HonchoSessionManager:
                     raise
                 logger.warning(
                     "Honcho dialectic query hit an auth error; forcing token "
-                    "refresh and retrying once: %s", e,
+                    "refresh and retrying once: %s", _redact_tokens(str(e)),
                 )
                 if not self._force_reauth():
                     self._record_auth_failure(e)

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -24,6 +24,38 @@ _PEER_ID_HASH_LEN = 8
 _PEER_ID_HASH_ESCALATION_LENGTHS = (_PEER_ID_HASH_LEN, 12, 16, 24, 32, 64)
 
 
+class HonchoAuthError(RuntimeError):
+    """Auth failure that survived a forced token refresh and one retry.
+
+    Raised instead of swallowed so callers can tell a rejected credential
+    apart from an empty result; cadence backoff must not count it as empty.
+    """
+
+
+# The SDK raises different exception classes per transport, but an auth failure always carries one of these markers.
+_AUTH_ERROR_MARKERS = (
+    "invalid or expired access token",
+    "authentication",
+    "unauthorized",
+    "401",
+)
+
+
+def _is_auth_error(exc: BaseException) -> bool:
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status == 401:
+        return True
+    text = str(exc).lower()
+    return any(marker in text for marker in _AUTH_ERROR_MARKERS)
+
+
+def _auth_error_message(exc: BaseException) -> str:
+    return (
+        f"Honcho rejected our credentials and a forced token refresh did not recover: {exc}. "
+        "Re-authenticate with 'hermes honcho setup'."
+    )
+
+
 @dataclass
 class HonchoSession:
     """
@@ -105,6 +137,10 @@ class HonchoSessionManager:
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
 
+        # Set when a call still fails auth after a forced token refresh; cleared on the next success.
+        self._auth_failure: str | None = None
+        self._auth_notice_emitted = False
+
         # Write frequency state
         write_frequency = (config.write_frequency if config else "async")
         self._write_frequency = write_frequency
@@ -160,6 +196,59 @@ class HonchoSessionManager:
         """
         self._honcho = get_honcho_client()
         return self._honcho
+
+    def _record_auth_failure(self, exc: BaseException) -> None:
+        if self._auth_failure is None:
+            logger.error(
+                "Honcho authentication failed and token refresh did not recover; "
+                "memory sync and recall are paused until the user re-authenticates: %s",
+                exc,
+            )
+        self._auth_failure = str(exc)
+
+    def _clear_auth_failure(self) -> None:
+        if self._auth_failure is not None:
+            logger.info("Honcho authentication recovered; memory sync and recall resumed")
+            self._auth_failure = None
+            self._auth_notice_emitted = False
+
+    def pop_auth_notice(self) -> str | None:
+        """Return the pending auth-failure message once; later calls return None."""
+        if self._auth_failure is None or self._auth_notice_emitted:
+            return None
+        self._auth_notice_emitted = True
+        return self._auth_failure
+
+    def _force_reauth(self) -> bool:
+        """Rotate the OAuth token after a server-side 401 and rebind the client.
+
+        Returns True when a fresh token was obtained and applied. False for
+        static API keys (no OAuth credential), a dead grant, or a failed
+        exchange — callers surface the original auth error in that case.
+        """
+        try:
+            from plugins.memory.honcho import oauth
+            from plugins.memory.honcho.client import (
+                reset_honcho_client,
+                resolve_config_path,
+            )
+
+            host = getattr(self._config, "host", "") or ""
+            if not host:
+                return False
+            token = oauth.force_refresh_token(resolve_config_path(), host)
+            if not token:
+                return False
+            if not oauth.apply_token_to_client(self.honcho, token):
+                # SDK shape changed: rebuild the client and drop objects holding the old transport.
+                reset_honcho_client()
+                with self._cache_lock:
+                    self._peers_cache.clear()
+                    self._sessions_cache.clear()
+            return True
+        except Exception:
+            logger.warning("Honcho post-401 token refresh failed", exc_info=True)
+            return False
 
     def _get_or_create_peer(self, peer_id: str) -> Any:
         """
@@ -442,7 +531,19 @@ class HonchoSessionManager:
             honcho_messages.append(peer.message(msg["content"]))
 
         try:
-            honcho_session.add_messages(honcho_messages)
+            try:
+                honcho_session.add_messages(honcho_messages)
+            except Exception as e:
+                if not _is_auth_error(e):
+                    raise
+                logger.warning(
+                    "Honcho message sync hit an auth error; forcing token "
+                    "refresh and retrying once: %s", e,
+                )
+                if not self._force_reauth():
+                    raise
+                honcho_session.add_messages(honcho_messages)
+            self._clear_auth_failure()
             for msg in new_messages:
                 msg["_synced"] = True
             logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
@@ -450,6 +551,8 @@ class HonchoSessionManager:
                 self._cache[session.key] = session
             return True
         except Exception as e:
+            if _is_auth_error(e):
+                self._record_auth_failure(e)
             for msg in new_messages:
                 msg["_synced"] = False
             logger.error("Failed to sync messages to Honcho: %s", e)
@@ -638,6 +741,10 @@ class HonchoSessionManager:
 
         Returns:
             Honcho's synthesized answer, or empty string on failure.
+
+        Raises:
+            HonchoAuthError: the backend rejected our credentials and a forced
+                token refresh plus one retry did not recover.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -656,23 +763,43 @@ class HonchoSessionManager:
         else:
             level = self._default_reasoning_level()
 
-        try:
+        def _chat_once() -> str:
             if self._ai_observe_others:
                 # AI peer can observe other peers — use assistant as observer.
                 ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                 if target_peer_id == session.assistant_peer_id:
-                    result = ai_peer_obj.chat(query, reasoning_level=level) or ""
-                else:
-                    result = ai_peer_obj.chat(
-                        query,
-                        target=target_peer_id,
-                        reasoning_level=level,
-                    ) or ""
-            else:
-                # Without cross-observation, each peer queries its own context.
-                target_peer = self._get_or_create_peer(target_peer_id)
-                result = target_peer.chat(query, reasoning_level=level) or ""
+                    return ai_peer_obj.chat(query, reasoning_level=level) or ""
+                return ai_peer_obj.chat(
+                    query,
+                    target=target_peer_id,
+                    reasoning_level=level,
+                ) or ""
+            # Without cross-observation, each peer queries its own context.
+            target_peer = self._get_or_create_peer(target_peer_id)
+            return target_peer.chat(query, reasoning_level=level) or ""
 
+        try:
+            try:
+                result = _chat_once()
+            except Exception as e:
+                if not _is_auth_error(e):
+                    raise
+                logger.warning(
+                    "Honcho dialectic query hit an auth error; forcing token "
+                    "refresh and retrying once: %s", e,
+                )
+                if not self._force_reauth():
+                    self._record_auth_failure(e)
+                    raise HonchoAuthError(_auth_error_message(e)) from e
+                try:
+                    result = _chat_once()
+                except Exception as retry_exc:
+                    if _is_auth_error(retry_exc):
+                        self._record_auth_failure(retry_exc)
+                        raise HonchoAuthError(_auth_error_message(retry_exc)) from retry_exc
+                    raise
+
+            self._clear_auth_failure()
             # Only automatic injection uses the Hermes-side character cap.
             if (
                 apply_injection_cap
@@ -682,6 +809,8 @@ class HonchoSessionManager:
             ):
                 result = result[:self._dialectic_max_chars].rsplit(" ", 1)[0] + " …"
             return result
+        except HonchoAuthError:
+            raise
         except Exception as e:
             logger.warning("Honcho dialectic query failed: %s", e)
             return ""

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -828,3 +828,160 @@ class TestToolAuthVisibility:
         out = self._provider(_Mgr()).handle_tool_call("honcho_profile", {})
         assert "No profile facts" not in out
         assert "authentication failed" in out
+
+
+# ---------------------------------------------------------------------------
+# initialization-time auth failures: the notice must survive the manager discard
+# ---------------------------------------------------------------------------
+
+
+def _healthy_client():
+    """A mock SDK client whose peers and sessions behave like an empty backend."""
+    client = MagicMock()
+    peer = MagicMock()
+    peer.chat.return_value = ""
+    peer.get_card.return_value = None
+    peer.context.return_value = SimpleNamespace(representation="", peer_card=[])
+    client.peer.return_value = peer
+    sdk_session = MagicMock()
+    sdk_session.context.return_value = SimpleNamespace(summary=None, messages=[])
+    client.session.return_value = sdk_session
+    return client
+
+
+def _wire_init(tmp_path, monkeypatch, client, *, recall_mode="hybrid", dead_refresh=True):
+    """Route provider initialization through a real manager backed by ``client``."""
+    from plugins.memory.honcho import client as client_mod
+    from plugins.memory.honcho import session as session_mod
+
+    path = tmp_path / "honcho.json"
+    _write(path, {"hosts": {"hermes": _host_block(expires_at=time.time() + 3600)}})
+    monkeypatch.setattr(client_mod, "resolve_config_path", lambda: path)
+    monkeypatch.setattr(client_mod, "get_honcho_client", lambda *a, **k: client)
+    monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
+    if dead_refresh:
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+    cfg = HonchoClientConfig(
+        host="hermes", api_key="hch-at-old", enabled=True, recall_mode=recall_mode,
+        timeout=0.5, session_strategy="per-session",
+    )
+    monkeypatch.setattr(
+        client_mod.HonchoClientConfig, "from_global_config", lambda *a, **k: cfg
+    )
+    return path
+
+
+def _initialized_provider():
+    provider = HonchoMemoryProvider()
+    provider.initialize(session_id="init-auth-session")
+    if provider._init_thread:
+        provider._init_thread.join(timeout=5)
+    return provider
+
+
+class TestInitAuthFailureNotice:
+    def test_peer_setup_401_in_hybrid_mode_produces_notice(self, tmp_path, monkeypatch):
+        client = MagicMock()
+        client.peer.side_effect = Exception("HTTP 401 Unauthorized")
+        _wire_init(tmp_path, monkeypatch, client)
+        provider = _initialized_provider()
+
+        assert provider._manager is None
+        notice = provider.prefetch("what did we decide about the schema?")
+        assert "hermes honcho setup" in notice
+        assert "paused" in notice
+
+    def test_notice_is_emitted_exactly_once(self, tmp_path, monkeypatch):
+        client = MagicMock()
+        client.peer.side_effect = Exception("HTTP 401 Unauthorized")
+        _wire_init(tmp_path, monkeypatch, client)
+        provider = _initialized_provider()
+
+        assert "hermes honcho setup" in provider.prefetch("first question")
+        # Retries keep failing, but the same episode never re-arms the notice.
+        for query in ("second question", "third question"):
+            assert provider.prefetch(query) == ""
+
+    def test_dead_grant_during_session_setup_produces_notice(self, tmp_path, monkeypatch):
+        client = _healthy_client()
+        env = {}
+
+        def _session_dies(*a, **k):
+            path = env["path"]
+            block = json.loads(path.read_text())["hosts"]["hermes"]
+            cred = oauth.OAuthCredential.from_host_block(block)
+            oauth._mark_grant_dead((str(path), "hermes"), cred)
+            raise Exception("Invalid or expired access token")
+
+        client.session.side_effect = _session_dies
+        env["path"] = _wire_init(tmp_path, monkeypatch, client, dead_refresh=False)
+        provider = _initialized_provider()
+
+        assert provider._manager is None
+        assert client.peer.called  # failure hit session setup, not peer setup
+        notice = provider.prefetch("what happened before the grant died?")
+        assert "hermes honcho setup" in notice
+
+    def test_tools_lazy_init_reports_auth_error(self, tmp_path, monkeypatch):
+        client = MagicMock()
+        client.peer.side_effect = Exception("Invalid or expired access token")
+        _wire_init(tmp_path, monkeypatch, client, recall_mode="tools")
+        provider = _initialized_provider()
+
+        out = provider.handle_tool_call("honcho_profile", {})
+        assert "authentication failed" in out
+        assert "could not be initialized" not in out
+
+    def test_relogin_resumes_init_and_clears_failure(self, tmp_path, monkeypatch):
+        client = _healthy_client()
+        client.peer.side_effect = Exception("HTTP 401 Unauthorized")
+        path = _wire_init(tmp_path, monkeypatch, client)
+        provider = _initialized_provider()
+        assert "hermes honcho setup" in provider.prefetch("first question")
+
+        _relogin(path)
+        client.peer.side_effect = None
+        provider.prefetch("after re-login")
+        if provider._init_thread:
+            provider._init_thread.join(timeout=5)
+
+        assert provider._session_initialized is True
+        assert provider._manager is not None
+        assert provider._init_auth_failure is None
+
+    def test_tools_relogin_resumes_without_restart(self, tmp_path, monkeypatch):
+        client = _healthy_client()
+        client.peer.side_effect = Exception("Invalid or expired access token")
+        path = _wire_init(tmp_path, monkeypatch, client, recall_mode="tools")
+        provider = _initialized_provider()
+        assert "authentication failed" in provider.handle_tool_call("honcho_profile", {})
+
+        _relogin(path)
+        client.peer.side_effect = None
+        out = provider.handle_tool_call("honcho_profile", {})
+
+        assert "authentication failed" not in out
+        assert provider._session_initialized is True
+        assert provider._init_auth_failure is None
+
+    def test_non_auth_init_timeout_fails_open_without_notice(self, tmp_path, monkeypatch):
+        client = MagicMock()
+        client.peer.side_effect = TimeoutError("request timed out")
+        _wire_init(tmp_path, monkeypatch, client, dead_refresh=False)
+        reauths = []
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: reauths.append(1))
+        provider = _initialized_provider()
+
+        assert provider._manager is None
+        assert provider._init_auth_failure is None
+        assert provider.prefetch("a real question") == ""
+        assert reauths == []
+
+    def test_non_auth_tools_init_failure_keeps_generic_error(self, tmp_path, monkeypatch):
+        client = MagicMock()
+        client.peer.side_effect = TimeoutError("request timed out")
+        _wire_init(tmp_path, monkeypatch, client, recall_mode="tools", dead_refresh=False)
+        provider = _initialized_provider()
+
+        out = provider.handle_tool_call("honcho_profile", {})
+        assert "could not be initialized" in out

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -399,6 +399,82 @@ class TestSyncAuthRetry:
 
 
 # ---------------------------------------------------------------------------
+# dead grant: skip calls entirely until re-login
+# ---------------------------------------------------------------------------
+
+
+def _kill_grant(tmp_path, monkeypatch) -> Path:
+    """Revoke the grant on a tmp config and point the manager's path at it."""
+    from plugins.memory.honcho import client as client_mod
+
+    path = tmp_path / "honcho.json"
+    _write(path, {"hosts": {"hermes": _host_block()}})
+    monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(
+        oauth, "_http_post_form_status",
+        lambda *a, **k: (400, {"error": "invalid_grant"}),
+    )
+    oauth.ensure_fresh_token(path, "hermes", now=1000)
+    assert oauth.reauth_required(path, "hermes") is True
+    monkeypatch.setattr(client_mod, "resolve_config_path", lambda: path)
+    return path
+
+
+def _relogin(path: Path) -> None:
+    oauth.install_grant(
+        path, "hermes",
+        {"access_token": "hch-at-fresh", "refresh_token": "hch-rt-fresh", "expires_in": 3600},
+        client_id="hermes-desktop",
+        token_endpoint="http://localhost:8000/oauth/token",
+    )
+
+
+class TestDeadGrantSkipsCalls:
+    def test_dead_grant_issues_no_dialectic_call(self, tmp_path, monkeypatch):
+        _kill_grant(tmp_path, monkeypatch)
+        peer = _FlakyPeer(failures=0)
+        mgr = _make_manager(peer)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert peer.calls == 0
+        assert mgr.pop_auth_notice() is not None
+
+    def test_relogin_resumes_dialectic_without_waiting(self, tmp_path, monkeypatch):
+        path = _kill_grant(tmp_path, monkeypatch)
+        peer = _FlakyPeer(failures=0)
+        mgr = _make_manager(peer)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert peer.calls == 0
+
+        _relogin(path)
+        assert mgr.dialectic_query("k", "q") == "synthesized answer"
+        assert peer.calls == 1
+        assert mgr._auth_failure is None
+
+    def test_dead_grant_issues_no_sync_call(self, tmp_path, monkeypatch):
+        _kill_grant(tmp_path, monkeypatch)
+        flaky = _FlakyHonchoSession(failures=0)
+        mgr, session = _make_sync_manager(flaky)
+        assert mgr._flush_session(session) is False
+        assert flaky.calls == 0
+        assert mgr._auth_failure is not None
+
+    def test_relogin_resumes_sync_without_waiting(self, tmp_path, monkeypatch):
+        path = _kill_grant(tmp_path, monkeypatch)
+        flaky = _FlakyHonchoSession(failures=0)
+        mgr, session = _make_sync_manager(flaky)
+        assert mgr._flush_session(session) is False
+        assert flaky.calls == 0
+
+        _relogin(path)
+        assert mgr._flush_session(session) is True
+        assert flaky.calls == 1
+        assert all(m["_synced"] for m in session.messages)
+        assert mgr._auth_failure is None
+
+
+# ---------------------------------------------------------------------------
 # one-time user-facing notice
 # ---------------------------------------------------------------------------
 

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -572,3 +572,259 @@ class TestBackoffExemption:
         provider = HonchoMemoryProvider()
         provider._note_dialectic_failure(RuntimeError("timeout"))
         assert provider._dialectic_empty_streak == 1
+
+
+# ---------------------------------------------------------------------------
+# session: context/search 401 recovery through _authed_call
+# ---------------------------------------------------------------------------
+
+
+class _FlakyContextPeer:
+    """context() raises an auth error N times, then succeeds."""
+
+    def __init__(self, failures: int, representation: str = "knows Python"):
+        self.failures = failures
+        self.representation = representation
+        self.calls = 0
+
+    def context(self, **kw):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise Exception("Invalid or expired access token")
+        return SimpleNamespace(representation=self.representation, peer_card=["fact one"])
+
+
+class TestContextAuthRetry:
+    def test_401_forces_refresh_and_retries_once(self):
+        peer = _FlakyContextPeer(failures=1)
+        mgr = _make_manager(peer)
+        ctx = mgr.get_session_context("k")
+        assert ctx["representation"] == "knows Python"
+        assert peer.calls == 2  # original + one retry
+
+    def test_persistent_401_records_failure_and_notices_once(self):
+        peer = _FlakyContextPeer(failures=99)
+        mgr = _make_manager(peer)
+        with pytest.raises(HonchoAuthError):
+            mgr.get_session_context("k")
+        assert peer.calls == 2  # exactly one retry, no loop
+        assert mgr._auth_failure is not None
+        assert mgr.pop_auth_notice() is not None
+        assert mgr.pop_auth_notice() is None
+
+    def test_peer_card_401_raises_instead_of_reading_empty(self):
+        class _FlakyCardPeer:
+            calls = 0
+
+            def get_card(self, **kw):
+                type(self).calls += 1
+                raise Exception("Invalid or expired access token")
+
+        mgr = _make_manager(_FlakyCardPeer(), reauth_ok=False)
+        with pytest.raises(HonchoAuthError):
+            mgr.get_peer_card("k")
+        assert _FlakyCardPeer.calls == 1
+
+
+class TestDeadGrantSkipsContextAndSearch:
+    def test_dead_grant_issues_no_context_call(self, tmp_path, monkeypatch):
+        _kill_grant(tmp_path, monkeypatch)
+        peer = _FlakyContextPeer(failures=0)
+        mgr = _make_manager(peer)
+        with pytest.raises(HonchoAuthError):
+            mgr.get_session_context("k")
+        assert peer.calls == 0
+
+    def test_dead_grant_issues_no_search_call(self, tmp_path, monkeypatch):
+        from plugins.memory.honcho import session as session_mod
+
+        _kill_grant(tmp_path, monkeypatch)
+        client = MagicMock()
+        monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
+        mgr = _make_manager(_FlakyContextPeer(failures=0))
+        with pytest.raises(HonchoAuthError):
+            mgr.search_context("k", "query")
+        client.search.assert_not_called()
+
+    def test_dead_grant_prefetch_returns_empty_and_arms_notice(self, tmp_path, monkeypatch):
+        _kill_grant(tmp_path, monkeypatch)
+        peer = _FlakyContextPeer(failures=0)
+        mgr = _make_manager(peer)
+        assert mgr.get_prefetch_context("k") == {}
+        assert peer.calls == 0
+        assert mgr.pop_auth_notice() is not None
+
+
+class TestNonAuthFailuresNotRetried:
+    def test_context_timeout_fails_open_without_refresh(self):
+        class _TimeoutPeer:
+            calls = 0
+
+            def _fail(self):
+                type(self).calls += 1
+                raise TimeoutError("request timed out")
+
+            def context(self, **kw):
+                self._fail()
+
+            def representation(self, **kw):
+                self._fail()
+
+            def get_card(self, **kw):
+                self._fail()
+
+        _TimeoutPeer.calls = 0
+        mgr = _make_manager(_TimeoutPeer())
+        reauths = []
+        mgr._force_reauth = lambda: reauths.append(1) or True
+
+        ctx = mgr.get_session_context("k")
+        assert ctx == {"representation": "", "card": []}
+        assert _TimeoutPeer.calls == 3  # context, representation, card — no retries
+        assert reauths == []
+
+    def test_search_timeout_fails_open_without_refresh(self, monkeypatch):
+        from plugins.memory.honcho import session as session_mod
+
+        class _TimeoutSearchPeer:
+            calls = 0
+
+            def search(self, *a, **kw):
+                type(self).calls += 1
+                raise TimeoutError("request timed out")
+
+        _TimeoutSearchPeer.calls = 0
+        client = MagicMock()
+        client.search.side_effect = TimeoutError("request timed out")
+        monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
+        mgr = _make_manager(_TimeoutSearchPeer())
+        reauths = []
+        mgr._force_reauth = lambda: reauths.append(1) or True
+
+        assert mgr.search_context("k", "q") == ""
+        assert client.search.call_count == 1
+        assert _TimeoutSearchPeer.calls == 1
+        assert reauths == []
+
+
+# ---------------------------------------------------------------------------
+# client rebuild: the retry must use freshly resolved SDK objects
+# ---------------------------------------------------------------------------
+
+
+def _wire_rebuild(tmp_path, monkeypatch, fresh_client):
+    """Route _force_reauth down its client-rebuild path, swapping in fresh_client."""
+    from plugins.memory.honcho import client as client_mod
+    from plugins.memory.honcho import session as session_mod
+
+    clients = {"current": MagicMock()}
+    monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: clients["current"])
+    monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
+    monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-rotated")
+    monkeypatch.setattr(oauth, "apply_token_to_client", lambda c, t: False)
+    monkeypatch.setattr(
+        client_mod, "reset_honcho_client",
+        lambda: clients.__setitem__("current", fresh_client),
+    )
+    return clients
+
+
+class TestClientRebuildRetry:
+    def test_flush_retry_uses_rebuilt_session_not_stale(self, tmp_path, monkeypatch):
+        stale_session = MagicMock()
+        stale_session.add_messages.side_effect = Exception("Invalid or expired access token")
+        stale_peer = MagicMock()
+        stale_peer.message.side_effect = lambda content: content
+
+        fresh_session = MagicMock()
+        fresh_session.context.return_value = SimpleNamespace(summary=None, messages=[])
+        fresh_peer = MagicMock()
+        fresh_peer.message.side_effect = lambda content: content
+        fresh_client = MagicMock()
+        fresh_client.session.return_value = fresh_session
+        fresh_client.peer.return_value = fresh_peer
+
+        _wire_rebuild(tmp_path, monkeypatch, fresh_client)
+
+        cfg = HonchoClientConfig(host="hermes", api_key="hch-at-x", enabled=True)
+        mgr = HonchoSessionManager(config=cfg)
+        mgr._peers_cache.update({"u": stale_peer, "a": stale_peer})
+        mgr._sessions_cache["s"] = stale_session
+        session = HonchoSession(
+            key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s"
+        )
+        session.add_message("user", "hello")
+        session.add_message("assistant", "hi")
+
+        assert mgr._flush_session(session) is True
+        # The stale pre-rebuild session must not be retried.
+        assert stale_session.add_messages.call_count == 1
+        assert fresh_session.add_messages.call_count == 1
+        assert all(m["_synced"] for m in session.messages)
+        assert mgr._auth_failure is None
+
+    def test_context_retry_uses_rebuilt_peer_not_stale(self, tmp_path, monkeypatch):
+        stale_peer = MagicMock()
+        stale_peer.context.side_effect = Exception("Invalid or expired access token")
+
+        fresh_peer = MagicMock()
+        fresh_peer.context.return_value = SimpleNamespace(
+            representation="rep after rebuild", peer_card=["fact"]
+        )
+        fresh_client = MagicMock()
+        fresh_client.peer.return_value = fresh_peer
+
+        _wire_rebuild(tmp_path, monkeypatch, fresh_client)
+
+        cfg = HonchoClientConfig(host="hermes", api_key="hch-at-x", enabled=True)
+        mgr = HonchoSessionManager(config=cfg)
+        mgr._peers_cache["u"] = stale_peer
+        mgr._cache["k"] = HonchoSession(
+            key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s"
+        )
+
+        ctx = mgr.get_session_context("k")
+        assert ctx["representation"] == "rep after rebuild"
+        assert stale_peer.context.call_count == 1
+        assert fresh_peer.context.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# tools: auth failures must never read as "no context"
+# ---------------------------------------------------------------------------
+
+
+class TestToolAuthVisibility:
+    def _provider(self, manager):
+        provider = HonchoMemoryProvider()
+        provider._manager = manager
+        provider._session_key = "k"
+        provider._session_initialized = True
+        return provider
+
+    def test_context_tool_reports_auth_failure(self):
+        class _Mgr:
+            def get_session_context(self, key, peer="user"):
+                raise HonchoAuthError("Honcho rejected our credentials")
+
+        out = self._provider(_Mgr()).handle_tool_call("honcho_context", {})
+        assert "No context available" not in out
+        assert "authentication failed" in out
+
+    def test_search_tool_reports_auth_failure(self):
+        class _Mgr:
+            def search_context(self, key, query, max_tokens=800, peer="user"):
+                raise HonchoAuthError("Honcho rejected our credentials")
+
+        out = self._provider(_Mgr()).handle_tool_call("honcho_search", {"query": "schema"})
+        assert "No relevant context found" not in out
+        assert "authentication failed" in out
+
+    def test_profile_tool_reports_auth_failure_not_empty_profile(self):
+        class _Mgr:
+            def get_peer_card(self, key, peer="user"):
+                raise HonchoAuthError("Honcho rejected our credentials")
+
+        out = self._provider(_Mgr()).handle_tool_call("honcho_profile", {})
+        assert "No profile facts" not in out
+        assert "authentication failed" in out

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -222,6 +222,32 @@ class TestAuthErrorDetection:
         assert not _is_auth_error(Exception("connection reset by peer"))
         assert not _is_auth_error(Exception("HTTP 500 internal error"))
 
+    def test_bare_401_digits_are_not_auth_errors(self):
+        """A false positive spends a token rotation and can revoke the grant;
+        digits appearing in latency figures, request ids, or identifiers must
+        never classify as auth failures."""
+        for msg in (
+            "Rate limited, retry after 4010 ms",
+            "500 Internal Server Error (request id req-4012ab)",
+            "connection timeout to workspace ws-401-prod",
+            "peer 401k-planning not found",
+        ):
+            assert not _is_auth_error(Exception(msg)), msg
+
+    def test_401_with_http_context_matches(self):
+        assert _is_auth_error(Exception("HTTP 401"))
+        assert _is_auth_error(Exception("status 401"))
+        assert _is_auth_error(Exception("status_code: 401"))
+        assert _is_auth_error(Exception("401 Unauthorized"))
+
+    def test_concrete_non_auth_status_wins_over_text(self):
+        exc = Exception("authentication failed")
+        exc.status = 429
+        assert not _is_auth_error(exc)
+
+    def test_bare_authentication_word_is_not_enough(self):
+        assert not _is_auth_error(Exception("authentication service unreachable"))
+
 
 # ---------------------------------------------------------------------------
 # session: dialectic 401 recovery
@@ -494,6 +520,13 @@ class TestAuthNotice:
         with pytest.raises(HonchoAuthError):
             mgr.dialectic_query("k", "q")
         assert mgr.pop_auth_notice() is None
+
+    def test_recorded_failure_and_notice_redact_token_values(self):
+        mgr = _make_manager(_FlakyPeer(failures=0))
+        mgr._record_auth_failure(Exception("rejected token hch-at-secretvalue99"))
+        notice = mgr.pop_auth_notice()
+        assert "secretvalue99" not in notice
+        assert "hch-at-[redacted]" in notice
 
     def test_provider_prefetch_injects_notice_once(self):
         class _FakeManager:

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -1,0 +1,465 @@
+"""Tests for OAuth 401 recovery: prompt exchange retry, invalid_grant handling,
+forced refresh + single retry on sync and dialectic, backoff exemption, and
+the one-time user-facing notice."""
+
+import json
+import logging
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho import oauth
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import (
+    HonchoAuthError,
+    HonchoSession,
+    HonchoSessionManager,
+    _is_auth_error,
+)
+
+
+def _host_block(refresh="hch-rt-old", expires_at=100):
+    return {
+        "apiKey": "hch-at-old",
+        "oauth": {
+            "refreshToken": refresh,
+            "expiresAt": expires_at,
+            "clientId": "hermes-desktop",
+            "tokenEndpoint": "http://localhost:8000/oauth/token",
+            "scope": "write",
+            "tokenType": "Bearer",
+        },
+    }
+
+
+def _write(path: Path, raw: dict) -> None:
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+
+def _rotated_body(n=1):
+    return {
+        "access_token": f"hch-at-new{n}",
+        "refresh_token": f"hch-rt-new{n}",
+        "expires_in": 3600,
+        "scope": "write",
+        "token_type": "Bearer",
+    }
+
+
+# ---------------------------------------------------------------------------
+# oauth: transient vs permanent exchange failures
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeRetry:
+    def test_transient_failure_recovers_on_immediate_retry(self, tmp_path, monkeypatch):
+        """A timed-out exchange retries right away — the server honors the
+        replayed refresh token only within its rotation grace window."""
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block()}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+
+        calls = []
+
+        def flaky(url, data, timeout):
+            calls.append(data["refresh_token"])
+            if len(calls) == 1:
+                raise TimeoutError("token exchange timed out")
+            return 200, _rotated_body()
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", flaky)
+        token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=1000)
+
+        assert token == "hch-at-new1" and refreshed is True
+        assert calls == ["hch-rt-old", "hch-rt-old"]
+        saved = json.loads(path.read_text())["hosts"]["hermes"]
+        assert saved["oauth"]["refreshToken"] == "hch-rt-new1"
+
+    def test_invalid_grant_stops_retries_and_marks_reauth_required(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block()}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+
+        calls = []
+
+        def revoked(url, data, timeout):
+            calls.append(1)
+            return 400, {"error": "invalid_grant", "error_description": "grant revoked"}
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", revoked)
+        token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=1000)
+
+        # Fail-open return, but no retry of a permanently rejected grant.
+        assert token == "hch-at-old" and refreshed is False
+        assert len(calls) == 1
+        assert oauth.reauth_required(path, "hermes") is True
+
+        # Later refresh attempts skip the endpoint entirely.
+        token2, refreshed2 = oauth.ensure_fresh_token(path, "hermes", now=2000)
+        assert token2 == "hch-at-old" and refreshed2 is False
+        assert len(calls) == 1
+
+        # The forced (post-401) path refuses a dead grant too.
+        assert oauth.force_refresh_token(path, "hermes") is None
+        assert len(calls) == 1
+
+    def test_relogin_clears_the_dead_grant(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block()}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: (400, {"error": "invalid_grant"}),
+        )
+        oauth.ensure_fresh_token(path, "hermes", now=1000)
+        assert oauth.reauth_required(path, "hermes") is True
+
+        oauth.install_grant(
+            path, "hermes",
+            {"access_token": "hch-at-fresh", "refresh_token": "hch-rt-fresh", "expires_in": 3600},
+            client_id="hermes-desktop",
+            token_endpoint="http://localhost:8000/oauth/token",
+            now=2000,
+        )
+        assert oauth.reauth_required(path, "hermes") is False
+        token, _ = oauth.ensure_fresh_token(path, "hermes", now=2000)
+        assert token == "hch-at-fresh"
+
+    def test_error_body_is_logged(self, tmp_path, monkeypatch, caplog):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block()}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: (400, {"error": "invalid_grant", "error_description": "grant revoked"}),
+        )
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.honcho.oauth"):
+            oauth.ensure_fresh_token(path, "hermes", now=1000)
+        assert "invalid_grant" in caplog.text
+        assert "grant revoked" in caplog.text
+
+    def test_redaction_strips_token_values(self):
+        redacted = oauth._redact_tokens(
+            "exchange failed for hch-rt-supersecret123 got hch-at-alsosecret456"
+        )
+        assert "supersecret123" not in redacted
+        assert "alsosecret456" not in redacted
+        assert "hch-rt-[redacted]" in redacted
+        assert "hch-at-[redacted]" in redacted
+
+
+class TestForceRefreshToken:
+    def test_rotates_despite_local_validity(self, tmp_path, monkeypatch):
+        """A server-side 401 forces a rotation even when the local clock says
+        the token is still live."""
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=time.time() + 3600)}})
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status", lambda *a, **k: (200, _rotated_body())
+        )
+        token = oauth.force_refresh_token(path, "hermes")
+        assert token == "hch-at-new1"
+        saved = json.loads(path.read_text())["hosts"]["hermes"]
+        assert saved["apiKey"] == "hch-at-new1"
+
+    def test_adopts_concurrent_rotation_without_exchange(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        far = time.time() + 7200
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
+        # Seed the expiry cache with the old token.
+        oauth.ensure_fresh_token(path, "hermes")
+        # Another process rotated the credential on disk.
+        rotated = _host_block(refresh="hch-rt-2", expires_at=far)
+        rotated["apiKey"] = "hch-at-2"
+        _write(path, {"hosts": {"hermes": rotated}})
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: pytest.fail("must adopt the on-disk rotation, not exchange"),
+        )
+        assert oauth.force_refresh_token(path, "hermes") == "hch-at-2"
+
+    def test_transient_failure_returns_none(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=time.time() + 3600)}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+
+        def boom(*a, **k):
+            raise ConnectionError("network down")
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", boom)
+        assert oauth.force_refresh_token(path, "hermes") is None
+        # Not permanent: a later attempt may exchange again.
+        assert oauth.reauth_required(path, "hermes") is False
+
+    def test_static_api_key_is_noop(self, tmp_path):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": {"apiKey": "hch-v3-static"}}})
+        assert oauth.force_refresh_token(path, "hermes") is None
+
+
+# ---------------------------------------------------------------------------
+# session: auth error detection
+# ---------------------------------------------------------------------------
+
+
+class TestAuthErrorDetection:
+    def test_matches_honcho_token_message(self):
+        assert _is_auth_error(Exception("Invalid or expired access token"))
+
+    def test_matches_status_code_attr(self):
+        exc = Exception("boom")
+        exc.status_code = 401
+        assert _is_auth_error(exc)
+
+    def test_matches_401_text(self):
+        assert _is_auth_error(Exception("HTTP 401 Unauthorized"))
+
+    def test_ignores_other_errors(self):
+        assert not _is_auth_error(Exception("connection reset by peer"))
+        assert not _is_auth_error(Exception("HTTP 500 internal error"))
+
+
+# ---------------------------------------------------------------------------
+# session: dialectic 401 recovery
+# ---------------------------------------------------------------------------
+
+
+class _FlakyPeer:
+    """chat() raises an auth error N times, then succeeds."""
+
+    def __init__(self, failures: int, result: str = "synthesized answer"):
+        self.failures = failures
+        self.result = result
+        self.calls = 0
+
+    def chat(self, query, **kw):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise Exception("Invalid or expired access token")
+        return self.result
+
+
+def _make_manager(peer, *, reauth_ok=True):
+    cfg = HonchoClientConfig(host="hermes", api_key="hch-at-x", enabled=True)
+    mgr = HonchoSessionManager(config=cfg)
+    session = HonchoSession(
+        key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s"
+    )
+    mgr._cache["k"] = session
+    mgr._get_or_create_peer = lambda peer_id: peer
+    mgr._force_reauth = lambda: reauth_ok
+    return mgr
+
+
+class TestDialecticAuthRetry:
+    def test_401_forces_refresh_and_retries_once(self):
+        peer = _FlakyPeer(failures=1)
+        mgr = _make_manager(peer)
+        assert mgr.dialectic_query("k", "who is this user?") == "synthesized answer"
+        assert peer.calls == 2  # original + one retry
+
+    def test_persistent_401_raises_auth_error(self):
+        peer = _FlakyPeer(failures=99)
+        mgr = _make_manager(peer)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert peer.calls == 2  # exactly one retry, no loop
+
+    def test_failed_reauth_raises_without_retry(self):
+        peer = _FlakyPeer(failures=99)
+        mgr = _make_manager(peer, reauth_ok=False)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert peer.calls == 1  # no retry without a fresh token
+
+    def test_non_auth_errors_stay_fail_open(self):
+        class _BrokenPeer:
+            def chat(self, *a, **kw):
+                raise Exception("connection reset by peer")
+
+        mgr = _make_manager(_BrokenPeer())
+        assert mgr.dialectic_query("k", "q") == ""
+
+    def test_success_after_failure_clears_auth_state(self):
+        peer = _FlakyPeer(failures=99)
+        mgr = _make_manager(peer, reauth_ok=False)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert mgr._auth_failure is not None
+
+        peer.failures = 0
+        mgr._force_reauth = lambda: True
+        assert mgr.dialectic_query("k", "q") == "synthesized answer"
+        assert mgr._auth_failure is None
+        assert mgr.pop_auth_notice() is None
+
+
+class TestForceReauth:
+    def test_rotates_and_applies_to_live_client(self, tmp_path, monkeypatch):
+        from plugins.memory.honcho import client as client_mod
+        from plugins.memory.honcho import session as session_mod
+
+        fake_client = object()
+        applied = {}
+        monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: fake_client)
+        monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-new")
+
+        def apply(client, token):
+            applied["client"] = client
+            applied["token"] = token
+            return True
+
+        monkeypatch.setattr(oauth, "apply_token_to_client", apply)
+
+        mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
+        assert mgr._force_reauth() is True
+        assert applied == {"client": fake_client, "token": "hch-at-new"}
+
+    def test_returns_false_when_refresh_yields_nothing(self, tmp_path, monkeypatch):
+        from plugins.memory.honcho import client as client_mod
+
+        monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+        mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
+        assert mgr._force_reauth() is False
+
+
+# ---------------------------------------------------------------------------
+# session: message sync 401 recovery
+# ---------------------------------------------------------------------------
+
+
+class _FlakyHonchoSession:
+    """add_messages() raises an auth error N times, then succeeds."""
+
+    def __init__(self, failures: int):
+        self.failures = failures
+        self.calls = 0
+
+    def add_messages(self, messages):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise Exception("Invalid or expired access token")
+
+
+def _make_sync_manager(flaky_session, *, reauth_ok=True):
+    cfg = HonchoClientConfig(host="hermes", api_key="hch-at-x", enabled=True)
+    mgr = HonchoSessionManager(config=cfg)
+    peer = MagicMock()
+    peer.message.side_effect = lambda content: content
+    mgr._get_or_create_peer = lambda peer_id: peer
+    mgr._sessions_cache["s"] = flaky_session
+    mgr._force_reauth = lambda: reauth_ok
+    session = HonchoSession(
+        key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s"
+    )
+    session.add_message("user", "hello")
+    session.add_message("assistant", "hi")
+    return mgr, session
+
+
+class TestSyncAuthRetry:
+    def test_401_forces_refresh_and_retries_once(self):
+        flaky = _FlakyHonchoSession(failures=1)
+        mgr, session = _make_sync_manager(flaky)
+        assert mgr._flush_session(session) is True
+        assert flaky.calls == 2
+        assert all(m["_synced"] for m in session.messages)
+
+    def test_persistent_401_fails_and_records_auth_failure(self):
+        flaky = _FlakyHonchoSession(failures=99)
+        mgr, session = _make_sync_manager(flaky)
+        assert mgr._flush_session(session) is False
+        assert flaky.calls == 2  # exactly one retry, no loop
+        assert not any(m.get("_synced") for m in session.messages)
+        assert mgr._auth_failure is not None
+
+    def test_failed_reauth_fails_without_retry(self):
+        flaky = _FlakyHonchoSession(failures=99)
+        mgr, session = _make_sync_manager(flaky, reauth_ok=False)
+        assert mgr._flush_session(session) is False
+        assert flaky.calls == 1
+        assert mgr._auth_failure is not None
+
+    def test_later_success_recovers_and_clears_auth_state(self):
+        flaky = _FlakyHonchoSession(failures=2)
+        mgr, session = _make_sync_manager(flaky, reauth_ok=False)
+        assert mgr._flush_session(session) is False
+        assert mgr._auth_failure is not None
+
+        mgr._force_reauth = lambda: True
+        assert mgr._flush_session(session) is True
+        assert all(m["_synced"] for m in session.messages)
+        assert mgr._auth_failure is None
+
+
+# ---------------------------------------------------------------------------
+# one-time user-facing notice
+# ---------------------------------------------------------------------------
+
+
+class TestAuthNotice:
+    def test_manager_emits_notice_exactly_once(self):
+        peer = _FlakyPeer(failures=99)
+        mgr = _make_manager(peer, reauth_ok=False)
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+
+        first = mgr.pop_auth_notice()
+        assert first and "Invalid or expired access token" in first
+        assert mgr.pop_auth_notice() is None
+
+        # A second failure inside the same episode does not re-arm the notice.
+        with pytest.raises(HonchoAuthError):
+            mgr.dialectic_query("k", "q")
+        assert mgr.pop_auth_notice() is None
+
+    def test_provider_prefetch_injects_notice_once(self):
+        class _FakeManager:
+            def __init__(self):
+                self.notices = ["Invalid or expired access token"]
+
+            def pop_auth_notice(self):
+                return self.notices.pop() if self.notices else None
+
+            def pop_context_result(self, session_key):
+                return {}
+
+        provider = HonchoMemoryProvider()
+        provider._manager = _FakeManager()
+        provider._config = SimpleNamespace(timeout=0.01, context_tokens=0)
+        provider._session_key = "k"
+        provider._session_initialized = True
+        provider._recall_mode = "context"
+        provider._turn_count = 2
+        provider._last_dialectic_turn = 0
+        provider._base_context_cache = ""
+
+        first = provider.prefetch("what did we decide about the schema?")
+        assert "hermes honcho setup" in first
+        assert "paused" in first
+
+        second = provider.prefetch("and the follow-up question?")
+        assert second == ""
+
+
+# ---------------------------------------------------------------------------
+# cadence backoff exemption
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffExemption:
+    def test_auth_error_does_not_widen_backoff(self):
+        provider = HonchoMemoryProvider()
+        provider._note_dialectic_failure(HonchoAuthError("still 401 after refresh"))
+        assert provider._dialectic_empty_streak == 0
+
+    def test_other_errors_still_widen_backoff(self):
+        provider = HonchoMemoryProvider()
+        provider._note_dialectic_failure(RuntimeError("timeout"))
+        assert provider._dialectic_empty_streak == 1

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -69,7 +69,7 @@ class TestEnsureFreshToken:
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"hermes": _host_block(expires_at=10_000)}})
         monkeypatch.setattr(
-            oauth, "_http_post_form",
+            oauth, "_http_post_form_status",
             lambda *a, **k: pytest.fail("refresh must not be called when fresh"),
         )
         token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=0)
@@ -84,7 +84,7 @@ class TestEnsureFreshToken:
             assert data["grant_type"] == "refresh_token"
             assert data["refresh_token"] == "hch-rt-old"
             assert data["client_id"] == "hermes-desktop"
-            return {
+            return 200, {
                 "access_token": "hch-at-new",
                 "refresh_token": "hch-rt-new",
                 "expires_in": 3600,
@@ -92,7 +92,7 @@ class TestEnsureFreshToken:
                 "token_type": "Bearer",
             }
 
-        monkeypatch.setattr(oauth, "_http_post_form", fake_post)
+        monkeypatch.setattr(oauth, "_http_post_form_status", fake_post)
         token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=1000)
         assert token == "hch-at-new" and refreshed is True
 
@@ -105,14 +105,20 @@ class TestEnsureFreshToken:
     def test_refresh_failure_fails_open(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"hermes": _host_block(expires_at=100)}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+
+        calls = []
 
         def boom(*a, **k):
+            calls.append(a)
             raise RuntimeError("network down")
 
-        monkeypatch.setattr(oauth, "_http_post_form", boom)
+        monkeypatch.setattr(oauth, "_http_post_form_status", boom)
         token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=1000)
-        # Stale token returned, no crash, file untouched.
+        # Stale token returned, no crash, file untouched. Transient failures
+        # retry exactly once, then fail open.
         assert token == "hch-at-old" and refreshed is False
+        assert len(calls) == 2
         assert json.loads(path.read_text())["hosts"]["hermes"]["apiKey"] == "hch-at-old"
 
     def test_double_check_uses_disk_when_already_rotated(self, tmp_path, monkeypatch):
@@ -123,7 +129,7 @@ class TestEnsureFreshToken:
         stale_raw = {"hosts": {"hermes": _host_block(refresh="hch-rt-old", expires_at=100)}}
         stale_raw["hosts"]["hermes"]["apiKey"] = "hch-at-stale"
         monkeypatch.setattr(
-            oauth, "_http_post_form",
+            oauth, "_http_post_form_status",
             lambda *a, **k: pytest.fail("must not refresh; disk token is fresh"),
         )
         token, refreshed = oauth.ensure_fresh_token(path, "hermes", stale_raw, now=1000)


### PR DESCRIPTION
## Symptom

Token refresh works — tokens rotate on schedule and both the sync and dialectic paths pick up the new one. What is missing is a recovery path for the times a refresh does not go through. When an exchange fails, Hermes keeps the stale token, every later memory call gets a 401, and the session carries on without telling anyone memory has stopped.

From a ~7-hour session (hermes 0.20.0), repeating for the rest of the session once a refresh failed:

```
Failed to sync messages to Honcho: Invalid or expired access token
Honcho dialectic query failed: Invalid or expired access token
```

## Root cause

Refresh is not missing. #44335 added it and `get_honcho_client()` calls `_refresh_cached_oauth()` on every cached acquisition, so both paths already attempt one.

The gap is that a failed exchange had no follow-up. `ensure_fresh_token` caught every failure, logged a warning, and returned the stale token; nothing handled the 401 that followed. Searching `plugins/memory/honcho/` for `401` found only comments, two describing handling that no code performed. So one failed exchange became permanent. `_http_post_form` also discarded the response body, so `invalid_grant` and a transient 5xx were indistinguishable.

Hypothesis for the first failure, not confirmed: the endpoint rotates the refresh token on every exchange and revokes the grant if a superseded one is replayed outside a short grace window. An exchange that times out after the server rotated leaves Hermes holding the old token, and waiting for the next memory call to retry can land outside that window.

## Fix

At the token layer, in `oauth.py`:

- A failed exchange retries promptly rather than on the next memory call, keeping a replay inside the rotation grace window.
- The endpoint's error body is captured. `invalid_grant`, `invalid_client`, `unauthorized_client` mark the grant dead; anything else is transient.
- `reauth_required()` compares the on-disk refresh-token digest, so a new login clears a dead grant with no network call.
- Log paths carrying exception text are redacted.

At the call layer, in `session.py`, one helper — `_authed_call()` — now wraps every runtime call that goes through `HonchoSessionManager`:

1. Skip and raise when the grant is dead, without touching the network.
2. Run the operation.
3. Retry only a confirmed auth failure, once, after a single forced refresh. Non-auth failures propagate untouched and keep today's fail-open behaviour.
4. Record the failure and raise `HonchoAuthError` when the retry also fails; clear the auth state on success.

Operations are passed as closures that re-resolve their own peer and session objects. That matters because a failed in-place token application rebuilds the client and clears the caches — a retry holding an object captured before the refresh would still be bound to the old transport.

Routed through the helper: peer and session setup including `add_peers` and configuration reads, message sync, dialectic queries, prefetch and peer context, representations, peer cards, session context, search and its peer fallback, conclusion create/delete/list, `set_peer_card`, `seed_ai_identity`, and both migration uploads.

Tool-facing reads now raise `HonchoAuthError` rather than returning their empty-result default, and `handle_tool_call` turns that into an explicit error. An auth failure reported as "No context available" is indistinguishable from genuinely having no memory. Background paths keep their existing return contracts and surface the failure through the one-time notice instead.

The user is told once that memory is paused and that `hermes honcho setup` fixes it, and auth failures skip dialectic cadence backoff so recovery is not delayed. That notice also survives a failure during session initialization: the provider keeps the error after the manager is discarded, so context mode still emits the notice and tools mode returns an explicit authentication error rather than a generic initialization failure. A successful re-login lets initialization retry without a restart.

`cli.py::_ensure_peer_exists()` deliberately keeps its direct `client.peer()` call. It runs interactively right after credentials are written, treats the call as best-effort, and prints its own outcome, so the runtime recovery machinery does not apply.

Auth failures are classified by HTTP status first; the text fallback requires HTTP context, so an identifier merely containing `401` is not one. A false positive would spend a token rotation and a lost rotation revokes the grant, so the classifier is biased toward false negatives.

Note on `client.peer()` and `client.session()`: in honcho-ai 2.2.0 these are get-or-create calls that hit the API, so they go through the helper too. A stale comment in this file described peers as lazy.

## Tests

58 tests in `tests/honcho_plugin/test_auth_recovery.py`: transient retry and recovery, `invalid_grant` terminality and clearing on re-login, forced refresh and single retry, the one-time notice, backoff exemption, `401`-digit false positives, token redaction, dead-grant skipping for context and search, tool-facing auth visibility, timeouts staying fail-open, two client-rebuild tests asserting the retry uses newly resolved objects rather than the stale ones, and eight covering an auth failure during session initialization.

`tests/honcho_plugin/` passes at 286, adjacent suites at 90. Merged into current `origin/main` the merge is clean and both suites pass unchanged.

Also driven end to end against a local fake token endpoint: a fresh token makes no network call, an expired one rotates and persists, a 503 retries twice and fails open without marking the grant dead, `invalid_grant` sends nothing further, and a timed-out exchange retries with both attempts inside the grace window.
