### PR TITLE
feat(providers): add Meta provider for Muse Spark (#80591)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1367,7 +1367,6 @@ _PROVIDER_ALIASES = {
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
     "meta-ai": "meta",
-    "muse-spark": "meta",
 }
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1366,6 +1366,8 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "meta-ai": "meta",
+    "muse-spark": "meta",
 }
 
 

--- a/plugins/model-providers/meta/__init__.py
+++ b/plugins/model-providers/meta/__init__.py
@@ -9,14 +9,11 @@ meta = ProviderProfile(
     display_name="Meta",
     description="Meta — Model API (OpenAI-compatible)",
     signup_url="https://dev.meta.ai/",
-    env_vars=("META_API_KEY",),
+    env_vars=("MODEL_API_KEY",),
     base_url="https://api.meta.ai/v1",
     auth_type="api_key",
     default_aux_model="muse-spark-1.1",
-    fallback_models=(
-        "muse-spark-1.1",
-        "muse-spark-1",
-    ),
+    fallback_models=("muse-spark-1.1",),
 )
 
 register_provider(meta)

--- a/plugins/model-providers/meta/__init__.py
+++ b/plugins/model-providers/meta/__init__.py
@@ -1,0 +1,22 @@
+"""Meta provider profile — Muse Spark via Meta Model API."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+meta = ProviderProfile(
+    name="meta",
+    aliases=("meta-ai", "muse-spark"),
+    display_name="Meta",
+    description="Meta — Muse Spark via Meta Model API",
+    signup_url="https://dev.meta.ai/",
+    env_vars=("META_API_KEY",),
+    base_url="https://api.meta.ai/v1",
+    auth_type="api_key",
+    default_aux_model="muse-spark-1.1",
+    fallback_models=(
+        "muse-spark-1.1",
+        "muse-spark-1",
+    ),
+)
+
+register_provider(meta)

--- a/plugins/model-providers/meta/__init__.py
+++ b/plugins/model-providers/meta/__init__.py
@@ -1,13 +1,13 @@
-"""Meta provider profile — Muse Spark via Meta Model API."""
+"""Meta provider profile — Meta Model API (OpenAI-compatible)."""
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
 meta = ProviderProfile(
     name="meta",
-    aliases=("meta-ai", "muse-spark"),
+    aliases=("meta-ai",),
     display_name="Meta",
-    description="Meta — Muse Spark via Meta Model API",
+    description="Meta — Model API (OpenAI-compatible)",
     signup_url="https://dev.meta.ai/",
     env_vars=("META_API_KEY",),
     base_url="https://api.meta.ai/v1",

--- a/plugins/model-providers/meta/plugin.yaml
+++ b/plugins/model-providers/meta/plugin.yaml
@@ -1,0 +1,5 @@
+name: meta-provider
+kind: model-provider
+version: 1.0.0
+description: Meta — Muse Spark via Meta Model API
+author: Nous Research

--- a/plugins/model-providers/meta/plugin.yaml
+++ b/plugins/model-providers/meta/plugin.yaml
@@ -1,5 +1,5 @@
 name: meta-provider
 kind: model-provider
 version: 1.0.0
-description: Meta — Muse Spark via Meta Model API
+description: Meta — Model API (OpenAI-compatible)
 author: Nous Research


### PR DESCRIPTION
## What does this PR do?

Adds a Meta Model API provider (`api.meta.ai/v1`) via a model-provider plugin. Enables `--provider meta` (alias `meta-ai`) with Meta's documented `MODEL_API_KEY`, OpenAI-compatible `chat_completions`, and `muse-spark-1.1` as the offline fallback and auxiliary model. Live `/models` discovery will surface future Meta models without conflating the provider with the Muse Spark model family.

The provider auto-wires through the existing registry into doctor, `hermes model`, runtime resolution, configuration, and `/model`.

## Related Issue

Fixes #80591

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/meta/__init__.py` — Meta `ProviderProfile` using `https://api.meta.ai/v1`, `MODEL_API_KEY`, and the documented `muse-spark-1.1` fallback
- `plugins/model-providers/meta/plugin.yaml` — model-provider manifest
- `hermes_cli/models.py` — maps the provider alias `meta-ai` to `meta`

## How to Test

1. `uv sync --extra dev`
2. `uv run python -c "from providers import get_provider_profile; print(get_provider_profile('meta'))"`
3. `uv run python -c "from hermes_cli.config import OPTIONAL_ENV_VARS; print('MODEL_API_KEY' in OPTIONAL_ENV_VARS)"`
4. Set `MODEL_API_KEY`, then run `hermes model --provider meta` or `hermes -p meta -m muse-spark-1.1 "hello"`

## Verification

- Hermetic direct check: provider credentials resolve only through `MODEL_API_KEY`; catalog failure falls back only to `muse-spark-1.1`
- `scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_provider_parity.py tests/hermes_cli/test_models.py -q`
- Result: 141 passed, 0 failed

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this feature
- [x] I searched for existing PRs to ensure this is not a duplicate
- [x] I verified provider discovery and registry auto-wiring in the project-managed uv environment
- [x] Tested on macOS arm64 with CPython 3.11.15
