### PR TITLE
fix(a2a): eager-load explicitly enabled bundled platform plugins

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1466,7 +1466,28 @@ class PluginManager:
             # path actually asks for that platform. Every platform Hermes ships
             # remains available out of the box — it just loads on first use.
             if manifest.source == "bundled" and manifest.kind == "platform":
-                self._register_deferred_platform(manifest)
+                # Explicitly-enabled bundled platform plugins load eagerly so
+                # their client tools/hooks are registered before sessions
+                # compose their toolset (otherwise e.g. the a2a client tools
+                # never reach the agent session). Non-enabled platforms stay
+                # deferred so plain `hermes` invocations don't import heavy
+                # platform SDKs they never use.
+                _lk = manifest.key or manifest.name
+                _path_key = None
+                try:
+                    from pathlib import Path
+                    _pp = Path(manifest.path).resolve()
+                    _root = Path(get_bundled_plugins_dir()).resolve()
+                    _path_key = str(_pp.relative_to(_root))
+                except Exception:
+                    pass
+                _cands = {manifest.name, _lk}
+                if _path_key:
+                    _cands.add(_path_key)
+                if enabled is not None and (enabled & _cands):
+                    self._load_plugin(manifest)
+                else:
+                    self._register_deferred_platform(manifest)
                 continue
 
             # Everything else (standalone, user-installed backends,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1472,19 +1472,27 @@ class PluginManager:
                 # never reach the agent session). Non-enabled platforms stay
                 # deferred so plain `hermes` invocations don't import heavy
                 # platform SDKs they never use.
+                _enabled_set = set(enabled) if enabled is not None else set()
                 _lk = manifest.key or manifest.name
+                _cands = {manifest.name, _lk}
                 _path_key = None
                 try:
                     from pathlib import Path
                     _pp = Path(manifest.path).resolve()
                     _root = Path(get_bundled_plugins_dir()).resolve()
-                    _path_key = str(_pp.relative_to(_root))
-                except Exception:
-                    pass
-                _cands = {manifest.name, _lk}
+                    # as_posix(): canonical keys are forward-slash even on
+                    # Windows (str(relative_to) would yield backslashes there
+                    # and never match user-saved enable keys).
+                    _path_key = _pp.relative_to(_root).as_posix()
+                except (OSError, ValueError):
+                    logger.debug(
+                        "Could not derive path-derived key for plugin %r; "
+                        "falling back to name/key matching only",
+                        _lk,
+                    )
                 if _path_key:
                     _cands.add(_path_key)
-                if enabled is not None and (enabled & _cands):
+                if _enabled_set & _cands:
                     self._load_plugin(manifest)
                 else:
                     self._register_deferred_platform(manifest)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where client tools from explicitly enabled bundled platform plugins (such as the A2A plugin) were unavailable in agent sessions because they were registered after toolset composition.

Bundled platform plugins that are explicitly enabled are now loaded eagerly during plugin discovery, ensuring their tools and hooks are registered before sessions are created. Bundled platforms that are not enabled continue to use lazy loading to avoid importing unnecessary platform SDKs.

## Issues

The A2A plugin's five client tools (a2a_call, a2a_list, a2a_discover,
a2a_history, a2a_orchestrate) never appear in agent sessions, even with
the plugin enabled and the a2a toolset explicitly listed in
platform_toolsets.

## Fixes

In the plugin-discovery loop, explicitly-enabled bundled platform plugins
now load eagerly (_load_plugin) so their tools/hooks are in the registry
before any session composes its toolset. Enabled-ness is matched against
the manifest name, manifest key, or the path-derived key (e.g.
platforms/a2a) — the form hermes plugins enable actually saves.
Non-enabled bundled platforms keep the lazy path, so plain hermes
invocations don't start importing heavy platform SDKs (telegram, slack,
...) they never use.

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✅ Tests (adding or improving test coverage)

## Changes Made

* Eagerly load explicitly enabled bundled platform plugins during plugin discovery.
* Preserve lazy loading for bundled platform plugins that are not enabled.
* Match enabled plugins using the manifest name, manifest key, or path-derived key (e.g. `platforms/a2a`) to align with how `hermes plugins enable` stores configuration.
* Improve robustness by:

  * Using `as_posix()` for cross-platform path normalization.
  * Defensively handling non-set `enabled` values.
  * Replacing a broad `except Exception` with a narrowed `(OSError, ValueError)` catch and debug logging.
* Added regression tests covering eager loading, plugin discovery, and startup behavior.

## How to Test

1. Enable the A2A plugin and configure the `a2a` platform toolset.
2. Start Hermes and verify that the A2A client tools (`a2a_call`, `a2a_list`, `a2a_discover`, `a2a_history`, `a2a_orchestrate`) are available in the agent session.
3. Run:

   ```bash
   scripts/run_tests.sh \
     tests/plugins/test_a2a_plugin.py \
     tests/plugins/test_a2a_phase23.py \
     tests/hermes_cli/test_startup_plugin_gating.py \
     tests/hermes_cli/test_plugin_scanner_recursion.py
   ```

   Expected result: **165 passed, 0 failed**.

### Notes

This PR only changes plugin loading behavior.

During validation, the following runtime configuration was also required for the A2A tools to appear in gateway-hosted sessions, but these configuration requirements are **not introduced by this PR**:

* `tools.tool_search.enabled: off` (otherwise plugin tools are exposed through the Tool Search bridge).
* `platform_toolsets.<platform>` (e.g. `a2a`) configured alongside the `cli` toolset, since gateway sessions use the platform-specific toolset.
