### PR TITLE
fix(desktop): keep SSH forwards alive across mux idle

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 import {
   baseSshOptions,
@@ -415,6 +415,37 @@ test('forward() issues -O forward with a loopback-bound -L spec', async () => {
   assert.equal(args[0], '-O')
   assert.equal(args[1], 'forward')
   assert.ok(args.includes('127.0.0.1:5000:127.0.0.1:6000'))
+  await conn.cancelForward(5000, 6000)
+})
+
+test('mux forward keeps the ControlPersist master alive until the final forward is cancelled', async () => {
+  vi.useFakeTimers()
+
+  try {
+    const spawnFn = scriptedSpawn({ code: 0 })
+
+    const conn = new SshConnection(
+      { host: 'box', user: 'me' },
+      { spawnFn, controlDir: '/tmp/d', controlKeepaliveMs: 1_000 }
+    )
+
+    await conn.forward(5000, 6000)
+    await conn.forward(5001, 6001)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    const checks = () => spawnFn.calls.filter(args => args[0] === '-O' && args[1] === 'check').length
+    assert.equal(checks(), 1, 'a tracked forward refreshes the ControlPersist timer')
+
+    await conn.cancelForward(5000, 6000)
+    await vi.advanceTimersByTimeAsync(1_000)
+    assert.equal(checks(), 2, 'cancelling one of several forwards keeps the refresh active')
+
+    await conn.cancelForward(5001, 6001)
+    await vi.advanceTimersByTimeAsync(2_000)
+    assert.equal(checks(), 2, 'cancelling the final forward stops the refresh timer')
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test('lifecycle logging passes through redaction', async () => {

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -13,6 +13,8 @@ import {
   buildInteractiveSshArgs,
   buildMasterArgs,
   classifySshError,
+  CONTROL_FORWARD_KEEPALIVE_MS,
+  CONTROL_PERSIST_SECONDS,
   controlSocketPath,
   createSshProbeConnection,
   forwardSpec,
@@ -426,22 +428,23 @@ test('mux forward keeps the ControlPersist master alive until the final forward 
 
     const conn = new SshConnection(
       { host: 'box', user: 'me' },
-      { spawnFn, controlDir: '/tmp/d', controlKeepaliveMs: 1_000 }
+      { spawnFn, controlDir: '/tmp/d' }
     )
 
     await conn.forward(5000, 6000)
     await conn.forward(5001, 6001)
-    await vi.advanceTimersByTimeAsync(1_000)
+    assert.ok(CONTROL_FORWARD_KEEPALIVE_MS < CONTROL_PERSIST_SECONDS * 1_000)
+    await vi.advanceTimersByTimeAsync(CONTROL_FORWARD_KEEPALIVE_MS)
 
     const checks = () => spawnFn.calls.filter(args => args[0] === '-O' && args[1] === 'check').length
     assert.equal(checks(), 1, 'a tracked forward refreshes the ControlPersist timer')
 
     await conn.cancelForward(5000, 6000)
-    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(CONTROL_FORWARD_KEEPALIVE_MS)
     assert.equal(checks(), 2, 'cancelling one of several forwards keeps the refresh active')
 
     await conn.cancelForward(5001, 6001)
-    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(CONTROL_FORWARD_KEEPALIVE_MS * 2)
     assert.equal(checks(), 2, 'cancelling the final forward stops the refresh timer')
   } finally {
     vi.useRealTimers()

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -40,7 +40,7 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 const DEFAULT_EXEC_TIMEOUT_MS = 20_000
 const DEFAULT_FORWARD_TIMEOUT_MS = 15_000
 const CONTROL_PERSIST_SECONDS = 300
-const DEFAULT_CONTROL_KEEPALIVE_MS = 60_000
+const CONTROL_FORWARD_KEEPALIVE_MS = Math.min(60_000, Math.floor((CONTROL_PERSIST_SECONDS * 1_000) / 2))
 
 // eslint-disable-next-line no-control-regex -- deliberately reject control chars in ssh targets
 const _CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/
@@ -471,7 +471,6 @@ class SshConnection {
   _mux: boolean
   _tunnels: Map<string, any>
   _forwardedSpecs: Set<string>
-  _controlKeepaliveMs: number
   _controlKeepaliveTimer: ReturnType<typeof setInterval> | null
 
   constructor(cfg, opts: any = {}) {
@@ -512,7 +511,6 @@ class SshConnection {
     this._connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
     this._execTimeoutMs = opts.execTimeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS
     this._forwardTimeoutMs = opts.forwardTimeoutMs ?? DEFAULT_FORWARD_TIMEOUT_MS
-    this._controlKeepaliveMs = opts.controlKeepaliveMs ?? DEFAULT_CONTROL_KEEPALIVE_MS
     this._controlKeepaliveTimer = null
     this._opened = false
   }
@@ -656,8 +654,10 @@ class SshConnection {
     }
 
     this._controlKeepaliveTimer = setInterval(() => {
+      // Remote liveness owns reconnect/teardown. Keep refreshing through a
+      // transient failed check rather than turning one timeout into expiry.
       void this.isAlive()
-    }, this._controlKeepaliveMs)
+    }, CONTROL_FORWARD_KEEPALIVE_MS)
     this._controlKeepaliveTimer.unref?.()
   }
 
@@ -943,6 +943,7 @@ export {
   buildInteractiveSshArgs,
   buildMasterArgs,
   classifySshError,
+  CONTROL_FORWARD_KEEPALIVE_MS,
   CONTROL_PERSIST_SECONDS,
   controlSocketPath,
   createSshProbeConnection,

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -40,6 +40,7 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 const DEFAULT_EXEC_TIMEOUT_MS = 20_000
 const DEFAULT_FORWARD_TIMEOUT_MS = 15_000
 const CONTROL_PERSIST_SECONDS = 300
+const DEFAULT_CONTROL_KEEPALIVE_MS = 60_000
 
 // eslint-disable-next-line no-control-regex -- deliberately reject control chars in ssh targets
 const _CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/
@@ -469,6 +470,9 @@ class SshConnection {
   _opened: boolean
   _mux: boolean
   _tunnels: Map<string, any>
+  _forwardedSpecs: Set<string>
+  _controlKeepaliveMs: number
+  _controlKeepaliveTimer: ReturnType<typeof setInterval> | null
 
   constructor(cfg, opts: any = {}) {
     if (!cfg || !cfg.host) {
@@ -500,6 +504,7 @@ class SshConnection {
         })
       : ''
     this._tunnels = new Map()
+    this._forwardedSpecs = new Set()
 
     this._spawnFn = opts.spawnFn || spawn
 
@@ -507,6 +512,8 @@ class SshConnection {
     this._connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
     this._execTimeoutMs = opts.execTimeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS
     this._forwardTimeoutMs = opts.forwardTimeoutMs ?? DEFAULT_FORWARD_TIMEOUT_MS
+    this._controlKeepaliveMs = opts.controlKeepaliveMs ?? DEFAULT_CONTROL_KEEPALIVE_MS
+    this._controlKeepaliveTimer = null
     this._opened = false
   }
 
@@ -637,6 +644,30 @@ class SshConnection {
     } catch {
       return false
     }
+  }
+
+  // `ssh -O forward` does not keep a ControlPersist master busy by itself.
+  // Refresh the mux while Desktop owns local forwards so the 300s idle timer
+  // cannot silently remove their listener sockets. The finite persist timeout
+  // still cleans up an orphaned master if Desktop crashes.
+  _startControlKeepalive() {
+    if (!this._mux || this._controlKeepaliveTimer || this._forwardedSpecs.size === 0) {
+      return
+    }
+
+    this._controlKeepaliveTimer = setInterval(() => {
+      void this.isAlive()
+    }, this._controlKeepaliveMs)
+    this._controlKeepaliveTimer.unref?.()
+  }
+
+  _stopControlKeepalive() {
+    if (!this._controlKeepaliveTimer) {
+      return
+    }
+
+    clearInterval(this._controlKeepaliveTimer)
+    this._controlKeepaliveTimer = null
   }
 
   // A real exec through the master (`exit 0` works under POSIX shells and
@@ -798,6 +829,9 @@ class SshConnection {
     if (result.code !== 0) {
       throw this._fail(result.stderr)
     }
+
+    this._forwardedSpecs.add(spec)
+    this._startControlKeepalive()
   }
 
   // Cancel a previously-established forward. Best-effort: a failure here is
@@ -824,12 +858,21 @@ class SshConnection {
       this._logLine(`cancelled forward 127.0.0.1:${localPort}`)
     } catch (error: any) {
       this._logLine(`cancelForward failed (ignored): ${error.message}`)
+    } finally {
+      this._forwardedSpecs.delete(spec)
+
+      if (this._forwardedSpecs.size === 0) {
+        this._stopControlKeepalive()
+      }
     }
   }
 
   // Tear down. Mux: exit the master (drops every forward with it). No-mux:
   // kill the tunnel children. Best-effort; never throws.
   async close() {
+    this._stopControlKeepalive()
+    this._forwardedSpecs.clear()
+
     if (!this._opened) {
       return
     }


### PR DESCRIPTION
## Problem

Hermes Desktop creates each SSH tunnel through a background ControlMaster with `ControlPersist=300`, then installs the local listener with `ssh -O forward`. A static mux forward does not keep the master's persist timer refreshed. When a remote profile has no multiplexed SSH client for five minutes, OpenSSH can exit the otherwise healthy master and remove the local listener while Desktop retains its `http://127.0.0.1:{port}` descriptor. The next renderer request fails with `ECONNREFUSED`, even though the remote `hermes serve --isolated` backend is still healthy.

This is distinct from the half-open network path in #74998 / #75044 and complements the remote pool-reaper fix in #75398: in this case OpenSSH intentionally expires a healthy idle control master.

## Fix

- Track active mux forward specs on `SshConnection`.
- While at least one forward is owned, issue an unref'd `-O check` every 60 seconds through the existing `isAlive()` path. This refreshes the finite ControlPersist timer.
- Stop the refresh after the final forward is cancelled or the connection closes.
- Leave no-mux/Windows behavior unchanged.

The finite 300-second persist timeout remains in place, so an orphaned master still cleans itself up after a Desktop crash.

## Verification

A real OpenSSH probe with `ControlPersist=5` remained alive for more than 12 seconds when `-O check` ran every four seconds, then exited cleanly on `-O exit`.

- `npx vitest run --project electron electron/ssh-connection.test.ts` — 59 passed
- `npx vitest run --project electron` — 939 passed, 2 skipped
- `npx tsc -p tsconfig.electron.json --noEmit`
- `npx eslint electron/ssh-connection.ts electron/ssh-connection.test.ts`
- `git diff --check`