### PR TITLE
Port from superagent-ai/grok-cli: per-workspace trust store (untrusted → manual approvals, tighten-only)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2156,6 +2156,16 @@ DEFAULT_CONFIG = {
         # for restricted networks, audited environments, or air-gapped
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
+        # Prompt on first interactive CLI run in a new workspace whether to
+        # trust it, and persist the decision (keyed by the realpath of the
+        # git root, or cwd outside a repo) to
+        # ~/.hermes/workspace-trust.json. A workspace answered "no" gets
+        # approvals forced to 'manual' for its sessions — the decision only
+        # ever tightens the configured approval mode, never loosens it.
+        # Manage recorded decisions with `hermes trust list|set|remove`.
+        # Opt-in: default false keeps existing startup behavior unchanged.
+        # Ported from superagent-ai/grok-cli's workspace trust store.
+        "workspace_trust_prompt": False,
     },
 
     "cron": {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2708,6 +2708,16 @@ def cmd_chat(args):
     # Import and run the CLI
     from cli import main as cli_main
 
+    # Opt-in workspace trust gate (security.workspace_trust_prompt). Plain
+    # interactive CLI only — the TUI branch above never returns. Never let
+    # the gate break startup.
+    try:
+        from hermes_cli.workspace_trust import maybe_prompt_workspace_trust
+
+        maybe_prompt_workspace_trust()
+    except Exception:
+        pass
+
     # Build kwargs from args
     kwargs = {
         "model": args.model,
@@ -10613,7 +10623,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
-        "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
+        "skin", "skills", "slack", "status", "sync", "tools", "trust", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an
@@ -11252,6 +11262,33 @@ def main():
     moa_delete = moa_subparsers.add_parser("delete", aliases=["rm"], help="Delete a MoA preset")
     moa_delete.add_argument("name", help="Preset name to delete")
     moa_parser.set_defaults(func=cmd_moa)
+
+    # =========================================================================
+    # trust command — per-workspace trust decisions (workspace-trust.json)
+    # =========================================================================
+    from hermes_cli.workspace_trust import cmd_trust
+
+    trust_parser = subparsers.add_parser(
+        "trust",
+        help="Manage per-workspace trust decisions (untrusted → manual approvals)",
+        description=(
+            "Manage the per-workspace trust store (~/.hermes/workspace-trust.json). "
+            "Sessions started in an untrusted workspace get approvals forced to "
+            "'manual' — the decision only ever tightens the configured approval "
+            "mode. Prompting on first run is opt-in via "
+            "security.workspace_trust_prompt in config.yaml."
+        ),
+    )
+    trust_subparsers = trust_parser.add_subparsers(dest="trust_command")
+    trust_subparsers.add_parser("list", aliases=["ls"], help="Show recorded workspace trust decisions")
+    trust_set = trust_subparsers.add_parser("set", help="Record a trust decision for a workspace")
+    trust_set.add_argument("path", nargs="?", help="Workspace path (default: current directory)")
+    trust_set_group = trust_set.add_mutually_exclusive_group(required=True)
+    trust_set_group.add_argument("--trusted", action="store_true", dest="trusted", help="Mark the workspace trusted")
+    trust_set_group.add_argument("--untrusted", action="store_false", dest="trusted", help="Mark the workspace untrusted (manual approvals)")
+    trust_remove = trust_subparsers.add_parser("remove", aliases=["rm"], help="Forget a workspace's trust decision")
+    trust_remove.add_argument("path", nargs="?", help="Workspace path (default: current directory)")
+    trust_parser.set_defaults(func=cmd_trust)
 
     # =========================================================================
     # fallback command — manage the fallback provider chain

--- a/hermes_cli/workspace_trust.py
+++ b/hermes_cli/workspace_trust.py
@@ -1,0 +1,308 @@
+"""Per-workspace trust store.
+
+Ported from superagent-ai/grok-cli (src/utils/workspace-trust.ts): grok-cli
+records a per-workspace sandbox decision on first run, keyed by the realpath
+of the working directory, in a versioned JSON file under the user's config
+home. The Hermes port keeps the same store shape (versioned schema, tolerant
+loader, 0600 perms) but maps the decision onto Hermes' approval posture:
+
+- A workspace marked **untrusted** forces the terminal approval mode to
+  ``manual`` for the session via a one-way latch in ``tools/approval.py``
+  (:func:`tools.approval.enforce_untrusted_workspace`). The latch only ever
+  *tightens* — a trusted workspace never weakens the configured mode, and an
+  untrusted one can never end up looser than the profile config.
+- Decisions are keyed by ``os.path.realpath`` of the workspace **root**: the
+  enclosing git repository root when inside one, else the directory itself.
+  This mirrors grok-cli's realpath keying while making every subdirectory of
+  a repo share one decision.
+- Session-only decisions ("s" at the prompt) are kept in-process and never
+  written to disk, matching grok-cli's ``remember: false`` path.
+
+The prompt itself is opt-in via ``security.workspace_trust_prompt`` (default
+false) and only runs in the plain interactive CLI path — TUI and gateway
+sessions are unaffected.
+
+Store location: ``get_hermes_home()/workspace-trust.json`` (0600).
+Schema: ``{"version": 1, "workspaces": {"<realpath>": {"trusted": bool,
+"decidedAt": "<iso8601>"}}}``. Malformed files and malformed entries are
+silently ignored (fresh empty store), matching grok-cli's tolerant loader.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+WORKSPACE_TRUST_FILENAME = "workspace-trust.json"
+
+# In-process, session-only decisions (never persisted). Keyed like the store.
+_SESSION_DECISIONS: Dict[str, bool] = {}
+
+
+def get_workspace_trust_path() -> Path:
+    """Return the trust store path under the profile-aware Hermes home."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / WORKSPACE_TRUST_FILENAME
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    """Walk *start* and its parents looking for a ``.git`` directory.
+
+    Same pattern as ``agent/prompt_builder.py``. Returns the directory
+    containing ``.git``, or ``None`` when the filesystem root is reached.
+    """
+    try:
+        current = start.resolve()
+    except OSError:
+        return None
+    for parent in [current, *current.parents]:
+        try:
+            if (parent / ".git").exists():
+                return parent
+        except OSError:
+            continue
+    return None
+
+
+def get_workspace_trust_key(path: Optional[str] = None) -> str:
+    """Return the store key for *path* (default: cwd).
+
+    The key is the realpath of the workspace root — the enclosing git repo
+    root when inside one, else the directory itself.
+    """
+    base = Path(path or os.getcwd())
+    root = _find_git_root(base) or base
+    return os.path.realpath(str(root))
+
+
+def _normalize_entry(value: object) -> Optional[dict]:
+    """Return a normalized ``{"trusted", "decidedAt"}`` entry or ``None``."""
+    if not isinstance(value, dict):
+        return None
+    trusted = value.get("trusted")
+    if not isinstance(trusted, bool):
+        return None
+    decided_at = value.get("decidedAt")
+    return {
+        "trusted": trusted,
+        "decidedAt": decided_at if isinstance(decided_at, str) else "",
+    }
+
+
+def load_workspace_trust_store(store_path: Optional[Path] = None) -> dict:
+    """Load the trust store, tolerating a missing or corrupt file.
+
+    Malformed JSON yields a fresh empty store; malformed individual entries
+    are dropped while valid siblings are kept (grok-cli parity).
+    """
+    path = store_path or get_workspace_trust_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"version": 1, "workspaces": {}}
+    raw_workspaces = raw.get("workspaces") if isinstance(raw, dict) else None
+    workspaces: Dict[str, dict] = {}
+    if isinstance(raw_workspaces, dict):
+        for workspace, entry in raw_workspaces.items():
+            normalized = _normalize_entry(entry)
+            if normalized is not None and isinstance(workspace, str):
+                workspaces[workspace] = normalized
+    return {"version": 1, "workspaces": workspaces}
+
+
+def _save_store(store: dict, store_path: Optional[Path] = None) -> None:
+    """Write the store with owner-only permissions (0600 file, 0700 dir)."""
+    path = store_path or get_workspace_trust_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(store, fh, indent=2)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    os.replace(str(tmp), str(path))
+    try:
+        os.chmod(str(path), 0o600)
+    except OSError:
+        pass
+
+
+def get_workspace_trust(path: Optional[str] = None) -> Optional[str]:
+    """Return ``'trusted'``, ``'untrusted'``, or ``None`` for a workspace.
+
+    Session-only (in-process) decisions take precedence over persisted ones.
+    """
+    key = get_workspace_trust_key(path)
+    if key in _SESSION_DECISIONS:
+        return "trusted" if _SESSION_DECISIONS[key] else "untrusted"
+    entry = load_workspace_trust_store()["workspaces"].get(key)
+    if entry is None:
+        return None
+    return "trusted" if entry["trusted"] else "untrusted"
+
+
+def set_workspace_trust(path: Optional[str], trusted: bool, remember: bool = True) -> str:
+    """Record a trust decision for a workspace. Returns the store key used.
+
+    ``remember=False`` keeps the decision in-process only (session-only),
+    never touching the on-disk store.
+    """
+    key = get_workspace_trust_key(path)
+    if not remember:
+        _SESSION_DECISIONS[key] = trusted
+        return key
+    store = load_workspace_trust_store()
+    store["workspaces"][key] = {
+        "trusted": trusted,
+        "decidedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    _save_store(store)
+    return key
+
+
+def remove_workspace_trust(path: Optional[str] = None) -> bool:
+    """Forget the persisted decision for a workspace. Returns True if removed."""
+    key = get_workspace_trust_key(path)
+    _SESSION_DECISIONS.pop(key, None)
+    store = load_workspace_trust_store()
+    if key not in store["workspaces"]:
+        return False
+    del store["workspaces"][key]
+    _save_store(store)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Interactive CLI startup hook
+# ---------------------------------------------------------------------------
+
+def _workspace_trust_prompt_enabled() -> bool:
+    """Return the opt-in ``security.workspace_trust_prompt`` config flag."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        security = load_config_readonly().get("security", {}) or {}
+        return bool(security.get("workspace_trust_prompt", False))
+    except Exception:
+        return False
+
+
+def maybe_prompt_workspace_trust() -> None:
+    """First-run workspace trust gate for the plain interactive CLI.
+
+    Called from ``cmd_chat`` before the CLI is constructed. No-op unless
+    ``security.workspace_trust_prompt`` is true (opt-in — default behavior is
+    unchanged). When the current workspace has a recorded **untrusted**
+    decision, arms the tighten-only manual-approvals latch. When there is no
+    recorded decision (and the workspace is not the user's home directory),
+    prompts::
+
+        Trust this workspace? [y]es / [n]o (restricted) / [s]ession-only
+
+    - y: trusted, persisted — configured approval mode applies as-is.
+    - n: untrusted, persisted — approvals forced to manual this session and
+      every future session in this workspace (tighten-only).
+    - s: trusted for this process only; nothing is written to disk.
+
+    A declined/EOF prompt is treated as session-only untrusted: approvals are
+    forced to manual for this run but nothing is persisted.
+    """
+    if not _workspace_trust_prompt_enabled():
+        return
+
+    key = get_workspace_trust_key()
+    if key == os.path.realpath(os.path.expanduser("~")):
+        # Never prompt for the home directory itself — it isn't a project
+        # workspace, and marking $HOME untrusted would catch every shell.
+        return
+
+    decision = get_workspace_trust()
+    if decision == "trusted":
+        return
+    if decision == "untrusted":
+        from tools.approval import enforce_untrusted_workspace
+
+        enforce_untrusted_workspace()
+        print("⚠ Untrusted workspace — approvals forced to manual for this session.")
+        return
+
+    try:
+        if not (os.isatty(0) and os.isatty(1)):
+            return
+    except OSError:
+        return
+
+    print(f"\nNew workspace: {key}")
+    try:
+        answer = input("Trust this workspace? [y]es / [n]o (restricted) / [s]ession-only: ")
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+    normalized = answer.strip().lower()
+
+    if normalized in {"y", "yes"}:
+        set_workspace_trust(None, trusted=True, remember=True)
+        return
+    if normalized in {"s", "session"}:
+        set_workspace_trust(None, trusted=True, remember=False)
+        return
+
+    # "n", empty, or anything else: restricted. Persist only an explicit no.
+    remember = normalized in {"n", "no"}
+    set_workspace_trust(None, trusted=False, remember=remember)
+    from tools.approval import enforce_untrusted_workspace
+
+    enforce_untrusted_workspace()
+    print("⚠ Workspace restricted — approvals forced to manual for this session.")
+
+
+# ---------------------------------------------------------------------------
+# ``hermes trust`` subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_trust(args) -> None:
+    """Entry point for ``hermes trust [list|set|remove]``."""
+    action = getattr(args, "trust_command", None) or "list"
+
+    if action == "list":
+        store = load_workspace_trust_store()
+        workspaces = store["workspaces"]
+        if not workspaces:
+            print("No workspace trust decisions recorded.")
+            return
+        for workspace in sorted(workspaces):
+            entry = workspaces[workspace]
+            label = "trusted" if entry["trusted"] else "untrusted"
+            decided = entry.get("decidedAt") or "unknown"
+            print(f"{label:>9}  {workspace}  ({decided})")
+        return
+
+    if action == "set":
+        path = getattr(args, "path", None) or os.getcwd()
+        if not os.path.isdir(path):
+            print(f"Not a directory: {path}")
+            raise SystemExit(1)
+        trusted = bool(getattr(args, "trusted", False))
+        key = set_workspace_trust(path, trusted=trusted, remember=True)
+        print(f"Marked {'trusted' if trusted else 'untrusted'}: {key}")
+        return
+
+    if action == "remove":
+        path = getattr(args, "path", None) or os.getcwd()
+        key = get_workspace_trust_key(path)
+        if remove_workspace_trust(path):
+            print(f"Removed trust decision for {key}")
+        else:
+            print(f"No trust decision recorded for {key}")
+        return
+
+    print(f"Unknown trust action: {action}")
+    raise SystemExit(1)

--- a/tests/hermes_cli/test_workspace_trust.py
+++ b/tests/hermes_cli/test_workspace_trust.py
@@ -1,0 +1,219 @@
+"""Tests for the per-workspace trust store (hermes_cli/workspace_trust.py).
+
+Ported from superagent-ai/grok-cli src/utils/workspace-trust.ts.
+"""
+
+import json
+import os
+import stat
+
+import pytest
+
+from hermes_cli import workspace_trust as wt
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Point the trust store at a temp HERMES_HOME and clear session state."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(wt, "_SESSION_DECISIONS", {})
+    yield home
+
+
+def _store_path():
+    return wt.get_workspace_trust_path()
+
+
+# ---------------------------------------------------------------------------
+# Store round-trip + permissions
+# ---------------------------------------------------------------------------
+
+def test_roundtrip_persisted_decision(tmp_path):
+    ws = tmp_path / "project"
+    ws.mkdir()
+    assert wt.get_workspace_trust(str(ws)) is None
+
+    key = wt.set_workspace_trust(str(ws), trusted=True, remember=True)
+    assert key == os.path.realpath(str(ws))
+    assert wt.get_workspace_trust(str(ws)) == "trusted"
+
+    wt.set_workspace_trust(str(ws), trusted=False, remember=True)
+    assert wt.get_workspace_trust(str(ws)) == "untrusted"
+
+    # On-disk schema is versioned and entry carries a decidedAt timestamp.
+    raw = json.loads(_store_path().read_text(encoding="utf-8"))
+    assert raw["version"] == 1
+    assert raw["workspaces"][key]["trusted"] is False
+    assert raw["workspaces"][key]["decidedAt"]
+
+
+def test_store_file_written_with_0600_perms(tmp_path):
+    ws = tmp_path / "project"
+    ws.mkdir()
+    wt.set_workspace_trust(str(ws), trusted=True, remember=True)
+    mode = stat.S_IMODE(os.stat(_store_path()).st_mode)
+    assert mode == 0o600
+
+
+def test_remove_workspace_trust(tmp_path):
+    ws = tmp_path / "project"
+    ws.mkdir()
+    wt.set_workspace_trust(str(ws), trusted=True, remember=True)
+    assert wt.remove_workspace_trust(str(ws)) is True
+    assert wt.get_workspace_trust(str(ws)) is None
+    assert wt.remove_workspace_trust(str(ws)) is False
+
+
+# ---------------------------------------------------------------------------
+# Tolerant loader
+# ---------------------------------------------------------------------------
+
+def test_corrupt_store_file_yields_empty_store(tmp_path):
+    _store_path().write_text("{not json!!", encoding="utf-8")
+    assert wt.load_workspace_trust_store() == {"version": 1, "workspaces": {}}
+    # And a fresh decision can still be written over the corrupt file.
+    ws = tmp_path / "project"
+    ws.mkdir()
+    wt.set_workspace_trust(str(ws), trusted=True, remember=True)
+    assert wt.get_workspace_trust(str(ws)) == "trusted"
+
+
+def test_malformed_entries_dropped_valid_entries_kept():
+    _store_path().write_text(json.dumps({
+        "version": 1,
+        "workspaces": {
+            "/good": {"trusted": True, "decidedAt": "2026-01-01T00:00:00Z"},
+            "/bad-type": {"trusted": "yes"},
+            "/not-a-dict": 42,
+            "/missing-decided": {"trusted": False},
+        },
+    }), encoding="utf-8")
+    store = wt.load_workspace_trust_store()
+    assert set(store["workspaces"]) == {"/good", "/missing-decided"}
+    assert store["workspaces"]["/missing-decided"]["decidedAt"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Keying: realpath + git root
+# ---------------------------------------------------------------------------
+
+def test_key_resolves_symlinks(tmp_path):
+    real = tmp_path / "real-project"
+    real.mkdir()
+    link = tmp_path / "link-project"
+    link.symlink_to(real)
+    assert wt.get_workspace_trust_key(str(link)) == os.path.realpath(str(real))
+    wt.set_workspace_trust(str(link), trusted=False, remember=True)
+    assert wt.get_workspace_trust(str(real)) == "untrusted"
+
+
+def test_key_uses_git_root_for_subdirectories(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    sub = repo / "src" / "deep"
+    sub.mkdir(parents=True)
+    assert wt.get_workspace_trust_key(str(sub)) == os.path.realpath(str(repo))
+    wt.set_workspace_trust(str(sub), trusted=True, remember=True)
+    assert wt.get_workspace_trust(str(repo)) == "trusted"
+
+
+def test_key_falls_back_to_dir_outside_git(tmp_path):
+    ws = tmp_path / "no-repo"
+    ws.mkdir()
+    assert wt.get_workspace_trust_key(str(ws)) == os.path.realpath(str(ws))
+
+
+# ---------------------------------------------------------------------------
+# Session-only decisions
+# ---------------------------------------------------------------------------
+
+def test_session_only_decision_not_persisted(tmp_path):
+    ws = tmp_path / "project"
+    ws.mkdir()
+    wt.set_workspace_trust(str(ws), trusted=True, remember=False)
+    assert wt.get_workspace_trust(str(ws)) == "trusted"
+    assert not _store_path().exists()
+
+
+def test_session_decision_overrides_persisted(tmp_path):
+    ws = tmp_path / "project"
+    ws.mkdir()
+    wt.set_workspace_trust(str(ws), trusted=True, remember=True)
+    wt.set_workspace_trust(str(ws), trusted=False, remember=False)
+    assert wt.get_workspace_trust(str(ws)) == "untrusted"
+    # Disk still says trusted — session state never leaked to the store.
+    raw = json.loads(_store_path().read_text(encoding="utf-8"))
+    key = wt.get_workspace_trust_key(str(ws))
+    assert raw["workspaces"][key]["trusted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tighten-only approval interaction
+# ---------------------------------------------------------------------------
+
+def test_untrusted_latch_forces_manual_over_looser_modes(monkeypatch):
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_UNTRUSTED_WORKSPACE_LATCH", False)
+    monkeypatch.setattr(approval, "_get_approval_config", lambda: {"mode": "off"})
+    assert approval._get_approval_mode() == "off"
+
+    approval.enforce_untrusted_workspace()
+    assert approval._get_approval_mode() == "manual"
+
+    # Tighten-only: even a smart config reads as manual once latched.
+    monkeypatch.setattr(approval, "_get_approval_config", lambda: {"mode": "smart"})
+    assert approval._get_approval_mode() == "manual"
+
+
+def test_latch_untouched_leaves_configured_mode(monkeypatch):
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_UNTRUSTED_WORKSPACE_LATCH", False)
+    monkeypatch.setattr(approval, "_get_approval_config", lambda: {"mode": "smart"})
+    assert approval._get_approval_mode() == "smart"
+
+
+# ---------------------------------------------------------------------------
+# Startup gate behavior
+# ---------------------------------------------------------------------------
+
+def test_prompt_disabled_by_default_is_noop(tmp_path, monkeypatch):
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_UNTRUSTED_WORKSPACE_LATCH", False)
+    monkeypatch.setattr(wt, "_workspace_trust_prompt_enabled", lambda: False)
+    called = []
+    monkeypatch.setattr("builtins.input", lambda *_: called.append(1) or "y")
+    wt.maybe_prompt_workspace_trust()
+    assert called == []
+    assert approval._UNTRUSTED_WORKSPACE_LATCH is False
+
+
+def test_recorded_untrusted_workspace_arms_latch(tmp_path, monkeypatch):
+    from tools import approval
+
+    ws = tmp_path / "project"
+    ws.mkdir()
+    monkeypatch.setattr(approval, "_UNTRUSTED_WORKSPACE_LATCH", False)
+    monkeypatch.setattr(wt, "_workspace_trust_prompt_enabled", lambda: True)
+    monkeypatch.chdir(ws)
+    wt.set_workspace_trust(str(ws), trusted=False, remember=True)
+
+    wt.maybe_prompt_workspace_trust()
+    assert approval._UNTRUSTED_WORKSPACE_LATCH is True
+    assert approval._get_approval_mode() == "manual"
+
+
+def test_home_directory_never_prompted(monkeypatch):
+    monkeypatch.setattr(wt, "_workspace_trust_prompt_enabled", lambda: True)
+    monkeypatch.setattr(
+        wt, "get_workspace_trust_key",
+        lambda path=None: os.path.realpath(os.path.expanduser("~")),
+    )
+    called = []
+    monkeypatch.setattr("builtins.input", lambda *_: called.append(1) or "y")
+    wt.maybe_prompt_workspace_trust()
+    assert called == []

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2933,8 +2933,26 @@ def _get_approval_config() -> dict:
         return {}
 
 
+# One-way, process-scoped latch armed by the workspace-trust gate
+# (hermes_cli/workspace_trust.py) when the current workspace is marked
+# untrusted. Once armed it can only tighten: every approval-mode read for
+# the rest of the process returns 'manual' regardless of the configured
+# mode. There is deliberately no API to clear it — an untrusted workspace
+# must never be able to end up with a weaker posture than the profile
+# config (mirrors the _YOLO_MODE_FROZEN one-way pattern above, inverted).
+_UNTRUSTED_WORKSPACE_LATCH = False
+
+
+def enforce_untrusted_workspace() -> None:
+    """Force approval mode to 'manual' for the rest of this process."""
+    global _UNTRUSTED_WORKSPACE_LATCH
+    _UNTRUSTED_WORKSPACE_LATCH = True
+
+
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
+    if _UNTRUSTED_WORKSPACE_LATCH:
+        return "manual"
     mode = _get_approval_config().get("mode", "manual")
     return _normalize_approval_mode(mode)
 


### PR DESCRIPTION
Ports grok-cli's per-workspace trust store to Hermes: workspaces get a persisted trusted/untrusted decision keyed by the realpath of their git root, and sessions in an untrusted workspace have their approval mode forced to `manual` — a tighten-only posture that can never weaken the configured mode.

Source being ported: [superagent-ai/grok-cli — src/utils/workspace-trust.ts](https://github.com/superagent-ai/grok-cli/blob/main/src/utils/workspace-trust.ts)

## Changes

- **`hermes_cli/workspace_trust.py`** (new): versioned JSON store at `get_hermes_home()/workspace-trust.json` — schema `{version: 1, workspaces: {<realpath>: {trusted, decidedAt}}}`, written atomically with `0600` perms, tolerant loader that drops malformed entries and survives corrupt files (grok-cli parity). Keys are `os.path.realpath` of the workspace **root** (enclosing git repo root when inside one, else the directory — same `_find_git_root` pattern as `agent/prompt_builder.py`). Session-only decisions (`remember=False`) stay in-process and are never persisted.
- **`tools/approval.py`**: one-way `_UNTRUSTED_WORKSPACE_LATCH` + `enforce_untrusted_workspace()`. Once armed, `_get_approval_mode()` returns `manual` for the rest of the process regardless of configured mode. There is deliberately no clear API — it only ever tightens (mirrors the `_YOLO_MODE_FROZEN` one-way pattern, inverted). No config mutation, no system-prompt impact.
- **`hermes trust` subcommand** (`hermes_cli/main.py`): `trust list`, `trust set [path] --trusted|--untrusted`, `trust remove [path]`, registered following the existing `moa`/`fallback` pattern and added to `_BUILTIN_SUBCOMMANDS`.
- **Opt-in first-run prompt**: `security.workspace_trust_prompt` (default **false** in `hermes_cli/config_defaults.py` — existing behavior unchanged). When enabled, interactive CLI startup in an undecided, non-`$HOME` workspace asks `Trust this workspace? [y]es / [n]o (restricted) / [s]ession-only`; "no"/decline arms the manual-approvals latch. Wired in `cmd_chat` after the TUI branch, wrapped so it can never break startup.
- **Tests** (`tests/hermes_cli/test_workspace_trust.py`, 15): store roundtrip, on-disk 0600 perms, corrupt-file + malformed-entry tolerance, symlink/realpath keying, git-root resolution, session-only semantics, and the tighten-only latch (config `off`/`smart` both read as `manual` once armed; untouched latch leaves configured mode alone).

**Scope note:** the interactive prompt runs only in the plain CLI path (`cmd_chat` → classic `cli.main`), not in the TUI or gateway — those surfaces still honor a persisted untrusted decision only via future wiring; the store, CLI management, and tighten-only enforcement are surface-independent. Kept deliberately narrow to avoid touching the TUI JSON-RPC prompt machinery.

## Validation

| Check | Command | Result |
|---|---|---|
| New store/latch tests | `scripts/run_tests.sh tests/hermes_cli/test_workspace_trust.py` | 15 passed, 0 failed |
| Approval regression | `scripts/run_tests.sh tests/tools/test_approval.py tests/tools/test_approval_config_readonly.py tests/tools/test_cron_approval_mode.py` | 129 passed, 0 failed |
| Approvals command parity | `scripts/run_tests.sh tests/tools/test_approval_mode_parity.py tests/hermes_cli/test_approvals_command.py` | all passed |
| CLI end-to-end | `HERMES_HOME=$(mktemp -d) python3 -m hermes_cli.main trust list / set /tmp --untrusted / list / remove /tmp` | works; store file `-rw-------` (0600) |
| Lint | `ruff check --fix` on all touched files | All checks passed |
| Windows footguns | `scripts/check-windows-footguns.py` on new files | ✓ No Windows footguns found |
| Attribution | `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

## Infographic

![Per-workspace trust store infographic](https://v3b.fal.media/files/b/0aa55165/Tn1irM40wSSLJVYpXBgk__nI5XBaNL.png)
