### PR TITLE
fix(streaming): flag empty tool-call args on clean stream end (#80498)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3434,6 +3434,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True
+                elif finish_reason is None:
+                    # Stream ended with no finish_reason AND this tool call's
+                    # arguments never received a single byte (name arrived,
+                    # argument generation never started before the connection
+                    # died). Left unflagged, this fell through to
+                    # `effective_finish_reason = finish_reason or "stop"`
+                    # below — a normal "stop" turn carrying a tool call whose
+                    # empty arguments string later gets silently coerced to
+                    # "{}" at the dispatch boundary and executed with no
+                    # arguments and no retry (#80498). Route it through the
+                    # same dropped-mid-tool-call stub path already used for a
+                    # truncated-but-nonempty JSON string.
+                    has_truncated_tool_args = True
                 mock_tool_calls.append(SimpleNamespace(
                     id=tc["id"],
                     type=tc["type"],

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -207,6 +207,68 @@ class TestCleanStreamEndBeforeAnyToolArgs:
         assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
 
 
+# ── Mixed response: one complete call, one dropped (#80498) ─────────────────
+
+class TestMixedToolCallsOneDroppedOneComplete:
+    """A single response can carry more than one tool call in parallel. If
+    the stream dies before one call's arguments ever start while a sibling
+    call in the SAME response already completed with valid, parseable
+    arguments, the whole response is still discarded as one partial-stream
+    stub — ``_build_partial_stream_stub`` unconditionally sets
+    ``tool_calls=None``, so the valid sibling is not selectively kept.
+
+    This all-or-nothing behavior predates #80498 (it already applied to the
+    partial-but-nonempty-JSON case); this test just locks it in now that the
+    zero-byte case routes through the same stub path, so a future change
+    towards per-tool-call granularity doesn't silently regress either case.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_valid_sibling_tool_call_is_discarded_with_dropped_one(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _clean_ending_stream():
+            # Tool call 0: complete, valid JSON arguments.
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_ok", name="read_file"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "a.txt"}'),
+            ])
+            # Tool call 1: name arrives, then the stream dies before a
+            # single argument byte — the #80498 zero-byte case.
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=1, tc_id="call_x", name="write_file"),
+            ])
+            # falls off the end — clean close, no terminator
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None, (
+            "The valid 'read_file' call must not be selectively kept — the "
+            "whole response is discarded as one stub so the retry "
+            "regenerates every call in it together."
+        )
+        assert getattr(response, "_dropped_tool_names", None) == [
+            "read_file", "write_file",
+        ], (
+            "_dropped_tool_names lists every tool call in the response, "
+            "not just the one that actually failed to complete."
+        )
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -151,6 +151,62 @@ class TestCleanStreamEndMidToolCall:
 
 
 
+# ── Clean stream-end before any argument byte arrives (#80498) ─────────────
+
+class TestCleanStreamEndBeforeAnyToolArgs:
+    """The upstream closes the SSE stream cleanly right after delivering the
+    tool NAME — not a single byte of the arguments delta ever arrived, no
+    exception, no finish_reason, no [DONE].
+
+    Before the fix, an empty ``arguments`` string skipped the
+    truncated-JSON check entirely (it only ran when ``arguments and
+    arguments.strip()``), so ``has_truncated_tool_args`` stayed False. With
+    no other guard catching this shape, the stub-builder fell through to
+    ``effective_finish_reason = finish_reason or "stop"`` and returned a
+    normal "stop" turn carrying a tool call with ``arguments=""`` — which
+    the dispatch boundary silently coerces to "{}" and executes with no
+    retry (#80498, e.g. ``write_file`` running with no arguments).
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_empty_tool_args_routes_to_stub_not_silent_empty_object(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _clean_ending_stream():
+            # Tool name arrives, then the generator simply RETURNS
+            # (StopIteration) before any arguments delta chunk — no raise,
+            # no finish_reason chunk, no [DONE].
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_x", name="write_file"),
+            ])
+            # falls off the end — clean close, no terminator, zero args bytes
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID, (
+            "A tool call whose arguments never started streaming before a "
+            "clean stream end must be tagged as a partial-stream stub, not "
+            "silently returned as a completed 'stop' turn with empty "
+            "arguments (#80498)."
+        )
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None, (
+            "A tool call with zero argument bytes delivered must never "
+            "auto-execute with a silently substituted empty object."
+        )
+        assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4023,6 +4023,47 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
+    def test_zero_byte_tool_args_stub_recovers_within_retries(self, agent):
+        """#80498: a stream that dies before a single argument byte arrives
+        (name-only tool call) produces a stub with tool_calls=None and
+        _dropped_tool_names set — the real shape _build_partial_stream_stub
+        returns, distinct from the truncated-JSON stub above (which still
+        carries a tool_calls list). Confirms the zero-byte trigger is wired
+        end-to-end through the retry loop, not just detected at the
+        chat_completion_helpers unit level."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+
+        stall = _mock_response(content="", finish_reason="length", tool_calls=None)
+        stall.id = PARTIAL_STREAM_STUB_ID
+        stall._dropped_tool_names = ["write_file"]
+
+        good_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"full content"}',
+            call_id="c2",
+        )
+        good_resp = _mock_response(content="", finish_reason="stop", tool_calls=[good_tc])
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [
+                stall, good_resp, final_resp,
+            ]
+            result = agent.run_conversation("write the report")
+
+        # The zero-byte stub must trigger a retry, not silently execute
+        # write_file with coerced empty arguments (the #80498 regression).
+        mock_hfc.assert_called_once()
+        assert result["final_response"] == "Done!"
+
 
     def test_truncated_tool_json_after_tool_batch_closes_tool_tail(self, agent):
         """finish_reason=tool_calls + truncated args after a real tool must close tool→user."""


### PR DESCRIPTION
## Summary

Fixes #80498. When the underlying stream closes right after a tool call's `name` arrives but before **any** argument bytes are delivered, the truncation-detection guard was skipped entirely (it required a non-empty, whitespace-stripped `arguments` buffer). The call fell through to a normal `stop` finish reason, and its empty argument string was later silently coerced to `"{}"` at the dispatch boundary — executed with no arguments and no retry.

This adds an `elif finish_reason is None:` branch that routes the zero-byte case through the same dropped-mid-tool-call stub/retry path already used for partially-truncated JSON (e.g. `"{"`), so the agent retries instead of silently executing the tool with empty arguments.

## Infographic :

<img width="1024" height="1024" alt="pr_80498_infographic" src="https://github.com/user-attachments/assets/3b51be34-f916-4db5-88ae-a3ddc20f4786" />


## Root cause

In `agent/chat_completion_helpers.py`, inside `interruptible_streaming_api_call()`, the truncation check was gated behind `arguments and arguments.strip()`. When the stream dies with **zero** argument bytes (name-only), it never entered that block, so `has_truncated_tool_args` stayed `False` and the response was treated as a clean `stop`.

## Test plan

- [x] Added `TestCleanStreamEndBeforeAnyToolArgs` in `tests/run_agent/test_partial_stream_finish_reason.py` reproducing the exact zero-byte-args scenario — passes with the fix, fails without it.
- [x] Added `TestMixedToolCallsOneDroppedOneComplete` (same file) — a response with one complete, valid tool call alongside one zero-byte call still discards the whole response as a single stub (`_build_partial_stream_stub` always sets `tool_calls=None`). Locks in this pre-existing all-or-nothing behavior so it doesn't silently regress now that the zero-byte case shares the same stub path.
- [x] Added `test_zero_byte_tool_args_stub_recovers_within_retries` in `tests/run_agent/test_run_agent.py::TestRunConversation` — end-to-end through `run_conversation()`'s retry loop (not just the `chat_completion_helpers` unit level), confirming the zero-byte trigger actually recovers via retry instead of dispatching with coerced empty arguments.
- [x] Ran the broader suite (`tests/run_agent/ tests/agent/ -k "stream or tool_call or tool_arg or truncat or partial or dropped"`) with and without the fix via `git stash`/`stash pop`: **identical pre-existing failures** in both runs (unrelated subsystems: concurrent dispatch, guardrails, incremental persistence, subagent stop hook, title generator) — zero regressions introduced.
- [x] Full `tests/run_agent/test_partial_stream_finish_reason.py` (17/17) and `tests/run_agent/test_run_agent.py::TestRunConversation` (46/46) green after the new tests.