### PR TITLE
refactor(context_compressor): extract skill-prune/ghost-skill cluster (LB2)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -40,6 +40,10 @@ from agent.model_metadata import (
     estimate_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
+from agent.context_compressor_text_utils import (
+    _content_text_for_contains,
+    _redact_compaction_text,
+)
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -676,27 +680,6 @@ _HISTORICAL_TASK_SECTION_RE = re.compile(
 )
 
 
-def _redact_compaction_text(text: Any) -> str:
-    """Redact text that crosses a compaction summary boundary.
-
-    Compaction summaries persist across sessions and are re-injected into
-    every subsequent summarizer prompt, so this boundary uses strict mode:
-
-    - ``force=True`` — deliberately overrides ``security.redact_secrets:
-      false``. That opt-out targets *live tool output* (e.g. working on the
-      redactor itself); a summary is a persistence boundary where a leaked
-      credential keeps re-entering prompts indefinitely.
-    - ``redact_url_credentials=True`` — OAuth callback codes, magic-link
-      tokens, and URL userinfo never need to survive summarization the way
-      they must survive live navigation flows.
-    """
-    return redact_sensitive_text(
-        text or "",
-        force=True,
-        redact_url_credentials=True,
-    )
-
-
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
     value = value.strip()
     if value and value not in items and len(items) < limit:
@@ -865,29 +848,6 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
             // _CHARS_PER_TOKEN
         )
     return tokens
