### PR TITLE
fix(whatsapp): propagate reply_to through Baileys media sends (#80064)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1022,6 +1022,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         media_type: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send any media file via bridge /send-media endpoint."""
         if not self._running or not self._http_session:
@@ -1044,6 +1045,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 payload["caption"] = caption
             if file_name:
                 payload["fileName"] = file_name
+            if reply_to:
+                payload["replyTo"] = reply_to
 
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/send-media",
@@ -1213,7 +1216,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """
         try:
             local_path = await cache_image_from_url(image_url)
-            return await self._send_media_to_bridge(chat_id, local_path, "image", caption)
+            return await self._send_media_to_bridge(chat_id, local_path, "image", caption, reply_to=reply_to)
         except Exception:
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata)
 
@@ -1226,7 +1229,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a local image file natively via bridge."""
-        return await self._send_media_to_bridge(chat_id, image_path, "image", caption)
+        return await self._send_media_to_bridge(chat_id, image_path, "image", caption, reply_to=reply_to)
 
     async def send_video(
         self,
@@ -1237,7 +1240,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a video natively via bridge — plays inline in WhatsApp."""
-        return await self._send_media_to_bridge(chat_id, video_path, "video", caption)
+        return await self._send_media_to_bridge(chat_id, video_path, "video", caption, reply_to=reply_to)
 
     async def send_voice(
         self,
@@ -1248,7 +1251,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send an audio file as a WhatsApp voice message via bridge."""
-        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption, reply_to=reply_to)
 
     async def send_document(
         self,
@@ -1263,6 +1266,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return await self._send_media_to_bridge(
             chat_id, file_path, "document", caption,
             file_name or os.path.basename(file_path),
+            reply_to=reply_to,
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -898,7 +898,7 @@ app.post('/send-media', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, filePath, mediaType, caption, fileName } = req.body;
+  const { chatId, filePath, mediaType, caption, fileName, replyTo } = req.body;
   if (!chatId || !filePath) {
     return res.status(400).json({ error: 'chatId and filePath are required' });
   }
@@ -982,7 +982,13 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sendWithTimeout(chatId, msgPayload);
+    const options = {};
+    const quoted = messageStore?.get(replyTo);
+    if (quoted?.key && quoted?.message) {
+      options.quoted = quoted;
+    }
+
+    const sent = await sendWithTimeout(chatId, msgPayload, options);
     trackSentMessageId(sent);
     messageStore.remember(sent);
     res.json({ success: true, messageId: sent?.key?.id });

--- a/tests/gateway/test_whatsapp_media_reply_to.py
+++ b/tests/gateway/test_whatsapp_media_reply_to.py
@@ -1,0 +1,136 @@
+"""Tests for WhatsApp Baileys outbound media reply_to propagation (#80064).
+
+The Cloud adapter already forwards reply_to; this covers the Baileys bridge
+Python adapter and the Node.js bridge /send-media endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+def _resp(json_data=None, status=200):
+    r = AsyncMock()
+    r.status = status
+    r.json = AsyncMock(return_value=json_data or {"messageId": "m1"})
+    r.text = AsyncMock(return_value="")
+    return r
+
+
+def _session_with():
+    calls = []
+
+    def _post(url, **kwargs):
+        calls.append((url, kwargs.get("json")))
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=_resp())
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    session = MagicMock()
+    session.post = MagicMock(side_effect=_post)
+    return session, calls
+
+
+def _make_adapter():
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True)
+    adapter._running = True
+    adapter._bridge_port = 3000
+    adapter._check_managed_bridge_exit = AsyncMock(return_value=False)
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    adapter._free_response_chats = set()
+    adapter._whatsapp_free_response_chats = lambda: set()
+    return adapter
+
+
+@pytest.fixture
+def tmp_media():
+    f = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    f.write(b"x")
+    f.close()
+    try:
+        yield f.name
+    finally:
+        os.unlink(f.name)
+
+
+def test_send_image_file_includes_reply_to(tmp_media):
+    adapter = _make_adapter()
+    session, calls = _session_with()
+    adapter._http_session = session
+
+    result = asyncio.run(
+        adapter.send_image_file("12345", tmp_media, reply_to="msg-123")
+    )
+
+    assert result.success is True
+    assert len(calls) == 1
+    url, payload = calls[0]
+    assert url.endswith("/send-media")
+    assert payload["replyTo"] == "msg-123"
+
+
+def test_send_video_includes_reply_to(tmp_media):
+    adapter = _make_adapter()
+    session, calls = _session_with()
+    adapter._http_session = session
+
+    result = asyncio.run(
+        adapter.send_video("12345", tmp_media, reply_to="msg-456")
+    )
+
+    assert result.success is True
+    assert calls[0][1]["replyTo"] == "msg-456"
+
+
+def test_send_voice_includes_reply_to(tmp_media):
+    adapter = _make_adapter()
+    session, calls = _session_with()
+    adapter._http_session = session
+
+    result = asyncio.run(
+        adapter.send_voice("12345", tmp_media, reply_to="msg-789")
+    )
+
+    assert result.success is True
+    assert calls[0][1]["replyTo"] == "msg-789"
+
+
+def test_send_document_includes_reply_to(tmp_media):
+    adapter = _make_adapter()
+    session, calls = _session_with()
+    adapter._http_session = session
+
+    result = asyncio.run(
+        adapter.send_document("12345", tmp_media, reply_to="msg-abc")
+    )
+
+    assert result.success is True
+    assert calls[0][1]["replyTo"] == "msg-abc"
+
+
+def test_send_image_file_omits_reply_to_when_not_given(tmp_media):
+    adapter = _make_adapter()
+    session, calls = _session_with()
+    adapter._http_session = session
+
+    result = asyncio.run(adapter.send_image_file("12345", tmp_media))
+
+    assert result.success is True
+    assert "replyTo" not in calls[0][1]


### PR DESCRIPTION
## What does this PR do?

Fixes #80064: `reply_to` is now propagated through the WhatsApp Baileys media send path, so image/video/voice/document replies show the quoted bubble on the recipient side.

## Related Issue

- Fixes #80064

## Type of Change

- 🐛 Bug fix
- ✅ Tests

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`:
  - `_send_media_to_bridge` accepts `reply_to` and forwards it as `replyTo` in the JSON payload.
  - `send_image`, `send_image_file`, `send_video`, `send_voice`, and `send_document` pass their `reply_to` argument through.
- `scripts/whatsapp-bridge/bridge.js`:
  - `/send-media` accepts `replyTo`, resolves it through the bounded message store, and passes `options.quoted` to `sendMessage`.
- `tests/gateway/test_whatsapp_media_reply_to.py`:
  - Regression tests for each media type confirming `replyTo` is included when supplied and omitted when not.

## How to Test

1. `pytest tests/gateway/test_whatsapp_media_reply_to.py -q`
2. `ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_media_reply_to.py`

## Checklist

- Tests added.
- `ruff check .` passes.
- `uv lock --check` passes.
- No new `ty` diagnostics introduced.