### PR TITLE
fix(agent): classify Anthropic Console spend-limit 400 as billing (#80553)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -116,6 +116,7 @@ _BILLING_PATTERNS = [
     "account is deactivated",
     "plan does not include",
     "out of extra usage",  # Anthropic OAuth Pro/Max overage bucket depleted (HTTP 400)
+    "specified api usage limits",  # Anthropic Console monthly spend cap (HTTP 400)
     "out of funds",
     "run out of funds",
     "balance_depleted",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -711,6 +711,27 @@ class TestAdversarialEdgeCases:
         assert result.retryable is False
         assert result.should_rotate_credential is True
 
+    def test_400_anthropic_console_spend_limit(self):
+        """Anthropic Console monthly spend cap arrives as HTTP 400
+        ("You have reached your specified API usage limits. You will regain
+        access on ..."). Must classify as billing — not format_error — so the
+        eager billing path and billing guidance engage; a spend cap was
+        previously surfaced as a malformed-request error, hiding a month-long
+        provider switch. (#80553)"""
+        e = MockAPIError(
+            "You have reached your specified API usage limits. You will regain access on 2026-09-01",
+            status_code=400,
+            body={"error": {
+                "type": "invalid_request_error",
+                "message": "You have reached your specified API usage limits. You will regain access on 2026-09-01",
+            }},
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-opus-5")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+
     def test_200_with_error_body(self):
         """200 status with error in body — should be unknown, not crash."""
         class WeirdSuccess(Exception):


### PR DESCRIPTION
## What does this PR do?

Fixes #80553. Anthropic's Console monthly spend cap arrives as HTTP 400 with
"You have reached your specified API usage limits. You will regain access on
<date>", but `_BILLING_PATTERNS` had no entry for it, so
`classify_api_error` returned `format_error` instead of `billing`.

This is a functional misclassification, not just a label:

| Flag | Pre-fix (`format_error`) | Post-fix (`billing`) |
|---|---|---|
| `should_rotate_credential` | False — pool re-selects the capped key every 60s | True — key marked exhausted (60 min) and rotated |
| `is_rate_limited` gate (conversation_loop.py:4447) | not engaged | eager billing fallback + correct status line |
| Billing guidance (lines 5166/5360) | never prints | top-up / cycle-reset guidance surfaces |

Net effect before: a spend cap looked like a malformed request, the dead key
stayed "healthy" in the pool, and the operator got no actionable signal —
exactly the silent month-long provider switch the reporter describes.

**Fix:** add `"specified api usage limits"` to `_BILLING_PATTERNS`
(agent/error_classifier.py), adjacent to the existing Anthropic `"out of
extra usage"` entry. The message is lowercased upstream in
`classify_api_error` (lines 675–704), so the pattern is lowercase like every
other entry. All four `_BILLING_PATTERNS` check sites (403/404/400/message)
benefit — whole bug class, one entry.

**Honest caveat:** the exact upstream message string is reporter-verified;
I could not hit a live spend cap to confirm it. If Anthropic's wording drifts,
the pattern silently stops matching — it degrades to "no match," never a
misclassification. Controls prove it doesn't swallow genuine format errors.

## Related Issue

Fixes #80553

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — `_BILLING_PATTERNS`: add `"specified api usage limits"` (+1)
- `tests/agent/test_error_classifier.py` — `test_400_anthropic_console_spend_limit` regression test (+21)

## How to Test

1. **Reproduce:** with the reporter's harness (HTTP 400, the Console
   message, provider=anthropic), `classify_api_error` returned `format_error`
   on current main; with this change it returns `billing`.
2. **Controls:** 402→`billing`, 429→`rate_limit`,
   `400 "credit balance"`→`billing`, `400 "roles must alternate"`→`format_error` — unchanged.
3. **Sibling paths:** same message as 403/404/no-status → `billing` in all.
4. **Caller sweep:** all test files importing `error_classifier` pass
   (207 + 244 tests), plus `tests/agent/test_error_classifier.py` (73) via
   `scripts/run_tests.sh` (canonical runner, per-file isolation).

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — none open or merged touch
  `error_classifier` billing or this message (checked open + merged, per
  CONTRIBUTING); issue #80553 was open and unassigned at filing
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Tests added for my changes (required for bug fixes) — 1 new test
- [x] I've tested on my platform: **Windows 11** (x64)

### Documentation & Housekeeping

- [x] Docstrings updated on all changed functions — or N/A
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture or workflow changes)
- [x] Cross-platform impact considered — string-list addition only;
  `scripts/check-windows-footguns.py` clean on the diff (2 files)
- [x] Tool descriptions/schemas — N/A (no model-tool schema changes)

## Security impact

No shell execution, path handling, credentials, or network changes — a
substring added to a maintainer-controlled pattern constant, matched against
error text only.

## Files (2)

- agent/error_classifier.py [MODIFIED] (+1)
- tests/agent/test_error_classifier.py [MODIFIED] (+21)
