### PR TITLE
feat(telegram): capture-aware pre-ack intake queue (Slice 1.1R-B)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11090,7 +11090,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile needs the same whole-handler runtime scope as a
             # secondary profile: authorization and prompt rendering both run
             # before the narrower agent-turn scope is installed.
-            self._stamp_receiving_profile(adapter, self._active_profile_name())
+            if not await self._stamp_primary_adapter_or_dispose(adapter, platform):
+                continue
             adapter.set_message_handler(self._primary_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
@@ -12463,7 +12464,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
-                    self._stamp_receiving_profile(adapter, self._active_profile_name())
+                    if not await self._stamp_primary_adapter_or_dispose(adapter, platform):
+                        # Left in self._failed_platforms at its existing
+                        # backoff schedule -- this scan's attempt is
+                        # abandoned, not retried immediately; the next
+                        # scheduled scan tries again (Slice 1.1R-B: a
+                        # stamp failure must not be silently swallowed, but
+                        # a transient one also must not permanently drop a
+                        # retryable platform from the reconnect queue).
+                        continue
                     adapter.set_message_handler(self._primary_message_handler())
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
@@ -13410,16 +13419,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         specifically, since ``BasePlatformAdapter`` (shared by every
         platform) is out of this envelope's scope to change -- adapters that
         don't expose ``receiving_profile`` are silently skipped.
+
+        Deliberately does not catch anything: a failed stamp (missing
+        profile name, a profile name that fails the adapter's own format
+        validation, or a double-stamp on an already-immutable field) must
+        propagate to the caller, not be swallowed into a debug log line
+        while the adapter is left running unstamped -- an unstamped
+        secondary-profile adapter must never be silently treated as if it
+        were the default profile. Each call site decides its own blast
+        radius (skip this platform, retry this profile, etc.); this method
+        only refuses to hide the failure.
         """
         if not hasattr(adapter, "receiving_profile"):
             return
+        if not profile_name:
+            raise ValueError(f"missing profile_name for {getattr(adapter, 'platform', '?')} adapter")
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", str(profile_name)):
+            raise ValueError(f"invalid receiving_profile {profile_name!r}")
+        adapter.receiving_profile = profile_name
+
+    async def _stamp_primary_adapter_or_dispose(
+        self, adapter: BasePlatformAdapter, platform: Platform
+    ) -> bool:
+        """Shared by the primary-profile startup and reconnect loops.
+
+        Returns True if the caller should proceed with this adapter, False
+        if a stamp failure means this platform must be skipped this
+        attempt. Never swallows the failure silently (Slice 1.1R-B blocker
+        2) -- contained to just this one platform/attempt, not the whole
+        startup or reconnect loop, mirroring the "no adapter" skip-and-
+        continue pattern already used right above each call site.
+        """
         try:
-            adapter.receiving_profile = profile_name
-        except Exception:
-            logger.debug(
-                "Could not stamp receiving_profile=%r on %s adapter",
-                profile_name, getattr(adapter, "platform", "?"), exc_info=True,
+            self._stamp_receiving_profile(adapter, self._active_profile_name())
+        except Exception as e:
+            logger.error(
+                "✗ %s: failed to stamp receiving_profile, skipping: %s",
+                platform.value, e,
             )
+            await _dispose_unused_adapter(adapter)
+            return False
+        return True
 
     def _configure_profile_adapter(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11090,6 +11090,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile needs the same whole-handler runtime scope as a
             # secondary profile: authorization and prompt rendering both run
             # before the narrower agent-turn scope is installed.
+            self._stamp_receiving_profile(adapter, self._active_profile_name())
             adapter.set_message_handler(self._primary_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
@@ -12462,6 +12463,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
+                    self._stamp_receiving_profile(adapter, self._active_profile_name())
                     adapter.set_message_handler(self._primary_message_handler())
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
@@ -13395,6 +13397,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
 
+    @staticmethod
+    def _stamp_receiving_profile(adapter: BasePlatformAdapter, profile_name: str) -> None:
+        """Stamp the immutable per-adapter receiving-profile field, if this adapter type has one.
+
+        Slice 1.1R-B (conflict #7): TelegramAdapter's capture-aware queue
+        seam needs to know which profile's bot account received an update
+        at construction time, before dispatch -- profile identity was
+        previously only stamped onto outbound message sources, after
+        dispatch, too late for a pre-dispatch capture seam. Duck-typed
+        (``hasattr``) rather than an isinstance check against TelegramAdapter
+        specifically, since ``BasePlatformAdapter`` (shared by every
+        platform) is out of this envelope's scope to change -- adapters that
+        don't expose ``receiving_profile`` are silently skipped.
+        """
+        if not hasattr(adapter, "receiving_profile"):
+            return
+        try:
+            adapter.receiving_profile = profile_name
+        except Exception:
+            logger.debug(
+                "Could not stamp receiving_profile=%r on %s adapter",
+                profile_name, getattr(adapter, "platform", "?"), exc_info=True,
+            )
+
     def _configure_profile_adapter(
         self,
         adapter: BasePlatformAdapter,
@@ -13402,6 +13428,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        self._stamp_receiving_profile(adapter, profile_name)
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1214,6 +1214,27 @@ class TelegramAdapter(BasePlatformAdapter):
         two different questions, and capture must ask the second one, not
         the first.
         """
+        source = self._source_from_message_for_auth(message)
+        authorization_check = getattr(self, "_authorization_check", None)
+        if callable(authorization_check):
+            try:
+                return bool(
+                    authorization_check(
+                        source.user_id,
+                        source.chat_type,
+                        source.chat_id,
+                    )
+                )
+            except Exception:
+                logger.error(
+                    "[Telegram] Capture authorization check failed for user %s; denying capture",
+                    source.user_id,
+                    exc_info=True,
+                )
+                return False
+
+        # Standalone/test fallback when no gateway callback has been installed.
+        # Normal gateway startup always installs the profile-bound callback.
         early, authorized, _source = self._resolve_sender_authorization(message)
         if early is not None:
             return early
@@ -8782,7 +8803,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 f"[{self.name}] receiving_profile is immutable once set "
                 f"(already {self._receiving_profile!r}, refused {value!r})"
             )
-        if not re.match(r"^[a-z][a-z0-9_-]{0,63}$", str(value)):
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", str(value)):
             raise ValueError(f"invalid receiving_profile {value!r}")
         self._receiving_profile = str(value)
 
@@ -8801,12 +8822,16 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         cached = getattr(self, "_capture_route_table_cache", None)
         if cached is None:
-            cached = RoutePolicyTable(self.config.extra.get("capture_routes"))
+            extra = self.config.extra
+            raw_routes = extra["capture_routes"] if "capture_routes" in extra else []
+            if raw_routes is None:
+                raise ValueError("capture_routes must be a list")
+            cached = RoutePolicyTable(raw_routes)
             self._capture_route_table_cache = cached
         return cached
 
     def _capture_is_configured(self) -> bool:
-        return bool(self.config.extra.get("capture_routes"))
+        return "capture_routes" in self.config.extra
 
     def _capture_route_for_message(self, message: Message):
         """The matching route-policy entry for ``message``, or None if unrouted."""
@@ -8837,14 +8862,56 @@ class TelegramAdapter(BasePlatformAdapter):
         self._capture_store = None
         self._capture_queue = None
 
-    def _alert_capture_failure(self, message: str) -> None:
-        # Deliverable per the plan: "only deterministic failure is alerted,
-        # and only to Hermes Hub General topic -- never a per-message
-        # acknowledgment." Wiring an actual outbound alert send is out of
-        # scope for this envelope (excluded: no new outbound-send path, no
-        # live Telegram call) -- log loudly; the raised exception is what
-        # actually enforces fail-closed (blocks offset advance / webhook ack).
+    def _alert_capture_failure(self, message: str, source_message: Message) -> None:
+        """Log and asynchronously reply to the failed Capture-topic message."""
         logger.error("[%s] %s", self.name, message)
+        alerted = getattr(self, "_capture_alerted_failures", None)
+        if alerted is None:
+            alerted = set()
+            self._capture_alerted_failures = alerted
+        if message in alerted:
+            return
+        if len(alerted) >= 256:
+            alerted.clear()
+        alerted.add(message)
+        try:
+            asyncio.get_running_loop().create_task(
+                self._deliver_capture_failure_alert(message, source_message)
+            )
+        except RuntimeError:
+            logger.error("[%s] No event loop available for capture failure alert", self.name)
+
+    async def _deliver_capture_failure_alert(
+        self, message: str, source_message: Message
+    ) -> None:
+        chat_id = getattr(getattr(source_message, "chat", None), "id", None)
+        if not chat_id:
+            logger.error(
+                "[%s] Capture failure could not be delivered: source chat is unavailable",
+                self.name,
+            )
+            return
+        metadata: Dict[str, Any] = {}
+        thread_id = getattr(source_message, "message_thread_id", None)
+        if thread_id is not None:
+            metadata["thread_id"] = str(thread_id)
+        source_message_id = getattr(source_message, "message_id", None)
+        if source_message_id is not None:
+            metadata["telegram_reply_to_message_id"] = int(source_message_id)
+        try:
+            result = await self.send(
+                str(chat_id),
+                "Capture ingress failure: " + message,
+                metadata=metadata,
+            )
+            if not getattr(result, "success", False):
+                logger.error(
+                    "[%s] Capture failure alert send failed: %s",
+                    self.name,
+                    getattr(result, "error", "unknown error"),
+                )
+        except Exception:
+            logger.error("[%s] Capture failure alert send raised", self.name, exc_info=True)
 
     def _require_receiving_profile(self) -> str:
         """Fail closed: no silent "default" fallback for an unstamped adapter.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1100,17 +1100,17 @@ class TelegramAdapter(BasePlatformAdapter):
         extra = getattr(getattr(self, "config", None), "extra", None) or {}
         return str(extra.get("unauthorized_dm_behavior", "")).strip().lower() == "pair"
 
-    def _is_user_authorized_from_message(self, message: Message) -> bool:
-        """Check if the sender of a Telegram message is authorized.
+    def _resolve_sender_authorization(self, message: Message):
+        """Shared authorization resolution for ``_is_user_authorized_from_message``
+        and ``_is_capture_sender_authorized``.
 
-        Intake prefilter that runs BEFORE text batching, event construction,
-        and unmentioned-group observation, so a removed/unauthorized user
-        cannot inject prompt content into the agent path or the observed
-        transcript (fixes #40863). It only rejects when it can make the same
-        context-aware decision the runner would make. Unknown DMs with no
-        allowlist still pass through so the normal pairing flow can run.
-        Unknown DMs with an allowlist still pass through when pairing is the
-        effective unauthorized-DM behavior (explicit platform override).
+        Returns ``(early_result, authorized, source)``. When ``early_result``
+        is not ``None``, both callers return it directly as-is -- these are
+        "no authorization infrastructure configured at all, wide open"
+        cases (no identity, no runner + no env configured, no allowlist
+        CSV), not pairing-specific, so both callers treat them identically.
+        Otherwise ``authorized`` is the resolved True/False and each caller
+        applies its own policy for the False case.
         """
         source = self._source_from_message_for_auth(message)
         user_id = source.user_id
@@ -1120,7 +1120,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # they carry no authorizable identity, so let the normal
         # _should_process_message gating handle them.
         if not user_id:
-            return True
+            return True, None, source
 
         authorized: Optional[bool] = None
 
@@ -1163,7 +1163,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # actually exists; otherwise unknown DMs must reach the pairing
                 # flow rather than being default-denied here.
                 if not self._telegram_auth_env_configured():
-                    return True
+                    return True, None, source
                 try:
                     authorized = bool(auth_fn(source))
                 except Exception:
@@ -1176,14 +1176,48 @@ class TelegramAdapter(BasePlatformAdapter):
         if authorized is None:
             allowed_csv = _scoped_gate_env("TELEGRAM_ALLOWED_USERS").strip()
             if not allowed_csv:
-                return True
+                return True, None, source
             allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
             authorized = "*" in allowed_ids or user_id in allowed_ids
 
+        return None, authorized, source
+
+    def _is_user_authorized_from_message(self, message: Message) -> bool:
+        """Check if the sender of a Telegram message is authorized.
+
+        Intake prefilter that runs BEFORE text batching, event construction,
+        and unmentioned-group observation, so a removed/unauthorized user
+        cannot inject prompt content into the agent path or the observed
+        transcript (fixes #40863). It only rejects when it can make the same
+        context-aware decision the runner would make. Unknown DMs with no
+        allowlist still pass through so the normal pairing flow can run.
+        Unknown DMs with an allowlist still pass through when pairing is the
+        effective unauthorized-DM behavior (explicit platform override).
+        """
+        early, authorized, source = self._resolve_sender_authorization(message)
+        if early is not None:
+            return early
         if authorized:
             return True
         # Unauthorized DM that the gateway would pair: forward so pairing can run.
         return self._should_pass_unauthorized_dm_for_pairing(source)
+
+    def _is_capture_sender_authorized(self, message: Message) -> bool:
+        """Like ``_is_user_authorized_from_message``, but never treats an
+        unauthorized DM that is merely being let through for the gateway
+        pairing handshake as authorized.
+
+        Slice 1.1R-B: the capture-aware queue must not durably record an
+        unauthenticated stranger's DM into the ledger just because the
+        pairing flow needs to see that same message to run -- "letting a
+        message through to dispatch" and "this sender is authorized" are
+        two different questions, and capture must ask the second one, not
+        the first.
+        """
+        early, authorized, _source = self._resolve_sender_authorization(message)
+        if early is not None:
+            return early
+        return bool(authorized)
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -3723,7 +3757,47 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("[%s] No bot token configured", self.name)
             self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
-        
+
+        # Slice 1.1R-B fail-closed, both scoped to capture_is_configured():
+        # an adapter with no capture_routes at all (every platform except a
+        # deliberately capture-configured Telegram profile) never reaches
+        # CaptureAwareQueue.put()'s route-match branch, so it needs neither
+        # a validated route table nor a stamped profile to connect.
+        if self._capture_is_configured():
+            # 1) Reject a malformed capture_routes entry before dispatch/
+            # admission -- i.e. here, at connect() time, once -- rather
+            # than lazily re-validating (and potentially re-raising) on
+            # every single message deep inside CaptureAwareQueue.put().
+            try:
+                self._capture_route_table()
+            except ValueError as exc:
+                logger.error("[%s] invalid capture_routes configuration: %s", self.name, exc)
+                self._set_fatal_error("invalid_capture_routes", str(exc), retryable=False)
+                return False
+            # 2) The capture-aware queue's ledger rows are keyed in part by
+            # profile, so an adapter that was never stamped by gateway/
+            # run.py's startup path must never connect -- doing so silently
+            # would risk this adapter's captures (or, worse, its dispatch
+            # decisions) being attributed to no profile at all instead of
+            # refusing outright. No "or 'default'" fallback: a genuinely
+            # default-profile adapter is always stamped "default" explicitly
+            # by gateway/run.py's _active_profile_name(), so a None here
+            # means the startup path was skipped or failed, not that the
+            # profile really is "default".
+            if not self.receiving_profile:
+                logger.error(
+                    "[%s] capture_routes configured but receiving_profile was never "
+                    "stamped -- refusing to connect (Slice 1.1R-B fail-closed; see "
+                    "gateway/run.py's _stamp_receiving_profile)",
+                    self.name,
+                )
+                self._set_fatal_error(
+                    "missing_receiving_profile",
+                    "receiving_profile not stamped before connect() with capture_routes configured",
+                    retryable=False,
+                )
+                return False
+
         try:
             if not self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
                 return False
@@ -4454,8 +4528,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
         self._release_platform_lock()
 
+        # PTB admission has stopped, so no queue put can still be using the
+        # SQLite connection. Close it now and discard the queue bound to it;
+        # a later explicit reconnect constructs a fresh store and queue.
+        self._close_capture_store()
+
         self._app = None
         self._bot = None
+
         logger.info("[%s] Disconnected from Telegram", self.name)
 
     def _should_thread_reply(self, reply_to: Optional[str], chunk_index: int) -> bool:
@@ -8707,16 +8787,26 @@ class TelegramAdapter(BasePlatformAdapter):
         self._receiving_profile = str(value)
 
     def _capture_route_table(self) -> "RoutePolicyTable":
-        """(chat_id, thread_id) -> route entry, read fresh from config each call.
+        """(chat_id, thread_id) -> route entry. Built once and cached.
 
-        Matches this adapter's existing convention (``_telegram_allowed_topics``,
-        ``_telegram_ignored_threads``, etc.) of re-reading ``config.extra``
-        per call rather than caching -- the route list is small and static
-        per process, and this keeps the value correct for adapters
-        constructed via ``object.__new__`` in tests without requiring
-        ``__init__`` to have run.
+        RoutePolicyTable now validates the merged route-policy contract
+        strictly and raises ValueError on a malformed entry (Slice 1.1R-B:
+        "reject invalid configured entries before dispatch/admission") --
+        so this must be validated once, eagerly, at connect() time (see
+        connect()'s own guard, which calls this before installing the
+        capture queue), not re-attempted, and potentially re-raised, deep
+        inside per-message handling. ``getattr`` (not a plain ``__init__``
+        default) so adapters constructed via ``object.__new__`` in tests
+        (bypassing ``__init__``) still work without requiring it to have run.
         """
-        return RoutePolicyTable(self.config.extra.get("capture_routes"))
+        cached = getattr(self, "_capture_route_table_cache", None)
+        if cached is None:
+            cached = RoutePolicyTable(self.config.extra.get("capture_routes"))
+            self._capture_route_table_cache = cached
+        return cached
+
+    def _capture_is_configured(self) -> bool:
+        return bool(self.config.extra.get("capture_routes"))
 
     def _capture_route_for_message(self, message: Message):
         """The matching route-policy entry for ``message``, or None if unrouted."""
@@ -8739,6 +8829,14 @@ class TelegramAdapter(BasePlatformAdapter):
             self._capture_store = CaptureIngressStore(self._capture_db_path())
         return self._capture_store
 
+    def _close_capture_store(self) -> None:
+        """Close durable capture state after intake stops; reset for reconnect."""
+        store = getattr(self, "_capture_store", None)
+        if store is not None:
+            store.close()
+        self._capture_store = None
+        self._capture_queue = None
+
     def _alert_capture_failure(self, message: str) -> None:
         # Deliverable per the plan: "only deterministic failure is alerted,
         # and only to Hermes Hub General topic -- never a per-message
@@ -8748,21 +8846,44 @@ class TelegramAdapter(BasePlatformAdapter):
         # actually enforces fail-closed (blocks offset advance / webhook ack).
         logger.error("[%s] %s", self.name, message)
 
+    def _require_receiving_profile(self) -> str:
+        """Fail closed: no silent "default" fallback for an unstamped adapter.
+
+        A genuinely default-profile adapter is always stamped "default"
+        explicitly by gateway/run.py's ``_active_profile_name()`` -- this
+        only fires if the startup path was skipped entirely (a future call
+        path that forgets to stamp, or a test double), which must never be
+        allowed to masquerade as the default profile.
+        """
+        profile = self.receiving_profile
+        if not profile:
+            raise RuntimeError(
+                f"[{self.name}] receiving_profile was not stamped before capture-queue "
+                "use -- refusing (Slice 1.1R-B fail-closed)"
+            )
+        return profile
+
     def _build_capture_queue(self) -> CaptureAwareQueue:
         """Construct a fresh capture-aware queue bound to this adapter's own gating logic.
 
         Reuses ``_is_own_message`` and ``_is_user_authorized_from_message``
         (the same authorization decision the rest of the adapter already
         makes) rather than re-implementing sender gating in the queue seam.
