### PR TITLE
fix(windows): resolve Local AppData via known folder when LOCALAPPDATA is absent

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -50,11 +50,57 @@ def get_hermes_home_override() -> str | None:
     return str(override)
 
 
+def _windows_local_appdata() -> Path | None:
+    """Ask Windows for the Local AppData known folder, or None if unavailable.
+
+    Used only when ``LOCALAPPDATA`` is missing from the environment, which
+    happens under services, scheduled tasks, and sandboxed launchers.
+    """
+    try:
+        import ctypes
+
+        class _GUID(ctypes.Structure):
+            _fields_ = [
+                ("Data1", ctypes.c_uint32),
+                ("Data2", ctypes.c_uint16),
+                ("Data3", ctypes.c_uint16),
+                ("Data4", ctypes.c_ubyte * 8),
+            ]
+
+        # FOLDERID_LocalAppData {F1B32785-6FBA-4FCF-9D55-7B8E7F157091}
+        folder_id = _GUID(
+            0xF1B32785,
+            0x6FBA,
+            0x4FCF,
+            (ctypes.c_ubyte * 8)(0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91),
+        )
+        path_ptr = ctypes.c_wchar_p()
+        # The shell allocates the string; the caller must CoTaskMemFree it.
+        hresult = ctypes.windll.shell32.SHGetKnownFolderPath(  # type: ignore[attr-defined]
+            ctypes.byref(folder_id), 0, None, ctypes.byref(path_ptr)
+        )
+        try:
+            if hresult == 0 and path_ptr.value:
+                return Path(path_ptr.value)
+        finally:
+            ctypes.windll.ole32.CoTaskMemFree(path_ptr)  # type: ignore[attr-defined]
+    except (AttributeError, ImportError, OSError, RuntimeError, ValueError):
+        pass
+    return None
+
+
 def _get_platform_default_hermes_home() -> Path:
     """Return the platform-native default Hermes home path."""
     if sys.platform == "win32":
         local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
-        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        if local_appdata:
+            base = Path(local_appdata)
+        else:
+            # Services, tests, and tightly-sandboxed launchers may omit the
+            # usual profile environment variables. Ask Windows for its Local
+            # AppData known folder before falling back to Path.home(), which
+            # is wrong on a redirected profile.
+            base = _windows_local_appdata() or Path.home() / "AppData" / "Local"
         return base / "hermes"
     return Path.home() / ".hermes"
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,5 +1,6 @@
 """Tests for hermes_constants module."""
 
+import ctypes
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -665,3 +666,84 @@ class TestWslPathTranslation:
         assert hermes_constants.translate_cwd_for_wsl_backend(r"\\wsl.localhost\Ubuntu\home\alex") == "/home/alex"
         # Already-POSIX paths pass through untouched.
         assert hermes_constants.translate_cwd_for_wsl_backend("/home/alex") == "/home/alex"
