### PR TITLE
feat(api_server): headless provider OAuth (paste-a-code PKCE)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2018,6 +2018,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
+            # Headless provider login (paste-a-code PKCE). Lets deployments
+            # that run only the gateway re-authenticate a model provider
+            # without an interactive TTY on the host.
+            ("POST", "/api/providers/{provider}/oauth/start", self._handle_provider_oauth_start),
+            ("POST", "/api/providers/{provider}/oauth/submit", self._handle_provider_oauth_submit),
             ("POST", "/v1/runs", self._handle_runs),
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
@@ -3009,6 +3014,82 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=500,
             )
 
+    async def _handle_provider_oauth_start(self, request: "web.Request") -> "web.Response":
+        """POST /api/providers/{provider}/oauth/start — begin a PKCE login.
+
+        Returns the authorization URL for a human to open. Nothing is
+        persisted until the code comes back through the submit endpoint.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        provider = request.match_info.get("provider", "")
+        try:
+            from gateway.provider_oauth import ProviderOAuthError, start
+
+            # urllib call chain is blocking-free here, but constant import
+            # touches disk — keep it off the event loop for consistency.
+            payload = await asyncio.to_thread(start, provider)
+            return web.json_response(payload)
+        except ProviderOAuthError as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="provider_oauth_failed"),
+                status=exc.status,
+            )
+        except Exception:
+            logger.exception(
+                "[%s] POST /api/providers/%s/oauth/start failed", self.name, provider
+            )
+            return web.json_response(
+                _openai_error(
+                    "Failed to start provider OAuth.", code="provider_oauth_failed"
+                ),
+                status=500,
+            )
+
+    async def _handle_provider_oauth_submit(self, request: "web.Request") -> "web.Response":
+        """POST /api/providers/{provider}/oauth/submit — finish a PKCE login.
+
+        Body: ``{"session_id": "...", "code": "<code>#<state>"}``. On success
+        the credential is written exactly as ``hermes auth add`` would, and
+        the running gateway picks it up without a restart.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        provider = request.match_info.get("provider", "")
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        session_id = str(body.get("session_id") or "").strip()
+        code = str(body.get("code") or "")
+        if not session_id:
+            return web.json_response(
+                _openai_error("session_id is required", code="invalid_request"),
+                status=400,
+            )
+        try:
+            from gateway.provider_oauth import ProviderOAuthError, submit
+
+            # Token exchange is a blocking HTTP round-trip.
+            payload = await asyncio.to_thread(submit, session_id, code, provider)
+            return web.json_response(payload)
+        except ProviderOAuthError as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="provider_oauth_failed"),
+                status=exc.status,
+            )
+        except Exception:
+            logger.exception(
+                "[%s] POST /api/providers/%s/oauth/submit failed", self.name, provider
+            )
+            return web.json_response(
+                _openai_error(
+                    "Failed to complete provider OAuth.", code="provider_oauth_failed"
+                ),
+                status=500,
+            )
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -3052,6 +3133,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "approval_events": True,
                 "session_resources": True,
                 "model_options": True,
+                "provider_oauth": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
                 "session_fork": True,

