### PR TITLE
fix(agent): only mark agent-created skills as learned in learning graph

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -31,6 +31,7 @@ class SkillNode:
     use_count: int = 0
     state: str = "active"
     created_by: Optional[str] = None
+    provenance: Optional[str] = None
     pinned: bool = False
     related: list[str] = field(default_factory=list)
 
@@ -103,7 +104,8 @@ def build_skill_nodes(skill_roots: list[tuple[str, Path]]) -> dict[str, SkillNod
                 name=name, category=str(cat) if cat else parts[-3] if len(parts) >= 3 else "general", source=source,
                 timestamp=usage_ts or _to_int_ts(skill_md.stat().st_mtime),
                 use_count=int(rec.get("use_count", 0) or 0), state=str(rec.get("state", "active") or "active"),
-                created_by=rec.get("created_by"), pinned=bool(rec.get("pinned", False)), related=_related(fm),
+                created_by=rec.get("created_by"), provenance=rec.get("provenance"),
+                pinned=bool(rec.get("pinned", False)), related=_related(fm),
             )
     return nodes
 
@@ -120,7 +122,7 @@ def density_stats(nodes: dict[str, SkillNode], edges: list[tuple[str, str]]) -> 
     return {
         "nodes": len(nodes), "related_edges": len(edges), "edges_per_node": round(len(edges) / n, 3),
         "linked_nodes": len(linked), "isolated_pct": round(100 * (n - len(linked)) / n, 1), "categories": len(cats),
-        "agent_created": sum(1 for x in nodes.values() if x.created_by == "agent"),
+        "agent_created": sum(1 for x in nodes.values() if x.provenance == "agent"),
         "used": sum(1 for x in nodes.values() if x.use_count > 0),
         "top_categories": sorted(cats.items(), key=lambda kv: -kv[1])[:8],
     }
