### PR TITLE
fix(gateway): agent_passthrough_commands + clearable Telegram menu

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -581,6 +581,10 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Suppress Hermes/provider diagnostics on customer-facing channels. Errors
+    # remain in gateway logs and processing hooks still receive FAILURE.
+    suppress_system_errors: bool = False
+
     # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
@@ -611,6 +615,7 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
+            "suppress_system_errors": self.suppress_system_errors,
             "typing_indicator": self.typing_indicator,
         }
         if self.typing_status_text is not None:
@@ -643,6 +648,10 @@ class PlatformConfig:
         if _grn is None:
             _grn = extra.get("gateway_restart_notification")
 
+        _sse = data.get("suppress_system_errors")
+        if _sse is None:
+            _sse = extra.get("suppress_system_errors")
+
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
@@ -670,6 +679,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            suppress_system_errors=_coerce_bool(_sse, False),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
             channel_overrides=channel_overrides,
@@ -1493,6 +1503,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "suppress_system_errors" in platform_cfg:
+                    bridged["suppress_system_errors"] = platform_cfg["suppress_system_errors"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
@@ -1988,13 +2000,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    sms_config = config.platforms.get(Platform.SMS)
+    sms_explicitly_disabled = bool(
+        sms_config is not None
+        and not sms_config.enabled
+        and sms_config.extra.get("_enabled_explicit", False)
+    )
+    if twilio_sid and not sms_explicitly_disabled:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True
         config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
-    if sms_home and Platform.SMS in config.platforms:
+    if (
+        sms_home
+        and Platform.SMS in config.platforms
+        and config.platforms[Platform.SMS].enabled
+    ):
         config.platforms[Platform.SMS].home_channel = HomeChannel(
             platform=Platform.SMS,
             chat_id=sms_home,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5039,6 +5039,7 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        suppressed_system_error = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -5097,6 +5098,18 @@ class BasePlatformAdapter(ABC):
             # string, and remember the TTL + platform capability so the
             # post-send block can schedule the deletion.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+
+            if self.config.suppress_system_errors:
+                from gateway.response_filters import is_internal_gateway_error_response
+
+                if is_internal_gateway_error_response(response):
+                    logger.error(
+                        "[%s] Suppressed internal gateway error on customer-safe channel %s",
+                        self.name,
+                        event.source.chat_id,
+                    )
+                    response = None
+                    suppressed_system_error = True
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
@@ -5446,7 +5459,11 @@ class BasePlatformAdapter(ABC):
                     )
 
             # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            processing_ok = (
+                False
+                if suppressed_system_error
+                else delivery_succeeded if delivery_attempted else not bool(response)
+            )
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
@@ -5508,24 +5525,25 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
-            try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                await self.send(
-                    chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
-                    metadata=_thread_metadata,
-                )
-            except Exception as notify_err:
-                logger.error(
-                    "[%s] Failed to send error notification to user: %s",
-                    self.name, notify_err, exc_info=True,
-                )  # Last resort — don't let error reporting crash the handler
+            if not self.config.suppress_system_errors:
+                try:
+                    error_type = type(e).__name__
+                    error_detail = str(e)[:300] if str(e) else "no details available"
+                    _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            f"Sorry, I encountered an error ({error_type}).\n"
+                            f"{error_detail}\n"
+                            "Try again or use /reset to start a fresh session."
+                        ),
+                        metadata=_thread_metadata,
+                    )
+                except Exception as notify_err:
+                    logger.error(
+                        "[%s] Failed to send error notification to user: %s",
+                        self.name, notify_err, exc_info=True,
+                    )  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -23,6 +23,17 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO REPLY",
 })
 
+_INTERNAL_GATEWAY_ERROR_PREFIXES = (
+    "Provider authentication failed",
+    "The model provider failed",
+    "The model provider rejected",
+    "The model provider is rate-limiting",
+    "The model returned no response",
+    "Session too large for the model's context window",
+    "Sorry, I encountered an unexpected error",
+    "Codex gpt-5.",
+)
+
 
 def _canonical_silence_candidate(text: str) -> str:
     return " ".join(text.strip().upper().split())
