### PR TITLE
fix(a2a): eager-load explicitly enabled bundled platform plugins

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1466,7 +1466,28 @@ class PluginManager:
             # path actually asks for that platform. Every platform Hermes ships
             # remains available out of the box — it just loads on first use.
             if manifest.source == "bundled" and manifest.kind == "platform":
-                self._register_deferred_platform(manifest)
+                # Explicitly-enabled bundled platform plugins load eagerly so
+                # their client tools/hooks are registered before sessions
+                # compose their toolset (otherwise e.g. the a2a client tools
+                # never reach the agent session). Non-enabled platforms stay
+                # deferred so plain `hermes` invocations don't import heavy
+                # platform SDKs they never use.
+                _lk = manifest.key or manifest.name
+                _path_key = None
+                try:
+                    from pathlib import Path
+                    _pp = Path(manifest.path).resolve()
+                    _root = Path(get_bundled_plugins_dir()).resolve()
+                    _path_key = str(_pp.relative_to(_root))
+                except Exception:
+                    pass
+                _cands = {manifest.name, _lk}
+                if _path_key:
+                    _cands.add(_path_key)
+                if enabled is not None and (enabled & _cands):
+                    self._load_plugin(manifest)
+                else:
+                    self._register_deferred_platform(manifest)
                 continue
 
             # Everything else (standalone, user-installed backends,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1472,19 +1472,27 @@ class PluginManager:
                 # never reach the agent session). Non-enabled platforms stay
                 # deferred so plain `hermes` invocations don't import heavy
                 # platform SDKs they never use.
+                _enabled_set = set(enabled) if enabled is not None else set()
                 _lk = manifest.key or manifest.name
+                _cands = {manifest.name, _lk}
                 _path_key = None
                 try:
                     from pathlib import Path
                     _pp = Path(manifest.path).resolve()
                     _root = Path(get_bundled_plugins_dir()).resolve()
-                    _path_key = str(_pp.relative_to(_root))
-                except Exception:
-                    pass
-                _cands = {manifest.name, _lk}
+                    # as_posix(): canonical keys are forward-slash even on
+                    # Windows (str(relative_to) would yield backslashes there
+                    # and never match user-saved enable keys).
+                    _path_key = _pp.relative_to(_root).as_posix()
+                except (OSError, ValueError):
+                    logger.debug(
+                        "Could not derive path-derived key for plugin %r; "
+                        "falling back to name/key matching only",
+                        _lk,
+                    )
                 if _path_key:
                     _cands.add(_path_key)
-                if enabled is not None and (enabled & _cands):
+                if _enabled_set & _cands:
                     self._load_plugin(manifest)
                 else:
                     self._register_deferred_platform(manifest)


### PR DESCRIPTION
## Problem

The A2A plugin's five client tools (`a2a_call`, `a2a_list`, `a2a_discover`, `a2a_history`, `a2a_orchestrate`) never appear in agent sessions, even with the plugin enabled and the `a2a` toolset explicitly listed in `platform_toolsets`.

Root cause: every bundled `platform` plugin is registered **lazily** via `_register_deferred_platform` — its module and `register()` (which registers both the inbound adapter AND the client tools) are imported only when the gateway connects to that platform. That happens **after** the agent session has already composed its toolset, so the client tools are registered too late and no session ever sees them. The inbound adapter works (it's mounted at connect time), which makes the missing tools look like a config problem.

## Fix

In the plugin-discovery loop, explicitly-enabled bundled platform plugins now load **eagerly** (`_load_plugin`) so their tools/hooks are in the registry before any session composes its toolset. Enabled-ness is matched against the manifest name, manifest key, or the path-derived key (e.g. `platforms/a2a`) — the form `hermes plugins enable` actually saves. Non-enabled bundled platforms keep the lazy path, so plain `hermes` invocations don't start importing heavy platform SDKs (telegram, slack, ...) they never use.

## Verification

- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py tests/hermes_cli/test_startup_plugin_gating.py tests/hermes_cli/test_plugin_scanner_recursion.py` → **165 passed, 0 failed**
- Regression probe: with the patch, `a2a-platform` eager-loads at discovery; the other 21 bundled platforms remain deferred.
- Live end-to-end: gateway-hosted agent successfully invoked `a2a_list` over the A2A wire protocol and returned configured peers.

## Notes for maintainers

Two per-profile config settings were additionally required on top of this patch for the tools to surface (not part of this PR, but relevant):

1. `tools.tool_search.enabled: off` — Tool Search (progressive disclosure) defers *plugin* tools behind the `tool_search`/`tool_describe`/`tool_call` bridge.
2. `platform_toolsets.<platform>` (e.g. `a2a`) mirroring the `cli` list — gateway sessions routed over a platform use that platform's key, not `cli`.

Review feedback already addressed in `b348555`: `as_posix()` path normalization (Windows-safe), defensive `enabled` set coercion, and a narrowed `(OSError, ValueError)` catch with a debug log instead of `except Exception: pass`.