### PR TITLE
fix(codex): preserve scaled large-request TTFB tier

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -227,6 +227,41 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _resolve_openai_codex_ttfb_timeout(
+    *,
+    base_timeout: float,
+    estimated_tokens: int,
+    idle_timeout: float,
+) -> float:
+    """Resolve the finite no-byte cutoff for one OpenAI Codex request.
+
+    Large requests use the existing context-scaled idle tier instead of
+    disabling first-byte recovery. The default maximum matches the ladder's
+    180-second top tier; an operator override can still impose a lower cap.
+    """
+    timeout = base_timeout
+    large_request_threshold = _env_float(
+        "HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0
+    )
+    strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if (
+        not strict
+        and large_request_threshold > 0
+        and estimated_tokens >= large_request_threshold
+    ):
+        timeout = max(timeout, idle_timeout)
+
+    max_timeout = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 180.0)
+    if max_timeout > 0:
+        timeout = min(timeout, max_timeout)
+    return timeout
+
+
 def _estimate_chunk_bytes(chunk: Any) -> int:
     """Cheap per-chunk size estimate for the stream diagnostic counters.
 
@@ -821,12 +856,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # main retry loop can reconnect promptly. Large subscription-backed Codex
     # requests can legitimately spend tens of seconds in backend admission /
     # prompt prefill before the first SSE event, so the no-byte TTFB watchdog
-    # is disabled for large chatgpt.com/backend-api/codex requests. A second
-    # failure mode emits an opening SSE frame and then stalls forever in SSL
-    # read; for that we watch the gap since the last Codex stream event. This
-    # matches Codex CLI's stream_idle_timeout model: any valid SSE event is
-    # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
-    # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
+    # scales with request size instead of being disabled for large requests. A
+    # second failure mode emits an opening SSE frame and then stalls forever in
+    # SSL read; for that we watch the gap since the last Codex stream event.
+    # This matches Codex CLI's stream_idle_timeout model: any valid SSE event is
+    # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS,
+    # HERMES_CODEX_TTFB_MAX_SECONDS, and
+    # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each watchdog/cap).
     _codex_watchdog_enabled = agent.api_mode == "codex_responses"
     _openai_codex_backend = _is_openai_codex_backend(agent)
     _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
@@ -879,37 +915,21 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
-        _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
-            "1", "true", "yes", "on"
-        }
-        if (
-            not _ttfb_strict
-            and _ttfb_disable_above > 0
-            and _est_tokens_for_codex_watchdog >= _ttfb_disable_above
-        ):
-            _large_request_ttfb_timeout = _codex_idle_timeout_default
-            if _ttfb_timeout < _large_request_ttfb_timeout:
-                logger.info(
-                    "Scaling openai-codex no-byte TTFB watchdog from %.0fs to %.0fs "
-                    "for large request (context=~%s tokens >= %.0f). "
-                    "Set HERMES_CODEX_TTFB_STRICT=1 to keep the smaller cutoff.",
-                    _ttfb_timeout,
-                    _large_request_ttfb_timeout,
-                    f"{_est_tokens_for_codex_watchdog:,}",
-                    _ttfb_disable_above,
-                )
-                _ttfb_timeout = _large_request_ttfb_timeout
-        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
-        if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
-            logger.info(
-                "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
-                "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.",
+        _base_ttfb_timeout = _ttfb_timeout
+        _ttfb_timeout = _resolve_openai_codex_ttfb_timeout(
+            base_timeout=_base_ttfb_timeout,
+            estimated_tokens=_est_tokens_for_codex_watchdog,
+            idle_timeout=_codex_idle_timeout_default,
+        )
+        if _ttfb_timeout != _base_ttfb_timeout:
+            logger.debug(
+                "Adjusted openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
+                "for request context=~%s tokens. Set HERMES_CODEX_TTFB_STRICT=1 "
+                "to keep the base cutoff or HERMES_CODEX_TTFB_MAX_SECONDS to cap it.",
+                _base_ttfb_timeout,
                 _ttfb_timeout,
-                _ttfb_cap,
                 f"{_est_tokens_for_codex_watchdog:,}",
             )
-            _ttfb_timeout = _ttfb_cap
 
     _codex_idle_enabled = _codex_watchdog_enabled
     _codex_idle_timeout = _env_float(

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -16,6 +16,7 @@ stall.
 
 from __future__ import annotations
 
+import logging
 import sys
 import time
 import types
@@ -57,8 +58,76 @@ def _make_codex_agent(tmp_path, monkeypatch):
     return agent
 
 
+def test_large_codex_request_default_preserves_scaled_ttfb_timeout(monkeypatch):
+    """The default max must not undo the 180s >100k-token timeout tier."""
+    from agent import chat_completion_helpers as h
+
+    for name in (
+        "HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS",
+        "HERMES_CODEX_TTFB_STRICT",
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert h._resolve_openai_codex_ttfb_timeout(
+        base_timeout=120.0,
+        estimated_tokens=125_000,
+        idle_timeout=180.0,
+    ) == 180.0
 
 
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "expected"),
+    [
+        ("HERMES_CODEX_TTFB_MAX_SECONDS", "150", 150.0),
+        ("HERMES_CODEX_TTFB_STRICT", "1", 120.0),
+    ],
+)
+def test_large_codex_request_preserves_operator_ttfb_overrides(
+    monkeypatch, env_name, env_value, expected
+):
+    """Explicit caps and strict mode continue to override size scaling."""
+    for name in (
+        "HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS",
+        "HERMES_CODEX_TTFB_STRICT",
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, env_value)
+
+    from agent import chat_completion_helpers as h
+
+    assert h._resolve_openai_codex_ttfb_timeout(
+        base_timeout=120.0,
+        estimated_tokens=125_000,
+        idle_timeout=180.0,
+    ) == expected
+
+
+def test_routine_large_request_ttfb_adjustment_is_not_info_spam(
+    tmp_path, monkeypatch, caplog
+):
+    """Per-request timeout policy is diagnostic detail, not an INFO event."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(h, "estimate_request_context_tokens", lambda _kwargs: 125_000)
+    response = SimpleNamespace(ok=True)
+    monkeypatch.setattr(
+        h,
+        "_dispatch_nonstreaming_api_request",
+        lambda *_args, **_kwargs: response,
+    )
+
+    with caplog.at_level(logging.INFO, logger=h.logger.name):
+        result = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert result is response
+    assert not any(
+        "openai-codex no-byte TTFB timeout" in record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.INFO
+    )
 
 
 def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
