### PR TITLE
fix: summarize empty/malformed provider response (json.JSONDecodeError) into a readable one-liner

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2561,6 +2561,21 @@ class AIAgent:
                 )
             current = current.__cause__ or current.__context__
 
+        # Empty / malformed provider response body: the OpenAI/Anthropic
+        # SDK raises json.JSONDecodeError when the upstream returns 200 with
+        # an empty (or non-JSON) body — commonly a dead upstream channel
+        # behind a proxy that swallows a 502/EOF into an empty stream.
+        # Surface a readable one-liner instead of the raw
+        # "Expecting value: line 1 column 1 (char 0)" so users can tell it's
+        # an upstream outage, not a local config bug.
+        if isinstance(error, json.JSONDecodeError):
+            status_code = getattr(error, "status_code", None)
+            prefix = f"HTTP {status_code}: " if status_code else ""
+            return (
+                f"{prefix}Provider returned an empty or malformed response "
+                "(upstream may be down or connection cut mid-stream)"
+            )
+
         if (
             isinstance(error, ValueError)
             and "expected ident at line" in raw.lower()

--- a/tests/run_agent/test_summarize_json_decode_error.py
+++ b/tests/run_agent/test_summarize_json_decode_error.py
@@ -1,0 +1,50 @@
+"""Regression: json.JSONDecodeError from empty provider responses must be
+summarized into a readable one-liner.
+
+When an upstream (or a proxy in front of it) returns an HTTP 200 with an
+empty — or otherwise non-JSON — body, the OpenAI/Anthropic SDK raises
+``json.JSONDecodeError`` ("Expecting value: line 1 column 1 (char 0)").
+Before the fix, ``_summarize_api_error`` fell through to the raw
+``str(error)`` fallback, so the cryptic message reached cron delivery
+with no indication the provider channel was dead.
+"""
+import json
+
+from run_agent import AIAgent
+
+
+def _make_empty_response_error() -> json.JSONDecodeError:
+    """Simulate the SDK parsing an empty 200 response body."""
+    err = json.JSONDecodeError("Expecting value: line 1 column 1 (char 0)", "", 0)
+    err.status_code = 200
+    return err
+
+
+def test_summarize_json_decode_error_is_readable():
+    """``_summarize_api_error`` must turn a bare JSONDecodeError into a
+    readable one-liner about an empty/malformed upstream response."""
+    summary = AIAgent._summarize_api_error(_make_empty_response_error())
+
+    # The raw SDK message must not leak through.
+    assert "Expecting value" not in summary.lower()
+
+    # The summary should mention the HTTP status so the user can see it's
+    # a server-side issue, not a local config error.
+    assert "200" in summary
+
+    # A one-liner — not a multi-line traceback.
+    assert len(summary) < 200
+
+    # Must mention the actual problem (empty/malformed response).
+    assert "malformed" in summary.lower() or "empty" in summary.lower()
+
+
+def test_summarize_json_decode_error_no_status_code():
+    """Handle JSONDecodeError without a status_code attribute gracefully."""
+    err = json.JSONDecodeError("Expecting value: line 1 column 1 (char 0)", "", 0)
+    # Do NOT set status_code — some SDK paths don't attach it.
+    summary = AIAgent._summarize_api_error(err)
+
+    assert "Expecting value" not in summary.lower()
+    assert "malformed" in summary.lower() or "empty" in summary.lower()
+    assert len(summary) < 200


### PR DESCRIPTION
## Problem
When an upstream (or a proxy in front of it) returns an HTTP 200 with an empty (or otherwise non-JSON) body, the OpenAI/Anthropic SDK raises `json.JSONDecodeError` with a cryptic message like `Expecting value: line 1 column 1 (char 0)`. This is commonly a dead upstream channel behind a proxy that swallows a 502/EOF into an empty stream — but the raw error gave users no indication the provider was down, only an opaque JSON parse error.

For cron jobs (and interactive sessions using the same retry path), this meant delivery of a confusing `Expecting value: line 1 column 1 (char 0)` error with no actionable context.

## Fix
Add a `json.JSONDecodeError` branch to `_summarize_api_error` (run_agent.py) that returns a readable one-liner:

> `Provider returned an empty or malformed response (upstream may be down or connection cut mid-stream)`

The HTTP status code is included when available (e.g. `HTTP 200: Provider returned an empty or malformed response...`).

## Testing
- Added `tests/run_agent/test_summarize_json_decode_error.py` with two tests:
  - `test_summarize_json_decode_error_is_readable`: verifies the raw JSONDecodeError message is replaced by a readable summary that includes the HTTP status
  - `test_summarize_json_decode_error_no_status_code`: verifies graceful handling when `status_code` is not attached
- Existing `test_nonretryable_error_html_summary.py` continues to pass (Cloudflare HTML error pages still get their own branch).