### PR TITLE
fix(models): parse openai-codex slash model switches

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2198,6 +2198,16 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     provider from the input or *current_provider* if none was specified.
     """
     stripped = raw.strip()
+
+    # Provider-qualified input normally uses ``provider:model``.  A common
+    # human mistake is ``openai-codex/gpt-5.5`` because OpenRouter-style model
+    # slugs also use slashes.  Treat only the Codex OAuth provider this way:
+    # broad ``provider/model`` parsing would break legitimate aggregator slugs
+    # such as ``anthropic/claude-sonnet-4.5`` on OpenRouter.
+    codex_prefix = "openai-codex/"
+    if stripped.lower().startswith(codex_prefix) and len(stripped) > len(codex_prefix):
+        return ("openai-codex", stripped[len(codex_prefix):].strip())
+
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -55,6 +55,17 @@ class TestParseModelInput:
         assert provider == "openrouter"
         assert model == "anthropic/claude-sonnet-4.5"
 
+    def test_openai_codex_slash_provider_model_switches_provider(self):
+        """Human-friendly openai-codex/model should not stay on the current provider."""
+        provider, model = parse_model_input("openai-codex/gpt-5.5", "claude-api-proxy")
+        assert provider == "openai-codex"
+        assert model == "gpt-5.5"
+
+    def test_openai_codex_empty_slash_keeps_current_provider(self):
+        provider, model = parse_model_input("openai-codex/", "claude-api-proxy")
+        assert provider == "claude-api-proxy"
+        assert model == "openai-codex/"
+
 
 # -- curated_models_for_provider ---------------------------------------------
 


### PR DESCRIPTION
Re-port of #34292 onto current `main`. The original branch was ~11k commits behind and hard-conflicted; only the test file conflicted (upstream test-class churn), so this is the same fix re-applied cleanly with the original authorship preserved.

**Verified still-live on current main before re-porting:** `parse_model_input` supports `provider:model` (colon, guarded by `_KNOWN_PROVIDER_NAMES`) but has no `openai-codex/` handling, so `openai-codex/gpt-5.5` silently stays on the current provider.

**Scope is deliberately narrow:** only the `openai-codex` OAuth provider is parsed this way. Broad `provider/model` parsing would steal legitimate aggregator slugs like `anthropic/claude-sonnet-4.5` on OpenRouter — the existing `test_plain_model_keeps_current_provider` asserts that stays intact.

+10/-0 in `hermes_cli/models.py`, +2 tests. 31/31 in `test_model_validation.py`, RED-proven (neutering the branch fails the new test).

Supersedes #34292 — I will close that one referencing this.