### PR TITLE
fix(acp): normalize CRLF/CR to LF in decoded text resources

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -303,15 +303,23 @@ def _path_from_file_uri(uri: str) -> Path | None:
 
 
 def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
-    """Decode resource bytes if they are probably text; return None for binary."""
+    """Decode resource bytes if they are probably text; return None for binary.
+
+    Decoded text is newline-normalized (CRLF and bare CR become LF): editors
+    on Windows send CRLF attachments, and leaving the CR in place embeds
+    stray carriage returns into prompt context and diffs downstream.
+    """
     if b"\x00" in data and not _is_text_resource(mime_type):
         return None
     for encoding in ("utf-8-sig", "utf-8", "latin-1"):
         try:
-            return data.decode(encoding)
+            text = data.decode(encoding)
+            break
         except UnicodeDecodeError:
             continue
-    return data.decode("utf-8", errors="replace")
+    else:
+        text = data.decode("utf-8", errors="replace")
+    return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
 def _format_resource_text(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -40,6 +40,7 @@ from acp_adapter.server import (
     ACP_MAX_MODELS_PER_PROVIDER,
     HermesACPAgent,
     HERMES_VERSION,
+    _decode_text_bytes,
 )
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
@@ -726,3 +727,34 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+# ---------------------------------------------------------------------------
+# _decode_text_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeTextBytesNewlines:
+    """Decoded ACP text resources are newline-normalized (CRLF/CR to LF).
+
+    Editors on Windows attach CRLF files; without normalization the raw CR
+    bytes flow into prompt context and diffs downstream.
+    """
+
+    def test_crlf_and_bare_cr_normalized(self):
+        assert _decode_text_bytes(b"a\r\nb\rc\n", "text/plain") == "a\nb\nc\n"
+
+    def test_utf8_sig_content_normalized(self):
+        data = "line1\r\nline2\r\n".encode("utf-8-sig")
+        assert _decode_text_bytes(data, "text/plain") == "line1\nline2\n"
+
+    def test_binary_still_rejected(self):
+        assert _decode_text_bytes(b"\x00\x01\x02", None) is None
+
+    def test_lf_only_content_unchanged(self):
+        assert _decode_text_bytes(b"a\nb\n", "text/plain") == "a\nb\n"
+
+    def test_nul_byte_kept_when_mime_forces_text(self):
+        """A text mime type overrides the NUL-byte binary heuristic, and the
+        content is still normalized on the way out."""
+        assert _decode_text_bytes(b"\x00a\r\nb", "text/plain") == "\x00a\nb"


### PR DESCRIPTION
## Problem

Editors on Windows attach CRLF files over ACP. `_decode_text_bytes` passed the raw `\r` bytes through, so stray carriage returns flowed into prompt context and downstream diffs (visible as `^M` artifacts and wasted tokens).

## Fix

Normalize decoded text to LF (`\r\n` → `\n`, then bare `\r` → `\n`) at the decode boundary. Binary detection and truncation behavior are unchanged.

The encoding loop is restructured into `for … break … else` so normalization happens once on the way out, rather than being written twice. (The trailing `errors="replace"` arm is preserved as-is; note it is already unreachable on `main`, since `latin-1` decodes every byte and never raises — this PR neither fixes nor relies on that.)

## Tests

Five new tests in `tests/acp/test_server.py`: CRLF + bare-CR normalization, UTF-8-sig content, binary rejection unchanged, LF-only passthrough, and a NUL byte kept when the mime type forces text. Full file green on native Windows 11: 35 passed.

Platforms tested: native Windows 11 (Python 3.11); Linux covered by CI — the change is platform-independent.

Related: #42775 also normalizes CRLF in `_decode_text_bytes` as part of a broader Windows-compatibility patch. This PR is narrower and additionally normalizes bare CR, with dedicated decode-boundary coverage. #40649 handles the sibling native file-URI path issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
