### PR TITLE
fix(mcp): retire chronically dead parked servers instead of probing forever

### DIFF
--- a/tests/tools/test_mcp_parked_retirement.py
+++ b/tests/tools/test_mcp_parked_retirement.py
@@ -1,0 +1,213 @@
+"""Regression tests for parked-server retirement (#71948).
+
+A chronically dead MCP server — one whose initial connection fails and whose
+subsequent parked self-probes keep failing — must retire (deregister + stop)
+after ``_PARKED_PROBE_RETIRE_LIMIT`` failed probes instead of self-probing
+every ``_PARKED_RETRY_INTERVAL`` forever (the node_repl retry storm reported
+from ChatGPT desktop app ACP injection).
+"""
+
+import asyncio
+import pytest
+
+from tools import mcp_tool
+
+
+def _reset_mcp_state(mcp_tool) -> None:
+    mcp_tool.shutdown_mcp_servers()
+    with mcp_tool._lock:
+        mcp_tool._servers.clear()
+        mcp_tool._server_connecting.clear()
+        mcp_tool._server_connect_errors.clear()
+        mcp_tool._server_connect_retry_after.clear()
+        mcp_tool._server_connect_failures.clear()
+
+
+def _cleanup_mcp_state(mcp_tool, created=()) -> None:
+    try:
+        mcp_tool.shutdown_mcp_servers()
+    except Exception:
+        pass
+    with mcp_tool._lock:
+        mcp_tool._servers.clear()
+        mcp_tool._server_connecting.clear()
+        mcp_tool._server_connect_errors.clear()
+        mcp_tool._server_connect_retry_after.clear()
+        mcp_tool._server_connect_failures.clear()
+    for server in created:
+        task = getattr(server, "_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+
+
+def _wait_until(predicate, timeout=10.0, interval=0.02) -> bool:
+    """Poll a predicate across threads (the MCP task runs on its own loop)."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+class _FailingServerTask(mcp_tool.MCPServerTask):
+    """MCPServerTask subclass whose stdio transport always fails."""
+
+    created = []
+
+    def __init__(self, name):
+        self.__class__.created.append(self)
+        super().__init__(name)
+
+    async def _run_stdio(self, config):
+        raise ConnectionError("deterministic connection failure")
+
+
+def test_parked_server_retires_after_failed_probes(monkeypatch, tmp_path):
+    """A parked server whose self-probes keep failing retires: task ends,
+    entry removed from _servers, tracking maps cleaned."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    _reset_mcp_state(mcp_tool)
+    _FailingServerTask.created = []
+
+    monkeypatch.setattr(mcp_tool, "MCPServerTask", _FailingServerTask)
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 0)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.02)
+    monkeypatch.setattr(mcp_tool, "_PARKED_PROBE_RETIRE_LIMIT", 2)
+
+    try:
+        assert mcp_tool.register_mcp_servers({
+            "dead-server": {"command": "unused", "connect_timeout": 5}
+        }) == []
+
+        assert len(_FailingServerTask.created) == 1
+        server = _FailingServerTask.created[0]
+        with mcp_tool._lock:
+            assert mcp_tool._servers["dead-server"] is server
+
+        # Wait for the retirement path: 3 probe wakes (limit 2) with a
+        # 20ms park interval, then the task exits.
+        assert _wait_until(lambda: server._task.done()), (
+            "server task did not retire"
+        )
+
+        with mcp_tool._lock:
+            assert "dead-server" not in mcp_tool._servers, (
+                "retired server must be removed from _servers"
+            )
+            assert "dead-server" not in mcp_tool._server_connect_errors, (
+                "retired server's connect error must be cleaned up"
+            )
+            assert "dead-server" not in mcp_tool._server_connecting
+        assert server._parked_probe_failures > mcp_tool._PARKED_PROBE_RETIRE_LIMIT
+        assert server._task.done(), "retired task must have exited"
+    finally:
+        _cleanup_mcp_state(mcp_tool, _FailingServerTask.created)
+
+
+def test_retired_server_revives_via_re_registration(monkeypatch, tmp_path):
+    """After retirement a fresh registration creates a NEW task — the
+    explicit-revive path (/mcp refresh, next ACP session)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    _reset_mcp_state(mcp_tool)
+    _FailingServerTask.created = []
+
+    monkeypatch.setattr(mcp_tool, "MCPServerTask", _FailingServerTask)
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 0)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.02)
+    monkeypatch.setattr(mcp_tool, "_PARKED_PROBE_RETIRE_LIMIT", 1)
+    # No cooldown monkeypatch: retirement must clear the cooldown maps so a
+    # re-registration proceeds immediately (validates _retire_server cleanup).
+
+    try:
+        assert mcp_tool.register_mcp_servers({
+            "dead-server": {"command": "unused", "connect_timeout": 5}
+        }) == []
+        first = _FailingServerTask.created[0]
+        assert _wait_until(lambda: first._task.done()), (
+            "server task did not retire"
+        )
+        with mcp_tool._lock:
+            assert "dead-server" not in mcp_tool._servers
+
+        # Re-registration creates a fresh task (revive path).
+        mcp_tool.register_mcp_servers({
+            "dead-server": {"command": "unused", "connect_timeout": 5}
+        })
+        assert len(_FailingServerTask.created) == 2
+        second = _FailingServerTask.created[1]
+        assert second is not first
+        with mcp_tool._lock:
+            assert mcp_tool._servers["dead-server"] is second
+        # Let the second task finish its own retirement.
+        assert _wait_until(lambda: second._task.done()), (
+            "re-registered server task did not retire"
+        )
+    finally:
+        _cleanup_mcp_state(mcp_tool, _FailingServerTask.created)
+
+
+def test_wait_wake_classification_explicit_vs_probe():
+    """_wait_for_reconnect_or_shutdown distinguishes an explicit reconnect
+    request from a timed self-probe wake — the distinction that drives the
+    parked-probe counter (#71948)."""
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask("classify")
+
+    async def _drive():
+        server._reconnect_event.set()
+        assert await server._wait_for_reconnect_or_shutdown(timeout=5) == (
+            "reconnect"
+        )
+        # Event was cleared by the previous wake; a fresh wait times out.
+        assert await server._wait_for_reconnect_or_shutdown(timeout=0.05) == (
+            "probe"
+        )
+        # Shutdown takes precedence.
+        server._shutdown_event.set()
+        assert await server._wait_for_reconnect_or_shutdown(timeout=5) == (
+            "shutdown"
+        )
+
+    asyncio.run(_drive())
+
+
+def test_retirement_emits_warning_and_stops_probing(monkeypatch, tmp_path, caplog):
+    """Retirement is announced with a WARNING and the probe cycle stops —
+    the log-storm suppression property of #71948."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import logging
+
+    _reset_mcp_state(mcp_tool)
+    _FailingServerTask.created = []
+
+    monkeypatch.setattr(mcp_tool, "MCPServerTask", _FailingServerTask)
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 0)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.02)
+    monkeypatch.setattr(mcp_tool, "_PARKED_PROBE_RETIRE_LIMIT", 1)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+            assert mcp_tool.register_mcp_servers({
+                "dead-server": {"command": "unused", "connect_timeout": 5}
+            }) == []
+            server = _FailingServerTask.created[0]
+            assert _wait_until(lambda: server._task.done()), (
+                "server task did not retire"
+            )
+
+        assert any(
+            "retiring" in record.message
+            and "dead-server" in record.message
+            for record in caplog.records
+        ), "retirement must be announced with a WARNING"
+    finally:
+        _cleanup_mcp_state(mcp_tool, _FailingServerTask.created)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -340,6 +340,13 @@ _MAX_BACKOFF_SECONDS = 60
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+# Consecutive failed parked self-probes after which a chronically dead
+# server is retired (#71948): deregistered and its task stopped, instead of
+# self-probing every _PARKED_RETRY_INTERVAL forever. With the default 300s
+# interval, 3 failed probes = ~15 minutes of tolerance for transient
+# outages; an explicit reconnect (OAuth recovery, /mcp refresh) or a fresh
+# registration (new ACP session) revives the server with a new task.
+_PARKED_PROBE_RETIRE_LIMIT = 3
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
@@ -1840,6 +1847,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_parked_probe_failures",
     )
 
     def __init__(self, name: str):
@@ -1874,6 +1882,13 @@ class MCPServerTask:
         # until the session proves healthy again — used to log the
         # parked→revived transition exactly once.
         self._was_parked: bool = False
+        # Consecutive failed self-probes while parked. A parked server wakes
+        # every _PARKED_RETRY_INTERVAL and probes once; a probe that fails
+        # lands back in the park. After _PARKED_PROBE_RETIRE_LIMIT failed
+        # probes the server is retired (#71948) instead of probing forever.
+        # Reset by any successful transport return, an explicit reconnect
+        # request, or _mark_session_proven.
+        self._parked_probe_failures: int = 0
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -2218,6 +2233,7 @@ class MCPServerTask:
         if not self._session_proven:
             self._session_proven = True
             self._reconnect_retries = 0
+            self._parked_probe_failures = 0
             if self._was_parked:
                 self._was_parked = False
                 logger.warning(
@@ -2348,10 +2364,14 @@ class MCPServerTask:
 
         Returns:
             ``"shutdown"`` if the server should exit the run loop entirely,
-            ``"reconnect"`` if it should rebuild the transport (explicit
-            request or self-probe timeout). The reconnect event is cleared
-            before returning so the next park cycle starts from a fresh
-            signal. Shutdown takes precedence.
+            ``"reconnect"`` if it should rebuild the transport because an
+            EXPLICIT reconnect was requested (event set — OAuth recovery,
+            manual ``/mcp`` refresh), or ``"probe"`` when the wait timed out
+            (a scheduled self-probe wake, used to bound how many failed
+            self-probes a parked server is allowed before it retires —
+            #71948). The reconnect event is cleared before returning so the
+            next park cycle starts from a fresh signal. Shutdown takes
+            precedence.
         """
         shutdown_task = asyncio.ensure_future(self._shutdown_event.wait())
         reconnect_task = asyncio.ensure_future(self._reconnect_event.wait())
@@ -2371,8 +2391,11 @@ class MCPServerTask:
                         pass
         if self._shutdown_event.is_set():
             return "shutdown"
+        if self._reconnect_event.is_set():
+            self._reconnect_event.clear()
+            return "reconnect"
         self._reconnect_event.clear()
-        return "reconnect"
+        return "probe"
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
@@ -3152,6 +3175,9 @@ class MCPServerTask:
                         self.name, self._recycled_reason,
                     )
                     self.session = None
