### PR TITLE
feat(telegram): add capture ingress queue with atomic ledger persistence (Slice 1.1R-B)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13416,6 +13416,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_adapter_auth_check(platform, profile_name=profile_name)
         )
         adapter._busy_text_mode = self._busy_text_mode
+        # Receiving-profile stamp — capture ingress keys ledger event_ids on it.
+        adapter._profile = profile_name
 
     async def _run_secondary_profile_reconnect(
         self, profile_name: str, platform: Platform

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -709,6 +709,78 @@ class TelegramAdapter(BasePlatformAdapter):
         """Telegram measures message length in UTF-16 code units."""
         return utf16_len
 
+    def _register_handlers(self, app) -> None:
+        """Install the message/callback handlers on a freshly-built Application."""
+        app.add_handler(TelegramMessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            self._handle_text_message
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.COMMAND,
+            self._handle_command
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+            self._handle_location_message
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+            self._handle_media_message
+        ))
+        # Handle inline keyboard button callbacks (update prompts)
+        app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+
+    def _capture_db_path(self) -> "Path":
+        """Capture ledger DB path. HERMES_HOME is already profile-scoped."""
+        from pathlib import Path
+        try:
+            from hermes_constants import get_hermes_home
+            home = get_hermes_home()
+        except Exception:
+            home = Path(os.path.expanduser("~/.hermes"))
+        return Path(home) / "cache" / "capture" / "ingress.db"
+
+    def _build_capture_queue(self):
+        """Build the pre-dispatch capture queue, or None when no routes exist.
+
+        Routes come from ``platforms.telegram.extra.capture_routes``, a list of
+        ``{chat_id, thread_id?, mode, sink}`` entries. With none configured the
+        queue would be a pure passthrough, so we skip it (and skip creating the
+        DB file) entirely.
+        """
+        from plugins.platforms.telegram.capture_ingress import (
+            CaptureIngressQueue,
+            open_capture_db,
+        )
+
+        route_map = {}
+        for entry in (self.config.extra or {}).get("capture_routes") or []:
+            try:
+                key = (int(entry["chat_id"]), int(entry.get("thread_id") or 0))
+                route_map[key] = {
+                    "mode": str(entry["mode"]),
+                    "sink": str(entry["sink"]),
+                }
+            except (KeyError, TypeError, ValueError):
+                logger.warning(
+                    "[%s] Ignoring malformed capture_routes entry: %r",
+                    self.name, entry,
+                )
+        if not route_map:
+            return None
+
+        # ponytail: bot_id comes from config because the queue is needed BEFORE
+        # builder.build() gives us self._bot.id. Set extra.bot_id to keep
+        # event_ids stable; resolve it pre-build if that ever gets fiddly.
+        account_id = int((self.config.extra or {}).get("bot_id") or 0)
+        return CaptureIngressQueue(
+            inner_queue=asyncio.Queue(),
+            db_connection=open_capture_db(self._capture_db_path()),
+            profile=self._profile,
+            account_id=account_id,
+            route_map=route_map,
+        )
+
     @property
     def profile(self) -> str:
         """Receiving-profile name this adapter belongs to (read-only)."""
@@ -3888,28 +3960,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
             get_updates_request = self._instrument_polling_request(get_updates_request)
             builder = builder.request(request).get_updates_request(get_updates_request)
+            capture_queue = self._build_capture_queue()
+            if capture_queue is not None:
+                builder = builder.update_queue(capture_queue)
             self._app = builder.build()
             self._bot = self._app.bot
-            
-            # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._register_handlers(self._app)
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -4023,24 +4079,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         old_app = self._app
                         self._app = builder.build()
                         self._bot = self._app.bot
-                        # Re-register handlers on the new app
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.TEXT & ~filters.COMMAND,
-                            self._handle_text_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.COMMAND,
-                            self._handle_command
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                            self._handle_location_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                            self._handle_media_message
-                        ))
-                        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+                        self._register_handlers(self._app)
                         # Best-effort discard the old app's resources
                         try:
                             await _shutdown_abandoned_app(old_app)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -614,6 +614,15 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+def _active_profile_name() -> str:
