### PR TITLE
feat(gateway): add provider_model, context_full, and reasoning runtime footer fields

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5470,6 +5470,7 @@ class TurnRunner:
             _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
         _resolved_model = getattr(_agent, "model", None) if _agent else None
+        _resolved_provider = getattr(_agent, "provider", None) if _agent else None
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
@@ -5605,6 +5606,7 @@ class TurnRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
                 "context_length": _context_length,
             }
 
@@ -5743,6 +5745,7 @@ class TurnRunner:
             "input_tokens": _input_toks,
             "output_tokens": _output_toks,
             "model": _resolved_model,
+            "provider": _resolved_provider,
             "context_length": _context_length,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
@@ -17773,10 +17776,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
+                    # Session-scoped /reasoning wins over config; resolve it
+                    # here so the footer reports what the session actually ran.
+                    reasoning_config=self._resolve_session_reasoning_config(
+                        source=source, model=agent_result.get("model") or ""
+                    ),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -11,11 +11,16 @@ Config (``~/.hermes/config.yaml``)::
         enabled: true                       # off by default
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
 
-Available fields:
-    model        — bare model id, vendor prefix dropped (``gpt-5.4``)
-    context_pct  — last-call context occupancy as a percent (``5%``)
-    latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
-    cwd          — home-relative working dir (``~``)
+Available fields (the default set is unchanged — ``model``, ``context_pct``,
+``cwd`` — so an existing footer renders byte-identically; the new fields are
+opt-in via ``fields``):
+    model           — bare model id, vendor prefix dropped (``claude-opus-4-8``)
+    provider_model  — ``provider/model`` (``claude-bridge-f3/claude-opus-4-8``)
+    context_pct     — last-call occupancy as a percent (``5%``)
+    context_full    — ``used/window (pct)``, both humanized (``50.2k/1M (5%)``)
+    reasoning       — model reasoning-effort level, ``r:<level>`` (``r:xhigh``)
+    latency         — wall-clock duration of the turn (``22s``, ``1m05s``)
+    cwd             — home-relative working dir (``~``)
 
 ``latency`` is opt-in: it is NOT in the default field set, so a footer whose
 ``fields`` are unset renders exactly as before.