+                    # The transport was healthy enough to recycle — the
+                    # parked-probe budget does not apply to this server.
+                    self._parked_probe_failures = 0
                     await self._wait_for_lazy_reconnect()
                     if self._shutdown_event.is_set():
                         break
@@ -3167,8 +3193,12 @@ class MCPServerTask:
                 )
                 # A clean transport return means a session was established and
                 # then asked to rebuild (auth recovery / manual refresh /
-                # keepalive failure / transport TaskGroup drop). That alone is
-                # NOT proof of health: a flapping transport handshakes fine and
+                # keepalive failure / transport TaskGroup drop). The transport
+                # demonstrably works — reset the parked-probe budget so a
+                # later park starts from a fresh count (#71948).
+                self._parked_probe_failures = 0
+                # That alone is NOT proof of health: a flapping transport
+                # handshakes fine and
                 # drops moments later, and resetting the budget here let such
                 # servers respawn forever (#62212 — 6212 spawns in 63h).
                 # Only clear the consecutive-failure budget once the session
@@ -3198,6 +3228,17 @@ class MCPServerTask:
                         )
                         if parked == "shutdown":
                             break
+                        if parked == "probe":
+                            # Scheduled self-probe: count it. A chronically
+                            # dead server retires after the limit instead of
+                            # probing forever (#71948).
+                            if self._note_parked_probe():
+                                await self._retire_server()
+                                return
+                        else:
+                            # Explicit reconnect request (OAuth recovery,
+                            # /mcp refresh): fresh parked-probe budget.
+                            self._parked_probe_failures = 0
                         logger.debug(
                             "MCP server '%s': attempting revival from parked "
                             "state (self-probe or explicit reconnect request); "
@@ -3281,6 +3322,17 @@ class MCPServerTask:
                         )
                         if parked == "shutdown":
                             return