-
-
-def _content_text_for_contains(content: Any) -> str:
-    """Return a best-effort text view of message content.
-
-    Used only for substring checks when we need to know whether we've already
-    appended a note to a message. Keeps multimodal lists intact elsewhere.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "\n".join(part for part in parts if part)
-    return str(content)
 
 
 def _append_text_to_content(content: Any, text: str, *, prepend: bool = False) -> Any:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -44,6 +44,20 @@ from agent.context_compressor_text_utils import (
     _content_text_for_contains,
     _redact_compaction_text,
 )
+from agent.context_compressor_skill_prune import (  # noqa: E402
+    SKILL_PRUNED_MARKER_PREFIX,
+    _MAX_PRUNED_SKILL_MARKERS,
+    _PRUNED_SKILLS_SECTION_HEADING,
+    _SKILL_PRUNE_RECENT_WINDOW,
+    _SKILL_PRUNED_MARKER_RE,
+    _SKILL_VIEW_PRUNE_MIN_CHARS,
+    _collect_ghosted_skill_names,
+    _collect_protected_skill_names,
+    _extract_pruned_skill_names,
+    _reinject_pruned_skill_markers,
+    _skill_pruned_marker,
+    _skill_view_call_sites,
+)
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -401,221 +415,6 @@ _SUMMARY_INPUT_MAX_CHARS = 160_000
 
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
-
-# Ghost-skill defense (#32106): when compaction reduces an old ``skill_view``
-# result to a 1-line metadata summary, the model still believes the skill is
-# loaded even though its instructions are gone. The marker below is the ONE
-# canonical prune signal — ``_skill_pruned_marker()`` builds it and every
-# presence check matches against the same string, so the emit side and the
-# check side can never drift apart (the original PR #44166 emitted
-# ``[SKILL_PRUNED:`` but presence-checked ``[SKILL_PRUNED]``, making
-# re-injection fire even when the marker had survived).
-SKILL_PRUNED_MARKER_PREFIX = "[SKILL_PRUNED:"
-# skill_view results at or below this size stay verbatim in pruned
-# summaries — small skills are cheap to keep and their loss is unlikely to
-# ghost the model. Shared by the emit site and the summarizer-input scan.
-_SKILL_VIEW_PRUNE_MIN_CHARS = 5000
-# Cap for the deterministic marker re-injection list — keeps a very long
-# session from growing an unbounded "## Pruned Skills" block in every
-# iterative summary update. Newest-referenced skills win.
-_MAX_PRUNED_SKILL_MARKERS = 20
-
-
-def _skill_pruned_marker(skill_name: str) -> str:
-    """Return the canonical prune marker for *skill_name*.
-
-    Used verbatim by BOTH the emit sites (tool-result summarization,
-    summary re-injection) and the survival check in
-    ``_reinject_pruned_skill_markers`` — one string, no drift.
-    """
-    return (
-        f"{SKILL_PRUNED_MARKER_PREFIX} content lost in compression; "
-        f"reload with skill_view(name='{skill_name}')]"
-    )
-
-
-# Matches the canonical marker and captures the skill name. Anchored on the
-# shared prefix constant so a wording change to the marker body updates the
-# emit helper and this extractor together.
-_SKILL_PRUNED_MARKER_RE = re.compile(
-    re.escape(SKILL_PRUNED_MARKER_PREFIX)
-    + r"[^\]]*?reload with skill_view\(name='([^']+)'\)"
-)
-
-
-def _extract_pruned_skill_names(text: str) -> list[str]:
-    """Return skill names referenced by prune markers in *text*, in order."""
-    names: list[str] = []
-    for match in _SKILL_PRUNED_MARKER_RE.finditer(text or ""):
-        name = match.group(1)
-        if name not in names:
-            names.append(name)
-    return names
-
-
-def _collect_ghosted_skill_names(turns: List[Dict[str, Any]]) -> list[str]:
-    """Skill names whose instructions are about to be lost in compaction.
-
-    Covers BOTH shapes a compacted middle window can carry:
-
-    - a ``skill_view`` result already demoted by Phase-1 pruning — the
-      canonical ``[SKILL_PRUNED: ...]`` marker is in the row content;
-    - a RAW ``skill_view`` body that was never demoted (it sat inside the
-      protected tail of an earlier prune, then aged into the compression
-      window). The summarizer will paraphrase the instructions away, which
-      is exactly the ghost-skill failure — so it needs a marker too.
-    """
-    names: list[str] = []
-
-    def _add(name: str) -> None:
-        if name and name not in names:
-            names.append(name)
-
-    call_id_to_skill: dict[str, str] = {}
-    for idx, skill in _skill_view_call_sites(turns):
-        msg = turns[idx]
-        for tc in msg.get("tool_calls") or []:
-            tc_fn = tc.get("function", {}) if isinstance(tc, dict) else getattr(tc, "function", None)
-            tc_name = tc_fn.get("name", "") if isinstance(tc_fn, dict) else getattr(tc_fn, "name", "")
-            if tc_name != "skill_view":
-                continue
-            cid = tc.get("id", "") if isinstance(tc, dict) else (getattr(tc, "id", "") or "")
-            if cid:
-                call_id_to_skill[cid] = skill
-    for msg in turns:
-        content = msg.get("content")
-        text = content if isinstance(content, str) else _content_text_for_contains(content)
-        for name in _extract_pruned_skill_names(text):
-            _add(name)
-        if (
-            msg.get("role") == "tool"
-            and isinstance(content, str)
-            and len(content) > _SKILL_VIEW_PRUNE_MIN_CHARS
-        ):
-            skill = call_id_to_skill.get(str(msg.get("tool_call_id") or ""))
-            if skill:
-                _add(skill)
-    return names
-
-
-_PRUNED_SKILLS_SECTION_HEADING = "## Pruned Skills"
-
-
-def _reinject_pruned_skill_markers(summary: str, skill_names: list[str]) -> str:
-    """Deterministically restore prune markers the summarizer dropped.
-
-    ``skill_names`` was extracted from the summarizer INPUT before the LLM
-    call. For every skill whose canonical marker (``_skill_pruned_marker``)
-    is absent from the model's output, append it under a ``## Pruned
-    Skills`` section. Presence is checked against the SAME canonical string
-    the emit sites produce — a paraphrased or renamed marker counts as
-    dropped and is restored (the original PR checked the literal
-    ``[SKILL_PRUNED]``, which never matches the emitted ``[SKILL_PRUNED:``
-    form, so it duplicated markers that HAD survived).
-
-    The appended block is plain body text: it never carries a handoff
-    prefix, the merged-summary delimiter, or a start-of-content scaffolding
-    marker, so ``classify_summary_content`` / todo-snapshot flag handling
-    are unaffected. The block is routed through ``_redact_compaction_text``
-    like every other compaction-boundary text.
-    """
-    if not skill_names:
-        return summary
-    missing = [
-        name for name in skill_names
-        if _skill_pruned_marker(name) not in summary
-    ]
-    if not missing:
-        return summary
-    lines = [_skill_pruned_marker(name) for name in missing]
-    block = (
-        "\n\n" + _PRUNED_SKILLS_SECTION_HEADING + "\n"
-        + "\n".join(lines)
-        + "\n(The listed skills' instructions were pruned during context "
-        "compression. Reload with the skill_view call in each marker before "
-        "relying on that skill; one reload per skill is enough — ignore any "
-        "older markers for the same skill.)"
-    )
-    return summary + _redact_compaction_text(block)
-
-
-# A skill_view call within this many trailing messages counts as "just
-# loaded": its full instruction body must survive the Phase-1 prune even when
-# the token-budget boundary would otherwise demote it (#32106). Distinct from
-# the protected-tail boundary, which is token-based and can land immediately
-# after a bulky just-loaded skill body.
-_SKILL_PRUNE_RECENT_WINDOW = 10
-
-
-def _skill_view_call_sites(
-    messages: List[Dict[str, Any]],
-) -> list[tuple[int, str]]:
-    """Yield ``(message_index, skill_name)`` for every skill_view tool call."""
-    sites: list[tuple[int, str]] = []
-    for i, msg in enumerate(messages):
-        if msg.get("role") != "assistant":
-            continue
-        for tc in msg.get("tool_calls") or []:
-            if isinstance(tc, dict):
-                fn = tc.get("function", {})
-                name = fn.get("name", "") if isinstance(fn, dict) else ""
-                args_str = fn.get("arguments", "") if isinstance(fn, dict) else ""
-            else:
-                fn = getattr(tc, "function", None)
-                name = getattr(fn, "name", "") if fn else ""
-                args_str = getattr(fn, "arguments", "") if fn else ""
-            if name != "skill_view" or not isinstance(args_str, str) or not args_str:
-                continue
-            try:
-                args = json.loads(args_str)
-            except (json.JSONDecodeError, TypeError):
-                continue
-            if isinstance(args, dict):
-                skill = args.get("name", "")
-                if isinstance(skill, str) and skill:
-                    sites.append((i, skill))
-    return sites
-
-
-def _collect_protected_skill_names(
-    messages: List[Dict[str, Any]], prune_boundary: int,
-) -> set[str]:
-    """Skill names whose skill_view bodies must survive Phase-1 demotion.
-
-    A skill is protected (lower-cased set) when any of these hold:
-
-    - its most recent ``skill_view`` call sits within the last
-      ``_SKILL_PRUNE_RECENT_WINDOW`` messages (just loaded / just reloaded);
-    - its most recent ``skill_view`` call sits inside the protected tail
-      (at or after *prune_boundary*);
-    - its name is mentioned in a user message inside the protected tail
-      (the user is actively steering work that depends on it).
-
-    Protection applies to the ordinary Phase-1/2 prune only. The Pass-4
-    pressure demotion deliberately ignores it: when the protected region
-    itself exceeds the soft budget, exempting skill bodies would recreate
-    the #61932 dead-end shape.
-    """
-    total = len(messages)
-    if not total:
-        return set()
-    recent_start = max(0, total - _SKILL_PRUNE_RECENT_WINDOW)
-    tail_start = max(0, prune_boundary)
-    tail_user_texts: list[str] = []
-    for msg in messages[tail_start:]:
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str) and content:
-            tail_user_texts.append(content.lower())
-    protected: set[str] = set()
-    for idx, skill in _skill_view_call_sites(messages):
-        key = skill.lower()
-        if idx >= recent_start or idx >= tail_start:
-            protected.add(key)
-        elif any(key in text for text in tail_user_texts):
-            protected.add(key)
-    return protected
 
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4

--- a/agent/context_compressor_skill_prune.py
+++ b/agent/context_compressor_skill_prune.py
@@ -1,0 +1,236 @@
+"""Skill-prune / ghost-skill defense helpers extracted from context_compressor.
+
+Ghost-skill defense (#32106): when compaction reduces an old ``skill_view``
+result to a 1-line metadata summary, the model still believes the skill is
+loaded even though its instructions are gone. This module owns the canonical
+prune marker, extraction, re-injection, and protected-name collection.
+
+Part of #78645 + #78647.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+from agent.context_compressor_text_utils import (
+    _content_text_for_contains,
+    _redact_compaction_text,
+)
+
+
+
+# Ghost-skill defense (#32106): when compaction reduces an old ``skill_view``
+# result to a 1-line metadata summary, the model still believes the skill is
+# loaded even though its instructions are gone. The marker below is the ONE
+# canonical prune signal — ``_skill_pruned_marker()`` builds it and every
+# presence check matches against the same string, so the emit side and the
+# check side can never drift apart (the original PR #44166 emitted
+# ``[SKILL_PRUNED:`` but presence-checked ``[SKILL_PRUNED]``, making
+# re-injection fire even when the marker had survived).
+SKILL_PRUNED_MARKER_PREFIX = "[SKILL_PRUNED:"
+# skill_view results at or below this size stay verbatim in pruned
+# summaries — small skills are cheap to keep and their loss is unlikely to
+# ghost the model. Shared by the emit site and the summarizer-input scan.
+_SKILL_VIEW_PRUNE_MIN_CHARS = 5000
+# Cap for the deterministic marker re-injection list — keeps a very long
+# session from growing an unbounded "## Pruned Skills" block in every
+# iterative summary update. Newest-referenced skills win.
+_MAX_PRUNED_SKILL_MARKERS = 20
+
+
+def _skill_pruned_marker(skill_name: str) -> str:
+    """Return the canonical prune marker for *skill_name*.
+
+    Used verbatim by BOTH the emit sites (tool-result summarization,
+    summary re-injection) and the survival check in
+    ``_reinject_pruned_skill_markers`` — one string, no drift.
+    """
+    return (
+        f"{SKILL_PRUNED_MARKER_PREFIX} content lost in compression; "
+        f"reload with skill_view(name='{skill_name}')]"
+    )
+
+
+# Matches the canonical marker and captures the skill name. Anchored on the
+# shared prefix constant so a wording change to the marker body updates the
+# emit helper and this extractor together.
+_SKILL_PRUNED_MARKER_RE = re.compile(
+    re.escape(SKILL_PRUNED_MARKER_PREFIX)
+    + r"[^\]]*?reload with skill_view\(name='([^']+)'\)"
+)
+
+
+def _extract_pruned_skill_names(text: str) -> list[str]:
+    """Return skill names referenced by prune markers in *text*, in order."""
+    names: list[str] = []
+    for match in _SKILL_PRUNED_MARKER_RE.finditer(text or ""):
+        name = match.group(1)
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def _collect_ghosted_skill_names(turns: List[Dict[str, Any]]) -> list[str]:
+    """Skill names whose instructions are about to be lost in compaction.
+
+    Covers BOTH shapes a compacted middle window can carry:
+
+    - a ``skill_view`` result already demoted by Phase-1 pruning — the
+      canonical ``[SKILL_PRUNED: ...]`` marker is in the row content;
+    - a RAW ``skill_view`` body that was never demoted (it sat inside the
+      protected tail of an earlier prune, then aged into the compression
+      window). The summarizer will paraphrase the instructions away, which
+      is exactly the ghost-skill failure — so it needs a marker too.
+    """
+    names: list[str] = []
+
+    def _add(name: str) -> None:
+        if name and name not in names:
+            names.append(name)
+
+    call_id_to_skill: dict[str, str] = {}
+    for idx, skill in _skill_view_call_sites(turns):
+        msg = turns[idx]
+        for tc in msg.get("tool_calls") or []:
+            tc_fn = tc.get("function", {}) if isinstance(tc, dict) else getattr(tc, "function", None)
+            tc_name = tc_fn.get("name", "") if isinstance(tc_fn, dict) else getattr(tc_fn, "name", "")
+            if tc_name != "skill_view":
+                continue
+            cid = tc.get("id", "") if isinstance(tc, dict) else (getattr(tc, "id", "") or "")
+            if cid:
+                call_id_to_skill[cid] = skill
+    for msg in turns:
+        content = msg.get("content")
+        text = content if isinstance(content, str) else _content_text_for_contains(content)
+        for name in _extract_pruned_skill_names(text):
+            _add(name)
+        if (
+            msg.get("role") == "tool"
+            and isinstance(content, str)
+            and len(content) > _SKILL_VIEW_PRUNE_MIN_CHARS
+        ):
+            skill = call_id_to_skill.get(str(msg.get("tool_call_id") or ""))
+            if skill:
+                _add(skill)
+    return names
+
+
+_PRUNED_SKILLS_SECTION_HEADING = "## Pruned Skills"
+
+
+def _reinject_pruned_skill_markers(summary: str, skill_names: list[str]) -> str:
+    """Deterministically restore prune markers the summarizer dropped.
+
+    ``skill_names`` was extracted from the summarizer INPUT before the LLM
+    call. For every skill whose canonical marker (``_skill_pruned_marker``)
+    is absent from the model's output, append it under a ``## Pruned
+    Skills`` section. Presence is checked against the SAME canonical string
+    the emit sites produce — a paraphrased or renamed marker counts as
+    dropped and is restored (the original PR checked the literal
+    ``[SKILL_PRUNED]``, which never matches the emitted ``[SKILL_PRUNED:``
+    form, so it duplicated markers that HAD survived).
+
+    The appended block is plain body text: it never carries a handoff
+    prefix, the merged-summary delimiter, or a start-of-content scaffolding
+    marker, so ``classify_summary_content`` / todo-snapshot flag handling
+    are unaffected. The block is routed through ``_redact_compaction_text``
+    like every other compaction-boundary text.
+    """
+    if not skill_names:
+        return summary
+    missing = [
+        name for name in skill_names
+        if _skill_pruned_marker(name) not in summary
+    ]
+    if not missing:
+        return summary
+    lines = [_skill_pruned_marker(name) for name in missing]
+    block = (
+        "\n\n" + _PRUNED_SKILLS_SECTION_HEADING + "\n"
+        + "\n".join(lines)
+        + "\n(The listed skills' instructions were pruned during context "
+        "compression. Reload with the skill_view call in each marker before "
+        "relying on that skill; one reload per skill is enough — ignore any "
+        "older markers for the same skill.)"
+    )
+    return summary + _redact_compaction_text(block)
+
+
+# A skill_view call within this many trailing messages counts as "just
+# loaded": its full instruction body must survive the Phase-1 prune even when
+# the token-budget boundary would otherwise demote it (#32106). Distinct from
+# the protected-tail boundary, which is token-based and can land immediately
+# after a bulky just-loaded skill body.
+_SKILL_PRUNE_RECENT_WINDOW = 10
+
+
+def _skill_view_call_sites(
+    messages: List[Dict[str, Any]],
+) -> list[tuple[int, str]]:
+    """Yield ``(message_index, skill_name)`` for every skill_view tool call."""
+    sites: list[tuple[int, str]] = []
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if isinstance(tc, dict):
+                fn = tc.get("function", {})
+                name = fn.get("name", "") if isinstance(fn, dict) else ""
+                args_str = fn.get("arguments", "") if isinstance(fn, dict) else ""
+            else:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", "") if fn else ""
+                args_str = getattr(fn, "arguments", "") if fn else ""
+            if name != "skill_view" or not isinstance(args_str, str) or not args_str:
+                continue
+            try:
+                args = json.loads(args_str)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(args, dict):
+                skill = args.get("name", "")
+                if isinstance(skill, str) and skill:
+                    sites.append((i, skill))
+    return sites
+
+
+def _collect_protected_skill_names(
+    messages: List[Dict[str, Any]], prune_boundary: int,
+) -> set[str]:
+    """Skill names whose skill_view bodies must survive Phase-1 demotion.
+
+    A skill is protected (lower-cased set) when any of these hold:
+
+    - its most recent ``skill_view`` call sits within the last
+      ``_SKILL_PRUNE_RECENT_WINDOW`` messages (just loaded / just reloaded);
+    - its most recent ``skill_view`` call sits inside the protected tail
+      (at or after *prune_boundary*);
+    - its name is mentioned in a user message inside the protected tail
+      (the user is actively steering work that depends on it).
+
+    Protection applies to the ordinary Phase-1/2 prune only. The Pass-4
+    pressure demotion deliberately ignores it: when the protected region
+    itself exceeds the soft budget, exempting skill bodies would recreate
+    the #61932 dead-end shape.
+    """
+    total = len(messages)
+    if not total:
+        return set()
+    recent_start = max(0, total - _SKILL_PRUNE_RECENT_WINDOW)
+    tail_start = max(0, prune_boundary)
+    tail_user_texts: list[str] = []
+    for msg in messages[tail_start:]:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content:
+            tail_user_texts.append(content.lower())
+    protected: set[str] = set()
+    for idx, skill in _skill_view_call_sites(messages):
+        key = skill.lower()
+        if idx >= recent_start or idx >= tail_start:
+            protected.add(key)
+        elif any(key in text for text in tail_user_texts):
+            protected.add(key)
+    return protected

--- a/agent/context_compressor_text_utils.py
+++ b/agent/context_compressor_text_utils.py
@@ -1,0 +1,57 @@
+"""Text helpers extracted from context_compressor (leaf util, epic #78647).
+
+Pure module-level helpers used across skill-prune, summary serialize, and
+identity paths. Extracted first so skill-prune can import without a cycle
+back into the god file.
+
+Part of #78645 + #78647.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+def _redact_compaction_text(text: Any) -> str:
+    """Redact text that crosses a compaction summary boundary.
+
+    Compaction summaries persist across sessions and are re-injected into
+    every subsequent summarizer prompt, so this boundary uses strict mode:
+
+    - ``force=True`` — deliberately overrides ``security.redact_secrets:
+      false``. That opt-out targets *live tool output* (e.g. working on the
+      redactor itself); a summary is a persistence boundary where a leaked
+      credential keeps re-entering prompts indefinitely.
+    - ``redact_url_credentials=True`` — OAuth callback codes, magic-link
+      tokens, and URL userinfo never need to survive summarization the way
+      they must survive live navigation flows.
+    """
+    return redact_sensitive_text(
+        text or "",
+        force=True,
+        redact_url_credentials=True,
+    )
+
+
+def _content_text_for_contains(content: Any) -> str:
+    """Return a best-effort text view of message content.
+
+    Used only for substring checks when we need to know whether we've already
+    appended a note to a message. Keeps multimodal lists intact elsewhere.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)

