### PR TITLE
fix(monitoring): honor configured resource_attributes on the span plane

### DIFF
--- a/agent/monitoring/otlp_exporter.py
+++ b/agent/monitoring/otlp_exporter.py
@@ -116,14 +116,18 @@ def build_exporter(config: Dict[str, Any]):
 
 
 def _resource_attributes(config: Dict[str, Any]) -> Dict[str, str]:
-    from agent.monitoring.gateway_health import _safe_instance_id
-    from agent.monitoring.policy import ensure_install_id
+    """Span-plane OTLP resource: same shape as the metrics/logs planes.
 
-    return {
-        "service.name": "hermes-gateway",
-        "service.instance.id": _safe_instance_id(ensure_install_id(config)),
-        "telemetry.scope": "gateway_monitoring",
-    }
+    Delegates to the shared helper so configured
+    ``monitoring.gateway_health_export.resource_attributes`` (allowlist-filtered,
+    e.g. ``deployment.environment.name``) are honored on spans exactly as they
+    are on metrics and diagnostic logs. The hardcoded identity keys
+    (``service.name``, sanitized ``service.instance.id``, ``telemetry.scope``)
+    are stamped last and cannot be overridden by config.
+    """
+    from agent.monitoring.gateway_health_export import _runtime_resource_attributes
+
+    return _runtime_resource_attributes(config, telemetry_scope="gateway_monitoring")
 
 
 def _make_provider(config: Dict[str, Any]):

--- a/tests/monitoring/test_otlp_exporter.py
+++ b/tests/monitoring/test_otlp_exporter.py
@@ -66,6 +66,62 @@ def test_trace_resource_includes_stable_hashed_instance():
     assert attrs["telemetry.scope"] == "gateway_monitoring"
 
 
+def test_trace_resource_honors_configured_resource_attributes():
+    """Configured resource_attributes must reach spans, not just metrics/logs.
+
+    Regression test for the span plane ignoring
+    monitoring.gateway_health_export.resource_attributes (spans landed as
+    env-less, e.g. env:none in Datadog, while metrics/logs carried the env).
+    """
+    config = {
+        "monitoring": {
+            "install_id": "private-install-id",
+            "gateway_health_export": {
+                "resource_attributes": {
+                    "deployment.environment.name": "production",
+                    "service.namespace": "hermes",
+                    "user.email": "user@example.com",  # not allowlisted
+                    "service.name": "attacker-override",  # identity: not overridable
+                },
+            },
+        },
+    }
+    attrs = OE._resource_attributes(config)
+
+    assert attrs["deployment.environment.name"] == "production"
+    assert attrs["service.namespace"] == "hermes"
+    assert "user.email" not in attrs
+    assert attrs["service.name"] == "hermes-gateway"
+    assert attrs["telemetry.scope"] == "gateway_monitoring"
+
+
+def test_trace_resource_matches_metrics_and_logs_resource():
+    """Invariant: all three export planes build the same resource for the same
+    config, differing only in telemetry.scope."""
+    from agent.monitoring.gateway_health_export import _runtime_resource_attributes
+
+    config = {
+        "monitoring": {
+            "install_id": "private-install-id",
+            "gateway_health_export": {
+                "resource_attributes": {
+                    "deployment.environment.name": "staging",
+                    "cloud.provider": "azure",
+                },
+            },
+        },
+    }
+    span_attrs = OE._resource_attributes(config)
+    metric_attrs = _runtime_resource_attributes(config, telemetry_scope="gateway_health")
+    log_attrs = _runtime_resource_attributes(config, telemetry_scope="gateway_diagnostics")
+
+    def _without_scope(attrs):
+        return {k: v for k, v in attrs.items() if k != "telemetry.scope"}
+
+    assert _without_scope(span_attrs) == _without_scope(metric_attrs) == _without_scope(log_attrs)
+    assert span_attrs["telemetry.scope"] == "gateway_monitoring"
+
+
 
 
 def test_streamer_receives_events_and_respects_filter(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #78897.

The gateway-health **span** exporter built its OTLP `Resource` from a hardcoded set (`service.name`, `service.instance.id`, `telemetry.scope`), ignoring configured `monitoring.gateway_health_export.resource_attributes`. The metrics and diagnostic-log planes already merge those attributes (allowlist-filtered through `_RESOURCE_ATTRIBUTE_KEYS`). Result: spans could never carry `deployment.environment.name` / `service.namespace`, so environment-scoped backends (e.g. Datadog APM) filed `hermes.gateway_health` / `hermes.cron_execution` spans under `env:none` while metrics and logs from the same runtime landed under the configured env.

**Root cause:** the refactor that introduced the shared `_runtime_resource_attributes()` helper switched the metrics provider and the diagnostic log streamer to it, but left `otlp_exporter._resource_attributes()` on the old hardcoded shape. The cron span plane later inherited the gap.

## Changes

- `agent/monitoring/otlp_exporter.py`: `_resource_attributes()` now delegates to the shared `_runtime_resource_attributes()` helper with its existing `telemetry.scope="gateway_monitoring"`. Configured attributes merge first; the identity keys (`service.name`, sanitized `service.instance.id`, `telemetry.scope`) are stamped last and cannot be overridden by config — identical semantics to the metrics/logs planes. (This deliberately differs from the issue's suggested `attrs.update(configured)` ordering, which would have let config override the sanitized identity keys.)
- `tests/monitoring/test_otlp_exporter.py`:
  - regression test: configured `resource_attributes` reach the span resource; non-allowlisted keys and identity-override attempts do not.
  - invariant test: all three export planes (spans, metrics, logs) build the same resource for the same config, differing only in `telemetry.scope`.

## Test Plan

- [x] `pytest tests/monitoring/` — 26 passed (includes the two new tests; existing hashed-instance-id and allowlist tests unchanged and green)

No new config surface, no new telemetry: export remains operator-configured and gated exactly as before; this only makes the span plane honor the already-documented setting.
