### PR TITLE
fix(langfuse-plugin): close suspended traces and shutdown client on session end

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -22,6 +22,7 @@ Optional env vars:
 """
 from __future__ import annotations
 
+import atexit
 import json
 import logging
 import os
@@ -1125,6 +1126,67 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     )
 
 
+_SHUTDOWN_HOOK_INSTALLED = False
+
+
+def _shutdown_langfuse() -> None:
+    """Close lingering trace observations, then flush and shut down the client.
+
+    A turn that never reaches _finish_trace (interrupted, tool-only final
+    step, or empty final content) leaves its root_span observation context
+    manager suspended in _TRACE_STATE. Its ``_create_span_with_parent_context``
+    generator is only finalized by GC on interpreter exit, by which point
+    OpenTelemetry's module globals have already been cleared -- so
+    ``use_span``'s ``isinstance(span, Span)`` raises
+    ``TypeError: isinstance() arg 2 must be a type`` (the "Exception ignored
+    in: ..._create_span_with_parent_context" spam printed on CLI exit).
+    Close every suspended context manager HERE, while the interpreter is
+    still healthy, so Langfuse receives complete traces and the process
+    exits cleanly.
+    """
+    with _STATE_LOCK:
+        states = list(_TRACE_STATE.values())
+        _TRACE_STATE.clear()
+    for state in states:
+        try:
+            for observation in state.generations.values():
+                _end_observation(observation)
+            for observation in state.tools.values():
+                _end_observation(observation)
+            for queue in state.pending_tools_by_name.values():
+                for observation in queue:
+                    _end_observation(observation)
+            _end_observation(state.root_span)
+            # __exit__ drives the suspended _create_span_with_parent_context
+            # generator to completion -- this is what the GC/teardown path
+            # used to do fatally late.
+            if state.root_ctx is not None:
+                state.root_ctx.__exit__(None, None, None)
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"shutdown trace '{state.trace_id}' failed: {exc}")
+
+    client = _get_langfuse()
+    if client is not None:
+        try:
+            client.flush()
+            client.shutdown()
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"langfuse shutdown failed: {exc}")
+
+
+def _install_shutdown_cleanup() -> None:
+    global _SHUTDOWN_HOOK_INSTALLED
+    if _SHUTDOWN_HOOK_INSTALLED:
+        return
+    _SHUTDOWN_HOOK_INSTALLED = True
+    atexit.register(_shutdown_langfuse)
+
+
+def _on_session_finalize(*, session_id: str = "", platform: str = "", **_: Any) -> None:
+    """Session-boundary cleanup so incomplete traces are closed and flushed."""
+    _shutdown_langfuse()
+
+
 def register(ctx) -> None:
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
@@ -1135,3 +1197,8 @@ def register(ctx) -> None:
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+    # Session-boundary + interpreter-exit cleanup: closes any suspended
+    # observation generators a non-finalized turn left behind, then flushes
+    # and shuts down the client (prevents OTel teardown TypeError spam).
+    ctx.register_hook("on_session_finalize", _on_session_finalize)
+    _install_shutdown_cleanup()

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -12,3 +12,4 @@ hooks:
   - post_llm_call
   - pre_tool_call
   - post_tool_call
+  - on_session_finalize

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -25,11 +25,13 @@ class TestManifest:
         data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
         assert data["name"] == "langfuse"
         assert data["version"]
-        # All six hooks the plugin implements.
+        # All seven hooks the plugin implements (six observation hooks
+        # plus on_session_finalize for exit-time cleanup).
         assert set(data["hooks"]) == {
             "pre_api_request", "post_api_request",
             "pre_llm_call", "post_llm_call",
             "pre_tool_call", "post_tool_call",
+            "on_session_finalize",
         }
         # Required env vars are the user-facing HERMES_ prefixed keys.
         assert "HERMES_LANGFUSE_PUBLIC_KEY" in data["requires_env"]
@@ -779,3 +781,153 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# Exit-time cleanup: _shutdown_langfuse / on_session_finalize close any
+# suspended observations a non-finalized turn left behind (interrupted,
+# tool-only-final, or empty-final turns never reach _finish_trace), then
+# flush and shut down the client.  Without this the suspended
+# ``_create_span_with_parent_context`` generators are only finalized by GC
+# during interpreter teardown, when OpenTelemetry's module globals have
+# already been cleared -- surfacing as
+# ``TypeError: isinstance() arg 2 must be a type`` spam on CLI exit.
+# ---------------------------------------------------------------------------
+
+class _FakeObservation:
+    """Duck-typed observation: records update()/end() calls."""
+
+    def __init__(self, name=""):
+        self.name = name
+        self.ended = False
+        self.updated = []
+
+    def update(self, **kwargs):
+        self.updated.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+
+class _FakeRootContext:
+    """Duck-typed context manager standing in for the suspended
+    ``_AgnosticContextManager`` returned by ``start_as_current_observation``.
+    """
+
+    def __init__(self):
+        self.exited = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.exited = exc
+        return False
+
+    def start_observation(self, **kwargs):
+        return _FakeObservation(kwargs.get("name", ""))
+
+
+class _FakeClient:
+    """Duck-typed Langfuse client for shutdown-path assertions."""
+
+    def __init__(self):
+        self.flushed = 0
+        self.shutdown_called = 0
+
+    def flush(self):
+        self.flushed += 1
+
+    def shutdown(self):
+        self.shutdown_called += 1
+
+
+class TestShutdownCleanup:
+
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        mod = importlib.import_module(mod_name)
+        mod._TRACE_STATE.clear()
+        mod._SHUTDOWN_HOOK_INSTALLED = False
+        return mod
+
+    def _inject_suspended_trace(self, mod):
+        root_ctx = _FakeRootContext()
+        root_span = _FakeObservation("root")
+        child = _FakeObservation("child")
+        state = mod.TraceState(
+            trace_id="t1",
+            root_ctx=root_ctx,
+            root_span=root_span,
+        )
+        state.generations["child"] = child
+        state.tools["tool"] = _FakeObservation("tool")
+        mod._TRACE_STATE["session::turn"] = state
+        return root_ctx, root_span, child
+
+    def test_shutdown_langfuse_clears_state_and_closes_suspended_observations(self, monkeypatch):
+        mod = self._fresh_plugin()
+        client = _FakeClient()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        root_ctx, root_span, child = self._inject_suspended_trace(mod)
+
+        mod._shutdown_langfuse()
+
+        assert mod._TRACE_STATE == {}
+        assert root_span.ended and child.ended
+        # The suspended _create_span_with_parent_context generator is driven
+        # to completion via root_ctx.__exit__, NOT deferred to GC/teardown.
+        assert root_ctx.exited is not None
+        # Client flushed + shut down exactly once.
+        assert client.flushed == 1
+        assert client.shutdown_called == 1
+
+    def test_shutdown_langfuse_idempotent_when_nothing_pending(self, monkeypatch):
+        mod = self._fresh_plugin()
+        client = _FakeClient()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+
+        mod._shutdown_langfuse()
+        mod._shutdown_langfuse()
+
+        assert mod._TRACE_STATE == {}
+        assert client.shutdown_called == 2
+
+    def test_on_session_finalize_delegates_to_shutdown(self, monkeypatch):
+        mod = self._fresh_plugin()
+        client = _FakeClient()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        _, root_span, child = self._inject_suspended_trace(mod)
+
+        mod._on_session_finalize(session_id="sess-1", platform="cli", extra=1)
+
+        assert mod._TRACE_STATE == {}
+        assert root_span.ended and child.ended
+
+    def test_install_shutdown_cleanup_registers_atexit_once(self, monkeypatch):
+        mod = self._fresh_plugin()
+        import atexit
+
+        registered = []
+        monkeypatch.setattr(
+            atexit, "register", lambda fn, *a, **k: registered.append(fn)
+        )
+
+        mod._install_shutdown_cleanup()
+        mod._install_shutdown_cleanup()
+
+        assert registered == [mod._shutdown_langfuse]
+
+    def test_register_binds_session_finalize_hook(self, monkeypatch):
+        mod = self._fresh_plugin()
+        bound = {}
+
+        class _Ctx:
+            @staticmethod
+            def register_hook(name, fn):
+                bound[name] = fn
+
+        mod.register(_Ctx())
+
+        assert bound.get("on_session_finalize") is mod._on_session_finalize


### PR DESCRIPTION
## Summary

Fixes the `TypeError: isinstance() arg 2 must be a type` spam printed to stderr on every CLI/gateway exit when the bundled `observability/langfuse` plugin is enabled.

### Root cause

`plugins/observability/langfuse/__init__.py` registers only the six observation hooks — it has **no session/exit lifecycle hook and no flush/shutdown path**. A turn that never reaches `_finish_trace` (interrupted, tool-only final step, or empty final content) leaves its root observation context manager suspended in `_TRACE_STATE`. Its `Langfuse._create_span_with_parent_context` generator is then only finalized by GC during interpreter teardown, **at which point OpenTelemetry's module globals have already been cleared** — so `use_span`'s `isinstance(span, Span)` raises:

```
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
Exception ignored in: <generator object Langfuse._create_span_with_parent_context ...>
```

One copy is printed per lingering generator (typically 1–3 on a busy session). The traces themselves are silently left incomplete on the Langfuse side.

### Fix

In `register()`:

- bind **`on_session_finalize`** → closes every suspended root context manager via `__exit__`, ends child/generation observations, then `client.flush()` + `client.shutdown()` — all fail-open and idempotent
- install an **`atexit`** fallback (registered once) so non-binding exit paths are covered too
- declare `on_session_finalize` in `plugin.yaml` (manifest was previously out of sync with the code's six hooks; now seven)

`on_session_finalize` is already fired by the CLI (`cli.py` → `hermes_cli/lifecycle.py:finalize_session`) and the TUI gateway on shutdown, so no core changes are needed — this is purely plugin-side.

### Verification

- `tests/plugins/test_langfuse_plugin.py`: **29 passed** (24 existing + 5 new covering cleanup, idempotency, hook binding, atexit-once)
- Manual: real interactive CLI `/quit` exits cleanly (`Shutting down… finalizing session → Goodbye`), no `Exception ignored` output
- Reproduced the suspended-generator state offline and confirmed `_TRACE_STATE` is drained and every suspended generator is driven to completion by the cleanup