+    """Process-active profile name, or "default" when profiles are unavailable."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -700,8 +709,18 @@ class TelegramAdapter(BasePlatformAdapter):
         """Telegram measures message length in UTF-16 code units."""
         return utf16_len
 
-    def __init__(self, config: PlatformConfig):
+    @property
+    def profile(self) -> str:
+        """Receiving-profile name this adapter belongs to (read-only)."""
+        return self._profile
+
+    def __init__(self, config: PlatformConfig, *, profile: Optional[str] = None):
         super().__init__(config, Platform.TELEGRAM)
+        # Receiving-profile name. Stamped by gateway/run.py for secondary
+        # profiles; falls back to the process-active profile for the primary.
+        # Read-only via the `profile` property — capture event_ids are keyed on
+        # it, so it must not drift after construction.
+        self._profile: str = profile or _active_profile_name()
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
         self._webhook_mode: bool = False

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -47,6 +47,49 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+CAPTURE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ingress_ledger (
+    event_id TEXT PRIMARY KEY,
+    profile TEXT NOT NULL,
+    account_id INTEGER NOT NULL,
+    update_id INTEGER NOT NULL,
+    chat_id INTEGER NOT NULL,
+    message_id INTEGER NOT NULL,
+    sender_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    route_mode TEXT NOT NULL,
+    sink TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    message_thread_id INTEGER,
+    media_kind TEXT,
+    command_text TEXT,
+    content_preview TEXT,
+    lifecycle TEXT NOT NULL DEFAULT 'pending',
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    recorded_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS capture_payload (
+    event_id TEXT PRIMARY KEY REFERENCES ingress_ledger(event_id),
+    payload BLOB NOT NULL,
+    recorded_at TEXT NOT NULL
+);
+"""
+
+
+def open_capture_db(path) -> sqlite3.Connection:
+    """Open (creating parents + schema) the capture ledger DB at ``path``."""
+    from pathlib import Path
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(CAPTURE_SCHEMA)
+    conn.commit()
+    return conn
+
+
 def atomic_insert_capture(
     conn: sqlite3.Connection,
     *,
@@ -151,9 +194,14 @@ class CaptureIngressQueue(asyncio.Queue):
         routes are consumed here (terminal deny); agent routes persist THEN
         delegate via super().put().
         """
+        # PTB enqueues telegram.Update objects; tests and replays enqueue the
+        # equivalent dict. Normalize for inspection but delegate the ORIGINAL
+        # object so PTB's dispatcher gets what it expects.
+        raw = update.to_dict() if hasattr(update, "to_dict") else update
+
         effective_msg = (
-            self._get_effective_message(update)
-            if self._is_message_like(update)
+            self._get_effective_message(raw)
+            if self._is_message_like(raw)
             else None
         )
         if effective_msg is None:
@@ -169,7 +217,7 @@ class CaptureIngressQueue(asyncio.Queue):
             return
 
         event_type = self._classify_event_type(effective_msg)
-        update_id = update.get("update_id", 0)
+        update_id = raw.get("update_id", 0)
         message_id = effective_msg.get("message_id", 0)
         sender_id = effective_msg.get("from", {}).get("id", 0)
         event_id = build_event_id(self._profile, self._account_id, update_id)
@@ -188,8 +236,8 @@ class CaptureIngressQueue(asyncio.Queue):
                 event_type=event_type,
                 route_mode=route["mode"],
                 sink=route["sink"],
-                payload=canonicalize_payload(update),
-                payload_hash_str=payload_hash(update),
+                payload=canonicalize_payload(raw),
+                payload_hash_str=payload_hash(raw),
                 message_thread_id=thread_id,
                 command_text=(text if event_type == "command" else None),
                 content_preview=text[:200] or None,

--- a/plugins/platforms/telegram/capture_ingress.py
+++ b/plugins/platforms/telegram/capture_ingress.py
@@ -1,0 +1,251 @@
+"""Capture ingress — pre-dispatch update interception queue for Telegram.
+
+Provides a capture-aware asyncio.Queue that intercepts PTB Update objects
+before they reach PTB's own dispatch loop, guaranteeing durable pre-ack
+ledger recording for capture-only routes per Slice 1.1R-B.
+"""
+
+import asyncio
+import hashlib
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+_PROFILE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+# Route key: (chat_id, thread_id or 0 for None)
+RouteKey = Tuple[int, int]
+
+
+def build_event_id(profile: str, account_id: int, update_id: int) -> str:
+    """Build capture event identity string.
+
+    Format: telegram:{profile}:{account_id}:{update_id}
+    Must match ingress-ledger.schema.json's event_id regex.
+    """
+    if not _PROFILE_RE.match(profile):
+        raise ValueError(f"Invalid profile name for event_id: {profile!r}")
+    return f"telegram:{profile}:{account_id}:{update_id}"
+
+
+def canonicalize_payload(data: dict) -> bytes:
+    """Produce compact sorted-key UTF-8 JSON bytes from a dict.
+
+    Deterministic output regardless of input key order. No trailing newline.
+    """
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def payload_hash(data: dict) -> str:
+    """SHA-256 hex digest of canonicalized payload bytes."""
+    return f"sha256:{hashlib.sha256(canonicalize_payload(data)).hexdigest()}"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def atomic_insert_capture(
+    conn: sqlite3.Connection,
+    *,
+    event_id: str,
+    profile: str,
+    account_id: int,
+    update_id: int,
+    chat_id: int,
+    message_id: int,
+    sender_id: int,
+    event_type: str,
+    route_mode: str,
+    sink: str,
+    payload: bytes,
+    payload_hash_str: str,
+    message_thread_id: Optional[int] = None,
+    media_kind: Optional[str] = None,
+    command_text: Optional[str] = None,
+    content_preview: Optional[str] = None,
+) -> None:
+    """Atomically insert a ledger row + companion payload in one transaction.
+
+    Idempotent on identical payload_hash; raises sqlite3.IntegrityError when
+    the same event_id already exists with a different payload_hash
+    (conflicting replay — fail closed, no overwrite).
+    """
+    now = _utcnow_iso()
+    with conn:
+        existing = conn.execute(
+            "SELECT payload_hash FROM ingress_ledger WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+        if existing is not None:
+            if existing[0] != payload_hash_str:
+                raise sqlite3.IntegrityError(
+                    f"Conflicting payload for event_id={event_id}: "
+                    f"existing={existing[0]} new={payload_hash_str}"
+                )
+            return  # Idempotent: same identity, same hash — first capture wins
+
+        conn.execute(
+            """INSERT INTO ingress_ledger
+               (event_id, profile, account_id, update_id, chat_id,
+                message_id, sender_id, event_type, route_mode, sink,
+                payload_hash, received_at, message_thread_id, media_kind,
+                command_text, content_preview, lifecycle, retry_count,
+                recorded_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?)""",
+            (
+                event_id, profile, account_id, update_id, chat_id,
+                message_id, sender_id, event_type, route_mode, sink,
+                payload_hash_str, now, message_thread_id, media_kind,
+                command_text, content_preview, now,
+            ),
+        )
+        conn.execute(
+            """INSERT INTO capture_payload (event_id, payload, recorded_at)
+               VALUES (?, ?, ?)""",
+            (event_id, payload, now),
+        )
+
+
+class CaptureIngressQueue(asyncio.Queue):
+    """An asyncio.Queue that intercepts PTB Updates before inner dispatch.
+
+    Installed at ``ApplicationBuilder(...).update_queue(...)``. Every ``put``
+    is intercepted: message-like updates on capture-only routes are atomically
+    persisted then consumed without delegating to the inner queue; agent-route
+    updates persist THEN delegate; non-message-like updates pass through
+    unchanged.
+
+    Parameters
+    ----------
+    inner_queue: The underlying asyncio.Queue that feeds PTB's dispatcher.
+    db_connection: SQLite connection for atomic ledger+payload writes.
+    profile: Immutable adapter receiving-profile name.
+    account_id: Telegram bot account ID.
+    route_map: {(chat_id, thread_id_or_0): {"mode": ..., "sink": ...}}
+    """
+
+    def __init__(
+        self,
+        inner_queue: asyncio.Queue,
+        db_connection,
+        profile: str,
+        account_id: int,
+        route_map: Dict[RouteKey, Dict[str, str]],
+    ):
+        super().__init__()
+        self._inner = inner_queue
+        self._db = db_connection
+        self._profile = profile
+        self._account_id = account_id
+        self._route_map = route_map
+
+    async def put(self, update: Any) -> None:
+        """Intercept an Update before PTB dispatch.
+
+        Non-Update sentinels and non-message-like updates pass through
+        unchanged via super().put() so PTB's own dispatcher receives them.
+        Message-like updates are routed by (chat_id, thread_id); capture_only
+        routes are consumed here (terminal deny); agent routes persist THEN
+        delegate via super().put().
+        """
+        effective_msg = (
+            self._get_effective_message(update)
+            if self._is_message_like(update)
+            else None
+        )
+        if effective_msg is None:
+            await super().put(update)
+            return
+
+        chat_id = effective_msg.get("chat", {}).get("id")
+        thread_id = effective_msg.get("message_thread_id")
+        route = self._route_map.get((chat_id, thread_id or 0))
+
+        if route is None or route["mode"] == "drop":
+            await super().put(update)
+            return
+
+        event_type = self._classify_event_type(effective_msg)
+        update_id = update.get("update_id", 0)
+        message_id = effective_msg.get("message_id", 0)
+        sender_id = effective_msg.get("from", {}).get("id", 0)
+        event_id = build_event_id(self._profile, self._account_id, update_id)
+        text = effective_msg.get("text") or effective_msg.get("caption") or ""
+
+        try:
+            atomic_insert_capture(
+                self._db,
+                event_id=event_id,
+                profile=self._profile,
+                account_id=self._account_id,
+                update_id=update_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                event_type=event_type,
+                route_mode=route["mode"],
+                sink=route["sink"],
+                payload=canonicalize_payload(update),
+                payload_hash_str=payload_hash(update),
+                message_thread_id=thread_id,
+                command_text=(text if event_type == "command" else None),
+                content_preview=text[:200] or None,
+            )
+        except sqlite3.IntegrityError:
+            # Conflicting payload for a known identity — fail closed:
+            # no overwrite, no delegation, no ACK.
+            import logging
+            logging.getLogger(__name__).warning(
+                "CaptureIngressQueue: conflicting payload for event_id=%s — "
+                "dropping update (fail-closed)", event_id
+            )
+            return
+
+        if route["mode"] == "capture_only":
+            return  # Terminal deny: consumed without delegating
+
+        # Agent route: persist-then-delegate via super().put()
+        await super().put(update)
+
+    # --- Internal helpers ---
+
+    @staticmethod
+    def _is_message_like(update: Any) -> bool:
+        """Return True if the PTB Update carries an effective_message."""
+        if not isinstance(update, dict):
+            return False
+        return bool(
+            update.get("message")
+            or update.get("edited_message")
+            or update.get("channel_post")
+            or update.get("edited_channel_post")
+        )
+
+    @staticmethod
+    def _get_effective_message(update: dict) -> Optional[dict]:
+        """Extract the effective_message dict from a PTB Update."""
+        for key in ("message", "edited_message", "channel_post", "edited_channel_post"):
+            msg = update.get(key)
+            if msg:
+                return msg
+        return None
+
+    @staticmethod
+    def _classify_event_type(msg: dict) -> str:
+        """Classify a message dict into an event_type string."""
+        text = msg.get("text") or msg.get("caption") or ""
+        if msg.get("location") or msg.get("venue"):
+            return "location"
+        if (
+            msg.get("photo") or msg.get("video") or msg.get("audio")
+            or msg.get("voice") or msg.get("document") or msg.get("sticker")
+        ):
+            return "media"
+        if text.startswith("/"):
+            return "command"
+        if text:
+            return "text"
+        return "other"

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -495,3 +495,43 @@ class TestFeishuPortBindingConditional:
         assert connected == 0  # no error, just nothing connected
 
 
+
+
+class TestAdapterProfile:
+    """Slice 1.1R-B Task 10/11: adapters carry an immutable receiving-profile name."""
+
+    def test_adapter_stores_profile_immutably(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        cfg = PlatformConfig(enabled=True, token="123:abc")
+        adapter = TelegramAdapter(cfg, profile="default")
+        assert adapter.profile == "default"
+        with pytest.raises(AttributeError):
+            adapter.profile = "other"
+
+    def test_configure_profile_adapter_stamps_profile(self):
+        """gateway/run.py must stamp the profile onto every profile-scoped adapter."""
+        from gateway.config import Platform
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.session_store = None
+        runner._busy_text_mode = "off"
+        runner._make_profile_message_handler = lambda p: None
+        runner._make_profile_fatal_error_handler = lambda p, pl: None
+        runner._handle_active_session_busy_message = None
+        runner._handle_reaction_event = None
+        runner._recover_telegram_topic_thread_id = None
+        runner._make_adapter_auth_check = lambda pl, profile_name=None: None
+
+        class _Adapter:
+            set_message_handler = lambda self, h: None
+            set_fatal_error_handler = lambda self, h: None
+            set_session_store = lambda self, s: None
+            set_busy_session_handler = lambda self, h: None
+            set_topic_recovery_fn = lambda self, f: None
+            set_authorization_check = lambda self, c: None
+
+        adapter = _Adapter()
+        runner._configure_profile_adapter(adapter, "reviewer", Platform.TELEGRAM)
+        assert adapter._profile == "reviewer"

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -1,0 +1,536 @@
+"""Tests for capture ingress — capture-aware asyncio.Queue for Telegram."""
+import asyncio
+import hashlib
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from plugins.platforms.telegram.capture_ingress import (
+    CaptureIngressQueue,
+    atomic_insert_capture,
+    build_event_id,
+    canonicalize_payload,
+    payload_hash,
+)
+
+
+# --- Task 1: event_id construction ---
+
+def test_event_id_format():
+    """event_id must match ingress-ledger.schema.json: telegram:{profile}:{account_id}:{update_id}"""
+    event_id = build_event_id(profile="default", account_id=123456789, update_id=987654321)
+    assert event_id == "telegram:default:123456789:987654321"
+
+
+def test_event_id_rejects_invalid_profile():
+    """Profile must match ^[a-z][a-z0-9_-]{0,63}$"""
+    with pytest.raises(ValueError):
+        build_event_id(profile="INVALID UPPERCASE", account_id=1, update_id=1)
+
+
+# --- Task 2: canonical payload serialization ---
+
+def test_canonicalize_payload_is_deterministic():
+    """Same dict must produce identical bytes regardless of key order."""
+    d1 = {"b": 2, "a": 1}
+    d2 = {"a": 1, "b": 2}
+    assert canonicalize_payload(d1) == canonicalize_payload(d2)
+
+
+def test_canonicalize_payload_is_utf8():
+    """Output must be UTF-8 bytes."""
+    result = canonicalize_payload({"text": "café"})
+    assert isinstance(result, bytes)
+    assert result == json.dumps(
+        {"text": "café"}, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def temp_capture_db():
+    """Create a temporary SQLite database with capture tables and row_factory."""
+    db_path = Path(tempfile.mkdtemp()) / "capture_test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS ingress_ledger (
+            event_id TEXT PRIMARY KEY,
+            profile TEXT NOT NULL,
+            account_id INTEGER NOT NULL,
+            update_id INTEGER NOT NULL,
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            sender_id INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            route_mode TEXT NOT NULL,
+            sink TEXT NOT NULL,
+            payload_hash TEXT NOT NULL,
+            received_at TEXT NOT NULL,
+            message_thread_id INTEGER,
+            media_kind TEXT,
+            command_text TEXT,
+            content_preview TEXT,
+            lifecycle TEXT NOT NULL DEFAULT 'pending',
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            recorded_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS capture_payload (
+            event_id TEXT PRIMARY KEY REFERENCES ingress_ledger(event_id),
+            payload BLOB NOT NULL,
+            recorded_at TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def make_text_update(update_id, chat_id, text, user_id=98765, thread_id=None):
+    """Build a minimal PTB-like Update dict for a text message."""
+    update = {
+        "update_id": update_id,
+        "message": {
+            "message_id": update_id + 100,
+            "date": 1722900000,
+            "chat": {"id": chat_id, "type": "supergroup"},
+            "from": {"id": user_id, "is_bot": False, "first_name": "Test"},
+            "text": text,
+        },
+    }
+    if thread_id is not None:
+        update["message"]["message_thread_id"] = thread_id
+        update["message"]["is_topic_message"] = True
+    return update
+
+
+# --- Task 3: atomic ledger + payload storage ---
+
+def test_atomic_insert_creates_both_rows(temp_capture_db):
+    """Ledger row and payload must be inserted in one transaction."""
+    conn = temp_capture_db
+    event_id = build_event_id("default", 123456789, 1001)
+    update_dict = {
+        "update_id": 1001,
+        "message": {
+            "message_id": 55,
+            "chat": {"id": -1001111222},
+            "from": {"id": 98765, "is_bot": False},
+            "text": "hello world",
+        },
+    }
+    payload_bytes = canonicalize_payload(update_dict)
+    p_hash = f"sha256:{hashlib.sha256(payload_bytes).hexdigest()}"
+    assert p_hash == payload_hash(update_dict)
+
+    atomic_insert_capture(
+        conn,
+        event_id=event_id,
+        profile="default",
+        account_id=123456789,
+        update_id=1001,
+        chat_id=-1001111222,
+        message_id=55,
+        sender_id=98765,
+        event_type="text",
+        route_mode="capture_only",
+        sink="inbox",
+        payload=payload_bytes,
+        payload_hash_str=p_hash,
+    )
+
+    row = conn.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["payload_hash"] == p_hash
+    assert row["route_mode"] == "capture_only"
+
+    prow = conn.execute(
+        "SELECT * FROM capture_payload WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert prow is not None
+    assert prow["payload"] == payload_bytes
+
+
+# --- Task 4: idempotency, conflict, first-capture preservation ---
+
+def test_atomic_insert_idempotent(temp_capture_db):
+    """Second insert with same event_id must not create duplicate row."""
+    conn = temp_capture_db
+    event_id = build_event_id("default", 1, 2001)
+    p = b'{"test":true}'
+
+    for _ in range(2):
+        atomic_insert_capture(
+            conn, event_id=event_id, profile="default", account_id=1,
+            update_id=2001, chat_id=1, message_id=1, sender_id=1,
+            event_type="text", route_mode="capture_only", sink="inbox",
+            payload=p, payload_hash_str="sha256:abc",
+        )
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    ).fetchone()[0]
+    assert count == 1
+
+
+def test_atomic_insert_rejects_conflicting_payload(temp_capture_db):
+    """Same event_id + different payload_hash must raise IntegrityError."""
+    conn = temp_capture_db
+    event_id = build_event_id("default", 1, 3001)
+
+    atomic_insert_capture(
+        conn, event_id=event_id, profile="default", account_id=1,
+        update_id=3001, chat_id=1, message_id=1, sender_id=1,
+        event_type="text", route_mode="capture_only", sink="inbox",
+        payload=b'{"v":1}', payload_hash_str="sha256:aaa",
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        atomic_insert_capture(
+            conn, event_id=event_id, profile="default", account_id=1,
+            update_id=3001, chat_id=1, message_id=1, sender_id=1,
+            event_type="text", route_mode="capture_only", sink="inbox",
+            payload=b'{"v":2}', payload_hash_str="sha256:bbb",
+        )
+
+    # No overwrite: original hash and payload survive
+    row = conn.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert row["payload_hash"] == "sha256:aaa"
+    prow = conn.execute(
+        "SELECT * FROM capture_payload WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert prow["payload"] == b'{"v":1}'
+
+
+def test_atomic_insert_preserves_first_capture_timestamps(temp_capture_db):
+    """A repeat insert must not rewrite received_at/recorded_at."""
+    conn = temp_capture_db
+    event_id = build_event_id("default", 1, 4001)
+    kwargs = dict(
+        event_id=event_id, profile="default", account_id=1,
+        update_id=4001, chat_id=1, message_id=1, sender_id=1,
+        event_type="text", route_mode="capture_only", sink="inbox",
+        payload=b'{"v":1}', payload_hash_str="sha256:aaa",
+    )
+
+    atomic_insert_capture(conn, **kwargs)
+    first = conn.execute(
+        "SELECT received_at, recorded_at FROM ingress_ledger WHERE event_id = ?",
+        (event_id,),
+    ).fetchone()
+
+    atomic_insert_capture(conn, **kwargs)
+    second = conn.execute(
+        "SELECT received_at, recorded_at FROM ingress_ledger WHERE event_id = ?",
+        (event_id,),
+    ).fetchone()
+
+    assert (first["received_at"], first["recorded_at"]) == (
+        second["received_at"],
+        second["recorded_at"],
+    )
+
+
+# --- Task 5: CaptureIngressQueue basic interception ---
+
+@pytest.mark.asyncio
+async def test_capture_queue_intercepts_text_and_denies_delegate(temp_capture_db):
+    """Text on capture-only route: persisted, not delegated to PTB dispatcher."""
+    inner_queue = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+
+    queue = CaptureIngressQueue(
+        inner_queue=inner_queue,
+        db_connection=temp_capture_db,
+        profile="default",
+        account_id=123456789,
+        route_map=route_map,
+    )
+
+    update = make_text_update(1, -1001111222, "hello capture")
+    await queue.put(update)
+
+    # CaptureIngressQueue IS the queue PTB reads from — must be empty for capture_only
+    assert queue.empty()
+
+    event_id = build_event_id("default", 123456789, 1)
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["event_type"] == "text"
+    assert row["content_preview"] == "hello capture"
+
+    # Companion payload written in the same transaction
+    prow = temp_capture_db.execute(
+        "SELECT * FROM capture_payload WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert prow["payload"] == canonicalize_payload(update)
+
+
+# --- Task 6: command interception ---
+
+@pytest.mark.asyncio
+async def test_capture_queue_intercepts_command_as_inert_text(temp_capture_db):
+    """/command on capture-only route: captured as event_type=command, never dispatched."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = make_text_update(2, -1001111222, "/start")
+    await queue.put(update)
+
+    assert queue.empty()
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?",
+        (build_event_id("default", 123456789, 2),),
+    ).fetchone()
+    assert row is not None
+    assert row["event_type"] == "command"
+    assert row["command_text"] == "/start"
+
+
+# --- Task 7: media and location ---
+
+@pytest.mark.asyncio
+async def test_capture_queue_media_no_dispatch(temp_capture_db):
+    """Photo on capture-only route: event_type=media, no media download, no dispatch."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = {
+        "update_id": 3,
+        "message": {
+            "message_id": 103,
+            "date": 1722900000,
+            "chat": {"id": -1001111222, "type": "supergroup"},
+            "from": {"id": 98765, "is_bot": False},
+            "photo": [
+                {"file_id": "abc123", "file_unique_id": "uniq1", "width": 100, "height": 100}
+            ],
+            "caption": "check this out",
+        },
+    }
+    await queue.put(update)
+    assert queue.empty()
+
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?",
+        (build_event_id("default", 123456789, 3),),
+    ).fetchone()
+    assert row is not None
+    assert row["event_type"] == "media"
+    assert row["command_text"] is None
+
+
+@pytest.mark.asyncio
+async def test_capture_queue_location_no_dispatch(temp_capture_db):
+    """Location on capture-only route: event_type=location, no dispatch."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = {
+        "update_id": 4,
+        "message": {
+            "message_id": 104,
+            "date": 1722900000,
+            "chat": {"id": -1001111222, "type": "supergroup"},
+            "from": {"id": 98765, "is_bot": False},
+            "location": {"latitude": 51.5074, "longitude": -0.1278},
+        },
+    }
+    await queue.put(update)
+    assert queue.empty()
+
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?",
+        (build_event_id("default", 123456789, 4),),
+    ).fetchone()
+    assert row is not None
+    assert row["event_type"] == "location"
+
+
+# --- Task 8: pass-through, agent delegation, drop route ---
+
+@pytest.mark.asyncio
+async def test_non_message_like_update_passes_through(temp_capture_db):
+    """Callback query passes through to PTB queue unchanged, no capture."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = {
+        "update_id": 5,
+        "callback_query": {"id": "cb1", "from": {"id": 98765}, "data": "ping"},
+    }
+    await queue.put(update)
+    # Pass-through via super().put() — item is in the CaptureIngressQueue
+    assert not queue.empty()
+    passed = queue.get_nowait()
+    assert passed == update
+
+    rows = temp_capture_db.execute("SELECT COUNT(*) FROM ingress_ledger").fetchone()[0]
+    assert rows == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_route_persists_then_delegates(temp_capture_db):
+    """Agent route: persist first, then delegate to PTB queue via super().put()."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "agent", "sink": "general"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = make_text_update(6, -1001111222, "hello agent")
+    await queue.put(update)
+
+    assert not queue.empty()
+    delegated = queue.get_nowait()
+    assert delegated == update
+
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?",
+        (build_event_id("default", 123456789, 6),),
+    ).fetchone()
+    assert row is not None
+    assert row["route_mode"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_drop_route_no_capture_unchanged_dispatch(temp_capture_db):
+    """Drop route: no ledger row, pass-through to PTB queue unchanged."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "drop", "sink": ""}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = make_text_update(7, -1001111222, "should drop")
+    await queue.put(update)
+
+    assert not queue.empty()
+    got = queue.get_nowait()
+    assert got == update
+    rows = temp_capture_db.execute("SELECT COUNT(*) FROM ingress_ledger").fetchone()[0]
+    assert rows == 0
+
+
+# --- Task 9: duplicate, conflict, route matching, sentinels ---
+
+@pytest.mark.asyncio
+async def test_identical_duplicate_no_second_row(temp_capture_db):
+    """Same (profile, account_id, update_id): no second row, first timestamps preserved."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = make_text_update(8, -1001111222, "first capture")
+    await queue.put(update)
+    first = temp_capture_db.execute(
+        "SELECT received_at FROM ingress_ledger WHERE update_id = 8"
+    ).fetchone()["received_at"]
+
+    await queue.put(update)  # Duplicate
+
+    count = temp_capture_db.execute(
+        "SELECT COUNT(*) FROM ingress_ledger WHERE update_id = 8 AND account_id = 123456789"
+    ).fetchone()[0]
+    assert count == 1
+    still = temp_capture_db.execute(
+        "SELECT received_at FROM ingress_ledger WHERE update_id = 8"
+    ).fetchone()["received_at"]
+    assert still == first
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_same_identity_different_payload_fails_closed(temp_capture_db):
+    """Same event_id, different payload: no overwrite, no delegation."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 0): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update1 = make_text_update(9, -1001111222, "original")
+    await queue.put(update1)
+
+    update2 = make_text_update(9, -1001111222, "tampered")  # Same update_id!
+    await queue.put(update2)
+
+    event_id = build_event_id("default", 123456789, 9)
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert row is not None
+    # Must still hold the original content, not the conflicting replay
+    assert row["payload_hash"] == payload_hash(update1)
+    prow = temp_capture_db.execute(
+        "SELECT payload FROM capture_payload WHERE event_id = ?", (event_id,)
+    ).fetchone()
+    assert prow["payload"] == canonicalize_payload(update1)
+    # Queue must NOT have the conflicting update
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_exact_route_matching_requires_chat_and_thread(temp_capture_db):
+    """Same thread_id in a different chat does not match."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 10): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    update = make_text_update(10, -1009999999, "wrong chat", thread_id=10)
+    await queue.put(update)
+
+    # No matching route → must pass through
+    assert not queue.empty()
+    got = queue.get_nowait()
+    assert got == update
+    rows = temp_capture_db.execute("SELECT COUNT(*) FROM ingress_ledger").fetchone()[0]
+    assert rows == 0
+
+
+@pytest.mark.asyncio
+async def test_thread_scoped_route_captures_matching_thread(temp_capture_db):
+    """A thread-scoped route matches only its own (chat_id, thread_id) pair."""
+    inner = asyncio.Queue()
+    route_map = {(-1001111222, 10): {"mode": "capture_only", "sink": "inbox"}}
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, route_map)
+
+    await queue.put(make_text_update(11, -1001111222, "right thread", thread_id=10))
+    assert queue.empty()
+
+    row = temp_capture_db.execute(
+        "SELECT * FROM ingress_ledger WHERE event_id = ?",
+        (build_event_id("default", 123456789, 11),),
+    ).fetchone()
+    assert row is not None
+    assert row["message_thread_id"] == 10
+
+    # Same chat, different thread → no route, passes through
+    await queue.put(make_text_update(12, -1001111222, "other thread", thread_id=99))
+    assert not queue.empty()
+    got = queue.get_nowait()
+    assert got["message"]["message_thread_id"] == 99
+    rows = temp_capture_db.execute("SELECT COUNT(*) FROM ingress_ledger").fetchone()[0]
+    assert rows == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_sentinel_passes_through(temp_capture_db):
+    """Non-dict sentinel objects pass through unchanged."""
+    inner = asyncio.Queue()
+    queue = CaptureIngressQueue(inner, temp_capture_db, "default", 123456789, {})
+
+    sentinel = object()
+    await queue.put(sentinel)
+    assert not queue.empty()
+    assert queue.get_nowait() is sentinel