+        Always built, capture-configured or not (one capture-aware queue
+        for every Application, per the plan) -- ``profile_provider`` is
+        only ever *called* from inside ``put()`` when a message actually
+        matches a configured route, so an adapter with no ``capture_routes``
+        at all never needs ``receiving_profile`` set (see connect()'s own
+        guard, scoped to ``_capture_is_configured()``, for the eager check).
         """
         return CaptureAwareQueue(
             store=self._ensure_capture_store(),
             route_table_provider=self._capture_route_table,
             account_id_provider=lambda: getattr(self._bot, "id", None),
-            profile_provider=lambda: self.receiving_profile or "default",
+            profile_provider=self._require_receiving_profile,
             thread_id_resolver=self._effective_message_thread_id,
             is_own_message=self._is_own_message,
-            is_authorized_sender=self._is_user_authorized_from_message,
+            is_authorized_sender=self._is_capture_sender_authorized,
             alert_failure=self._alert_capture_failure,
         )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -305,6 +305,12 @@ from plugins.platforms.telegram.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
+from plugins.platforms.telegram.capture_ingress import (
+    CaptureAwareQueue,
+    CaptureIngressStore,
+    RoutePolicyTable,
+    normalize_thread_id,
+)
 from utils import atomic_replace, env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -705,6 +711,19 @@ class TelegramAdapter(BasePlatformAdapter):
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
         self._webhook_mode: bool = False
+        # Slice 1.1R-B: which config profile's bot account this adapter
+        # instance is receiving updates for. Immutable once set (see the
+        # ``receiving_profile`` property below) -- it is stamped once by
+        # gateway/run.py's per-profile startup path, right after this
+        # adapter is constructed and before it ever connects, and every
+        # ingress-ledger row this adapter captures carries it verbatim.
+        self._receiving_profile: Optional[str] = None
+        # Reused across the rebuild-on-init-failure loop inside connect() so
+        # a rebuilt Application never silently reverts to a plain queue (see
+        # "Rebuilt PTB application after init failure" in the capture
+        # acceptance matrix). Recreated fresh on each new connect() call.
+        self._capture_queue: Optional[CaptureAwareQueue] = None
+        self._capture_store: Optional[CaptureIngressStore] = None
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
@@ -3869,6 +3888,29 @@ class TelegramAdapter(BasePlatformAdapter):
 
             get_updates_request = self._instrument_polling_request(get_updates_request)
             builder = builder.request(request).get_updates_request(get_updates_request)
+            # Slice 1.1R-B: installed before .build() so every update this
+            # Application ever delivers -- polling or webhook, initial build
+            # or a rebuild below after a retried init failure -- is captured
+            # before PTB's own dispatch ever sees it. One instance, reused
+            # for the whole connect() attempt loop (not recreated per
+            # rebuild), so a rebuild can never silently revert to a plain
+            # queue.
+            if self._capture_queue is None:
+                self._capture_queue = self._build_capture_queue()
+            # Not reassigned (unlike the chained calls above): PTB's real
+            # ApplicationBuilder.update_queue() mutates self and returns
+            # self, same as every other builder setter, so a plain call is
+            # equivalent to `builder = builder.update_queue(...)` for the
+            # real builder -- and it does not require test doubles that
+            # construct a bare MagicMock() builder (see test_telegram_conflict.py)
+            # to also stub update_queue's return value just to keep their
+            # existing `.build.return_value` wiring intact. hasattr-gated
+            # because some pre-existing test doubles (test_telegram_polling_progress.py's
+            # _LifecycleBuilder) implement only the specific builder methods
+            # they exercise; the real ApplicationBuilder always has this
+            # method, so the guard only ever matters for those fakes.
+            if hasattr(builder, "update_queue"):
+                builder.update_queue(self._capture_queue)
             self._app = builder.build()
             self._bot = self._app.bot
             
@@ -4002,6 +4044,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     # and will be GC'd (#67498).
                     if rebuild_app and _attempt < _max_connect - 1:
                         old_app = self._app
+                        # `builder` is the same ApplicationBuilder instance
+                        # configured above (mutate-and-return-self per PTB),
+                        # so the capture-aware queue installed via
+                        # .update_queue() before the first .build() is still
+                        # in effect here -- a rebuild never reverts to a
+                        # plain queue. Do not replace `builder` with a fresh
+                        # ApplicationBuilder() in this retry loop.
                         self._app = builder.build()
                         self._bot = self._app.bot
                         # Re-register handlers on the new app
@@ -8634,6 +8683,89 @@ class TelegramAdapter(BasePlatformAdapter):
             adapter_name = getattr(self, "name", "telegram")
             logger.warning("[%s] Failed to observe Telegram group message: %s", adapter_name, exc)
 
+    @property
+    def receiving_profile(self) -> Optional[str]:
+        """Config profile this adapter instance receives Telegram updates for.
+
+        Immutable once set -- see conflict #7 in the 1.1R-B plan
+        (``docs/hermes-program/phases/01-reliable-capture/
+        slice-1.1r-b-capture-first-intake.md`` in hermes-control-plane):
+        multiplex profile identity was previously applied only *after*
+        dispatch, too late for a pre-dispatch capture seam.
+        """
+        return self._receiving_profile
+
+    @receiving_profile.setter
+    def receiving_profile(self, value: str) -> None:
+        if self._receiving_profile is not None:
+            raise RuntimeError(
+                f"[{self.name}] receiving_profile is immutable once set "
+                f"(already {self._receiving_profile!r}, refused {value!r})"
+            )
+        if not re.match(r"^[a-z][a-z0-9_-]{0,63}$", str(value)):
+            raise ValueError(f"invalid receiving_profile {value!r}")
+        self._receiving_profile = str(value)
+
+    def _capture_route_table(self) -> "RoutePolicyTable":
+        """(chat_id, thread_id) -> route entry, read fresh from config each call.
+
+        Matches this adapter's existing convention (``_telegram_allowed_topics``,
+        ``_telegram_ignored_threads``, etc.) of re-reading ``config.extra``
+        per call rather than caching -- the route list is small and static
+        per process, and this keeps the value correct for adapters
+        constructed via ``object.__new__`` in tests without requiring
+        ``__init__`` to have run.
+        """
+        return RoutePolicyTable(self.config.extra.get("capture_routes"))
+
+    def _capture_route_for_message(self, message: Message):
+        """The matching route-policy entry for ``message``, or None if unrouted."""
+        chat_id = getattr(getattr(message, "chat", None), "id", None)
+        if chat_id is None:
+            return None
+        thread_id = normalize_thread_id(self._effective_message_thread_id(message))
+        return self._capture_route_table().lookup(chat_id, thread_id)
+
+    def _capture_db_path(self) -> str:
+        override = self.config.extra.get("capture_db_path")
+        if override:
+            return str(override)
+        from hermes_constants import get_hermes_home
+
+        return str(get_hermes_home() / "capture_ingress.db")
+
+    def _ensure_capture_store(self) -> CaptureIngressStore:
+        if self._capture_store is None:
+            self._capture_store = CaptureIngressStore(self._capture_db_path())
+        return self._capture_store
+
+    def _alert_capture_failure(self, message: str) -> None:
+        # Deliverable per the plan: "only deterministic failure is alerted,
+        # and only to Hermes Hub General topic -- never a per-message
+        # acknowledgment." Wiring an actual outbound alert send is out of
+        # scope for this envelope (excluded: no new outbound-send path, no
+        # live Telegram call) -- log loudly; the raised exception is what
+        # actually enforces fail-closed (blocks offset advance / webhook ack).
+        logger.error("[%s] %s", self.name, message)
+
+    def _build_capture_queue(self) -> CaptureAwareQueue:
+        """Construct a fresh capture-aware queue bound to this adapter's own gating logic.
+
+        Reuses ``_is_own_message`` and ``_is_user_authorized_from_message``
+        (the same authorization decision the rest of the adapter already
+        makes) rather than re-implementing sender gating in the queue seam.
+        """
+        return CaptureAwareQueue(
+            store=self._ensure_capture_store(),
+            route_table_provider=self._capture_route_table,
+            account_id_provider=lambda: getattr(self._bot, "id", None),
+            profile_provider=lambda: self.receiving_profile or "default",
+            thread_id_resolver=self._effective_message_thread_id,
+            is_own_message=self._is_own_message,
+            is_authorized_sender=self._is_user_authorized_from_message,
+            alert_failure=self._alert_capture_failure,
+        )
+
     def _is_own_message(self, message: Message) -> bool:
         """Return True when the message was sent by this bot itself.
 
@@ -8685,6 +8817,15 @@ class TelegramAdapter(BasePlatformAdapter):
         # addressed to us as one addressed to some other bot.
         self._observe_bot_identity_from_message(message)
         if self._is_own_message(message):
+            return False
+
+        # Defense-in-depth (Slice 1.1R-B): a capture-only route must never
+        # reach reply/mention/command/free-response/wake-word gating, even
+        # though the queue-level terminal deny (CaptureAwareQueue.put) is
+        # meant to make this branch unreachable for a capture-only route in
+        # the first place. Deliberate belt-and-suspenders, tested directly.
+        route = self._capture_route_for_message(message)
+        if route is not None and route.mode == "capture_only":
             return False
 
         if not self._is_group_chat(message):

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -21,6 +21,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import re
 import sqlite3
 import threading
 from dataclasses import dataclass
@@ -30,8 +31,10 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from telegram import Update
+    from telegram.error import TelegramError
 except ImportError:  # pragma: no cover - PTB always present alongside adapter.py
     Update = None  # type: ignore
+    TelegramError = Exception  # type: ignore
 
 # Matches TelegramAdapter._GENERAL_TOPIC_THREAD_ID. Telegram's implicit
 # General forum topic is addressed as thread id "1" but route-policy and the
@@ -60,10 +63,18 @@ def normalize_thread_id(raw_thread_id: Any) -> Optional[int]:
 
 
 def canonicalize_update(update: "Update") -> bytes:
-    """Compact sorted-key UTF-8 JSON over ``Update.to_dict()`` -- frozen wire shape."""
+    """Compact sorted-key UTF-8 JSON over ``Update.to_dict()`` -- frozen wire shape.
+
+    ``allow_nan=False``: NaN/Infinity are not valid JSON (RFC 8259), so a
+    canonical serialization must reject them rather than silently emitting
+    Python's non-standard ``NaN``/``Infinity``/``-Infinity`` literals, which
+    a compliant JSON parser elsewhere in the pipeline would fail to read
+    back -- fail loud here instead of producing a payload_hash over bytes
+    nothing else can parse.
+    """
     payload = update.to_dict()
     return json.dumps(
-        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
     ).encode("utf-8")
 
 
@@ -90,17 +101,37 @@ def classify_event_type(message: Any) -> str:
     return "other"
 
 
-class RouteConflict(Exception):
+class CaptureAdmissionError(TelegramError):
+    """Base for capture-ingress failures raised from CaptureAwareQueue.put().
+
+    Deliberately a TelegramError subclass, not a plain Exception: PTB
+    22.6's own polling retry ladder (telegram.ext._utils.networkloop.
+    network_retry_loop, driving Updater.start_polling's real
+    polling_action_cb) wraps ``await update_queue.put(update)`` inside its
+    outer loop, whose except clauses only match RetryAfter / TimedOut /
+    InvalidToken / TelegramError -- a plain Exception here propagates
+    straight out on the very first attempt and kills the polling task
+    instead of entering PTB's bounded retry path. The webhook transport
+    doesn't need this (Tornado's default handler already returns a
+    non-2xx response for any uncaught exception), but subclassing
+    TelegramError here doesn't change that.
+    """
+
+
+class RouteConflict(CaptureAdmissionError):
     """Same event_id captured again with a different canonical payload/hash."""
 
 
-class CapturePersistenceError(Exception):
+class CapturePersistenceError(CaptureAdmissionError):
     """Ledger/payload commit failed for a reason that must fail closed (never a coding bug)."""
 
 
 logger = logging.getLogger(__name__)
 
 _VALID_ROUTE_MODES = ("capture_only", "agent", "drop")
+_ROUTE_FIELDS = {"chat_id", "thread_id", "mode", "sink", "policy_version"}
+_SINK_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_POLICY_VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
 
 @dataclass(frozen=True)
@@ -124,28 +155,66 @@ class RoutePolicyTable:
 
     def __init__(self, entries: Optional[List[Dict[str, Any]]] = None):
         self._by_key: Dict[Tuple[int, Optional[int]], RouteEntry] = {}