+
+
+class TestWindowsKnownFolderFallback:
+    """``_get_platform_default_hermes_home`` when ``LOCALAPPDATA`` is absent.
+
+    Services, scheduled tasks, test harnesses that scrub the environment,
+    and tightly sandboxed launchers can start Python without the usual
+    profile environment variables. The resolver must then ask Windows for
+    the Local AppData known folder before guessing ``Path.home() /
+    "AppData" / "Local"``. These tests run on any platform:
+    ``hermes_constants.sys.platform`` is patched and ``ctypes.windll`` is
+    substituted (created on POSIX, replaced on Windows).
+    """
+
+    def test_known_folder_queried_when_localappdata_missing(self, monkeypatch):
+        freed = []
+
+        class _FakeShell32:
+            @staticmethod
+            def SHGetKnownFolderPath(rfid, flags, token, out_ptr):
+                # FOLDERID_LocalAppData {F1B32785-6FBA-4FCF-...}
+                assert rfid._obj.Data1 == 0xF1B32785
+                assert flags == 0
+                out_ptr._obj.value = "C:\\KnownFolder\\Local"
+                return 0
+
+        class _FakeOle32:
+            @staticmethod
+            def CoTaskMemFree(ptr):
+                freed.append(ptr.value)
+
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.setattr(
+            ctypes,
+            "windll",
+            SimpleNamespace(shell32=_FakeShell32(), ole32=_FakeOle32()),
+            raising=False,
+        )
+
+        home = hermes_constants._get_platform_default_hermes_home()
+        assert home == Path("C:\\KnownFolder\\Local") / "hermes"
+        # The shell allocates the string; not freeing it leaks on every call.
+        assert freed == ["C:\\KnownFolder\\Local"]
+
+    def test_failed_hresult_falls_back_and_still_frees(self, monkeypatch):
+        freed = []
+
+        class _FakeShell32:
+            @staticmethod
+            def SHGetKnownFolderPath(rfid, flags, token, out_ptr):
+                return -2147024894  # HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+
+        class _FakeOle32:
+            @staticmethod
+            def CoTaskMemFree(ptr):
+                freed.append(ptr.value)
+
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.setattr(
+            ctypes,
+            "windll",
+            SimpleNamespace(shell32=_FakeShell32(), ole32=_FakeOle32()),
+            raising=False,
+        )
+        monkeypatch.setattr(Path, "home", lambda: Path("C:\\Users\\stub"))
+
+        home = hermes_constants._get_platform_default_hermes_home()
+        assert home == Path("C:\\Users\\stub") / "AppData" / "Local" / "hermes"
+        assert freed == [None]
+
+    def test_home_fallback_when_shell_api_unavailable(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        # No windll at all (POSIX reality; simulated on Windows by deletion).
+        monkeypatch.delattr(ctypes, "windll", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("C:\\Users\\stub"))
+
+        home = hermes_constants._get_platform_default_hermes_home()
+        assert home == Path("C:\\Users\\stub") / "AppData" / "Local" / "hermes"


### PR DESCRIPTION
## Problem

Services, scheduled tasks, test harnesses that scrub the environment, and tightly sandboxed launchers can start Hermes without `LOCALAPPDATA` set. The Windows default-home resolver then guessed `Path.home() / "AppData" / "Local"`, which is wrong for redirected profiles and cascades into misresolved state, config, and session paths.

This is reachable in-tree, not just in theory: tests that clear the environment wholesale (`patch.dict(os.environ, {}, clear=True)` — e.g. `tests/cli/test_cli_init.py`, `tests/gateway/test_allowlist_startup_check.py`) resolve the wrong Hermes home on Windows for this reason.

## Fix

Ask the OS for the real answer before guessing, using the API prescribed by [CONTRIBUTING](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) cross-platform rule 14: a new `_windows_local_appdata()` helper calls `SHGetKnownFolderPath(FOLDERID_LocalAppData)` via `ctypes` and `CoTaskMemFree`s the shell-allocated string, falling back to the previous `Path.home()` guess only when the call is unavailable or fails.

**No behavior change when `LOCALAPPDATA` is set** — the new code path only runs when the environment variable is absent or empty.

## Tests

Three new tests in `tests/test_hermes_constants.py`, all portable to the Ubuntu CI runner: `hermes_constants.sys.platform` is patched and `ctypes.windll` is substituted (created on POSIX, replaced on Windows). They cover the success path, a failed `HRESULT`, and no shell API at all. The first two assert `CoTaskMemFree` was called, so a leak regression fails the suite.

## Verification

- Exercised against the **real Windows API** on a native Windows 11 host (Python 3.11): with `LOCALAPPDATA` scrubbed from the environment, the resolver returns the correct `…\AppData\Local\hermes`.
- Mutation-checked: breaking the helper so it never consults the shell, and separately so it skips `CoTaskMemFree`, are each caught by the new tests.
- Platforms tested: native Windows 11 (full file: 40 passed, 9 skipped, plus the pre-existing failures below); Linux covered by CI.

Note: `tests/test_hermes_constants.py` has 4 pre-existing failures on native Windows (3 symlink-privilege `WinError 1314`, 1 POSIX-default assumption in `test_no_hermes_home_returns_native`) that reproduce identically on unmodified `main`; they are unrelated to this change.

No existing issue found for this (searched issues and PRs for `LOCALAPPDATA` / `SHGetKnownFolderPath`; the nearby Windows-home PRs #66801, #63939 and #40233 address legacy-state migration and `HERMES_HOME` prefill, not an absent `LOCALAPPDATA`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
