### PR TITLE
fix(config): recognize agent.system_prompt and agent.personalities in schema validation

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4651,6 +4651,13 @@ _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
 # accepted because ``PlatformConfig`` carries an open ``extra`` mapping.
 _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 
+# Nested dictionary paths whose child keys are user-defined.  These are
+# intentionally separate from :data:`_OPEN_DICT_TOP_LEVEL_KEYS` because the
+# container is a schema-defined field rather than a top-level config section.
+_OPEN_DICT_NESTED_KEYS = frozenset({
+    "agent.personalities",
+})
+
 
 def _known_top_level_keys() -> set[str]:
     """Return the union of known top-level config keys for validation.
@@ -4751,6 +4758,11 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     node: Any = DEFAULT_CONFIG.get(top)
     consumed = [top]
     for seg in segments[1:]:
+        # User-defined entries below a nested open-dict field (for example,
+        # ``agent.personalities.<name>``) are valid regardless of their name
+        # or inner shape.
+        if ".".join(consumed) in _OPEN_DICT_NESTED_KEYS:
+            return True, None
         # ``gateway.platforms.<name>.<field>`` (and any other nested
         # ``platforms`` container) — the segment after ``platforms`` is a
         # user-supplied platform name, so accept everything below it.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5213,6 +5213,13 @@ _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
 # accepted because ``PlatformConfig`` carries an open ``extra`` mapping.
 _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 
+# Nested dictionary paths whose child keys are user-defined.  These are
+# intentionally separate from :data:`_OPEN_DICT_TOP_LEVEL_KEYS` because the
+# container is a schema-defined field rather than a top-level config section.
+_OPEN_DICT_NESTED_KEYS = frozenset({
+    "agent.personalities",
+})
+
 
 def _known_top_level_keys() -> set[str]:
     """Return the union of known top-level config keys for validation.
@@ -5313,6 +5320,11 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     node: Any = DEFAULT_CONFIG.get(top)
     consumed = [top]
     for seg in segments[1:]:
+        # User-defined entries below a nested open-dict field (for example,
+        # ``agent.personalities.<name>``) are valid regardless of their name
+        # or inner shape.
+        if ".".join(consumed) in _OPEN_DICT_NESTED_KEYS:
+            return True, None
         # ``gateway.platforms.<name>.<field>`` (and any other nested
         # ``platforms`` container) — the segment after ``platforms`` is a
         # user-supplied platform name, so accept everything below it.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -370,6 +370,15 @@ DEFAULT_CONFIG = {
         # ``false`` keeps the historical strict-provider behavior (Mistral,
         # Groq, Cerebras reject the field with HTTP 400).
         "reasoning_echo": False,
