### PR TITLE
fix: make exact tool retry failures mutation-aware

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -278,7 +278,12 @@ class ToolCallGuardrailController:
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
-        self._exact_failure_counts: dict[ToolCallSignature, int] = {}
+        # Exact failure state contains canonical-argument and result hashes only;
+        # no raw arguments or results are retained. A successful landed file
+        # mutation advances the generation, making prior terminal failures stale.
+        self._exact_failure_generation = 0
+        self._exact_failure_counts: dict[tuple[ToolCallSignature, str, int], int] = {}
+        self._last_exact_failure: dict[ToolCallSignature, tuple[str, int]] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
@@ -308,7 +313,7 @@ class ToolCallGuardrailController:
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
-        exact_count = self._exact_failure_counts.get(signature, 0)
+        exact_count = self._exact_failure_count(signature)
         if exact_count >= self.config.exact_failure_block_after:
             decision = ToolGuardrailDecision(
                 action="block",
@@ -361,8 +366,7 @@ class ToolCallGuardrailController:
             failed, _ = classify_tool_failure(tool_name, result)
 
         if failed:
-            exact_count = self._exact_failure_counts.get(signature, 0) + 1
-            self._exact_failure_counts[signature] = exact_count
+            exact_count = self._record_exact_failure(signature, result)
             self._no_progress.pop(signature, None)
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
@@ -409,7 +413,10 @@ class ToolCallGuardrailController:
 
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
-        self._exact_failure_counts.pop(signature, None)
+        if file_mutation_result_landed(tool_name, result):
+            self._advance_exact_failure_generation()
+        else:
+            self._clear_exact_failure(signature)
         self._same_tool_failure_counts.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):
@@ -438,6 +445,37 @@ class ToolCallGuardrailController:
             )
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
+
+    def _exact_failure_count(self, signature: ToolCallSignature) -> int:
+        latest = self._last_exact_failure.get(signature)
+        if latest is None:
+            return 0
+        result_hash, generation = latest
+        if generation != self._exact_failure_generation:
+            return 0
+        return self._exact_failure_counts.get((signature, result_hash, generation), 0)
+
+    def _record_exact_failure(self, signature: ToolCallSignature, result: str | None) -> int:
+        result_hash = _result_hash(result)
+        key = (signature, result_hash, self._exact_failure_generation)
+        previous = self._last_exact_failure.get(signature)
+        if previous != (result_hash, self._exact_failure_generation):
+            self._clear_exact_failure(signature)
+        exact_count = self._exact_failure_counts.get(key, 0) + 1
+        self._exact_failure_counts[key] = exact_count
+        self._last_exact_failure[signature] = (result_hash, self._exact_failure_generation)
+        return exact_count
+
+    def _clear_exact_failure(self, signature: ToolCallSignature) -> None:
+        latest = self._last_exact_failure.pop(signature, None)
+        if latest is not None:
+            result_hash, generation = latest
+            self._exact_failure_counts.pop((signature, result_hash, generation), None)
+
+    def _advance_exact_failure_generation(self) -> None:
+        self._exact_failure_generation += 1
+        self._exact_failure_counts.clear()
+        self._last_exact_failure.clear()
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -177,3 +177,44 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
 
 
 
