### PR TITLE
docs(whatsapp): mark Phase 5 as planned and link #45935 for template demand (#80075)

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -22,7 +22,8 @@ Phase scope (this file evolves across phases):
             media download via the Graph media endpoint, voice-note opus
             conversion via ffmpeg with graceful MP3 fallback when ffmpeg
             isn't on PATH. Document text injection for readable types.
-- Phase 5 — 24-hour conversation window + template fallback.
+- Phase 5 — 24-hour conversation window + template fallback (planned, not yet
+  implemented).
 
 Required env vars to enable the adapter:
 - WHATSAPP_CLOUD_PHONE_NUMBER_ID  (the Graph URL path component)

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -309,7 +309,7 @@ Meta only allows **free-form messages** within a 24-hour window after the user's
 
 Hermes warns the agent about this window in its system prompt, so the model knows to mention it when scheduling delayed messages.
 
-Message-template support (the workaround for outside-window sends) is not yet implemented in Hermes. If you need it, please [open an issue](https://github.com/NousResearch/hermes-agent/issues) — it's planned but waiting on a clear demand signal.
+Message-template support (the workaround for outside-window sends) is not yet implemented in Hermes. A production use case is tracked in [#45935](https://github.com/NousResearch/hermes-agent/issues/45935); please comment there if you need it.
 
 ### Group chats
 


### PR DESCRIPTION
## What does this PR do?

Fixes #80075: removes an unshipped Phase-5 docstring claim in the WhatsApp Cloud adapter and updates the user-facing docs to reference the existing demand signal (#45935) for message-template support.

## Related Issue

- Fixes #80075
- Tracks template demand: #45935

## Type of Change

- 📝 Documentation update

## Changes Made

- `gateway/platforms/whatsapp_cloud.py`: the module docstring now marks "Phase 5 — 24-hour conversation window + template fallback" as planned and not yet implemented.
- `website/docs/user-guide/messaging/whatsapp-cloud.md`: the stale "waiting on a clear demand signal" note now links to #45935 and asks users to comment there if they need it.
- The verified-accurate "80 messages/second per business phone number" throughput figure is unchanged.

## How to Test

1. `git grep 'Phase 5' gateway/platforms/whatsapp_cloud.py` — should show the annotated planned state.
2. Read `website/docs/user-guide/messaging/whatsapp-cloud.md` around the 24-hour window section and confirm it links to #45935.

## Checklist

- Docstring contradiction removed.
- Stale demand note updated.
- `ruff check .` passes.
- `uv lock --check` passes.