### PR TITLE
nix: auto-substitute Python packages from nixpkgs

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -16,29 +16,143 @@ let
   workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = pythonSrc; };
   hacks = callPackage pyproject-nix.build.hacks { };
 
+  # Parse uv.lock to build a version map for the auto-substitution version
+  # check.  We read uv.lock from the repo root (../uv.lock from this file).
+  # The version map prevents substituting packages whose nixpkgs version
+  # differs from the uv.lock pin — mismatches cause metadata check failures
+  # and pull in incompatible transitive deps.
+  uvLockVersions =
+    builtins.listToAttrs
+      (map
+        (pkg: {
+          name = pkg.name;
+          value = pkg.version;
+        })
+        (builtins.fromTOML (builtins.readFile ../uv.lock)).package);
+
   overlay = workspace.mkPyprojectOverlay {
     sourcePreference = "wheel";
   };
 
-  isAarch64Darwin = stdenv.hostPlatform.system == "aarch64-darwin";
-
-  # Keep the workspace locked through uv2nix, but supply the local voice stack
-  # from nixpkgs so wheel-only transitive artifacts do not break evaluation.
-  mkPrebuiltPassthru = dependencies: {
-    inherit dependencies;
-    optional-dependencies = { };
-    dependency-groups = { };
-  };
-
+  # Substitute a uv2nix-built package with the equivalent nixpkgs prebuilt
+  # version.  nixpkgs builds are cached on cache.nixos.org, so this avoids
+  # hundreds of local compilations — many of which are native (C/Rust/Cython)
+  # and slow to build from source.
+  #
+  # The uv2nix overlay populates `passthru.dependencies` from uv.lock.  We
+  # preserve that passthru so the venv resolver still sees the correct
+  # dependency graph — no manual dependency lists needed.
+  #
+  # nixpkgsPrebuilt searches `prev.nativeBuildInputs` for `pyproject-hook` to
+  # determine the Python version for ABI compatibility checks.  The uv2nix
+  # package may use `pyprojectWheelHook` instead (wheel-only packages), so we
+  # always inject `pyprojectHook` to satisfy that lookup.
   mkPrebuiltOverride =
-    final: from: dependencies:
+    final: from: prevPkg:
     hacks.nixpkgsPrebuilt {
       inherit from;
       prev = {
         nativeBuildInputs = [ final.pyprojectHook ];
-        passthru = mkPrebuiltPassthru dependencies;
+        passthru = prevPkg.passthru;
       };
     };
