### PR TITLE
fix(discord): auto-thread reply messages

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7753,8 +7753,7 @@ class DiscordAdapter(BasePlatformAdapter):
             no_thread_channels = self._get_no_thread_channels()
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
-            is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            if auto_thread and not skip_thread and not is_voice_linked_channel:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -228,28 +228,35 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
 
 
 @pytest.mark.asyncio
-async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
-    """Quote-replies should stay in-channel instead of trying to create a thread."""
+async def test_discord_reply_message_auto_threads_when_channel_is_eligible(adapter, monkeypatch):
+    """Quote-replies should use the same auto-thread routing as new messages."""
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
-    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
-    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "123")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
-    adapter._auto_create_thread = AsyncMock()
+    parent = FakeTextChannel(channel_id=123)
+    thread = FakeThread(channel_id=999, parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
 
     message = make_message(
-        channel=FakeTextChannel(channel_id=123),
+        channel=parent,
         content="reply without mention",
         msg_type=discord_platform.discord.MessageType.reply,
+    )
+    message.reference = SimpleNamespace(
+        message_id=456,
+        resolved=SimpleNamespace(id=456, content="the message being replied to"),
     )
 
     await adapter._handle_message(message)
 
-    adapter._auto_create_thread.assert_not_awaited()
+    adapter._auto_create_thread.assert_awaited_once_with(message)
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "reply without mention"
-    assert event.source.chat_id == "123"
-    assert event.source.chat_type == "group"
+    assert event.source.chat_id == "999"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the Discord reply-message exception from auto-thread routing
- route eligible quote replies into a newly created thread like other parent-channel requests
- replace the old inline-reply expectation with a regression test asserting thread-scoped dispatch

## Root cause
`DiscordAdapter._handle_message()` explicitly excluded `discord.MessageType.reply` from auto-thread creation, so reply messages were dispatched in the parent channel even when `discord.auto_thread` was enabled.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_discord_free_response.py::test_discord_reply_message_auto_threads_when_channel_is_eligible -v`
- `scripts/run_tests.sh tests/gateway/test_discord_free_response.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_double_dispatch.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_discord_slash_commands.py tests/e2e/test_discord_adapter.py -v` (65 passed)
- `scripts/run_tests.sh tests/gateway/test_discord_*.py` (223 passed)