@@ -167,12 +169,27 @@ def _memory_skill_edges(memory_cards: list[dict[str, Any]], skills: list[SkillNo
 
 
 def build_learning_graph() -> dict[str, Any]:
-    """Full payload for the desktop learning panel: non-base skills with real
-    learning signal (agent-created or used) plus memory chunks as graph nodes."""
+    """Full payload for the desktop learning panel: non-base skills created by
+    the agent (``provenance == "agent"``) plus memory chunks as graph nodes.
+
+    ``provenance`` is a field in ``.usage.json`` set to ``"agent"`` on every
+    ``skill_manage(create)`` call — both foreground (user-directed) and
+    background (self-improvement review fork). It is distinct from
+    ``created_by``, which is a curator-management opt-in policy flag (see
+    ``_is_curator_managed_record`` in ``tools/skill_usage.py``, issue #67140).
+
+    The previous filter used ``created_by == "agent" or use_count > 0``.
+    ``created_by`` only reflects curator policy (not authorship), and
+    ``use_count`` is a telemetry counter incremented on every skill load
+    regardless of provenance. Both caused misclassification: externally
+    installed skills were mislabeled as "learned" via ``use_count > 0``, and
+    foreground agent-created skills were excluded because ``created_by`` is
+    only set for background-review creations.
+    """
     roots = [("base", Path(__file__).resolve().parent.parent / "skills"), ("profile", get_hermes_home() / "skills")]
     learned_skills = {
         name: node for name, node in build_skill_nodes(roots).items()
-        if node.source != "base" and (node.created_by == "agent" or node.use_count > 0)
+        if node.source != "base" and node.provenance == "agent"
     }
     skill_edges, memory_cards = build_edges(learned_skills), _memory_cards()
     memory_edges = _memory_skill_edges(memory_cards, list(learned_skills.values()))
@@ -183,7 +200,8 @@ def build_learning_graph() -> dict[str, Any]:
     graph_nodes = [
         {
             "id": n.name, "label": n.name, "kind": "skill", "timestamp": n.timestamp, "category": n.category,
-            "useCount": n.use_count, "state": n.state, "createdBy": n.created_by, "pinned": n.pinned,
+            "useCount": n.use_count, "state": n.state, "createdBy": n.created_by,
+            "provenance": n.provenance, "pinned": n.pinned,
         }
         for n in learned_skills.values()
     ] + [

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -255,15 +255,22 @@ def build_learning_graph() -> dict[str, Any]:
     """Full payload for the desktop learning panel.
 
     Focus on what is profile-learned and actionable:
-    - skills that are NOT base-installed and show real learning signal
-      (agent-created or used),
+    - skills that are NOT base-installed and were created by the agent
+      (``created_by == "agent"``),
     - memory chunks as first-class graph nodes connected to those learned skills.
+
+    ``use_count`` is a telemetry counter incremented on every skill load
+    regardless of provenance (bundled, hub-installed, externally installed, or
+    agent-created).  Using it as a learning signal caused externally-installed
+    skills (e.g. via ``npx skills add``) to be mislabeled as "learned" after a
+    single load.  Only ``created_by == "agent"`` reliably identifies skills the
+    agent actually created.
     """
     all_skills = build_skill_nodes(_skill_roots())
     learned_skills = {
         name: node
         for name, node in all_skills.items()
-        if node.source != "base" and (node.created_by == "agent" or node.use_count > 0)
+        if node.source != "base" and node.created_by == "agent"
     }
     skill_edges = build_edges(learned_skills)
     memory_cards = _memory_cards()

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -34,6 +34,7 @@ class SkillNode:
     use_count: int = 0
     state: str = "active"
     created_by: Optional[str] = None
+    provenance: Optional[str] = None
     pinned: bool = False
     related: list[str] = field(default_factory=list)
 
@@ -147,6 +148,7 @@ def build_skill_nodes(skill_roots: list[tuple[str, Path]]) -> dict[str, SkillNod
             use_count=int(rec.get("use_count", 0) or 0),
             state=str(rec.get("state", "active") or "active"),
             created_by=rec.get("created_by"),
+            provenance=rec.get("provenance"),
             pinned=bool(rec.get("pinned", False)),
             related=_related(fm),
         )
@@ -184,7 +186,7 @@ def density_stats(nodes: dict[str, SkillNode], edges: list[tuple[str, str]]) -> 
         "linked_nodes": len(linked),
         "isolated_pct": round(100 * (n - len(linked)) / n, 1),
         "categories": len(cats),
-        "agent_created": sum(1 for x in nodes.values() if x.created_by == "agent"),
+        "agent_created": sum(1 for x in nodes.values() if x.provenance == "agent"),
         "used": sum(1 for x in nodes.values() if x.use_count > 0),
         "top_categories": sorted(cats.items(), key=lambda kv: -kv[1])[:8],
     }
@@ -256,21 +258,28 @@ def build_learning_graph() -> dict[str, Any]:
 
     Focus on what is profile-learned and actionable:
     - skills that are NOT base-installed and were created by the agent
-      (``created_by == "agent"``),
+      (``provenance == "agent"``),
     - memory chunks as first-class graph nodes connected to those learned skills.
 
+    ``provenance`` is a field in ``.usage.json`` set to ``"agent"`` on every
+    ``skill_manage(create)`` call — both foreground (user-directed) and
+    background (self-improvement review fork).  It is distinct from
+    ``created_by``, which is a curator-management opt-in policy flag (see
+    ``_is_curator_managed_record`` in ``tools/skill_usage.py``, issue #67140).
+
+    The previous filter used ``created_by == "agent" or use_count > 0``.
+    ``created_by`` only reflects curator policy (not provenance), and
     ``use_count`` is a telemetry counter incremented on every skill load
-    regardless of provenance (bundled, hub-installed, externally installed, or
-    agent-created).  Using it as a learning signal caused externally-installed
-    skills (e.g. via ``npx skills add``) to be mislabeled as "learned" after a
-    single load.  Only ``created_by == "agent"`` reliably identifies skills the
-    agent actually created.
+    regardless of provenance.  Both caused misclassification: externally
+    installed skills were mislabeled as "learned" via ``use_count > 0``, and
+    foreground agent-created skills were excluded because ``created_by`` is
+    only set for background-review creations.
     """
     all_skills = build_skill_nodes(_skill_roots())
     learned_skills = {
         name: node
         for name, node in all_skills.items()
-        if node.source != "base" and node.created_by == "agent"
+        if node.source != "base" and node.provenance == "agent"
     }
     skill_edges = build_edges(learned_skills)
     memory_cards = _memory_cards()
@@ -293,6 +302,7 @@ def build_learning_graph() -> dict[str, Any]:
             "useCount": n.use_count,
             "state": n.state,
             "createdBy": n.created_by,
+            "provenance": n.provenance,
             "pinned": n.pinned,
         }
         for n in learned_skills.values()

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -8,6 +8,8 @@ change-detector.
 
 from __future__ import annotations
 
+import json
+
 from agent import learning_graph
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
@@ -79,3 +81,65 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
     assert graph["stats"]["nodes"] == len(skill_nodes)
     assert graph["stats"]["memory_nodes"] == len(graph["memory"])
     assert all("timestamp" in n for n in graph["nodes"])
+
+
+def test_externally_installed_skill_not_learned(tmp_path):
+    """Skills installed externally (e.g. ``npx skills add``) land in
+    ``~/.hermes/skills/`` with ``source="profile"`` and ``provenance=None``.
+
+    They must NOT appear as "learned" in the graph even when ``use_count > 0``
+    from telemetry tracking — only agent-created skills (``provenance == "agent"``)
+    should.
+    """
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    ext_category = skills_dir / "tools"
+    ext_category.mkdir(parents=True)
+
+    # Externally installed skill — provenance=None, use_count > 0
+    ext_skill = ext_category / "external-tool"
+    ext_skill.mkdir()
+    (ext_skill / "SKILL.md").write_text(
+        "---\nname: external-tool\ncategory: tools\n---\nExternal skill body.\n",
+        encoding="utf-8",
+    )
+
+    # Foreground agent-created skill — provenance="agent", created_by=None
+    # (user-directed skill_manage(create): curator policy not set)
+    fg_skill = ext_category / "fg-agent-skill"
+    fg_skill.mkdir()
+    (fg_skill / "SKILL.md").write_text(
+        "---\nname: fg-agent-skill\ncategory: tools\n---\nForeground agent skill.\n",
+        encoding="utf-8",
+    )
+
+    # Background-review agent-created skill — provenance="agent", created_by="agent"
+    # (background review fork: curator policy also set)
+    bg_skill = ext_category / "bg-agent-skill"
+    bg_skill.mkdir()
+    (bg_skill / "SKILL.md").write_text(
+        "---\nname: bg-agent-skill\ncategory: tools\n---\nBackground agent skill.\n",
+        encoding="utf-8",
+    )
+
+    usage = {
+        "external-tool": {"use_count": 15, "created_by": None, "provenance": None, "state": "active"},
+        "fg-agent-skill": {"use_count": 2, "created_by": None, "provenance": "agent", "state": "active"},
+        "bg-agent-skill": {"use_count": 5, "created_by": "agent", "provenance": "agent", "state": "active"},
+    }
+    (skills_dir / ".usage.json").write_text(json.dumps(usage), encoding="utf-8")
+
+    token = set_hermes_home_override(home)
+    try:
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    skill_names = {
+        n["id"] for n in graph["nodes"] if n["kind"] == "skill"
+    }
+    # Both agent-created skills (foreground and background) ARE in the learned graph
+    assert "fg-agent-skill" in skill_names
+    assert "bg-agent-skill" in skill_names
+    # Externally installed skill is NOT in the learned graph
+    assert "external-tool" not in skill_names

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -86,17 +86,18 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
 
 def test_externally_installed_skill_not_learned(tmp_path):
     """Skills installed externally (e.g. ``npx skills add``) land in
-    ``~/.hermes/skills/`` with ``source="profile"`` and ``created_by=None``.
+    ``~/.hermes/skills/`` with ``source="profile"`` and ``provenance=None``.
 
     They must NOT appear as "learned" in the graph even when ``use_count > 0``
-    from telemetry tracking — only agent-created skills should.
+    from telemetry tracking — only agent-created skills (``provenance == "agent"``)
+    should.
     """
     home = tmp_path / ".hermes"
     skills_dir = home / "skills"
     ext_category = skills_dir / "tools"
     ext_category.mkdir(parents=True)
 
-    # Externally installed skill — created_by=None, use_count > 0
+    # Externally installed skill — provenance=None, use_count > 0
     ext_skill = ext_category / "external-tool"
     ext_skill.mkdir()
     (ext_skill / "SKILL.md").write_text(
@@ -104,17 +105,28 @@ def test_externally_installed_skill_not_learned(tmp_path):
         encoding="utf-8",
     )
 
-    # Agent-created skill — created_by="agent"
-    agent_skill = ext_category / "agent-created"
-    agent_skill.mkdir()
-    (agent_skill / "SKILL.md").write_text(
-        "---\nname: agent-created\ncategory: tools\n---\nAgent skill body.\n",
+    # Foreground agent-created skill — provenance="agent", created_by=None
+    # (user-directed skill_manage(create): curator policy not set)
+    fg_skill = ext_category / "fg-agent-skill"
+    fg_skill.mkdir()
+    (fg_skill / "SKILL.md").write_text(
+        "---\nname: fg-agent-skill\ncategory: tools\n---\nForeground agent skill.\n",
+        encoding="utf-8",
+    )
+
+    # Background-review agent-created skill — provenance="agent", created_by="agent"
+    # (background review fork: curator policy also set)
+    bg_skill = ext_category / "bg-agent-skill"
+    bg_skill.mkdir()
+    (bg_skill / "SKILL.md").write_text(
+        "---\nname: bg-agent-skill\ncategory: tools\n---\nBackground agent skill.\n",
         encoding="utf-8",
     )
 
     usage = {
-        "external-tool": {"use_count": 15, "created_by": None, "state": "active"},
-        "agent-created": {"use_count": 3, "created_by": "agent", "state": "active"},
+        "external-tool": {"use_count": 15, "created_by": None, "provenance": None, "state": "active"},
+        "fg-agent-skill": {"use_count": 2, "created_by": None, "provenance": "agent", "state": "active"},
+        "bg-agent-skill": {"use_count": 5, "created_by": "agent", "provenance": "agent", "state": "active"},
     }
     (skills_dir / ".usage.json").write_text(json.dumps(usage), encoding="utf-8")
 
@@ -127,8 +139,9 @@ def test_externally_installed_skill_not_learned(tmp_path):
     skill_names = {
         n["id"] for n in graph["nodes"] if n["kind"] == "skill"
     }
-    # Agent-created skill IS in the learned graph
-    assert "agent-created" in skill_names
+    # Both agent-created skills (foreground and background) ARE in the learned graph
+    assert "fg-agent-skill" in skill_names
+    assert "bg-agent-skill" in skill_names
     # Externally installed skill is NOT in the learned graph
     assert "external-tool" not in skill_names
 

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -8,6 +8,8 @@ change-detector.
 
 from __future__ import annotations
 
+import json
+
 from agent import learning_graph
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
@@ -31,6 +33,7 @@ def test_density_stats_count_isolated_nodes():
     assert stats["nodes"] == 3
     assert stats["linked_nodes"] == 2
     assert stats["isolated_pct"] == round(100 / 3, 1)
+
 
 
 
@@ -79,3 +82,53 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
     assert graph["stats"]["nodes"] == len(skill_nodes)
     assert graph["stats"]["memory_nodes"] == len(graph["memory"])
     assert all("timestamp" in n for n in graph["nodes"])
+
+
+def test_externally_installed_skill_not_learned(tmp_path):
+    """Skills installed externally (e.g. ``npx skills add``) land in
+    ``~/.hermes/skills/`` with ``source="profile"`` and ``created_by=None``.
+
+    They must NOT appear as "learned" in the graph even when ``use_count > 0``
+    from telemetry tracking — only agent-created skills should.
+    """
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    ext_category = skills_dir / "tools"
+    ext_category.mkdir(parents=True)
+
+    # Externally installed skill — created_by=None, use_count > 0
+    ext_skill = ext_category / "external-tool"
+    ext_skill.mkdir()
+    (ext_skill / "SKILL.md").write_text(
+        "---\nname: external-tool\ncategory: tools\n---\nExternal skill body.\n",
+        encoding="utf-8",
+    )
+
+    # Agent-created skill — created_by="agent"
+    agent_skill = ext_category / "agent-created"
+    agent_skill.mkdir()
+    (agent_skill / "SKILL.md").write_text(
+        "---\nname: agent-created\ncategory: tools\n---\nAgent skill body.\n",
+        encoding="utf-8",
+    )
+
+    usage = {
+        "external-tool": {"use_count": 15, "created_by": None, "state": "active"},
+        "agent-created": {"use_count": 3, "created_by": "agent", "state": "active"},
+    }
+    (skills_dir / ".usage.json").write_text(json.dumps(usage), encoding="utf-8")
+
+    token = set_hermes_home_override(home)
+    try:
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    skill_names = {
+        n["id"] for n in graph["nodes"] if n["kind"] == "skill"
+    }
+    # Agent-created skill IS in the learned graph
+    assert "agent-created" in skill_names
+    # Externally installed skill is NOT in the learned graph
+    assert "external-tool" not in skill_names
+

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -396,6 +396,7 @@ class TestSkillManageDispatcher:
         record_created.assert_called_once_with(
             "test-skill",
             agent_created=False,
+            provenance="agent",
             task_id="task-mutation",
             session_id="session-mutation",
         )

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -432,10 +432,13 @@ class TestSkillManageDispatcher:
             usage = load_usage()
         result = json.loads(raw)
         assert result["success"] is True
-        # No provenance marker on a foreground create — record either missing
+        # No curator marker on a foreground create — record either missing
         # entirely (telemetry best-effort) or present with created_by unset.
+        # Authorship (provenance="agent") IS recorded on every create so the
+        # learning graph can identify agent-created skills (#80596).
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
+        assert rec.get("provenance") == "agent"
 
     def test_successful_mutations_emit_lifecycle_with_correlation(self, tmp_path):
         with (
@@ -473,6 +476,7 @@ class TestSkillManageDispatcher:
         record_created.assert_called_once_with(
             "test-skill",
             agent_created=False,
+            provenance="agent",
             task_id="task-mutation",
             session_id="session-mutation",
         )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -712,6 +712,8 @@ def _record_success(action, name, result, *, file_path, absorbed_into, task_id,
     # Curator telemetry: only the background review fork marks a skill agent-created
     # (foreground creates belong to the user). A recoverable curator archive keeps its
     # record as STATE_ARCHIVED (`hermes curator status`/`restore`); only a hard delete forgets.
+    # ``provenance`` is a separate authorship field, set to "agent" on every create so the
+    # learning graph can identify agent-created skills without touching curator policy.
     with suppress(Exception):
         from tools.skill_usage import bump_patch, forget, record_created
         # During the curator consolidation pass, a verified consolidation must be RECOVERABLE: archival into
@@ -721,7 +723,7 @@ def _record_success(action, name, result, *, file_path, absorbed_into, task_id,
         # Foreground, user-directed deletes keep their existing hard-delete semantics.
         from tools.skill_provenance import is_background_review
         if action == "create":
-            record_created(name, agent_created=is_background_review(),
+            record_created(name, agent_created=is_background_review(), provenance="agent",
                            task_id=task_id, session_id=session_id)
         elif action in {"patch", "edit", "write_file", "remove_file"}:
             bump_patch(name, action=action, task_id=task_id, session_id=session_id)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1593,6 +1593,12 @@ def skill_manage(
         # review fork creates it — foreground `skill_manage(create)` calls are
         # user-directed, and those skills belong to the user (the curator must
         # not touch them). Best-effort; telemetry failures never break the tool.
+        #
+        # ``provenance`` is a separate field that records who authored the skill
+        # file, independent of the ``created_by`` curator-policy flag. It is set
+        # to ``"agent"`` for every ``skill_manage(create)`` call so the learning
+        # graph can identify agent-created skills without conflating them with
+        # the curator management opt-in.
         try:
             from tools.skill_usage import bump_patch, forget, record_created
             from tools.skill_provenance import is_background_review
@@ -1600,6 +1606,7 @@ def skill_manage(
                 record_created(
                     name,
                     agent_created=is_background_review(),
+                    provenance="agent",
                     task_id=task_id,
                     session_id=session_id,
                 )

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -327,7 +327,7 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
 
 # --- Sidecar I/O ---
 def _empty_record() -> Dict[str, Any]:
-    return {"created_by": None, "use_count": 0, "view_count": 0, "last_used_at": None, "last_viewed_at": None,
+    return {"created_by": None, "provenance": None, "use_count": 0, "view_count": 0, "last_used_at": None, "last_viewed_at": None,
             "patch_count": 0, "patch_generation": 0, "last_reused_patch_generation": 0, "last_patched_at": None,
             "created_at": _now_iso(), "state": STATE_ACTIVE, "pinned": False, "archived_at": None}
 
@@ -487,12 +487,23 @@ def bump_patch(skill_name: str, *, action: str = "patch", task_id: Optional[str]
 
 
 def record_created(skill_name: str, *, agent_created: bool, task_id: Optional[str] = None,
-                   session_id: Optional[str] = None) -> None:
-    """Persist creation provenance and emit a create fact; the record is reset (a create is a new logical skill)."""
+                   session_id: Optional[str] = None, provenance: Optional[str] = None) -> None:
+    """Persist creation provenance and emit a create fact; the record is reset (a create is a new logical skill).
+
+    ``agent_created`` controls the curator-management opt-in policy flag
+    (``created_by = "agent"``). ``provenance`` is a separate field that records
+    who authored the skill file — set to ``"agent"`` for *every*
+    ``skill_manage(create)`` call regardless of whether it came from the
+    background review fork or a foreground user-directed session, so the
+    learning graph can identify agent-created skills without conflating them
+    with the curator policy.
+    """
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
         rec.clear()
         rec.update(_empty_record(), created_by="agent" if agent_created else None)
-        return {"created_by": rec["created_by"]}
+        if provenance:
+            rec["provenance"] = provenance
+        return {"created_by": rec["created_by"], "provenance": rec["provenance"]}
     _mutate_and_emit(skill_name, "created", _apply, task_id=task_id, session_id=session_id)
 
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -644,6 +644,7 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
 def _empty_record() -> Dict[str, Any]:
     return {
         "created_by": None,
+        "provenance": None,
         "use_count": 0,
         "view_count": 0,
         "last_used_at": None,
@@ -942,10 +943,20 @@ def record_created(
     skill_name: str,
     *,
     agent_created: bool,
+    provenance: Optional[str] = None,
     task_id: Optional[str] = None,
     session_id: Optional[str] = None,
 ) -> None:
-    """Persist explicit creation provenance and emit a successful create fact."""
+    """Persist explicit creation provenance and emit a successful create fact.
+
+    ``agent_created`` controls the curator-management opt-in policy flag
+    (``created_by = "agent"``).  ``provenance`` is a separate field that records
+    who authored the skill file — set to ``"agent"`` for *every*
+    ``skill_manage(create)`` call regardless of whether it came from the
+    background review fork or a foreground user-directed session, so the
+    learning graph can identify agent-created skills without conflating them
+    with the curator policy.
+    """
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
         # A successful create is a new logical skill even if stale sidecar
         # state survived an earlier deletion or manual filesystem change.
@@ -953,7 +964,9 @@ def record_created(
         rec.update(_empty_record())
         if agent_created:
             rec["created_by"] = "agent"
-        return {"created_by": rec["created_by"]}
+        if provenance:
+            rec["provenance"] = provenance
+        return {"created_by": rec["created_by"], "provenance": rec["provenance"]}
 
     facts = _mutate(skill_name, _apply)
     if isinstance(facts, dict):


### PR DESCRIPTION
## What does this PR do?

Fixes the learning graph in `agent/learning_graph.py` so that only agent-created skills are marked as "learned" in the Desktop learning panel.

### The problem

The previous filter used `created_by == "agent" or use_count > 0`:
- `use_count` is a telemetry counter incremented on every skill load regardless of provenance → externally-installed skills (e.g. `npx skills add`) were mislabeled as "learned" after a single load
- `created_by == "agent"` is a **curator-management opt-in policy flag** (see `_is_curator_managed_record()` in `tools/skill_usage.py`, issue #67140), only set during background self-improvement review → foreground agent-created skills were excluded

### The fix

Add a separate `provenance` field in `.usage.json`, set to `"agent"` on **every** `skill_manage(create)` call — both foreground (user-directed) and background (review fork). The learning graph now filters on `provenance == "agent"` instead of `created_by`.

This cleanly separates the two concerns:
- `created_by` = curator policy ("may autonomous curation mutate/archive this?") — unchanged
- `provenance` = authorship ("did the agent create this skill file?") — new field, used by the learning graph

## Related Issue

Fixes #80596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_usage.py` (`_empty_record`, `record_created`): Added `provenance` field (default `None`). `record_created` accepts a new `provenance` parameter and persists it to the usage record.
- `tools/skill_manager_tool.py` (`skill_manage` create path): Passes `provenance="agent"` on every `skill_manage(create)` call, independent of `is_background_review()`. The `agent_created` (curator policy) parameter is unchanged.
- `agent/learning_graph.py` (`SkillNode`, `build_skill_nodes`, `build_learning_graph`, `density_stats`): Added `provenance` field to `SkillNode`, reads it from the usage record, filters learned skills on `provenance == "agent"` instead of `created_by == "agent"`, exposes it in the graph output.
- `tests/agent/test_learning_graph.py`: Updated `test_externally_installed_skill_not_learned` to cover three cases — externally installed (`provenance=None`), foreground agent-created (`provenance="agent"`, `created_by=None`), and background agent-created (`provenance="agent"`, `created_by="agent"`).
- `tests/tools/test_skill_manager_tool.py`: Updated `test_successful_mutations_emit_lifecycle_with_correlation` to expect the `provenance="agent"` argument in the `record_created` call.

## How to Test

1. Run: `python3 -m pytest tests/agent/test_learning_graph.py tests/agent/test_learning_graph_render.py -x -q` — all 9 tests pass
2. Run: `python3 -m pytest tests/tools/test_skill_usage.py tests/tools/test_skill_manager_tool.py -x -q` — all 95 tests pass
3. Run: `python3 -m pytest tests/agent/test_curator.py -x -q` — all curator tests pass (no regression in curator behavior)
4. Manually: create a skill via `skill_manage(create)` in a foreground session, then check the Desktop learning panel — it should appear under "learned"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (trixie), Linux 6.12.100

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings updated in `build_learning_graph`, `record_created`, and `skill_manager_tool.py` create path) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A