--- a/agent/context_compressor_text_utils.py
+++ b/agent/context_compressor_text_utils.py
@@ -1,0 +1,56 @@
+"""Text helpers extracted from context_compressor (leaf util, epic #78647).
+
+Pure module-level helpers used across skill-prune, summary serialize, and
+identity paths. Extracted first so skill-prune can import without a cycle
+back into the god file.
+
+Part of #78645 + #78647.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+def _redact_compaction_text(text: Any) -> str:
+    """Redact text that crosses a compaction summary boundary.
+
+    Compaction summaries persist across sessions and are re-injected into
+    every subsequent summarizer prompt, so this boundary uses strict mode:
+
+    - ``force=True`` — deliberately overrides ``security.redact_secrets:
+      false``. That opt-out targets *live tool output* (e.g. working on the
+      redactor itself); a summary is a persistence boundary where a leaked
+      credential keeps re-entering prompts indefinitely.
+    - ``redact_url_credentials=True`` — OAuth callback codes, magic-link
+      tokens, and URL userinfo never need to survive summarization the way
+      they must survive live navigation flows.
+    """
+    return redact_sensitive_text(
+        text or "",
+        force=True,
+        redact_url_credentials=True,
+    )
+
+def _content_text_for_contains(content: Any) -> str:
+    """Return a best-effort text view of message content.
+
+    Used only for substring checks when we need to know whether we've already
+    appended a note to a message. Keeps multimodal lists intact elsewhere.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)

