### PR TITLE
fix(error_classifier): classify connect/DNS failure messages on generic exception types (port of opencode#40707)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -575,6 +575,43 @@ _TIMEOUT_MESSAGE_PATTERNS = [
     "upstream timed out",
 ]
 
+# Connection-establishment / DNS failure message patterns.  These surface
+# when the exception TYPE is generic (RuntimeError/Exception from a local
+# shim, MCP bridge, subprocess wrapper, or an SDK that re-raises without
+# chaining) so the _TRANSPORT_ERROR_TYPES check never fires, and the error
+# carries no HTTP status.  Without message-level matching they fall through
+# to FailoverReason.unknown, which misses the transport eager-fallback path
+# in the retry loop (unknown retries the same dead endpoint for the full
+# budget before fallback).  Ported from anomalyco/opencode#40707, which hit
+# the same bug shape: serialized midstream errors matched by type only.
+#
+# Deliberately EXCLUDES mid-stream disconnect strings ("connection reset by
+# peer", "peer closed connection", "unexpected eof", "socket hang up") —
+# those belong to _SERVER_DISCONNECT_PATTERNS, whose classification step
+# runs later and routes large sessions to context-overflow compression.
+# A connection that was never established cannot be a server-side overflow
+# rejection, so these are safe to classify as plain retryable transport.
+_CONNECTION_MESSAGE_PATTERNS = [
+    # TCP connect failures
+    "connection refused",
+    "econnrefused",
+    "no route to host",
+    "network is unreachable",
+    "network unreachable",
+    # DNS resolution failures (Python, glibc, macOS, Node bridge phrasings)
+    "name or service not known",
+    "temporary failure in name resolution",
+    "nodename nor servname provided",
+    "getaddrinfo failed",
+    "getaddrinfo enotfound",
+    "eai_again",
+    # Node/undici bridge generic network failure (MCP servers, local shims)
+    "fetch failed",
+    "failed to fetch",
+    # Envoy/proxy upstream connect failure (cloud gateways)
+    "upstream connect error",
+]
+
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
@@ -1792,6 +1829,16 @@ def _classify_by_message(
     # loop rebuilds the client instead of treating the turn as an empty
     # model response.
     if any(p in error_msg for p in _TIMEOUT_MESSAGE_PATTERNS):
+        return result_fn(FailoverReason.timeout, retryable=True)
+
+    # Connection-establishment / DNS failure message patterns — same shim
+    # problem as the timeout patterns above: the wrapping exception type is
+    # generic, so _TRANSPORT_ERROR_TYPES never matches and the error would
+    # fall through to FailoverReason.unknown. Classified as timeout (the
+    # transport bucket) so the retry loop's eager transport fallback and
+    # client rebuild apply. Never routes to compression: a connection that
+    # was never established is not a context-overflow signal.
+    if any(p in error_msg for p in _CONNECTION_MESSAGE_PATTERNS):
         return result_fn(FailoverReason.timeout, retryable=True)
 
     return None

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -523,6 +523,43 @@ _TIMEOUT_MESSAGE_PATTERNS = [
     "upstream timed out",
 ]
 
+# Connection-establishment / DNS failure message patterns.  These surface
+# when the exception TYPE is generic (RuntimeError/Exception from a local
+# shim, MCP bridge, subprocess wrapper, or an SDK that re-raises without
+# chaining) so the _TRANSPORT_ERROR_TYPES check never fires, and the error
+# carries no HTTP status.  Without message-level matching they fall through
+# to FailoverReason.unknown, which misses the transport eager-fallback path
+# in the retry loop (unknown retries the same dead endpoint for the full
+# budget before fallback).  Ported from anomalyco/opencode#40707, which hit
+# the same bug shape: serialized midstream errors matched by type only.
+#
+# Deliberately EXCLUDES mid-stream disconnect strings ("connection reset by
+# peer", "peer closed connection", "unexpected eof", "socket hang up") —
+# those belong to _SERVER_DISCONNECT_PATTERNS, whose classification step
+# runs later and routes large sessions to context-overflow compression.
+# A connection that was never established cannot be a server-side overflow
+# rejection, so these are safe to classify as plain retryable transport.
+_CONNECTION_MESSAGE_PATTERNS = [
+    # TCP connect failures
+    "connection refused",
+    "econnrefused",
+    "no route to host",
+    "network is unreachable",
+    "network unreachable",
+    # DNS resolution failures (Python, glibc, macOS, Node bridge phrasings)
+    "name or service not known",
+    "temporary failure in name resolution",
+    "nodename nor servname provided",
+    "getaddrinfo failed",
+    "getaddrinfo enotfound",
+    "eai_again",
+    # Node/undici bridge generic network failure (MCP servers, local shims)
+    "fetch failed",
+    "failed to fetch",
+    # Envoy/proxy upstream connect failure (cloud gateways)
+    "upstream connect error",
+]
+
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
@@ -1670,6 +1707,16 @@ def _classify_by_message(
     # loop rebuilds the client instead of treating the turn as an empty
     # model response.
     if any(p in error_msg for p in _TIMEOUT_MESSAGE_PATTERNS):
+        return result_fn(FailoverReason.timeout, retryable=True)
+
+    # Connection-establishment / DNS failure message patterns — same shim
+    # problem as the timeout patterns above: the wrapping exception type is
+    # generic, so _TRANSPORT_ERROR_TYPES never matches and the error would
+    # fall through to FailoverReason.unknown. Classified as timeout (the
+    # transport bucket) so the retry loop's eager transport fallback and
+    # client rebuild apply. Never routes to compression: a connection that
+    # was never established is not a context-overflow signal.
+    if any(p in error_msg for p in _CONNECTION_MESSAGE_PATTERNS):
         return result_fn(FailoverReason.timeout, retryable=True)
 
     return None

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1168,6 +1168,67 @@ class Test408RequestTimeout:
         assert result.should_compress is False
 
 
+# ── Test: connection/DNS failure message patterns on generic exception types ──
+# Port of anomalyco/opencode#40707 (expand retryable error patterns): errors
+# whose TYPE is generic (RuntimeError/Exception from local shims, MCP bridges,
+# re-raising SDKs) but whose MESSAGE carries a connection-establishment or DNS
+# failure must classify as retryable transport, not FailoverReason.unknown.
+
+class TestConnectionMessagePatterns:
+    """Generic-typed connect/DNS failures route to the transport bucket."""
+
+    @pytest.mark.parametrize("message", [
+        "connect ECONNREFUSED 127.0.0.1:11434",
+        "Connection refused by proxy",
+        "getaddrinfo failed",
+        "getaddrinfo ENOTFOUND api.example.com",
+        "[Errno -3] Temporary failure in name resolution",
+        "[Errno 8] nodename nor servname provided, or not known",
+        "getaddrinfo EAI_AGAIN openrouter.ai",
+        "Name or service not known",
+        "No route to host",
+        "[Errno 101] Network is unreachable",
+        "fetch failed",
+        "TypeError: Failed to fetch",
+        "upstream connect error or disconnect/reset before headers",
+    ])
+    def test_generic_exception_with_connect_failure_message_is_timeout(self, message):
+        # RuntimeError — NOT in _TRANSPORT_ERROR_TYPES, not a ConnectionError
+        # subclass, no status code. Without message matching this falls to
+        # FailoverReason.unknown and misses the eager transport fallback.
+        result = classify_api_error(RuntimeError(message))
+        assert result.reason == FailoverReason.timeout, message
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_connect_failure_never_routes_to_compression_on_large_session(self):
+        # A connection that was never established is not an overflow signal,
+        # even when the session is huge (the disconnect+large-session
+        # heuristic must not apply to connect-phase failures).
+        result = classify_api_error(
+            RuntimeError("connect ECONNREFUSED 10.0.0.5:443"),
+            approx_tokens=180000, context_length=200000, num_messages=400,
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.should_compress is False
+
+    def test_midstream_disconnect_patterns_still_use_disconnect_path(self):
+        # "connection reset by peer" is deliberately NOT in the connect-phase
+        # list — it stays on the _SERVER_DISCONNECT_PATTERNS path, which
+        # routes large sessions to context-overflow compression.
+        result = classify_api_error(
+            RuntimeError("Connection reset by peer"),
+            approx_tokens=180000, context_length=200000, num_messages=400,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_plain_unknown_error_still_unknown(self):
+        # Guard against over-matching: an unrelated message stays unknown.
+        result = classify_api_error(RuntimeError("something exploded"))
+        assert result.reason == FailoverReason.unknown
+
+
 # ── Test: throttle vs overflow disambiguation + new overflow shapes ─────
 # Port of anomalyco/opencode#37848 (expand context overflow patterns +
 # rate-limit exclusion guard).

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1019,6 +1019,67 @@ class Test408RequestTimeout:
         assert result.should_compress is False
 
 
+# ── Test: connection/DNS failure message patterns on generic exception types ──
+# Port of anomalyco/opencode#40707 (expand retryable error patterns): errors
+# whose TYPE is generic (RuntimeError/Exception from local shims, MCP bridges,
+# re-raising SDKs) but whose MESSAGE carries a connection-establishment or DNS
+# failure must classify as retryable transport, not FailoverReason.unknown.
+
+class TestConnectionMessagePatterns:
+    """Generic-typed connect/DNS failures route to the transport bucket."""
+
+    @pytest.mark.parametrize("message", [
+        "connect ECONNREFUSED 127.0.0.1:11434",
+        "Connection refused by proxy",
+        "getaddrinfo failed",
+        "getaddrinfo ENOTFOUND api.example.com",
+        "[Errno -3] Temporary failure in name resolution",
+        "[Errno 8] nodename nor servname provided, or not known",
+        "getaddrinfo EAI_AGAIN openrouter.ai",
+        "Name or service not known",
+        "No route to host",
+        "[Errno 101] Network is unreachable",
+        "fetch failed",
+        "TypeError: Failed to fetch",
+        "upstream connect error or disconnect/reset before headers",
+    ])
+    def test_generic_exception_with_connect_failure_message_is_timeout(self, message):
+        # RuntimeError — NOT in _TRANSPORT_ERROR_TYPES, not a ConnectionError
+        # subclass, no status code. Without message matching this falls to
+        # FailoverReason.unknown and misses the eager transport fallback.
+        result = classify_api_error(RuntimeError(message))
+        assert result.reason == FailoverReason.timeout, message
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_connect_failure_never_routes_to_compression_on_large_session(self):
+        # A connection that was never established is not an overflow signal,
+        # even when the session is huge (the disconnect+large-session
+        # heuristic must not apply to connect-phase failures).
+        result = classify_api_error(
+            RuntimeError("connect ECONNREFUSED 10.0.0.5:443"),
+            approx_tokens=180000, context_length=200000, num_messages=400,
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.should_compress is False
+
+    def test_midstream_disconnect_patterns_still_use_disconnect_path(self):
+        # "connection reset by peer" is deliberately NOT in the connect-phase
+        # list — it stays on the _SERVER_DISCONNECT_PATTERNS path, which
+        # routes large sessions to context-overflow compression.
+        result = classify_api_error(
+            RuntimeError("Connection reset by peer"),
+            approx_tokens=180000, context_length=200000, num_messages=400,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_plain_unknown_error_still_unknown(self):
+        # Guard against over-matching: an unrelated message stays unknown.
+        result = classify_api_error(RuntimeError("something exploded"))
+        assert result.reason == FailoverReason.unknown
+
+
 # ── Test: throttle vs overflow disambiguation + new overflow shapes ─────
 # Port of anomalyco/opencode#37848 (expand context overflow patterns +
 # rate-limit exclusion guard).


### PR DESCRIPTION
## Summary
Connection-establishment and DNS failure messages wrapped in generic exception types (RuntimeError from local shims, MCP bridges, re-raising SDKs) now classify as retryable transport (`FailoverReason.timeout`) instead of falling through to `FailoverReason.unknown`.

Port of [anomalyco/opencode#40707](https://github.com/anomalyco/opencode/pull/40707) (expand retryable error patterns), which fixed the same bug shape: serialized midstream errors were matched by exception type only, so message-borne connect/DNS failures missed the retry path.

Root cause on our side: `classify_api_error` recognizes transport failures via `_TRANSPORT_ERROR_TYPES` (type names) and `isinstance` checks. When the SDK or a shim re-raises without chaining, the type is `RuntimeError`/`Exception` — no status code, no matching type — and the error lands in the `unknown` bucket. `unknown` is retryable but does NOT count as `_is_transport_failure` in the retry loop, so the eager transport fallback (`retry_count >= 2` → next provider) never fires and the full retry budget burns against a dead endpoint.

## Changes
- `agent/error_classifier.py`: new `_CONNECTION_MESSAGE_PATTERNS` list (connect refused, no-route, network-unreachable, DNS phrasings for Python/glibc/macOS/Node, `fetch failed`, Envoy `upstream connect error`) + a message-level check in `_classify_by_message`, mirroring the existing `_TIMEOUT_MESSAGE_PATTERNS` mechanism.
- `tests/agent/test_error_classifier.py`: `TestConnectionMessagePatterns` — 13 parametrized message shapes, plus guards that (a) connect-phase failures never route to compression even on huge sessions, (b) mid-stream `connection reset by peer` still takes the `_SERVER_DISCONNECT_PATTERNS`/compression path, (c) unrelated messages stay `unknown`.

## Adaptation notes
- OpenCode's pattern list includes mid-stream disconnect strings (`socket hang up`, `terminated`). Deliberately excluded here: hermes routes those through `_SERVER_DISCONNECT_PATTERNS`, which sends large sessions to context-overflow compression — a connect-phase failure must never trigger compression, and a mid-stream reset must keep its existing routing.
- OpenCode also matches bare status-code digits (`/429|500|502.../`) in message text; skipped — hermes extracts real status codes via `_extract_status_code` and classifying on digit substrings is over-matching.

## Validation
| Probe | Before | After |
|---|---|---|
| `RuntimeError("connect ECONNREFUSED 127.0.0.1:11434")` | `unknown` | `timeout`, retryable |
| `RuntimeError("getaddrinfo ENOTFOUND api.example.com")` | `unknown` | `timeout`, retryable |
| Large session + `ECONNREFUSED` | — | no compression |
| `tests/agent/test_error_classifier.py` | 71 passed | 88 passed |

## Infographic

![connection-error-patterns](https://v3b.fal.media/files/b/0aa55085/Ke87QvvVmS4m06vJmBt4P_xr54L0Cg.png)
