### PR TITLE
feat(update): report version transition after hermes update (prime-agent#630 port)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -838,6 +838,42 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
+def _read_project_version() -> str | None:
+    """Read the ``version`` field from the checkout's pyproject.toml.
+
+    Reads the on-disk file (not importlib.metadata) because after a git
+    pull the installed distribution metadata still describes the OLD
+    version; the file is the only source that reflects what was just
+    pulled. Returns None on any failure — version reporting is cosmetic
+    and must never break an update.
+    """
+    try:
+        import tomllib
+
+        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:
+            version = tomllib.load(fh).get("project", {}).get("version")
+        return str(version) if version else None
+    except Exception:
+        return None
+
+
+def _update_complete_message(pre_version: str | None) -> str:
+    """Completion line with the version transition when it is known.
+
+    Ported from PrimeIntellect-ai/prime-agent#630: after a successful
+    self-update, show both versions (``v0.19.4 → v0.20.0``) so the user
+    can see what they actually got. Falls back to the plain message when
+    either side is unknown or the version did not change (e.g. several
+    commits landed within one release).
+    """
+    post_version = _read_project_version()
+    if pre_version and post_version and pre_version != post_version:
+        return f"✓ Update complete! (v{pre_version} → v{post_version})"
+    if post_version:
+        return f"✓ Update complete! (v{post_version})"
+    return "✓ Update complete!"
+
+
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -849,6 +885,10 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     import tempfile
     import zipfile
     from urllib.request import urlretrieve
+
+    # Snapshot the pre-update version before files are replaced so the
+    # completion line can report the transition (prime-agent#630 port).
+    pre_update_version = _read_project_version()
 
     # The ZIP fallback exists for Windows git-file-I/O breakage. It pulls a
     # static archive from GitHub, which is fine for the default "main"
@@ -1205,7 +1245,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
         print("  Code and Python deps are updated, but the dashboard/TUI may")
         print("  be in a mixed state until the Node deps are rebuilt.")
     else:
-        _print_update_completion("✓ Update complete!")
+        _print_update_completion(_update_complete_message(pre_update_version))
     try:
         _print_curator_first_run_notice()
     except Exception as e:
@@ -4406,6 +4446,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
     active_lazy_features = _m()._capture_active_lazy_features()
     active_tool_dependencies = _m()._capture_active_tool_dependencies()
 
+    # Snapshot the pre-update version before any code is pulled so the
+    # completion line can report the transition (prime-agent#630 port).
+    pre_update_version = _read_project_version()
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))
@@ -5582,7 +5625,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
-            _print_update_completion("✓ Update complete!")
+            _print_update_completion(_update_complete_message(pre_update_version))
 
         # Search-index optimization notice (v23). Existing installs keep their
         # working search index untouched on update; the compact v23 layout —

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -850,7 +850,7 @@ def _read_project_version() -> str | None:
     try:
         import tomllib
 
-        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:
+        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:  # windows-footgun: ok — binary mode, tomllib requires bytes
             version = tomllib.load(fh).get("project", {}).get("version")
         return str(version) if version else None
     except Exception:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -734,7 +734,7 @@ def _read_project_version() -> str | None:
     try:
         import tomllib
 
-        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:
+        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:  # windows-footgun: ok — binary mode, tomllib requires bytes
             version = tomllib.load(fh).get("project", {}).get("version")
         return str(version) if version else None
     except Exception:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -722,6 +722,42 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
+def _read_project_version() -> str | None:
+    """Read the ``version`` field from the checkout's pyproject.toml.
+
+    Reads the on-disk file (not importlib.metadata) because after a git
+    pull the installed distribution metadata still describes the OLD
+    version; the file is the only source that reflects what was just
+    pulled. Returns None on any failure — version reporting is cosmetic
+    and must never break an update.
+    """
+    try:
+        import tomllib
+
+        with open(_m().PROJECT_ROOT / "pyproject.toml", "rb") as fh:
+            version = tomllib.load(fh).get("project", {}).get("version")
+        return str(version) if version else None
+    except Exception:
+        return None
+
+
+def _update_complete_message(pre_version: str | None) -> str:
+    """Completion line with the version transition when it is known.
+
+    Ported from PrimeIntellect-ai/prime-agent#630: after a successful
+    self-update, show both versions (``v0.19.4 → v0.20.0``) so the user
+    can see what they actually got. Falls back to the plain message when
+    either side is unknown or the version did not change (e.g. several
+    commits landed within one release).
+    """
+    post_version = _read_project_version()
+    if pre_version and post_version and pre_version != post_version:
+        return f"✓ Update complete! (v{pre_version} → v{post_version})"
+    if post_version:
+        return f"✓ Update complete! (v{post_version})"
+    return "✓ Update complete!"
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -731,6 +767,10 @@ def _update_via_zip(args):
     import tempfile
     import zipfile
     from urllib.request import urlretrieve
+
+    # Snapshot the pre-update version before files are replaced so the
+    # completion line can report the transition (prime-agent#630 port).
+    pre_update_version = _read_project_version()
 
     # The ZIP fallback exists for Windows git-file-I/O breakage. It pulls a
     # static archive from GitHub, which is fine for the default "main"
