### PR TITLE
fix(desktop): expose preview tools for remote gateways

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1433,6 +1433,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        platform=agent.platform,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/model_tools.py
+++ b/model_tools.py
@@ -34,6 +34,7 @@ from tools.registry import (
     check_fn_cache_scope,
     discover_builtin_tools,
     registry,
+    tool_availability_platform,
     tool_error,
 )
 from toolsets import resolve_toolset, validate_toolset
@@ -273,8 +274,9 @@ _LEGACY_TOOLSET_MAP = {
 # get_tool_definitions  (the main schema provider)
 # =============================================================================
 
-# Module-level memoization for get_tool_definitions(). Keyed on
-# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry._generation).
+# Module-level memoization for get_tool_definitions(). The key covers toolset
+# filters, registry/config state, execution-context flags, profile scope, and
+# the session platform used for availability checks.
 # Hot callers (gateway runner, AIAgent.__init__) invoke this on every turn
 # with quiet_mode=True; caching avoids ~7 ms of registry walking + schema
 # filtering + check_fn probing per call. Only active when quiet_mode=True
@@ -307,6 +309,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -322,6 +325,7 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        platform: Session surface whose platform-gated tools are being assembled.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -335,6 +339,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
+    availability_platform = str(platform or "").strip().lower()
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -355,6 +360,7 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                availability_platform,
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -366,8 +372,13 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        platform=availability_platform,
+    )
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -393,6 +404,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -481,7 +493,8 @@ def _compute_tool_definitions(
     # other toolset.
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
-    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    with tool_availability_platform(platform):
+        filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references

--- a/tests/agent/test_desktop_tool_availability.py
+++ b/tests/agent/test_desktop_tool_availability.py
@@ -1,0 +1,97 @@
+"""Desktop tool availability when the gateway is not Desktop-managed."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from run_agent import AIAgent
+from tools.registry import invalidate_check_fn_cache
+
+
+def test_remote_desktop_agent_includes_preview_tools_without_process_flag(
+    monkeypatch, tmp_path
+):
+    """The session platform, not gateway launch ownership, defines the UI surface."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+
+    import model_tools
+
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://127.0.0.1:1/v1",
+            provider="custom",
+            model="anthropic/claude-sonnet-4.6",
+            platform="desktop",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=["terminal"],
+        )
+    finally:
+        reset_hermes_home_override(home_token)
+
+    assert {"open_preview", "read_preview"} <= getattr(agent, "valid_tool_names")
+
+
+def test_preview_tool_cache_isolated_between_desktop_and_cli(monkeypatch):
+    """A shared gateway must not leak Desktop-only schemas into other clients."""
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+
+    import model_tools
+
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+
+    def preview_names(platform):
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=["terminal"],
+            quiet_mode=True,
+            platform=platform,
+        )
+        return {
+            item["function"]["name"]
+            for item in definitions
+            if item["function"]["name"] in {"open_preview", "read_preview"}
+        }
+
+    assert preview_names("desktop") == {"open_preview", "read_preview"}
+    assert preview_names("cli") == set()
+
+
+def test_preview_tool_availability_context_is_thread_local(monkeypatch):
+    """Concurrent Desktop and non-Desktop builds must not share availability state."""
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+
+    import model_tools
+
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    barrier = Barrier(2)
+
+    def preview_names(platform):
+        barrier.wait()
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=["terminal"],
+            quiet_mode=True,
+            platform=platform,
+        )
+        return {
+            item["function"]["name"]
+            for item in definitions
+            if item["function"]["name"] in {"open_preview", "read_preview"}
+        }
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        desktop = pool.submit(preview_names, "desktop")
+        cli = pool.submit(preview_names, "cli")
+
+    assert desktop.result() == {"open_preview", "read_preview"}
+    assert cli.result() == set()

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -16,7 +16,7 @@ def _reset_emitter():
 
 
 def test_gated_on_desktop(monkeypatch):
-    """Hidden unless HERMES_DESKTOP is set (mirrors read_terminal/close_terminal)."""
+    """The legacy process flag still exposes the tool outside session assembly."""
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     assert op.check_open_preview_requirements() is False
 

--- a/tests/tools/test_read_preview_tool.py
+++ b/tests/tools/test_read_preview_tool.py
@@ -6,7 +6,7 @@ from tools import read_preview_tool as rp
 
 
 def test_gated_on_desktop(monkeypatch):
-    """Hidden unless HERMES_DESKTOP is set (mirrors read_terminal)."""
+    """The legacy process flag still exposes the tool outside session assembly."""
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     assert rp.check_read_preview_requirements() is False
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -27,6 +27,25 @@ def _agent(tool_names, *, enabled=None, disabled=None):
     return a
 
 
