### PR TITLE
fix: guard MCP stdio bridge against args=null in config

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -722,7 +722,7 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         "--ppid", str(my_pid),
         "--",
         command,
-        *args,
+        *(args or []),
     ]
     return sys.executable, watchdog_args
 
@@ -2384,7 +2384,7 @@ class MCPServerTask:
             )
 
         command = config.get("command")
-        args = config.get("args", [])
+        args = config.get("args") or []
         user_env = config.get("env")
 
         if not command:


### PR DESCRIPTION
## What

Fixes #80652

When an MCP server config entry has `args: null` or `args:` (no value in YAML), `config.get("args", [])` returns `None` because the key is present with value `None`. The `None` propagates to `_wrap_command_with_watchdog`, which unpacks it with `*args`, raising:

```
TypeError: Value after * must be an iterable, not NoneType
```

The server enters a `connecting -> parked` loop every ~5 minutes. Tools using a cached transport may still work, but any tool requiring a fresh MCP session handshake fails silently.

## Why

`dict.get(key, default)` returns `default` only when `key` is **absent**. When the key exists with value `None` (YAML `args:` or `args: null`), it returns `None`. This is a known Python gotcha.

`mcp_catalog.py:193` already handles this correctly with `transport_raw.get("args") or []`. The `mcp_tool.py` path was missed.

## How

Two one-line changes in `tools/mcp_tool.py`:

**1. Config read (line ~2387):**
```diff
-        args = config.get("args", [])
+        args = config.get("args") or []
```

**2. Watchdog wrapper defensive guard (line ~730):**
```diff
-        *args,
+        *(args or []),
```

Either change alone fixes the crash. Both together provide defense in depth.

## Testing

- `pytest tests/tools/test_mcp_schema_cache.py tests/tools/test_mcp_tool_issue_948.py tests/tools/test_mcp_reconnect_retry_reset.py` — 17 passed
- Manual reproduction: `*None` crashes, `*(None or [])` does not
- Verified YAML `args:` and `args: null` both produce `None` with `config.get("args", [])`