### PR TITLE
fix(desktop): detect CLI data by state.db, not bare directory — fixes #40178

### DIFF
--- a/apps/desktop/electron/hermes-home.test.ts
+++ b/apps/desktop/electron/hermes-home.test.ts
@@ -1,58 +1,21 @@
 /**
- * Unit tests for the Windows Hermes home resolution logic extracted
- * from resolveHermesHome() in main.ts (#40178).
+ * Unit tests for chooseWindowsHermesHome — the Windows Hermes home
+ * resolution helper extracted from resolveHermesHome() in main.ts.
  *
  * These test the pure decision function independently of Electron,
  * so they run on any platform.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import path from 'node:path'
+import { chooseWindowsHermesHome } from './hermes-home'
 
 // ---------------------------------------------------------------------------
-// Pure logic under test (extracted from resolveHermesHome, main.ts)
-// ---------------------------------------------------------------------------
-function chooseWindowsHermesHome(
-  localappdata: string,
-  legacy: string,
-  {
-    fileExists,
-    directoryExists,
-  }: {
-    fileExists: (p: string) => boolean
-    directoryExists: (p: string) => boolean
-  },
-): string {
-  const localDb = path.join(localappdata, 'state.db')
-  const legacyDb = path.join(legacy, 'state.db')
-  const localHasData = fileExists(localDb)
-  const legacyHasData = fileExists(legacyDb)
-
-  // An established desktop install (state.db present) always wins —
-  // never hijack back to legacy.
-  if (localHasData) {
-    return localappdata
-  }
-
-  // Only legacy has real data: honour the CLI-first user's setup.
-  if (legacyHasData) {
-    return legacy
-  }
-
-  // Neither has real data — fresh install.
-  if (!directoryExists(localappdata) && directoryExists(legacy)) {
-    return legacy
-  }
-
-  return localappdata
-}
-
-// ---------------------------------------------------------------------------
-// Test cases
+// Test fixtures
 // ---------------------------------------------------------------------------
 const LOCAL = 'C:\\Users\\test\\AppData\\Local\\hermes'
 const LEGACY = 'C:\\Users\\test\\.hermes'
 
-function makeFs(existingFiles: string[], existingDirs: string[]) {
+function makeProbes(existingFiles: string[], existingDirs: string[]) {
   return {
     fileExists: (p: string) => existingFiles.includes(p),
     directoryExists: (p: string) => existingDirs.includes(p),
@@ -60,65 +23,87 @@ function makeFs(existingFiles: string[], existingDirs: string[]) {
 }
 
 describe('chooseWindowsHermesHome', () => {
-  it('returns LOCALAPPDATA when desktop has an established state.db', () => {
-    const fs = makeFs(
+  // -----------------------------------------------------------------------
+  // Established desktop install — always wins
+  // -----------------------------------------------------------------------
+  it('returns LOCALAPPDATA when both sides have state.db (desktop wins)', () => {
+    const probes = makeProbes(
       [path.join(LOCAL, 'state.db'), path.join(LEGACY, 'state.db')],
       [LOCAL, LEGACY],
     )
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LOCAL)
   })
 
   it('returns LOCALAPPDATA when only LOCALAPPDATA has state.db', () => {
-    const fs = makeFs(
+    const probes = makeProbes(
       [path.join(LOCAL, 'state.db')],
       [LOCAL, LEGACY],
     )
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LOCAL)
   })
 
-  it('returns legacy when only legacy has state.db (the orphaned-CLI case)', () => {
-    const fs = makeFs(
+  // -----------------------------------------------------------------------
+  // CLI-first user — the #40178 scenario
+  // -----------------------------------------------------------------------
+  it('returns legacy when only legacy has state.db (orphaned CLI data)', () => {
+    // Installer pre-created LOCALAPPDATA dir (empty), legacy has real sessions.
+    const probes = makeProbes(
       [path.join(LEGACY, 'state.db')],
       [LOCAL, LEGACY],
     )
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LEGACY)
   })
 
-  it('returns legacy when LOCALAPPDATA is missing and legacy dir exists (fresh install heuristic)', () => {
-    const fs = makeFs([], [LEGACY])
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+  it('returns legacy when LOCALAPPDATA dir is missing entirely and legacy has state.db', () => {
+    // Test gap noted in #40233 review: LOCALAPPDATA does not exist as a
+    // directory, but legacy has real data. DB check fires before the dir
+    // heuristic, so legacy wins.
+    const probes = makeProbes(
+      [path.join(LEGACY, 'state.db')],
+      [LEGACY],  // LOCALAPPDATA dir does not exist
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LEGACY)
+  })
+
+  // -----------------------------------------------------------------------
+  // Fresh install — original heuristic preserved
+  // -----------------------------------------------------------------------
+  it('returns legacy when LOCALAPPDATA missing and legacy dir exists (fresh heuristic)', () => {
+    const probes = makeProbes([], [LEGACY])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LEGACY)
   })
 
   it('returns LOCALAPPDATA for a truly fresh install (no dirs, no dbs)', () => {
-    const fs = makeFs([], [])
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+    const probes = makeProbes([], [])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LOCAL)
   })
 
-  it('returns LOCALAPPDATA when installer pre-created the dir but no DB exists on either side', () => {
-    // This is the exact scenario #40178: the installer created
-    // %LOCALAPPDATA%\hermes (empty), legacy ~/.hermes exists but has no
-    // state.db (e.g. a pip install that never ran). Original heuristic
-    // would return LOCALAPPDATA; we keep that for the no-data case.
-    const fs = makeFs([], [LOCAL, LEGACY])
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  it('returns LOCALAPPDATA when installer pre-created dir but no DB on either side', () => {
+    // Both dirs exist but neither has state.db — config/.env-only legacy
+    // setup. Original heuristic picks LOCALAPPDATA because it exists.
+    const probes = makeProbes([], [LOCAL, LEGACY])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LOCAL)
   })
 
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
   it('returns LOCALAPPDATA when local DB exists even if legacy also exists', () => {
     // Desktop install established → never silently switch back to CLI data.
-    const fs = makeFs(
+    const probes = makeProbes(
       [path.join(LOCAL, 'state.db'), path.join(LEGACY, 'state.db')],
       [LOCAL, LEGACY],
     )
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LOCAL)
   })
 
-  it('returns legacy when LOCALAPPDATA dir exists but empty and legacy has data', () => {
-    // The exact #40178 scenario: installer created the LOCALAPPDATA dir
-    // but it's empty; legacy has real CLI sessions.
-    const fs = makeFs(
+  it('returns legacy when LOCALAPPDATA dir exists but empty, legacy has DB', () => {
+    // Exact #40178: installer created LOCALAPPDATA dir (empty),
+    // legacy has real CLI sessions.
+    const probes = makeProbes(
       [path.join(LEGACY, 'state.db')],
       [LOCAL, LEGACY],
     )
-    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, probes)).toBe(LEGACY)
   })
 })

--- a/apps/desktop/electron/hermes-home.test.ts
+++ b/apps/desktop/electron/hermes-home.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the Windows Hermes home resolution logic extracted
+ * from resolveHermesHome() in main.ts (#40178).
+ *
+ * These test the pure decision function independently of Electron,
+ * so they run on any platform.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import path from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Pure logic under test (extracted from resolveHermesHome, main.ts)
+// ---------------------------------------------------------------------------
+function chooseWindowsHermesHome(
+  localappdata: string,
+  legacy: string,
+  {
+    fileExists,
+    directoryExists,
+  }: {
+    fileExists: (p: string) => boolean
+    directoryExists: (p: string) => boolean
+  },
+): string {
+  const localDb = path.join(localappdata, 'state.db')
+  const legacyDb = path.join(legacy, 'state.db')
+  const localHasData = fileExists(localDb)
+  const legacyHasData = fileExists(legacyDb)
+
+  // An established desktop install (state.db present) always wins —
+  // never hijack back to legacy.
+  if (localHasData) {
+    return localappdata
+  }
+
+  // Only legacy has real data: honour the CLI-first user's setup.
+  if (legacyHasData) {
+    return legacy
+  }
+
+  // Neither has real data — fresh install.
+  if (!directoryExists(localappdata) && directoryExists(legacy)) {
+    return legacy
+  }
+
+  return localappdata
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+const LOCAL = 'C:\\Users\\test\\AppData\\Local\\hermes'
+const LEGACY = 'C:\\Users\\test\\.hermes'
+
+function makeFs(existingFiles: string[], existingDirs: string[]) {
+  return {
+    fileExists: (p: string) => existingFiles.includes(p),
+    directoryExists: (p: string) => existingDirs.includes(p),
+  }
+}
+
+describe('chooseWindowsHermesHome', () => {
+  it('returns LOCALAPPDATA when desktop has an established state.db', () => {
+    const fs = makeFs(
+      [path.join(LOCAL, 'state.db'), path.join(LEGACY, 'state.db')],
+      [LOCAL, LEGACY],
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  })
+
+  it('returns LOCALAPPDATA when only LOCALAPPDATA has state.db', () => {
+    const fs = makeFs(
+      [path.join(LOCAL, 'state.db')],
+      [LOCAL, LEGACY],
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  })
+
+  it('returns legacy when only legacy has state.db (the orphaned-CLI case)', () => {
+    const fs = makeFs(
+      [path.join(LEGACY, 'state.db')],
+      [LOCAL, LEGACY],
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+  })
+
+  it('returns legacy when LOCALAPPDATA is missing and legacy dir exists (fresh install heuristic)', () => {
+    const fs = makeFs([], [LEGACY])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+  })
+
+  it('returns LOCALAPPDATA for a truly fresh install (no dirs, no dbs)', () => {
+    const fs = makeFs([], [])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  })
+
+  it('returns LOCALAPPDATA when installer pre-created the dir but no DB exists on either side', () => {
+    // This is the exact scenario #40178: the installer created
+    // %LOCALAPPDATA%\hermes (empty), legacy ~/.hermes exists but has no
+    // state.db (e.g. a pip install that never ran). Original heuristic
+    // would return LOCALAPPDATA; we keep that for the no-data case.
+    const fs = makeFs([], [LOCAL, LEGACY])
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  })
+
+  it('returns LOCALAPPDATA when local DB exists even if legacy also exists', () => {
+    // Desktop install established → never silently switch back to CLI data.
+    const fs = makeFs(
+      [path.join(LOCAL, 'state.db'), path.join(LEGACY, 'state.db')],
+      [LOCAL, LEGACY],
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LOCAL)
+  })
+
+  it('returns legacy when LOCALAPPDATA dir exists but empty and legacy has data', () => {
+    // The exact #40178 scenario: installer created the LOCALAPPDATA dir
+    // but it's empty; legacy has real CLI sessions.
+    const fs = makeFs(
+      [path.join(LEGACY, 'state.db')],
+      [LOCAL, LEGACY],
+    )
+    expect(chooseWindowsHermesHome(LOCAL, LEGACY, fs)).toBe(LEGACY)
+  })
+})

--- a/apps/desktop/electron/hermes-home.ts
+++ b/apps/desktop/electron/hermes-home.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helper for choosing the Windows Hermes home directory.
+ *
+ * Extracted from ``resolveHermesHome()`` in ``main.ts`` so the decision
+ * table is trivially unit-testable without booting Electron (#40178).
+ *
+ * Accepts injected ``fileExists`` / ``directoryExists`` probes so tests
+ * can supply a fake filesystem.
+ */
+import path from 'node:path'
+
+export function chooseWindowsHermesHome(
+  localappdata: string,
+  legacy: string,
+  probes: {
+    fileExists: (p: string) => boolean
+    directoryExists: (p: string) => boolean
+  },
+): string {
+  const localDb = path.join(localappdata, 'state.db')
+  const legacyDb = path.join(legacy, 'state.db')
+  const localHasData = probes.fileExists(localDb)
+  const legacyHasData = probes.fileExists(legacyDb)
+
+  // An established desktop install (state.db present) always wins —
+  // never hijack back to legacy.
+  if (localHasData) {
+    return localappdata
+  }
+
+  // Only legacy has real data: honour the CLI-first user's setup
+  // even if the installer pre-created an empty LOCALAPPDATA dir.
+  if (legacyHasData) {
+    return legacy
+  }
+
+  // Neither has real data — fresh install.  Preserve the original
+  // heuristic so config / .env files in a pre-session legacy dir
+  // aren't orphaned.
+  if (!probes.directoryExists(localappdata) && probes.directoryExists(legacy)) {
+    return legacy
+  }
+
+  return localappdata
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -36,6 +36,7 @@ import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import { chooseWindowsHermesHome } from './hermes-home'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
@@ -569,30 +570,10 @@ function resolveHermesHome() {
     // so directoryExists(localappdata) is always true post-install and the
     // legacy branch is never reached — silently orphaning an existing CLI
     // setup with sessions, config, skills and memories (#40178).
-    //
-    // An established desktop install (state.db present) always wins — never
-    // hijack back to legacy. If only legacy has real data, honour the
-    // CLI-first user's setup. Fresh installs preserve the original
-    // heuristic (legacy dir without LOCALAPPDATA, else LOCALAPPDATA).
-    const localDb = path.join(localappdata, 'state.db')
-    const legacyDb = path.join(legacy, 'state.db')
-    const localHasData = fileExists(localDb)
-    const legacyHasData = fileExists(legacyDb)
-
-    if (localHasData) {
-      return localappdata
-    }
-
-    if (legacyHasData) {
-      return legacy
-    }
-
-    // Neither has real data — fresh install. Preserve original heuristic.
-    if (!directoryExists(localappdata) && directoryExists(legacy)) {
-      return legacy
-    }
-
-    return localappdata
+    return chooseWindowsHermesHome(localappdata, legacy, {
+      fileExists,
+      directoryExists,
+    })
   }
 
   return path.join(app.getPath('home'), '.hermes')

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -564,8 +564,30 @@ function resolveHermesHome() {
     const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')
     const legacy = path.join(app.getPath('home'), '.hermes')
 
-    // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
-    // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
+    // Decide by actual data, not bare directory existence. The installer
+    // creates %LOCALAPPDATA%\hermes before the Electron app first runs,
+    // so directoryExists(localappdata) is always true post-install and the
+    // legacy branch is never reached — silently orphaning an existing CLI
+    // setup with sessions, config, skills and memories (#40178).
+    //
+    // An established desktop install (state.db present) always wins — never
+    // hijack back to legacy. If only legacy has real data, honour the
+    // CLI-first user's setup. Fresh installs preserve the original
+    // heuristic (legacy dir without LOCALAPPDATA, else LOCALAPPDATA).
+    const localDb = path.join(localappdata, 'state.db')
+    const legacyDb = path.join(legacy, 'state.db')
+    const localHasData = fileExists(localDb)
+    const legacyHasData = fileExists(legacyDb)
+
+    if (localHasData) {
+      return localappdata
+    }
+
+    if (legacyHasData) {
+      return legacy
+    }
+
+    // Neither has real data — fresh install. Preserve original heuristic.
     if (!directoryExists(localappdata) && directoryExists(legacy)) {
       return legacy
     }


### PR DESCRIPTION
## Summary

Fixes #40178. Supersedes #40233 (TypeScript port of the same fix).

On Windows, the installer pre-creates `%LOCALAPPDATA%\hermes` before the Electron app first runs, so `directoryExists(localappdata)` is always true post-install and the legacy `~/.hermes` branch was never reached — silently orphaning an existing CLI setup with all its sessions, config, skills and memories.

## Fix

Replace the bare directory-existence check with a **data-signal check** (`fileExists(state.db)`) — same decision table as the 3×-approved #40233, ported to TypeScript:

| LOCALAPPDATA `state.db` | Legacy `state.db` | Result |
|---|---|---|
| ✅ | any | LOCALAPPDATA (established desktop always wins) |
| ❌ | ✅ | Legacy (the CLI-first case — this is #40178) |
| ❌ | ❌ | Original heuristic (dir existence) for fresh installs |

### Changes

- **`apps/desktop/electron/main.ts`**: Rewrite the Windows branch in `resolveHermesHome()` to key off `state.db` presence rather than bare directory existence (563-600).
- **`apps/desktop/electron/hermes-home.test.ts`**: 8 unit tests covering all decision-table states, including the exact #40178 scenario and the no-regression cases.

### Precedence (unchanged)

1. `HERMES_HOME` env var
2. `HERMES_DESKTOP_USER_DATA_DIR` override
3. Windows Registry `HERMES_HOME` (for `setx`-after-login)
4. **New**: `state.db` data-signal check
5. Original directory-existence heuristic (fresh-install fallback)
6. Platform default (`~/.hermes`)

### Backend sync

Python's `get_hermes_home()` receives the resolved path via `HERMES_HOME` env var (line 8512-8524) — no Python-side changes needed.

### Acknowledgments

Thanks to @xxxigm for the original fix in #40233 and to @austinpickett / @teknium1 for the thorough reviews that validated the approach. This PR ports the identical decision table to the current TypeScript surface.