+def test_refresh_preserves_remote_desktop_preview_tools(monkeypatch):
+    """MCP/tool reloads must rebuild using the agent's Desktop surface."""
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+
+    import model_tools
+    from tools.registry import invalidate_check_fn_cache
+
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+
+    agent = _agent(["open_preview", "read_preview"], enabled=["terminal"])
+    agent.platform = "desktop"
+
+    mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert {"open_preview", "read_preview"} <= agent.valid_tool_names
+
+
 def test_refresh_adds_late_landing_tools(monkeypatch):
     """A server that registers after build → its tools land in the snapshot."""
     agent = _agent(["read_file", "terminal"])

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6791,6 +6791,7 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            platform=getattr(agent, "platform", None),
         )
         or []
     )

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 """Open a URL, dev server, or file in the Hermes desktop GUI's preview pane.
 
-Gated on ``HERMES_DESKTOP`` (like ``read_terminal`` / ``close_terminal``) so it
-never appears outside the GUI. Emits ``preview.open`` through the shared
-``desktop_ui`` bridge; the renderer opens the pane beside the chat for the
-window that asked and never steals focus for a background session.
+Available to Desktop sessions, with ``HERMES_DESKTOP`` retained for locally
+managed gateways, so it never appears outside the GUI. Emits ``preview.open``
+through the shared ``desktop_ui`` bridge; the renderer opens the pane beside
+the chat for the window that asked and never steals focus for a background
+session.
 """
 
 import json
 import re
 
 from tools import desktop_ui
-from tools.registry import registry, tool_error
+from tools.registry import current_tool_availability_platform, registry, tool_error
 from utils import env_var_enabled
 
 
@@ -53,8 +54,11 @@ def open_preview_tool(url: str, label: str = "") -> str:
 
 
 def check_open_preview_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
