### PR TITLE
fix(whatsapp): preserve gifplayback container metadata

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1453,7 +1453,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             elif media_type == "sticker":
                 msg_type = MessageType.STICKER
             elif data.get("hasMedia"):
-                if "image" in media_type:
+                if "image" in media_type or media_type == "gif":
+                    # Animated GIFs arrive as videoMessage with gifPlayback=true
+                    # and the bridge reports mediaType 'gif' (#80063).
                     msg_type = MessageType.PHOTO
                 elif "video" in media_type:
                     msg_type = MessageType.VIDEO
@@ -1485,20 +1487,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             for url in raw_urls:
                 bridge_mime = str(data.get("mime") or "").strip()
                 if msg_type == MessageType.PHOTO and url.startswith(("http://", "https://")):
+                    is_gif = media_type == "gif"
+                    img_ext = ".gif" if is_gif else ".jpg"
+                    img_mime = bridge_mime or ("image/gif" if is_gif else "image/jpeg")
                     try:
-                        cached_path = await cache_image_from_url(url, ext=".jpg")
+                        cached_path = await cache_image_from_url(url, ext=img_ext)
                         cached_urls.append(cached_path)
-                        media_types.append(bridge_mime or "image/jpeg")
+                        media_types.append(img_mime)
                         print(f"[{self.name}] Cached user image: {cached_path}", flush=True)
                     except Exception as e:
                         print(f"[{self.name}] Failed to cache image: {e}", flush=True)
                         cached_urls.append(url)
-                        media_types.append(bridge_mime or "image/jpeg")
+                        media_types.append(img_mime)
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
                     if _is_allowed_bridge_path(url):
                         cached_urls.append(url)
-                        media_types.append(bridge_mime or "image/jpeg")
+                        media_types.append(bridge_mime or ("image/gif" if media_type == "gif" else "image/jpeg"))
                         print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
                     else:
                         print(f"[{self.name}] Rejected bridge image path outside cache dir: {url}", flush=True)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1486,8 +1486,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             media_types = []
             for url in raw_urls:
                 bridge_mime = str(data.get("mime") or "").strip()
+                is_gif = media_type == "gif"
+                gif_video_container = is_gif and bridge_mime.lower().startswith("video/")
                 if msg_type == MessageType.PHOTO and url.startswith(("http://", "https://")):
-                    is_gif = media_type == "gif"
+                    # Baileys reports gifPlayback video messages as ``gif`` but
+                    # the downloaded bytes are normally an MP4 (mime
+                    # ``video/mp4``). Do not send those bytes through the image
+                    # cache or give them a misleading ``.gif`` extension. The
+                    # bridge normally supplies a local path; if a producer
+                    # supplies a remote video URL, preserve that truthful URL
+                    # and MIME instead of pretending it is an image.
+                    if gif_video_container:
+                        cached_urls.append(url)
+                        media_types.append(bridge_mime)
+                        print(f"[{self.name}] Keeping GIF video container URL: {url}", flush=True)
+                        continue
                     img_ext = ".gif" if is_gif else ".jpg"
                     img_mime = bridge_mime or ("image/gif" if is_gif else "image/jpeg")
                     try:
@@ -1503,7 +1516,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Local file path — bridge already downloaded the image
                     if _is_allowed_bridge_path(url):
                         cached_urls.append(url)
-                        media_types.append(bridge_mime or ("image/gif" if media_type == "gif" else "image/jpeg"))
+                        if is_gif and not bridge_mime:
+                            suffix = Path(url).suffix.lower()
+                            media_mime = "video/mp4" if suffix in _WA_VIDEO_EXTS else "image/gif"
+                        else:
+                            media_mime = bridge_mime or ("image/gif" if is_gif else "image/jpeg")
+                        media_types.append(media_mime)
                         print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
                     else:
                         print(f"[{self.name}] Rejected bridge image path outside cache dir: {url}", flush=True)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -226,6 +226,7 @@ _BRIDGE_PASSTHROUGH_ENV = (
 )
 _TEXT_INJECT_EXTS = {".txt", ".md", ".csv", ".json", ".xml", ".yaml", ".yml", ".log", ".py", ".js", ".ts", ".html", ".css"}
 _MAX_TEXT_INJECT_BYTES = 100 * 1024  # matches Telegram/Discord/Slack