-        for raw in entries or []:
-            mode = str(raw["mode"])
-            if mode not in _VALID_ROUTE_MODES:
-                # Fail closed on a misconfigured entry, but with a small
-                # blast radius: drop only this entry (so its chat/topic
-                # falls back to "no route configured," today's safe
-                # pass-through default) rather than raising and taking every
-                # other configured route down with it over one typo.
-                logger.error(
-                    "capture_routes: dropping entry with unrecognized mode %r "
-                    "(chat_id=%r, thread_id=%r) -- must be one of %s",
-                    mode, raw.get("chat_id"), raw.get("thread_id"), _VALID_ROUTE_MODES,
+        if entries is not None and not isinstance(entries, list):
+            raise ValueError("capture_routes must be a list")
+        for index, raw in enumerate(entries or []):
+            if not isinstance(raw, dict):
+                raise ValueError(f"capture_routes[{index}] must be an object")
+            missing = _ROUTE_FIELDS - set(raw)
+            if missing:
+                raise ValueError(
+                    f"capture_routes[{index}] missing required fields: {sorted(missing)}"
                 )
-                continue
+            unknown = set(raw) - _ROUTE_FIELDS
+            if unknown:
+                raise ValueError(
+                    f"capture_routes[{index}] has unknown fields: {sorted(unknown)}"
+                )
+
+            chat_id = raw["chat_id"]
+            if isinstance(chat_id, bool) or not isinstance(chat_id, int) or chat_id == 0:
+                raise ValueError(f"capture_routes[{index}].chat_id must be a nonzero integer")
+
+            raw_thread_id = raw["thread_id"]
+            if raw_thread_id is not None and (
+                isinstance(raw_thread_id, bool)
+                or not isinstance(raw_thread_id, int)
+                or raw_thread_id < 1
+            ):
+                raise ValueError(
+                    f"capture_routes[{index}].thread_id must be null or a positive integer"
+                )
+            thread_id = None if raw_thread_id in (None, 1) else raw_thread_id
+
+            mode = raw["mode"]
+            if mode not in _VALID_ROUTE_MODES:
+                raise ValueError(
+                    f"capture_routes[{index}].mode must be one of {_VALID_ROUTE_MODES}"
+                )
+
+            sink = raw["sink"]
+            if not isinstance(sink, str) or not _SINK_PATTERN.fullmatch(sink):
+                raise ValueError(f"capture_routes[{index}].sink violates the route-policy schema")
+
+            policy_version = raw["policy_version"]
+            if not isinstance(policy_version, str) or not _POLICY_VERSION_PATTERN.fullmatch(
+                policy_version
+            ):
+                raise ValueError(
+                    f"capture_routes[{index}].policy_version must be semantic X.Y.Z"
+                )
+
             entry = RouteEntry(
-                chat_id=int(raw["chat_id"]),
-                thread_id=normalize_thread_id(raw.get("thread_id")),
+                chat_id=chat_id,
+                thread_id=thread_id,
                 mode=mode,
-                sink=str(raw["sink"]),
-                policy_version=str(raw.get("policy_version", "1.0.0")),
+                sink=sink,
+                policy_version=policy_version,
             )
-            self._by_key[(entry.chat_id, entry.thread_id)] = entry
+            key = (entry.chat_id, entry.thread_id)
+            if key in self._by_key:
+                raise ValueError(f"capture_routes[{index}] has duplicate normalized route key {key}")
+            self._by_key[key] = entry
 
     def lookup(self, chat_id: Any, thread_id: Optional[int]) -> Optional[RouteEntry]:
         if chat_id is None:
@@ -179,12 +248,27 @@ CREATE TABLE IF NOT EXISTS ingress_ledger (
 CREATE TABLE IF NOT EXISTS ingress_payload (
     event_id TEXT PRIMARY KEY REFERENCES ingress_ledger(event_id),
     payload_hash TEXT NOT NULL,
+    payload_format TEXT NOT NULL,
     payload_json TEXT NOT NULL
 );
 """
 
+# The owner-selected canonical JSON v1 shape (compact sorted-key UTF-8 JSON
+# over Update.to_dict()) -- recorded on every payload row so a future
+# format change is self-describing instead of silently reinterpreting old
+# rows under a new convention.
+PAYLOAD_FORMAT_V1 = "telegram-update-json-v1"
+
 INSERTED = "inserted"
 DUPLICATE_SAME = "duplicate_same"
+
+# Fail fast on write-lock contention instead of SQLite's 5s busy-wait
+# default: commit_capture runs synchronously inside CaptureAwareQueue.put(),
+# an async method PTB awaits directly -- blocking the event loop for
+# multiple seconds on lock contention is worse than surfacing
+# CapturePersistenceError promptly so PTB's bounded retry ladder (see
+# CaptureAdmissionError) can back off and try again.
+_CONNECT_TIMEOUT_SECONDS = 1.0
 
 
 class CaptureIngressStore:
@@ -201,12 +285,25 @@ class CaptureIngressStore:
         parent = Path(self._db_path).parent
         if str(parent) not in ("", "."):
             parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
+        self._conn = sqlite3.connect(
+            self._db_path,
+            isolation_level=None,
+            check_same_thread=False,
+            timeout=_CONNECT_TIMEOUT_SECONDS,
+        )
         self._lock = threading.Lock()
+        self._closed = False
         self._conn.execute("PRAGMA journal_mode=WAL")
+        # Per-connection, not persisted in the db file -- SQLite silently
+        # ignores REFERENCES clauses unless this is set on every connection
+        # that should enforce them.
+        self._conn.execute("PRAGMA foreign_keys = ON")
         self._conn.executescript(_SCHEMA)
 
     def close(self) -> None:
+        if self._closed:
+            return  # idempotent: safe to call more than once (e.g. disconnect() then GC)
+        self._closed = True
         self._conn.close()
 
     def commit_capture(
@@ -227,6 +324,7 @@ class CaptureIngressStore:
         route_mode: str,
         sink: str,
         payload_json: str,
+        payload_format: str = PAYLOAD_FORMAT_V1,
     ) -> str:
         """Idempotent atomic insert. Returns INSERTED or DUPLICATE_SAME.
 
@@ -267,12 +365,13 @@ class CaptureIngressStore:
                     ),
                 )
                 self._conn.execute(
-                    "INSERT INTO ingress_payload (event_id, payload_hash, payload_json) VALUES (?, ?, ?)",
-                    (event_id, payload_hash, payload_json),
+                    "INSERT INTO ingress_payload (event_id, payload_hash, payload_format, payload_json) "
+                    "VALUES (?, ?, ?, ?)",
+                    (event_id, payload_hash, payload_format, payload_json),
                 )
                 self._conn.execute("COMMIT")
             except sqlite3.IntegrityError as exc:
-                self._conn.execute("ROLLBACK")
+                self._safe_rollback()
                 # Only a genuine lost race against a concurrent insert of
                 # the same event_id -- confirmed by a row actually existing
                 # now -- is a RouteConflict. Any other IntegrityError (e.g.
@@ -291,9 +390,21 @@ class CaptureIngressStore:
                     f"event_id {event_id!r} already captured with a different payload_hash"
                 )
             except sqlite3.Error as exc:
-                self._conn.execute("ROLLBACK")
+                self._safe_rollback()
                 raise CapturePersistenceError(str(exc)) from exc
             return INSERTED
+
+    def _safe_rollback(self) -> None:
+        """ROLLBACK, but only if a transaction is actually open.
+
+        BEGIN IMMEDIATE itself can fail (lock contention, disk full before
+        any transaction ever opened) -- issuing ROLLBACK in that case raises
+        its own "cannot rollback - no transaction is active" error, which
+        would mask the real failure instead of letting it become
+        CapturePersistenceError.
+        """
+        if self._conn.in_transaction:
+            self._conn.execute("ROLLBACK")
 
 
 class CaptureAwareQueue(asyncio.Queue):
@@ -338,11 +449,6 @@ class CaptureAwareQueue(asyncio.Queue):
         if message is None:
             return await super().put(item)  # not message-like: callback_query/poll/chat_member/...
 
-        if self._is_own_message(message):
-            return await super().put(item)  # bot-authored: existing behavior preserved
-        if not self._is_authorized_sender(message):
-            return await super().put(item)  # unauthorized sender: existing behavior preserved
-
         chat = getattr(message, "chat", None)
         chat_id = getattr(chat, "id", None)
         thread_id = normalize_thread_id(self._thread_id_resolver(message))
@@ -354,22 +460,26 @@ class CaptureAwareQueue(asyncio.Queue):
         message_id = getattr(message, "message_id", None)
         sender = getattr(message, "from_user", None)
         sender_id = getattr(sender, "id", None)
-        if message_id is None or sender_id is None:
-            # No human-authored identity to key a ledger row on (e.g. a
-            # channel post, whose identity lives in sender_chat rather than
-            # from_user -- the ingress-ledger contract requires a non-null
-            # human sender_id, so this cannot be captured). The owner
-            # directive for a capture-only route is unconditional ("must
-            # never start an agent turn... for the capture-only topic"), not
-            # conditioned on whether a row could be produced -- so still
-            # terminally deny dispatch, just without a ledger row.
+        sender_is_bot = bool(getattr(sender, "is_bot", False))
+        sender_is_eligible = (
+            sender_id is not None
+            and not sender_is_bot
+            and not self._is_own_message(message)
+            and self._is_authorized_sender(message)
+        )
+        if message_id is None or not sender_is_eligible:
+            # The ledger contract is strictly human-authored and authorized.
+            # Capture-only denial is broader than ledger eligibility: commands,
+            # channel posts, service messages, bots, and unauthorized senders
+            # must still never reach PTB handlers on this route.
             if route.mode == "capture_only":
-                self._alert_failure(
-                    f"capture ingress: capture-only route matched update_id={item.update_id} "
-                    "with no human sender identity to key a ledger row on -- denying dispatch, not captured"
-                )
+                if message_id is None or sender_id is None:
+                    self._alert_failure(
+                        f"capture ingress: capture-only route matched update_id={item.update_id} "
+                        "with no human sender identity to key a ledger row on -- denying dispatch, not captured"
+                    )
                 return
-            return await super().put(item)  # agent/no-route: existing behavior unchanged
+            return await super().put(item)  # agent route preserves downstream auth/pairing behavior
 
         profile = self._profile_provider()
         account_id = self._account_id_provider()

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -336,15 +336,23 @@ class CaptureIngressStore:
         with self._lock:
             try:
                 existing = self._conn.execute(
-                    "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?", (event_id,)
+                    """
+                    SELECT l.payload_hash, p.payload_hash, p.payload_format, p.payload_json
+                    FROM ingress_ledger AS l
+                    LEFT JOIN ingress_payload AS p ON p.event_id = l.event_id
+                    WHERE l.event_id = ?
+                    """,
+                    (event_id,),
                 ).fetchone()
             except sqlite3.Error as exc:
                 raise CapturePersistenceError(str(exc)) from exc
             if existing is not None:
