### PR TITLE
fix(kanban): enforce target skill capability before start

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -229,6 +229,44 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
     return loaded_skill, skill_dir, skill_name
 
 
+def resolve_forced_preload_skills(
+    skill_identifiers: list[str],
+    task_id: str | None = None,
+) -> tuple[list[tuple[dict[str, Any], Path | None, str]], list[str]]:
+    """Resolve forced preloads without recording usage or building a prompt.
+
+    This is the runtime authority for ``--skills``: it deliberately follows
+    ``skill_view`` through :func:`_load_skill_payload`, then applies the same
+    disabled-name gate as session preloading.
+    """
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        disabled_names = get_disabled_skill_names()
+    except Exception:
+        disabled_names = set()
+
+    resolved: list[tuple[dict[str, Any], Path | None, str]] = []
+    missing: list[str] = []
+    seen: set[str] = set()
+    for raw_identifier in skill_identifiers:
+        identifier = (raw_identifier or "").strip()
+        if not identifier or identifier in seen:
+            continue
+        seen.add(identifier)
+
+        loaded = _load_skill_payload(identifier, task_id=task_id)
+        if not loaded:
+            missing.append(identifier)
+            continue
+        loaded_skill, skill_dir, skill_name = loaded
+        if skill_name in disabled_names or identifier in disabled_names:
+            missing.append(identifier)
+            continue
+        resolved.append((loaded_skill, skill_dir, skill_name))
+
+    return resolved, missing
+
+
 def _inject_skill_config(loaded_skill: dict[str, Any], parts: list[str]) -> None:
     """Resolve and inject skill-declared config values into the message parts.
 
@@ -761,31 +799,8 @@ def build_preloaded_skills_prompt(
     """
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
-    missing: list[str] = []
-
-    try:
-        from agent.skill_utils import get_disabled_skill_names
-        disabled_names = get_disabled_skill_names()
-    except Exception:
-        disabled_names = set()
-
-    seen: set[str] = set()
-    for raw_identifier in skill_identifiers:
-        identifier = (raw_identifier or "").strip()
-        if not identifier or identifier in seen:
-            continue
-        seen.add(identifier)
-
-        loaded = _load_skill_payload(identifier, task_id=task_id)
-        if not loaded:
-            missing.append(identifier)
-            continue
-
-        loaded_skill, skill_dir, skill_name = loaded
-
-        if skill_name in disabled_names or identifier in disabled_names:
-            missing.append(identifier)
-            continue
+    resolved, missing = resolve_forced_preload_skills(skill_identifiers, task_id)
+    for loaded_skill, skill_dir, skill_name in resolved:
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/cli.py
+++ b/cli.py
@@ -4097,6 +4097,52 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return parsed
 
 
+def _block_missing_kanban_forced_skills(skill_identifiers: list[str]) -> bool:
+    """Block an exact dispatcher claim whose forced skills vanished at startup."""
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    run_id_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    if not task_id or not run_id_raw or not claim_lock or not skill_identifiers:
+        return False
+    try:
+        run_id = int(run_id_raw)
+    except ValueError:
+        return False
+
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        if (
+            task is None
+            or task.status != "running"
+            or task.current_run_id != run_id
+            or task.claim_lock != claim_lock
+            or (task.skills or []) != skill_identifiers
+        ):
+            return False
+        from agent.skill_commands import resolve_forced_preload_skills
+
+        _resolved, missing = resolve_forced_preload_skills(skill_identifiers)
+        if not missing:
+            return False
+        reason = kb._missing_skills_reason(task.assignee, missing)
+        blocked = kb.block_task(
+            conn,
+            task_id,
+            reason=reason,
+            kind="capability",
+            expected_run_id=run_id,
+            synthesize_run=False,
+        )
+        if blocked:
+            logger.error("Kanban worker blocked before startup: %s", reason)
+        return blocked
+    finally:
+        conn.close()
+
+
 def save_config_value(key_path: str, value: any) -> bool:
     """
     Save a value to the active config file at the specified key path.
@@ -18169,6 +18215,8 @@ def main(
             toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
     
     parsed_skills = _parse_skills_argument(skills)
+    if _block_missing_kanban_forced_skills(parsed_skills):
+        return
 
     # Create CLI instance
     cli = HermesCLI(

--- a/cli.py
+++ b/cli.py
@@ -4135,6 +4135,7 @@ def _block_missing_kanban_forced_skills(skill_identifiers: list[str]) -> bool:
             kind="capability",
             expected_run_id=run_id,
             synthesize_run=False,
+            not_started=True,
         )
         if blocked:
             logger.error("Kanban worker blocked before startup: %s", reason)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -436,7 +436,13 @@ class GatewayKanbanWatchersMixin:
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
+                            if ev.payload and ev.payload.get("kind") == "capability":
+                                msg = (
+                                    f"⏸ {board_tag}{tag}Kanban {sub['task_id']} "
+                                    f"blocked before start{reason}"
+                                )
+                            else:
+                                msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -436,7 +436,7 @@ class GatewayKanbanWatchersMixin:
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            if ev.payload and ev.payload.get("kind") == "capability":
+                            if ev.payload and ev.payload.get("not_started") is True:
                                 msg = (
                                     f"⏸ {board_tag}{tag}Kanban {sub['task_id']} "
                                     f"blocked before start{reason}"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2878,6 +2878,88 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def resolve_assignee_skills(assignee: str, skill_names: Iterable[str]) -> list[str]:
+    """Resolve forced skills in a target profile without switching process state."""
+    from agent.skill_utils import (
+        iter_skill_index_files,
+        parse_frontmatter,
+        skill_matches_platform,
+        yaml_load,
+    )
+    from hermes_cli.profiles import get_profile_dir, profile_exists
+
+    requested = [str(name).strip() for name in skill_names if str(name).strip()]
+    if not requested or not assignee or not profile_exists(assignee):
+        return []
+
+    profile_home = get_profile_dir(assignee)
+    roots = [profile_home / "skills"]
+    try:
+        config = yaml_load((profile_home / "config.yaml").read_text(encoding="utf-8")) or {}
+        external = (config.get("skills") or {}).get("external_dirs") or []
+    except Exception:
+        external = []
+    if isinstance(external, str):
+        external = [external]
+    if isinstance(external, list):
+        for value in external:
+            path = Path(os.path.expanduser(os.path.expandvars(str(value).strip())))
+            path = path if path.is_absolute() else profile_home / path
+            try:
+                path = path.resolve()
+            except OSError:
+                continue
+            if path.is_dir() and path not in roots:
+                roots.append(path)
+
+    matches: dict[str, set[Path]] = {name: set() for name in requested}
+    for root in roots:
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
+            try:
+                frontmatter, _ = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not skill_matches_platform(frontmatter):
+                continue
+            declared = str(frontmatter.get("name") or skill_md.parent.name)
+            for name in requested:
+                categorized = name.replace(":", "/", 1)
+                if (
+                    name == declared
+                    or name == skill_md.parent.name
+                    or root / categorized == skill_md.parent
+                ):
+                    matches[name].add(skill_md.resolve())
+    return [name for name in requested if len(matches[name]) == 1]
+
+
+def _missing_assignee_skills(assignee: Optional[str], skills: Iterable[str]) -> list[str]:
+    """Return forced task skills unavailable to a spawnable card assignee."""
+    requested = [str(name).strip() for name in skills if str(name).strip()]
+    if not requested:
+        return []
+    if not assignee:
+        return requested
+    # Non-profile assignees are intentional pull-only control-plane lanes; the
+    # dispatcher already never spawns them, so they have no profile estate to
+    # preflight here.
+    from hermes_cli.profiles import profile_exists
+
+    if not profile_exists(assignee):
+        return []
+    resolved = set(resolve_assignee_skills(assignee, requested))
+    return [name for name in requested if name not in resolved]
+
+
+def _missing_skills_reason(assignee: Optional[str], missing: Iterable[str]) -> str:
+    display_assignee = assignee or "unassigned"
+    return (
+        f"Assignee {display_assignee} is missing required skill(s): "
+        + ", ".join(missing)
+        + f". Install them in profile {display_assignee} or reassign the task."
+    )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3115,6 +3197,14 @@ def create_task(
                 "capabilities (e.g. `web`, `browser`, `terminal`)."
             )
         skills_list = cleaned
+
+    # Forced skills are evaluated in the target worker's profile, never the
+    # creator/dispatcher profile.  Refuse before the idempotency/insert path so
+    # a bad request cannot leave a card that will only fail after a spawn.
+    if skills_list and assignee:
+        missing_skills = _missing_assignee_skills(assignee, skills_list)
+        if missing_skills:
+            raise ValueError(_missing_skills_reason(assignee, missing_skills))
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
@@ -5622,6 +5712,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    synthesize_run: bool = True,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5649,12 +5740,16 @@ def block_task(
 
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
+
+    ``synthesize_run=False`` is for preflight rejections that happen before a
+    worker ever starts; it keeps those capability events out of run history.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
     recurrences = 0
+    run_id: Optional[int] = None
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -5696,7 +5791,7 @@ def block_task(
                 outcome="blocked", status="blocked",
                 summary=reason,
             )
-            if run_id is None and reason:
+            if run_id is None and reason and synthesize_run:
                 run_id = _synthesize_ended_run(
                     conn, task_id, outcome="blocked", summary=reason,
                 )
@@ -5749,7 +5844,7 @@ def block_task(
                 outcome="blocked", status="blocked",
                 summary=reason,
             )
-            if run_id is None and reason:
+            if run_id is None and reason and synthesize_run:
                 run_id = _synthesize_ended_run(
                     conn, task_id, outcome="blocked", summary=reason,
                 )
@@ -5804,7 +5899,7 @@ def block_task(
             )
             # Synthesize a run when blocking a never-claimed task so the
             # reason is preserved in attempt history.
-            if run_id is None and reason:
+            if run_id is None and reason and synthesize_run:
                 run_id = _synthesize_ended_run(
                     conn, task_id,
                     outcome="blocked",
@@ -8517,6 +8612,32 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        # A task may predate create-time preflight, lose a profile skill after
+        # it was created, or be reassigned by another board client. Resolve
+        # against the row's current assignee immediately before any claim so a
+        # missing forced skill becomes an actionable capability block rather
+        # than a worker startup crash/retry loop.
+        candidate = get_task(conn, row["id"])
+        if (
+            candidate is None
+            or candidate.status != "ready"
+            or candidate.claim_lock is not None
+        ):
+            continue
+        missing_skills = _missing_assignee_skills(
+            candidate.assignee, candidate.skills or []
+        )
+        if missing_skills:
+            if not dry_run:
+                block_task(
+                    conn,
+                    candidate.id,
+                    reason=_missing_skills_reason(candidate.assignee, missing_skills),
+                    kind="capability",
+                    # This never started a worker, so leave no run/attempt record.
+                    synthesize_run=False,
+                )
+            continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
@@ -8528,7 +8649,7 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(conn, candidate.id, ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2879,13 +2879,7 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
 
 
 def resolve_assignee_skills(assignee: str, skill_names: Iterable[str]) -> list[str]:
-    """Resolve forced skills in a target profile without switching process state."""
-    from agent.skill_utils import (
-        iter_skill_index_files,
-        parse_frontmatter,
-        skill_matches_platform,
-        yaml_load,
-    )
+    """Resolve forced skills through the target profile's runtime resolver."""
     from hermes_cli.profiles import get_profile_dir, profile_exists
 
     requested = [str(name).strip() for name in skill_names if str(name).strip()]