--- a/tests/agent/test_context_compressor_skill_prune_seam.py
+++ b/tests/agent/test_context_compressor_skill_prune_seam.py
@@ -1,0 +1,69 @@
+"""Seam identity for context_compressor_skill_prune extract (LB2).
+
+Part of #78645 + #78647.
+"""
+
+from agent import context_compressor as cc
+from agent import context_compressor_skill_prune as sp
+
+
+def test_all_members_resolve_is_identical_through_godfile():
+    members = [
+        "SKILL_PRUNED_MARKER_PREFIX",
+        "_SKILL_VIEW_PRUNE_MIN_CHARS",
+        "_MAX_PRUNED_SKILL_MARKERS",
+        "_SKILL_PRUNED_MARKER_RE",
+        "_PRUNED_SKILLS_SECTION_HEADING",
+        "_SKILL_PRUNE_RECENT_WINDOW",
+        "_skill_pruned_marker",
+        "_extract_pruned_skill_names",
+        "_collect_ghosted_skill_names",
+        "_reinject_pruned_skill_markers",
+        "_skill_view_call_sites",
+        "_collect_protected_skill_names",
+    ]
+    for m in members:
+        assert getattr(cc, m) is getattr(sp, m), f"{m} not is-identical"
+
+
+def test_no_duplicate_defs_in_godfile():
+    from pathlib import Path
+
+    src = Path(cc.__file__).read_text(encoding="utf-8")
+    for name in [
+        "_skill_pruned_marker",
+        "_extract_pruned_skill_names",
+        "_collect_ghosted_skill_names",
+        "_reinject_pruned_skill_markers",
+        "_skill_view_call_sites",
+        "_collect_protected_skill_names",
+    ]:
+        assert src.count(f"def {name}") == 0, f"duplicate def {name} left in godfile"
+    assert "context_compressor_skill_prune" in src
+
+
+def test_behavior_smoke():
+    # marker build + extract round trip
+    marker = cc._skill_pruned_marker("my-skill")
+    assert marker.startswith("[SKILL_PRUNED:")
+    assert "my-skill" in marker
+    names = cc._extract_pruned_skill_names(marker)
+    assert "my-skill" in names
+    # ghosted collection on a turn list
+    turns = [{"role": "user", "content": f"loaded {marker}"}]
+    ghosted = cc._collect_ghosted_skill_names(turns)
+    assert "my-skill" in ghosted
+    # reinject restores marker
+    out = cc._reinject_pruned_skill_markers("summary text", ["my-skill"])
+    assert "[SKILL_PRUNED:" in out
+
+
+def test_import_orders_no_cycle():
+    import importlib
+
+    import agent.context_compressor_skill_prune as a
+    import agent.context_compressor as b
+
+    importlib.reload(a)
+    importlib.reload(b)
+    assert b._skill_pruned_marker is a._skill_pruned_marker