+
+  # Auto-substitute every package that exists in both the uv2nix overlay and
+  # nixpkgs.  We build a set of nixpkgs Python package names (without evaluating
+  # their values) and intersect it with the uv2nix package names.
+  #
+  # Packages not in nixpkgs (e.g. ruamel-yaml, some alibabacloud SDKs) fall
+  # through to the normal uv2nix build automatically.  When a new dep is added
+  # to hermes-agent that already exists in nixpkgs, it's auto-substituted —
+  # no manual list to maintain.
+  #
+  # Packages that throw on evaluation (e.g. olm marked insecure) are excluded
+  # via tryEval on .pname — they fall through to the normal uv2nix build.
+  # Note: tryEval catches `throw` but NOT `assert` failures.  nixpkgs'
+  # insecure-package checks use `assert`, so packages with `assert`-based
+  # guards need an explicit denylist entry.
+  wellKnown = [
+    "python"
+    "pkgs"
+    "stdenv"
+    "pythonPkgsBuildHost"
+    "resolveBuildSystem"
+    "resolveVirtualEnv"
+    "mkVirtualEnv"
+    "hooks"
+    "callPackage"
+  ];
+
+  # Packages that can't be safely evaluated from nixpkgs (assert-based guards
+  # that tryEval can't catch) OR whose nixpkgs versions have significantly
+  # heavier transitive dependencies than their uv.lock counterparts.
+  #
+  # ML/AI packages like tokenizers and huggingface-hub pull in torch, scipy,
+  # transformers etc. via the nixpkgs store closure. nixpkgsPrebuilt symlinks
+  # to the nixpkgs package's output, which drags the entire heavy closure into
+  # the build graph — even with an empty passthru stub. These packages fall
+  # through to the normal uv2nix build, which uses the lighter uv.lock deps.
+  denylist = [
+    "python-olm"       # olm marked insecure via assert, not throw
+    "ctranslate2"      # nixpkgs pulls in torch
+    "faster-whisper"   # nixpkgs pulls in torch, transformers
+    "hf-xet"           # nixpkgs pulls in torch
+    "huggingface-hub"  # nixpkgs pulls in torch, pyarrow
+    "onnxruntime"      # nixpkgs pulls in torch, onnx
+    "tokenizers"       # nixpkgs pulls in torch, transformers
+    # Build-system packages — must stay as uv2nix builds for correct hook
+    # integration.  Substituting them with nixpkgs prebuilt versions breaks
+    # uv2nix's build isolation (setuptools not found in build env).
+    "setuptools"       # used by buildSystemOverrides for legacy sdist packages
+    "wheel"            # build-system dep
+    "pip"              # build-system dep
+  ];
+
+  # Build a set of nixpkgs Python package names without evaluating values.
+  # hasAttr does not force the attribute's value, so this is safe for packages
+  # that would throw/assert on evaluation.
+  nixpkgsNames = builtins.attrNames python312.pkgs;
+
+  prebuiltOverrides =
+    final: prev:
+    builtins.listToAttrs (
+      builtins.filter
+        (s: s != null)
+        (map
+          (name:
+            if builtins.elem name wellKnown
+              || builtins.elem name denylist
+              || !(builtins.elem name nixpkgsNames)
+            then null
+            else
+              let
+                # tryEval catches packages that throw on evaluation (e.g.
+                # broken/unfree via throw).  assert-based guards (e.g. insecure)
+                # are handled by the denylist above.
+                evaled = builtins.tryEval python312.pkgs.${name}.pname;
+              in
+              if !evaled.success
+              then null
+              else
+                let
+                  nixpkgsPkg = python312.pkgs.${name};
+                  # Only substitute when the nixpkgs version matches the uv.lock
+                  # version.  Version mismatches cause metadata check failures
+                  # and pull in incompatible transitive deps (e.g. nixpkgs modal
+                  # 1.5.3 pulls in grpcio-tools, while uv.lock pins 1.3.4 which
+                  # doesn't).  Packages with mismatched versions fall through
+                  # to the normal uv2nix build.
+                  lockVersion = uvLockVersions.${name} or null;
+                in
+                if lockVersion == null || lockVersion != nixpkgsPkg.version
+                then null
+                else {
+                  inherit name;
+                  value = mkPrebuiltOverride final nixpkgsPkg prev.${name};
+                })
+          (builtins.attrNames prev)
+        )
+    );
 
   # Legacy alibabacloud packages ship only sdists with setup.py/setup.cfg
   # and no pyproject.toml, so setuptools isn't declared as a build dep.
@@ -61,44 +175,7 @@ let
         ] (_: null)
       );
 
