### PR TITLE
refactor(auth): extract TLS verification helpers (S3)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5070,22 +5070,14 @@ def resolve_xai_oauth_runtime_credentials(
 # TLS verification helper
 # =============================================================================
 
-def _default_verify() -> bool | ssl.SSLContext:
-    """Platform-aware default SSL verify for httpx clients.
+from hermes_cli import auth_tls_verify as _auth_tls_verify  # noqa: E402
 
-    On macOS with Homebrew Python, the system OpenSSL cannot locate the
-    system trust store and valid public certs fail verification. When
-    certifi is importable we pin its bundle explicitly; elsewhere we
-    defer to httpx's built-in default (certifi via its own dependency).
-    Mirrors the weixin fix in 3a0ec1d93.
-    """
-    if sys.platform == "darwin":
-        try:
-            import certifi
-            return ssl.create_default_context(cafile=certifi.where())
-        except ImportError:
-            pass
-    return True
+_AUTH_TLS_VERIFY_COMPAT_LOCK = threading.RLock()
+_AUTH_TLS_DEFAULT_VERIFY_IMPL = _auth_tls_verify._default_verify
+
+
+def _default_verify() -> bool | ssl.SSLContext:
+    return _AUTH_TLS_DEFAULT_VERIFY_IMPL()
 
 
 def _resolve_verify(
@@ -5094,33 +5086,25 @@ def _resolve_verify(
     ca_bundle: Optional[str] = None,
     auth_state: Optional[Dict[str, Any]] = None,
 ) -> bool | ssl.SSLContext:
-    tls_state = auth_state.get("tls") if isinstance(auth_state, dict) else {}
-    tls_state = tls_state if isinstance(tls_state, dict) else {}
+    # The extracted implementation resolves _default_verify in its own
+    # globals. Temporarily bridge that lookup to this module so existing
+    # monkeypatches of hermes_cli.auth._default_verify remain effective.
+    # The nested proxy keeps lookup lazy, preserving the pre-extraction
+    # NameError behavior if callers delete that compatibility name.
+    def _compat_default_verify() -> bool | ssl.SSLContext:
+        return _default_verify()
 
-    effective_insecure = (
-        is_truthy_value(insecure, default=False) if insecure is not None
-        else is_truthy_value(tls_state.get("insecure", False), default=False)
-    )
-    effective_ca = (
-        ca_bundle
-        or tls_state.get("ca_bundle")
-        or os.getenv("HERMES_CA_BUNDLE")
-        or os.getenv("SSL_CERT_FILE")
-        or os.getenv("REQUESTS_CA_BUNDLE")
-    )
-
-    if effective_insecure:
-        return False
-    if effective_ca:
-        ca_path = str(effective_ca)
-        if not os.path.isfile(ca_path):
-            logger.warning(
-                "CA bundle path does not exist: %s — falling back to default certificates",
-                ca_path,
+    with _AUTH_TLS_VERIFY_COMPAT_LOCK:
+        previous_default_verify = _auth_tls_verify._default_verify
+        _auth_tls_verify._default_verify = _compat_default_verify
+        try:
+            return _auth_tls_verify._resolve_verify(
+                insecure=insecure,
+                ca_bundle=ca_bundle,
+                auth_state=auth_state,
             )
-            return _default_verify()
-        return ssl.create_default_context(cafile=ca_path)
-    return _default_verify()
+        finally:
+            _auth_tls_verify._default_verify = previous_default_verify
 
 
 # =============================================================================

--- a/hermes_cli/auth_tls_verify.py
+++ b/hermes_cli/auth_tls_verify.py
@@ -1,0 +1,72 @@
+"""TLS verification helpers extracted from ``hermes_cli.auth``."""
+
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+import sys
+from typing import Any, Dict, Optional
+
+from utils import is_truthy_value
+
+logger = logging.getLogger("hermes_cli.auth")
+
+# =============================================================================
+# TLS verification helper
+# =============================================================================
+
+def _default_verify() -> bool | ssl.SSLContext:
+    """Platform-aware default SSL verify for httpx clients.
+
+    On macOS with Homebrew Python, the system OpenSSL cannot locate the
+    system trust store and valid public certs fail verification. When
+    certifi is importable we pin its bundle explicitly; elsewhere we
+    defer to httpx's built-in default (certifi via its own dependency).
+    Mirrors the weixin fix in 3a0ec1d93.
+    """
+    if sys.platform == "darwin":
+        try:
+            import certifi
+            return ssl.create_default_context(cafile=certifi.where())
+        except ImportError:
+            pass
+    return True
+
+
+def _resolve_verify(
+    *,
+    insecure: Optional[bool] = None,
+    ca_bundle: Optional[str] = None,
+    auth_state: Optional[Dict[str, Any]] = None,
+) -> bool | ssl.SSLContext:
+    tls_state = auth_state.get("tls") if isinstance(auth_state, dict) else {}
+    tls_state = tls_state if isinstance(tls_state, dict) else {}
+
+    effective_insecure = (
+        is_truthy_value(insecure, default=False) if insecure is not None
+        else is_truthy_value(tls_state.get("insecure", False), default=False)
+    )
+    effective_ca = (
+        ca_bundle
+        or tls_state.get("ca_bundle")
+        or os.getenv("HERMES_CA_BUNDLE")
+        or os.getenv("SSL_CERT_FILE")
+        or os.getenv("REQUESTS_CA_BUNDLE")
+    )
+
+    if effective_insecure:
+        return False
+    if effective_ca:
+        ca_path = str(effective_ca)
+        if not os.path.isfile(ca_path):
+            logger.warning(
+                "CA bundle path does not exist: %s — falling back to default certificates",
+                ca_path,
+            )
+            return _default_verify()
+        return ssl.create_default_context(cafile=ca_path)
+    return _default_verify()
+
+
+__all__ = ("_default_verify", "_resolve_verify")


### PR DESCRIPTION
## What changed

Extract the S3 TLS verification helpers from `hermes_cli/auth.py` into `hermes_cli/auth_tls_verify.py`.

- Exact pinned context window: `auth.py:5069–5125`.
- Exact moved definitions: `_default_verify` and `_resolve_verify` (`5073–5123`).
- The extraction is byte/AST faithful and keeps the legacy `hermes_cli.auth` compatibility seam.
- The destination remains standalone-importable and keeps `certifi` lazy.

This is one independently reviewable slice of the auth.py god-file . It does not claim the full auth.py decomposition is complete.

## Verification

Base: `origin/main` `0957277f2f468bac22bbfcfa7c43029858c9597e`.

- Two independent fresh W3 witnesses: PASS on byte/AST fidelity, standalone import, lazy certifi, zero orphans, monkeypatch transparency, `delattr`/`NameError` behavior, py_compile, reverse-apply, and diff hygiene.
- Baseline differential at the pinned source proved the only selected failures are pre-existing Windows mode-bit assertions: the mandatory pair was **33 passed / 1 identical failure** on both baseline and candidate; the expanded 83-test union was **81 passed / 2 identical baseline failures** on both trees.
- Current-main merger commit: `51b382430b25dc0eb88e6f7e3f535d68c2ffd07e`.
- Current-main selected suite: **81 passed, 0 failed**, with only the two proven baseline failure IDs deselected.
- `git diff --check`: clean.
- `py_compile`: both changed modules pass.
- Changed files only: `hermes_cli/auth.py`, `hermes_cli/auth_tls_verify.py`.

The two proven baseline-only failures are:

- `tests/hermes_cli/test_auth_nous_provider.py::test_shared_store_write_and_read_roundtrip`
- `tests/hermes_cli/test_web_server_oauth_write.py::test_dashboard_oauth_write_uses_owner_only_permissions`

They assert POSIX mode bits unavailable on this Windows host and fail byte-for-byte identically on the pristine pin and candidate. No candidate-related failure was deselected.

## Why this matters to users

The extraction removes a self-contained TLS verification cluster from the auth god-file while preserving the existing `hermes_cli.auth` patch/import contract. Users get the same TLS behavior with a smaller, independently maintainable module.

## Links

- This PR: https://github.com/NousResearch/hermes-agent/pull/80676
- tracker: https://github.com/NousResearch/hermes-agent/issues/78647
- Auth god-file issue: https://github.com/NousResearch/hermes-agent/issues/78637

- Merger receipt: `C:/tmp/tg-Feature Package/godfile/auth/extraction/w3/s3-ship-merger-20260806.md`
- Baseline receipt: `C:/tmp/tg-Feature Package/godfile/auth/extraction/w3/s3-baseline-differential-20260806.json`

Part of #78647
Part of #78637

## Scope note

This PR is S3 only. S1 is separately linked in #80673; S4 and S5 remain gated by their own evidence and are not included here.

## Credit

The shipped commit is authored and DCO-signed by `andrexibiza <84248988+andrexibiza@users.noreply.github.com>`.

## Interlock

The auth and scoreboard live on #78637. This PR is separately bound to the tracker and file tracker above.

Part of #78647
Part of #78637
