### PR TITLE
fix(whatsapp): reuse healthy Cloud webhook on reconnect

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -432,6 +432,33 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return self._is_dm_allowed(principal)
 
     # ------------------------------------------------------------------ lifecycle
+    async def _try_reuse_running_webhook(self) -> bool:
+        """Return True when the existing webhook server is still healthy.
+
+        Cloud reconnects happen in the same gateway process, so an already
+        bound ``AppRunner`` and Graph client can be reused without attempting
+        to bind the webhook port a second time. The health probe keeps this
+        fail-closed: a stale runner is discarded by ``connect()`` and the
+        normal startup path creates a fresh server.
+        """
+        if self._runner is None or self._http_client is None:
+            return False
+
+        host = self._webhook_host
+        if host in {None, "", "0.0.0.0", "::"}:
+            host = "127.0.0.1"
+        url = f"http://{host}:{self._webhook_port}{self._health_path}"
+        try:
+            response = await self._http_client.get(url, timeout=2.0)
+        except Exception:
+            return False
+        if response.status_code != 200:
+            return False
+
+        self._mark_connected()
+        logger.info("[whatsapp_cloud] Reusing existing webhook server on %s", url)
+        return True
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         if not check_whatsapp_cloud_requirements():
             self._set_fatal_error(
@@ -449,6 +476,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 retryable=False,
             )
             return False
+
+        if is_reconnect:
+            if await self._try_reuse_running_webhook():
+                return True
+            # A stale runner/client would otherwise leak the old HTTP client
+            # and make the subsequent TCPSite bind fail with EADDRINUSE.
+            if self._runner is not None or self._http_client is not None:
+                await self.disconnect()
 
         # Outbound HTTP client. Tighter keepalive matches other platform
         # adapters so idle CLOSE_WAIT drains promptly (#18451).

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -506,11 +506,70 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return float(default)
         return parsed
 
+    async def _try_reuse_running_bridge(
+        self,
+        bridge_path: Path,
+        *,
+        quiet: bool = False,
+    ) -> bool:
+        """Return True if a live bridge is running on the configured port,
+        reports status:connected, serves the same bridge.js that is on disk,
+        and matches the send-read-receipts config.
+
+        On success the adapter is marked connected and the polling loop is
+        started, mirroring the happy path in connect().
+        """
+        import aiohttp
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://127.0.0.1:{self._bridge_port}/health",
+                    timeout=aiohttp.ClientTimeout(total=2),
+                ) as resp:
+                    if resp.status != 200:
+                        return False
+                    data = await resp.json()
+                    bridge_status = data.get("status", "unknown")
+                    if bridge_status != "connected":
+                        if not quiet:
+                            print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
+                        return False
+                    running_hash = data.get("scriptHash", "")
+                    disk_hash = _file_content_hash(bridge_path)
+                    running_read_receipts = bool(data.get("sendReadReceipts", False))
+                    config_matches = running_read_receipts == self._send_read_receipts
+                    if (
+                        running_hash
+                        and disk_hash
+                        and running_hash == disk_hash
+                        and config_matches
+                    ):
+                        if not quiet:
+                            print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
+                        self._mark_connected()
+                        self._bridge_process = None  # Not managed by us
+                        self._http_session = aiohttp.ClientSession()
+                        self._poll_task = asyncio.create_task(self._poll_messages())
+                        return True
+                    stale_reason = (
+                        f"running={running_hash or 'unversioned'}, disk={disk_hash}"
+                        if running_hash != disk_hash
+                        else "send_read_receipts config changed"
+                    )
+                    if not quiet:
+                        print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
+                    return False
+        except Exception:
+            return False
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
         Start the WhatsApp bridge.
-        
+
         This launches the Node.js bridge process and waits for it to be ready.
