### PR TITLE
fix(mcp): honor config.yaml enabled:false for explicit MCP registration

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2527,6 +2527,106 @@ class TestRegisterMcpServers:
         _servers.pop("srv_a", None)
         _servers.pop("srv_b", None)
 
+    def test_skips_servers_disabled_in_config_yaml(self, monkeypatch, tmp_path):
+        """config.yaml ``mcp_servers.<name>.enabled: false`` is a hard override
+        for explicit registration calls carrying client-supplied configs (ACP
+        session ``mcpServers``, #71948)."""
+        from tools.mcp_tool import register_mcp_servers, _servers
+
+        (tmp_path / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  node_repl:\n"
+            "    command: /bin/false\n"
+            "    enabled: false\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            # ACP-style payload: no ``enabled`` key in the passed config.
+            result = register_mcp_servers({"node_repl": {"command": "/bin/false"}})
+
+        assert connect_calls == [], (
+            "Server disabled in config.yaml must not be spawned, even when "
+            "registration is requested with a client-supplied config"
+        )
+        assert "node_repl" not in _servers
+        assert result == []
+
+    def test_config_enabled_false_only_blocks_that_name(self, monkeypatch, tmp_path):
+        """A disabled name is skipped while other servers in the same
+        registration batch still connect."""
+        from tools.mcp_tool import register_mcp_servers, _servers
+
+        (tmp_path / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  node_repl:\n"
+            "    command: /bin/false\n"
+            "    enabled: false\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            result = register_mcp_servers({
+                "node_repl": {"command": "/bin/false"},
+                "ok-server": {"command": "npx", "args": ["test"]},
+            })
+
+        assert connect_calls == ["ok-server"]
+        assert "node_repl" not in _servers
+        assert "ok-server" in _servers
+        _servers.pop("ok-server", None)
+
+    def test_safe_mode_refuses_dynamic_registration(self, monkeypatch, tmp_path):
+        """HERMES_SAFE_MODE refuses client-supplied MCP servers outright —
+        the config lookup is empty in safe mode, so without this guard an ACP
+        injection would bypass the enabled:false override (#71948)."""
+        from tools.mcp_tool import register_mcp_servers, _servers
+
+        # Safe mode with NO config.yaml at all — the worst case for the
+        # config-priority lookup.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            result = register_mcp_servers({
+                "node_repl": {"command": "/bin/false"},
+                "ok-server": {"command": "npx", "args": ["test"]},
+            })
+
+        assert connect_calls == [], "safe mode must refuse dynamic servers"
+        assert result == []
+        assert not _servers
+
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6239,6 +6239,55 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
+    # HERMES_SAFE_MODE loads no config servers (_load_mcp_config returns {}),
+    # so the config-priority lookup below would be empty there. Refuse dynamic
+    # registration outright in safe mode: the point of SAFE_MODE is minimal
+    # exposure, and a client-supplied MCP definition is a local process launch
+    # request (ACP session ``mcpServers``, #71948). Deliberately fail-closed:
+    # no try/except around this guard — a failure to evaluate safe mode must
+    # not silently admit a dynamic server.
+    from utils import env_var_enabled as _env_enabled
+    if _env_enabled("HERMES_SAFE_MODE"):
+        for name in sorted(servers):
+            logger.warning(
+                "MCP server '%s': refusing registration in "
+                "HERMES_SAFE_MODE (dynamic MCP servers are disabled); "
+                "skipping",
+                name,
+            )
+        return []
+
+    # Honor explicit user opt-outs from config.yaml. ``register_mcp_servers``
+    # is also called with client-supplied configs — ACP sessions pass their
+    # own ``mcpServers`` list (acp_adapter/server.py:_register_session_mcp_servers)
+    # that never carries an ``enabled`` key, so a co-installed app could
+    # force-start a server the user disabled (#71948). config.yaml is the
+    # single source of truth: ``mcp_servers.<name>.enabled: false`` overrides
+    # any registration attempt, matching the discovery path which pre-filters
+    # the same key before calling us (lines 6483-6489, 6559-6574).
+    user_servers = _load_mcp_config()
+    disabled_by_user = {
+        name
+        for name, cfg in user_servers.items()
+        if isinstance(cfg, dict)
+        and not _parse_boolish(cfg.get("enabled", True), default=True)
+    }
+    if disabled_by_user:
+        for name in sorted(disabled_by_user & set(servers)):
+            logger.info(
+                "MCP server '%s': registration requested (e.g. via an ACP "
+                "session) but disabled in config.yaml "
+                "(mcp_servers.%s.enabled: false); skipping",
+                name, name,
+            )
+        servers = {
+            name: cfg for name, cfg in servers.items()
+            if name not in disabled_by_user
+        }
+        if not servers:
+            logger.debug("All explicit MCP servers are disabled in config.yaml")
+            return []
+
     # Only attempt servers that aren't already connected (or currently
     # connecting) and are enabled.  Checking ``_server_connecting`` prevents
     # duplicate subprocess spawns when ``discover_mcp_tools()`` is called


### PR DESCRIPTION
## Summary

Fixes the config side of #71948: ACP sessions inject client-supplied MCP servers via `register_mcp_servers()`, and the client payload never carries an `enabled` key — so `mcp_servers.<name>.enabled: false` in `config.yaml` was silently ignored. A co-installed app (e.g. the ChatGPT desktop app's `ChatGPTHelper`, which injects a `node_repl` MCP server over ACP) could force-start a server the user explicitly disabled.

This PR makes `config.yaml` the single source of truth for MCP server enablement on **every** registration path:

- `register_mcp_servers()` now consults `_load_mcp_config()` and skips any server whose user-config entry has `enabled: false` — matching the discovery path, which already pre-filters the same key (the ACP path was the only gap).
- `HERMES_SAFE_MODE` now refuses dynamic MCP registration outright. Safe mode loads no config servers, so the config-priority lookup is empty there — without this guard, safe mode would be the *least* protected state against ACP-injected server definitions (which are local process launch requests).

The companion PR (resilience side) retires chronically dead parked servers after `_PARKED_PROBE_RETIRE_LIMIT` failed self-probes instead of probing every 5 minutes forever.

## Design decisions

- **Central placement in `register_mcp_servers`** rather than in the ACP adapter: covers every current and future injection path (ACP today, anything else later), and matches the function's own docstring ("Servers with `enabled: false` are skipped").
- **Hard override, not merge**: if the user disabled a name, the ACP-supplied definition for that name is dropped entirely. Name-keyed, so a same-name collision resolves in the user's favor.
- **Safe mode = no dynamic servers**: consistent with the mode's purpose (minimal exposure); the user's own config servers are still loaded via the normal discovery path.

## Verification

- 3 new unit tests in `tests/tools/test_mcp_tool.py` (disabled-name skip, batch with mixed enabled/disabled, safe-mode refusal).
- `pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_bridge_single_failure.py tests/tools/test_mcp_register_wakes_stale.py tests/tools/test_mcp_discovery_cross_process.py tests/acp/test_mcp_e2e.py tests/acp/test_server.py tests/acp/test_session.py` — all pass (121 tests).

## Notes

- **Open question:** should a config-disabled name that an ACP client keeps supplying log at INFO (current) or WARNING? INFO keeps repeated ACP session churn quiet; WARNING would surface the injection more prominently. Happy to adjust.