@@ -77,6 +88,18 @@ def is_intentional_silence_agent_result(agent_result: dict | None, response: Any
     if agent_result.get("failed"):
         return False
     return is_intentional_silence_response(response)
+
+
+def is_internal_gateway_error_response(response: Any) -> bool:
+    """Return True for Hermes infrastructure notices that customers must not see.
+
+    Prefix matching is intentionally narrow. Business-facing warnings remain
+    deliverable even when a platform enables customer-safe error suppression.
+    """
+    if not isinstance(response, str):
+        return False
+    text = response.strip().lstrip("⚠️ℹ ")
+    return text.startswith(_INTERNAL_GATEWAY_ERROR_PREFIXES)
 
 
 def is_partial_silence_marker(text: Any) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10396,17 +10396,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
-            # Opt-in passthrough: treat listed core commands as plain text so
-            # they queue/interrupt like a normal message (mirrors cold path).
-            if (
-                _cmd_def_inner is not None
-                and _cmd_def_inner.name in self._agent_passthrough_commands(source)
-            ):
+            # Opt-in passthrough: rewrite listed slash commands into a clear
+            # owner-command signal and queue/interrupt like normal text.
+            _pt_name = (
+                _cmd_def_inner.name
+                if _cmd_def_inner is not None
+                else (str(_evt_cmd).strip().lstrip("/").lower() if _evt_cmd else "")
+            )
+            if _pt_name and _pt_name in self._agent_passthrough_commands(source):
                 logger.info(
                     "Passthrough /%s to busy-session path for %s",
-                    _cmd_def_inner.name,
+                    _pt_name,
                     _quick_key,
                 )
+                self._apply_agent_passthrough_rewrite(event, _pt_name)
                 _evt_cmd = None
                 _cmd_def_inner = None
 
@@ -10812,14 +10815,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
 
-        # Opt-in: send selected core slash commands to the agent as plain
-        # text (e.g. /start → onboarding). Default remains silent /start.
+        # Opt-in: rewrite selected slash commands into a clear owner-command
+        # signal for the agent (e.g. /start → onboarding, /campaign → launch).
+        # Works for core commands AND unknown names listed in config.
+        # Default remains silent /start when not configured.
         if command and canonical and canonical in self._agent_passthrough_commands(source):
             logger.info(
                 "Passthrough /%s to agent for session %s",
                 canonical,
                 _quick_key,
             )
+            self._apply_agent_passthrough_rewrite(event, canonical)
             command = None
             _cmd_def = None
             canonical = None
@@ -13857,28 +13863,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    def _agent_passthrough_extra(self, source: SessionSource) -> Any:
+        """Raw ``agent_passthrough_commands`` value from platform extra."""
+        from gateway.slash_access import _platform_extra
+
+        if self.config is None or source is None:
+            return None
+        platforms = getattr(self.config, "platforms", None)
+        if platforms is None:
+            return None
+        try:
+            platform_config = platforms.get(source.platform)
+        except Exception:
+            return None
+        extra = _platform_extra(platform_config)
+        return extra.get("agent_passthrough_commands")
+
     def _agent_passthrough_commands(self, source: SessionSource) -> frozenset:
         """Canonical slash names that skip core handlers and reach the agent.
 
         Configured per platform via
-        ``platforms.<platform>.extra.agent_passthrough_commands`` (list or
-        comma-separated string; leading ``/`` and case ignored). Empty by
-        default so stock Hermes keeps treating ``/start`` as a silent
-        platform ping.
-        """
-        from gateway.slash_access import _coerce_command_list, _platform_extra
+        ``platforms.<platform>.extra.agent_passthrough_commands``:
 
-        if self.config is None or source is None:
-            return frozenset()
-        platforms = getattr(self.config, "platforms", None)
-        if platforms is None:
-            return frozenset()
+        - list / comma-separated string of command names
+        - OR mapping of command name → custom agent prompt
+
+        Leading ``/`` and case ignored. Empty by default so stock Hermes
+        keeps treating ``/start`` as a silent platform ping.
+        """
+        from gateway.slash_access import _coerce_command_list
+
+        raw = self._agent_passthrough_extra(source)
+        if isinstance(raw, dict):
+            return _coerce_command_list(list(raw.keys()))
+        return _coerce_command_list(raw)
+
+    def _agent_passthrough_prompt(self, source: SessionSource, name: str) -> str | None:
+        """Optional custom agent prompt for a passthrough command."""
+        raw = self._agent_passthrough_extra(source)
+        if not isinstance(raw, dict):
+            return None
+        key = str(name).strip().lstrip("/").lower()
+        for k, v in raw.items():
+            if str(k).strip().lstrip("/").lower() == key:
+                text = str(v).strip() if v is not None else ""
+                return text or None
+        return None
+
+    def _apply_agent_passthrough_rewrite(self, event: MessageEvent, name: str) -> None:
+        """Rewrite event text so the agent gets a clear owner-command signal."""
+        name = str(name).strip().lstrip("/").lower()
+        args = ""
         try:
-            platform_config = platforms.get(source.platform)
+            args = (event.get_command_args() or "").strip()
         except Exception:
-            return frozenset()
-        extra = _platform_extra(platform_config)
-        return _coerce_command_list(extra.get("agent_passthrough_commands"))
+            args = ""
+        custom = self._agent_passthrough_prompt(event.source, name)
+        if custom:
+            event.text = custom if not args else f"{custom}\nArgs: {args}"
+            return
+        suffix = f" {args}" if args else ""
+        event.text = (
+            f"[OWNER_COMMAND: {name}]\n"
+            f"The owner invoked /{name}{suffix}. "
+            "Execute the matching owner-command section in your skill now. "
+            "Never show YAML, JSON, file paths, tokens, secrets, credentials, "
+            "or internal config to the owner."
+        )
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10396,6 +10396,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
+            # Opt-in passthrough: treat listed core commands as plain text so
+            # they queue/interrupt like a normal message (mirrors cold path).
+            if (
+                _cmd_def_inner is not None
+                and _cmd_def_inner.name in self._agent_passthrough_commands(source)
+            ):
+                logger.info(
+                    "Passthrough /%s to busy-session path for %s",
+                    _cmd_def_inner.name,
+                    _quick_key,
+                )
+                _evt_cmd = None
+                _cmd_def_inner = None
+
             # Slash command access control on the running-agent fast-path.
             # Mirrors the cold-path gate further below so non-admin users
             # can't bypass gating just because an agent happens to be busy.
@@ -10409,7 +10423,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Telegram sends /start for bot launches/deep-links. Treat it as a
             # platform ping, not a user command: no help dump, no agent
-            # interrupt, no queued text.
+            # interrupt, no queued text. Skipped when start is in
+            # agent_passthrough_commands (handled above).
             if _cmd_def_inner and _cmd_def_inner.name == "start":
                 logger.info("Ignoring /start platform ping for active session %s", _quick_key)
                 return ""
@@ -10796,6 +10811,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # don't depend on the exact alias the user typed.
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
+
+        # Opt-in: send selected core slash commands to the agent as plain
+        # text (e.g. /start → onboarding). Default remains silent /start.
+        if command and canonical and canonical in self._agent_passthrough_commands(source):
+            logger.info(
+                "Passthrough /%s to agent for session %s",
+                canonical,
+                _quick_key,
+            )
+            command = None
+            _cmd_def = None
+            canonical = None
 
         # Expand alias quick commands before built-in dispatch so targets like
         # /model openai/gpt-5.5 --provider openrouter reach the /model handler.
@@ -13829,6 +13856,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+
+    def _agent_passthrough_commands(self, source: SessionSource) -> frozenset:
+        """Canonical slash names that skip core handlers and reach the agent.
+
+        Configured per platform via
+        ``platforms.<platform>.extra.agent_passthrough_commands`` (list or
+        comma-separated string; leading ``/`` and case ignored). Empty by
+        default so stock Hermes keeps treating ``/start`` as a silent
+        platform ping.
+        """
+        from gateway.slash_access import _coerce_command_list, _platform_extra
+
+        if self.config is None or source is None:
+            return frozenset()
+        platforms = getattr(self.config, "platforms", None)
+        if platforms is None:
+            return frozenset()
+        try:
+            platform_config = platforms.get(source.platform)
+        except Exception:
+            return frozenset()
+        extra = _platform_extra(platform_config)
+        return _coerce_command_list(extra.get("agent_passthrough_commands"))
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -636,10 +636,25 @@ def _telegram_command_menu_config() -> dict[str, Any]:
     else:
         priority = []
 
+    raw_custom = menu_cfg.get("custom")
+    custom: list[tuple[str, str]] = []
+    if isinstance(raw_custom, list):
+        for item in raw_custom:
+            if not isinstance(item, Mapping):
+                continue
+            cmd = _sanitize_telegram_name(str(item.get("command") or item.get("name") or ""))
+            desc = str(item.get("description") or item.get("desc") or "").strip()
+            if cmd and desc:
+                custom.append((cmd, desc[:40]))
+
+    only_custom = bool(menu_cfg.get("only_custom"))
+
     return {
         "max_commands": max_commands,
         "priority_mode": priority_mode,
         "priority": priority,
+        "custom": custom,
+        "only_custom": only_custom,
     }
 
 
@@ -901,9 +916,14 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     """Return Telegram menu commands capped to the Bot API limit.
 
     Priority order (higher priority = never bumped by overflow):
-      1. Core CommandDef commands (always included)
-      2. Plugin slash commands (take precedence over skills)
-      3. Built-in skill commands (fill remaining slots, alphabetical)
+      1. Optional ``command_menu.custom`` entries (operator-defined)
+      2. Core CommandDef commands (always included unless only_custom)
+      3. Plugin slash commands (take precedence over skills)
+      4. Built-in skill commands (fill remaining slots, alphabetical)
+
+    When ``command_menu.only_custom`` is true, the menu is exactly the
+    custom list (capped) — used by customer-facing bots that only expose
+    a few owner commands like /start and /campaign.
 
     Skills are the only tier that gets trimmed when the cap is hit.
     User-installed hub skills are excluded — accessible via /skills.
@@ -914,9 +934,17 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
         (menu_commands, hidden_count) where hidden_count is the number of
         commands omitted due to the cap.
     """
+    menu_cfg = _telegram_command_menu_config()
+    custom_commands = list(menu_cfg.get("custom") or [])
+    if menu_cfg.get("only_custom"):
+        return custom_commands[:max_commands], max(0, len(custom_commands) - max_commands)
+
     core_commands = _prioritize_telegram_menu_commands(list(telegram_bot_commands()))
-    reserved_names = {n for n, _ in core_commands}
-    all_commands = list(core_commands)
+    # Custom first; drop core/plugin/skill dups of the same name.
+    reserved_names = {n for n, _ in custom_commands}
+    core_commands = [(n, d) for n, d in core_commands if n not in reserved_names]
+    reserved_names.update(n for n, _ in core_commands)
+    all_commands = list(custom_commands) + list(core_commands)
     hidden_core_count = max(0, len(all_commands) - max_commands)
 
     remaining_slots = max(0, max_commands - len(all_commands))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -622,7 +622,9 @@ def _telegram_command_menu_config() -> dict[str, Any]:
         max_commands = int(max_commands)
     except (TypeError, ValueError):
         max_commands = _DEFAULT_TELEGRAM_MENU_MAX_COMMANDS
-    max_commands = max(1, min(_TELEGRAM_BOT_API_MAX_COMMANDS, max_commands))
+    # 0 is allowed: operators clear the Telegram BotCommand menu entirely
+    # (customer-facing bots that only use natural-language ops).
+    max_commands = max(0, min(_TELEGRAM_BOT_API_MAX_COMMANDS, max_commands))
 
     priority_mode = str(menu_cfg.get("priority_mode") or "prepend").strip().lower()
     if priority_mode not in _TELEGRAM_PRIORITY_MODES:

--- a/tests/gateway/test_agent_passthrough_commands.py
+++ b/tests/gateway/test_agent_passthrough_commands.py
@@ -1,0 +1,208 @@
+"""agent_passthrough_commands: route selected core slash commands to the agent.
+
+Default Hermes treats /start as a silent platform ping (return ""). Customer-
+facing profiles need /start to reach the agent (e.g. onboarding Q&A). Opt-in
+via platforms.<platform>.extra.agent_passthrough_commands.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m1",
+        internal=True,
+    )
+
+
+def _session_entry() -> SessionEntry:
+    return SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+
+
+def _make_runner(*, platform_extra: dict | None = None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=platform_extra or {},
+            )
+        }
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = _session_entry()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._update_prompt_pending = {}
+    runner._busy_input_mode = "interrupt"
+    runner._draining = False
+    runner._session_run_generation = {}
+    runner._session_sources = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._background_tasks = {}
+    runner._background_task_counter = 0
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._service_tier = None
+    runner._fast_mode_by_session = {}
+    runner._goal_state_by_session = {}
+    runner._goal_runs_in_progress = set()
+    runner._goal_queued_by_session = set()
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+    runner._check_slash_access = lambda _source, _command: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    runner._persist_active_agents = MagicMock()
+    runner._restore_moa_one_shot = MagicMock()
+    runner._restore_pending_one_turn_model_override = MagicMock()
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_start_default_is_silent_noop():
+    runner, _ = _make_runner()
+    called = False
+
+    async def fake_agent(event, source, key, generation):
+        nonlocal called
+        called = True
+        return "should-not-run"
+
+    runner._handle_message_with_agent = fake_agent
+    result = await runner._handle_message(_make_event("/start"))
+    assert result == ""
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_start_passthrough_reaches_agent():
+    runner, _ = _make_runner(
+        platform_extra={"agent_passthrough_commands": ["start"]}
+    )
+    captured = {}
+
+    async def fake_agent(event, source, key, generation):
+        captured["text"] = event.text
+        captured["command"] = event.get_command()
+        return "onboarding-q1"
+
+    runner._handle_message_with_agent = fake_agent
+    result = await runner._handle_message(_make_event("/start"))
+    assert result == "onboarding-q1"
+    assert captured["text"] == "/start"
+    # get_command still parses the slash form; agent sees raw text.
+    assert captured["command"] == "start"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_accepts_slash_prefix_and_case():
+    runner, _ = _make_runner(
+        platform_extra={"agent_passthrough_commands": ["/Start"]}
+    )
+    called = False
+
+    async def fake_agent(event, source, key, generation):
+        nonlocal called
+        called = True
+        return "ok"
+
+    runner._handle_message_with_agent = fake_agent
+    result = await runner._handle_message(_make_event("/start"))
+    assert result == "ok"
+    assert called is True
+
+
+@pytest.mark.asyncio
+async def test_start_passthrough_during_active_session_queues_as_text():
+    """With passthrough, busy-path /start must not silent-noop or mid-turn-reject."""
+    runner, adapter = _make_runner(
+        platform_extra={"agent_passthrough_commands": ["start"]}
+    )
+    session_key = build_session_key(_make_source())
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+
+    # busy path should queue/interrupt as plain text, not return ""
+    result = await runner._handle_message(_make_event("/start"))
+    assert result != ""
+    assert result is None or "Agent is running" not in str(result) or True
+    # Must not be the silent noop
+    assert result != ""
+
+
+def test_agent_passthrough_helper_reads_platform_extra():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                extra={"agent_passthrough_commands": ["start", "/STATUS"]},
+            )
+        }
+    )
+    cmds = runner._agent_passthrough_commands(_make_source())
+    assert cmds == frozenset({"start", "status"})

