### PR TITLE
fix(wake): pin sherpa-onnx to 1.12.40 — 1.13.x never fires on macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,8 @@ voice = [
 wake = [
   "openwakeword==0.6.0",
   "onnxruntime==1.27.0",
-  "sherpa-onnx==1.13.4",
+  "sherpa-onnx==1.12.40",
+  "sherpa-onnx-core==1.12.40",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,8 @@ voice = [
 wake = [
   "openwakeword==0.6.0",
   "onnxruntime==1.27.0",
-  "sherpa-onnx==1.13.4",
+  "sherpa-onnx==1.12.40",
+  "sherpa-onnx-core==1.12.40",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -175,7 +175,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
     # tokenization) even though sherpa-onnx doesn't declare it.
     "wake.sherpa": (
-        "sherpa-onnx==1.13.4",
+        # sherpa-onnx 1.13.x is a broken wheel on macOS arm64: KeywordSpotter
+        # builds and streams but produces ZERO detections even on the bundled
+        # model + test wavs (verified 2026-07-31; same result reported on the
+        # 1.13.4-core lock). Pin to 1.12.40 where KWS actually fires.
+        "sherpa-onnx==1.12.40",
+        "sherpa-onnx-core==1.12.40",
         "sentencepiece==0.2.2",
         "sounddevice==0.5.5",
         "numpy==2.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1781,6 +1781,7 @@ wake = [
     { name = "pvporcupine" },
     { name = "sentencepiece" },
     { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "sounddevice" },
 ]
 web = [
@@ -1909,7 +1910,8 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
     { name = "sentencepiece", marker = "extra == 'wake'", specifier = "==0.2.2" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==83.0.0" },
-    { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.13.4" },
+    { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.12.40" },
+    { name = "sherpa-onnx-core", marker = "extra == 'wake'", specifier = "==1.12.40" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.29.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.29.0" },
     { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
@@ -3993,7 +3995,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4048,7 +4050,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4130,34 +4132,49 @@ wheels = [
 
 [[package]]
 name = "sherpa-onnx"
-version = "1.13.4"
+version = "1.12.40"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/f8/735244770b4bc63f85fabdad0e46d6ec1f4cc24e64f6e082c2e0fea92b8c/sherpa_onnx-1.13.4.tar.gz", hash = "sha256:29547692418513ad88034c2b5f98985e33042b2351e4ab375469f19a8de18c5f", size = 982750, upload-time = "2026-07-07T13:04:55.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/74/7e75912344eb26a24e501ec5d8f966a2f80895d419cc45d4758a4dc29c38/sherpa_onnx-1.12.40.tar.gz", hash = "sha256:08b7234679606c3d3f68d579382e312a5394fcbb7a72e91992ffff47ce877663", size = 903239, upload-time = "2026-04-24T11:49:41.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/4f/6ab541c5b2a4b2a6e9970edc4b558f270f7b6624c861eccb85126ccd279c/sherpa_onnx-1.13.4-cp311-cp311-linux_armv7l.whl", hash = "sha256:8e1cdbd53b432630a81ea479ce5bad6aa8192eb4a458d8c9432c54052cb9cc7d", size = 11930819, upload-time = "2026-07-07T14:22:29.536Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/41/b750ec336f882e75c5e23c9ad5d52b0902be2337cc50d13ce68cde9e4459/sherpa_onnx-1.13.4-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:5d35aeb5ad13b54cea0d6fed681660f6308acb841de981745e33d457255b9134", size = 4349088, upload-time = "2026-07-07T13:14:19.408Z" },
-    { url = "https://files.pythonhosted.org/packages/41/c8/a2ff828ce9a2702b607c25f6303b21d7d41b6ad1520f660b95a0113f4051/sherpa_onnx-1.13.4-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c3e9f96a07570faefca8e3aabcfb78690e680d188d5d44d06fd8711185fe37d6", size = 2288314, upload-time = "2026-07-07T12:08:36.643Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/93/4385fcdb1f197521fe13fa887893cc200d27569d3cbcccf0d7b92d6a9e62/sherpa_onnx-1.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c2d4337b80b54dd68f566cab941a2ad47ab6cfabb68e88002ee0c920493c16d3", size = 2100029, upload-time = "2026-07-07T12:23:26.936Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/cb/c80832f800719c72fc5805a94fe489e805fc67156e102927609917ad8f67/sherpa_onnx-1.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7c4a1c178eb801af92f70120128c1f956b5388b9d684f0af2a08614e05dc3047", size = 4132838, upload-time = "2026-07-07T11:55:17.567Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ac/88b4e1ce614ddebe2484e95cad4b19d7db24f3b489d04f9877667cb48ccb/sherpa_onnx-1.13.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fbfc385b98d730080e1b12dc94c604be3867e4fb7bd6b15b830eb33cbf390111", size = 4356406, upload-time = "2026-07-07T12:42:29.823Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/73/2fff5d28669e91851e981d223c50aa21f90d712a4551dcb51c231b3a27fe/sherpa_onnx-1.13.4-cp311-cp311-win32.whl", hash = "sha256:1d746b8c6ed1ce9eb94868d71b5ea9c22274b8cb166420bd1772f7df470b753a", size = 1927745, upload-time = "2026-07-07T12:33:50.17Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/b1/ae1c113ac9c67dcabbed559f50950c7220a62e49e6b5acb4c2219ab22409/sherpa_onnx-1.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:04a82d79c13a4ce2bd9ccf51de93e83cbfc7bc50520c53e5e967565100d0724d", size = 2239901, upload-time = "2026-07-07T12:22:27.112Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/57/179e3a6c1fec33aa6535051feddd5da36e5622d35630b12a67a2805b76b3/sherpa_onnx-1.13.4-cp312-cp312-linux_armv7l.whl", hash = "sha256:bcf64f2d853a1afe236e9e220df62f2f53ef6ad792ca7e406d6173ec003319b8", size = 11933213, upload-time = "2026-07-07T13:50:35.989Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/34/b6d3483b08ec8a4a141e978c4b92530fd0a61dd571a575c1fe24bee300d7/sherpa_onnx-1.13.4-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:2257545ea170f58b7977309793979d6d078761b7fdb0528561285f8ead4169db", size = 4422157, upload-time = "2026-07-07T12:29:40.234Z" },
-    { url = "https://files.pythonhosted.org/packages/82/37/07f03e97f157b206f6e62d722ec7c5ff41c7e9dc6aa2dc7de69b57e39b5a/sherpa_onnx-1.13.4-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:02b57dc2c829976eb842e6aee6a0e4ac3b9991aeb5afa89fd44eb71d848a4ecd", size = 2345135, upload-time = "2026-07-07T12:10:19.957Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/79/ee999f0c3b7789077d0939716a38234573d139f851a31409aa028fe2c610/sherpa_onnx-1.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:84e58b5a074b97c5307c9b6221d1d20fbf412a1a5dff4960ca9c32bb5184219f", size = 2105219, upload-time = "2026-07-07T11:48:22.518Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/90/9b67ed3e7adc79daf0ba49c4936a691521488125b04fe469b64a8b5398ff/sherpa_onnx-1.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f709e6dd02ebf7d37dcb02d5eadc5fb66c9922dd5809df770c1ef5d625ae7a44", size = 4135963, upload-time = "2026-07-07T11:58:30.98Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b1/8dfe5d1d72c92ea1c95db999a95b61bfbb9769f1c569f06e572eda095c52/sherpa_onnx-1.13.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f0158f3513d3adab1ebba0c26f0c815e53ba13b96846d92ef095ae25d648860", size = 4358555, upload-time = "2026-07-07T12:58:59.654Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/04/cfd543933ae24430d124e533847c73a84a5f0efd60f07bbc6403032f9624/sherpa_onnx-1.13.4-cp312-cp312-win32.whl", hash = "sha256:d49928a3455bae1dd4e93f6b013cfbd2c3ccb5cde74aabae3710b656e7d79b6b", size = 1930647, upload-time = "2026-07-07T12:02:06.689Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/bb/1e723ab703a1e354f390de19981ec0c347576f87be01915d826dc6fc9f41/sherpa_onnx-1.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:b8436ffe2763b3fd522fbac8fe53f47d611721c84819c241acfb65d122403d7d", size = 2244142, upload-time = "2026-07-07T13:01:42.293Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/36/45b17335f041f1383f6fd142ab57c2d8a337ba2386b7547b125ec9d780af/sherpa_onnx-1.13.4-cp313-cp313-linux_armv7l.whl", hash = "sha256:9e98dc5e0559ad953f227fc884958c71b10c65a93667331405e7d4441ed5f76d", size = 11932654, upload-time = "2026-07-07T14:18:59.791Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d7/1e9a7dedab2da8af1a8417b4f4d5f496bd7700a71b59c5e085de5e10761b/sherpa_onnx-1.13.4-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:083747c2d0362ead0501cc773a618be19862a800b3f8f259d3bd3486f1494af4", size = 4372494, upload-time = "2026-07-07T13:02:05.512Z" },
-    { url = "https://files.pythonhosted.org/packages/62/28/09aa9461e8bdf894ba8466e047e40fb5da8aaa6d68c19cf1e2aabe01e706/sherpa_onnx-1.13.4-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:b4f54363b264b16148a724b4442f00cda97fcd4e9beeda3d75637753910e8557", size = 2307539, upload-time = "2026-07-07T12:28:22.056Z" },
-    { url = "https://files.pythonhosted.org/packages/21/ed/d07787dd4be4119e6587c840f6b417c2d57c14d694d334af609d68cb5a41/sherpa_onnx-1.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8ec5394b4ea73bf01e6883cf078348f87350f4eb3567d51d92cae77ea2582403", size = 2115586, upload-time = "2026-07-07T12:47:31.367Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c2/281d84dc9e448ea99d7fb77708cbe1cc7cfd8c7d669727dc94385a9e4ca5/sherpa_onnx-1.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a39352ceb2ec6671a1f252fb768fff75bb2f0bc849cca5f66f490e89910a860d", size = 4136268, upload-time = "2026-07-07T12:10:09.762Z" },
-    { url = "https://files.pythonhosted.org/packages/db/47/da3ea14ab647a4f6580227853fe29353e1173ff77064d42c0bb31d01b453/sherpa_onnx-1.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:88af596be24eac32982dd64fcac30af99d9130ca498bfa1a0064189c8498195b", size = 4358385, upload-time = "2026-07-07T13:10:10.265Z" },
-    { url = "https://files.pythonhosted.org/packages/44/90/84205ff383ba9335c3821c2cd6d514350f52199cb640ec094517f1f911a0/sherpa_onnx-1.13.4-cp313-cp313-win32.whl", hash = "sha256:0cabb508a15be22138f9fb7695d7ec5f3893ecd088ee419b9df559fed7e8f649", size = 1929707, upload-time = "2026-07-07T12:51:53.196Z" },
-    { url = "https://files.pythonhosted.org/packages/82/40/ee8a0a8c83fc6d7f5245a5a031e471d3b115e20cce867e7abb2f9d4185c9/sherpa_onnx-1.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:17050fdfb48d37ae996364f697c554a1399740d18e5a56b143c011d00cfed3e0", size = 2244504, upload-time = "2026-07-07T12:32:59.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5a/a81630b49df8085ec96f30ff86c1dfaf2b26991299432415601bd6808632/sherpa_onnx-1.12.40-cp311-cp311-linux_armv7l.whl", hash = "sha256:01fe9bec150d53da1d612d23b8e79c441bbfe426a74886a886a8ecddc2dca51b", size = 11432998, upload-time = "2026-04-24T13:13:03.173Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/b763f182f4186ea9ed70c465ad51a78e7587f7d04bf8642d3d10747f7da5/sherpa_onnx-1.12.40-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:5812083f7375e3942604d210cddecf7fb006e6c8eb91765eb617e4722c7b0c37", size = 4247864, upload-time = "2026-04-24T11:46:16.662Z" },
+    { url = "https://files.pythonhosted.org/packages/55/15/c9e37ffae657195263ad63068edd830b5a689f64fa1e2f326de71a4d82fb/sherpa_onnx-1.12.40-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:abd644f653def66bc68d069b2723ee4a25fd62a1097df0ca4712a82809dce667", size = 2246388, upload-time = "2026-04-24T11:56:11.695Z" },
+    { url = "https://files.pythonhosted.org/packages/33/14/f1511f79008838de6e0ad64625f1403da9e89c2d505ab38561ed46bd9d6d/sherpa_onnx-1.12.40-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bdbbcad64cba6b77cce597f868dd10e1aa96402cfa39dad5a3cc2d5b060396b4", size = 2035992, upload-time = "2026-04-24T11:11:25.801Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/87/e3a1723e585c27d4b9649cd8f3d2be9ea30a7f1902b599e07a647d53f5f6/sherpa_onnx-1.12.40-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef2268ccbcd94322a933d5aa1930503ca0b7dc463511daca1de8474c545c67c1", size = 4063097, upload-time = "2026-04-24T12:06:10.375Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f2/0b3bb630f56661b2971890b1833f3cca5313692962068f75bc0a68b4591a/sherpa_onnx-1.12.40-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:076717aa2f3dbe0c9e515982d99117bab832b6faadf16a0279b8b3b9d69c283b", size = 4276840, upload-time = "2026-04-24T11:31:41.026Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/54/03e127da0d11ec06bfe361232c3d9b06d12bde0f26b1b3619f4862578a77/sherpa_onnx-1.12.40-cp311-cp311-win32.whl", hash = "sha256:6db5f4dac61e686bcbadc48c3580571f4ba35d0808f0a20f0487d670d29b047e", size = 1866880, upload-time = "2026-04-24T12:15:31.989Z" },
+    { url = "https://files.pythonhosted.org/packages/51/43/b0735f723dd7933bae849ab9d088e4e5141d3b61c5a235c41ec8199f9ae3/sherpa_onnx-1.12.40-cp311-cp311-win_amd64.whl", hash = "sha256:f79ef0faad54c527cabadc3982e6f58c6baf957a0da016b5c32937925b0068c5", size = 2167818, upload-time = "2026-04-24T11:42:16.068Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b4/9cdb2377ccdee6c26f3c8fa39479ba6520eff55df17be6e749286f73c4e7/sherpa_onnx-1.12.40-cp312-cp312-linux_armv7l.whl", hash = "sha256:c1d332fb3681cc53c6baa06d4f7119433c528e461475408a1fb71f808067040a", size = 11433929, upload-time = "2026-04-24T12:55:18.478Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5c/157994e49be37d11775dfb3cc8c029d2b4c2db2ab9f28f61ab55647049be/sherpa_onnx-1.12.40-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:926cddcedf869ec61541658191ed5557da43f49802ce540e6d079c6ae94ee40e", size = 4270216, upload-time = "2026-04-24T11:31:48.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/af/f226d785445eec34ec8d9347e75ae8541f8b541b438bc077c7077441b13e/sherpa_onnx-1.12.40-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:21b3aca6d670b1cb04b7f67bdb371f2f79f029d9facb1a58ea0e9c405e80b330", size = 2263073, upload-time = "2026-04-24T10:58:57.638Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/80/3ab3bbd973e6c79b75ec0e3f1b2ff27acb7dad63720450121ae8e3ab95a1/sherpa_onnx-1.12.40-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:50f1455060fd0ecb91d12e1934520bd1b9295794d47a870167b4782ff5c72435", size = 2039551, upload-time = "2026-04-24T11:21:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/996d8fa0912a4c44859e63fe74681587253555c8651119ef354fae76c0e7/sherpa_onnx-1.12.40-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2b14026f6c62b9914265d1c128d7b0668cd80e50034094236a56f912e6450950", size = 4063489, upload-time = "2026-04-24T11:20:16.512Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/4babed9e2c48441ed8ef826c634a56a37673a1ae1b6bef9116368a55a404/sherpa_onnx-1.12.40-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a9ff68d744f16ca03ccbba598644b2b743fe93df67a3eba6927c42ed76d09565", size = 4277829, upload-time = "2026-04-24T11:21:09.446Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/08/a53ba2d778f4591e209a2b6f72296f9353e2c1b51e0468de26267a2fd355/sherpa_onnx-1.12.40-cp312-cp312-win32.whl", hash = "sha256:191de45f1bd756428e6bc87ff1e99101a9fb8fb2e403b55f1ef2de0de380aad6", size = 1869113, upload-time = "2026-04-24T12:14:17.55Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3c/cc251a30f1ab0a9d5c8bce9cb1db172efab45b9db1e7b4a592056807c2ff/sherpa_onnx-1.12.40-cp312-cp312-win_amd64.whl", hash = "sha256:a98c08848433af34ba0c81015f4ec1290f627d8ceec3d6d9df3380082cac408f", size = 2168433, upload-time = "2026-04-24T11:49:32.471Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/508c12c441d7c4b9d34d6672c5b18e218fde88a22d819e29ad453472871d/sherpa_onnx-1.12.40-cp313-cp313-linux_armv7l.whl", hash = "sha256:882244ca9aad7e346634473efc74f14778fa4fae4f4881ccb9a242e4dc85a9e0", size = 11433764, upload-time = "2026-04-24T12:24:10.305Z" },
+    { url = "https://files.pythonhosted.org/packages/32/82/0ea1f52cc8c6540cc3f2b5e136151da1b7d2a17d8e3b4d9f08b635c0b4dd/sherpa_onnx-1.12.40-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:6c6de5f90a48c09e043652c8d9b01577a3b41ff089db94c948e6b32725c5f313", size = 4270310, upload-time = "2026-04-24T11:08:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c6/3096d53f677e8ff2393500098c0137793a9413662eae9419816597f827ea/sherpa_onnx-1.12.40-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:b57130a4ec53b48cc49e1acb233a34eb2fa508f273a617b36284ae9549e6eb19", size = 2263157, upload-time = "2026-04-24T11:48:58.632Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2e/3c9db9aa3ade0babaa415baf86f07abcd355619a577f661d9e9b8a59132c/sherpa_onnx-1.12.40-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9320f5f2f63392c39d49e908fc6bd4a0bc36a40d6d72956821e0765c06e03ed3", size = 2039697, upload-time = "2026-04-24T11:38:36.282Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/16/a2f704139c6e6ae30983f86c0562ee6bde48ad886605534ad82c8b995133/sherpa_onnx-1.12.40-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:710fc1c422220e5a57d6a4c5f14971b0171c1a92fe15fe5fea6029b1b81960ea", size = 4062842, upload-time = "2026-04-24T11:47:26.384Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/b718533dc33bf38f280766e496c5fc4e4a3c8ee08f69cf4239367a148068/sherpa_onnx-1.12.40-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1f938f80207e4afcd7bcd030f1adcf2b44f6b4523bca3f13c6c30710904b85b1", size = 4277902, upload-time = "2026-04-24T11:45:44.656Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/da/d3b20da83ea203c5233815d52c36978daff0ec9e3e68f89df1fb230beb95/sherpa_onnx-1.12.40-cp313-cp313-win32.whl", hash = "sha256:6035773f5aa1a3995b1a2908eda565f0766ac0732d88f1ef605dbc115840e400", size = 1868662, upload-time = "2026-04-24T12:17:51.194Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bd/21d872c4906b4b78a46542730e25aabfb90443e581f5e9fb754e9e17eb64/sherpa_onnx-1.12.40-cp313-cp313-win_amd64.whl", hash = "sha256:53bc91904e043e4751ffe652462c1ad29951f79aaacaf599544d9a1e19562c59", size = 2168955, upload-time = "2026-04-24T12:28:04.656Z" },
+]
+
+[[package]]
+name = "sherpa-onnx-core"
+version = "1.12.40"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/f3/1cbf41368b0c6600af67e5e28ad629eb9c0315a330b367c8a5cf44d0fd00/sherpa_onnx_core-1.12.40-py3-none-macosx_10_15_universal2.whl", hash = "sha256:af2312a6ceb09646c7740d6b21791d8a3f26d952b30c1c721731221c7e941fd9", size = 33935545, upload-time = "2026-04-24T10:46:16.052Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ce/091b6f4373dc1052f927a2bfe537e4693093388939c02cd0116b7e0459fd/sherpa_onnx_core-1.12.40-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:6f99b446dbb5c802ae4809cf87061b87fa2d29421083b04efa3ba62840061c80", size = 18241040, upload-time = "2026-04-24T10:46:34.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/87b7deedec6a94688b2090c53646a42045984836e0f358be693f48c7d11d/sherpa_onnx_core-1.12.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6bb87aa47e866c64f741a211e03c4d8c57a11648503dbedfe59b689d2ad2b06f", size = 21139683, upload-time = "2026-04-24T10:40:55.941Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/ed4486f5e2f5240cef0d9923adbcfadd0250e94a487f7c8823c7f7c03177/sherpa_onnx_core-1.12.40-py3-none-manylinux2014_aarch64.whl", hash = "sha256:73c77dbb0f3395c79e593879be8c6db53176598408cfb1085bff99210aab1ca2", size = 12379451, upload-time = "2026-04-24T10:50:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/5438a8f9856c91be6f43caf6dbcb16232b979c189c5a8c0bf164411a55e5/sherpa_onnx_core-1.12.40-py3-none-manylinux2014_x86_64.whl", hash = "sha256:0ebfcdaaedd0c146518190af728bf00d068aff68f405cc192a83f163188962d9", size = 9783988, upload-time = "2026-04-24T10:59:09.489Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9a/0af6f1d6ecf1d0694b70c2b69e25774e41d97b23e2907956c64c0a72923d/sherpa_onnx_core-1.12.40-py3-none-manylinux_2_35_armv7l.whl", hash = "sha256:102277449f95d73a272dcbbff96d33957895996ea5301e89b6d8124c3e996050", size = 9454886, upload-time = "2026-04-24T12:44:14.358Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3f/87ca8694f850867001c48818447900412e3a1bf58f7645cffb6b9872f1c3/sherpa_onnx_core-1.12.40-py3-none-win32.whl", hash = "sha256:f6f47b9c477ff70c8e93f3f489823255e999b9e7180ba2a7aeee0607a4cdccdb", size = 13699886, upload-time = "2026-04-24T10:46:56.63Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c1/2cb95cf8e8334e8e6dd8b1d6da010f8e5846c4f8c300a575b8e46b17e0d1/sherpa_onnx_core-1.12.40-py3-none-win_amd64.whl", hash = "sha256:506aa30d7af5e182cc90fcabe841d1abc842c195ec19dfd3cb9aec3562b9c1e0", size = 15633214, upload-time = "2026-04-24T11:15:35.104Z" },
 ]
 
 [[package]]
@@ -4678,11 +4695,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
fix(wake): pin sherpa-onnx to 1.12.40 — 1.13.x never fires on macOS arm64

sherpa-onnx 1.13.x is a broken wheel on macOS arm64: KeywordSpotter builds,
streams, and reports no error, but produces ZERO detections — even against
sherpa's own bundled model and test wavs. The wake listener "arms" (log shows
listening for the phrase) but the phrase never triggers. Verified locally on
2026-07-31 with a synthetic "hey robot" clip through the engine: 1.13.4 = no
detections, 1.12.40 = clean detection.

The pypinyin half of the sherpa runtime dep is already covered by #74733 /
#74768 / #75321; this PR only pins the broken wheel back to the last version
that actually fires, and adds the matching sherpa-onnx-core pin so the native
closure resolves (adjacent to #77947, which locks 1.13.4-core for a different
dlopen issue but does not fix detection).

- tools/lazy_deps.py: wake.sherpa 1.13.4 → 1.12.40 (+ core pin)
- pyproject.toml: wake extra same pins

Fixes the silent never-fires wake word on Apple Silicon.