@@ -294,19 +363,18 @@ def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
 
 
 def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkeypatch):
-    """#64507 regression: a large Codex request (TTFB watchdog disabled by the
-    size gate, stale floor *raised*) that never emits a single byte must still
-    be reclaimed at a finite hard ceiling — not hang for 13+ minutes while the
-    worker stays idle and the session shows as active.
+    """#64507 regression: a large Codex request with a raised stale floor that
+    never emits a single byte must still be reclaimed at a finite hard ceiling
+    — not hang for 13+ minutes while the worker stays idle and the session
+    shows as active.
 
     Uses the real default TTFB threshold (120s) and asserts the request dies at
-    the hard ceiling regardless of the size-based TTFB disable.
+    the lower hard ceiling before either watchdog tier.
     """
     from agent import chat_completion_helpers as h
 
     agent = _make_codex_agent(tmp_path, monkeypatch)
-    # Real default TTFB threshold (no HERMES_CODEX_TTFB_* override) → for a
-    # >10k-token request the no-byte TTFB watchdog is auto-disabled.
+    # Real default TTFB threshold (no HERMES_CODEX_TTFB_* override).
     monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "3")
 
     closes: list = []
@@ -332,7 +400,7 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
 
-    large_input = "x" * 44_000  # ~11k estimated tokens → TTFB disabled, stale raised
+    large_input = "x" * 44_000  # ~11k estimated tokens → stale floor raised
     t0 = time.time()
     try:
         with pytest.raises(TimeoutError) as excinfo:


### PR DESCRIPTION
## Summary

Large OpenAI Codex requests currently emit two contradictory INFO lines on every call: the watchdog scales from 120s to 180s, then the default max immediately caps it back to 120s. That makes the >100k-token tier introduced by #64594 dead under default settings and floods normal logs.

This change:
- resolves scaling and capping in one pure policy helper;
- aligns the default max with the existing 180s top tier;
- preserves strict mode, explicit max caps, cap disable, and threshold disable semantics;
- moves routine per-request adjustment telemetry to DEBUG;
- corrects stale comments that still described large-request TTFB as disabled.

## Reproduction

With default TTFB environment and an estimated request above 100k tokens, current `main` logs both:

```text
Scaling openai-codex no-byte TTFB watchdog from 120s to 180s ...
Capping openai-codex no-byte TTFB timeout from 180s to 120s ...
```

## Validation

- `pytest tests/agent/test_codex_ttfb_watchdog.py -q` — 12 passed
- `pytest tests/agent/test_codex_gpt55_autoraise_notice.py tests/hermes_cli/test_gpt56_registration.py -q` — 11 passed
- `ruff check .` — passed (one pre-existing invalid-noqa warning)
- `git diff --check` — passed
- independent review of exact diff SHA-256 `57139411a1be44f642de2bfac99f29429dedc019bed97d199c135052d024f41e` — approved, no blocking logic or security findings

Related: #61778, #64594