### PR TITLE
fix(gateway): multiplex mode no longer aliases per-profile sessions (#64934)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1716,13 +1716,32 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
+        """Prevent gateways from reviving a row that belongs to another routing key.
+
+        When ``multiplex_profiles`` is enabled, each profile's namespace is
+        encoded in the session key (``agent:<profile>:<platform>:...``). The
+        durable DB peer fallback matches on platform/chat/user/thread, so a row
+        created by one profile can be incorrectly resurrected under another
+        profile's session key, aliasing two routing keys to one session_id.
+        In multiplex mode we therefore require the recovered row's stored key
+        to either match exactly or be absent (legacy pre-key row).
+
+        When multiplexing is off, the legacy guard remains: a non-multiplexed
+        gateway may only revive rows whose profile namespace matches the active
+        profile, so a named-profile gateway does not accidentally reuse a row
+        from a different profile's history.
+        """
+        recovered_key = str(recovered.get("session_key") or "")
+        if not recovered_key:
+            # Pre-session-key legacy row; no key to conflict on.
+            return True
+        if recovered_key == requested_session_key:
             return True
 
-        recovered_key = str(recovered.get("session_key") or "")
-        if not recovered_key or recovered_key == requested_session_key:
-            return True
+        if getattr(self.config, "multiplex_profiles", False):
+            # Different session_key in multiplex mode = different profile or
+            # different routing peer; never alias across keys.
+            return False
 
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
@@ -1908,9 +1927,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s: recovered "
+                "session_key does not belong to this routing key",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -1968,9 +1986,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s: recovered "
+                "session_key does not belong to this routing key",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -10,10 +10,12 @@ Covers the three Phase 0 deliverables:
 """
 import pytest
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import patch
 import yaml
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_state import SessionDB
 from gateway.config import GatewayConfig, Platform
 from gateway.session import SessionSource, SessionStore, build_session_key
 
@@ -139,3 +141,171 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+class TestSessionStoreMultiplexedRecovery:
+    """With multiplex_profiles on, peer fallback must not alias profiles."""
+
+    def _store_with_row(self, tmp_path, row):
+        config = GatewayConfig(multiplex_profiles=True)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = _RecoveringDB(row)
+        store._loaded = True
+        return store
+
+    def test_different_profile_session_key_is_not_recovered(self, tmp_path):
+        """A row stored for agent:percy must not be reused under agent:claude."""
+        row = {
+            "id": "sess-percy",
+            "started_at": 1700000000,
+            "session_key": "agent:percy:mattermost:channel:ch1:user1",
+        }
+        store = self._store_with_row(tmp_path, row)
+        source = _src(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="claude",
+        )
+
+        recovered = store._recover_session_from_db(
+            session_key="agent:claude:mattermost:channel:ch1:user1",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is None
+        assert store._db.reopened == []
+
+    def test_matching_profile_session_key_is_recovered(self, tmp_path):
+        row = {
+            "id": "sess-claude",
+            "started_at": 1700000000,
+            "session_key": "agent:claude:mattermost:channel:ch1:user1",
+        }
+        store = self._store_with_row(tmp_path, row)
+        source = _src(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="claude",
+        )
+
+        recovered = store._recover_session_from_db(
+            session_key="agent:claude:mattermost:channel:ch1:user1",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-claude"
+        assert recovered.session_key == "agent:claude:mattermost:channel:ch1:user1"
+        assert store._db.reopened == ["sess-claude"]
+
+    def test_null_session_key_legacy_row_still_recovers(self, tmp_path):
+        """Pre-session-key rows with no key survive the multiplex guard."""
+        row = {
+            "id": "sess-legacy",
+            "started_at": 1700000000,
+            "session_key": None,
+        }
+        store = self._store_with_row(tmp_path, row)
+        source = _src(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="claude",
+        )
+
+        recovered = store._recover_session_from_db(
+            session_key="agent:claude:mattermost:channel:ch1:user1",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-legacy"
+        assert recovered.session_key == "agent:claude:mattermost:channel:ch1:user1"
+        assert store._db.reopened == ["sess-legacy"]
+
+    def test_query_recoverable_session_also_rejects_cross_profile(self, tmp_path):
+        """The no-lock helper used by get_or_create_session must apply the same guard."""
+        row = {
+            "id": "sess-percy",
+            "started_at": 1700000000,
+            "session_key": "agent:percy:mattermost:channel:ch1:user1",
+        }
+        store = self._store_with_row(tmp_path, row)
+        source = _src(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="claude",
+        )
+
+        recovered = store._query_recoverable_session(
+            session_key="agent:claude:mattermost:channel:ch1:user1",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is None
+        assert store._db.reopened == []
+
+
+class TestSessionStoreMultiplexedIsolation:
+    """Real DB integration: per-profile session keys stay distinct end-to-end."""
+
+    def _store(self, tmp_path):
+        config = GatewayConfig(multiplex_profiles=True)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = SessionDB(Path(tmp_path) / "state.db")
+        store._ensure_loaded()
+        return store
+
+    def test_two_profiles_same_channel_get_distinct_sessions(self, tmp_path):
+        """The bug #64934 multiplex variant: same chat/user must not collapse."""
+        store = self._store(tmp_path)
+        s_percy = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="percy",
+        )
+        s_claude = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="ch1",
+            chat_type="channel",
+            user_id="user1",
+            profile="claude",
+        )
+
+        e_percy = store.get_or_create_session(s_percy)
+        e_claude = store.get_or_create_session(s_claude)
+
+        assert e_percy.session_key == "agent:percy:mattermost:channel:ch1:user1"
+        assert e_claude.session_key == "agent:claude:mattermost:channel:ch1:user1"
+        assert e_percy.session_id != e_claude.session_id
+
+        # Restart: new store loads the same durable index.
+        store2 = self._store(tmp_path)
+        e2_percy = store2.get_or_create_session(s_percy)
+        e2_claude = store2.get_or_create_session(s_claude)
+        assert e2_percy.session_id == e_percy.session_id
+        assert e2_claude.session_id == e_claude.session_id
+
+        # DB rows themselves are keyed distinctly.
+        rows = [
+            store._db.get_session(e_percy.session_id),
+            store._db.get_session(e_claude.session_id),
+        ]
+        assert {r["session_key"] for r in rows} == {
+            e_percy.session_key,
+            e_claude.session_key,
+        }


### PR DESCRIPTION
Clean rebase of the multiplex session fix onto current NousResearch/main.

- gateway/session.py: include the Mattermost profile id in multiplex session keys so each profile on the same channel gets its own session.
- tests/gateway/test_multiplex_phase0.py: regression suite covering group/thread/DM keys and cross-profile isolation.

Closes #64934.