+                        if parked == "probe":
+                            # Scheduled self-probe: count it. A chronically
+                            # dead server retires after the limit instead of
+                            # probing forever (#71948).
+                            if self._note_parked_probe():
+                                await self._retire_server()
+                                return
+                        else:
+                            # Explicit reconnect request (OAuth recovery,
+                            # /mcp refresh): fresh parked-probe budget.
+                            self._parked_probe_failures = 0
                         logger.debug(
                             "MCP server '%s': attempting revival after "
                             "permanent initial failure (self-probe or explicit "
@@ -3313,6 +3365,17 @@ class MCPServerTask:
                         )
                         if parked == "shutdown":
                             return
+                        if parked == "probe":
+                            # Scheduled self-probe: count it. A chronically
+                            # dead server retires after the limit instead of
+                            # probing forever (#71948).
+                            if self._note_parked_probe():
+                                await self._retire_server()
+                                return
+                        else:
+                            # Explicit reconnect request (OAuth recovery,
+                            # /mcp refresh): fresh parked-probe budget.
+                            self._parked_probe_failures = 0
                         logger.debug(
                             "MCP server '%s': attempting revival after initial "
                             "connection failures (self-probe or explicit "
@@ -3371,6 +3434,17 @@ class MCPServerTask:
                     )
                     if parked == "shutdown":
                         return