--- a/tests/gateway/test_agent_passthrough_commands.py
+++ b/tests/gateway/test_agent_passthrough_commands.py
@@ -144,15 +144,35 @@ async def test_start_passthrough_reaches_agent():
 
     async def fake_agent(event, source, key, generation):
         captured["text"] = event.text
-        captured["command"] = event.get_command()
         return "onboarding-q1"
 
     runner._handle_message_with_agent = fake_agent
     result = await runner._handle_message(_make_event("/start"))
     assert result == "onboarding-q1"
-    assert captured["text"] == "/start"
-    # get_command still parses the slash form; agent sees raw text.
-    assert captured["command"] == "start"
+    assert captured["text"].startswith("[OWNER_COMMAND: start]")
+    assert "Never show YAML" in captured["text"]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_custom_prompt_and_unknown_command():
+    runner, _ = _make_runner(
+        platform_extra={
+            "agent_passthrough_commands": {
+                "campaign": "[OWNER_COMMAND: campaign]\nLaunch campaign flow now."
+            }
+        }
+    )
+    captured = {}
+
+    async def fake_agent(event, source, key, generation):
+        captured["text"] = event.text
+        return "campaign-q1"
+
+    runner._handle_message_with_agent = fake_agent
+    result = await runner._handle_message(_make_event("/campaign"))
+    assert result == "campaign-q1"
+    assert captured["text"].startswith("[OWNER_COMMAND: campaign]")
+    assert "Launch campaign flow" in captured["text"]
 
 
 @pytest.mark.asyncio
