### PR TITLE
fix(desktop): expose react_to_message on remote-desktop sessions

### DIFF
--- a/tests/test_message_reactions.py
+++ b/tests/test_message_reactions.py
@@ -173,3 +173,115 @@ def test_row_id_is_opt_in_and_never_reaches_the_provider(session, db):
     for message in db.get_messages_as_conversation(key, include_row_ids=True):
         assert "_row_id" in message
         assert all(not k.startswith("_") or k == "_row_id" for k in message)
+
+
+def test_react_tool_gate_requires_opt_in(monkeypatch, tmp_path):
+    """Off by default — even a desktop-spawned backend must not see the tool."""
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: False)
+    monkeypatch.setattr(mod, "_desktop_session_context", lambda: True)
+
+    assert mod.check_react_requirements() is False
+
+
+def test_react_tool_gate_local_desktop_env(monkeypatch):
+    """Local Electron child: HERMES_DESKTOP=1 + opt-in → tool available."""
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: True)
+
+    assert mod.check_react_requirements() is True
+
+
+def test_react_tool_gate_remote_desktop_session_source(monkeypatch, tmp_path):
+    """MBA → shared dashboard: no HERMES_DESKTOP, but session source=desktop."""
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: True)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session("desktop-remote", "desktop")
+
+    monkeypatch.setattr(
+        mod,
+        "get_session_env",
+        lambda key, default="": sid if key in ("HERMES_SESSION_ID", "HERMES_SESSION_KEY") else default,
+    )
+    monkeypatch.setattr(mod, "_open_session_db", lambda: db)
+
+    assert mod._desktop_session_context() is True
+    assert mod.check_react_requirements() is True
+
+
+def test_react_tool_gate_rejects_non_desktop_session(monkeypatch, tmp_path):
+    """Opt-in alone must not expose the tool on messaging/CLI sessions."""
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: True)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session("imessage-chat", "bluebubbles")
+
+    monkeypatch.setattr(
+        mod,
+        "get_session_env",
+        lambda key, default="": sid if key in ("HERMES_SESSION_ID", "HERMES_SESSION_KEY") else default,
+    )
+    monkeypatch.setattr(mod, "_open_session_db", lambda: db)
+
+    assert mod._desktop_session_context() is False
+    assert mod.check_react_requirements() is False
+
+
+def test_react_tool_gate_serve_backend_session_source_env(monkeypatch, tmp_path):
+    """Current desktop app (serve backend): no HERMES_DESKTOP and the DB row
+    carries the webui platform label — but the backend binds
+    HERMES_SESSION_SOURCE=desktop for the turn, so the tool must be available.
+    """
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: True)
+    monkeypatch.setattr(
+        mod,
+        "get_session_env",
+        lambda key, default="": "desktop" if key == "HERMES_SESSION_SOURCE" else default,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("serve-desktop", "webui")
+    monkeypatch.setattr(mod, "_open_session_db", lambda: db)
+
+    assert mod._desktop_session_context() is True
+    assert mod.check_react_requirements() is True
+
+
+def test_react_tool_gate_rejects_webui_session_without_desktop_marker(monkeypatch, tmp_path):
+    """Browser WebUI sessions are also source='webui' but get no desktop marker
+    — the tool must stay gated off there."""
+    from tools import react_to_message_tool as mod
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mod, "_message_reactions_opted_in", lambda: True)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session("browser-webui", "webui")
+
+    monkeypatch.setattr(
+        mod,
+        "get_session_env",
+        lambda key, default="": sid if key in ("HERMES_SESSION_ID", "HERMES_SESSION_KEY") else default,
+    )
+    monkeypatch.setattr(mod, "_open_session_db", lambda: db)
+
+    assert mod._desktop_session_context() is False
+    assert mod.check_react_requirements() is False

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -89,15 +89,8 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
     )
 
 
-def check_react_requirements() -> bool:
-    """Desktop GUI only, and opt-in.
-
-    HERMES_DESKTOP is set on the gateway the app spawns; the feature itself is
-    off by default and enabled from Settings → Appearance (the desktop mirrors
-    the toggle into ``display.message_reactions``).
-    """
-    if not env_var_enabled("HERMES_DESKTOP"):
-        return False
+def _message_reactions_opted_in() -> bool:
+    """True when Settings → Appearance reactions (or config) is on."""
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -105,6 +98,57 @@ def check_react_requirements() -> bool:
     except Exception:
         return False
     return isinstance(display, dict) and bool(display.get("message_reactions", False))
