### PR TITLE
refactor(auth): extract remote session helpers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -41,6 +41,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
+from hermes_cli import auth_remote_session as _auth_remote_session
+
 import httpx
 
 from hermes_cli.config import (
@@ -130,7 +132,6 @@ SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/featur
 SPOTIFY_DASHBOARD_URL = "https://developer.spotify.com/dashboard"
 SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
-OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
 DEFAULT_SPOTIFY_SCOPE = " ".join((
     "user-modify-playback-state",
     "user-read-playback-state",
@@ -3392,169 +3393,27 @@ def login_spotify_command(args) -> None:
 # =============================================================================
 # SSH / remote session detection
 # =============================================================================
-
+# The implementations live in hermes_cli.auth_remote_session. These wrappers
+# retain auth.py's import and monkeypatch seams for existing callers.
 def _is_remote_session() -> bool:
-    """Detect environments where loopback OAuth can't reach the local browser.
-
-    Historically only SSH was checked, but #26923 surfaced that
-    **browser-only remote consoles** (GCP Cloud Shell, GitHub
-    Codespaces, AWS EC2 Instance Connect, Gitpod, Replit, etc.) hit
-    the exact same problem — the user has a browser on their laptop
-    but the loopback listener is bound on the remote VM that the
-    laptop's browser can't reach.  These environments typically don't
-    set ``SSH_CLIENT`` / ``SSH_TTY``, so the SSH-only check left
-    them with no guidance and no fallback.
-    """
-    if os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY"):
-        return True
-    # Browser-only remote IDEs / cloud shells.  Keep this list narrow
-    # (well-known, documented env vars set by the host platform) so
-    # we don't falsely trip on a developer's local shell.
-    for var in (
-        "CLOUD_SHELL",         # GCP Cloud Shell
-        "CODESPACES",          # GitHub Codespaces
-        "CODESPACE_NAME",      # GitHub Codespaces (alt)
-        "GITPOD_WORKSPACE_ID", # Gitpod
-        "REPL_ID",             # Replit
-        "STACKBLITZ",          # StackBlitz
-    ):
-        if os.getenv(var):
-            return True
-    return False
-
-
-# Console/text-mode browsers that ``webbrowser`` will happily launch INSIDE
-# the terminal.  Opening one of these is worse than not opening anything —
-# it hijacks the user's TTY with an unusable text browser (the xAI OAuth
-# "Account Management" page rendered in w3m, reported May 2026) instead of
-# letting them copy the URL to a real browser.  When the resolved browser is
-# one of these we refuse to auto-open and fall back to the print-the-URL
-# path, same as a remote session.
-_CONSOLE_BROWSER_NAMES: FrozenSet[str] = frozenset(
-    {
-        "w3m",
-        "lynx",
-        "links",
-        "links2",
-        "elinks",
-        "www-browser",
-        "browsh",  # TUI browser — still hijacks the terminal
-    }
-)
+    return _auth_remote_session._canonical_is_remote_session()
 
 
 def _can_open_graphical_browser() -> bool:
-    """Return True only when a *graphical* browser is likely to open.
-
-    ``webbrowser.open()`` resolves to whatever the platform offers, and on a
-    headless / CLI-only Linux box with no GUI browser installed that is often
-    a text-mode browser (w3m/lynx/links) which launches inside the terminal
-    and takes over the user's session.  This guard distinguishes "a real
-    windowed browser will pop up" from "a console browser will hijack the
-    TTY", so callers can fall back to printing the URL instead.
-
-    Heuristics:
-      * Respect ``$BROWSER`` — if it names a known console browser, refuse.
-      * On Linux, require a display server (``$DISPLAY`` / ``$WAYLAND_DISPLAY``)
-        unless ``$BROWSER`` points at something graphical; no display server
-        almost always means no GUI browser.
-      * Ask ``webbrowser.get()`` what it resolved to and refuse when the
-        underlying command is a known console browser.
-      * macOS and Windows always have a usable default GUI browser.
-    """
-    import webbrowser as _webbrowser
-
-    def _names_console_browser(value: str) -> bool:
-        token = value.strip().split()[0] if value.strip() else ""
-        base = os.path.basename(token).lower()
-        return base in _CONSOLE_BROWSER_NAMES
-
-    browser_env = os.environ.get("BROWSER", "")
-    if browser_env and _names_console_browser(browser_env):
-        return False
-
-    if sys.platform.startswith("linux"):
-        has_display = bool(
-            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
-        )
-        # An explicit graphical $BROWSER can work without $DISPLAY in odd
-        # setups, but a console $BROWSER already returned False above, so the
-        # only way to reach here with a $BROWSER set is a graphical one.
-        if not has_display and not browser_env:
-            return False
-
-    try:
-        controller = _webbrowser.get()
-    except Exception:
-        # No browser resolvable at all → definitely don't auto-open.
-        return False
-
-    candidate = (
-        getattr(controller, "name", "")
-        or getattr(controller, "basename", "")
-        or ""
-    )
-    if candidate and _names_console_browser(candidate):
-        return False
-
-    return True
+    return _auth_remote_session._canonical_can_open_graphical_browser()
 
 
 def _ssh_user_at_host() -> str:
-    """Return best-effort 'user@hostname' for the SSH tunnel hint command.
-
-    Falls back to placeholder tokens when the values cannot be determined so
-    the hint is always syntactically valid even if not copy-pasteable.
-    """
-    try:
-        import socket as _socket
-        hostname = _socket.gethostname() or "<this-host>"
-    except OSError:
-        hostname = "<this-host>"
-    user = os.getenv("USER") or os.getenv("LOGNAME") or "<user>"
-    return f"{user}@{hostname}"
+    return _auth_remote_session._canonical_ssh_user_at_host()
 
 
 def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) -> None:
-    """Print an SSH tunnel hint when running a loopback-redirect OAuth flow on a
-    remote host. The auth server (Spotify, MCP servers, ...) will redirect the
-    user's browser to ``127.0.0.1:<port>/callback``. If the browser is on a
-    different machine than the loopback listener (the usual SSH case), the
-    redirect can't reach the listener without a local port forward.
-
-    The hint is best-effort: silent if we don't think we're remote, or if we
-    can't parse a host/port out of the redirect URI.
-
-    Pass ``docs_url`` for a provider-specific guide; the generic OAuth-over-SSH
-    guide is always shown after it.
-    """
-    if not _is_remote_session():
-        return
-    try:
-        parsed = urlparse(redirect_uri)
-    except Exception:
-        return
-    host = parsed.hostname or ""
-    port = parsed.port
-    if host not in {"127.0.0.1", "::1", "localhost"} or not port:
-        return
-    divider = "-" * 60
-    print()
-    print(divider)
-    print("Remote session detected — SSH tunnel required")
-    print(divider)
-    print(f"Hermes is waiting for the OAuth callback on {redirect_uri}")
-    print("but your browser is on a different machine. Run this command")
-    print("in a NEW terminal on your local machine BEFORE opening the URL:")
-    print()
-    print(f"  ssh -N -L {port}:127.0.0.1:{port} {_ssh_user_at_host()}")
-    print()
-    print("Then open the authorize URL above in your local browser.")
-    if docs_url:
-        print(f"Provider docs:      {docs_url}")
-    print(f"SSH/jump-box guide: {OAUTH_OVER_SSH_DOCS_URL}")
-    print(divider)
-    print()
+    return _auth_remote_session._call_with_auth_seam(
+        _is_remote_session,
+        _ssh_user_at_host,
+        redirect_uri,
+        docs_url=docs_url,
+    )
 
 
 # =============================================================================

--- a/hermes_cli/auth_remote_session.py
+++ b/hermes_cli/auth_remote_session.py
@@ -1,0 +1,220 @@
+"""SSH, remote-session, and graphical-browser authentication helpers."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+import os
+import sys
+from typing import Callable, FrozenSet
+from urllib.parse import urlparse
+
+OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
+
+
+def _is_remote_session() -> bool:
+    """Detect environments where loopback OAuth can't reach the local browser.
+
+    Historically only SSH was checked, but #26923 surfaced that
+    **browser-only remote consoles** (GCP Cloud Shell, GitHub
+    Codespaces, AWS EC2 Instance Connect, Gitpod, Replit, etc.) hit
+    the exact same problem — the user has a browser on their laptop
+    but the loopback listener is bound on the remote VM that the
+    laptop's browser can't reach.  These environments typically don't
+    set ``SSH_CLIENT`` / ``SSH_TTY``, so the SSH-only check left
+    them with no guidance and no fallback.
+    """
+    if os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY"):
+        return True
+    # Browser-only remote IDEs / cloud shells.  Keep this list narrow
+    # (well-known, documented env vars set by the host platform) so
+    # we don't falsely trip on a developer's local shell.
+    for var in (
+        "CLOUD_SHELL",         # GCP Cloud Shell
+        "CODESPACES",          # GitHub Codespaces
+        "CODESPACE_NAME",      # GitHub Codespaces (alt)
+        "GITPOD_WORKSPACE_ID", # Gitpod
+        "REPL_ID",             # Replit
+        "STACKBLITZ",          # StackBlitz
+    ):
+        if os.getenv(var):
+            return True
+    return False
+
+
+# Console/text-mode browsers that ``webbrowser`` will happily launch INSIDE
+# the terminal.  Opening one of these is worse than not opening anything —
+# it hijacks the user's TTY with an unusable text browser (the xAI OAuth
+# "Account Management" page rendered in w3m, reported May 2026) instead of
+# letting them copy the URL to a real browser.  When the resolved browser is
+# one of these we refuse to auto-open and fall back to the print-the-URL
+# path, same as a remote session.
+_CONSOLE_BROWSER_NAMES: FrozenSet[str] = frozenset(
+    {
+        "w3m",
+        "lynx",
+        "links",
+        "links2",
+        "elinks",
+        "www-browser",
+        "browsh",  # TUI browser — still hijacks the terminal
+    }
+)
+
+
+def _can_open_graphical_browser() -> bool:
+    """Return True only when a *graphical* browser is likely to open.
+
+    ``webbrowser.open()`` resolves to whatever the platform offers, and on a
+    headless / CLI-only Linux box with no GUI browser installed that is often
+    a text-mode browser (w3m/lynx/links) which launches inside the terminal
+    and takes over the user's session.  This guard distinguishes "a real
+    windowed browser will pop up" from "a console browser will hijack the
+    TTY", so callers can fall back to printing the URL instead.
+
+    Heuristics:
+      * Respect ``$BROWSER`` — if it names a known console browser, refuse.
+      * On Linux, require a display server (``$DISPLAY`` / ``$WAYLAND_DISPLAY``)
+        unless ``$BROWSER`` points at something graphical; no display server
+        almost always means no GUI browser.
+      * Ask ``webbrowser.get()`` what it resolved to and refuse when the
+        underlying command is a known console browser.
+      * macOS and Windows always have a usable default GUI browser.
+    """
+    import webbrowser as _webbrowser
+
+    def _names_console_browser(value: str) -> bool:
+        token = value.strip().split()[0] if value.strip() else ""
+        base = os.path.basename(token).lower()
+        return base in _CONSOLE_BROWSER_NAMES
+
+    browser_env = os.environ.get("BROWSER", "")
+    if browser_env and _names_console_browser(browser_env):
+        return False
+
+    if sys.platform.startswith("linux"):
+        has_display = bool(
+            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+        )
+        # An explicit graphical $BROWSER can work without $DISPLAY in odd
+        # setups, but a console $BROWSER already returned False above, so the
+        # only way to reach here with a $BROWSER set is a graphical one.
+        if not has_display and not browser_env:
+            return False
+
+    try:
+        controller = _webbrowser.get()
+    except Exception:
+        # No browser resolvable at all → definitely don't auto-open.
+        return False
+
+    candidate = (
+        getattr(controller, "name", "")
+        or getattr(controller, "basename", "")
+        or ""
+    )
+    if candidate and _names_console_browser(candidate):
+        return False
+
+    return True
+
+
+def _ssh_user_at_host() -> str:
+    """Return best-effort 'user@hostname' for the SSH tunnel hint command.
+
+    Falls back to placeholder tokens when the values cannot be determined so
+    the hint is always syntactically valid even if not copy-pasteable.
+    """
+    try:
+        import socket as _socket
+        hostname = _socket.gethostname() or "<this-host>"
+    except OSError:
+        hostname = "<this-host>"
+    user = os.getenv("USER") or os.getenv("LOGNAME") or "<user>"
+    return f"{user}@{hostname}"
+
+
+def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) -> None:
+    """Print an SSH tunnel hint when running a loopback-redirect OAuth flow on a
+    remote host. The auth server (Spotify, MCP servers, ...) will redirect the
+    user's browser to ``127.0.0.1:<port>/callback``. If the browser is on a
+    different machine than the loopback listener (the usual SSH case), the
+    redirect can't reach the listener without a local port forward.
+
+    The hint is best-effort: silent if we don't think we're remote, or if we
+    can't parse a host/port out of the redirect URI.
+
+    Pass ``docs_url`` for a provider-specific guide; the generic OAuth-over-SSH
+    guide is always shown after it.
+    """
+    if not _is_remote_session():
+        return
+    try:
+        parsed = urlparse(redirect_uri)
+    except Exception:
+        return
+    host = parsed.hostname or ""
+    port = parsed.port
+    if host not in {"127.0.0.1", "::1", "localhost"} or not port:
+        return
+    divider = "-" * 60
+    print()
+    print(divider)
+    print("Remote session detected — SSH tunnel required")
+    print(divider)
+    print(f"Hermes is waiting for the OAuth callback on {redirect_uri}")
+    print("but your browser is on a different machine. Run this command")
+    print("in a NEW terminal on your local machine BEFORE opening the URL:")
+    print()
+    print(f"  ssh -N -L {port}:127.0.0.1:{port} {_ssh_user_at_host()}")
+    print()
+    print("Then open the authorize URL above in your local browser.")
+    if docs_url:
+        print(f"Provider docs:      {docs_url}")
+    print(f"SSH/jump-box guide: {OAUTH_OVER_SSH_DOCS_URL}")
+    print(divider)
+    print()
+
+
+# Keep the extracted function bodies verbatim while allowing auth.py's
+# historical monkeypatch seam to reach the moved loopback helper.
+_canonical_is_remote_session = _is_remote_session
+_canonical_can_open_graphical_browser = _can_open_graphical_browser
+_canonical_ssh_user_at_host = _ssh_user_at_host
+_canonical_print_loopback_ssh_hint = _print_loopback_ssh_hint
+
+_AUTH_SEAM: ContextVar[tuple[Callable[[], bool], Callable[[], str]] | None] = ContextVar(
+    "_AUTH_SEAM", default=None
+)
+
+
+def _seamed_is_remote_session() -> bool:
+    seam = _AUTH_SEAM.get()
+    if seam is not None:
+        return seam[0]()
+    return _canonical_is_remote_session()
+
+
+def _seamed_ssh_user_at_host() -> str:
+    seam = _AUTH_SEAM.get()
+    if seam is not None:
+        return seam[1]()
+    return _canonical_ssh_user_at_host()
+
+
+_is_remote_session = _seamed_is_remote_session
+_ssh_user_at_host = _seamed_ssh_user_at_host
+
+
+def _call_with_auth_seam(
+    remote_session: Callable[[], bool],
+    ssh_user_at_host: Callable[[], str],
+    redirect_uri: str,
+    *,
+    docs_url: str | None = None,
+) -> None:
+    token = _AUTH_SEAM.set((remote_session, ssh_user_at_host))
+    try:
+        return _canonical_print_loopback_ssh_hint(redirect_uri, docs_url=docs_url)
+    finally:
+        _AUTH_SEAM.reset(token)


### PR DESCRIPTION
## What changed

Extract the canonical SSH/remote-session/graphical-browser helper cluster from `hermes_cli/auth.py` into `hermes_cli/auth_remote_session.py`.

- Source window: `hermes_cli/auth.py:3396-3557` at pin `aaf9688519cca58dd5f76a589a0911aff269b060`
- Destination: `hermes_cli/auth_remote_session.py`
- Moved names: `_is_remote_session`, `_CONSOLE_BROWSER_NAMES`, `_can_open_graphical_browser` (including `_names_console_browser`), `_ssh_user_at_host`, `_print_loopback_ssh_hint`
- The original `hermes_cli.auth` namespace remains the compatibility surface; callers and monkeypatch targets do not change.
- Pure extraction: no intended behavior change.

This is one independently verified slice of the larger `auth.py` kill. It does not claim that the whole god-file is dead.

Part of #78647
Part of #78637

## Why this matters to users

Authentication setup and browser/SSH detection remain behaviorally identical while this high-cohesion helper cluster stops expanding the auth god-file. Existing CLI, setup, memory, and test patch surfaces continue to resolve through `hermes_cli.auth`.

## Verification

- Blind extraction W2-A: PASS.
- Blind extraction W2-B: PASS.
- Blind Wave-3 A: VERIFIED.
- Blind Wave-3 B: VERIFIED.
- Pinned window: 6,466 bytes; SHA-256 with final LF `91e0fd158ce44af1b2f32ce24363e1254587825df4cf9bda8c16c480a2544bc6`.
- AST/byte fidelity: exact.
- Orphan gate: PASS.
- Original-module monkeypatch seam: PASS.
- Standalone destination import: PASS.
- `py_compile`: PASS.
- `git diff --check`: PASS.
- Targeted CI-parity run from this worktree: **31 passed, 0 failed**.
- Local commit: `cc0667f3f8b57c7faac8900cf4249d5390e4c30b`.

The repo-wide enforcement suite also passed independently: **18 passed, 0 failed**. GitHub CI status is not represented as green here; this PR is being opened with local receipts and will be watched after GitHub creates checks.

## Collision and merge order

The W2/W3 witnesses found no blocking hunk collision in the canonical 3396–3557 window. The branch is based on the validated auth pin. Any later auth extraction touching this surface must retarget after this slice and preserve the original-module compatibility seam.

## Links

- This PR: https://github.com/NousResearch/hermes-agent/pull/80620
- KILL LOCK: https://github.com/NousResearch/hermes-agent/issues/78637#issuecomment-5209579518
- File issue: https://github.com/NousResearch/hermes-agent/issues/78637
- Campaign epic: https://github.com/NousResearch/hermes-agent/issues/78647
- Local consensus: `C:/tmp/tg-campaign/godfile/auth/consensus/S2-CONSENSUS.md`
- Local W2 receipts: `C:/tmp/tg-campaign/godfile/auth/extraction/w2/s2-w2a.json`, `s2-w2b.json`
- Local W3 receipts: `C:/tmp/tg-campaign/godfile/auth/extraction/w3/s2-w3a.json`, `s2-w3b.json`

## Authorship

This slice is authored and DCO-signed under `andrexibiza <84248988+andrexibiza@users.noreply.github.com>`.
