### PR TITLE
fix(agent): validate tool_call argument type and unwrap single-element arrays (#58057)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -375,15 +375,9 @@ def sanitize_tool_call_arguments(
             if not isinstance(arguments, str):
                 continue
 
-            try:
-                json.loads(arguments)
-            except json.JSONDecodeError:
-                # Use the canonical ``call_id || id`` precedence so both the
-                # scan for an existing tool result and any inserted stub key
-                # on the same id the rest of the pipeline uses. Keying on bare
-                # ``id`` here would fail to find a result built with ``call_id``
-                # (Codex Responses format) and insert a duplicate stub that
-                # itself becomes an orphan (#58168).
+            def _mark_corrupted(function, tool_call, insert_at):
+                """Replace arguments with {} and inject the corruption marker."""
+                nonlocal repaired
                 tool_call_id = _ra().AIAgent._get_tool_call_id_static(tool_call) or None
                 function_name = function.get("name", "?")
                 # Log the FULL original argument string (bounded), not an
@@ -432,6 +426,26 @@ def sanitize_tool_call_arguments(
                     _prepend_marker(existing_tool_msg)
 
                 repaired += 1
+                return insert_at
+
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                insert_at = _mark_corrupted(function, tool_call, insert_at)
+                continue
+
+            if isinstance(parsed, dict):
+                continue
+            if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+                # Some models emit a single-element array wrapping the intended
+                # argument object. Unwrap it instead of sending the array to
+                # strict OpenAI-compatible endpoints, which reject it (#58057).
+                stripped = arguments.strip()
+                if stripped.startswith("[") and stripped.endswith("]"):
+                    function["arguments"] = stripped[1:-1].strip()
+                    continue
+
+            insert_at = _mark_corrupted(function, tool_call, insert_at)
 
         message_index += 1
 

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -158,3 +158,58 @@ def test_non_assistant_messages_ignored():
 
     assert repaired == 0
     assert messages == original
+
+
+def test_single_element_array_unwrapped_to_dict():
+    """Regression: a single-element array wrapping the intended object is
+    unwrapped rather than being sent as-is to strict providers (#58057)."""
+    messages = [
+        _assistant_message(_tool_call(arguments='[{"path": "/tmp/foo"}]')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 0
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"path": "/tmp/foo"}'
+
+
+def test_multi_element_array_replaced_with_empty_object(caplog):
+    """Multi-element arrays cannot be unwrapped unambiguously (#58057)."""
+    messages = [
+        _assistant_message(_tool_call(arguments='[{"path": "/tmp/foo"}, {"path": "/tmp/bar"}]')),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        repaired = AIAgent._sanitize_tool_call_arguments(
+            messages,
+            logger=logging.getLogger("run_agent"),
+            session_id="session-123",
+        )
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert any(
+        "Corrupted tool_call arguments repaired" in record.message
+        for record in caplog.records
+    )
+
+
+def test_scalar_argument_replaced_with_empty_object(caplog):
+    """Non-dict, non-list JSON values are not valid tool_call arguments (#58057)."""
+    messages = [
+        _assistant_message(_tool_call(arguments='"just a string"')),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        repaired = AIAgent._sanitize_tool_call_arguments(
+            messages,
+            logger=logging.getLogger("run_agent"),
+            session_id="session-123",
+        )
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert any(
+        "Corrupted tool_call arguments repaired" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes `sanitize_tool_call_arguments()` in `agent/agent_runtime_helpers.py` so it validates the *type* of the parsed `function.arguments` JSON, not just its syntax.

Some models (e.g. `glm-5.2` on strict OpenAI-compatible endpoints) occasionally emit `function.arguments` as a JSON array: `[{"mode": "replace", "path": "config.yaml"}]`. The current sanitizer only calls `json.loads()`; a valid JSON array passes the check and is sent to the provider as-is, causing a non-retryable HTTP 400 `InvalidParameter` that kills the conversation.

After this fix:

- A top-level JSON object is left unchanged.
- A single-element array containing one object is unwrapped to that object (the most likely form of the model mistake).
- Multi-element arrays, strings, numbers, booleans, `null`, or any other non-dict type are treated as corrupted and replaced with `"{}"` plus the existing corruption marker / tool-result stub.

This closes the bug class described in #58057 without touching message persistence or the `_repair_tool_call_arguments` pipeline.

## Related Issue

Fixes #58057

Also preserves the existing behavior for the repairable-escape path (#79699) by only adding a type/unwrap check after successful `json.loads()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`:
  - Extracted the existing corrupted-argument handling into a local `_mark_corrupted` helper so it can be reused for both `JSONDecodeError` and non-dict type failures.
  - After `json.loads()` succeeds, the parsed value is now type-checked:
    - `dict` → keep the original argument string.
    - single-element `list` containing a `dict` → unwrap by extracting the inner object text from the original string, preserving original formatting/escaping.
    - everything else → route through `_mark_corrupted` with the same warning + `"{}"` replacement + corruption marker injection.
- `tests/run_agent/test_tool_call_args_sanitizer.py`:
  - Added `test_single_element_array_unwrapped_to_dict`
  - Added `test_multi_element_array_replaced_with_empty_object`
  - Added `test_scalar_argument_replaced_with_empty_object`

## How to Test

```bash
uv run pytest tests/run_agent/test_tool_call_args_sanitizer.py -q
```

The new `test_single_element_array_unwrapped_to_dict` fails on `main` (the array is left as `"[{...}]"`) and passes on this branch (unwrapped to `"{...}"`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and this issue was clean
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all related tests pass
- [x] I've added regression tests that fail on base
- [x] I've tested on my platform: macOS 15, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no user-facing docs beyond this body
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change