--- a/tests/gateway/test_telegram_capture_ingress.py
+++ b/tests/gateway/test_telegram_capture_ingress.py
@@ -534,3 +534,98 @@ async def test_queue_sentinel_passes_through(temp_capture_db):
     await queue.put(sentinel)
     assert not queue.empty()
     assert queue.get_nowait() is sentinel
+
+
+# --- Task 12: PTB Application wiring ---
+
+def test_put_normalizes_ptb_update_objects(temp_capture_db):
+    """PTB puts Update objects, not dicts — the queue must still capture them."""
+    class _FakeUpdate:
+        def __init__(self, d):
+            self._d = d
+
+        def to_dict(self):
+            return self._d
+
+    raw = make_text_update(4242, -1001111222, "captured")
+    queue = CaptureIngressQueue(
+        inner_queue=asyncio.Queue(),
+        db_connection=temp_capture_db,
+        profile="default",
+        account_id=555,
+        route_map={(-1001111222, 0): {"mode": "capture_only", "sink": "ledger"}},
+    )
+    asyncio.run(queue.put(_FakeUpdate(raw)))
+
+    row = temp_capture_db.execute(
+        "SELECT event_id, route_mode FROM ingress_ledger"
+    ).fetchone()
+    assert row["event_id"] == "telegram:default:555:4242"
+    assert row["route_mode"] == "capture_only"
+    assert queue.qsize() == 0  # capture_only is terminal — never dispatched
+
+
+def test_open_capture_db_creates_schema(tmp_path):
+    """open_capture_db must create both tables so callers need no external DDL."""
+    from plugins.platforms.telegram.capture_ingress import open_capture_db
+
+    conn = open_capture_db(tmp_path / "nested" / "ingress.db")
+    tables = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert {"ingress_ledger", "capture_payload"} <= tables
+    conn.close()
+
+
+def _adapter(extra=None):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    return TelegramAdapter(
+        PlatformConfig(enabled=True, token="123:abc", extra=extra or {}),
+        profile="default",
+    )
+
+
+def test_build_capture_queue_returns_none_without_routes():
+    """No configured capture routes → no queue, no DB file created."""
+    assert _adapter()._build_capture_queue() is None
+
+
+def test_build_capture_queue_reads_routes_from_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter({
+        "bot_id": 777,
+        "capture_routes": [
+            {"chat_id": -1003910549809, "thread_id": 6,
+             "mode": "capture_only", "sink": "ledger"},
+            {"chat_id": -1003910549809, "mode": "agent", "sink": "ledger"},
+        ],
+    })
+    queue = adapter._build_capture_queue()
+    assert isinstance(queue, CaptureIngressQueue)
+    assert queue._account_id == 777
+    assert queue._profile == "default"
+    assert queue._route_map == {
+        (-1003910549809, 6): {"mode": "capture_only", "sink": "ledger"},
+        (-1003910549809, 0): {"mode": "agent", "sink": "ledger"},
+    }
+    queue._db.close()
+
+
+def test_register_handlers_installs_all_handlers():
+    """Both build sites must share one handler-registration helper."""
+    adapter = _adapter()
+
+    class _App:
+        def __init__(self):
+            self.handlers = []
+
+        def add_handler(self, h):
+            self.handlers.append(h)
+
+    app = _App()
+    adapter._register_handlers(app)
+    assert len(app.handlers) == 5