--- a/tests/agent/test_context_compressor_text_utils_seam.py
+++ b/tests/agent/test_context_compressor_text_utils_seam.py
@@ -1,0 +1,41 @@
+"""Seam identity for context_compressor_text_utils leaf extract (LB-textutil).
+
+Part of #78645 + #78647.
+"""
+
+from agent import context_compressor as cc
+from agent import context_compressor_text_utils as tu
+
+
+def test_redact_and_content_text_resolve_is_identical_through_godfile():
+    assert cc._redact_compaction_text is tu._redact_compaction_text
+    assert cc._content_text_for_contains is tu._content_text_for_contains
+
+
+def test_no_duplicate_defs_in_godfile():
+    import inspect
+    from pathlib import Path
+
+    src = Path(cc.__file__).read_text(encoding="utf-8")
+    assert src.count("def _redact_compaction_text") == 0
+    assert src.count("def _content_text_for_contains") == 0
+    assert "context_compressor_text_utils" in src
+
+
+def test_redact_behavior_smoke():
+    # None-safety preserved
+    assert cc._redact_compaction_text(None) == ""
+    # content text view
+    assert cc._content_text_for_contains(None) == ""
+    assert cc._content_text_for_contains("hi") == "hi"
+    assert cc._content_text_for_contains([{"type": "text", "text": "a"}, "b"]) == "a\nb"
+
+
+def test_import_orders_no_cycle():
+    import importlib
+    import agent.context_compressor_text_utils as a
+    import agent.context_compressor as b
+
+    importlib.reload(a)
+    importlib.reload(b)
+    assert b._redact_compaction_text is a._redact_compaction_text