+                    if parked == "probe":
+                        # Scheduled self-probe: count it. A chronically
+                        # dead server retires after the limit instead of
+                        # probing forever (#71948).
+                        if self._note_parked_probe():
+                            await self._retire_server()
+                            return
+                    else:
+                        # Explicit reconnect request (OAuth recovery,
+                        # /mcp refresh): fresh parked-probe budget.
+                        self._parked_probe_failures = 0
                     logger.debug(
                         "MCP server '%s': attempting revival from parked state "
                         "(permanent error; self-probe or explicit reconnect "
@@ -3410,6 +3484,17 @@ class MCPServerTask:
                     )
                     if parked == "shutdown":
                         return
+                    if parked == "probe":
+                        # Scheduled self-probe: count it. A chronically
+                        # dead server retires after the limit instead of
+                        # probing forever (#71948).
+                        if self._note_parked_probe():
+                            await self._retire_server()
+                            return
+                    else:
+                        # Explicit reconnect request (OAuth recovery,
+                        # /mcp refresh): fresh parked-probe budget.
+                        self._parked_probe_failures = 0
                     logger.debug(
                         "MCP server '%s': attempting revival from parked state "
                         "(self-probe or explicit reconnect request); "
@@ -3505,6 +3590,71 @@ class MCPServerTask:
             registry.deregister(tool_name)
             _forget_mcp_tool_server(tool_name)
         self._registered_tool_names = []
+
+    def _note_parked_probe(self) -> bool:
+        """Account for a failed parked self-probe wake.
+
+        Called when ``_wait_for_reconnect_or_shutdown`` returns ``"probe"``:
+        the previous probe cycle failed (that is why the task is parked) and
+        the timeout wake is another scheduled self-probe. Returns True once
+        ``_PARKED_PROBE_RETIRE_LIMIT`` consecutive probes have FAILED, so the
+        caller should retire the server instead of probing again.
+
+        Counter semantics: the counter increments on a probe wake and the
+        probe attempt happens after the check, so with the ``> limit`` test
+        the server gets exactly ``_PARKED_PROBE_RETIRE_LIMIT`` genuine probe
+        attempts (wakes 1..limit) and retires on the (limit+1)-th wake, when
+        all of them failed.
+        """
+        self._parked_probe_failures += 1
+        if self._parked_probe_failures > _PARKED_PROBE_RETIRE_LIMIT:
+            logger.warning(
+                "MCP server '%s': %d consecutive failed self-probes while "
+                "parked (limit %d), retiring until an explicit reconnect or "
+                "re-registration (state: parked → retired)",
+                self.name, self._parked_probe_failures,
+                _PARKED_PROBE_RETIRE_LIMIT,
+            )
+            return True
+        return False
+
+    async def _retire_server(self) -> None:
+        """Permanently stop a chronically dead parked server.
+
+        Deregisters its tools and removes it from the module-global
+        ``_servers`` registry and all per-server tracking maps, then the run
+        loop exits. A later explicit registration (new ACP session, ``/mcp``
+        refresh, discovery pass) creates a fresh task, which is the intended
+        revive path — clearing the cooldown maps here is what lets that
+        re-registration proceed immediately instead of inheriting stale
+        backoff.
+
+        Removing the server from ``_servers`` first is what makes exiting
+        safe — the #16788 wedge (a returned task still owned by ``_servers``
+        with no reconnect listener) does not apply once the name is gone.
+
+        Note: ``_deregister_tools`` must stay OUTSIDE the ``_lock`` block —
+        it acquires ``_lock`` itself (via ``_forget_mcp_tool_server``) and
+        ``_lock`` is a non-reentrant ``threading.Lock``.
+        """
+        self._deregister_tools()
+        # All map mutations are scoped to the identity guard: if a same-name
+        # server was re-registered while this task was retiring, it owns the
+        # name now and its fresh state must not be wiped by the stale instance.
+        with _lock:
+            if _servers.get(self.name) is self:
+                _servers.pop(self.name, None)
+                _server_connect_errors.pop(self.name, None)
+                _server_connecting.discard(self.name)
+                _server_connect_retry_after.pop(self.name, None)
+                _server_connect_failures.pop(self.name, None)
+                _parallel_safe_servers.discard(self.name)
+                # Lazy-registration state would otherwise make
+                # register_mcp_servers skip a re-registration of this name
+                # (#56832 lazy skip check), blocking the revive path.
+                _lazy_server_configs.pop(self.name, None)
+                _lazy_server_fingerprints.pop(self.name, None)
+                _lazy_server_tool_names.pop(self.name, None)
 
     async def _wait_for_lazy_reconnect(self) -> None:
         """Wait while an intentionally recycled stdio server is dormant."""
@@ -5787,7 +5937,11 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
 def _existing_tool_names() -> List[str]:
     """Return tool names for all currently connected servers."""
     names: List[str] = []
-    for _sname, server in _servers.items():
+    # Snapshot under the lock: a parked server can retire itself (removing
+    # its entry) from the MCP loop thread while this iterates (#71948).
+    with _lock:
+        servers_snapshot = list(_servers.items())
+    for _sname, server in servers_snapshot:
         if hasattr(server, "_registered_tool_names"):
             names.extend(server._registered_tool_names)
             continue


### PR DESCRIPTION
## Summary

Closes #71948 (resilience side). A parked `MCPServerTask` self-probes every `_PARKED_RETRY_INTERVAL` (300s) **forever**. For a server whose handshake always fails — e.g. the `node_repl` MCP server the ChatGPT desktop app's `ChatGPTHelper` injects via ACP — that is a perpetual 5-minute retry storm: WARNING log pollution, repeated process spawns, and event-loop stalls during each attempt.

This PR adds a retirement path to the parked state:

- `_wait_for_reconnect_or_shutdown()` now distinguishes an **explicit reconnect request** (`"reconnect"` — OAuth recovery, manual `/mcp` refresh) from a **timed self-probe wake** (`"probe"`).
- After `_PARKED_PROBE_RETIRE_LIMIT` (3) consecutive **failed** self-probes (~15 minutes), the server is retired: tools deregistered, entry removed from `_servers` and the per-server tracking maps under the lock, task exits.
- The counter resets on any successful transport return, an explicit reconnect wake, or a proven session (`_mark_session_proven`), so a flaky-but-recoverable server is never retired on a transient blip.
- Revive path: an explicit reconnect or a fresh registration (new ACP session, `/mcp refresh`) creates a new task. Removing the server from `_servers` first is what makes task exit safe — the #16788 wedge (returned task still owned by `_servers` with no reconnect listener) doesn't apply.
- `_existing_tool_names()` now snapshots `_servers` under the lock, since retirement is a new concurrent mutation site (the task runs on the MCP loop thread).

Net effect for the reported scenario: one spawn + 3 probe cycles per ACP injection, then silence — instead of infinite 5-minute probes.

The companion PR (config side) makes `mcp_servers.<name>.enabled: false` a hard override for ACP-injected servers, giving users an opt-out.

## Design decisions

- **Retire after 3 failed probes, not 1**: 15 minutes of tolerance for transient outages; the issue's reported pain (10k+ log lines/day) comes from the *endlessness*, not from a few probes.
- **Retirement is not permanent**: re-registration (next ACP session, `/mcp refresh`) revives the server with a fresh task. No sticky blocklist, no new config surface.
- **Counter placement**: increments on a `"probe"` wake (a failed probe is what lands the task back at a park site); the `> limit` check means the server gets 3 genuine probe attempts before retiring.

## Verification

- 4 new tests in `tests/tools/test_mcp_parked_retirement.py` (retire path + tracking-map cleanup, revive via re-registration, wake classification, retirement WARNING/log suppression).
- Full MCP + ACP suite: `pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_bridge_single_failure.py tests/tools/test_mcp_register_wakes_stale.py tests/tools/test_mcp_discovery_cross_process.py tests/tools/test_mcp_parked_retirement.py tests/acp/test_mcp_e2e.py tests/acp/test_server.py tests/acp/test_session.py` — all pass (123 tests).

## Notes

- **Open question:** the retirement threshold is a module constant (`_PARKED_PROBE_RETIRE_LIMIT = 3`). If maintainers prefer it configurable per-server (`mcp_servers.<name>.parked_probe_retire_limit`), that's a small follow-up.