+
+        # User-owned manual system-prompt overlay. Personality selection is
+        # stored separately under ``display.personality`` and never writes
+        # this field. An empty string means no manual overlay.
+        "system_prompt": "",
+
+        # User-defined personality presets. Entries may be prompt strings or
+        # mappings with metadata such as description and system_prompt.
+        "personalities": {},
     },
 
     "terminal": {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -233,6 +233,20 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Ephemeral system prompt prepended to every agent turn. Read at
+        # runtime by cli.py (CLI_CONFIG["agent"].get("system_prompt", ""))
+        # and gateway paths — see tui_gateway/server.py. Empty string means
+        # no user-supplied prompt; the framework default applies. This is
+        # NOT a secret (secrets go in .env) — it's a behavioral setting.
+        "system_prompt": "",
+
+        # Custom user-defined personality presets. Each entry is either a
+        # string (used directly as a system-prompt fragment) or a dict with
+        # keys like {"system_prompt": ..., "description": ..., "tone": ...}.
+        # Read at runtime from agent.personalities — see cli.py line ~4478
+        # and tui_gateway/server.py. Empty dict means no custom personalities.
+        "personalities": {},
     },
 
     "terminal": {

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -514,6 +514,7 @@ class TestValidateConfigKey:
         "approvals.mode",
         "agent.system_prompt",
         "agent.personalities",
+        "agent.personalities.sherlock",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -465,6 +465,25 @@ class TestSchemaValidation:
         assert saved["desktop"]["macos_signing_identity"] == "Hermes Local Signing"
         assert "not a recognized config key" not in capsys.readouterr().out
 
+    def test_agent_system_prompt_is_accepted(self, _isolated_hermes_home, capsys):
+        """``agent.system_prompt`` is a real, runtime-consumed key (read by
+        cli.py and gateway paths). The validator must recognize it so
+        ``hermes config set agent.system_prompt`` doesn't emit a false
+        "not a recognized config key" warning."""
+        set_config_value("agent.system_prompt", "You are a concise assistant.")
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["agent"]["system_prompt"] == "You are a concise assistant."
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    def test_agent_personalities_is_accepted(self, _isolated_hermes_home, capsys):
+        """``agent.personalities`` is a real, runtime-consumed key (read by
+        cli.py and tui_gateway/server.py). The validator must recognize it.
+        Sub-keys (user-defined personality names) are open-dict entries."""
+        set_config_value("agent.personalities", '{"sherlock": "You are a detective."}')
+        out = capsys.readouterr().out
+        assert "not a recognized config key" not in out
+
 
 
     def test_force_suppresses_notice(self, _isolated_hermes_home, capsys):
@@ -493,6 +512,8 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "agent.system_prompt",
+        "agent.personalities",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -502,6 +502,25 @@ class TestSchemaValidation:
         assert saved["desktop"]["macos_signing_identity"] == "Hermes Local Signing"
         assert "not a recognized config key" not in capsys.readouterr().out
 
+    def test_agent_system_prompt_is_accepted(self, _isolated_hermes_home, capsys):
+        """``agent.system_prompt`` is a real, runtime-consumed key (read by
+        cli.py and gateway paths). The validator must recognize it so
+        ``hermes config set agent.system_prompt`` doesn't emit a false
+        "not a recognized config key" warning."""
+        set_config_value("agent.system_prompt", "You are a concise assistant.")
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["agent"]["system_prompt"] == "You are a concise assistant."
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    def test_agent_personalities_is_accepted(self, _isolated_hermes_home, capsys):
+        """``agent.personalities`` is a real, runtime-consumed key (read by
+        cli.py and tui_gateway/server.py). The validator must recognize it.
+        Sub-keys (user-defined personality names) are open-dict entries."""
+        set_config_value("agent.personalities", '{"sherlock": "You are a detective."}')
+        out = capsys.readouterr().out
+        assert "not a recognized config key" not in out
+
 
 
     def test_force_suppresses_notice(self, _isolated_hermes_home, capsys):
@@ -530,6 +549,8 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "agent.system_prompt",
+        "agent.personalities",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -551,6 +551,7 @@ class TestValidateConfigKey:
         "approvals.mode",
         "agent.system_prompt",
         "agent.personalities",
+        "agent.personalities.sherlock",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key


### PR DESCRIPTION
## Problem

`hermes config set agent.system_prompt "..."` and writes under `agent.personalities` emit a false warning that the key is unrecognized, even though both paths are consumed at runtime.

## Fix

- Add `agent.system_prompt` and `agent.personalities` to `DEFAULT_CONFIG` with behavior-preserving empty defaults.
- Treat `agent.personalities.<name>` as a nested open dictionary so user-defined personality names and metadata validate without weakening typo detection elsewhere.
- Add focused config-write and schema-validation regressions.

This aligns validation with the existing runtime contract; it does not change prompt or personality behavior.

## Verification

- Current-main RED check: the PR tests fail in exactly five expected cases before the implementation is applied.
- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/hermes_cli/test_personality_single_owner.py -q` — **186 passed**.
- Real CLI round-trip against a temporary `HERMES_HOME` — `agent.system_prompt` and `agent.personalities.sherlock` persisted without an unknown-key warning.
- Ruff, bytecode compilation, contributor-attribution audit, and `git diff --check` passed.

Tested on macOS. GitHub CI remains the full-suite authority; the local managed venv lacks the current `dev` extra (`pytest-asyncio`), and the resulting async-test failures reproduce unchanged on upstream `main`.