@@ -60,6 +65,42 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _split_provider_model(
+    provider: Optional[str], model: Optional[str]
+) -> tuple[str, str]:
+    """Resolve a clean ``(provider, model)`` pair.
+
+    When ``provider`` is unset but ``model`` carries a ``provider/model``
+    prefix, split it so the footer reads cleanly (``provider/model``, not
+    ``unset/a/b``).
+
+    When the ``model`` ALREADY carries a ``provider/`` prefix, that embedded
+    prefix wins and any separately-supplied ``provider`` is ignored — this
+    avoids an ugly triple like ``openai-codex/claude-app/claude-opus-4-8`` when
+    a caller passes both a provider and a prefixed model. The model's own
+    prefix is the more specific source.
+    """
+    prov = (provider or "").strip()
+    mdl = (model or "").strip()
+    if "/" in mdl:
+        # The model carries its own provider prefix — it's authoritative.
+        prov, _, mdl = mdl.partition("/")
+    return prov, mdl
+
+
+def _humanize_tok(n: Any) -> str:
+    """Token count -> compact string (``50k``, ``1.5k``, ``1M``, ``1.0M``)."""
+    try:
+        n = int(n or 0)
+    except (TypeError, ValueError):
+        n = 0
+    if abs(n) >= 1_000_000:
+        return f"{n // 1_000_000}M" if n % 1_000_000 == 0 else f"{n / 1_000_000:.1f}M"
+    if abs(n) >= 1000:
+        return f"{n // 1000}k" if n % 1000 == 0 else f"{n / 1000:.1f}k"
+    return str(n)
 
 
 def resolve_footer_config(
@@ -115,6 +156,8 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    provider: Optional[str] = None,
+    reasoning: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -128,10 +171,30 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider_model":
+            prov, mdl = _split_provider_model(provider, model)
+            if prov and mdl:
+                parts.append(f"{prov}/{mdl}")
+            elif mdl:
+                parts.append(mdl)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
+        elif field == "context_full":
+            # Both used and window humanized (50.2k/1M); pct from raw values.
+            if context_length and context_length > 0 and context_tokens >= 0:
+                pct = max(0, min(100, round((context_tokens / context_length) * 100)))
+                parts.append(
+                    f"{_humanize_tok(context_tokens)}/{_humanize_tok(context_length)} ({pct}%)"
+                )
+            elif context_tokens and context_tokens > 0:
+                parts.append(_humanize_tok(context_tokens))
+        elif field == "reasoning":
+            # Model reasoning-effort level (none/minimal/low/medium/high/xhigh).
+            r = (reasoning or "").strip()
+            if r:
+                parts.append(f"r:{r}")
         elif field == "latency":
             # Wall-clock turn duration. Skipped when the caller supplied no
             # timing (call sites that don't measure) or the value is negative.
@@ -148,6 +211,46 @@ def format_runtime_footer(
     return _SEP.join(parts)
 
 
+def _reasoning_label(reasoning_config: Any) -> str:
+    """Render a parsed reasoning-config dict as a footer label.
+
+    Accepts the dict shape produced by
+    :func:`hermes_constants.parse_reasoning_effort` — ``{"enabled": True,
+    "effort": "<level>"}`` or ``{"enabled": False}``.  Returns the bare level
+    (``xhigh``), ``none`` when thinking is explicitly disabled, or ``""`` when
+    unset (caller drops the field).
+    """
+    if not isinstance(reasoning_config, dict):
+        return ""
+    if not reasoning_config.get("enabled", True):
+        return "none"
+    return str(reasoning_config.get("effort", "") or "").strip()
+
+
+def _reasoning_from_config(
+    user_config: dict[str, Any] | None, model: Optional[str] = None
+) -> str:
+    """Resolve the effective reasoning level for *model* from *user_config*.
+
+    Routes through the shared chokepoint
+    :func:`hermes_constants.resolve_reasoning_config` so the footer honors
+    per-model overrides (``agent.reasoning_overrides``) and the YAML-boolean
+    "disabled" spelling exactly as the agent does, rather than re-reading
+    ``agent.reasoning_effort`` raw.
+
+    Session-scoped ``/reasoning`` overrides are resolved by the CALLER (they
+    always win) and passed to :func:`build_footer_line` as ``reasoning_config``.
+    """
+    try:
+        from hermes_constants import resolve_reasoning_config
+
+        return _reasoning_label(
+            resolve_reasoning_config(user_config or {}, model or "")
+        )
+    except Exception:
+        return ""
+
+
 def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
@@ -157,6 +260,9 @@ def build_footer_line(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    provider: Optional[str] = None,
+    reasoning: Optional[str] = None,
+    reasoning_config: Any = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -167,15 +273,31 @@ def build_footer_line(
     ``turn_seconds`` is the wall-clock duration of the agent run, measured by
     the caller with ``time.monotonic()``.  Callers that don't measure it leave
     it ``None`` and the ``latency`` field is skipped.
+
+    ``reasoning_config`` is the caller's ALREADY-RESOLVED reasoning config for
+    this session (gateway/run.py's ``_resolve_session_reasoning_config``, which
+    honors a session-scoped ``/reasoning <level>``).  Passing it keeps the
+    footer in step with what the session actually runs; without it the footer
+    falls back to the config-level resolution, which can be stale for a session
+    that set a session-scoped override.
     """
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+    # Reasoning: prefer an explicit label, then the caller's session-resolved
+    # config, then config-level resolution for this model.
+    if reasoning is None:
+        if reasoning_config is not None:
+            reasoning = _reasoning_label(reasoning_config)
+        else:
+            reasoning = _reasoning_from_config(user_config, model)
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
         turn_seconds=turn_seconds,
+        provider=provider,
+        reasoning=reasoning,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -13,6 +13,8 @@ from gateway.runtime_footer import (
     build_footer_line,
     format_runtime_footer,
     resolve_footer_config,
+    _humanize_tok,
+    _split_provider_model,
 )
 
 
@@ -317,3 +319,420 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     with_timing = build_footer_line(**common, turn_seconds=125.0)
     assert baseline == "gpt-5.4 · 5% · /var/data"
     assert with_timing == baseline
+
+
+# ---------------------------------------------------------------------------
+# provider_model / context_full / reasoning — re-ported from PR #47600
+# ---------------------------------------------------------------------------
+
+
+def test_build_footer_empty_when_disabled():
+    out = build_footer_line(
+        user_config={},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=10, context_length=100,
+        cwd="/tmp",
+    )
+    assert out == ""
+
+
+def test_build_footer_no_data_returns_empty_even_when_enabled():
+    # Enabled, but context_length is None AND cwd empty AND model empty ⇒ no fields
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        platform_key="telegram",
+        model="",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    # With no TERMINAL_CWD env either
+    if not os.environ.get("TERMINAL_CWD"):
+        assert out == ""
+
+
+def test_build_footer_reasoning_absent_config_drops_field(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}}},
+        platform_key="discord",
+        model="m",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    # no agent.reasoning_effort -> field silently dropped -> empty footer
+    assert out == ""
+
+
+def test_build_footer_reasoning_resolved_from_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # agent.reasoning_effort is the canonical source /reasoning writes to
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "high"},
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    assert out == "r:high"
+
+
+def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=25, context_length=100,
+        cwd=str(tmp_path / "proj"),
+    )
+    (tmp_path / "proj").mkdir(exist_ok=True)
+    assert "gpt-5.4" in out
+    assert "25%" in out
+
+
+def test_default_build_footer_line_ignores_new_data(monkeypatch):
+    """Supplying provider/reasoning changes nothing under the default fields."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    user = {
+        "display": {"runtime_footer": {"enabled": True}},
+        "agent": {"reasoning_effort": "xhigh"},
+    }
+    common = dict(
+        user_config=user,
+        platform_key="discord",
+        model="openai/gpt-5.4",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd="/var/data",
+    )
+    baseline = build_footer_line(**common)
+    enriched = build_footer_line(
+        **common, provider="claude-bridge-f3", reasoning="xhigh"
+    )
+    assert baseline == "gpt-5.4 · 5% · /var/data"
+    assert enriched == baseline
+
+
+def test_default_fields_unchanged():
+    """The default field set is exactly the pre-change one."""
+    from gateway.runtime_footer import _DEFAULT_FIELDS
+
+    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
+
+
+def test_format_footer_aces_target_layout(monkeypatch, tmp_path):
+    # The exact footer Ace asked for — both counts humanized:
+    #   claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · ~
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd=str(tmp_path),
+        fields=("provider_model", "context_full", "cwd"),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · ~"
+
+
+def test_format_footer_context_full():
+    # both used and window humanized (50.2k/1M)
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == "50.2k/1M (5%)"
+
+
+def test_format_footer_context_full_no_data_dropped():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == ""
+
+
+def test_format_footer_context_full_no_window_shows_used_only():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=50_247,
+        context_length=None,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == "50.2k"
+
+
+def test_format_footer_context_pct_clamped_to_100():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=500_000,  # way over
+        context_length=100_000,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == "100%"
+
+
+def test_format_footer_context_pct_never_negative():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=-50,
+        context_length=100,
+        cwd="",
+        fields=("context_pct",),
+    )
+    # Negative input => no field emitted (we require context_tokens >= 0)
+    assert out == ""
+
+
+def test_format_footer_custom_field_order():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="/opt/project",
+        fields=("context_pct", "model"),  # swapped + no cwd
+    )
+    assert out == "50% · gpt-5.4"
+
+
+def test_format_footer_drops_cwd_when_empty(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="",
+        fields=("model", "context_pct", "cwd"),
+    )
+    # cwd silently dropped; model + pct remain
+    assert out == "gpt-5.4 · 50%"
+
+
+def test_format_footer_empty_fields_returns_empty():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="/x", fields=(),
+    )
+    assert out == ""
+
+
+def test_format_footer_full_layout_with_reasoning(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd=str(tmp_path),
+        reasoning="xhigh",
+        fields=("provider_model", "context_full", "reasoning", "cwd"),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · r:xhigh · ~"
+
+
+def test_format_footer_provider_model_bare_model_only():
+    # no provider anywhere -> just the model, no leading slash
+    out = format_runtime_footer(
+        model="gpt-5.4",
+        provider="",
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "gpt-5.4"
+
+
+def test_format_footer_provider_model_explicit():
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8"
+
+
+def test_format_footer_provider_model_split_from_prefixed_model():
+    # provider unset; model carries the prefix
+    out = format_runtime_footer(
+        model="claude-bridge-f3/claude-opus-4-8",
+        provider=None,
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8"
+
+
+def test_format_footer_reasoning_renders_with_prefix():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=None, cwd="",
+        reasoning="xhigh",
+        fields=("reasoning",),
+    )
+    assert out == "r:xhigh"
+
+
+def test_format_footer_reasoning_skipped_when_empty():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=None, cwd="",
+        reasoning="",
+        fields=("reasoning",),
+    )
+    assert out == ""
+
+
+def test_format_footer_unknown_field_silently_ignored():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="/x",
+        fields=("model", "bogus", "context_pct"),
+    )
+    assert out == "gpt-5.4 · 50%"
+
+
+def test_home_relative_cwd_empty_returns_empty():
+    assert _home_relative_cwd("") == ""
+
+
+def test_home_relative_cwd_leaves_abs_path_alone(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "other"))
+    result = _home_relative_cwd(str(tmp_path / "outside" / "dir"))
+    assert result == str(tmp_path / "outside" / "dir")
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (50_000, "50k"),
+        (1_500, "1.5k"),
+        (1_000_000, "1M"),
+        (1_048_576, "1.0M"),
+        (500, "500"),
+        (0, "0"),
+        (None, "0"),
+    ],
+)
+def test_humanize_tok(n, expected):
+    assert _humanize_tok(n) == expected
+
+
+def test_reasoning_honors_per_model_override():
+    """Config resolution routes through resolve_reasoning_config.
+
+    `agent.reasoning_overrides.<model>` must beat the global effort, matching
+    what the agent itself runs.
+    """
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {
+                "reasoning_effort": "low",
+                "reasoning_overrides": {"claude-opus-4-8": "xhigh"},
+            },
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    assert out == "r:xhigh"
+
+
+def test_reasoning_session_disabled_renders_none():
+    """A session that disabled thinking reports `r:none`, not the global level."""
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "high"},
+        },
+        platform_key="discord",
+        model="m",
+        context_tokens=0, context_length=None,
+        cwd="",
+        reasoning_config={"enabled": False},
+    )
+    assert out == "r:none"
+
+
+def test_reasoning_uses_caller_session_resolved_config():
+    """A session-scoped /reasoning override wins over the global config value.
+
+    gateway/run.py resolves the session's effective reasoning config and hands
+    it to build_footer_line; the footer must report THAT, not the stale global.
+    """
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "low"},  # global says low
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        context_tokens=0, context_length=None,
+        cwd="",
+        # session said xhigh
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    assert out == "r:xhigh"
+
+
+def test_resolve_defaults_off_empty_config():
+    cfg = resolve_footer_config({}, "telegram")
+    assert cfg == {
+        "enabled": False,
+        "fields": ["model", "context_pct", "cwd"],
+    }
+
+
+def test_resolve_footer_config_default_fields_unchanged():
+    """An untouched config still resolves to the legacy default field set."""
+    assert resolve_footer_config({}, "telegram")["fields"] == _LEGACY_DEFAULT_FIELDS
+    assert resolve_footer_config(
+        {"display": {"runtime_footer": {"enabled": True}}}, "discord"
+    )["fields"] == _LEGACY_DEFAULT_FIELDS
+
+
+def test_resolve_global_enable():
+    user = {"display": {"runtime_footer": {"enabled": True}}}
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["enabled"] is True
+    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+
+
+def test_resolve_ignores_malformed_config():
+    # Non-dict runtime_footer shouldn't crash
+    user = {"display": {"runtime_footer": "on"}}
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "provider,model,expected",
+    [
+        ("claude-bridge-f3", "claude-opus-4-8", ("claude-bridge-f3", "claude-opus-4-8")),
+        # provider unset, model carries the prefix -> split it
+        ("", "claude-bridge-f3/claude-opus-4-8", ("claude-bridge-f3", "claude-opus-4-8")),
+        (None, "openai/gpt-5.4", ("openai", "gpt-5.4")),
+        # bare model, no provider anywhere
+        ("", "gpt-5.4", ("", "gpt-5.4")),
+        (None, None, ("", "")),
+        # BOTH provider given AND model carries a prefix -> model's prefix wins
+        # (no ugly triple openai-codex/claude-app/claude-opus-4-8)
+        ("openai-codex", "claude-app/claude-opus-4-8", ("claude-app", "claude-opus-4-8")),
+    ],
+)
+def test_split_provider_model(provider, model, expected):
+    assert _split_provider_model(provider, model) == expected

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -87,7 +87,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
 | `/approvals [manual\|smart\|off]` | Show or set the persistent dangerous-command approval mode. |
-| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (default fields: model, context %, and cwd; `display.runtime_footer.fields` can also select `provider_model`, `context_full`, `reasoning`, and `latency`). |
 | `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1772,11 +1772,14 @@ Supported fields:
 | Field | Renders | Example |
 | --- | --- | --- |
 | `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
+| `provider_model` | `provider/model` — useful behind bridges/proxies/failover, where the same model is served by different providers | `claude-bridge-f3/claude-opus-4-8` |
 | `context_pct` | Last-call context occupancy as a percent | `5%` |
+| `context_full` | `used/window (pct)`, both humanized | `50.2k/1M (5%)` |
+| `reasoning` | Effective reasoning-effort level, `r:<level>` (honors a session-scoped `/reasoning`) | `r:xhigh` |
 | `latency` | Wall-clock duration of the turn | `22s`, `1m05s` |
 | `cwd` | Home-relative working directory | `~` |
 
-The default field set is `["model", "context_pct", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
+The default field set is `["model", "context_pct", "cwd"]`. The other fields are opt-in — add them to `fields` to use them. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
 
 The `/footer` slash command toggles this at runtime in any session.
 


### PR DESCRIPTION
Re-port of #47600 onto current `main`. The original branch was ~2.9k commits behind and hard-conflicted — upstream added the `latency` footer field and extracted `TurnRunner` in `gateway/run.py` since. This re-applies the same feature cleanly on top of both, carrying the review-response from the original PR (default fields kept, session reasoning honored).

Three **opt-in** footer fields; the default set (`model`, `context_pct`, `cwd`) is unchanged and an existing footer renders byte-identically (asserted by `test_default_footer_renders_byte_identically`):

| Field | Renders | Example |
| --- | --- | --- |
| `provider_model` | `provider/model`; the models own embedded `provider/` prefix wins over a separately-passed provider | `claude-bridge-f3/claude-opus-4-8` |
| `context_full` | `used/window (pct)`, humanized | `50.2k/1M (5%)` |
| `reasoning` | effective reasoning level, honors session-scoped `/reasoning` via caller-resolved `reasoning_config`, else `hermes_constants.resolve_reasoning_config` | `r:xhigh` |

`gateway/run.py`: `agent_result` now carries `provider` on both return paths, and the footer call site passes `provider` + the session-resolved `reasoning_config`.

82/82 in `test_runtime_footer.py` (48 existing + 34 re-ported), mutation-proven (renaming the three field branches fails 12 tests; restore goes green). Docs updated (configuration field table + `/footer` slash-command row), including the upstream `latency` field in the table.

Supersedes #47600 — I will close that one referencing this.