### PR TITLE
fix(setup): preserve launcher across linked worktrees

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -55,6 +55,19 @@ get_command_link_display_dir() {
     fi
 }
 
+is_linked_worktree() {
+    local git_dir git_common_dir
+    git_dir="$(git -C "$SCRIPT_DIR" rev-parse --absolute-git-dir 2>/dev/null)" || return 1
+    git_dir="$(cd "$git_dir" 2>/dev/null && pwd -P)" || return 1
+    git_common_dir="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    case "$git_common_dir" in
+        /*|[A-Za-z]:/*) ;;
+        *) git_common_dir="$SCRIPT_DIR/$git_common_dir" ;;
+    esac
+    git_common_dir="$(cd "$git_common_dir" 2>/dev/null && pwd -P)" || return 1
+    [ "$git_dir" != "$git_common_dir" ]
+}
+
 echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
@@ -350,9 +363,15 @@ echo -e "${CYAN}→${NC} Setting up hermes command..."
 HERMES_BIN="$SCRIPT_DIR/venv/bin/hermes"
 COMMAND_LINK_DIR="$(get_command_link_dir)"
 COMMAND_LINK_DISPLAY_DIR="$(get_command_link_display_dir)"
-mkdir -p "$COMMAND_LINK_DIR"
-ln -sf "$HERMES_BIN" "$COMMAND_LINK_DIR/hermes"
-echo -e "${GREEN}✓${NC} Symlinked hermes → $COMMAND_LINK_DISPLAY_DIR/hermes"
+COMMAND_LINK="$COMMAND_LINK_DIR/hermes"
+if is_linked_worktree && { [ -e "$COMMAND_LINK" ] || [ -L "$COMMAND_LINK" ]; }; then
+    echo -e "${YELLOW}⚠${NC} Linked Git worktree detected; leaving $COMMAND_LINK_DISPLAY_DIR/hermes unchanged"
+    echo "  Run $HERMES_BIN directly to use this worktree."
+else
+    mkdir -p "$COMMAND_LINK_DIR"
+    ln -sf "$HERMES_BIN" "$COMMAND_LINK"
+    echo -e "${GREEN}✓${NC} Symlinked hermes → $COMMAND_LINK_DISPLAY_DIR/hermes"
+fi
 
 if is_termux; then
     export PATH="$COMMAND_LINK_DIR:$PATH"

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -1,9 +1,115 @@
+import os
 from pathlib import Path
+import re
 import subprocess
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_SCRIPT = REPO_ROOT / "setup-hermes.sh"
+
+
+def _run(
+    *args: str,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _run("git", "-c", "init.defaultBranch=main", "init", "-q", str(path))
+    _run("git", "config", "user.name", "Hermes Test", cwd=path)
+    _run("git", "config", "user.email", "hermes-test@example.invalid", cwd=path)
+    (path / "tracked").write_text("test\n", encoding="utf-8")
+    _run("git", "add", "tracked", cwd=path)
+    _run("git", "commit", "-qm", "initial", cwd=path)
+    return path
+
+
+def _make_checkout(tmp_path: Path, *, linked_worktree: bool) -> Path:
+    primary = _init_repo(tmp_path / "primary")
+    if not linked_worktree:
+        return primary
+
+    checkout = tmp_path / "linked"
+    _run("git", "worktree", "add", "--detach", str(checkout), cwd=primary)
+    return checkout
+
+
+def _extract_function(name: str) -> str:
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", content)
+    assert match is not None, f"could not locate {name} in setup-hermes.sh"
+    return match.group(0)
+
+
+def _command_link_block() -> str:
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+    start = content.index('HERMES_BIN="$SCRIPT_DIR/venv/bin/hermes"')
+    end = content.index("\n\nif is_termux; then", start)
+    return content[start:end]
+
+
+def _run_command_link_block(
+    tmp_path: Path,
+    *,
+    linked_worktree: bool,
+    existing_launcher: bool,
+    broken_launcher: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    checkout = _make_checkout(tmp_path, linked_worktree=linked_worktree)
+    hermes_bin = checkout / "venv" / "bin" / "hermes"
+    hermes_bin.parent.mkdir(parents=True)
+    hermes_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+    command_dir = tmp_path / "bin"
+    command_dir.mkdir()
+    launcher = command_dir / "hermes"
+    if broken_launcher:
+        launcher.symlink_to(tmp_path / "missing-launcher-target")
+    elif existing_launcher:
+        launcher.write_text("canonical launcher\n", encoding="utf-8")
+
+    harness = "\n".join(
+        [
+            "set -euo pipefail",
+            "GREEN=''",
+            "YELLOW=''",
+            "NC=''",
+            "get_command_link_dir() { printf '%s' \"$COMMAND_DIR\"; }",
+            "get_command_link_display_dir() { printf '%s' \"$COMMAND_DIR\"; }",
+            _extract_function("is_linked_worktree"),
+            _command_link_block(),
+        ]
+    )
+    env = os.environ | {"SCRIPT_DIR": str(checkout), "COMMAND_DIR": str(command_dir)}
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, launcher, hermes_bin
+
+
+def _classify_checkout(checkout: Path) -> str:
+    harness = "\n".join(
+        [
+            "set -euo pipefail",
+            _extract_function("is_linked_worktree"),
+            "if is_linked_worktree; then printf linked; else printf ordinary; fi",
+        ]
+    )
+    env = os.environ | {"SCRIPT_DIR": str(checkout)}
+    return _run("bash", "-c", harness, env=env).stdout
 
 
 def test_setup_hermes_script_is_valid_shell():
@@ -18,3 +124,73 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
+
+
+def test_setup_preserves_existing_launcher_from_linked_worktree(tmp_path: Path):
+    result, launcher, _ = _run_command_link_block(
+        tmp_path,
+        linked_worktree=True,
+        existing_launcher=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Linked Git worktree detected" in result.stdout
+    assert not launcher.is_symlink()
+    assert launcher.read_text(encoding="utf-8") == "canonical launcher\n"
+
+
+def test_setup_links_from_linked_worktree_when_launcher_is_absent(tmp_path: Path):
+    result, launcher, hermes_bin = _run_command_link_block(
+        tmp_path,
+        linked_worktree=True,
+        existing_launcher=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert launcher.is_symlink()
+    assert launcher.resolve() == hermes_bin
+
+
+def test_setup_preserves_broken_launcher_from_linked_worktree(tmp_path: Path):
+    result, launcher, _ = _run_command_link_block(
+        tmp_path,
+        linked_worktree=True,
+        existing_launcher=False,
+        broken_launcher=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Linked Git worktree detected" in result.stdout
+    assert launcher.is_symlink()
+    assert launcher.readlink() == tmp_path / "missing-launcher-target"
+
+
+def test_setup_replaces_launcher_from_primary_checkout(tmp_path: Path):
+    result, launcher, hermes_bin = _run_command_link_block(
+        tmp_path,
+        linked_worktree=False,
+        existing_launcher=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert launcher.is_symlink()
+    assert launcher.resolve() == hermes_bin
+
+
+def test_worktree_detection_does_not_classify_submodule_as_linked_worktree(tmp_path: Path):
+    source = _init_repo(tmp_path / "source")
+    superproject = _init_repo(tmp_path / "superproject")
+    _run(
+        "git",
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(source),
+        "submodule",
+        cwd=superproject,
+    )
+
+    assert (superproject / "submodule" / ".git").is_file()
+    assert _classify_checkout(superproject / "submodule") == "ordinary"


### PR DESCRIPTION
## What does this PR do?

`setup-hermes.sh` currently replaces the user-facing `hermes` launcher unconditionally. Running it from a linked Git worktree therefore silently repoints every future `hermes` invocation at that worktree's venv, even when the user already has a canonical installation.

This change detects a true linked worktree by comparing Git's per-checkout directory with its common directory. When an existing launcher is present, setup leaves it unchanged and prints the worktree-local command to use instead. A fresh worktree with no launcher still installs one, and primary checkouts keep the existing replacement behavior.

The topology check deliberately distinguishes linked worktrees from submodules: both can use `.git` files, but only a linked worktree has different Git and common directories. It also avoids Git 2.31's `--path-format` option.

## Related Issue

No matching issue found after searching open/closed issues and PRs. Related but non-duplicate work includes #77138 (adds the ACP launcher), #76518/#15310 (update-time launcher repair), #71487 (worktree test-venv reuse), and the closed installer recursion fixes #24112/#22472/#24452.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `setup-hermes.sh`
  - detect linked worktrees through canonical Git-dir/common-dir comparison;
  - preserve an existing launcher from worktree takeover;
  - retain launcher creation when absent and normal primary-checkout replacement.
- `tests/hermes_cli/test_setup_hermes_script.py`
  - exercise real temporary primary and linked worktrees;
  - cover existing and absent launcher behavior;
  - verify a real submodule is not misclassified.

## How to Test

1. Run the focused behavioral suite:
   ```bash
   HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh tests/hermes_cli/test_setup_hermes_script.py -q
   ```
   Expected: 7 passed.
2. Run shell/static checks:
   ```bash
   bash -n setup-hermes.sh
   shellcheck -e SC2016,SC2088,SC2155,SC2129 setup-hermes.sh
   ruff check tests/hermes_cli/test_setup_hermes_script.py
   git diff upstream/main..HEAD --check
   ```
3. Optional manual reproduction: create a linked worktree, place a sentinel launcher at the command-link path, execute the extracted setup link block, and verify the sentinel remains byte-identical with the warning shown.

Broad local result on the final exact commit: `tests/hermes_cli/` completed with **4,385 passed, 1 failed** across 551 files. The sole failure, `test_doctor_reports_vercel_backend_diagnostics`, reproduces unchanged on a clean detached `upstream/main` checkout; this PR does not modify doctor code or tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the scoped `tests/hermes_cli/` run has one confirmed upstream baseline failure, disclosed above
- [x] I've added behavioral tests for the change
- [x] I've tested on Ubuntu Linux with real Git primary/worktree/submodule topology

### Documentation & Housekeeping

- [x] Documentation update: N/A — warning text is self-explanatory and no public command/config changed
- [x] `cli-config.yaml.example`: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow change
- [x] Cross-platform impact considered: uses Bash and existing Git primitives available on Linux, macOS, Termux, and Git Bash; no `realpath` or Git 2.31-only `--path-format`
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused suite:

```text
7 passed, 0 failed
```

Exact-head broad suite:

```text
551 files, 4385 tests passed, 1 confirmed-baseline failure
```