+
+
+
+def test_exact_failure_requires_same_result_identity_and_resets_after_landed_file_mutation():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            exact_failure_warn_after=2,
+            exact_failure_block_after=2,
+            same_tool_failure_warn_after=99,
+            same_tool_failure_halt_after=99,
+        )
+    )
+    command = {"command": "pytest tests/agent/test_tool_guardrails.py"}
+    first_failure = json.dumps({"exit_code": 1, "stderr": "first failure"})
+    changed_failure = json.dumps({"exit_code": 1, "stderr": "different failure"})
+
+    controller.after_call("terminal", command, first_failure, failed=True)
+    controller.after_call("terminal", command, first_failure, failed=True)
+    assert controller.before_call("terminal", command).code == "repeated_exact_failure_block"
+
+    controller.after_call(
+        "write_file",
+        {"path": "/tmp/fix.py", "content": "fixed"},
+        json.dumps({"bytes_written": 5}),
+        failed=False,
+    )
+    assert controller.before_call("terminal", command).action == "allow"
+
+    first_after_progress = controller.after_call("terminal", command, first_failure, failed=True)
+    assert first_after_progress.action == "allow"
+    assert first_after_progress.count == 1
+
+    changed_result = controller.after_call("terminal", command, changed_failure, failed=True)
+    assert changed_result.action == "allow"
+    assert changed_result.count == 1
+    assert controller.before_call("terminal", command).action == "allow"
+
+    repeated_changed_result = controller.after_call("terminal", command, changed_failure, failed=True)
+    assert repeated_changed_result.code == "repeated_exact_failure_warning"
+    assert controller.before_call("terminal", command).code == "repeated_exact_failure_block"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -420,3 +420,56 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+
+def test_sequential_runtime_allows_failed_terminal_retry_after_landed_write_mutation():
+    agent = _make_agent("write_file", "terminal", config=_hard_stop_config())
+    command = {"command": "pytest tests/agent/test_tool_guardrails.py"}
+    _seed_exact_failures(agent, "terminal", command)
+    calls = [
+        _mock_tool_call("write_file", json.dumps({"path": "/tmp/fix.py", "content": "fixed"}), "c-write"),
+        _mock_tool_call("terminal", json.dumps(command), "c-terminal"),
+    ]
+    messages = []
+
+    with patch(
+        "run_agent.handle_function_call",
+        side_effect=[json.dumps({"bytes_written": 5}), json.dumps({"exit_code": 1, "stderr": "still failing"})],
+    ) as handle:
+        agent._execute_tool_calls_sequential(SimpleNamespace(content="", tool_calls=calls), messages, "task-1")
+
+    assert handle.call_count == 2
+    assert [message["tool_call_id"] for message in messages] == ["c-write", "c-terminal"]
+    assert "repeated_exact_failure_block" not in messages[1]["content"]
+
+
+def test_concurrent_runtime_allows_failed_terminal_retry_after_landed_write_mutation():
+    agent = _make_agent("write_file", "terminal", config=_hard_stop_config())
+    command = {"command": "pytest tests/agent/test_tool_guardrails.py"}
+    _seed_exact_failures(agent, "terminal", command)
+    agent._tool_guardrails.after_call(
+        "write_file",
+        {"path": "/tmp/fix.py", "content": "fixed"},
+        json.dumps({"bytes_written": 5}),
+        failed=False,
+    )
+    calls = [
+        _mock_tool_call("terminal", json.dumps(command), "c-terminal"),
+        _mock_tool_call("web_search", json.dumps({"query": "unrelated"}), "c-search"),
+    ]
+    messages = []
+    executed = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        executed.append((name, kwargs["tool_call_id"]))
+        if name == "terminal":
+            return json.dumps({"exit_code": 1, "stderr": "still failing"})
+        return json.dumps({"ok": True})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_concurrent(SimpleNamespace(content="", tool_calls=calls), messages, "task-1")
+
+    assert {name for name, _ in executed} == {"terminal", "web_search"}
+    assert [message["tool_call_id"] for message in messages] == ["c-terminal", "c-search"]
+    assert "repeated_exact_failure_block" not in messages[0]["content"]


### PR DESCRIPTION
## Summary
- key exact-failure streaks by canonical arguments, canonical result hash, and mutation generation
- reset exact-failure eligibility after a proven canonical file mutation
- preserve same-tool runaway and idempotent no-progress protections

## Regression
- identical terminal failures still warn and block
- changed failure results start a new exact streak
- a landed patch/write allows the same focused test command to rerun
- sequential and concurrent runtime ordering remain covered

## Verification
- 20 focused tests passed
- ruff passed
- ty passed
- independent frozen-commit review: PASS