+    """Desktop GUI only — including Desktop sessions on an external gateway."""
+    return (
+        env_var_enabled("HERMES_DESKTOP")
+        or current_tool_availability_platform() == "desktop"
+    )
 
 
 OPEN_PREVIEW_SCHEMA = {

--- a/tools/read_preview_tool.py
+++ b/tools/read_preview_tool.py
@@ -12,7 +12,7 @@ dispatcher over the platform-injected callback.
 import json
 from typing import Callable, Optional
 
-from tools.registry import registry, tool_error
+from tools.registry import current_tool_availability_platform, registry, tool_error
 from utils import env_var_enabled
 
 
@@ -50,8 +50,11 @@ def read_preview_tool(
 
 
 def check_read_preview_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
+    """Desktop GUI only — including Desktop sessions on an external gateway."""
+    return (
+        env_var_enabled("HERMES_DESKTOP")
+        or current_tool_availability_platform() == "desktop"
+    )
 
 
 READ_PREVIEW_SCHEMA = {

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -21,10 +21,33 @@ import logging
 import sys
 import threading
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, Iterator, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+_TOOL_AVAILABILITY_PLATFORM: ContextVar[str] = ContextVar(
+    "tool_availability_platform", default=""
+)
+
+
+def current_tool_availability_platform() -> str:
+    """Return the session platform whose tool schemas are being assembled."""
+    return _TOOL_AVAILABILITY_PLATFORM.get()
+
+
+@contextmanager
+def tool_availability_platform(platform: Optional[str]) -> Iterator[None]:
+    """Scope availability probes to one agent surface without mutating the process env."""
+    normalized = str(platform or "").strip().lower()
+    token = _TOOL_AVAILABILITY_PLATFORM.set(normalized)
+    try:
+        yield
+    finally:
+        _TOOL_AVAILABILITY_PLATFORM.reset(token)
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -219,9 +242,9 @@ _CHECK_FN_TTL_SECONDS = 30.0
 # so a genuinely-down backend is reflected within a couple of turns.
 _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _CHECK_FN_CACHE_MAX = 512
-_check_fn_cache: Dict[tuple[Callable, Optional[str]], tuple[float, bool]] = {}
+_check_fn_cache: Dict[tuple[Callable, Optional[str], str], tuple[float, bool]] = {}
 # Monotonic timestamp of the most recent True result per check_fn.
-_check_fn_last_good: Dict[tuple[Callable, Optional[str]], float] = {}
+_check_fn_last_good: Dict[tuple[Callable, Optional[str], str], float] = {}
 _check_fn_cache_lock = threading.Lock()
 CHECK_FN_CACHE_BYPASS = ""
 
@@ -290,7 +313,7 @@ def _check_fn_cached(fn: Callable) -> bool:
                 exc_info=True,
             )
             return False
-    cache_key = (fn, scope)
+    cache_key = (fn, scope, current_tool_availability_platform())
     with _check_fn_cache_lock:
         _prune_check_fn_caches(now)
         cached = _check_fn_cache.get(cache_key)
@@ -361,7 +384,9 @@ def get_cached_check_fn_result(fn: Callable) -> Optional[bool]:
         # trustworthy cached verdict to report.
         return None
     with _check_fn_cache_lock:
-        cached = _check_fn_cache.get((fn, scope))
+        cached = _check_fn_cache.get(
+            (fn, scope, current_tool_availability_platform())
+        )
         if cached is None:
             return None
         ts, value = cached

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,8 +35,9 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # Desktop GUI affordances: read the embedded terminal pane, close an agent's
     # read-only terminal tab, open a URL/file in the preview pane, focus a
-    # pane, and react to a message with an emoji (all gated on HERMES_DESKTOP
-    # via check_fn — hidden outside the GUI).
+    # pane, and react to a message with an emoji (all use check_fn and are
+    # hidden outside the GUI; preview tools also accept external Desktop
+    # session context).
     "read_terminal", "close_terminal", "open_preview", "read_preview", "focus_pane", "react_to_message",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop identifies remote-gateway sessions as `platform="desktop"`, but the preview tools were gated only by the gateway process's `HERMES_DESKTOP` environment variable. A separately launched gateway does not inherit that variable, so `open_preview` and `read_preview` were omitted from the agent's tool schemas even though the existing gateway transport can route their events to Desktop.

This change evaluates preview-tool availability in a context-local session-platform scope. It keeps the existing `HERMES_DESKTOP` behavior for locally Desktop-managed gateways while making the tools available to remote Desktop sessions. Both the tool-definition cache and requirement-check cache include the session platform so concurrent Desktop and CLI sessions cannot influence each other's tool surfaces.

## Related Issue

Fixes #79585

Related: #76008 addressed rendering remote HTML files over SSH. This PR covers the separate case where the model never receives the in-app browser tools when Desktop connects to an independently launched gateway.

Also distinct from #48760, which proposes a separate `desktop_browser_*` surface. This patch fixes the existing `open_preview` / `read_preview` tools on current `main` and does not add a new browser implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a context-local platform scope for tool-availability checks in `tools/registry.py`.
- Include the scoped platform in the inner requirement-check cache and outer tool-definition cache keys.
- Build initial agent tool definitions using the agent's resolved platform.
- Preserve the agent platform when MCP/tool refreshes rebuild definitions.
- Allow `open_preview` and `read_preview` for Desktop-platform sessions while retaining the existing environment-based behavior.
- Update module/toolset comments to describe both local environment and remote Desktop-session availability.
- Add regressions for remote Desktop availability, Desktop/CLI cache isolation, concurrent definition builds, and MCP refreshes.

## How to Test

1. Unset `HERMES_DESKTOP` and construct an `AIAgent` with `platform="desktop"`; verify `open_preview` and `read_preview` remain in `valid_tool_names`.
2. Build Desktop and CLI tool definitions sequentially and concurrently; verify only Desktop receives the preview tools and the caches remain isolated.
3. Refresh a remote Desktop agent's MCP/tool definitions; verify both preview tools remain available.
4. Run the focused suite:
   ```bash
   scripts/run_tests.sh tests/agent/test_desktop_tool_availability.py tests/tools/test_open_preview_tool.py tests/tools/test_read_preview_tool.py tests/tools/test_refresh_agent_mcp_tools.py tests/tools/test_registry.py tests/test_model_tools.py tests/test_get_tool_definitions_cache_isolation.py tests/test_toolsets.py tests/tui_gateway/test_compute_host.py tests/tui_gateway/test_compute_host_phase1.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Security / Cross-platform Impact

This does not change authentication, gateway routing, renderer permissions, or the preview event protocol. It only makes an existing Desktop-only tool surface depend on immutable per-session context rather than mutable process-global state. `ContextVar` scoping prevents concurrent sessions from leaking availability state. The implementation uses only cross-platform Python primitives, and `scripts/check-windows-footguns.py` reports no new issues.

## Limitations

This intentionally covers only the Desktop preview/browser tools involved in #79585. It does not broaden remote availability for unrelated Desktop terminal or pane-control tools.

## Screenshots / Logs

Final focused canonical suite: **110 tests passed across 10 files**. The full canonical suite completed before the comment-only review follow-up with **26,143 passed and 1 failed**. The failure was the unrelated `tests/agent/test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`; it reproduces with the same assertion on a disposable worktree at the exact `upstream/main` base commit. The runner also retried two unrelated flaky files (`test_config_read_guard.py` and `test_wake_word.py`), both of which passed on retry.

The split-process compute-host path also emitted a real `preview.open` JSON-RPC event to the owning session, confirming that current gateway event transport is already present once the tool is exposed.
