### PR TITLE
feat(desktop): activate selected profiles on next launch

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -252,6 +252,7 @@ const WINDOW_BUTTON_POSITION = {
 // non-macOS platforms.
 const NATIVE_OVERLAY_BUTTON_WIDTH = 144
 const APP_ICON_PATHS = [
+  path.join(unpackedPathFor(APP_ROOT), 'public', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
   path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -165,6 +165,7 @@
     "asar": true,
     "afterSign": "scripts/notarize.cjs",
     "asarUnpack": [
+      "public/apple-touch-icon.png",
       "**/*.node",
       "**/prebuilds/**"
     ],

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -17,11 +17,13 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   createProfile,
   deleteProfile,
+  getActiveProfile,
   getProfiles,
   getProfileSetupCommand,
   getProfileSoul,
   type ProfileInfo,
   renameProfile,
+  setActiveProfile,
   updateProfileSoul
 } from '@/hermes'
 import { AlertTriangle, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
@@ -47,14 +49,17 @@ interface ProfilesViewProps {
 export function ProfilesView({ onClose }: ProfilesViewProps) {
   const [profiles, setProfiles] = useState<null | ProfileInfo[]>(null)
   const [selectedName, setSelectedName] = useState<null | string>(null)
+  const [activeProfileName, setActiveProfileName] = useState('default')
   const [createOpen, setCreateOpen] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
   const [deleting, setDeleting] = useState(false)
+  const [activating, setActivating] = useState(false)
 
   const refresh = useCallback(async () => {
     try {
-      const { profiles: list } = await getProfiles()
+      const [{ profiles: list }, active] = await Promise.all([getProfiles(), getActiveProfile()])
       setProfiles(list)
+      setActiveProfileName(active.active)
       setSelectedName(current => {
         if (current && list.some(p => p.name === current)) {
           return current
@@ -137,6 +142,24 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
     }
   }, [pendingDelete, refresh])
 
+  const handleActivate = useCallback(async (name: string) => {
+    setActivating(true)
+
+    try {
+      const result = await setActiveProfile(name)
+      setActiveProfileName(result.active)
+      notify({
+        kind: 'success',
+        title: 'Profile activated for next launch',
+        message: `${name} will be used when Hermes Desktop is restarted.`
+      })
+    } catch (err) {
+      notifyError(err, 'Failed to activate profile')
+    } finally {
+      setActivating(false)
+    }
+  }, [])
+
   return (
     <OverlayView closeLabel="Close profiles" onClose={onClose}>
       {!profiles ? (
@@ -172,7 +195,10 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
           <OverlayMain className="px-0">
             {selected ? (
               <ProfileDetail
+                activating={activating}
+                activeProfileName={activeProfileName}
                 key={selected.name}
+                onActivate={() => void handleActivate(selected.name)}
                 onDelete={() => setPendingDelete(selected)}
                 onRename={newName => handleRename(selected.name, newName)}
                 profile={selected}
@@ -247,10 +273,16 @@ function ProfileRow({ active, onSelect, profile }: { active: boolean; onSelect: 
 }
 
 function ProfileDetail({
+  activeProfileName,
+  activating,
+  onActivate,
   onDelete,
   onRename,
   profile
 }: {
+  activeProfileName: string
+  activating: boolean
+  onActivate: () => void
   onDelete: () => void
   onRename: (newName: string) => Promise<void>
   profile: ProfileInfo
@@ -289,6 +321,14 @@ function ProfileDetail({
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-3">
+                <Button
+                  disabled={activating || activeProfileName === profile.name}
+                  onClick={onActivate}
+                  size="sm"
+                  variant="text"
+                >
+                  {activeProfileName === profile.name ? 'Active for next launch' : 'Activate'}
+                </Button>
                 {!profile.is_default && (
                   <Button onClick={() => setRenameOpen(true)} size="sm" variant="text">
                     <Pencil />

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -3,6 +3,7 @@ import { JsonRpcGatewayClient } from '@hermes/shared'
 import type {
   ActionResponse,
   ActionStatusResponse,
+  ActiveProfileResponse,
   AnalyticsResponse,
   AudioSpeakResponse,
   AudioTranscriptionResponse,
@@ -45,6 +46,7 @@ const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 export type {
   ActionResponse,
   ActionStatusResponse,
+  ActiveProfileResponse,
   AnalyticsDailyEntry,
   AnalyticsModelEntry,
   AnalyticsResponse,
@@ -445,6 +447,20 @@ export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
 export function getProfiles(): Promise<ProfilesResponse> {
   return window.hermesDesktop.api<ProfilesResponse>({
     path: '/api/profiles'
+  })
+}
+
+export function getActiveProfile(): Promise<ActiveProfileResponse> {
+  return window.hermesDesktop.api<ActiveProfileResponse>({
+    path: '/api/profiles/active'
+  })
+}
+
+export function setActiveProfile(name: string): Promise<{ active: string; ok: boolean }> {
+  return window.hermesDesktop.api<{ active: string; ok: boolean }>({
+    path: '/api/profiles/active',
+    method: 'POST',
+    body: { name }
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -463,6 +463,11 @@ export interface ProfilesResponse {
   profiles: ProfileInfo[]
 }
 
+export interface ActiveProfileResponse {
+  active: string
+  current: string
+}
+
 export interface SkillInfo {
   category: string
   description: string


### PR DESCRIPTION
## Summary
- add active-profile read/write API bindings and an Activate action to the Profiles view
- show the selected profile as active for the next launch
- include the unpacked macOS icon path so packaged desktop builds launch reliably

## Validation
- targeted ESLint and TypeScript checks passed
- production desktop build passed
- Swift helper parse/build/sign checks passed
- `git diff --check` passed

Profile switching is intentionally next-launch behavior because the running Hermes backend cannot change profiles in place.