### PR TITLE
fix(auth): support ?token= query parameter for remote media downloads

### DIFF
--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -372,6 +372,25 @@ async def gated_auth_middleware(
         # re-login, rather than falling through to the cookie/login redirect.
         return _unauth_response(request, reason="invalid_or_expired_session")
 
+    # Media elements (<video>/<audio>) in remote desktop mode cannot attach
+    # Authorization headers or cookies, so they send ?token=<access_token> on
+    # /api/files/download. Verify query tokens through the same _verify_bearer
+    # provider stack strictly for this path when no Bearer header was present.
+    if path == "/api/files/download":
+        query_token = request.query_params.get("token", "").strip()
+        if query_token:
+            try:
+                query_session = _verify_bearer(request, access_token=query_token)
+            except ProviderError as e:
+                return JSONResponse(
+                    {"detail": f"Auth provider {str(e)!r} unreachable"},
+                    status_code=503,
+                )
+            if query_session is not None:
+                request.state.session = query_session
+                return await call_next(request)
+            return _unauth_response(request, reason="invalid_or_expired_session")
+
     at, _rt = read_session_cookies(request)
     provider_hint = read_session_provider(request)
     if not at and not _rt:

--- a/tests/hermes_cli/test_dashboard_auth_media_query_token.py
+++ b/tests/hermes_cli/test_dashboard_auth_media_query_token.py
@@ -1,0 +1,180 @@
+"""Regression and behavioural tests for ?token= query parameter authentication
+
+on /api/files/download in gated OAuth mode (Issue #80577).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth.base import ProviderError
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider, _sign
+
+
+class UnreachableAuthProvider(StubAuthProvider):
+    name = "unreachable_stub"
+
+    def verify_session(self, *, access_token: str):
+        raise ProviderError("unreachable_idp")
+
+
+@pytest.fixture
+def gated_client():
+    """Configure web_server.app for gated mode with StubAuthProvider."""
+    clear_providers()
+    provider = StubAuthProvider()
+    register_provider(provider)
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    import time
+    valid_token = _sign({
+        "sub": "stub-user-1",
+        "email": "stub@example.test",
+        "name": "Stub User",
+        "org_id": "stub-org-1",
+        "exp": int(time.time()) + 3600,
+    })
+
+    yield client, valid_token
+
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+@pytest.fixture
+def loopback_client():
+    """Configure web_server.app for loopback mode (auth_required=False)."""
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+    yield client
+
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def test_gated_download_valid_query_token(gated_client, tmp_path, monkeypatch):
+    """GET /api/files/download?path=...&token=<valid_token> succeeds under auth_required=True."""
+    client, valid_token = gated_client
+
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"fake mp4 video content")
+
+    # Point read_desktop_file or file resolver if needed
+    r = client.get(
+        f"/api/files/download?path={test_file}&token={valid_token}"
+    )
+    # The request must pass auth (not 401/403/302). It should return 200 with content or file response.
+    assert r.status_code == 200
+    assert r.content == b"fake mp4 video content"
+
+
+def test_gated_download_invalid_query_token(gated_client, tmp_path):
+    """Invalid query token on /api/files/download returns 401 with reason='invalid_or_expired_session'."""
+    client, _ = gated_client
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"content")
+
+    r = client.get(
+        f"/api/files/download?path={test_file}&token=invalid_bogus_token"
+    )
+    assert r.status_code == 401
+    body = r.json()
+    assert body.get("error") == "session_expired"
+    assert body.get("reason") == "invalid_or_expired_session"
+
+
+def test_gated_non_download_route_ignores_query_token(gated_client):
+    """Non-download /api/* route with ?token=<valid token> ignores query token and returns 401 no_cookie."""
+    client, valid_token = gated_client
+
+    r = client.get(f"/api/sessions?token={valid_token}")
+    assert r.status_code == 401
+    body = r.json()
+    assert body.get("error") == "unauthenticated"
+    assert body.get("reason") == "no_cookie"
+
+
+def test_loopback_download_query_token_regression(loopback_client, tmp_path, monkeypatch):
+    """Loopback mode (auth_required=False) still validates _SESSION_TOKEN query token on /api/files/download."""
+    client = loopback_client
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"loopback sample content")
+
+    session_token = getattr(web_server, "_SESSION_TOKEN", "test_session_token")
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", session_token)
+
+    r = client.get(
+        f"/api/files/download?path={test_file}&token={session_token}"
+    )
+    assert r.status_code == 200
+    assert r.content == b"loopback sample content"
+
+
+def test_bearer_takes_precedence_over_query_token(gated_client, tmp_path):
+    """When Bearer header and query token are both present, Bearer header is evaluated first."""
+    client, valid_token = gated_client
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"content")
+
+    # Case 1: Valid Bearer + invalid query token -> succeeds via Bearer (200)
+    r1 = client.get(
+        f"/api/files/download?path={test_file}&token=bogus_invalid",
+        headers={"Authorization": f"Bearer {valid_token}"},
+    )
+    assert r1.status_code == 200
+
+    # Case 2: Invalid Bearer + valid query token -> fails via Bearer (401 invalid_or_expired_session)
+    r2 = client.get(
+        f"/api/files/download?path={test_file}&token={valid_token}",
+        headers={"Authorization": "Bearer bogus_invalid"},
+    )
+    assert r2.status_code == 401
+    assert r2.json().get("reason") == "invalid_or_expired_session"
+
+
+def test_provider_unreachable_returns_503(tmp_path):
+    """When auth provider raises ProviderError during query token verification, returns 503."""
+    clear_providers()
+    register_provider(UnreachableAuthProvider())
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"content")
+
+    try:
+        r = client.get(f"/api/files/download?path={test_file}&token=any_token")
+        assert r.status_code == 503
+        assert "unreachable" in r.json().get("detail", "")
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required


### PR DESCRIPTION
## What changed & why

**Root cause.** In gated/OAuth mode (`auth_required: true`), browser `<audio>`/`<video>` elements inline in chat messages fetch `/api/files/download` from the remote gateway. Unlike XHR/fetch, media elements cannot attach `Authorization` headers or session cookies — the only credential they can carry is a URL query parameter.

The desktop already builds `{baseUrl}/api/files/download?path=…&token=encodeURIComponent(conn.token)` for remote gateways (`apps/desktop/src/lib/media.ts :: mediaExternalUrl()`), but `gated_auth_middleware` never consulted the `?token=` query parameter, so every such request was rejected with `401 no_cookie`.

**The fix.** A narrow query-token branch is inserted in `gated_auth_middleware` — after the `Authorization: Bearer` block, before the cookie block — that verifies `?token=` through the **identical** `_verify_bearer` provider stack, strictly scoped to `/api/files/download`:

```python
if path == "/api/files/download":
    query_token = request.query_params.get("token", "").strip()
    if query_token:
        try:
            query_session = _verify_bearer(request, access_token=query_token)
        except ProviderError as e:
            return JSONResponse({"detail": f"Auth provider {str(e)!r} unreachable"}, status_code=503)
        if query_session is not None:
            request.state.session = query_session
            return await call_next(request)
        return _unauth_response(request, reason="invalid_or_expired_session")
```

Precedence is preserved: `Authorization: Bearer` still takes full priority over `?token=`. An invalid bearer returns `401 invalid_or_expired_session` without falling back to the query token.

**Known limitation.** OAuth access tokens have a TTL (~15 min). Playback of an inline media file from an old message after token expiry will still fail — acceptable and consistent with the existing bearer-auth TTL contract. Token refresh via `/auth/native/refresh` restores playback.

**No desktop changes needed.** `apps/desktop/src/lib/media.ts` already builds the correct `?token=` URL; `media.remote.test.ts` already covers URL-encoding (19 tests, verified as regression check).

---

## How to reproduce

**Environment:** macOS 14.x / Linux, Python 3.11, Hermes v2026.7.x, gateway deployed with `auth_required: true` (OAuth mode).

1. Start the gateway in OAuth/gated mode (non-loopback bind, OAuth provider registered).
2. Open Hermes Desktop and connect to the remote gateway.
3. Send a message that includes an agent-generated audio or video file (the inline `<audio>`/`<video>` src points to `/api/files/download`).
4. **Before fix:** Media element fails to load; devtools show `401 {"error":"unauthenticated","reason":"no_cookie"}`.
5. **After fix:** Media plays inline.

---

## Verification

New test file: `tests/hermes_cli/test_dashboard_auth_media_query_token.py` — 6 tests covering the full behaviour matrix:

| Test | What it checks |
|---|---|
| `test_gated_download_valid_query_token` | Valid `?token=` → 200, file content returned |
| `test_gated_download_invalid_query_token` | Invalid `?token=` → 401 `invalid_or_expired_session` |
| `test_gated_non_download_route_ignores_query_token` | Query token NOT honoured on other routes → 401 `no_cookie` |
| `test_loopback_download_query_token_regression` | Loopback `_SESSION_TOKEN` path unchanged |
| `test_bearer_takes_precedence_over_query_token` | Valid Bearer + bogus `?token=` → 200; bogus Bearer + valid `?token=` → 401 |
| `test_provider_unreachable_returns_503` | `ProviderError` during query-token verify → 503 |

All tests pass:

```
$ uv run pytest tests/hermes_cli/test_dashboard_auth_media_query_token.py -v
======================== 6 passed, 1 warning in 1.36s =========================
```

Existing regression suites also green:
- `tests/hermes_cli/test_web_server_files.py` — 6/6 (loopback query-token + credential-file guards)
- `apps/desktop/src/lib/media.remote.test.ts` — 19/19

---

## Related Issues

Fixes #80577

**Preserved / not re-opened:**
- #72207, #44748 (closed) — prior cookie/session discussions
- #73521 (merged, v2026.7.30) — loopback `_SESSION_TOKEN` fix that introduced `_QUERY_TOKEN_API_PATHS`; this PR extends the same escape-hatch semantics to the OAuth/gated gate