--- a/gateway/provider_oauth.py
+++ b/gateway/provider_oauth.py
@@ -1,0 +1,257 @@
+"""Headless provider OAuth (PKCE) for the API server.
+
+The dashboard already implements a paste-a-code Anthropic login
+(``hermes_cli/web_server.py``), but that lives in the ``hermes web``
+process. Deployments that run only ``hermes gateway`` — headless servers,
+containers, k8s pods — have no way to (re)authenticate a provider except
+an interactive TTY inside the process's host, which is exactly the thing
+those deployments are built to avoid.
+
+This module holds the transport-agnostic half of that flow so the API
+server can expose it (see ``api_server._handle_provider_oauth_*``):
+
+    start()  -> {session_id, auth_url}      # human opens the URL
+    submit() -> {ok: True}                  # human pastes back "code#state"
+
+No callback listener is required: Anthropic's redirect target is its own
+hosted page, so the code travels via copy/paste and the pod never needs
+inbound reachability from the browser.
+
+The PKCE verifier must survive between the two calls, so sessions are held
+in memory with a TTL. That is deliberate: a gateway is a single long-lived
+process, and an unfinished login is worthless after the TTL anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import threading
+import time
+import urllib.parse
+import urllib.request
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# An unfinished login is worthless after this; also bounds memory.
+SESSION_TTL_SECONDS = 600
+_MAX_SESSIONS = 32
+
+AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+
+_sessions: Dict[str, Dict[str, Any]] = {}
+_sessions_lock = threading.Lock()
+
+
+class ProviderOAuthError(Exception):
+    """Flow could not proceed. ``status`` is the HTTP status to return."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
+def _anthropic_constants() -> Tuple[Any, ...]:
+    """Import the adapter's OAuth constants, or fail with a clear error."""
+    try:
+        from agent.anthropic_adapter import (  # noqa: WPS433 - optional dep
+            _OAUTH_CLIENT_ID,
+            _OAUTH_REDIRECT_URI,
+            _OAUTH_SCOPES,
+            _OAUTH_TOKEN_URLS,
+            _generate_pkce,
+        )
+    except Exception as exc:  # pragma: no cover - adapter always ships
+        raise ProviderOAuthError(
+            f"Anthropic OAuth unavailable: {exc}", status=501
+        ) from exc
+    return (
+        _OAUTH_CLIENT_ID,
+        _OAUTH_REDIRECT_URI,
+        _OAUTH_SCOPES,
+        _OAUTH_TOKEN_URLS,
+        _generate_pkce,
+    )
+
+
+def _prune_locked(now: float) -> None:
+    expired = [
+        sid for sid, s in _sessions.items() if now - s["created_at"] > SESSION_TTL_SECONDS
+    ]
+    for sid in expired:
+        _sessions.pop(sid, None)
+    # Hard cap: drop oldest first if a caller spams start(). ``>=`` because
+    # pruning runs before the caller inserts — leave room for one more.
+    while len(_sessions) >= _MAX_SESSIONS:
+        oldest = min(_sessions, key=lambda k: _sessions[k]["created_at"])
+        _sessions.pop(oldest, None)
+
+
+def start(provider: str = "anthropic") -> Dict[str, Any]:
+    """Begin a PKCE login. Returns the auth URL for a human to open."""
+    if provider != "anthropic":
+        raise ProviderOAuthError(f"Unsupported provider: {provider}", status=400)
+    client_id, redirect_uri, scopes, _token_urls, generate_pkce = _anthropic_constants()
+
+    verifier, challenge = generate_pkce()
+    session_id = uuid.uuid4().hex
+    now = time.time()
+    with _sessions_lock:
+        _prune_locked(now)
+        _sessions[session_id] = {
+            "provider": provider,
+            "verifier": verifier,
+            # Anthropic round-trips the verifier as `state`.
+            "state": verifier,
+            "created_at": now,
+        }
+
+    params = {
+        "code": "true",
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": scopes,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": verifier,
+    }
+    return {
+        "session_id": session_id,
+        "provider": provider,
+        "flow": "pkce",
+        "auth_url": f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}",
+        "expires_in": SESSION_TTL_SECONDS,
+    }
+
+
+def _exchange(token_urls, payload: bytes) -> Dict[str, Any]:
+    """POST the code exchange, trying each known token host in order."""
+    last_exc: Optional[Exception] = None
+    for endpoint in token_urls:
+        req = urllib.request.Request(
+            endpoint,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "hermes-gateway/1.0",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                return json.loads(resp.read().decode())
+        except Exception as exc:  # noqa: PERF203 - fallback host is the point
+            last_exc = exc
+    raise ProviderOAuthError(f"Token exchange failed: {last_exc}", status=502)
+
+
+def submit(session_id: str, code_input: str, provider: str = "anthropic") -> Dict[str, Any]:
+    """Exchange the pasted code for tokens and persist the credential."""
+    if provider != "anthropic":
+        raise ProviderOAuthError(f"Unsupported provider: {provider}", status=400)
+    client_id, redirect_uri, _scopes, token_urls, _gen = _anthropic_constants()
+
+    now = time.time()
+    with _sessions_lock:
+        _prune_locked(now)
+        sess = _sessions.get(session_id)
+    if not sess or sess["provider"] != provider:
+        raise ProviderOAuthError("Unknown or expired session", status=404)
+
+    # Anthropic's callback page renders the code as `<code>#<state>`.
+    parts = (code_input or "").strip().split("#", 1)
+    code = parts[0].strip()
+    if not code:
+        raise ProviderOAuthError("No code provided", status=400)
+    state = parts[1].strip() if len(parts) > 1 else sess["state"]
+
+    result = _exchange(
+        token_urls,
+        json.dumps(
+            {
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "code": code,
+                "state": state,
+                "redirect_uri": redirect_uri,
+                "code_verifier": sess["verifier"],
+            }
+        ).encode(),
+    )
+
+    access_token = result.get("access_token") or ""
+    refresh_token = result.get("refresh_token") or ""
+    if not access_token:
+        raise ProviderOAuthError("No access token returned", status=502)
+    expires_at_ms = int(now * 1000) + int(result.get("expires_in") or 3600) * 1000
+
+    _persist_anthropic(access_token, refresh_token, expires_at_ms)
+
+    # One-shot: a consumed code cannot be replayed.
+    with _sessions_lock:
+        _sessions.pop(session_id, None)
+
+    logger.info("[api_server] anthropic OAuth login completed (session=%s)", session_id)
+    return {"ok": True, "provider": provider, "expires_at_ms": expires_at_ms}
+
+
+def _persist_anthropic(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
+    """Write the credential file and register it in the pool.
+
+    Mirrors ``hermes auth add anthropic`` (and the dashboard flow) so a
+    gateway-side login leaves the system in the same state. The running
+    gateway picks the new credential up without a restart: the auth store
+    is re-read from disk per resolution.
+    """
+    from agent.anthropic_adapter import _get_hermes_oauth_file
+    from utils import atomic_json_write
+
+    atomic_json_write(
+        _get_hermes_oauth_file(),
+        {
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "expiresAt": expires_at_ms,
+        },
+        indent=2,
+        mode=0o600,
+    )
+
+    # Best-effort pool registration: the file write above is what runtime
+    # credential resolution reads; the pool only drives rotation.
+    try:
+        from agent.credential_pool import (
+            AUTH_TYPE_OAUTH,
+            SOURCE_MANUAL,
+            PooledCredential,
+            load_pool,
+        )
+
+        pool = load_pool("anthropic")
+        source = f"{SOURCE_MANUAL}:gateway_pkce"
+        for entry in [
+            e for e in pool.entries() if getattr(e, "source", "").startswith(source)
+        ]:
+            try:
+                pool.remove_entry(getattr(entry, "id", ""))
+            except Exception:
+                pass
+        pool.add_entry(
+            PooledCredential(
+                provider="anthropic",
+                id=secrets.token_hex(3),
+                label="gateway PKCE",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source=source,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at_ms=expires_at_ms,
+            )
+        )
+    except Exception as exc:
+        logger.warning("[api_server] anthropic pool add failed: %s", exc)

--- a/tests/gateway/test_api_server_provider_oauth.py
+++ b/tests/gateway/test_api_server_provider_oauth.py
@@ -1,0 +1,238 @@
+"""Tests for headless provider OAuth on the API server.
+
+Covers the flow module (session lifecycle, code parsing, persistence) and
+the two HTTP handlers (auth gate, validation, error mapping).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway import provider_oauth
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions():
+    with provider_oauth._sessions_lock:
+        provider_oauth._sessions.clear()
+    yield
+    with provider_oauth._sessions_lock:
+        provider_oauth._sessions.clear()
+
+
+def _app(api_key: str = "k" * 32) -> web.Application:
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": api_key}))
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post(
+        "/api/providers/{provider}/oauth/start",
+        adapter._handle_provider_oauth_start,
+    )
+    app.router.add_post(
+        "/api/providers/{provider}/oauth/submit",
+        adapter._handle_provider_oauth_submit,
+    )
+    return app
+
+
+class TestFlow:
+
+    def test_start_returns_auth_url_and_session(self):
+        out = provider_oauth.start("anthropic")
+        assert out["flow"] == "pkce"
+        assert out["auth_url"].startswith("https://claude.ai/oauth/authorize?")
+        assert "code_challenge=" in out["auth_url"]
+        assert "code_challenge_method=S256" in out["auth_url"]
+        assert out["session_id"] in provider_oauth._sessions
+
+    def test_start_rejects_unknown_provider(self):
+        with pytest.raises(provider_oauth.ProviderOAuthError) as exc:
+            provider_oauth.start("openai")
+        assert exc.value.status == 400
+
+    def test_submit_unknown_session_is_404(self):
+        with pytest.raises(provider_oauth.ProviderOAuthError) as exc:
+            provider_oauth.submit("nope", "code#state")
+        assert exc.value.status == 404
+
+    def test_submit_requires_a_code(self):
+        sid = provider_oauth.start("anthropic")["session_id"]
+        with pytest.raises(provider_oauth.ProviderOAuthError) as exc:
+            provider_oauth.submit(sid, "   ")
+        assert exc.value.status == 400
+
+    def test_submit_exchanges_and_persists(self):
+        started = provider_oauth.start("anthropic")
+        sid = started["session_id"]
+        verifier = provider_oauth._sessions[sid]["verifier"]
+
+        captured = {}
+
+        def _fake_exchange(token_urls, payload):
+            captured.update(json.loads(payload.decode()))
+            return {
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_in": 3600,
+            }
+
+        with patch.object(provider_oauth, "_exchange", _fake_exchange), patch.object(
+            provider_oauth, "_persist_anthropic"
+        ) as persist:
+            out = provider_oauth.submit(sid, "  thecode#thestate  ")
+
+        assert out["ok"] is True
+        # code/state split on '#', verifier bound to the session
+        assert captured["code"] == "thecode"
+        assert captured["state"] == "thestate"
+        assert captured["code_verifier"] == verifier
+        assert captured["grant_type"] == "authorization_code"
+        persist.assert_called_once()
+        assert persist.call_args[0][0] == "at"
+        assert persist.call_args[0][1] == "rt"
+        # session is consumed — a code cannot be replayed
+        assert sid not in provider_oauth._sessions
+
+    def test_submit_without_state_falls_back_to_session_state(self):
+        sid = provider_oauth.start("anthropic")["session_id"]
+        verifier = provider_oauth._sessions[sid]["verifier"]
+        captured = {}
+
+        def _fake_exchange(token_urls, payload):
+            captured.update(json.loads(payload.decode()))
+            return {"access_token": "at", "refresh_token": "rt", "expires_in": 60}
+
+        with patch.object(provider_oauth, "_exchange", _fake_exchange), patch.object(
+            provider_oauth, "_persist_anthropic"
+        ):
+            provider_oauth.submit(sid, "onlycode")
+
+        assert captured["state"] == verifier
+
+    def test_missing_access_token_is_502(self):
+        sid = provider_oauth.start("anthropic")["session_id"]
+        with patch.object(
+            provider_oauth, "_exchange", lambda *_: {"refresh_token": "rt"}
+        ):
+            with pytest.raises(provider_oauth.ProviderOAuthError) as exc:
+                provider_oauth.submit(sid, "code#state")
+        assert exc.value.status == 502
+
+    def test_sessions_are_capped(self):
+        for _ in range(provider_oauth._MAX_SESSIONS + 5):
+            provider_oauth.start("anthropic")
+        assert len(provider_oauth._sessions) <= provider_oauth._MAX_SESSIONS
+
+    def test_expired_session_is_pruned(self):
+        sid = provider_oauth.start("anthropic")["session_id"]
+        with provider_oauth._sessions_lock:
+            provider_oauth._sessions[sid]["created_at"] -= (
+                provider_oauth.SESSION_TTL_SECONDS + 1
+            )
+        with pytest.raises(provider_oauth.ProviderOAuthError) as exc:
+            provider_oauth.submit(sid, "code#state")
+        assert exc.value.status == 404
+
+
+class TestHandlers:
+
+    @pytest.mark.asyncio
+    async def test_start_requires_auth(self):
+        async with TestClient(TestServer(_app())) as cli:
+            resp = await cli.post("/api/providers/anthropic/oauth/start")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_start_returns_url_with_auth(self):
+        key = "k" * 32
+        async with TestClient(TestServer(_app(key))) as cli:
+            resp = await cli.post(
+                "/api/providers/anthropic/oauth/start",
+                headers={"Authorization": f"Bearer {key}"},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["auth_url"].startswith("https://claude.ai/oauth/authorize?")
+            assert body["session_id"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_provider_maps_to_400(self):
+        key = "k" * 32
+        async with TestClient(TestServer(_app(key))) as cli:
+            resp = await cli.post(
+                "/api/providers/openai/oauth/start",
+                headers={"Authorization": f"Bearer {key}"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_submit_requires_session_id(self):
+        key = "k" * 32
+        async with TestClient(TestServer(_app(key))) as cli:
+            resp = await cli.post(
+                "/api/providers/anthropic/oauth/submit",
+                headers={"Authorization": f"Bearer {key}"},
+                json={"code": "abc"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_submit_success_roundtrip(self):
+        key = "k" * 32
+        async with TestClient(TestServer(_app(key))) as cli:
+            started = await (
+                await cli.post(
+                    "/api/providers/anthropic/oauth/start",
+                    headers={"Authorization": f"Bearer {key}"},
+                )
+            ).json()
+            with patch.object(
+                provider_oauth,
+                "_exchange",
+                lambda *_: {
+                    "access_token": "at",
+                    "refresh_token": "rt",
+                    "expires_in": 3600,
+                },
+            ), patch.object(provider_oauth, "_persist_anthropic"):
+                resp = await cli.post(
+                    "/api/providers/anthropic/oauth/submit",
+                    headers={"Authorization": f"Bearer {key}"},
+                    json={"session_id": started["session_id"], "code": "c#s"},
+                )
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+
+
+class TestPersistence:
+
+    def test_persist_writes_file_and_pool(self, tmp_path):
+        oauth_file = tmp_path / ".anthropic_oauth.json"
+        pool = MagicMock()
+        pool.entries.return_value = []
+
+        with patch(
+            "agent.anthropic_adapter._get_hermes_oauth_file", return_value=oauth_file
+        ), patch("agent.credential_pool.load_pool", return_value=pool):
+            provider_oauth._persist_anthropic("at", "rt", 1234)
+
+        written = json.loads(oauth_file.read_text())
+        assert written["accessToken"] == "at"
+        assert written["refreshToken"] == "rt"
+        assert written["expiresAt"] == 1234
+        # file must not be world/group readable
+        assert oct(oauth_file.stat().st_mode)[-3:] == "600"
+        pool.add_entry.assert_called_once()
+
+    def test_pool_failure_does_not_break_login(self, tmp_path):
+        oauth_file = tmp_path / ".anthropic_oauth.json"
+        with patch(
+            "agent.anthropic_adapter._get_hermes_oauth_file", return_value=oauth_file
+        ), patch("agent.credential_pool.load_pool", side_effect=RuntimeError("boom")):
+            provider_oauth._persist_anthropic("at", "rt", 1234)
+        assert json.loads(oauth_file.read_text())["accessToken"] == "at"


### PR DESCRIPTION
## Motivation

Deployments that run only `hermes gateway` — containers, k8s pods, headless servers — have no way to (re)authenticate a model provider. `hermes auth add` needs an interactive TTY inside the process host, which is exactly what those deployments are built to avoid (in k8s it means `kubectl exec` into a production pod). The dashboard already ships a paste-a-code PKCE flow for this, but it lives in the separate `hermes web` process that headless deployments don't run.

## What this adds

The same paste-a-code flow, exposed on the API server the gateway already runs:

```
POST /api/providers/anthropic/oauth/start
  -> { "session_id": "...", "auth_url": "https://claude.ai/oauth/authorize?...", "expires_in": 600 }

# human opens auth_url, authenticates, copies the code from Anthropic's hosted callback page

POST /api/providers/anthropic/oauth/submit
  { "session_id": "...", "code": "<code>#<state>" }
  -> { "ok": true, "expires_at_ms": ... }
```

No callback listener is required — Anthropic's redirect target is its own hosted page, so the code travels by copy/paste and the pod never needs inbound reachability from a browser.

## Design notes

- Flow logic lives in a new transport-agnostic `gateway/provider_oauth.py`; the api_server handlers are thin wrappers. It reuses the adapter's existing PKCE and token-endpoint primitives rather than duplicating them.
- Persistence is identical to `hermes auth add anthropic` (oauth file written 0600 + credential-pool entry), so the running gateway picks the new credential up without a restart.
- PKCE verifiers are held in memory with a 10-minute TTL and a hard session cap; a completed session is deleted, so an authorization code can't be replayed through a second submit.
- Both routes sit behind the standard `API_SERVER_KEY` bearer auth, and no endpoint ever returns token material.
- Advertised as `features.provider_oauth` in `/v1/capabilities` for client feature-detection.
- Anthropic only for now; the `{provider}` path segment leaves room for the device-code providers (nous/openai/minimax/xai) as a follow-up.

## Testing

16 new tests in `tests/gateway/test_api_server_provider_oauth.py`: flow lifecycle (TTL expiry, session cap, one-shot consumption), code/state parsing, exchange payload shape (verifier binding), persistence (file mode 0600, pool registration, pool-failure isolation), and handler behavior (auth gate, validation, error mapping). The existing `tests/gateway/test_api_server.py` suite is unaffected (same pass/fail set as `main` in my environment).