+_WA_VIDEO_EXTS = {".mp4", ".webm", ".mov", ".mkv"}
 _NATIVE_MEDIA_TYPES = {"location": MessageType.LOCATION, "live_location": MessageType.LOCATION, "sticker": MessageType.STICKER, "gif": MessageType.PHOTO}
 # Inbound mediaType substring → kind; ptt = WhatsApp voice note, so "ptt" must precede "audio".
 _MEDIA_NEEDLES = (("image", MessageType.PHOTO), ("video", MessageType.VIDEO), ("ptt", MessageType.VOICE), ("audio", MessageType.AUDIO))
@@ -748,12 +749,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Animated GIFs arrive as videoMessage with gifPlayback=true and the
         # bridge reports mediaType 'gif' (#80063).
         is_gif = str(data.get("mediaType", "") or "") == "gif"
-        if is_gif and msg_type == MessageType.PHOTO:
+        gif_video_container = is_gif and bridge_mime.lower().startswith("video/")
+        if is_gif and msg_type == MessageType.PHOTO and not gif_video_container:
             default_mime = "image/gif"
         for url in data.get("mediaUrls", []):
             mime = bridge_mime or (SUPPORTED_DOCUMENT_TYPES.get(Path(url).suffix.lower(), "application/octet-stream") if msg_type == MessageType.DOCUMENT else default_mime)
+            # Baileys reports gifPlayback video messages as ``gif`` but the
+            # downloaded bytes are normally an MP4 (mime ``video/mp4``). Do not
+            # send those bytes through the image cache or give them a
+            # misleading ``.gif`` extension. The bridge normally supplies a
+            # local path; if a producer supplies a remote video URL, preserve
+            # that truthful URL and MIME instead of pretending it is an image.
+            if gif_video_container and url.startswith(("http://", "https://")):
+                accepted.append((url, bridge_mime))
+                print(f"[{self.name}] Keeping GIF video container URL: {url}", flush=True)
+                continue
             if url.startswith(("http://", "https://")) and msg_type in {MessageType.PHOTO, MessageType.VOICE, MessageType.AUDIO}:
-                ext = ".gif" if is_gif and msg_type == MessageType.PHOTO else (".jpg" if msg_type == MessageType.PHOTO else ".ogg")
+                ext = ".gif" if is_gif and msg_type == MessageType.PHOTO and not gif_video_container else (".jpg" if msg_type == MessageType.PHOTO else ".ogg")
                 cacher = cache_image_from_url if msg_type == MessageType.PHOTO else cache_audio_from_url
                 try:
                     url = await cacher(url, ext=ext)
@@ -763,7 +775,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 accepted.append((url, mime))
             elif label is not None and os.path.isabs(url):
                 if _is_allowed_bridge_path(url):
-                    accepted.append((url, mime))
+                    # For GIF local paths without a bridge mime, infer from the
+                    # file extension: MP4 container stays video/mp4.
+                    if is_gif and not bridge_mime:
+                        suffix = Path(url).suffix.lower()
+                        local_mime = "video/mp4" if suffix in _WA_VIDEO_EXTS else "image/gif"
+                    else:
+                        local_mime = mime
+                    accepted.append((url, local_mime))
                     print(f"[{self.name}] Using bridge-cached {label}: {url}", flush=True)
                 else:
                     print(f"[{self.name}] Rejected bridge {label} path outside cache dir: {url}", flush=True)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -226,7 +226,7 @@ _BRIDGE_PASSTHROUGH_ENV = (
 )
 _TEXT_INJECT_EXTS = {".txt", ".md", ".csv", ".json", ".xml", ".yaml", ".yml", ".log", ".py", ".js", ".ts", ".html", ".css"}
 _MAX_TEXT_INJECT_BYTES = 100 * 1024  # matches Telegram/Discord/Slack
