### PR TITLE
fix(gateway): preserve archived compaction history on /retry rewrite (#80216)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3379,7 +3379,13 @@ class SessionStore:
             return True
         self._clear_dirty_transcript(session_id)
         try:
-            self._db.replace_messages(session_id, messages)
+            # When the session has soft-archived rows (e.g. in-place compaction
+            # history), restrict the DELETE to active-only rows so the archived
+            # turns survive the rewrite.  Without this guard, /retry (and any
+            # other caller of rewrite_transcript) silently destroys the
+            # durable pre-compaction history (#80216).
+            active_only = self._db.has_archived_messages(session_id)
+            self._db.replace_messages(session_id, messages, active_only=active_only)
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)


### PR DESCRIPTION
## Summary

`rewrite_transcript()` called `replace_messages()` with the default `active_only=False`, which DELETEd **every row** for the session — including soft-archived (`active=0`) compaction turns that in-place compaction deliberately keeps on disk for searchable history.

After any `/retry` on a compacted session, the archived pre-compaction history was gone permanently: hard ID gaps, empty archive queries, missing `in_place_committed` history. Nothing was logged.

## Root Cause

`gateway/slash_commands.py:2587` (`_handle_retry_command`):

```python
truncated = history[:last_user_idx]
await self.async_session_store.rewrite_transcript(session_entry.session_id, truncated)
```

`gateway/session.py` `rewrite_transcript` then called:

```python
self._db.replace_messages(session_id, messages)
```

with `active_only` defaulting to `False`, so the DELETE had no `active` clause and took the archived rows with it.

## Fix

Probe `has_archived_messages()` before the rewrite and pass `active_only=True` when archives exist, mirroring the ACP adapter's `_persist` and the TUI `prompt.submit` path after #80195.

## Testing

- Verified the code compiles and the `has_archived_messages` method exists on `SessionDB` (line 7130 of `hermes_state.py`)
- The fix is a minimal, surgical change: 1 file, 7 lines added, 1 removed
- No behavioral change when no archived rows exist (the probe returns `False`, so `active_only=False` — same as before)

Fixes #80216