### PR DESCRIPTION
## Summary

God-file Feature Package (tracker #78647): `agent/context_compressor.py` slice **LB2** — extract the skill-prune / ghost-skill defense cluster into `agent/context_compressor_skill_prune.py` with an `is`-identical re-export seam.

## Slice

- **God-file:** `agent/context_compressor.py` (6,883 lines @ pin `6e9cae6ac4b`)
- **Window:** 404–618 banner-inclusive (pin numbering; re-anchored at leaf commit `2b7a1b97807`)
- **Golden sha256:** `ec5defbef6a402ad302b28369c81f5f9182162f1c8353b231d2d863fe59305c0` — byte-exact, verified by 5/5 blind reviewers
- **Module:** `agent/context_compressor_skill_prune.py` (12 members: 6 constants + 6 functions)
- **Deps:** one-way into `context_compressor_text_utils` (leaf extract #80626) — **no cycle** (W2 C1 resolved)
- **Seam:** godfile re-exports all 12 members; `cc.<m> is sp.<m>` verified at runtime

## Verification

- 35/35 targeted tests (seam + ghost-skill + redaction + zero-user-guard + text-utils seam)
- 5/5 blind re-review **APPROVED** (0 CRITICAL / 0 IMPORTANT)
- ruff clean · `git diff --check` clean · LF-only · DCO signed
- Collision census clean

Part of #78645
Part of #78647
## Prior Work / Attribution

**Related work searched** (multiple methods, all states, before finalizing this PR):

- **GraphQL dedup — PR/issue graph** (`context_compressor` + `skill-prune`/`ghost-skill`):
  - 16 open extraction shards on `agent/context_compressor.py`: #80626 (LB text-utils), #80628 (LB2, this), #80634 (LB3 budget), #80636 (LB4 strip), #80644 (LB7 threshold), #80645 (LB5a), #81074 (LB6 guards), #81181 (summary kernel), #81243 (message markers), plus shard tracker **#78645** and epic **#78647**.
  - Compressor bug/feature landscape: #74632/#56715 (md5 FIPS), #29859 (ratio logging), #12588, #55941, #70328, #19003, #58630, #10719, #12242, #31067, #49193, #44932, #17883, #55576, #25716, #60311, #62777.
- **Source-tree search** of `agent/context_compressor.py` for `SKILL_PRUNED` / `ghost-skill`: confirmed the extracted cluster is the merged ghost-skill defense implementation (markers, protected prune, deterministic survival).
- **File-collision dedup**: extracted module `agent/context_compressor_skill_prune.py` and its seam test are touched by **no other open PR** (collision-clean). The godfile is shared across the shard series — expected; each PR extracts a disjoint cluster.

**Unlinked related work (stars not bound to this PR by keywords):**
- **#70275 [MERGED]** — `fix(compression): ghost-skill defense — [SKILL_PRUNED] markers, protected prune, deterministic survival` — the merged origin of the cluster this PR verbatim-extracts. **Credited; no duplicate filed; no code copied — pure extraction of already-shipped work.**
- **#86852 [MERGED]** — couple pruned-skill reload instruction to the preserved todo snapshot.
- **#87090 [OPEN]** + **#84718 [OPEN]** — compaction retention asymmetry (skills pruned, todos preserved).
- **#32375 [OPEN]** — mark pruned skill_view summaries.
- **#85146 [OPEN]** — reset retrieval dedup after proactive prune.
- **#86421 [OPEN]** — compaction: re-inject skill content (or block on stale SKILL_PRUNED marker).

**Builds on:** #80626 (`context_compressor_text_utils` leaf dependency, one-way, no cycle).
**Merge-order / dependency:** merge #80626 before #80628.
**Duplicates:** none — no existing PR covers the LB2 skill-prune/ghost-skill cluster.
## Prior Work / Attribution

**Prior credit** — the humans whose work this builds on, before anyone else:
- **@teknium1** — wrote the merged ghost-skill defense (SKILL_PRUNED markers, protected prune, deterministic survival) that this slice verbatim-extracts (#70275)
- **@teknium1** — coupled the pruned-skill reload instruction to the preserved todo snapshot (#86852)
- **@JoaoMarcos44** — the compaction retention asymmetry (skills pruned, todos kept) this cluster's behavior sits inside of (#87090, #86421)
- **@Thiago-Mota-Santos** — filed the retention-asymmetry report that motivates this region (#84718)
- **@LeonSGP43** — marked pruned skill_view summaries, adjacent to the same cluster (#32375)
- **@milnerrad** — reset retrieval dedup after proactive prune (#85146)

If a related artifact has no attributable human author, say so plainly rather than crediting a ticket number as if it were a person.

**Related work searched** (multiple methods, all states, before finalizing this PR):

- **GraphQL dedup — PR/issue graph** (`context_compressor` + `skill-prune`/`ghost-skill`): 16 open extraction shards on `agent/context_compressor.py` (LB2 this, #80626 text-utils, #80634 budget, #80636 strip, #80644 threshold, #80645 summarizers, #81074 guards, #81181 summary kernel, #81243 message markers, plus conversation_loop siblings #84310/#84653/#84619/#84583/#84275); bug landscape #74632/#56715 (md5 FIPS), #29859 (ratio logging), #12588, #55941, #70328, #19003, #58630, #10719, #12242, #31067, #49193, #44932, #17883, #55576, #25716, #60311, #62777; tracker #78645; tracker #78647.
- **Source-tree search** of `agent/context_compressor.py` for `SKILL_PRUNED`/`ghost-skill`/`_skill_pruned_marker`: confirmed the extracted cluster is the merged ghost-skill defense implementation from @teknium1's #70275 (markers, protected prune, deterministic survival).
- **File-collision dedup**: extracted module `agent/context_compressor_skill_prune.py` and its seam test touched by **no other open PR** (collision-clean). The godfile is shared across the shard series — expected; each PR extracts a disjoint cluster.

**Unlinked related work (stars not bound to this PR by keywords):**
- **@teknium1 — #70275 [MERGED]** — ghost-skill defense (SKILL_PRUNED markers) — the merged origin of this cluster; pure extraction of already-shipped work, no copy.
- **@teknium1 — #86852 [MERGED]** — pruned-skill reload instruction coupled to the todo snapshot.
- **@JoaoMarcos44 — #87090 [OPEN], #86421 [OPEN]** — compaction retention asymmetry / skill re-injection.
- **@Thiago-Mota-Santos — #84718 [OPEN]** — the retention-asymmetry report.
- **@LeonSGP43 — #32375 [OPEN]** — mark pruned skill_view summaries.
- **@milnerrad — #85146 [OPEN]** — reset retrieval dedup after proactive prune.

**Builds on:** @andrexibiza, #80626 (`context_compressor_text_utils` leaf dependency, one-way, no cycle).
**Merge-order / dependency:** merge #80626 before #80628.
**Duplicates:** none — no existing PR covers the LB2 skill-prune/ghost-skill cluster.