@@ -2893,44 +2887,57 @@ def resolve_assignee_skills(assignee: str, skill_names: Iterable[str]) -> list[s
         return []
 
     profile_home = get_profile_dir(assignee)
-    roots = [profile_home / "skills"]
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(profile_home)
+    env["HERMES_PROFILE"] = assignee
+    script = (
+        "import json, sys\n"
+        "from hermes_cli.env_loader import load_hermes_dotenv\n"
+        "from hermes_constants import get_hermes_home\n"
+        "load_hermes_dotenv(hermes_home=get_hermes_home())\n"
+        "from agent.skill_commands import resolve_forced_preload_skills\n"
+        "resolved, missing = resolve_forced_preload_skills(json.loads(sys.argv[1]))\n"
+        "print('__HERMES_SKILL_RESOLUTION__' + json.dumps({\n"
+        "    'resolved': [name for _payload, _dir, name in resolved],\n"
+        "    'missing': missing,\n"
+        "}))\n"
+    )
     try:
-        config = yaml_load((profile_home / "config.yaml").read_text(encoding="utf-8")) or {}
-        external = (config.get("skills") or {}).get("external_dirs") or []
-    except Exception:
-        external = []
-    if isinstance(external, str):
-        external = [external]
-    if isinstance(external, list):
-        for value in external:
-            path = Path(os.path.expanduser(os.path.expandvars(str(value).strip())))
-            path = path if path.is_absolute() else profile_home / path
-            try:
-                path = path.resolve()
-            except OSError:
-                continue
-            if path.is_dir() and path not in roots:
-                roots.append(path)
-
-    matches: dict[str, set[Path]] = {name: set() for name in requested}
-    for root in roots:
-        for skill_md in iter_skill_index_files(root, "SKILL.md"):
-            try:
-                frontmatter, _ = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
-            except Exception:
-                continue
-            if not skill_matches_platform(frontmatter):
-                continue
-            declared = str(frontmatter.get("name") or skill_md.parent.name)
-            for name in requested:
-                categorized = name.replace(":", "/", 1)
-                if (
-                    name == declared
-                    or name == skill_md.parent.name
-                    or root / categorized == skill_md.parent
-                ):
-                    matches[name].add(skill_md.resolve())
-    return [name for name in requested if len(matches[name]) == 1]
+        completed = subprocess.run(
+            [sys.executable, "-c", script, json.dumps(requested)],
+            cwd=str(Path(__file__).resolve().parent.parent),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(
+            f"could not run target-profile skill resolver: {exc}"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(
+            "target-profile skill resolver failed"
+            + (f": {detail[-500:]}" if detail else "")
+        )
+    marker = "__HERMES_SKILL_RESOLUTION__"
+    payload_line = next(
+        (line[len(marker):] for line in reversed(completed.stdout.splitlines())
+         if line.startswith(marker)),
+        None,
+    )
+    try:
+        payload = json.loads(payload_line or "")
+        resolved = payload["resolved"]
+        missing = payload["missing"]
+        if not isinstance(resolved, list) or not isinstance(missing, list):
+            raise ValueError("invalid resolver result")
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError("target-profile skill resolver returned no usable result") from exc
+    missing_names = {str(name) for name in missing}
+    return [name for name in requested if name not in missing_names]
 
 
 def _missing_assignee_skills(assignee: Optional[str], skills: Iterable[str]) -> list[str]:
@@ -2947,7 +2954,13 @@ def _missing_assignee_skills(assignee: Optional[str], skills: Iterable[str]) -> 
 
     if not profile_exists(assignee):
         return []
-    resolved = set(resolve_assignee_skills(assignee, requested))
+    try:
+        resolved = set(resolve_assignee_skills(assignee, requested))
+    except RuntimeError as exc:
+        raise ValueError(
+            f"Could not verify required skills for profile {assignee}: {exc}. "
+            "Fix the profile's skill configuration and retry."
+        ) from exc
     return [name for name in requested if name not in resolved]
 
 
@@ -4319,11 +4332,13 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    expected_ready_snapshot: tuple[Optional[str], Optional[str]] | None = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
-    already claimed (or is not in ``ready`` status).
+    already claimed (or is not in ``ready`` status). When supplied,
+    ``expected_ready_snapshot`` also CAS-binds assignee and raw skills JSON.
     """
     now = int(time.time())
     lock = claimer or _claimer_id()
@@ -4362,6 +4377,26 @@ def claim_task(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'ready'",
             (task_id,),
         ).fetchone()
+        snapshot_clause = ""
+        snapshot_params: tuple[Optional[str], Optional[str]] = ()
+        if expected_ready_snapshot is not None:
+            snapshot_clause = " AND assignee IS ? AND skills IS ?"
+            snapshot_params = expected_ready_snapshot
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status        = 'running',
+                   claim_lock    = ?,
+                   claim_expires = ?,
+                   started_at    = COALESCE(started_at, ?)
+             WHERE id = ?
+               AND status = 'ready'
+               AND claim_lock IS NULL
+            """ + snapshot_clause,
+            (lock, expires, now, task_id, *snapshot_params),
+        )
+        if cur.rowcount != 1:
+            return None
         if stale and stale["current_run_id"]:
             conn.execute(
                 """
@@ -4374,21 +4409,6 @@ def claim_task(
                 """,
                 (now, int(stale["current_run_id"])),
             )
-        cur = conn.execute(
-            """
-            UPDATE tasks
-               SET status        = 'running',
-                   claim_lock    = ?,
-                   claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
-             WHERE id = ?
-               AND status = 'ready'
-               AND claim_lock IS NULL
-            """,
-            (lock, expires, now, task_id),
-        )
-        if cur.rowcount != 1:
-            return None
         # Look up the current task row so we can populate the run with
         # its assignee / step / runtime cap.
         trow = conn.execute(
@@ -5712,6 +5732,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_ready_snapshot: tuple[Optional[str], Optional[str]] | None = None,
     synthesize_run: bool = True,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
@@ -5743,6 +5764,8 @@ def block_task(
 
     ``synthesize_run=False`` is for preflight rejections that happen before a
     worker ever starts; it keeps those capability events out of run history.
+    ``expected_ready_snapshot`` makes a dispatcher preflight verdict a no-op
+    if another writer changed or claimed the ready row in the meantime.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
@@ -5750,6 +5773,18 @@ def block_task(
         )
     recurrences = 0
     run_id: Optional[int] = None
+    snapshot_clause = ""
+    snapshot_params: tuple[Optional[str], Optional[str]] = ()
+    if expected_ready_snapshot is not None:
+        snapshot_clause = (
+            " AND status = 'ready' AND claim_lock IS NULL"
+            " AND assignee IS ? AND skills IS ?"
+        )
+        snapshot_params = expected_ready_snapshot
+
+    def _with_snapshot(*params: object) -> tuple[object, ...]:
+        return params + snapshot_params
+
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -5780,9 +5815,10 @@ def block_task(
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                """ + ("" if expected_run_id is None else " AND current_run_id = ?")
+                + snapshot_clause,
+                _with_snapshot(kind, task_id) if expected_run_id is None
+                else _with_snapshot(kind, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
@@ -5833,9 +5869,10 @@ def block_task(
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                """ + ("" if expected_run_id is None else " AND current_run_id = ?")
+                + snapshot_clause,
+                _with_snapshot(kind, recurrences, task_id) if expected_run_id is None
+                else _with_snapshot(kind, recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
@@ -5871,8 +5908,8 @@ def block_task(
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
+                    """ + snapshot_clause,
+                    _with_snapshot(kind, recurrences, task_id),
                 )
             else:
                 cur = conn.execute(
@@ -5887,8 +5924,8 @@ def block_task(
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                        AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
+                    """ + snapshot_clause,
+                    _with_snapshot(kind, recurrences, task_id, int(expected_run_id)),
                 )
             if cur.rowcount != 1:
                 return False
@@ -8453,7 +8490,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, skills FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -8617,23 +8654,40 @@ def _dispatch_once_locked(
         # against the row's current assignee immediately before any claim so a
         # missing forced skill becomes an actionable capability block rather
         # than a worker startup crash/retry loop.
-        candidate = get_task(conn, row["id"])
+        snapshot = conn.execute(
+            "SELECT status, claim_lock, assignee, skills FROM tasks WHERE id = ?",
+            (row["id"],),
+        ).fetchone()
         if (
-            candidate is None
-            or candidate.status != "ready"
-            or candidate.claim_lock is not None
+            snapshot is None
+            or snapshot["status"] != "ready"
+            or snapshot["claim_lock"] is not None
         ):
             continue
-        missing_skills = _missing_assignee_skills(
-            candidate.assignee, candidate.skills or []
-        )
+        snapshot_skills: list[str] = []
+        try:
+            parsed_snapshot_skills = json.loads(snapshot["skills"] or "[]")
+            if not isinstance(parsed_snapshot_skills, list):
+                raise ValueError("task skills snapshot is not a list")
+            snapshot_skills = parsed_snapshot_skills
+            missing_skills = _missing_assignee_skills(
+                snapshot["assignee"], snapshot_skills
+            )
+        except ValueError as exc:
+            missing_skills = snapshot_skills or ["<invalid skills snapshot>"]
+            capability_reason = str(exc)
+        else:
+            capability_reason = _missing_skills_reason(
+                snapshot["assignee"], missing_skills
+            )
         if missing_skills:
             if not dry_run:
                 block_task(
                     conn,
-                    candidate.id,
-                    reason=_missing_skills_reason(candidate.assignee, missing_skills),
+                    row["id"],
+                    reason=capability_reason,
                     kind="capability",
+                    expected_ready_snapshot=(snapshot["assignee"], snapshot["skills"]),
                     # This never started a worker, so leave no run/attempt record.
                     synthesize_run=False,
                 )
@@ -8649,7 +8703,12 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, candidate.id, ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            expected_ready_snapshot=(snapshot["assignee"], snapshot["skills"]),
+        )
         if claimed is None:
             continue
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5734,6 +5734,7 @@ def block_task(
     expected_run_id: Optional[int] = None,
     expected_ready_snapshot: tuple[Optional[str], Optional[str]] | None = None,
     synthesize_run: bool = True,
+    not_started: bool = False,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5766,6 +5767,8 @@ def block_task(
     worker ever starts; it keeps those capability events out of run history.
     ``expected_ready_snapshot`` makes a dispatcher preflight verdict a no-op
     if another writer changed or claimed the ready row in the meantime.
+    ``not_started=True`` marks blocks from an authoritative pre-start gate for
+    truthful notification wording; capability blocks do not imply this alone.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
@@ -5942,10 +5945,13 @@ def block_task(
                     outcome="blocked",
                     summary=reason,
                 )
+            blocked_payload = {
+                "reason": reason, "kind": kind, "recurrences": recurrences,
+            }
+            if not_started:
+                blocked_payload["not_started"] = True
             _append_event(
-                conn, task_id, "blocked",
-                {"reason": reason, "kind": kind, "recurrences": recurrences},
-                run_id=run_id,
+                conn, task_id, "blocked", blocked_payload, run_id=run_id,
             )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -8690,6 +8696,7 @@ def _dispatch_once_locked(
                     expected_ready_snapshot=(snapshot["assignee"], snapshot["skills"]),
                     # This never started a worker, so leave no run/attempt record.
                     synthesize_run=False,
+                    not_started=True,
                 )
             continue
         if dry_run:

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -155,6 +156,11 @@ def test_kanban_worker_blocks_removed_forced_skill_before_cli_construction(
         ).fetchone()
         assert dict(run) == {"status": "blocked", "outcome": "blocked"}
         assert row["consecutive_failures"] == 0
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked'",
+            (task_id,),
+        ).fetchone()
+        assert json.loads(event["payload"])["not_started"] is True
     finally:
         conn.close()
 

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -106,6 +106,96 @@ def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
         cli_mod.main(skills="missing-skill", list_tools=True)
 
 
+def test_kanban_worker_blocks_removed_forced_skill_before_cli_construction(
+    tmp_path, monkeypatch,
+):
+    """A dispatcher claim cannot start the model after a skill vanishes."""
+    from hermes_cli import kanban_db as kb
+
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "alpha"
+    skill_md = profile / "skills" / "vanished" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("---\nname: vanished\n---\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn, title="startup gate", assignee="alpha", skills=["vanished"]
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="dispatcher")
+        assert claimed is not None
+        skill_md.unlink()
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+        monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "dispatcher")
+
+        import cli as cli_mod
+
+        constructed = []
+        monkeypatch.setattr(
+            cli_mod, "HermesCLI", lambda **kwargs: constructed.append(kwargs)
+        )
+        cli_mod.main(skills="vanished", list_tools=True)
+
+        row = conn.execute(
+            "SELECT status, block_kind, claim_lock, current_run_id, consecutive_failures "
+            "FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        assert constructed == []
+        assert row["status"] == "blocked"
+        assert row["block_kind"] == "capability"
+        assert row["claim_lock"] is None
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id = ?",
+            (claimed.current_run_id,),
+        ).fetchone()
+        assert dict(run) == {"status": "blocked", "outcome": "blocked"}
+        assert row["consecutive_failures"] == 0
+    finally:
+        conn.close()
+
+
+def test_nested_cli_skill_mismatch_cannot_block_parent_kanban_claim(
+    tmp_path, monkeypatch,
+):
+    from hermes_cli import kanban_db as kb
+
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "alpha"
+    skill_md = profile / "skills" / "parent-skill" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("---\nname: parent-skill\n---\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn, title="parent claim", assignee="alpha", skills=["parent-skill"]
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="dispatcher")
+        assert claimed is not None
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+        monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "dispatcher")
+
+        import cli as cli_mod
+
+        assert cli_mod._block_missing_kanban_forced_skills(["nested-missing"]) is False
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == claimed.current_run_id
+        assert task.claim_lock == "dispatcher"
+    finally:
+        conn.close()
+
+
 def test_show_banner_does_not_print_skills():
     """show_banner() no longer prints the activated skills line — it moved to run()."""
     cli_obj = _make_real_cli(compact=False)

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -177,7 +177,9 @@ def test_capability_block_notification_says_worker_never_started(tmp_path, monke
     try:
         tid = kb.create_task(conn, title="release", assignee="alpha")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb.block_task(conn, tid, reason=reason, kind="capability")
+        kb.block_task(
+            conn, tid, reason=reason, kind="capability", not_started=True
+        )
     finally:
         conn.close()
 
@@ -192,6 +194,33 @@ def test_capability_block_notification_says_worker_never_started(tmp_path, monke
     assert "release-notes, api-review" in message
     assert "gave up" not in message
     assert "crashed" not in message
+
+
+def test_runtime_capability_block_notification_does_not_claim_worker_never_started(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "runtime-capability.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    reason = "credential unavailable after inspection"
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="inspect credentials", assignee="alpha")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    message = adapter.sent[0]["text"]
+    assert "blocked" in message
+    assert "blocked before start" not in message
+    assert reason in message
 
 
 def test_non_dispatch_gateway_claims_only_its_profile_subscriptions(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -167,6 +167,33 @@ def test_active_named_profile_subscription_is_delivered(tmp_path, monkeypatch):
     assert "blocked" in message
 
 
+def test_capability_block_notification_says_worker_never_started(tmp_path, monkeypatch):
+    """Dispatcher preflight blocks are actionable, not a worker crash/retry."""
+    db_path = tmp_path / "capability-preflight.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    reason = "Assignee alpha is missing required skill(s): release-notes, api-review"
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="release", assignee="alpha")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    message = adapter.sent[0]["text"]
+    assert "blocked before start" in message
+    assert "alpha" in message
+    assert "release-notes, api-review" in message
+    assert "gave up" not in message
+    assert "crashed" not in message
+
+
 def test_non_dispatch_gateway_claims_only_its_profile_subscriptions(
     tmp_path, monkeypatch,
 ):

--- a/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
+++ b/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -178,8 +179,10 @@ def test_dispatch_blocks_skill_removed_after_valid_create_without_starting(
     assert row["consecutive_failures"] == 0
     assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)).fetchone()[0] == 0
     assert [event["kind"] for event in events] == ["created", "blocked"]
-    assert "alpha" in events[-1]["payload"]
-    assert "removable" in events[-1]["payload"]
+    blocked_payload = json.loads(events[-1]["payload"])
+    assert "alpha" in blocked_payload["reason"]
+    assert "removable" in blocked_payload["reason"]
+    assert blocked_payload["not_started"] is True
 
 
 def test_dispatch_revalidates_a_reassigned_card_before_claim_or_spawn(

--- a/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
+++ b/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
@@ -1,0 +1,165 @@
+"""Kanban forced-skill capability preflight regression coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _write_skill(root: Path, name: str, *, directory: str | None = None) -> Path:
+    skill_dir = root / (directory or name)
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: {name}\ndescription: test skill\n---\n\nTest instructions.\n",
+        encoding="utf-8",
+    )
+    return skill_md
+
+
+@pytest.fixture
+def isolated_kanban_profiles(tmp_path, monkeypatch):
+    """A real shared board plus two isolated named profile homes."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    for profile in ("alpha", "beta"):
+        (home / "profiles" / profile / "skills").mkdir(parents=True)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn, home
+    finally:
+        conn.close()
+
+
+def test_create_task_rejects_all_missing_assignee_skills_before_insert(
+    isolated_kanban_profiles,
+):
+    conn, _home = isolated_kanban_profiles
+
+    with pytest.raises(ValueError, match=r"alpha.*missing-one.*missing-two"):
+        kb.create_task(
+            conn,
+            title="requires unavailable capabilities",
+            assignee="alpha",
+            skills=["missing-one", "missing-two"],
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_create_task_reports_only_partial_missing_assignee_skills(
+    isolated_kanban_profiles,
+):
+    conn, home = isolated_kanban_profiles
+    _write_skill(home / "profiles" / "alpha" / "skills", "available")
+
+    with pytest.raises(ValueError, match=r"alpha.*unavailable") as exc_info:
+        kb.create_task(
+            conn,
+            title="requires one unavailable capability",
+            assignee="alpha",
+            skills=["available", "unavailable"],
+        )
+
+    assert "required skill(s): unavailable." in str(exc_info.value)
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_create_task_accepts_target_local_and_external_skills(
+    isolated_kanban_profiles,
+):
+    conn, home = isolated_kanban_profiles
+    profile = home / "profiles" / "alpha"
+    _write_skill(profile / "skills", "bundled-like", directory="development/bundled-like")
+    external = home / "shared-skills"
+    _write_skill(external, "external-only")
+    (profile / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external}\n",
+        encoding="utf-8",
+    )
+
+    task_id = kb.create_task(
+        conn,
+        title="uses target capabilities",
+        assignee="alpha",
+        skills=["bundled-like", "external-only"],
+    )
+
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.skills == ["bundled-like", "external-only"]
+
+
+def test_dispatch_blocks_skill_removed_after_valid_create_without_starting(
+    isolated_kanban_profiles,
+):
+    conn, home = isolated_kanban_profiles
+    skill_md = _write_skill(home / "profiles" / "alpha" / "skills", "removable")
+    task_id = kb.create_task(
+        conn, title="skill can disappear", assignee="alpha", skills=["removable"]
+    )
+    skill_md.unlink()
+    spawned = []
+
+    kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: spawned.append(args) or 7)
+
+    row = conn.execute(
+        "SELECT status, block_kind, claim_lock, worker_pid, current_run_id, "
+        "consecutive_failures FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    events = list(conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+    ))
+    assert spawned == []
+    assert row["status"] == "blocked"
+    assert row["block_kind"] == "capability"
+    assert row["claim_lock"] is None
+    assert row["worker_pid"] is None
+    assert row["current_run_id"] is None
+    assert row["consecutive_failures"] == 0
+    assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)).fetchone()[0] == 0
+    assert [event["kind"] for event in events] == ["created", "blocked"]
+    assert "alpha" in events[-1]["payload"]
+    assert "removable" in events[-1]["payload"]
+
+
+def test_dispatch_revalidates_a_reassigned_card_before_claim_or_spawn(
+    isolated_kanban_profiles,
+):
+    conn, home = isolated_kanban_profiles
+    _write_skill(home / "profiles" / "alpha" / "skills", "alpha-only")
+    task_id = kb.create_task(
+        conn, title="reassigned after create", assignee="alpha", skills=["alpha-only"]
+    )
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET assignee = 'beta' WHERE id = ?", (task_id,))
+    spawned = []
+
+    kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: spawned.append(args) or 7)
+
+    row = conn.execute(
+        "SELECT status, block_kind, claim_lock, worker_pid, current_run_id, "
+        "consecutive_failures FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    blocked = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked'",
+        (task_id,),
+    ).fetchone()
+    assert spawned == []
+    assert row["status"] == "blocked"
+    assert row["block_kind"] == "capability"
+    assert row["claim_lock"] is None
+    assert row["worker_pid"] is None
+    assert row["current_run_id"] is None
+    assert row["consecutive_failures"] == 0
+    assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)).fetchone()[0] == 0
+    assert "beta" in blocked["payload"]
+    assert "alpha-only" in blocked["payload"]

--- a/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
+++ b/tests/hermes_cli/test_kanban_assignee_skill_preflight.py
@@ -71,12 +71,19 @@ def test_create_task_reports_only_partial_missing_assignee_skills(
     assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
 
 
-def test_create_task_accepts_target_local_and_external_skills(
+def test_create_task_accepts_runtime_resolved_local_external_plugin_and_legacy_skills(
     isolated_kanban_profiles,
 ):
     conn, home = isolated_kanban_profiles
     profile = home / "profiles" / "alpha"
     _write_skill(profile / "skills", "bundled-like", directory="development/bundled-like")
+    _write_skill(
+        profile / "skills", "plugin-local", directory="plugin-local/qualified"
+    )
+    (profile / "skills" / "legacy-flat.md").write_text(
+        "---\nname: legacy-flat\ndescription: legacy test skill\n---\n\nLegacy.\n",
+        encoding="utf-8",
+    )
     external = home / "shared-skills"
     _write_skill(external, "external-only")
     (profile / "config.yaml").write_text(
@@ -88,12 +95,57 @@ def test_create_task_accepts_target_local_and_external_skills(
         conn,
         title="uses target capabilities",
         assignee="alpha",
-        skills=["bundled-like", "external-only"],
+        skills=["bundled-like", "external-only", "plugin-local:qualified", "legacy-flat"],
     )
 
     task = kb.get_task(conn, task_id)
     assert task is not None
-    assert task.skills == ["bundled-like", "external-only"]
+    assert task.skills == [
+        "bundled-like", "external-only", "plugin-local:qualified", "legacy-flat",
+    ]
+
+
+def test_create_task_accepts_external_skill_configured_by_target_profile_dotenv(
+    isolated_kanban_profiles, monkeypatch,
+):
+    conn, home = isolated_kanban_profiles
+    profile = home / "profiles" / "alpha"
+    external = home / "dotenv-skills"
+    _write_skill(external, "dotenv-only")
+    (profile / ".env").write_text(f"SKILL_ROOT={external}\n", encoding="utf-8")
+    (profile / "config.yaml").write_text(
+        "skills:\n  external_dirs:\n    - ${SKILL_ROOT}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("SKILL_ROOT", raising=False)
+
+    task_id = kb.create_task(
+        conn, title="uses target dotenv", assignee="alpha", skills=["dotenv-only"]
+    )
+
+    assert kb.get_task(conn, task_id).skills == ["dotenv-only"]
+
+
+def test_create_task_rejects_skill_disabled_in_target_profile(
+    isolated_kanban_profiles,
+):
+    conn, home = isolated_kanban_profiles
+    profile = home / "profiles" / "alpha"
+    _write_skill(profile / "skills", "disabled-on-disk")
+    (profile / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - disabled-on-disk\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"alpha.*disabled-on-disk"):
+        kb.create_task(
+            conn,
+            title="must not force disabled skill",
+            assignee="alpha",
+            skills=["disabled-on-disk"],
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
 
 
 def test_dispatch_blocks_skill_removed_after_valid_create_without_starting(
@@ -163,3 +215,60 @@ def test_dispatch_revalidates_a_reassigned_card_before_claim_or_spawn(
     assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)).fetchone()[0] == 0
     assert "beta" in blocked["payload"]
     assert "alpha-only" in blocked["payload"]
+
+
+def test_dispatch_refuses_claim_when_assignee_changes_after_preflight(
+    isolated_kanban_profiles, monkeypatch,
+):
+    conn, home = isolated_kanban_profiles
+    _write_skill(home / "profiles" / "alpha" / "skills", "alpha-only")
+    task_id = kb.create_task(
+        conn, title="racy assignee", assignee="alpha", skills=["alpha-only"]
+    )
+    real_resolve = kb.resolve_assignee_skills
+
+    def change_assignee_after_resolution(assignee, skills):
+        resolved = real_resolve(assignee, skills)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET assignee = 'beta' WHERE id = ?", (task_id,))
+        return resolved
+
+    monkeypatch.setattr(kb, "resolve_assignee_skills", change_assignee_after_resolution)
+    spawned = []
+    kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: spawned.append(args) or 7)
+
+    row = conn.execute(
+        "SELECT status, assignee, claim_lock, current_run_id, consecutive_failures "
+        "FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert spawned == []
+    assert dict(row) == {
+        "status": "ready", "assignee": "beta", "claim_lock": None,
+        "current_run_id": None, "consecutive_failures": 0,
+    }
+
+
+def test_stale_missing_preflight_does_not_block_a_new_running_claim(
+    isolated_kanban_profiles, monkeypatch,
+):
+    conn, home = isolated_kanban_profiles
+    _write_skill(home / "profiles" / "alpha" / "skills", "race-skill")
+    task_id = kb.create_task(
+        conn, title="stale missing verdict", assignee="alpha", skills=["race-skill"]
+    )
+
+    def claim_before_missing_verdict(_assignee, _skills):
+        assert kb.claim_task(conn, task_id, claimer="contender") is not None
+        return []
+
+    monkeypatch.setattr(kb, "resolve_assignee_skills", claim_before_missing_verdict)
+    kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: pytest.fail("must not spawn"))
+
+    row = conn.execute(
+        "SELECT status, claim_lock, current_run_id, consecutive_failures "
+        "FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert row["status"] == "running"
+    assert row["claim_lock"] == "contender"
+    assert row["current_run_id"] is not None
+    assert row["consecutive_failures"] == 0


### PR DESCRIPTION
## Summary

Kanban task-level `skills` are a hard worker capability requirement, but the current dispatch path can accept a task and later start a worker that cannot actually load them. This closes that bug class at each authoritative boundary:

- validate forced skills at task creation against the **target assignee profile**;
- use the same forced-skill resolver as runtime, including disabled skills, plugin and legacy sources, external skill directories, and target-profile dotenv settings;
- revalidate immediately before claim, binding both claim and capability-block writes to the observed ready/unclaimed/assignee/serialized-skills snapshot;
- perform one final claim-bound child-startup check before CLI/model/tool construction, so filesystem changes after claim cannot start a worker without its required skills;
- classify pre-start failures as typed capability blocks without consuming retry/failure budget; and
- emit an explicit `not_started` event discriminator so notifications say "blocked before start" only for authoritative pre-start gates, while runtime capability blocks say only "blocked."

No schema, migration, service, endpoint, or generalized state-machine change is introduced.

## Relationship to #33747

I reviewed #33747 before preparing this PR. It addresses the same user-visible symptom with a dispatcher-time local skill scan in `hermes_cli/kanban_db.py` plus focused tests. That is useful coverage, but it does not cover the full failure window reproduced here: creation-time validation, runtime-equivalent disabled/plugin/legacy/external resolution, snapshot-bound claim/block CAS, post-claim filesystem drift at child startup, retry/failure accounting, or the explicit notification discriminator.

This PR therefore is not a duplicate of that two-file preflight proposal; it fixes the broader capability-invariant and race class while keeping the implementation bounded to the existing Kanban, skill-loading, CLI-startup, and notifier paths.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_assignee_skill_preflight.py tests/cli/test_cli_preloaded_skills.py tests/gateway/test_kanban_notifier.py -q` — 24 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/cli/test_cli_preloaded_skills.py tests/gateway/test_kanban_notifier.py -q` — 185 passed
- `uv run ruff check agent/skill_commands.py cli.py gateway/kanban_watchers.py hermes_cli/kanban_db.py tests/cli/test_cli_preloaded_skills.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_assignee_skill_preflight.py` — passed
- `git diff --check upstream/main...HEAD` — passed