+        On a reconnect, it first tries to reuse an already running bridge so
+        the watcher does not pay the full cold-start cost.
         """
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
@@ -530,6 +589,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 retryable=False,
             )
             return False
+
+        # Fast path: on a reconnect, a previously started bridge may still be
+        # alive. Probe /health before touching npm, pidfiles, or ports to avoid
+        # the full cold-start cost (#80094).
+        if is_reconnect:
+            if await self._try_reuse_running_bridge(bridge_path):
+                return True
 
         # Pre-flight: skip the 30s bridge bootstrap entirely if the user
         # never finished pairing.  Without creds.json the bridge prints
@@ -613,54 +679,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
-            
-            # Check if bridge is already running and connected
-            import aiohttp
-            try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
-                        timeout=aiohttp.ClientTimeout(total=2)
-                    ) as resp:
-                        if resp.status == 200:
-                            data = await resp.json()
-                            bridge_status = data.get("status", "unknown")
-                            if bridge_status == "connected":
-                                # Staleness handshake: only reuse a running
-                                # bridge if it is serving the same bridge.js
-                                # that is on disk right now.  A long-lived
-                                # bridge survives gateway restarts AND
-                                # `hermes update`, so without this check it
-                                # keeps serving pre-update code forever
-                                # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
-                                # treated as stale by definition.
-                                running_hash = data.get("scriptHash", "")
-                                disk_hash = _file_content_hash(bridge_path)
-                                running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
-                                if (
-                                    running_hash
-                                    and disk_hash
-                                    and running_hash == disk_hash
-                                    and config_matches
-                                ):
-                                    print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
-                                    self._mark_connected()
-                                    self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
-                                    self._poll_task = asyncio.create_task(self._poll_messages())
-                                    return True
-                                stale_reason = (
-                                    f"running={running_hash or 'unversioned'}, disk={disk_hash}"
-                                    if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
-                                )
-                                print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
-                            else:
-                                print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
-            except Exception:
-                pass  # Bridge not running, start a new one
+
+            # Check if bridge is already running and connected.
+            if await self._try_reuse_running_bridge(bridge_path):
+                return True
             
             # Kill any orphaned bridge from a previous gateway run
             _kill_stale_bridge_by_pidfile(self._session_path)

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -125,6 +125,43 @@ def _mock_httpx_response(status_code: int, json_body: dict):
     return resp
 
 
+class TestReconnectFastPath:
+    """Cloud reconnects reuse a healthy in-process webhook server."""
+
+    @pytest.mark.asyncio
+    async def test_reconnect_reuses_healthy_webhook(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._runner = object()
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(200, {"status": "ok"})
+        )
+
+        monkeypatch.setattr(
+            "gateway.platforms.whatsapp_cloud.check_whatsapp_cloud_requirements",
+            lambda: True,
+        )
+        result = await adapter.connect(is_reconnect=True)
+
+        assert result is True
+        assert adapter._running is True
+        adapter._http_client.get.assert_awaited_once_with(
+            "http://127.0.0.1:8090/health", timeout=2.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_does_not_reuse_unhealthy_webhook(self):
+        adapter = _make_adapter()
+        adapter._runner = object()
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(503, {"status": "starting"})
+        )
+
+        assert await adapter._try_reuse_running_webhook() is False
+        assert adapter._running is True
+
+
 # ---------------------------------------------------------------------------
 # Outbound send via Graph API
 # ---------------------------------------------------------------------------
@@ -1399,4 +1436,3 @@ class TestReplyContextResolution:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
-

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -478,3 +478,126 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# Reconnect fast path: reuse a live bridge instead of full cold start (#80094)
+# ---------------------------------------------------------------------------
+
+class TestReconnectFastPath:
+    """Verify ``is_reconnect=True`` probes /health before npm/pidfile/port."""
+
+    @pytest.mark.asyncio
+    async def test_is_reconnect_reuses_live_bridge(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        bridge = tmp_path / "bridge.js"
+        bridge.write_text("// bridge stub")
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        (session_dir / "creds.json").write_text("{}")
+
+        adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+        adapter.platform = Platform.WHATSAPP
+        adapter.config = MagicMock()
+        adapter._bridge_port = 19878
+        adapter._bridge_script = str(bridge)
+        adapter._session_path = session_dir
+        adapter._bridge_log_fh = None
+        adapter._bridge_process = None
+        adapter._reply_prefix = None
+        adapter._send_read_receipts = False
+        adapter._running = False
+        adapter._message_handler = None
+        adapter._fatal_error_code = None
+        adapter._fatal_error_message = None
+        adapter._fatal_error_retryable = True
+        adapter._fatal_error_handler = None
+        adapter._active_sessions = {}
+        adapter._pending_messages = {}
+        adapter._background_tasks = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter._message_queue = asyncio.Queue()
+        adapter._http_session = None
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "status": "connected",
+            "scriptHash": "deadbeef",
+            "sendReadReceipts": False,
+        })
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+        mock_client_cls = MagicMock(return_value=_AsyncCM(mock_session))
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._file_content_hash", return_value="deadbeef"), \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()), \
+             patch("aiohttp.ClientSession", mock_client_cls), \
+             patch("subprocess.run") as mock_run, \
+             patch("subprocess.Popen") as mock_popen, \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile") as mock_kill_pid, \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill_port:
+            result = await adapter.connect(is_reconnect=True)
+
+        assert result is True
+        mock_run.assert_not_called()
+        mock_popen.assert_not_called()
+        mock_kill_pid.assert_not_called()
+        mock_kill_port.assert_not_called()
+        assert adapter._running is True
+
+    @pytest.mark.asyncio
+    async def test_is_reconnect_falls_through_when_bridge_not_running(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        bridge = tmp_path / "bridge.js"
+        bridge.write_text("// bridge stub")
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        (session_dir / "creds.json").write_text("{}")
+
+        adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+        adapter.platform = Platform.WHATSAPP
+        adapter.config = MagicMock()
+        adapter._bridge_port = 19879
+        adapter._bridge_script = str(bridge)
+        adapter._session_path = session_dir
+        adapter._bridge_log_fh = None
+        adapter._bridge_process = None
+        adapter._reply_prefix = None
+        adapter._send_read_receipts = False
+        adapter._running = False
+        adapter._message_handler = None
+        adapter._fatal_error_code = None
+        adapter._fatal_error_message = None
+        adapter._fatal_error_retryable = True
+        adapter._fatal_error_handler = None
+        adapter._active_sessions = {}
+        adapter._pending_messages = {}
+        adapter._background_tasks = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter._message_queue = asyncio.Queue()
+        adapter._http_session = None
+
+        # GET /health raises (bridge not running); the call must continue to
+        # the cold path and eventually attempt a restart.
+        mock_client_cls = MagicMock(side_effect=OSError("Connection refused"))
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client_cls), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile") as mock_kill_pid, \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill_port, \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("subprocess.Popen", return_value=mock_proc):
+            result = await adapter.connect(is_reconnect=True)
+
+        assert result is False
+        mock_kill_pid.assert_called_once()
+        mock_kill_port.assert_called_once()
+        assert adapter._running is False


### PR DESCRIPTION
## What does this PR do?

Fixes #80094: both WhatsApp adapters now consume `connect(is_reconnect=True)` correctly. Baileys probes and reuses a matching live bridge before its cold preflight; WhatsApp Cloud probes and reuses an existing in-process webhook server, cleaning stale runner/client state before a fresh bind when the probe fails.

## Related Issue

- Fixes #80094

## Type of Change

- 🐛 Bug fix
- ✅ Tests

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`:
  - Extracted the existing `/health` staleness handshake into `_try_reuse_running_bridge`.
  - Added an early fast path in `connect()` when `is_reconnect=True`.
  - Kept the same handshake at the end of the cold path so normal boots still reuse a surviving bridge.

- `gateway/platforms/whatsapp_cloud.py`:
  - Added a fail-closed local health probe for an existing webhook runner on reconnect.
  - Reuses the existing Graph client/server when healthy and cleans stale state before rebinding when unhealthy.

- `tests/gateway/test_whatsapp_connect.py`:
  - Added `test_is_reconnect_reuses_live_bridge` (proves npm/pidfile/port are skipped on reconnect).
  - Added `test_is_reconnect_falls_through_when_bridge_not_running` (proves cold path still runs when no bridge is alive).

- `tests/gateway/test_whatsapp_cloud.py`:
  - Added healthy-reuse and unhealthy-rejection coverage for the Cloud webhook reconnect path.

## How to Test

1. `HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh tests/gateway/test_whatsapp_cloud.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_platform_reconnect.py` (80/80)
2. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/80094`

## Checklist

- Tests added.
- `ruff check .` passes.
- `uv lock --check` passes.
- No new `ty` diagnostics introduced.
- Rebased onto current `main`; no merge conflicts.