### PR TITLE
refactor(context_compressor): extract text-util leaves into context_compressor_text_utils

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -40,6 +40,10 @@ from agent.model_metadata import (
     estimate_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
+from agent.context_compressor_text_utils import (
+    _content_text_for_contains,
+    _redact_compaction_text,
+)
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -676,27 +680,6 @@ _HISTORICAL_TASK_SECTION_RE = re.compile(
 )
 
 
-def _redact_compaction_text(text: Any) -> str:
-    """Redact text that crosses a compaction summary boundary.
-
-    Compaction summaries persist across sessions and are re-injected into
-    every subsequent summarizer prompt, so this boundary uses strict mode:
-
-    - ``force=True`` — deliberately overrides ``security.redact_secrets:
-      false``. That opt-out targets *live tool output* (e.g. working on the
-      redactor itself); a summary is a persistence boundary where a leaked
-      credential keeps re-entering prompts indefinitely.
-    - ``redact_url_credentials=True`` — OAuth callback codes, magic-link
-      tokens, and URL userinfo never need to survive summarization the way
-      they must survive live navigation flows.
-    """
-    return redact_sensitive_text(
-        text or "",
-        force=True,
-        redact_url_credentials=True,
-    )
-
-
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
     value = value.strip()
     if value and value not in items and len(items) < limit:
@@ -865,29 +848,6 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
             // _CHARS_PER_TOKEN
         )
     return tokens
-
-
-def _content_text_for_contains(content: Any) -> str:
-    """Return a best-effort text view of message content.
-
-    Used only for substring checks when we need to know whether we've already
-    appended a note to a message. Keeps multimodal lists intact elsewhere.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "\n".join(part for part in parts if part)
-    return str(content)
 
 
 def _append_text_to_content(content: Any, text: str, *, prepend: bool = False) -> Any:

--- a/agent/context_compressor_text_utils.py
+++ b/agent/context_compressor_text_utils.py
@@ -1,0 +1,56 @@
+"""Text helpers extracted from context_compressor (leaf util, epic #78647).
+
+Pure module-level helpers used across skill-prune, summary serialize, and
+identity paths. Extracted first so skill-prune can import without a cycle
+back into the god file.
+
+Part of #78645 + #78647.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+def _redact_compaction_text(text: Any) -> str:
+    """Redact text that crosses a compaction summary boundary.
+
+    Compaction summaries persist across sessions and are re-injected into
+    every subsequent summarizer prompt, so this boundary uses strict mode:
+
+    - ``force=True`` — deliberately overrides ``security.redact_secrets:
+      false``. That opt-out targets *live tool output* (e.g. working on the
+      redactor itself); a summary is a persistence boundary where a leaked
+      credential keeps re-entering prompts indefinitely.
+    - ``redact_url_credentials=True`` — OAuth callback codes, magic-link
+      tokens, and URL userinfo never need to survive summarization the way
+      they must survive live navigation flows.
+    """
+    return redact_sensitive_text(
+        text or "",
+        force=True,
+        redact_url_credentials=True,
+    )
+
+def _content_text_for_contains(content: Any) -> str:
+    """Return a best-effort text view of message content.
+
+    Used only for substring checks when we need to know whether we've already
+    appended a note to a message. Keeps multimodal lists intact elsewhere.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)

--- a/tests/agent/test_context_compressor_text_utils_seam.py
+++ b/tests/agent/test_context_compressor_text_utils_seam.py
@@ -1,0 +1,41 @@
+"""Seam identity for context_compressor_text_utils leaf extract (LB-textutil).
+
+Part of #78645 + #78647.
+"""
+
+from agent import context_compressor as cc
+from agent import context_compressor_text_utils as tu
+
+
+def test_redact_and_content_text_resolve_is_identical_through_godfile():
+    assert cc._redact_compaction_text is tu._redact_compaction_text
+    assert cc._content_text_for_contains is tu._content_text_for_contains
+
+
+def test_no_duplicate_defs_in_godfile():
+    import inspect
+    from pathlib import Path
+
+    src = Path(cc.__file__).read_text(encoding="utf-8")
+    assert src.count("def _redact_compaction_text") == 0
+    assert src.count("def _content_text_for_contains") == 0
+    assert "context_compressor_text_utils" in src
+
+
+def test_redact_behavior_smoke():
+    # None-safety preserved
+    assert cc._redact_compaction_text(None) == ""
+    # content text view
+    assert cc._content_text_for_contains(None) == ""
+    assert cc._content_text_for_contains("hi") == "hi"
+    assert cc._content_text_for_contains([{"type": "text", "text": "a"}, "b"]) == "a\nb"
+
+
+def test_import_orders_no_cycle():
+    import importlib
+    import agent.context_compressor_text_utils as a
+    import agent.context_compressor as b
+
+    importlib.reload(a)
+    importlib.reload(b)
+    assert b._redact_compaction_text is a._redact_compaction_text


### PR DESCRIPTION
## Summary

Large-file decomposition feature package (tracker #78647): `agent/context_compressor.py` slice — extract the two pure text-util leaves (`_redact_compaction_text`, `_content_text_for_contains`) into `agent/context_compressor_text_utils.py` with an `is`-identical re-export seam.

## Why these two first

Wave-2 graph redraw (dual REQUEST_CHANGES, #78645): the skill-prune cluster (LB2) depends on both helpers — extracting them first breaks the import cycle and unblocks LB2 as a clean one-way dependency.

## Slice

- **God-file:** `agent/context_compressor.py` (6,883 lines @ pin `6e9cae6ac4b`)
- **Window:** 679–697 + 870–890 (pin line numbers)
- **Golden sha256:** `5591e8c923958085…` / `3f79a957ac93230a…` — both byte-exact, verified by 5/5 blind reviewers
- **Module:** `agent/context_compressor_text_utils.py` (imports only `typing` + `agent.redact`; no cycle)
- **Seam:** godfile re-exports both names; `cc._redact is tu._redact` verified at runtime

## Verification

- 31/31 targeted tests (seam + redaction boundaries + ghost-skill + zero-user-guard)
- 5/5 blind re-review **APPROVED** (0 CRITICAL / 0 IMPORTANT; 1 provenance MINOR)
- ruff clean · `git diff --check` clean · LF-only · DCO signed
- Collision census clean (no open PR modifies either window)

Part of #78645
Part of #78647