+
+
+def _desktop_session_context() -> bool:
+    """True when this turn is a Desktop chat (local child or remote client).
+
+    Local Electron sets ``HERMES_DESKTOP=1`` on the backend it spawns. Remote
+    Desktop (e.g. MBA → mini dashboard :9120) does **not** — the shared
+    launchd dashboard has no that env — but sessions are still recorded with
+    ``source='desktop'``. Without this branch the react tool stays gated off
+    for the remote-gateway layout even when the user opted in.
+
+    One more shape (2026-08): the current desktop app spawns ``hermes serve``
+    for its chat backend, which — unlike the legacy dashboard spawn and the
+    remote-SSH spawn — sets neither ``HERMES_DESKTOP`` nor records
+    ``source='desktop'`` (sessions carry the ``webui`` platform label). What
+    it *does* bind for every desktop turn is ``HERMES_SESSION_SOURCE=desktop``
+    (see gateway/session_context.py — the same marker CLI/TUI sessions use).
+    Check that before falling back to the DB.
+    """
+    if env_var_enabled("HERMES_DESKTOP"):
+        return True
+    if get_session_env("HERMES_SESSION_SOURCE", "").lower() == "desktop":
+        return True
+    try:
+        sid = get_session_env("HERMES_SESSION_ID", "") or get_session_env(
+            "HERMES_SESSION_KEY", ""
+        )
+        if not sid:
+            return False
+        db = _open_session_db()
+        if db is None:
+            return False
+        sess = db.get_session(sid) if hasattr(db, "get_session") else None
+        if isinstance(sess, dict):
+            return (sess.get("source") or "").lower() == "desktop"
+        # Some SessionDB builds expose attribute access / row mapping
+        source = getattr(sess, "source", None) if sess is not None else None
+        return str(source or "").lower() == "desktop"
+    except Exception:
+        return False
+
+
+def check_react_requirements() -> bool:
+    """Desktop chat only, and opt-in.
+
+    Feature is off by default; Settings → Appearance mirrors the toggle into
+    ``display.message_reactions``. Surface gate: local Desktop backend
+    (``HERMES_DESKTOP``) **or** a session with ``source=desktop`` (remote
+    Desktop clients on a shared dashboard).
+    """
+    return _message_reactions_opted_in() and _desktop_session_context()
 
 
 REACT_TO_MESSAGE_SCHEMA = {


### PR DESCRIPTION
## Summary

Fixes #80259 — the message-reactions agent tool (`react_to_message`) stays gated off for desktop sessions served by the current `serve` backend — **both local and remote** — even when the user opted in via Settings → Appearance.

## Root cause

`check_react_requirements()` required `HERMES_DESKTOP=1`:

```python
if not env_var_enabled("HERMES_DESKTOP"):
    return False
```

That env var is only set by two spawn paths: the **legacy `dashboard` backend spawn** and the **remote-SSH spawn**. The current `serve` backend the desktop app spawns locally gets it from neither — `buildDesktopBackendEnv` (`apps/desktop/electron/backend-env.ts`) sets only `PYTHONPATH`/`PYTHONUTF8`/`PATH` — and sessions recorded by `serve` carry the `webui` platform label, not `source='desktop'`. So the gate fails for local desktop sessions too, and for remote-desktop topologies (Desktop client on machine A → always-on dashboard/gateway on machine B — e.g. laptop → home mini `:9120`), the opt-in (`display.message_reactions`) is never reached, and the tool is simply absent from the agent's toolset.

## Fix

The backend binds one reliable per-turn marker for every desktop session: **`HERMES_SESSION_SOURCE=desktop`** (the same durable signal CLI/TUI sessions use, per `gateway/session_context.py`). The gate now accepts that marker before falling back to the DB `source='desktop'` check:

- `tools/react_to_message_tool.py` — `_desktop_session_context()` accepts `HERMES_SESSION_SOURCE=desktop`
- `tests/test_message_reactions.py` — +2 tests: the serve-backend shape (no `HERMES_DESKTOP`, session source `webui`, per-turn marker present) **must pass**; the browser-WebUI shape **without** the desktop marker **must stay gated** (so the third-party/headless WebUI never gets the tool)

## Behavior preserved

- **Opt-in still required** (`display.message_reactions`) — no surface gets the tool by default
- **Non-desktop surfaces stay gated** (bluebubbles, CLI, browser-WebUI without the marker) — covered by tests
- Sibling GUI tools (`read_terminal`, `focus_pane`, `open_preview`, …) keep their existing gates; if maintainers want the whole family unified on the session-source signal, that's a natural follow-up (happy to do it)

## Testing

- `scripts/run_tests.sh tests/test_message_reactions.py` — 19/19 green
- Live gate check evaluates `True` on both the local `serve`-backend shape and the remote-dashboard shape

This PR is deliberately **not** mixed with any other carry (e.g. the bluebubbles webhook fix in #69593).
