### PR TITLE
fix(whatsapp): classify npm install failures as non-retryable fatal errors (#80095)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -600,6 +600,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")
+                        self._set_fatal_error(
+                            "whatsapp_npm_install_failed",
+                            f"WhatsApp bridge npm install failed. Run `cd {bridge_dir} && {_npm_bin} install` manually, then restart `hermes gateway`.",
+                            retryable=False,
+                        )
                         return False
                     print(f"[{self.name}] Dependencies installed")
                     if _pkg_hash:
@@ -609,6 +614,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             pass  # Stamp is an optimization; install still succeeded
                 except Exception as e:
                     print(f"[{self.name}] Failed to install dependencies: {e}")
+                    self._set_fatal_error(
+                        "whatsapp_npm_install_failed",
+                        f"WhatsApp bridge npm install failed ({e}). Run `cd {bridge_dir} && {_npm_bin} install` manually, then restart `hermes gateway`.",
+                        retryable=False,
+                    )
                     return False
 
             # Ensure session directory exists

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -216,6 +216,9 @@ class TestConnectCleanup:
             result = await adapter.connect()
 
         assert result is False
+        assert adapter.fatal_error_code == "whatsapp_npm_install_failed"
+        assert adapter.fatal_error_retryable is False
+        assert "npm install failed" in (adapter.fatal_error_message or "")
         mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
         assert adapter._platform_lock_identity is None
 


### PR DESCRIPTION
## What does this PR do?

Fixes #80095: when `WhatsAppAdapter.connect()` auto-runs `npm install` and the install fails or raises, the adapter now sets a non-retryable fatal error with an actionable install hint instead of silently returning `False`. This stops the gateway reconnect watcher from spinning on an unfixable dependency problem.

## Related Issue

- Fixes #80095
- Adjacent: #54217 (aiohttp ModuleNotFoundError — same unclassified-connect-failure class)

## Type of Change

- 🐛 Bug fix
- ✅ Tests

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`:
  - `npm install` returning non-zero now sets a non-retryable fatal error (`whatsapp_npm_install_failed`).
  - An exception during `npm install` also sets the same fatal error and includes the exception details.
  - Error message tells the operator to run `cd <bridge_dir> && <npm> install` manually.

- `tests/gateway/test_whatsapp_connect.py`:
  - `test_releases_lock_when_npm_install_fails` now also asserts that `fatal_error_code`, `fatal_error_retryable`, and the error message are set correctly.

## How to Test

1. `pytest tests/gateway/test_whatsapp_connect.py::TestConnectCleanup -q`
2. `pytest tests/gateway/test_whatsapp_connect.py -q`

## Checklist

- Bug fix has a regression test.
- `ruff check .` passes.
- `uv lock --check` passes.
- `ty check` introduces no new diagnostics.