-                if existing[0] == payload_hash:
-                    return DUPLICATE_SAME
-                raise RouteConflict(
-                    f"event_id {event_id!r} already captured with a different payload_hash"
+                return self._classify_duplicate(
+                    event_id=event_id,
+                    existing=existing,
+                    payload_hash=payload_hash,
+                    payload_format=payload_format,
+                    payload_json=payload_json,
                 )
             try:
                 self._conn.execute("BEGIN IMMEDIATE")
@@ -379,20 +387,59 @@ class CaptureIngressStore:
                 # behind and is a real persistence failure, not a duplicate;
                 # misreporting it as RouteConflict would mislead debugging
                 # even though both fail closed the same way.
-                existing = self._conn.execute(
-                    "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?", (event_id,)
-                ).fetchone()
+                try:
+                    existing = self._conn.execute(
+                        """
+                        SELECT l.payload_hash, p.payload_hash, p.payload_format, p.payload_json
+                        FROM ingress_ledger AS l
+                        LEFT JOIN ingress_payload AS p ON p.event_id = l.event_id
+                        WHERE l.event_id = ?
+                        """,
+                        (event_id,),
+                    ).fetchone()
+                except sqlite3.Error as lookup_exc:
+                    raise CapturePersistenceError(str(lookup_exc)) from exc
                 if existing is None:
                     raise CapturePersistenceError(str(exc)) from exc
-                if existing[0] == payload_hash:
-                    return DUPLICATE_SAME
-                raise RouteConflict(
-                    f"event_id {event_id!r} already captured with a different payload_hash"
+                return self._classify_duplicate(
+                    event_id=event_id,
+                    existing=existing,
+                    payload_hash=payload_hash,
+                    payload_format=payload_format,
+                    payload_json=payload_json,
                 )
             except sqlite3.Error as exc:
                 self._safe_rollback()
                 raise CapturePersistenceError(str(exc)) from exc
             return INSERTED
+
+    @staticmethod
+    def _classify_duplicate(
+        *,
+        event_id: str,
+        existing: Any,
+        payload_hash: str,
+        payload_format: str,
+        payload_json: str,
+    ) -> str:
+        ledger_hash, companion_hash, companion_format, companion_json = existing
+        if ledger_hash != payload_hash:
+            raise RouteConflict(
+                f"event_id {event_id!r} already captured with a different payload_hash"
+            )
+        if companion_hash is None:
+            raise CapturePersistenceError(
+                f"event_id {event_id!r} has no companion payload row"
+            )
+        if (
+            companion_hash != payload_hash
+            or companion_format != payload_format
+            or companion_json != payload_json
+        ):
+            raise CapturePersistenceError(
+                f"event_id {event_id!r} has a corrupt or inconsistent companion payload"
+            )
+        return DUPLICATE_SAME
 
     def _safe_rollback(self) -> None:
         """ROLLBACK, but only if a transaction is actually open.
@@ -404,7 +451,12 @@ class CaptureIngressStore:
         CapturePersistenceError.
         """
         if self._conn.in_transaction:
-            self._conn.execute("ROLLBACK")
+            try:
+                self._conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                # Preserve the original storage exception being normalized by
+                # the caller; rollback failure is secondary diagnostic context.
+                logger.error("capture ingress rollback failed", exc_info=True)
 
 
 class CaptureAwareQueue(asyncio.Queue):
@@ -429,7 +481,7 @@ class CaptureAwareQueue(asyncio.Queue):
         thread_id_resolver: Callable[[Any], Optional[str]],
         is_own_message: Callable[[Any], bool],
         is_authorized_sender: Callable[[Any], bool],
-        alert_failure: Optional[Callable[[str], None]] = None,
+        alert_failure: Optional[Callable[[str, Any], None]] = None,
     ) -> None:
         super().__init__()
         self._store = store
@@ -439,7 +491,7 @@ class CaptureAwareQueue(asyncio.Queue):
         self._thread_id_resolver = thread_id_resolver
         self._is_own_message = is_own_message
         self._is_authorized_sender = is_authorized_sender
-        self._alert_failure = alert_failure or (lambda _msg: None)
+        self._alert_failure = alert_failure or (lambda _failure, _source: None)
 
     async def put(self, item: Any) -> None:
         if Update is None or not isinstance(item, Update):
@@ -476,7 +528,8 @@ class CaptureAwareQueue(asyncio.Queue):
                 if message_id is None or sender_id is None:
                     self._alert_failure(
                         f"capture ingress: capture-only route matched update_id={item.update_id} "
-                        "with no human sender identity to key a ledger row on -- denying dispatch, not captured"
+                        "with no human sender identity to key a ledger row on -- denying dispatch, not captured",
+                        message,
                     )
                 return
             return await super().put(item)  # agent route preserves downstream auth/pairing behavior
@@ -490,7 +543,7 @@ class CaptureAwareQueue(asyncio.Queue):
         event_type = classify_event_type(message)
 
         try:
-            self._store.commit_capture(
+            commit_result = self._store.commit_capture(
                 event_id=eid,
                 platform="telegram",
                 account_id=account_id,
@@ -508,11 +561,16 @@ class CaptureAwareQueue(asyncio.Queue):
                 payload_json=payload_bytes.decode("utf-8"),
             )
         except RouteConflict:
-            self._alert_failure(f"capture ingress: conflicting duplicate for {eid}")
+            self._alert_failure(f"capture ingress: conflicting duplicate for {eid}", message)
             raise
         except CapturePersistenceError:
-            self._alert_failure(f"capture ingress: persistence failure for {eid}")
+            self._alert_failure(f"capture ingress: persistence failure for {eid}", message)
             raise
+
+        if commit_result == DUPLICATE_SAME:
+            # PTB retries a whole polling batch when a later update fails.
+            # A previously admitted agent update must not be delegated again.
+            return
 
         if route.mode == "capture_only":
             return  # terminal deny: consumed here, never delegated to the underlying queue

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import sqlite3
 import threading
 from dataclasses import dataclass
@@ -97,6 +98,11 @@ class CapturePersistenceError(Exception):
     """Ledger/payload commit failed for a reason that must fail closed (never a coding bug)."""
 
 
+logger = logging.getLogger(__name__)
+
+_VALID_ROUTE_MODES = ("capture_only", "agent", "drop")
+
+
 @dataclass(frozen=True)
 class RouteEntry:
     chat_id: int
@@ -119,10 +125,23 @@ class RoutePolicyTable:
     def __init__(self, entries: Optional[List[Dict[str, Any]]] = None):
         self._by_key: Dict[Tuple[int, Optional[int]], RouteEntry] = {}
         for raw in entries or []:
+            mode = str(raw["mode"])
+            if mode not in _VALID_ROUTE_MODES:
+                # Fail closed on a misconfigured entry, but with a small
+                # blast radius: drop only this entry (so its chat/topic
+                # falls back to "no route configured," today's safe
+                # pass-through default) rather than raising and taking every
+                # other configured route down with it over one typo.
+                logger.error(
+                    "capture_routes: dropping entry with unrecognized mode %r "
+                    "(chat_id=%r, thread_id=%r) -- must be one of %s",
+                    mode, raw.get("chat_id"), raw.get("thread_id"), _VALID_ROUTE_MODES,
+                )
+                continue
             entry = RouteEntry(
                 chat_id=int(raw["chat_id"]),
                 thread_id=normalize_thread_id(raw.get("thread_id")),
-                mode=str(raw["mode"]),
+                mode=mode,
                 sink=str(raw["sink"]),
                 policy_version=str(raw.get("policy_version", "1.0.0")),
             )
@@ -252,13 +271,21 @@ class CaptureIngressStore:
                     (event_id, payload_hash, payload_json),
                 )
                 self._conn.execute("COMMIT")
-            except sqlite3.IntegrityError:
+            except sqlite3.IntegrityError as exc:
                 self._conn.execute("ROLLBACK")
-                # Lost a race against a concurrent insert of the same event_id.
+                # Only a genuine lost race against a concurrent insert of
+                # the same event_id -- confirmed by a row actually existing
+                # now -- is a RouteConflict. Any other IntegrityError (e.g.
+                # a NOT NULL violation on a required column) leaves no row
+                # behind and is a real persistence failure, not a duplicate;
+                # misreporting it as RouteConflict would mislead debugging
+                # even though both fail closed the same way.
                 existing = self._conn.execute(
                     "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?", (event_id,)
                 ).fetchone()
-                if existing is not None and existing[0] == payload_hash:
+                if existing is None:
+                    raise CapturePersistenceError(str(exc)) from exc
+                if existing[0] == payload_hash:
                     return DUPLICATE_SAME
                 raise RouteConflict(
                     f"event_id {event_id!r} already captured with a different payload_hash"
@@ -328,7 +355,21 @@ class CaptureAwareQueue(asyncio.Queue):
         sender = getattr(message, "from_user", None)
         sender_id = getattr(sender, "id", None)
         if message_id is None or sender_id is None:
-            return await super().put(item)  # no human-authored identity to key a row on
+            # No human-authored identity to key a ledger row on (e.g. a
+            # channel post, whose identity lives in sender_chat rather than
+            # from_user -- the ingress-ledger contract requires a non-null
+            # human sender_id, so this cannot be captured). The owner
+            # directive for a capture-only route is unconditional ("must
+            # never start an agent turn... for the capture-only topic"), not
+            # conditioned on whether a row could be produced -- so still
+            # terminally deny dispatch, just without a ledger row.
+            if route.mode == "capture_only":
+                self._alert_failure(
+                    f"capture ingress: capture-only route matched update_id={item.update_id} "
+                    "with no human sender identity to key a ledger row on -- denying dispatch, not captured"
+                )
+                return
+            return await super().put(item)  # agent/no-route: existing behavior unchanged
 
         profile = self._profile_provider()
         account_id = self._account_id_provider()

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -1,0 +1,369 @@
+"""Capture-first Telegram intake (Slice 1.1R-B).
+
+Implements the capture-aware ``asyncio.Queue`` seam described in
+``docs/hermes-program/phases/01-reliable-capture/slice-1.1r-b-capture-first-intake.md``
+(hermes-control-plane repo): every message-like Telegram update is durably
+recorded -- ledger row plus companion payload, committed atomically -- before
+PTB's own dispatch ever sees it. Both the polling loop and the webhook
+handler await ``update_queue.put(update)`` before advancing/acking, so
+gating admission at ``put()`` is what makes the durable-before-ack guarantee
+hold for either transport.
+
+Row/field shapes here match the merged Slice 1.1R-A contract
+(``capture/schema/ingress-ledger.schema.json`` and
+``capture/schema/route-policy.schema.json`` in hermes-control-plane) exactly;
+this module is the runtime that produces rows conforming to that contract,
+not a redefinition of it.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+try:
+    from telegram import Update
+except ImportError:  # pragma: no cover - PTB always present alongside adapter.py
+    Update = None  # type: ignore
+
+# Matches TelegramAdapter._GENERAL_TOPIC_THREAD_ID. Telegram's implicit
+# General forum topic is addressed as thread id "1" but route-policy and the
+# ingress-ledger both normalize "no specific topic" (non-forum chat OR the
+# General topic) to a single value: null.
+GENERAL_TOPIC_SENTINEL = "1"
+
+
+def normalize_thread_id(raw_thread_id: Any) -> Optional[int]:
+    """Collapse "no topic" and "the General topic" to the same null value.
+
+    ``raw_thread_id`` is whatever TelegramAdapter._effective_message_thread_id
+    already returned (None, or a numeric-string thread id, or the General
+    topic sentinel "1") -- this function only applies the route-policy/ledger
+    normalization rule on top of that, it does not itself detect forum-ness.
+    """
+    if raw_thread_id is None:
+        return None
+    text = str(raw_thread_id).strip()
+    if not text or text == GENERAL_TOPIC_SENTINEL:
+        return None
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def canonicalize_update(update: "Update") -> bytes:
+    """Compact sorted-key UTF-8 JSON over ``Update.to_dict()`` -- frozen wire shape."""
+    payload = update.to_dict()
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def compute_payload_hash(payload_bytes: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
+
+
+def compute_event_id(profile: str, account_id: int, update_id: int) -> str:
+    return f"telegram:{profile}:{account_id}:{update_id}"
+
+
+def classify_event_type(message: Any) -> str:
+    """Content kind of a message-like update, per the ingress-ledger enum."""
+    text = getattr(message, "text", None) or getattr(message, "caption", None)
+    if text and str(text).startswith("/"):
+        return "command"
+    if getattr(message, "location", None) is not None or getattr(message, "venue", None) is not None:
+        return "location"
+    for attr in ("photo", "video", "audio", "voice", "document", "sticker", "video_note", "animation"):
+        if getattr(message, attr, None):
+            return "media"
+    if text:
+        return "text"
+    return "other"
+
+
+class RouteConflict(Exception):
+    """Same event_id captured again with a different canonical payload/hash."""
+
+
+class CapturePersistenceError(Exception):
+    """Ledger/payload commit failed for a reason that must fail closed (never a coding bug)."""
+
+
+@dataclass(frozen=True)
+class RouteEntry:
+    chat_id: int
+    thread_id: Optional[int]
+    mode: str  # "capture_only" | "agent" | "drop"
+    sink: str
+    policy_version: str = "1.0.0"
+
+
+class RoutePolicyTable:
+    """(chat_id, normalized thread_id) -> RouteEntry, from route-policy-shaped dicts.
+
+    Exact match only: both chat_id and normalized thread_id must match. There
+    is no chat-level wildcard/fallback -- a chat with no matching entry (or a
+    thread number that only matches in a *different* chat) has no route, and
+    an update on it is out of scope for capture, identical to today's
+    behavior (see "Exact route matching" in the plan's acceptance matrix).
+    """
+
+    def __init__(self, entries: Optional[List[Dict[str, Any]]] = None):
+        self._by_key: Dict[Tuple[int, Optional[int]], RouteEntry] = {}
+        for raw in entries or []:
+            entry = RouteEntry(
+                chat_id=int(raw["chat_id"]),
+                thread_id=normalize_thread_id(raw.get("thread_id")),
+                mode=str(raw["mode"]),
+                sink=str(raw["sink"]),
+                policy_version=str(raw.get("policy_version", "1.0.0")),
+            )
+            self._by_key[(entry.chat_id, entry.thread_id)] = entry
+
+    def lookup(self, chat_id: Any, thread_id: Optional[int]) -> Optional[RouteEntry]:
+        if chat_id is None:
+            return None
+        return self._by_key.get((int(chat_id), thread_id))
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ingress_ledger (
+    event_id TEXT PRIMARY KEY,
+    platform TEXT NOT NULL,
+    account_id INTEGER NOT NULL,
+    profile TEXT NOT NULL,
+    update_id INTEGER NOT NULL,
+    chat_id INTEGER NOT NULL,
+    thread_id INTEGER,
+    message_id INTEGER NOT NULL,
+    sender_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    route_mode TEXT NOT NULL,
+    sink TEXT NOT NULL,
+    status TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    lease_expires_at TEXT,
+    next_attempt_at TEXT,
+    last_error TEXT,
+    completed_at TEXT
+);
+CREATE TABLE IF NOT EXISTS ingress_payload (
+    event_id TEXT PRIMARY KEY REFERENCES ingress_ledger(event_id),
+    payload_hash TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+"""
+
+INSERTED = "inserted"
+DUPLICATE_SAME = "duplicate_same"
+
+
+class CaptureIngressStore:
+    """Durable ledger + companion-payload store, one atomic transaction per capture.
+
+    A real SQLite database (never mocked persistence) keyed on ``event_id``,
+    matching the merged ingress-ledger contract exactly -- 19 required
+    fields, ``additionalProperties: false`` in the JSON Schema sense (the
+    table simply has no other columns).
+    """
+
+    def __init__(self, db_path: "str | Path"):
+        self._db_path = str(db_path)
+        parent = Path(self._db_path).parent
+        if str(parent) not in ("", "."):
+            parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
+        self._lock = threading.Lock()
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def commit_capture(
+        self,
+        *,
+        event_id: str,
+        platform: str,
+        account_id: int,
+        profile: str,
+        update_id: int,
+        chat_id: int,
+        thread_id: Optional[int],
+        message_id: int,
+        sender_id: int,
+        event_type: str,
+        received_at: str,
+        payload_hash: str,
+        route_mode: str,
+        sink: str,
+        payload_json: str,
+    ) -> str:
+        """Idempotent atomic insert. Returns INSERTED or DUPLICATE_SAME.
+
+        Raises RouteConflict if ``event_id`` already exists with a different
+        ``payload_hash`` (never overwritten), or CapturePersistenceError on
+        any other storage failure (disk full, lock, corruption) -- the
+        caller must treat either as fail-closed: no delegation, no ack.
+        """
+        with self._lock:
+            try:
+                existing = self._conn.execute(
+                    "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?", (event_id,)
+                ).fetchone()
+            except sqlite3.Error as exc:
+                raise CapturePersistenceError(str(exc)) from exc
+            if existing is not None:
+                if existing[0] == payload_hash:
+                    return DUPLICATE_SAME
+                raise RouteConflict(
+                    f"event_id {event_id!r} already captured with a different payload_hash"
+                )
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                self._conn.execute(
+                    """
+                    INSERT INTO ingress_ledger (
+                        event_id, platform, account_id, profile, update_id,
+                        chat_id, thread_id, message_id, sender_id, event_type,
+                        received_at, payload_hash, route_mode, sink,
+                        status, attempts, lease_expires_at, next_attempt_at,
+                        last_error, completed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, NULL, NULL)
+                    """,
+                    (
+                        event_id, platform, account_id, profile, update_id,
+                        chat_id, thread_id, message_id, sender_id, event_type,
+                        received_at, payload_hash, route_mode, sink,
+                    ),
+                )
+                self._conn.execute(
+                    "INSERT INTO ingress_payload (event_id, payload_hash, payload_json) VALUES (?, ?, ?)",
+                    (event_id, payload_hash, payload_json),
+                )
+                self._conn.execute("COMMIT")
+            except sqlite3.IntegrityError:
+                self._conn.execute("ROLLBACK")
+                # Lost a race against a concurrent insert of the same event_id.
+                existing = self._conn.execute(
+                    "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?", (event_id,)
+                ).fetchone()
+                if existing is not None and existing[0] == payload_hash:
+                    return DUPLICATE_SAME
+                raise RouteConflict(
+                    f"event_id {event_id!r} already captured with a different payload_hash"
+                )
+            except sqlite3.Error as exc:
+                self._conn.execute("ROLLBACK")
+                raise CapturePersistenceError(str(exc)) from exc
+            return INSERTED
+
+
+class CaptureAwareQueue(asyncio.Queue):
+    """``asyncio.Queue`` that captures message-like updates before admission.
+
+    Installed via ``ApplicationBuilder(...).update_queue(...)``. PTB's
+    polling loop only advances ``_last_update_id`` after ``put()`` returns,
+    and its webhook handler only completes the HTTP response after the same
+    ``put()`` -- so raising here (persistence failure or a conflicting
+    duplicate) keeps both transports from acknowledging, and returning
+    without delegating to the real queue (capture-only terminal deny) keeps
+    the update out of dispatch entirely.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: CaptureIngressStore,
+        route_table_provider: Callable[[], RoutePolicyTable],
+        account_id_provider: Callable[[], int],
+        profile_provider: Callable[[], str],
+        thread_id_resolver: Callable[[Any], Optional[str]],
+        is_own_message: Callable[[Any], bool],
+        is_authorized_sender: Callable[[Any], bool],
+        alert_failure: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        super().__init__()
+        self._store = store
+        self._route_table_provider = route_table_provider
+        self._account_id_provider = account_id_provider
+        self._profile_provider = profile_provider
+        self._thread_id_resolver = thread_id_resolver
+        self._is_own_message = is_own_message
+        self._is_authorized_sender = is_authorized_sender
+        self._alert_failure = alert_failure or (lambda _msg: None)
+
+    async def put(self, item: Any) -> None:
+        if Update is None or not isinstance(item, Update):
+            return await super().put(item)  # non-Update sentinel (shutdown marker, etc.)
+
+        message = getattr(item, "effective_message", None)
+        if message is None:
+            return await super().put(item)  # not message-like: callback_query/poll/chat_member/...
+
+        if self._is_own_message(message):
+            return await super().put(item)  # bot-authored: existing behavior preserved
+        if not self._is_authorized_sender(message):
+            return await super().put(item)  # unauthorized sender: existing behavior preserved
+
+        chat = getattr(message, "chat", None)
+        chat_id = getattr(chat, "id", None)
+        thread_id = normalize_thread_id(self._thread_id_resolver(message))
+
+        route = self._route_table_provider().lookup(chat_id, thread_id)
+        if route is None or route.mode == "drop":
+            return await super().put(item)  # no route, or drop: not a capture boundary
+
+        message_id = getattr(message, "message_id", None)
+        sender = getattr(message, "from_user", None)
+        sender_id = getattr(sender, "id", None)
+        if message_id is None or sender_id is None:
+            return await super().put(item)  # no human-authored identity to key a row on
+
+        profile = self._profile_provider()
+        account_id = self._account_id_provider()
+        eid = compute_event_id(profile, account_id, item.update_id)
+        payload_bytes = canonicalize_update(item)
+        phash = compute_payload_hash(payload_bytes)
+        received_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        event_type = classify_event_type(message)
+
+        try:
+            self._store.commit_capture(
+                event_id=eid,
+                platform="telegram",
+                account_id=account_id,
+                profile=profile,
+                update_id=item.update_id,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                event_type=event_type,
+                received_at=received_at,
+                payload_hash=phash,
+                route_mode=route.mode,
+                sink=route.sink,
+                payload_json=payload_bytes.decode("utf-8"),
+            )
+        except RouteConflict:
+            self._alert_failure(f"capture ingress: conflicting duplicate for {eid}")
+            raise
+        except CapturePersistenceError:
+            self._alert_failure(f"capture ingress: persistence failure for {eid}")
+            raise
+
+        if route.mode == "capture_only":
+            return  # terminal deny: consumed here, never delegated to the underlying queue
+
+        return await super().put(item)  # route.mode == "agent": commit already succeeded

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,6 +1,7 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
 import logging
 import asyncio
+import re
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -511,7 +512,9 @@ class _ImmutableProfileAdapter:
     def receiving_profile(self, value):
         if self._receiving_profile is not None:
             raise RuntimeError("receiving_profile is immutable once set")
-        self._receiving_profile = value
+        if not re.match(r"^[a-z][a-z0-9_-]{0,63}$", str(value)):
+            raise ValueError(f"invalid receiving_profile {value!r}")
+        self._receiving_profile = str(value)
 
     def set_message_handler(self, handler):
         pass
@@ -550,11 +553,31 @@ class TestReceivingProfileStamping:
         GatewayRunner._stamp_receiving_profile(adapter, "coder")  # must not raise
         assert not hasattr(adapter, "_receiving_profile")
 
-    def test_does_not_raise_when_adapter_setter_rejects_a_second_stamp(self):
+    def test_repeat_stamp_raises_not_swallowed(self):
+        """A second stamp attempt must propagate, not be silently logged
+        away: an unstamped/mis-stamped secondary-profile adapter must never
+        be left running as if it were the default profile (Slice 1.1R-B,
+        blocker 2 -- "gateway/run.py must not suppress ... stamp errors")."""
         adapter = _ImmutableProfileAdapter()
         adapter.receiving_profile = "coder"
-        GatewayRunner._stamp_receiving_profile(adapter, "different")  # logged, not raised
-        assert adapter.receiving_profile == "coder"  # first stamp wins
+        with pytest.raises(RuntimeError):
+            GatewayRunner._stamp_receiving_profile(adapter, "different")
+        assert adapter.receiving_profile == "coder"  # first stamp still wins, never overwritten
+
+    def test_missing_profile_name_raises_not_swallowed(self):
+        adapter = _ImmutableProfileAdapter()
+        with pytest.raises(ValueError):
+            GatewayRunner._stamp_receiving_profile(adapter, "")
+        assert adapter.receiving_profile is None
+        with pytest.raises(ValueError):
+            GatewayRunner._stamp_receiving_profile(adapter, None)
+        assert adapter.receiving_profile is None
+
+    def test_invalid_profile_name_raises_not_swallowed(self):
+        adapter = _ImmutableProfileAdapter()
+        with pytest.raises(ValueError):
+            GatewayRunner._stamp_receiving_profile(adapter, "Not Valid!")
+        assert adapter.receiving_profile is None
 
     def test_configure_profile_adapter_stamps_receiving_profile(self):
         runner = GatewayRunner.__new__(GatewayRunner)
@@ -570,5 +593,71 @@ class TestReceivingProfileStamping:
         runner._configure_profile_adapter(adapter, "coder", Platform.TELEGRAM)
 
         assert adapter.receiving_profile == "coder"
+
+
+class TestStampPrimaryAdapterOrDispose:
+    """gateway/run.py's ``_stamp_primary_adapter_or_dispose`` is the single
+    helper both the primary-profile startup loop (``start()``) and the
+    primary-profile reconnect loop (``_platform_reconnect_watcher``) call
+    before wiring handlers -- by construction, one test class covers both
+    call sites' stamp-failure handling, since they now share the exact
+    same code rather than two independent copies.
+    """
+
+    @staticmethod
+    def _runner():
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._active_profile_name = lambda: "coder"
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_primary_startup_stamps_successfully(self):
+        runner = self._runner()
+        adapter = _ImmutableProfileAdapter()
+
+        ok = await runner._stamp_primary_adapter_or_dispose(adapter, Platform.TELEGRAM)
+
+        assert ok is True
+        assert adapter.receiving_profile == "coder"
+
+    @pytest.mark.asyncio
+    async def test_primary_startup_stamp_failure_disposes_and_skips(self):
+        """A stamp failure (here: already stamped, simulating a double-
+        construction bug) must not be swallowed -- the platform is skipped
+        (False) and the half-wired adapter is disposed, not left running
+        unstamped as if it were correctly configured."""
+        runner = self._runner()
+        adapter = _ImmutableProfileAdapter()
+        adapter.receiving_profile = "already-set"
+
+        ok = await runner._stamp_primary_adapter_or_dispose(adapter, Platform.TELEGRAM)
+
+        assert ok is False
+        assert adapter.receiving_profile == "already-set"  # untouched, not overwritten
+
+    @pytest.mark.asyncio
+    async def test_primary_reconnect_stamp_failure_disposes_and_skips(self):
+        """Same helper, exercised the way the reconnect loop uses it: a
+        freshly re-created adapter for a platform that's retrying after an
+        earlier failure. Stamp failure must skip just this attempt, not
+        raise out of the reconnect watcher's scan loop."""
+        runner = self._runner()
+        adapter = _ImmutableProfileAdapter()
+        adapter.receiving_profile = "already-set"  # e.g. a reused/misrouted adapter object
+
+        ok = await runner._stamp_primary_adapter_or_dispose(adapter, Platform.DISCORD)
+
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_missing_active_profile_name_fails_closed(self):
+        runner = self._runner()
+        runner._active_profile_name = lambda: ""
+        adapter = _ImmutableProfileAdapter()
+
+        ok = await runner._stamp_primary_adapter_or_dispose(adapter, Platform.TELEGRAM)
+
+        assert ok is False
+        assert adapter.receiving_profile is None
 
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -495,3 +495,80 @@ class TestFeishuPortBindingConditional:
         assert connected == 0  # no error, just nothing connected
 
 
+class _ImmutableProfileAdapter:
+    """Mimics TelegramAdapter's immutable receiving_profile property (Slice 1.1R-B)."""
+
+    platform = Platform.TELEGRAM
+
+    def __init__(self):
+        self._receiving_profile = None
+
+    @property
+    def receiving_profile(self):
+        return self._receiving_profile
+
+    @receiving_profile.setter
+    def receiving_profile(self, value):
+        if self._receiving_profile is not None:
+            raise RuntimeError("receiving_profile is immutable once set")
+        self._receiving_profile = value
+
+    def set_message_handler(self, handler):
+        pass
+
+    def set_fatal_error_handler(self, handler):
+        pass
+
+    def set_session_store(self, store):
+        pass
+
+    def set_busy_session_handler(self, handler):
+        pass
+
+    def set_topic_recovery_fn(self, handler):
+        pass
+
+    def set_authorization_check(self, handler):
+        pass
+
+
+class TestReceivingProfileStamping:
+    """Slice 1.1R-B, conflict #7: profile identity must reach the adapter
+    at construction time, before dispatch -- not only stamped onto outbound
+    message sources afterward. See gateway/run.py's ``_stamp_receiving_profile``
+    and TelegramAdapter's ``receiving_profile`` property.
+    """
+
+    def test_stamps_receiving_profile_when_adapter_supports_it(self):
+        adapter = _ImmutableProfileAdapter()
+        GatewayRunner._stamp_receiving_profile(adapter, "coder")
+        assert adapter.receiving_profile == "coder"
+
+    def test_silently_skips_adapters_without_the_field(self):
+        # _FakeAdapter (top of this file) has no receiving_profile property.
+        adapter = _FakeAdapter()
+        GatewayRunner._stamp_receiving_profile(adapter, "coder")  # must not raise
+        assert not hasattr(adapter, "_receiving_profile")
+
+    def test_does_not_raise_when_adapter_setter_rejects_a_second_stamp(self):
+        adapter = _ImmutableProfileAdapter()
+        adapter.receiving_profile = "coder"
+        GatewayRunner._stamp_receiving_profile(adapter, "different")  # logged, not raised
+        assert adapter.receiving_profile == "coder"  # first stamp wins
+
+    def test_configure_profile_adapter_stamps_receiving_profile(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.session_store = object()
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+        runner._busy_text_mode = "queue"
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+        runner._make_profile_message_handler = lambda profile_name: (lambda event: None)
+        runner._make_profile_fatal_error_handler = lambda profile_name, platform: (lambda *_a: None)
+
+        adapter = _ImmutableProfileAdapter()
+        runner._configure_profile_adapter(adapter, "coder", Platform.TELEGRAM)
+
+        assert adapter.receiving_profile == "coder"
+
+

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -221,6 +221,19 @@ class TestRoutePolicyTable:
         table = RoutePolicyTable([])
         assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is None
 
+    def test_unrecognized_mode_fails_closed_not_registered(self):
+        """A typo'd/unrecognized mode (e.g. wrong case) must not silently
+        behave like 'agent' dispatch just because it fails the exact
+        string comparisons in CaptureAwareQueue.put(). Fail closed: the
+        entry is dropped, so the route is treated as unconfigured (today's
+        safe pass-through default), not as a hidden 'deliver' policy.
+        """
+        routes = [
+            {"chat_id": CAPTURE_CHAT_ID, "thread_id": CAPTURE_THREAD_ID, "mode": "Capture_Only", "sink": "s", "policy_version": "1.0.0"}
+        ]
+        table = RoutePolicyTable(routes)
+        assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is None
+
 
 class TestCaptureIngressStore:
     def _kwargs(self, **override):
@@ -270,6 +283,19 @@ class TestCaptureIngressStore:
         row = _ledger_row(store, "telegram:default:777:1000")
         assert row["payload_hash"] == "sha256:" + "a" * 64  # unchanged
 
+    def test_integrity_error_unrelated_to_a_duplicate_race_is_persistence_error_not_conflict(self, store):
+        """A NOT-NULL violation (e.g. a caller passing account_id=None,
+        which can happen if commit_capture is ever reached before the bot's
+        own id is known) is a genuine storage/programming-adjacent failure,
+        not a lost race against a concurrent insert of the same event_id --
+        raising RouteConflict here would misdiagnose it and mislead
+        debugging/alerting, even though both exception types fail closed the
+        same way (no delegation, no ack).
+        """
+        with pytest.raises(CapturePersistenceError):
+            store.commit_capture(**self._kwargs(account_id=None))
+        assert _ledger_row(store, "telegram:default:777:1000") is None
+
     def test_injected_storage_failure_raises_capture_persistence_error(self, store):
         store._conn.close()  # simulate a hard storage failure (closed handle)
         with pytest.raises(CapturePersistenceError):
@@ -289,6 +315,63 @@ class TestCaptureAwareQueueDispatchGating:
         row = _ledger_row(store, eid)
         assert row is not None
         assert row["route_mode"] == "capture_only"
+
+    @pytest.mark.asyncio
+    async def test_sender_identity_less_message_on_capture_only_route_still_denied(self, store):
+        """A message-like update with no from_user (e.g. a channel post,
+        whose identity lives in sender_chat instead) cannot be keyed into a
+        ledger row -- the ingress-ledger contract requires a non-null human
+        sender_id -- but a capture-only route's terminal deny is an
+        unconditional owner directive ("Capture must never start an agent
+        turn... for the capture-only topic"), not conditioned on whether a
+        ledger row could be produced. It must still be denied, not silently
+        delegated to dispatch just because it couldn't be captured.
+        """
+        queue = _make_queue(store, _capture_only_routes())
+        msg = _message(text="channel announcement", from_user=None)
+        msg = Message(
+            message_id=msg.message_id,
+            date=msg.date,
+            chat=msg.chat,
+            from_user=None,
+            sender_chat=_chat(chat_id=-500, chat_type="channel"),
+            text=msg.text,
+            message_thread_id=msg.message_thread_id,
+            is_topic_message=msg.is_topic_message,
+        )
+        upd = _update(update_id=16, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 16)
+        assert _ledger_row(store, eid) is None  # cannot be captured (no human sender_id)
+        assert queue.qsize() == 0  # but must NOT be delegated to dispatch either
+
+    @pytest.mark.asyncio
+    async def test_sender_identity_less_message_on_agent_route_passes_through(self, store):
+        """Same identity-less shape, but on an 'agent' route: existing
+        (non-capture) dispatch behavior is unaffected -- this envelope only
+        adds a new hard deny for capture_only, never a new block for agent.
+        """
+        queue = _make_queue(store, _agent_routes())
+        msg = _message(text="channel announcement", from_user=None)
+        msg = Message(
+            message_id=msg.message_id,
+            date=msg.date,
+            chat=msg.chat,
+            from_user=None,
+            sender_chat=_chat(chat_id=-500, chat_type="channel"),
+            text=msg.text,
+            message_thread_id=msg.message_thread_id,
+            is_topic_message=msg.is_topic_message,
+        )
+        upd = _update(update_id=17, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 17)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1  # unchanged existing behavior
 
     @pytest.mark.asyncio
     async def test_command_on_capture_only_route_captured_as_inert_text_not_dispatched(self, store):

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -150,7 +151,7 @@ def _make_queue(store, routes, *, is_own=False, is_authorized=True, alert=None):
         ),
         is_own_message=lambda message: is_own,
         is_authorized_sender=lambda message: is_authorized,
-        alert_failure=alert,
+        alert_failure=(lambda failure, _source: alert(failure)) if alert else None,
     )
 
 
@@ -296,6 +297,29 @@ class TestPureHelpers:
 
         adapter._close_capture_store()
         assert store.closed == 1
+
+    @pytest.mark.asyncio
+    async def test_capture_failure_alert_replies_in_capture_topic(self):
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = object.__new__(TelegramAdapter)
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+        source_message = _message(
+            chat=_chat(chat_id=CAPTURE_CHAT_ID),
+            thread_id=CAPTURE_THREAD_ID,
+            message_id=42,
+        )
+
+        await adapter._deliver_capture_failure_alert("disk full", source_message)
+
+        adapter.send.assert_awaited_once_with(
+            str(CAPTURE_CHAT_ID),
+            "Capture ingress failure: disk full",
+            metadata={
+                "thread_id": str(CAPTURE_THREAD_ID),
+                "telegram_reply_to_message_id": 42,
+            },
+        )
 
 
 class TestRoutePolicyTable:

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -10,6 +10,7 @@ import sqlite3
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -27,6 +28,12 @@ import telegram as _real_telegram  # noqa: E402
 assert hasattr(_real_telegram, "__file__"), (
     "expected the real python-telegram-bot package, not tests/gateway/conftest.py's mock"
 )
+
+# Other Telegram test modules can import capture_ingress during collection while
+# conftest's lightweight telegram stand-in is installed. Reload this focused
+# module only after restoring real PTB so Update and TelegramError are real
+# classes regardless of test collection order.
+sys.modules.pop("plugins.platforms.telegram.capture_ingress", None)
 
 from telegram import CallbackQuery, Chat, Message, Update, User  # noqa: E402
 
@@ -175,8 +182,18 @@ class TestPureHelpers:
         a = canonicalize_update(upd)
         b = canonicalize_update(upd)
         assert a == b
+
+    def test_canonicalize_update_is_compact_no_whitespace_padding(self):
+        upd = _update()
+        a = canonicalize_update(upd)
         assert a == a.strip()  # no incidental whitespace padding
         assert b'": ' not in a  # compact separators, not the default json.dumps spacing
+
+    def test_canonicalize_update_rejects_nan_and_infinity(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            fake_update = SimpleNamespace(to_dict=lambda bad=bad: {"x": bad})
+            with pytest.raises(ValueError):
+                canonicalize_update(fake_update)
 
     def test_event_id_format(self):
         assert compute_event_id("default", 777, 1000) == "telegram:default:777:1000"
@@ -200,6 +217,86 @@ class TestPureHelpers:
     def test_classify_event_type_other_when_no_recognized_content(self):
         assert classify_event_type(_message(text=None)) == "other"
 
+    def test_capture_authorization_excludes_pairing_passthrough_dm(self):
+        from gateway.config import Platform, PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = object.__new__(TelegramAdapter)
+        adapter.platform = Platform.TELEGRAM
+        adapter.config = PlatformConfig(
+            enabled=True,
+            token="fake-token",
+            extra={"allow_from": ["111"], "unauthorized_dm_behavior": "pair"},
+        )
+        adapter._bot = SimpleNamespace(id=999, username="capture_bot")
+        adapter._message_handler = None
+        message = _message(
+            chat=_chat(chat_id=333, is_forum=False, chat_type="private"),
+            from_user=_user(user_id=333),
+            thread_id=None,
+        )
+
+        assert adapter._is_user_authorized_from_message(message) is True
+        assert adapter._is_capture_sender_authorized(message) is False
+
+    def test_capture_authorization_uses_registered_profile_bound_callback(self):
+        from gateway.config import Platform, PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = object.__new__(TelegramAdapter)
+        adapter.platform = Platform.TELEGRAM
+        adapter.config = PlatformConfig(enabled=True, token="fake-token", extra={})
+        adapter._bot = SimpleNamespace(id=999, username="capture_bot")
+        adapter._message_handler = lambda _event: None
+        adapter._authorization_check = lambda user_id, chat_type, chat_id: False
+        message = _message(
+            chat=_chat(chat_id=333, is_forum=False, chat_type="private"),
+            from_user=_user(user_id=333),
+            thread_id=None,
+        )
+
+        assert adapter._is_capture_sender_authorized(message) is False
+
+    @pytest.mark.parametrize("malformed", [{}, "", 0, None])
+    def test_present_falsey_capture_routes_are_configured_and_rejected(self, malformed):
+        from gateway.config import Platform, PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = object.__new__(TelegramAdapter)
+        adapter.platform = Platform.TELEGRAM
+        adapter.config = PlatformConfig(
+            enabled=True, token="fake-token", extra={"capture_routes": malformed}
+        )
+        adapter._capture_route_table_cache = None
+
+        assert adapter._capture_is_configured() is True
+        with pytest.raises(ValueError):
+            adapter._capture_route_table()
+
+    def test_capture_store_close_resets_store_and_queue_for_reconnect(self):
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        class _Store:
+            def __init__(self):
+                self.closed = 0
+
+            def close(self):
+                self.closed += 1
+
+        adapter = object.__new__(TelegramAdapter)
+        store = _Store()
+        adapter._capture_store = store
+        adapter._capture_queue = object()
+
+        adapter._close_capture_store()
+
+        assert store.closed == 1
+        assert adapter._capture_store is None
+        assert adapter._capture_queue is None
+
+        adapter._close_capture_store()
+        assert store.closed == 1
+
 
 class TestRoutePolicyTable:
     def test_exact_match_requires_both_chat_and_thread(self):
@@ -221,18 +318,43 @@ class TestRoutePolicyTable:
         table = RoutePolicyTable([])
         assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is None
 
-    def test_unrecognized_mode_fails_closed_not_registered(self):
-        """A typo'd/unrecognized mode (e.g. wrong case) must not silently
-        behave like 'agent' dispatch just because it fails the exact
-        string comparisons in CaptureAwareQueue.put(). Fail closed: the
-        entry is dropped, so the route is treated as unconfigured (today's
-        safe pass-through default), not as a hidden 'deliver' policy.
-        """
+    def test_unrecognized_mode_raises_instead_of_becoming_unrouted_passthrough(self):
         routes = [
-            {"chat_id": CAPTURE_CHAT_ID, "thread_id": CAPTURE_THREAD_ID, "mode": "Capture_Only", "sink": "s", "policy_version": "1.0.0"}
+            {
+                "chat_id": CAPTURE_CHAT_ID,
+                "thread_id": CAPTURE_THREAD_ID,
+                "mode": "Capture_Only",
+                "sink": "s",
+                "policy_version": "1.0.0",
+            }
         ]
-        table = RoutePolicyTable(routes)
-        assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is None
+        with pytest.raises(ValueError, match="mode"):
+            RoutePolicyTable(routes)
+
+    @pytest.mark.parametrize(
+        "mutate, expected",
+        [
+            (lambda route: route.update(extra="x"), "unknown"),
+            (lambda route: route.pop("sink"), "required"),
+            (lambda route: route.update(chat_id=True), "chat_id"),
+            (lambda route: route.update(chat_id=0), "chat_id"),
+            (lambda route: route.update(thread_id="271"), "thread_id"),
+            (lambda route: route.update(thread_id=0), "thread_id"),
+            (lambda route: route.update(sink="Bad Sink"), "sink"),
+            (lambda route: route.update(policy_version="v1"), "policy_version"),
+        ],
+    )
+    def test_route_policy_rejects_values_outside_merged_schema(self, mutate, expected):
+        route = dict(_capture_only_routes()[0])
+        mutate(route)
+        with pytest.raises(ValueError, match=expected):
+            RoutePolicyTable([route])
+
+    def test_route_policy_rejects_duplicate_normalized_route_key(self):
+        first = dict(_capture_only_routes()[0], thread_id=None)
+        duplicate = dict(_capture_only_routes()[0], thread_id=1)
+        with pytest.raises(ValueError, match="duplicate"):
+            RoutePolicyTable([first, duplicate])
 
 
 class TestCaptureIngressStore:
@@ -268,6 +390,7 @@ class TestCaptureIngressStore:
         assert row["completed_at"] is None
         payload = _payload_row(store, "telegram:default:777:1000")
         assert payload["payload_json"] == "{}"
+        assert payload["payload_format"] == "telegram-update-json-v1"
 
     def test_identical_duplicate_is_a_noop_first_fields_preserved(self, store):
         store.commit_capture(**self._kwargs(received_at="2026-08-06T20:00:00Z"))
@@ -275,6 +398,36 @@ class TestCaptureIngressStore:
         assert result == DUPLICATE_SAME
         row = _ledger_row(store, "telegram:default:777:1000")
         assert row["received_at"] == "2026-08-06T20:00:00Z"  # first write wins, not overwritten
+
+    def test_duplicate_same_rejects_missing_companion_payload(self, store):
+        kwargs = self._kwargs()
+        store.commit_capture(**kwargs)
+        store._conn.execute("DELETE FROM ingress_payload WHERE event_id = ?", (kwargs["event_id"],))
+
+        with pytest.raises(CapturePersistenceError):
+            store.commit_capture(**kwargs)
+
+    def test_rollback_failure_does_not_mask_normalized_persistence_error(self, store):
+        real = store._conn
+
+        class _RollbackFailingConnection:
+            @property
+            def in_transaction(self):
+                return real.in_transaction
+
+            def execute(self, sql, parameters=()):
+                if sql == "ROLLBACK":
+                    raise sqlite3.OperationalError("rollback failed")
+                if sql.startswith("INSERT INTO ingress_payload"):
+                    raise sqlite3.OperationalError("payload insert failed")
+                return real.execute(sql, parameters)
+
+        store._conn = _RollbackFailingConnection()
+        try:
+            with pytest.raises(CapturePersistenceError, match="payload insert failed"):
+                store.commit_capture(**self._kwargs())
+        finally:
+            store._conn = real
 
     def test_conflicting_duplicate_payload_raises_and_does_not_overwrite(self, store):
         store.commit_capture(**self._kwargs(payload_hash="sha256:" + "a" * 64))
@@ -300,6 +453,43 @@ class TestCaptureIngressStore:
         store._conn.close()  # simulate a hard storage failure (closed handle)
         with pytest.raises(CapturePersistenceError):
             store.commit_capture(**self._kwargs())
+
+    def test_begin_immediate_failure_surfaces_persistence_error_not_a_secondary_rollback_error(
+        self, store, db_path
+    ):
+        """A real lock-contention failure (not mocked): a second connection
+        holds SQLite's one write lock (even under WAL, writers still
+        serialize) so the store's own BEGIN IMMEDIATE fails before any
+        transaction of its own ever opens. Rolling back a transaction that
+        was never started raises its own sqlite3 error ("cannot rollback -
+        no transaction is active"), which must not mask the original
+        failure or escape uncaught as a different, uncategorized error --
+        CapturePersistenceError must be exactly what surfaces.
+        """
+        blocker = sqlite3.connect(str(db_path), isolation_level=None, timeout=0)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            with pytest.raises(CapturePersistenceError):
+                store.commit_capture(**self._kwargs())
+        finally:
+            blocker.execute("ROLLBACK")
+            blocker.close()
+        assert _ledger_row(store, "telegram:default:777:1000") is None
+
+    def test_foreign_key_enforcement_rejects_orphan_payload_row(self, store):
+        """Defense-in-depth: commit_capture always inserts ledger-then-payload
+        atomically, so this never fires in normal operation -- but the FK
+        constraint declared in the schema (ingress_payload.event_id
+        REFERENCES ingress_ledger.event_id) must actually be enforced, not
+        merely decorative (SQLite requires PRAGMA foreign_keys=ON per
+        connection; without it, the REFERENCES clause is silently a no-op).
+        """
+        with pytest.raises(sqlite3.IntegrityError):
+            store._conn.execute(
+                "INSERT INTO ingress_payload (event_id, payload_hash, payload_format, payload_json) "
+                "VALUES (?, ?, ?, ?)",
+                ("telegram:default:777:9999", "sha256:" + "a" * 64, "telegram-update-json-v1", "{}"),
+            )
 
 
 class TestCaptureAwareQueueDispatchGating:
@@ -454,6 +644,17 @@ class TestCaptureAwareQueueDispatchGating:
         assert queue.get_nowait() is upd
 
     @pytest.mark.asyncio
+    async def test_identical_agent_retry_does_not_delegate_twice(self, store):
+        queue = _make_queue(store, _agent_routes())
+        upd = _update(update_id=70)
+
+        await queue.put(upd)
+        await queue.put(upd)
+
+        assert queue.qsize() == 1
+        assert queue.get_nowait() is upd
+
+    @pytest.mark.asyncio
     async def test_drop_route_no_ledger_row_passthrough(self, store):
         queue = _make_queue(store, _drop_routes())
         upd = _update(update_id=8)
@@ -532,7 +733,7 @@ class TestCaptureAwareQueueDispatchGating:
         assert alerts  # deterministic failure was alerted
 
     @pytest.mark.asyncio
-    async def test_unauthorized_sender_no_capture_existing_behavior_preserved(self, store):
+    async def test_unauthorized_sender_on_capture_only_route_is_neither_captured_nor_delegated(self, store):
         queue = _make_queue(store, _capture_only_routes(), is_authorized=False)
         upd = _update(update_id=14)
 
@@ -540,18 +741,30 @@ class TestCaptureAwareQueueDispatchGating:
 
         eid = compute_event_id(PROFILE, ACCOUNT_ID, 14)
         assert _ledger_row(store, eid) is None
-        assert queue.qsize() == 1  # existing (downstream) authorization behavior unchanged
+        assert queue.qsize() == 0
 
     @pytest.mark.asyncio
-    async def test_bot_authored_no_capture(self, store):
-        queue = _make_queue(store, _capture_only_routes(), is_own=True)
-        upd = _update(update_id=15)
+    async def test_unauthorized_sender_on_agent_route_preserves_downstream_pairing_behavior(self, store):
+        queue = _make_queue(store, _agent_routes(), is_authorized=False)
+        upd = _update(update_id=140)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 140)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1
+        assert queue.get_nowait() is upd
+
+    @pytest.mark.asyncio
+    async def test_any_bot_authored_message_on_capture_only_route_is_denied(self, store):
+        queue = _make_queue(store, _capture_only_routes(), is_own=False, is_authorized=True)
+        upd = _update(update_id=15, from_user=_user(user_id=888, is_bot=True))
 
         await queue.put(upd)
 
         eid = compute_event_id(PROFILE, ACCOUNT_ID, 15)
         assert _ledger_row(store, eid) is None
-        assert queue.qsize() == 1
+        assert queue.qsize() == 0
 
     @pytest.mark.asyncio
     async def test_queue_sentinel_passes_through_unchanged(self, store):
@@ -592,3 +805,294 @@ class TestCaptureAwareQueueDispatchGating:
             ).fetchone()[0] == 1
         finally:
             reopened.close()
+
+
+class TestPollingRetryCompatibility:
+    """Production-shaped: drives PTB's REAL network_retry_loop (not a
+    reimplementation) with a polling_action_cb shaped exactly like PTB
+    22.6's actual ``Updater.start_polling`` closure -- get a batch, loop
+    ``await update_queue.put(update)`` over it, only then advance the
+    offset. Verified directly against PTB 22.6 source
+    (telegram.ext._utils.networkloop.network_retry_loop): its outer retry
+    loop catches only RetryAfter/TimedOut/InvalidToken/TelegramError. Any
+    other exception type from ``put()`` propagates straight out on the
+    first attempt, killing the polling task instead of entering the
+    bounded retry ladder -- exactly what this test would catch.
+    """
+
+    @staticmethod
+    async def _drive_real_ptb_retry_loop(queue, updates, *, max_retries):
+        from telegram.ext._utils.networkloop import network_retry_loop
+
+        state = {"last_update_id": 0, "attempts": 0}
+        errors_seen = []
+
+        async def polling_action_cb():
+            state["attempts"] += 1
+            for u in updates:
+                await queue.put(u)  # the seam under test
+            state["last_update_id"] = updates[-1].update_id + 1
+
+        exc_raised = None
+        try:
+            await network_retry_loop(
+                action_cb=polling_action_cb,
+                on_err_cb=errors_seen.append,
+                description="test polling",
+                interval=0,
+                max_retries=max_retries,
+                repeat_on_success=False,
+            )
+        except Exception as exc:  # the loop re-raises once max_retries is exhausted
+            exc_raised = exc
+        return state, errors_seen, exc_raised
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_enters_bounded_retry_not_immediate_crash(self, store):
+        from telegram.error import TelegramError
+
+        queue = _make_queue(store, _capture_only_routes())
+        store.close()  # every commit_capture call will now fail
+        upd = _update(update_id=99, text="hello")
+
+        state, errors_seen, exc_raised = await self._drive_real_ptb_retry_loop(
+            queue, [upd], max_retries=2,
+        )
+
+        # Bounded: the real PTB loop retried (didn't die on attempt 1), then
+        # gave up and re-raised once max_retries was exhausted.
+        assert state["attempts"] == 3  # initial attempt + 2 retries
+        assert state["last_update_id"] == 0  # offset never advanced
+        assert len(errors_seen) == 3
+        assert all(isinstance(e, TelegramError) for e in errors_seen)
+        assert isinstance(exc_raised, TelegramError)
+        assert isinstance(exc_raised, CapturePersistenceError)
+
+    @pytest.mark.asyncio
+    async def test_conflicting_duplicate_enters_bounded_retry_not_immediate_crash(self, store):
+        from telegram.error import TelegramError
+
+        queue = _make_queue(store, _agent_routes())
+        first = _update(update_id=100, message_id=42, text="hello")
+        await queue.put(first)  # commits and delegates once
+        queue.get_nowait()
+
+        conflicting = _update(update_id=100, message_id=42, text="different content")
+
+        state, errors_seen, exc_raised = await self._drive_real_ptb_retry_loop(
+            queue, [conflicting], max_retries=1,
+        )
+
+        assert state["attempts"] == 2
+        assert state["last_update_id"] == 0
+        assert all(isinstance(e, TelegramError) for e in errors_seen)
+        assert isinstance(exc_raised, TelegramError)
+        assert isinstance(exc_raised, RouteConflict)
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_does_not_delegate_to_underlying_queue_across_retries(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        store.close()
+        upd = _update(update_id=101, text="hello")
+
+        await self._drive_real_ptb_retry_loop(queue, [upd], max_retries=1)
+
+        assert queue.qsize() == 0  # never delegated on any attempt
+
+    def test_capture_persistence_error_and_route_conflict_are_distinct_telegram_errors(self):
+        from telegram.error import TelegramError
+
+        assert issubclass(CapturePersistenceError, TelegramError)
+        assert issubclass(RouteConflict, TelegramError)
+        assert not issubclass(CapturePersistenceError, RouteConflict)
+        assert not issubclass(RouteConflict, CapturePersistenceError)
+        # Constructible the same way PTB's own TelegramError subclasses are
+        # (single message string), so PTB's logging (str(exc)) still works.
+        assert str(CapturePersistenceError("boom")) == "boom"
+        assert str(RouteConflict("boom")) == "boom"
+
+
+class TestConnectFailsClosedBeforeTouchingPTB:
+    """Slice 1.1R-B: route-policy validation and receiving_profile identity
+    must be rejected *before* dispatch/admission -- i.e. at connect() time,
+    before the adapter ever touches PTB's ApplicationBuilder -- not
+    discovered lazily on the first message. Scoped to
+    ``_capture_is_configured()``: an adapter with no ``capture_routes`` at
+    all must connect exactly as it did before this slice.
+    """
+
+    @staticmethod
+    def _adapter(extra):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        return TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra=extra))
+
+    @pytest.mark.asyncio
+    async def test_invalid_capture_routes_fails_before_touching_ptb(self, monkeypatch):
+        import plugins.platforms.telegram.adapter as tg_adapter
+
+        builder_calls = []
+        monkeypatch.setattr(
+            tg_adapter,
+            "Application",
+            SimpleNamespace(builder=lambda: builder_calls.append(1)),
+        )
+        adapter = self._adapter(
+            {"capture_routes": [{"chat_id": -1, "thread_id": None, "mode": "bogus", "sink": "s", "policy_version": "1.0.0"}]}
+        )
+
+        ok = await adapter.connect()
+
+        assert ok is False
+        assert builder_calls == []  # never reached PTB at all
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "invalid_capture_routes"
+        assert adapter.fatal_error_retryable is False
+
+    @pytest.mark.asyncio
+    async def test_configured_but_unstamped_profile_fails_before_touching_ptb(self, monkeypatch):
+        import plugins.platforms.telegram.adapter as tg_adapter
+
+        builder_calls = []
+        monkeypatch.setattr(
+            tg_adapter,
+            "Application",
+            SimpleNamespace(builder=lambda: builder_calls.append(1)),
+        )
+        adapter = self._adapter({"capture_routes": _capture_only_routes()})
+        assert adapter.receiving_profile is None  # never stamped
+
+        ok = await adapter.connect()
+
+        assert ok is False
+        assert builder_calls == []
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "missing_receiving_profile"
+        assert adapter.fatal_error_retryable is False
+
+    @pytest.mark.asyncio
+    async def test_valid_capture_routes_and_stamped_profile_reaches_ptb(self, monkeypatch):
+        """Positive control: both guards pass and connect() proceeds into
+        the real PTB builder chain (proven by reaching Application.builder()
+        -- connect()'s own outer try/except catches whatever the stubbed
+        builder raises and returns False, same as any real connect
+        failure, so this only asserts the guards let it through)."""
+        import plugins.platforms.telegram.adapter as tg_adapter
+
+        builder_calls = []
+
+        def _builder():
+            builder_calls.append(1)
+            raise RuntimeError("stop here -- past the capture guards")
+
+        monkeypatch.setattr(tg_adapter, "Application", SimpleNamespace(builder=_builder))
+        adapter = self._adapter({"capture_routes": _capture_only_routes()})
+        adapter.receiving_profile = "coder"
+
+        ok = await adapter.connect()
+
+        assert ok is False  # the stubbed builder failure, not a capture guard
+        assert builder_calls == [1]
+        assert adapter.fatal_error_code != "invalid_capture_routes"
+        assert adapter.fatal_error_code != "missing_receiving_profile"
+
+    @pytest.mark.asyncio
+    async def test_no_capture_routes_configured_never_requires_profile(self, monkeypatch):
+        """Regression guard: an adapter with no capture_routes at all must
+        not be blocked by either check -- same as before this slice."""
+        import plugins.platforms.telegram.adapter as tg_adapter
+
+        builder_calls = []
+
+        def _builder():
+            builder_calls.append(1)
+            raise RuntimeError("stop here -- past the capture guards")
+
+        monkeypatch.setattr(tg_adapter, "Application", SimpleNamespace(builder=_builder))
+        adapter = self._adapter({})
+        assert adapter.receiving_profile is None
+
+        ok = await adapter.connect()
+
+        assert ok is False
+        assert builder_calls == [1]  # reached PTB despite no stamped profile
+        assert adapter.fatal_error_code != "missing_receiving_profile"
+
+    def test_capture_route_table_is_cached_not_rebuilt_per_call(self):
+        adapter = self._adapter({"capture_routes": _capture_only_routes()})
+        first = adapter._capture_route_table()
+        second = adapter._capture_route_table()
+        assert first is second
+
+    def test_capture_route_table_validation_error_surfaces_on_first_access(self):
+        adapter = self._adapter(
+            {"capture_routes": [{"chat_id": -1, "thread_id": None, "mode": "bogus", "sink": "s", "policy_version": "1.0.0"}]}
+        )
+        with pytest.raises(ValueError, match="mode"):
+            adapter._capture_route_table()
+
+
+class TestDisconnectClosesCaptureStore:
+    """Slice 1.1R-B blocker 4: disconnect() must close the capture ledger
+    (after PTB update admission has already stopped) and clear both the
+    store and queue references, so a later connect() builds fresh ones
+    instead of reusing a closed sqlite3 connection.
+    """
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_store_and_clears_references(self, tmp_path, monkeypatch):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra={"capture_db_path": str(tmp_path / "c.db")})
+        )
+        real_store = adapter._ensure_capture_store()
+        adapter._capture_queue = adapter._build_capture_queue()
+        assert real_store._closed is False
+
+        await adapter.disconnect()
+
+        assert real_store._closed is True
+        assert adapter._capture_store is None
+        assert adapter._capture_queue is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_is_safe_when_capture_store_was_never_created(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        assert adapter._capture_store is None
+
+        await adapter.disconnect()  # must not raise
+
+        assert adapter._capture_store is None
+        assert adapter._capture_queue is None
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_disconnect_builds_a_fresh_store_not_a_closed_one(self, tmp_path):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra={"capture_db_path": str(tmp_path / "c.db")})
+        )
+        first_store = adapter._ensure_capture_store()
+        await adapter.disconnect()
+        assert first_store._closed is True
+
+        second_store = adapter._ensure_capture_store()
+
+        assert second_store is not first_store
+        assert second_store._closed is False
+        # Proves it's a live, usable connection, not the closed one.
+        second_store.commit_capture(
+            event_id="telegram:default:1:1", platform="telegram", account_id=1,
+            profile="default", update_id=1, chat_id=-1, thread_id=None,
+            message_id=1, sender_id=1, event_type="text", received_at="2026-01-01T00:00:00Z",
+            payload_hash="sha256:" + "a" * 64, route_mode="capture_only", sink="s",
+            payload_json="{}",
+        )
+        second_store.close()

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -1,0 +1,511 @@
+"""Slice 1.1R-B: capture-aware pre-ack queue seam.
+
+Real PTB ``Update``/``Message`` fixtures, a real temporary SQLite database
+per test (no mocked persistence) -- proving the durable-before-ack guarantee
+at the one seam early enough for both polling and webhook: ``Queue.put()``.
+"""
+import asyncio
+import datetime
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# tests/gateway/conftest.py unconditionally installs a MagicMock stand-in for
+# the ``telegram`` package at collection time (see its ``_ensure_telegram_mock``
+# docstring) so unrelated adapter tests don't need python-telegram-bot
+# installed. This slice's TDD sequence explicitly requires real PTB fixtures
+# and a real temporary SQLite database, no mocked persistence -- so force the
+# genuine installed package back in before importing anything that touches it.
+for _mod_name in [n for n in list(sys.modules) if n == "telegram" or n.startswith("telegram.")]:
+    if not hasattr(sys.modules[_mod_name], "__file__"):
+        del sys.modules[_mod_name]
+import telegram as _real_telegram  # noqa: E402
+
+assert hasattr(_real_telegram, "__file__"), (
+    "expected the real python-telegram-bot package, not tests/gateway/conftest.py's mock"
+)
+
+from telegram import CallbackQuery, Chat, Message, Update, User  # noqa: E402
+
+from plugins.platforms.telegram.capture_ingress import (
+    CaptureAwareQueue,
+    CaptureIngressStore,
+    CapturePersistenceError,
+    DUPLICATE_SAME,
+    INSERTED,
+    RouteConflict,
+    RoutePolicyTable,
+    canonicalize_update,
+    classify_event_type,
+    compute_event_id,
+    compute_payload_hash,
+    normalize_thread_id,
+)
+
+ACCOUNT_ID = 777
+PROFILE = "default"
+CAPTURE_CHAT_ID = -1001
+CAPTURE_THREAD_ID = 271
+
+
+def _chat(chat_id=CAPTURE_CHAT_ID, is_forum=True, chat_type="supergroup"):
+    return Chat(id=chat_id, type=chat_type, is_forum=is_forum)
+
+
+def _user(user_id=555, is_bot=False):
+    return User(id=user_id, first_name="Alice", is_bot=is_bot)
+
+
+def _message(
+    *,
+    message_id=42,
+    chat=None,
+    from_user=None,
+    text="hello",
+    thread_id=CAPTURE_THREAD_ID,
+    **extra,
+):
+    return Message(
+        message_id=message_id,
+        date=datetime.datetime.now(datetime.timezone.utc),
+        chat=chat or _chat(),
+        from_user=from_user if from_user is not None else _user(),
+        text=text,
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        **extra,
+    )
+
+
+def _update(update_id=1000, message=None, **kwargs):
+    return Update(update_id=update_id, message=message if message is not None else _message(**kwargs))
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return tmp_path / "capture_ingress.db"
+
+
+@pytest.fixture()
+def store(db_path):
+    s = CaptureIngressStore(db_path)
+    yield s
+    s.close()
+
+
+def _capture_only_routes():
+    return [
+        {
+            "chat_id": CAPTURE_CHAT_ID,
+            "thread_id": CAPTURE_THREAD_ID,
+            "mode": "capture_only",
+            "sink": "braindump",
+            "policy_version": "1.0.0",
+        }
+    ]
+
+
+def _agent_routes():
+    return [
+        {
+            "chat_id": CAPTURE_CHAT_ID,
+            "thread_id": CAPTURE_THREAD_ID,
+            "mode": "agent",
+            "sink": "agent-dispatch",
+            "policy_version": "1.0.0",
+        }
+    ]
+
+
+def _drop_routes():
+    return [
+        {
+            "chat_id": CAPTURE_CHAT_ID,
+            "thread_id": CAPTURE_THREAD_ID,
+            "mode": "drop",
+            "sink": "n-a",
+            "policy_version": "1.0.0",
+        }
+    ]
+
+
+def _make_queue(store, routes, *, is_own=False, is_authorized=True, alert=None):
+    return CaptureAwareQueue(
+        store=store,
+        route_table_provider=lambda: RoutePolicyTable(routes),
+        account_id_provider=lambda: ACCOUNT_ID,
+        profile_provider=lambda: PROFILE,
+        thread_id_resolver=lambda message: (
+            str(message.message_thread_id) if message.message_thread_id is not None else None
+        ),
+        is_own_message=lambda message: is_own,
+        is_authorized_sender=lambda message: is_authorized,
+        alert_failure=alert,
+    )
+
+
+def _ledger_row(store, event_id):
+    cur = store._conn.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    cols = [d[0] for d in cur.description]
+    return dict(zip(cols, row))
+
+
+def _payload_row(store, event_id):
+    cur = store._conn.execute(
+        "SELECT * FROM ingress_payload WHERE event_id = ?", (event_id,)
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    cols = [d[0] for d in cur.description]
+    return dict(zip(cols, row))
+
+
+class TestPureHelpers:
+    def test_canonicalize_update_is_deterministic_sorted_json(self):
+        upd = _update()
+        a = canonicalize_update(upd)
+        b = canonicalize_update(upd)
+        assert a == b
+        assert a == a.strip()  # no incidental whitespace padding
+        assert b'": ' not in a  # compact separators, not the default json.dumps spacing
+
+    def test_event_id_format(self):
+        assert compute_event_id("default", 777, 1000) == "telegram:default:777:1000"
+
+    def test_payload_hash_format(self):
+        h = compute_payload_hash(b"abc")
+        assert h.startswith("sha256:")
+        assert len(h) == len("sha256:") + 64
+
+    def test_general_topic_normalizes_to_null(self):
+        assert normalize_thread_id("1") is None
+        assert normalize_thread_id(None) is None
+        assert normalize_thread_id("271") == 271
+
+    def test_classify_event_type_command(self):
+        assert classify_event_type(_message(text="/start")) == "command"
+
+    def test_classify_event_type_text(self):
+        assert classify_event_type(_message(text="hello")) == "text"
+
+    def test_classify_event_type_other_when_no_recognized_content(self):
+        assert classify_event_type(_message(text=None)) == "other"
+
+
+class TestRoutePolicyTable:
+    def test_exact_match_requires_both_chat_and_thread(self):
+        table = RoutePolicyTable(_capture_only_routes())
+        assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is not None
+        # Same thread number, different chat: must not match.
+        assert table.lookup(-999, CAPTURE_THREAD_ID) is None
+        # Same chat, different thread: must not match.
+        assert table.lookup(CAPTURE_CHAT_ID, 999) is None
+
+    def test_general_topic_route_matches_null_thread(self):
+        routes = [
+            {"chat_id": CAPTURE_CHAT_ID, "thread_id": None, "mode": "capture_only", "sink": "s", "policy_version": "1.0.0"}
+        ]
+        table = RoutePolicyTable(routes)
+        assert table.lookup(CAPTURE_CHAT_ID, None) is not None
+
+    def test_no_configured_route_is_none(self):
+        table = RoutePolicyTable([])
+        assert table.lookup(CAPTURE_CHAT_ID, CAPTURE_THREAD_ID) is None
+
+
+class TestCaptureIngressStore:
+    def _kwargs(self, **override):
+        base = dict(
+            event_id="telegram:default:777:1000",
+            platform="telegram",
+            account_id=ACCOUNT_ID,
+            profile=PROFILE,
+            update_id=1000,
+            chat_id=CAPTURE_CHAT_ID,
+            thread_id=CAPTURE_THREAD_ID,
+            message_id=42,
+            sender_id=555,
+            event_type="text",
+            received_at="2026-08-06T20:00:00Z",
+            payload_hash="sha256:" + "a" * 64,
+            route_mode="capture_only",
+            sink="braindump",
+            payload_json="{}",
+        )
+        base.update(override)
+        return base
+
+    def test_first_insert_returns_inserted_and_persists_row_and_payload(self, store):
+        result = store.commit_capture(**self._kwargs())
+        assert result == INSERTED
+        row = _ledger_row(store, "telegram:default:777:1000")
+        assert row["status"] == "pending"
+        assert row["attempts"] == 0
+        assert row["lease_expires_at"] is None
+        assert row["last_error"] is None
+        assert row["completed_at"] is None
+        payload = _payload_row(store, "telegram:default:777:1000")
+        assert payload["payload_json"] == "{}"
+
+    def test_identical_duplicate_is_a_noop_first_fields_preserved(self, store):
+        store.commit_capture(**self._kwargs(received_at="2026-08-06T20:00:00Z"))
+        result = store.commit_capture(**self._kwargs(received_at="2026-08-06T20:05:00Z"))
+        assert result == DUPLICATE_SAME
+        row = _ledger_row(store, "telegram:default:777:1000")
+        assert row["received_at"] == "2026-08-06T20:00:00Z"  # first write wins, not overwritten
+
+    def test_conflicting_duplicate_payload_raises_and_does_not_overwrite(self, store):
+        store.commit_capture(**self._kwargs(payload_hash="sha256:" + "a" * 64))
+        with pytest.raises(RouteConflict):
+            store.commit_capture(**self._kwargs(payload_hash="sha256:" + "b" * 64))
+        row = _ledger_row(store, "telegram:default:777:1000")
+        assert row["payload_hash"] == "sha256:" + "a" * 64  # unchanged
+
+    def test_injected_storage_failure_raises_capture_persistence_error(self, store):
+        store._conn.close()  # simulate a hard storage failure (closed handle)
+        with pytest.raises(CapturePersistenceError):
+            store.commit_capture(**self._kwargs())
+
+
+class TestCaptureAwareQueueDispatchGating:
+    @pytest.mark.asyncio
+    async def test_capture_only_route_commits_then_terminal_deny(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        upd = _update(update_id=1, text="hello")
+
+        await queue.put(upd)
+
+        assert queue.qsize() == 0  # never delegated to the underlying queue
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 1)
+        row = _ledger_row(store, eid)
+        assert row is not None
+        assert row["route_mode"] == "capture_only"
+
+    @pytest.mark.asyncio
+    async def test_command_on_capture_only_route_captured_as_inert_text_not_dispatched(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        upd = _update(update_id=2, text="/deploy prod")
+
+        await queue.put(upd)
+
+        assert queue.qsize() == 0
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 2)
+        row = _ledger_row(store, eid)
+        assert row["event_type"] == "command"
+
+    @pytest.mark.asyncio
+    async def test_media_on_capture_only_route(self, store):
+        from telegram import PhotoSize
+
+        queue = _make_queue(store, _capture_only_routes())
+        msg = _message(text=None, photo=[PhotoSize(file_id="f1", file_unique_id="u1", width=10, height=10)])
+        upd = _update(update_id=3, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 3)
+        row = _ledger_row(store, eid)
+        assert row["event_type"] == "media"
+        assert queue.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_location_on_capture_only_route(self, store):
+        from telegram import Location
+
+        queue = _make_queue(store, _capture_only_routes())
+        msg = _message(text=None, location=Location(longitude=1.0, latitude=2.0))
+        upd = _update(update_id=4, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 4)
+        row = _ledger_row(store, eid)
+        assert row["event_type"] == "location"
+        assert queue.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_other_message_like_content_kind(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        # message_id/from_user present, no text/media/location: e.g. a
+        # message the ledger contract still requires a row for.
+        msg = _message(text=None)
+        upd = _update(update_id=5, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 5)
+        row = _ledger_row(store, eid)
+        assert row["event_type"] == "other"
+
+    @pytest.mark.asyncio
+    async def test_non_message_like_update_passes_through_unchanged(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        cq = CallbackQuery(id="cbq1", from_user=_user(), chat_instance="ci1", data="x")
+        upd = Update(update_id=6, callback_query=cq)
+
+        await queue.put(upd)
+
+        assert queue.qsize() == 1  # delegated unchanged, not captured
+        assert queue.get_nowait() is upd
+
+    @pytest.mark.asyncio
+    async def test_agent_route_commits_then_delegates_exactly_once(self, store):
+        queue = _make_queue(store, _agent_routes())
+        upd = _update(update_id=7)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 7)
+        row = _ledger_row(store, eid)
+        assert row["route_mode"] == "agent"
+        assert queue.qsize() == 1
+        assert queue.get_nowait() is upd
+
+    @pytest.mark.asyncio
+    async def test_drop_route_no_ledger_row_passthrough(self, store):
+        queue = _make_queue(store, _drop_routes())
+        upd = _update(update_id=8)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 8)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_no_configured_route_passthrough(self, store):
+        queue = _make_queue(store, [])  # nothing configured for this chat/topic
+        upd = _update(update_id=9)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 9)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_exact_route_matching_same_thread_number_other_chat_no_match(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        msg = _message(chat=_chat(chat_id=-2002), thread_id=CAPTURE_THREAD_ID)
+        upd = _update(update_id=10, message=msg)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 10)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1  # unmatched: passes through like an unrouted chat
+
+    @pytest.mark.asyncio
+    async def test_identical_duplicate_no_second_row_capture_only_still_denied(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        upd = _update(update_id=11, text="hello")
+
+        await queue.put(upd)
+        await queue.put(upd)  # simulated redelivery of the same update
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 11)
+        cur = store._conn.execute(
+            "SELECT COUNT(*) FROM ingress_ledger WHERE event_id = ?", (eid,)
+        )
+        assert cur.fetchone()[0] == 1
+        assert queue.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_conflicting_duplicate_fails_closed_no_delegation(self, store):
+        queue = _make_queue(store, _agent_routes())
+        msg_a = _message(message_id=42, text="hello")
+        upd_a = Update(update_id=12, message=msg_a)
+        await queue.put(upd_a)
+        assert queue.qsize() == 1
+        queue.get_nowait()
+
+        # Same update_id, different canonical payload (different text).
+        msg_b = _message(message_id=42, text="different content")
+        upd_b = Update(update_id=12, message=msg_b)
+        with pytest.raises(RouteConflict):
+            await queue.put(upd_b)
+        assert queue.qsize() == 0  # no delegation on conflict
+
+    @pytest.mark.asyncio
+    async def test_injected_storage_failure_no_delegation(self, store):
+        alerts = []
+        queue = _make_queue(store, _capture_only_routes(), alert=alerts.append)
+        store.close()  # force every commit to fail
+        upd = _update(update_id=13)
+
+        with pytest.raises(CapturePersistenceError):
+            await queue.put(upd)
+
+        assert queue.qsize() == 0
+        assert alerts  # deterministic failure was alerted
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_no_capture_existing_behavior_preserved(self, store):
+        queue = _make_queue(store, _capture_only_routes(), is_authorized=False)
+        upd = _update(update_id=14)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 14)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1  # existing (downstream) authorization behavior unchanged
+
+    @pytest.mark.asyncio
+    async def test_bot_authored_no_capture(self, store):
+        queue = _make_queue(store, _capture_only_routes(), is_own=True)
+        upd = _update(update_id=15)
+
+        await queue.put(upd)
+
+        eid = compute_event_id(PROFILE, ACCOUNT_ID, 15)
+        assert _ledger_row(store, eid) is None
+        assert queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_queue_sentinel_passes_through_unchanged(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        sentinel = object()
+
+        await queue.put(sentinel)
+
+        assert queue.qsize() == 1
+        assert queue.get_nowait() is sentinel
+
+    @pytest.mark.asyncio
+    async def test_polling_batch_partial_failure_then_retry_collapses_first_inserts_second_once(self, store):
+        queue = _make_queue(store, _capture_only_routes())
+        upd_n = _update(update_id=20, message_id=100, text="first")
+        upd_n1 = _update(update_id=21, message_id=101, text="second")
+
+        await queue.put(upd_n)  # N commits
+
+        store.close()  # simulate N+1 failing to persist
+        with pytest.raises(CapturePersistenceError):
+            await queue.put(upd_n1)
+
+        # Reopen (as a fresh retry attempt would) and replay both.
+        reopened = CaptureIngressStore(store._db_path)
+        try:
+            retry_queue = _make_queue(reopened, _capture_only_routes())
+            await retry_queue.put(upd_n)  # redelivered N: collapses, no second row
+            await retry_queue.put(upd_n1)  # N+1 inserts once now that storage recovered
+
+            eid_n = compute_event_id(PROFILE, ACCOUNT_ID, 20)
+            eid_n1 = compute_event_id(PROFILE, ACCOUNT_ID, 21)
+            assert reopened._conn.execute(
+                "SELECT COUNT(*) FROM ingress_ledger WHERE event_id = ?", (eid_n,)
+            ).fetchone()[0] == 1
+            assert reopened._conn.execute(
+                "SELECT COUNT(*) FROM ingress_ledger WHERE event_id = ?", (eid_n1,)
+            ).fetchone()[0] == 1
+        finally:
+            reopened.close()

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -95,6 +95,7 @@ def _group_message(
     from_user_id=111,
     from_user_name="Alice Example",
     thread_id=None,
+    is_forum=None,
     reply_to_bot=False,
     entities=None,
     caption=None,
@@ -103,6 +104,8 @@ def _group_message(
     reply_to_message = None
     if reply_to_bot:
         reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999), message_id=10, text="previous bot reply", caption=None)
+    if is_forum is None:
+        is_forum = thread_id is not None
     return SimpleNamespace(
         message_id=42,
         text=text,
@@ -111,7 +114,7 @@ def _group_message(
         caption_entities=caption_entities or [],
         message_thread_id=thread_id,
         is_topic_message=thread_id is not None,
-        chat=SimpleNamespace(id=chat_id, type="group", title="Test Group", is_forum=thread_id is not None),
+        chat=SimpleNamespace(id=chat_id, type="group", title="Test Group", is_forum=is_forum),
         from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
         reply_to_message=reply_to_message,
         date=None,
@@ -969,6 +972,24 @@ def test_general_topic_route_applies_to_null_thread_message():
     adapter = _with_capture_only_route(_make_adapter(), thread_id=None)
     message = _group_message("hello", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=None)
 
+    assert adapter._should_process_message(message) is False
+
+
+def test_general_topic_route_applies_to_real_forum_general_topic_message():
+    """A forum group's General topic (is_forum=True, message_thread_id=None
+    -- Telegram never assigns a message_thread_id to it, unlike every real
+    topic) must collapse to the same null route key as a non-forum chat.
+    Unlike the sibling test above (a non-forum group, is_forum=False by
+    construction), this exercises the actual sentinel-collapsing branch in
+    _effective_message_thread_id / normalize_thread_id: is_forum_group=True
+    -> _GENERAL_TOPIC_THREAD_ID ("1") -> normalized to None.
+    """
+    adapter = _with_capture_only_route(_make_adapter(), thread_id=None)
+    message = _group_message(
+        "hello", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=None, is_forum=True,
+    )
+
+    assert adapter._effective_message_thread_id(message) == adapter._GENERAL_TOPIC_THREAD_ID
     assert adapter._should_process_message(message) is False
 
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -882,3 +882,101 @@ def test_identity_freshness_does_not_depend_on_host_uptime(monkeypatch):
 
     adapter._note_bot_username("new_helper_bot")
     assert adapter._bot_identity_is_fresh() is True
+
+
+# ── Slice 1.1R-B: capture-only route defense-in-depth ───────────────────
+#
+# The queue-level terminal deny (CaptureAwareQueue.put, see
+# tests/gateway/test_telegram_capture_ingress.py) is meant to make a
+# capture-only route's update unreachable here in the first place.
+# _should_process_message must independently return False anyway --
+# deliberate belt-and-suspenders, not redundant dead code (see the plan's
+# "Corrected seam" section).
+
+_CAPTURE_ONLY_CHAT_ID = -1003910549809
+_CAPTURE_ONLY_THREAD_ID = 271
+
+
+def _with_capture_only_route(adapter, *, chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=_CAPTURE_ONLY_THREAD_ID):
+    adapter.config.extra["capture_routes"] = [
+        {
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+            "mode": "capture_only",
+            "sink": "braindump",
+            "policy_version": "1.0.0",
+        }
+    ]
+    return adapter
+
+
+def test_capture_only_route_denies_plain_text():
+    adapter = _with_capture_only_route(_make_adapter())
+    message = _group_message("just some notes", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=_CAPTURE_ONLY_THREAD_ID)
+
+    assert adapter._should_process_message(message) is False
+
+
+def test_capture_only_route_denies_command():
+    adapter = _with_capture_only_route(_make_adapter())
+    message = _group_message("/deploy prod", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=_CAPTURE_ONLY_THREAD_ID)
+
+    assert adapter._should_process_message(message, is_command=True) is False
+
+
+def test_capture_only_route_denies_reply_to_bot():
+    adapter = _with_capture_only_route(_make_adapter(require_mention=True))
+    message = _group_message(
+        "yes", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=_CAPTURE_ONLY_THREAD_ID, reply_to_bot=True,
+    )
+
+    assert adapter._should_process_message(message) is False
+
+
+def test_capture_only_route_denies_explicit_mention():
+    adapter = _with_capture_only_route(_make_adapter(require_mention=True))
+    text = "@hermes_bot are you there"
+    message = _group_message(
+        text,
+        chat_id=_CAPTURE_ONLY_CHAT_ID,
+        thread_id=_CAPTURE_ONLY_THREAD_ID,
+        entities=[_mention_entity(text)],
+    )
+
+    assert adapter._should_process_message(message) is False
+
+
+def test_capture_only_route_denies_free_response_topic_override():
+    adapter = _with_capture_only_route(
+        _make_adapter(free_response_topics=[str(_CAPTURE_ONLY_THREAD_ID)])
+    )
+    message = _group_message("hi", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=_CAPTURE_ONLY_THREAD_ID)
+
+    assert adapter._should_process_message(message) is False
+
+
+def test_same_thread_number_other_chat_is_not_capture_only():
+    """Route matching is exact on (chat_id, thread_id) -- no chat-agnostic wildcard."""
+    adapter = _with_capture_only_route(_make_adapter())
+    message = _group_message(
+        "hello", chat_id=-999, thread_id=_CAPTURE_ONLY_THREAD_ID,
+    )
+
+    assert adapter._should_process_message(message) is True
+
+
+def test_general_topic_route_applies_to_null_thread_message():
+    adapter = _with_capture_only_route(_make_adapter(), thread_id=None)
+    message = _group_message("hello", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=None)
+
+    assert adapter._should_process_message(message) is False
+
+
+def test_non_capture_route_unaffected():
+    """Regression: a chat/topic with no configured route behaves exactly as before."""
+    adapter = _with_capture_only_route(_make_adapter(require_mention=True))
+    message = _group_message(
+        "hello", chat_id=_CAPTURE_ONLY_CHAT_ID, thread_id=999,  # different topic, unrouted
+    )
+
+    assert adapter._should_process_message(message) is False  # require_mention still gates it


### PR DESCRIPTION
## Slice 1.1R-B — Capture-first intake

**Authorization:** control-plane PR `#20` owner-merged 2026-08-06T20:55:00Z (`6bffb10579cb9567eb936c23b8b3a9da6d96380f`)
**Baseline:** `0957277f2f468bac22bbfcfa7c43029858c9597e` (origin/main at authorization time)
**Scope digest:** `sha256:141eb918da2f6643a57c75119f2cf1d363db7173e32ae8f33c7ee341a0a6ea13`

---

### What this does

Installs one `CaptureAwareQueue` at `ApplicationBuilder(...).update_queue(...)` for every PTB Application (initial build and every rebuild-after-init-failure). Every authorized human-authored message-like Telegram update is durably committed — idempotent ledger row + atomic companion payload in one `BEGIN IMMEDIATE` transaction — before PTB's own offset advancement (polling) or HTTP response (webhook).

- **`capture_only` routes:** committed once, then terminally denied — never reach PTB handlers. Covers text, commands (captured as inert text, never executed), media, location, and channel posts (no human identity → terminally denied without capture).
- **`agent` routes:** committed before delegation to existing PTB dispatch. Authorization parity: uses gateway-installed profile-bound callback; pairing-passthrough DMs are not captured.
- **`drop`/unrouted:** pass through unchanged; no ledger row.
- **Persistence failures:** raise `CaptureAdmissionError` (a `TelegramError` subclass) → PTB polling retry loop enters bounded retry without offset advancement; webhook returns non-2xx.
- **Receiving profile:** immutable field stamped by `gateway/run.py` before `connect()`; fail-closed if `capture_routes` configured but profile not stamped.
- **Route validation:** `RoutePolicyTable` raises on invalid/malformed entries at connect time; duplicate normalized keys rejected.
- **SQLite lifecycle:** store closed after PTB teardown in `disconnect()`; references cleared for clean reconnect; FK enforcement enabled per-connection; `in_transaction` guard on rollback.

### Changed paths (all within authorized scope manifest)
- `gateway/run.py` (+67 lines) — immutable receiving-profile stamping, 4 call sites
- `plugins/platforms/telegram/adapter.py` (+373/-49) — queue wiring, profile/lifecycle/alert
- `plugins/platforms/telegram/capture_ingress.py` (new, 577 lines) — store, queue, route table, canonicalization
- `tests/gateway/test_multiplex_adapter_registry.py` (+166) — profile stamping tests
- `tests/gateway/test_telegram_capture_ingress.py` (new, ~1,124 lines) — 73 focused tests
- `tests/gateway/test_telegram_group_gating.py` (+121) — defense-in-depth tests

**Out of scope / unchanged:** `capture/` contracts, `drop_pending_updates`, media byte download, Slice 1.1R-C consumer behavior, any live deployment or config.

### Test evidence
- 129 focused tests pass (73 capture-ingress + 56 multiplex/gating)
- Full 76-file gateway test sweep: 0 failures
- 2× independent read-only blocker reviews: PASS (second review at HEAD + uncommitted edits, 2026-08-06 22:54)

### Residual / deferred (not blockers)
- Commit-before-delegate crash window on agent routes produces a `pending` row that will not auto-dispatch in this envelope — documented in plan; 1.1R-C consumer scope resolves it.
- `capture_ingest.py` gap-3 (zero-capture silent exit) is the one scope-manifest item outside this repo (`hermes-eu1-live-file`); fix is in the live file at `~/.hermes/scripts/capture_ingest.py` (sha256: `2b45022990666fcc5db0e1f25bd7d4a79f628be10d54ae4e7d83f507922cbf67`), not committed here.
- Synchronous SQLite I/O on the event loop inside `put()` — mitigated by 1s connect timeout; async offload is 1.1R-C scope.

**Do not merge** — owner review required. No deployment or live config change inferred from this PR.