### PR TITLE
fix: wire gateway SessionDB into the hygiene compression agent (#21301)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9352,6 +9352,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    # Wire the gateway's SessionDB so
+                                    # _compress_context can rotate the session
+                                    # forward (archive + create the new row).
+                                    # Without it hygiene compresses in a loop:
+                                    # it produces a summary every run but can
+                                    # never write it back (#21301).
+                                    session_db=self._session_db,
                                 )
                                 try:
                                     # The hygiene agent rotates the session

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -396,6 +396,105 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_agent_receives_session_db(monkeypatch, tmp_path):
+    """Fix for #21301: the hygiene agent must be constructed with the
+    gateway's SessionDB so _compress_context can rotate the session forward.
+    Previously session_db was omitted, so hygiene compressed in a loop —
+    producing a summary every run but never able to write it back."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    captured: dict = {}
+
+    class CapturingCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.compression_in_place = False
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CapturingCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    session_db = object()  # sentinel: the gateway's SessionDB instance
+    runner._session_db = session_db
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    await runner._handle_message(event)
+
+    assert CapturingCompressAgent.last_instance is not None
+    assert captured.get("session_db") is session_db
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch, tmp_path):
     """Regression for #21301: the hygiene agent is built without a session_db,
     so _compress_context cannot rotate. When it neither rotates NOR compacts


### PR DESCRIPTION
## Problem

The session-hygiene compression agent is the only `AIAgent` constructed in the gateway without a `session_db`. When a long-lived conversation crosses the hygiene threshold, `_compress_context` runs (summarizing the transcript), but has no session DB handle, so the rotation/write-back step silently no-ops. The compressed summary is discarded, the session stays at full size, and hygiene re-fires every few minutes — each run billing a full-context model call. Observed: 679 runs in 7 days, ~465k-token context each, ~1.66B cache-read tokens, with the summary never landing.

## Fix

Pass `session_db=self._session_db` when spawning the hygiene agent (line ~9347), mirroring how every other gateway agent is built (e.g. line ~11329). The existing no-rotation guard remains as a data-loss safety net, so the change only enables write-back when a session DB is actually available.

## Test

- Kept the existing #21301 regression (which deliberately runs with `runner._session_db = None` and asserts graceful no-op behavior).
- Added a positive test asserting the hygiene agent now receives the gateway's SessionDB, so a future refactor can't silently drop the wiring again.
- Full hygiene test suite: 39 passed.

Fixes #21301