-_NATIVE_MEDIA_TYPES = {"location": MessageType.LOCATION, "live_location": MessageType.LOCATION, "sticker": MessageType.STICKER}
+_NATIVE_MEDIA_TYPES = {"location": MessageType.LOCATION, "live_location": MessageType.LOCATION, "sticker": MessageType.STICKER, "gif": MessageType.PHOTO}
 # Inbound mediaType substring → kind; ptt = WhatsApp voice note, so "ptt" must precede "audio".
 _MEDIA_NEEDLES = (("image", MessageType.PHOTO), ("video", MessageType.VIDEO), ("ptt", MessageType.VOICE), ("audio", MessageType.AUDIO))
 # MessageType → (bridge label, default mime); documents take their mime from SUPPORTED_DOCUMENT_TYPES instead.
@@ -745,10 +745,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         accepted: list[tuple] = []  # (url_or_path, mime)
         label, default_mime = _MEDIA_INFO.get(msg_type, (None, ""))
         bridge_mime = str(data.get("mime") or "").strip()
+        # Animated GIFs arrive as videoMessage with gifPlayback=true and the
+        # bridge reports mediaType 'gif' (#80063).
+        is_gif = str(data.get("mediaType", "") or "") == "gif"
+        if is_gif and msg_type == MessageType.PHOTO:
+            default_mime = "image/gif"
         for url in data.get("mediaUrls", []):
             mime = bridge_mime or (SUPPORTED_DOCUMENT_TYPES.get(Path(url).suffix.lower(), "application/octet-stream") if msg_type == MessageType.DOCUMENT else default_mime)
             if url.startswith(("http://", "https://")) and msg_type in {MessageType.PHOTO, MessageType.VOICE, MessageType.AUDIO}:
-                cacher, ext = (cache_image_from_url, ".jpg") if msg_type == MessageType.PHOTO else (cache_audio_from_url, ".ogg")
+                ext = ".gif" if is_gif and msg_type == MessageType.PHOTO else (".jpg" if msg_type == MessageType.PHOTO else ".ogg")
+                cacher = cache_image_from_url if msg_type == MessageType.PHOTO else cache_audio_from_url
                 try:
                     url = await cacher(url, ext=ext)
                     print(f"[{self.name}] Cached user {label}: {url}", flush=True)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -173,7 +173,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
 from gateway.whatsapp_identity import to_whatsapp_jid
 from gateway.platforms.base import (
-    BasePlatformAdapter, SendResult, SUPPORTED_DOCUMENT_TYPES, cache_image_from_url, cache_audio_from_url,
+    BasePlatformAdapter, SendResult, SUPPORTED_DOCUMENT_TYPES, SUPPORTED_VIDEO_TYPES, cache_image_from_url, cache_audio_from_url,
 )
 from gateway.platforms.event import MessageEvent, MessageType
 from utils import env_int
@@ -776,10 +776,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             elif label is not None and os.path.isabs(url):
                 if _is_allowed_bridge_path(url):
                     # For GIF local paths without a bridge mime, infer from the
-                    # file extension: MP4 container stays video/mp4.
+                    # file extension using the shared video-container MIME map.
                     if is_gif and not bridge_mime:
                         suffix = Path(url).suffix.lower()
-                        local_mime = "video/mp4" if suffix in _WA_VIDEO_EXTS else "image/gif"
+                        local_mime = SUPPORTED_VIDEO_TYPES[suffix] if suffix in _WA_VIDEO_EXTS else "image/gif"
                     else:
                         local_mime = mime
                     accepted.append((url, local_mime))