@@ -1069,7 +1109,7 @@ def _update_via_zip(args):
         print("  Code and Python deps are updated, but the dashboard/TUI may")
         print("  be in a mixed state until the Node deps are rebuilt.")
     else:
-        _print_update_completion("✓ Update complete!")
+        _print_update_completion(_update_complete_message(pre_update_version))
     try:
         _print_curator_first_run_notice()
     except Exception as e:
@@ -3564,6 +3604,9 @@ def _normalize_managed_eol(git_cmd, repo_root):
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    # Snapshot the pre-update version before any code is pulled so the
+    # completion line can report the transition (prime-agent#630 port).
+    pre_update_version = _read_project_version()
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))
@@ -4602,7 +4645,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
-            _print_update_completion("✓ Update complete!")
+            _print_update_completion(_update_complete_message(pre_update_version))
 
         # Search-index optimization notice (v23). Existing installs keep their
         # working search index untouched on update; the compact v23 layout —

--- a/tests/hermes_cli/test_update_version_report.py
+++ b/tests/hermes_cli/test_update_version_report.py
@@ -1,0 +1,67 @@
+"""Version transition reporting after ``hermes update``.
+
+Ported from PrimeIntellect-ai/prime-agent#630: a successful self-update
+reports both versions (``v0.19.4 → v0.20.0``) when the pyproject version
+changed, and degrades gracefully when either side is unknown.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _write_pyproject(root: Path, version: str) -> None:
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "hermes-agent"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def fake_root(tmp_path, monkeypatch):
+    class _FakeMain:
+        PROJECT_ROOT = tmp_path
+
+    monkeypatch.setattr(update_cmd, "_m", lambda: _FakeMain)
+    return tmp_path
+
+
+class TestReadProjectVersion:
+    def test_reads_version(self, fake_root):
+        _write_pyproject(fake_root, "0.20.0")
+        assert update_cmd._read_project_version() == "0.20.0"
+
+    def test_missing_file_returns_none(self, fake_root):
+        assert update_cmd._read_project_version() is None
+
+    def test_malformed_toml_returns_none(self, fake_root):
+        (fake_root / "pyproject.toml").write_text("not [ toml", encoding="utf-8")
+        assert update_cmd._read_project_version() is None
+
+
+class TestUpdateCompleteMessage:
+    def test_reports_transition_when_version_changed(self, fake_root):
+        _write_pyproject(fake_root, "0.20.0")
+        assert (
+            update_cmd._update_complete_message("0.19.4")
+            == "✓ Update complete! (v0.19.4 → v0.20.0)"
+        )
+
+    def test_same_version_reports_single_version(self, fake_root):
+        _write_pyproject(fake_root, "0.20.0")
+        assert (
+            update_cmd._update_complete_message("0.20.0")
+            == "✓ Update complete! (v0.20.0)"
+        )
+
+    def test_unknown_pre_version_still_shows_current(self, fake_root):
+        _write_pyproject(fake_root, "0.20.0")
+        assert (
+            update_cmd._update_complete_message(None)
+            == "✓ Update complete! (v0.20.0)"
+        )
+
+    def test_unknown_post_version_falls_back_to_plain(self, fake_root):
+        assert update_cmd._update_complete_message("0.19.4") == "✓ Update complete!"


### PR DESCRIPTION
## Summary
`hermes update` now reports the version transition it delivered: `✓ Update complete! (v0.19.4 → v0.20.0)` when the pyproject version changed, `(v0.20.0)` when commits landed within one release, and the plain message when the version can't be read.

Ported from [PrimeIntellect-ai/prime-agent#630](https://github.com/PrimeIntellect-ai/prime-agent/pull/630) (their self-update prints "Updated prime-agent from v0.6.1 to v0.6.2"), adapted to Hermes' git-pull and Windows-ZIP update paths.

## Changes
- `hermes_cli/update_cmd.py`: new `_read_project_version()` (reads the on-disk `pyproject.toml` — installed distribution metadata still describes the OLD version after a pull) and `_update_complete_message(pre_version)`; pre-update version snapshotted at the top of `_cmd_update_impl` and `_update_via_zip`, applied at both success-path completion prints. "Already up to date" / venv-repair paths are untouched (no transition to report).
- `tests/hermes_cli/test_update_version_report.py`: 7 tests covering transition, same-version, unknown-pre, unknown-post, missing/malformed pyproject.

## Validation
| | Before | After |
|---|---|---|
| Completion line after update crossing a release | `✓ Update complete!` | `✓ Update complete! (v0.19.4 → v0.20.0)` |
| New tests | — | 7/7 pass |
| Existing `test_cmd_update.py` + `test_update_zip_two_phase.py` | 40 pass | 40 pass |

E2E: real `_read_project_version()` against the live checkout returns `0.20.0`; message formatting verified with real file I/O.

## Infographic

![hermes update version transition](https://v3b.fal.media/files/b/0aa55089/6VAKMXBJLVohgKDlj2slr_mCM90xF0.png)