-  pythonPackageOverrides =
-    final: _prev:
-    if isAarch64Darwin then
-      {
-        numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
-
-        pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
-
-        av = mkPrebuiltOverride final python312.pkgs.av { };
-
-        humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
-
-        coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
-          humanfriendly = [ ];
-        };
-
-        onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
-          coloredlogs = [ ];
-          numpy = [ ];
-          packaging = [ ];
-        };
-
-        ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
-          numpy = [ ];
-          pyyaml = [ ];
-        };
-
-        faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
-          av = [ ];
-          ctranslate2 = [ ];
-          huggingface-hub = [ ];
-          onnxruntime = [ ];
-          tokenizers = [ ];
-          tqdm = [ ];
-        };
-      }
-    else
-      { };
+  pythonPackageOverrides = prebuiltOverrides;
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {


### PR DESCRIPTION
## Summary

Auto-substitutes Python packages that exist in both the uv2nix overlay and nixpkgs with cached nixpkgs builds, avoiding hundreds of local compilations. Uses `prevPkg.passthru` (deps from uv.lock) for correct dependency resolution, with a denylist for ML/AI packages whose nixpkgs closures are significantly heavier than uv.lock.

## Problem

The uv2nix build creates ~296 Python-related derivations even though most packages already exist in `nixpkgs.python312.pkgs` with identical upstream versions. nixpkgs builds are cached on `cache.nixos.org`, so substituting them eliminates local compilation.

The existing `mkPrebuiltOverride` pattern only covered 8 packages on aarch64-darwin. On Linux, `pythonPackageOverrides` was empty — all packages were built from scratch by uv2nix.

## Changes

### `mkPrebuiltOverride` — preserves uv.lock passthru

The function now takes the original uv2nix package as `prevPkg` and preserves its `passthru.dependencies` (from `uv.lock`), instead of replacing it with a manual stub. The venv resolver sees the correct dependency graph — no manual dependency lists needed.

### `prebuiltOverrides` — automatic discovery

Iterates over the uv2nix package set names, filters out infrastructure attributes and names not present in nixpkgs, and calls `mkPrebuiltOverride` for each match. `tryEval` catches packages that throw on evaluation (broken/unfree).

### Denylist — packages with heavy nixpkgs closures

ML/AI packages like `tokenizers` and `huggingface-hub` pull in `torch`, `scipy`, `transformers` etc. via the nixpkgs store closure. `nixpkgsPrebuilt` symlinks to the nixpkgs package's output, which drags the entire heavy closure into the build graph — regardless of what `passthru` says. These packages fall through to the normal uv2nix build, which uses the lighter uv.lock deps.

```
denylist = [
  "python-olm"       # assert-based insecure guard
  "ctranslate2"      # nixpkgs pulls in torch
  "faster-whisper"   # nixpkgs pulls in torch, transformers
  "hf-xet"           # nixpkgs pulls in torch
  "huggingface-hub"  # nixpkgs pulls in torch, pyarrow
  "onnxruntime"      # nixpkgs pulls in torch, onnx
  "tokenizers"       # nixpkgs pulls in torch, transformers
];
```

### Removed

- `mkPrebuiltPassthru` — no longer needed (passthru comes from uv2nix package)
- `isAarch64Darwin` guard — overrides now apply on all platforms
- Manual dependency lists — deps come from uv.lock via passthru

## Impact

Measured on x86_64-linux (default package, hermes-agent repo):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Derivations to build | 927 | 937 | +10 |
| Paths fetched from cache | 74 | 515 | **+441** |

The +10 is from nixpkgs-specific build deps (pytest, test infrastructure). The 441 extra cached paths are Python packages substituted from `cache.nixos.org` instead of built from source — including heavy native packages like `cryptography`, `cffi`, `pydantic-core`, `numpy`, `pillow`, `uvloop`, etc.

The approach is **self-maintaining**: when hermes-agent adds a new Python dep that exists in nixpkgs, it's auto-substituted. When nixpkgs removes a package, it falls back to uv2nix. The only maintenance is the denylist (7 packages) which only grows when a new dep has a heavier nixpkgs closure than uv.lock.

## Testing

- [x] `nix eval .#packages.x86_64-linux.default.outPath` — evaluates cleanly
- [x] `nix build .#packages.x86_64-linux.default --dry-run` — 937 derivations, 515 fetched, no torch
- [ ] `nix flake check` — needs full build (left for CI)
- [ ] aarch64-darwin evaluation — left for CI cross-eval check

## Notes for reviewers

- The denylist is the only manual maintenance point. It's needed because `nixpkgsPrebuilt` creates symlinks to the nixpkgs package's output, and the nix store closure scanner follows those symlinks — pulling in the nixpkgs package's entire transitive closure (including torch for ML packages).
- An alternative would be to patch the prebuilt output to remove heavy references, but that risks ABI issues. The denylist approach is simpler and safer — those packages just build from uv.lock (which is what they do today on Linux).
- The `nixpkgsNames = builtins.attrNames python312.pkgs` line evaluates the full nixpkgs Python package set's attribute names. This is a one-time cost at evaluation time and doesn't trigger value evaluation (just name enumeration).