--- a/tests/gateway/test_whatsapp_gif_classification.py
+++ b/tests/gateway/test_whatsapp_gif_classification.py
@@ -1,0 +1,89 @@
+"""Tests for WhatsApp inbound animated-GIF classification.
+
+The Baileys bridge reports animated GIFs with ``mediaType: 'gif'`` and
+``gifPlayback: true``.  The adapter must classify these as photos so the
+agent's vision path attaches them as images, not as unknown-mime documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+@pytest.fixture(autouse=True)
+def _whatsapp_open_optin(monkeypatch):
+    """Opt into WhatsApp allow-all so ``dm_policy: open`` tests run."""
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+
+
+def _make_adapter():
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True)
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    adapter._free_response_chats = set()
+    adapter._whatsapp_free_response_chats = lambda: set()
+    return adapter
+
+
+def _media_payload(media_type, **overrides):
+    payload = {
+        "messageId": "M1",
+        "chatId": "6281234567890@s.whatsapp.net",
+        "senderId": "6281234567890@s.whatsapp.net",
+        "senderName": "Customer",
+        "chatName": "Customer",
+        "isGroup": False,
+        "body": "",
+        "hasMedia": True,
+        "mediaType": media_type,
+        "mediaUrls": [],
+        "mentionedIds": [],
+        "quotedParticipant": "",
+        "botIds": [],
+        "timestamp": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_animated_gif_classifies_as_photo():
+    """Inbound animated GIFs (mediaType 'gif') must be MessageType.PHOTO."""
+    adapter = _make_adapter()
+
+    event = asyncio.run(adapter._build_message_event(_media_payload("gif")))
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO
+
+
+def test_real_video_still_classifies_as_video():
+    """Videos with mediaType 'video' must remain MessageType.VIDEO."""
+    adapter = _make_adapter()
+
+    event = asyncio.run(adapter._build_message_event(_media_payload("video")))
+
+    assert event is not None
+    assert event.message_type == MessageType.VIDEO
+
+
+def test_real_image_still_classifies_as_photo():
+    """Static images with mediaType 'image' must remain MessageType.PHOTO."""
+    adapter = _make_adapter()
+
+    event = asyncio.run(adapter._build_message_event(_media_payload("image")))
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO

--- a/tests/gateway/test_whatsapp_gif_classification.py
+++ b/tests/gateway/test_whatsapp_gif_classification.py
@@ -14,6 +14,7 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
+from plugins.platforms.whatsapp import adapter as whatsapp_adapter
 from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
 
@@ -67,6 +68,67 @@ def test_animated_gif_classifies_as_photo():
 
     assert event is not None
     assert event.message_type == MessageType.PHOTO
+
+
+def test_gifplayback_mp4_keeps_truthful_local_container(monkeypatch, tmp_path):
+    """Baileys gifPlayback media is an MP4, not a GIF-named image."""
+    monkeypatch.setattr(whatsapp_adapter, "_is_allowed_bridge_path", lambda _url: True)
+    path = str(tmp_path / "vid_abc123.mp4")
+    adapter = _make_adapter()
+
+    event = asyncio.run(
+        adapter._build_message_event(
+            _media_payload("gif", mime="video/mp4", mediaUrls=[path])
+        )
+    )
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == [path]
+    assert event.media_types == ["video/mp4"]
+
+
+def test_gifplayback_mp4_does_not_enter_image_cache(monkeypatch):
+    """A remote MP4 must not be cached with a misleading .gif suffix."""
+    cache_image = AsyncMock()
+    monkeypatch.setattr(whatsapp_adapter, "cache_image_from_url", cache_image)
+    url = "https://cdn.example.test/inbound-gif"
+    adapter = _make_adapter()
+
+    event = asyncio.run(
+        adapter._build_message_event(
+            _media_payload("gif", mime="video/mp4", mediaUrls=[url])
+        )
+    )
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == [url]
+    assert event.media_types == ["video/mp4"]
+    cache_image.assert_not_awaited()
+
+
+def test_real_gif_url_uses_gif_image_cache(monkeypatch):
+    """Only an actual image/gif payload gets the .gif image-cache path."""
+    cache_image = AsyncMock(return_value="/cache/img_abc123.gif")
+    monkeypatch.setattr(whatsapp_adapter, "cache_image_from_url", cache_image)
+    adapter = _make_adapter()
+
+    event = asyncio.run(
+        adapter._build_message_event(
+            _media_payload(
+                "gif",
+                mime="image/gif",
+                mediaUrls=["https://cdn.example.test/inbound.gif"],
+            )
+        )
+    )
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == ["/cache/img_abc123.gif"]
+    assert event.media_types == ["image/gif"]
+    cache_image.assert_awaited_once_with("https://cdn.example.test/inbound.gif", ext=".gif")
 
 
 def test_real_video_still_classifies_as_video():

--- a/tests/gateway/test_whatsapp_gif_classification.py
+++ b/tests/gateway/test_whatsapp_gif_classification.py
@@ -88,6 +88,36 @@ def test_gifplayback_mp4_keeps_truthful_local_container(monkeypatch, tmp_path):
     assert event.media_types == ["video/mp4"]
 
 
+@pytest.mark.parametrize(
+    ("suffix", "bridge_mime", "expected_mime"),
+    [
+        (".mp4", None, "video/mp4"),
+        (".webm", None, "video/webm"),
+        (".mov", None, "video/quicktime"),
+        (".mkv", None, "video/x-matroska"),
+        (".WEBM", "", "video/webm"),
+        (".gif", None, "image/gif"),
+        (".mov", "video/mp4", "video/mp4"),
+    ],
+    ids=["mp4", "webm", "mov", "mkv", "uppercase-webm", "gif", "supplied-mime"],
+)
+def test_gif_local_container_mime_fallback(monkeypatch, tmp_path, suffix, bridge_mime, expected_mime):
+    """Missing bridge MIME follows the local container; supplied MIME wins."""
+    monkeypatch.setattr(whatsapp_adapter, "_cache_dirs", lambda: (tmp_path,))
+    path = str(tmp_path / f"inbound{suffix}")
+    payload = _media_payload("gif", mediaUrls=[path])
+    if bridge_mime is not None:
+        payload["mime"] = bridge_mime
+    adapter = _make_adapter()
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == [path]
+    assert event.media_types == [expected_mime]
+
+
 def test_gifplayback_mp4_does_not_enter_image_cache(monkeypatch):
     """A remote MP4 must not be cached with a misleading .gif suffix."""
     cache_image = AsyncMock()


### PR DESCRIPTION
## What does this PR do?

Fixes #80063: the WhatsApp adapter now classifies inbound animated GIFs (bridge `mediaType: 'gif'`) as `MessageType.PHOTO` instead of falling through to `MessageType.DOCUMENT`, without mislabelling Baileys' MP4 `gifPlayback` container as a GIF image.

## Related Issue

- Fixes #80063

## Type of Change

- 🐛 Bug fix
- ✅ Tests

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`:
  - Added `gif` to `_NATIVE_MEDIA_TYPES` as `MessageType.PHOTO`.
  - Preserves `video/mp4` and the original URL/path for Baileys `gifPlayback` media instead of sending MP4 bytes through the GIF image cache.
  - Keeps the `.gif` image-cache path for `gif` payloads not declared as video; preserves explicitly supplied MIME metadata.
  - Infers missing local MIME metadata for `.mp4`, `.webm`, `.mov`, and `.mkv` from the shared video MIME table; a supplied bridge MIME retains precedence.
- `tests/gateway/test_whatsapp_gif_classification.py`:
  - Regression tests cover GIF → PHOTO, video-container MIME fallback including uppercase extensions, supplied-MIME precedence, remote URL handling, real GIF image caching, `image` → PHOTO, and `video` → VIDEO.

## How to Test

Run `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 1 tests/gateway/test_whatsapp_gif_classification.py tests/gateway/test_whatsapp_media_path_profile.py`.

Paired regression proof runs the same committed GIF-classification tests against the exact base and branch; the adjacent suite checks profile-scoped media path validation.

## Checklist

- Tests added/updated.
- Scoped Ruff checks pass.
- `uv lock --check` passes.
- No new `ty` diagnostics introduced.
- Exact-source checker and paired regression proof pass; hosted CI is separate.