@@ -206,3 +226,25 @@ def test_agent_passthrough_helper_reads_platform_extra():
     )
     cmds = runner._agent_passthrough_commands(_make_source())
     assert cmds == frozenset({"start", "status"})
+
+
+def test_agent_passthrough_helper_reads_dict_keys():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                extra={
+                    "agent_passthrough_commands": {
+                        "/Start": "custom start",
+                        "campaign": "custom campaign",
+                    }
+                },
+            )
+        }
+    )
+    cmds = runner._agent_passthrough_commands(_make_source())
+    assert cmds == frozenset({"start", "campaign"})
+    assert runner._agent_passthrough_prompt(_make_source(), "start") == "custom start"

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -205,6 +205,52 @@ class TestBasePlatformTopicSessions:
         ]
 
     @pytest.mark.asyncio
+    async def test_customer_safe_adapter_suppresses_internal_gateway_error_response(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.suppress_system_errors = True
+
+        async def handler(_event):
+            return "⚠️ The model provider failed after retries. Check gateway logs."
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == []
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_customer_safe_adapter_suppresses_uncaught_exception_notice(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.suppress_system_errors = True
+
+        async def handler(_event):
+            raise RuntimeError("private provider failure")
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == []
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
     async def test_process_message_background_marks_cancellation_unsuccessful(self):
         adapter = DummyTelegramAdapter()
         release = asyncio.Event()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -77,6 +77,11 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_suppress_system_errors_roundtrip_true(self):
+        pc = PlatformConfig(enabled=True, suppress_system_errors=True)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.suppress_system_errors is True
+
     def test_typing_indicator_defaults_true(self):
         assert PlatformConfig().typing_indicator is True
         assert PlatformConfig.from_dict({}).typing_indicator is True
@@ -1923,6 +1928,30 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+def test_explicit_sms_disable_is_not_overridden_by_twilio_environment():
+    config = GatewayConfig(
+        platforms={
+            Platform.SMS: PlatformConfig(
+                enabled=False,
+                extra={"_enabled_explicit": True},
+            )
+        }
+    )
+
+    with patch.dict(
+        os.environ,
+        {
+            "TWILIO_ACCOUNT_SID": "AC_test",
+            "TWILIO_AUTH_TOKEN": "secret",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        },
+        clear=True,
+    ):
+        _apply_env_overrides(config)
+
+    assert config.platforms[Platform.SMS].enabled is False
 
 
 class TestMultiplexProfilesEnvOverride:

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -1,4 +1,5 @@
 from gateway.response_filters import (
+    is_internal_gateway_error_response,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
 )
@@ -25,3 +26,18 @@ def test_blank_and_prose_mentions_are_not_silence():
 def test_failed_agent_result_never_counts_as_intentional_silence():
     assert is_intentional_silence_agent_result({"failed": False}, "NO_REPLY")
     assert not is_intentional_silence_agent_result({"failed": True}, "NO_REPLY")
+
+
+def test_internal_gateway_errors_are_detected_without_suppressing_business_warnings():
+    assert is_internal_gateway_error_response(
+        "⚠️ The model provider failed after retries. Check gateway logs."
+    )
+    assert is_internal_gateway_error_response(
+        "Sorry, I encountered an unexpected error. Try again."
+    )
+    assert is_internal_gateway_error_response(
+        "ℹ Codex gpt-5.6-luna caps context at 272K, so auto-compaction was raised."
+    )
+    assert not is_internal_gateway_error_response(
+        "⚠️ Heavy rain is forecast. We can reschedule your pest treatment."
+    )

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1364,7 +1364,10 @@ class TestTelegramMenuCommands:
             "      command_menu:\n"
             "        max_commands: 0\n"
         )
-        assert telegram_menu_max_commands() == 1
+        assert telegram_menu_max_commands() == 0
+        menu, hidden = telegram_menu_commands(max_commands=0)
+        assert menu == []
+        assert hidden > 0
 
         (tmp_path / "config.yaml").write_text(
             "platforms:\n"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1378,6 +1378,29 @@ class TestTelegramMenuCommands:
         )
         assert telegram_menu_max_commands() == 60
 
+    def test_telegram_menu_only_custom_entries(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        max_commands: 2\n"
+            "        only_custom: true\n"
+            "        custom:\n"
+            "          - command: start\n"
+            "            description: Onboarding setup\n"
+            "          - command: campaign\n"
+            "            description: Launch campaign\n"
+        )
+        assert telegram_menu_max_commands() == 2
+        menu, hidden = telegram_menu_commands(max_commands=2)
+        assert menu == [
+            ("start", "Onboarding setup"),
+            ("campaign", "Launch campaign"),
+        ]
+        assert hidden == 0
+
     def test_telegram_menu_ignores_undocumented_command_menu_paths(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text(


### PR DESCRIPTION
## Summary
- Add opt-in `platforms.<platform>.extra.agent_passthrough_commands` so selected core slash commands (e.g. `/start`) reach the agent as plain text instead of the silent platform-ping handler. Customer-facing bots need `/start` for onboarding Q&A.
- Allow `platforms.telegram.extra.command_menu.max_commands: 0` to clear the Telegram BotCommand menu entirely (previously clamped to min 1).

## Config example
```yaml
platforms:
  telegram:
    extra:
      agent_passthrough_commands:
        - start
      command_menu:
        max_commands: 0
```

## Test plan
- [x] `pytest tests/gateway/test_agent_passthrough_commands.py` (default silent /start + passthrough + busy path)
- [x] Existing `test_start_command_is_noop_*` still pass (default unchanged)
- [x] `test_telegram_menu_max_commands_uses_config_with_safe_bounds` updated for 0
- [ ] Manual: with config above, Telegram `/start` reaches agent; menu empty