### PR DESCRIPTION
## Slice 1.1R-B — Capture-first intake

Installs a capture-aware `asyncio.Queue` at PTB `ApplicationBuilder(...).update_queue(...)` that intercepts message-like Telegram updates **before** PTB dispatch, guaranteeing durable pre-acknowledgment recording for capture-only routes.

### What changed

- **`capture_ingress.py`** (new) — `CaptureIngressQueue(asyncio.Queue)` intercepts `put()`, routes by `(chat_id, thread_id)`, atomically persists ledger row + companion payload, terminal deny on capture_only routes
- **`adapter.py`** — immutable `profile` field set at construction, `_build_capture_queue()` reads `capture_routes` config and wires queue via `builder.update_queue()`, extracted `_register_handlers()` helper
- **`gateway/run.py`** — profile stamped on adapter construction
- **`capture_ingest.py`** (live file, not in repo) — `CAPTURE_OK:0` output on zero-capture runs

### Test evidence

| Suite | Tests | Result |
|-------|-------|--------|
| capture ingress | 25 | PASS |
| group gating (regression) | 23 | PASS |
| multiplex adapter | 16 | PASS |
| **Total** | **64** | **PASS** |

### Architecture

```
Update queued → CaptureIngressQueue.put()
  ├─ sentinel / non-message-like → super().put() (pass through)
  ├─ route not found / mode=drop → super().put() (unchanged dispatch)
  ├─ mode=capture_only → atomic persist, consume silently (terminal deny)
  └─ mode=agent → atomic persist, then super().put() (delegate)
```

### Non-goals (not in this PR)

- No live deployment, config, cron, or service changes
- No media byte download/storage
- No change to `drop_pending_updates` cold-start behavior

### Authorization

Hermes control-plane Slice 1.1R-B, PRs #19 (plan) and #20 (authorization record, merged 2026-08-06T20:55Z). Scoped TDD implementation authorized; merge remains owner-gated.

Closes: control-plane envelope 1.1R-B