### PR TITLE
fix(desktop): statusbar visible by default for upgrading users

### DIFF
--- a/apps/desktop/src/store/statusbar-prefs.test.ts
+++ b/apps/desktop/src/store/statusbar-prefs.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// In-memory storage so each test controls the persisted state that
+// persistentAtom reads at module-init time. Mirrors the pattern in
+// updates.test.ts.
+const storage = new Map<string, string>()
+
+vi.mock('@/lib/storage', () => ({
+  readKey: (key: string) => storage.get(key) ?? null,
+  writeKey: (key: string, value: null | string) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, value)
+    }
+  },
+  onPersistenceEvent: () => () => {}
+}))
+
+describe('$statusbarVisible', () => {
+  beforeEach(() => {
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('defaults to true when no stored preference exists (upgrading users)', async () => {
+    const { $statusbarVisible } = await import('./statusbar-prefs')
+    expect($statusbarVisible.get()).toBe(true)
+  })
+
+  it('is false when a user explicitly hid the bar in a previous session', async () => {
+    storage.set('hermes.desktop.statusbarVisible', 'false')
+    const { $statusbarVisible } = await import('./statusbar-prefs')
+    expect($statusbarVisible.get()).toBe(false)
+  })
+
+  it('is true when a user explicitly showed the bar', async () => {
+    storage.set('hermes.desktop.statusbarVisible', 'true')
+    const { $statusbarVisible } = await import('./statusbar-prefs')
+    expect($statusbarVisible.get()).toBe(true)
+  })
+})
+
+describe('toggleStatusbarVisible', () => {
+  beforeEach(() => {
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('toggles from true to false', async () => {
+    const { $statusbarVisible, toggleStatusbarVisible } = await import('./statusbar-prefs')
+    expect($statusbarVisible.get()).toBe(true)
+    toggleStatusbarVisible()
+    expect($statusbarVisible.get()).toBe(false)
+  })
+
+  it('toggles from false to true', async () => {
+    storage.set('hermes.desktop.statusbarVisible', 'false')
+    const { $statusbarVisible, toggleStatusbarVisible } = await import('./statusbar-prefs')
+    expect($statusbarVisible.get()).toBe(false)
+    toggleStatusbarVisible()
+    expect($statusbarVisible.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,11 +3,11 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. On by default
+// — existing users who never stored a preference get the bar. Hiding it unmounts
+// the bar (its 15s status poll goes with it), so the way back is the
+// `view.toggleStatusbar` keybind or the ⌘K row.
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())


### PR DESCRIPTION
## What does this PR do?

Fix the 0.20.0 desktop status bar regression: the entire bottom operation panel is missing for all upgrading users because the `persistentAtom` default was changed from `true` to `false` in `d399c1644`. Since the storage key `hermes.desktop.statusbarVisible` is new in 0.20.0, upgrading users have no stored preference and the `false` default unmounts the entire bar. The one-line fix restores `true` as the default — users who explicitly hid the bar already have `false` in localStorage and keep their choice.

## Related Issue

Fixes #79407
Related: #77594 (duplicate), #77616 (same fix)

## Type of Change

- [x] Bug fix (P1 functional regression — desktop GUI becomes a viewer-only shell without operational controls)

## Changes Made

- `apps/desktop/src/store/statusbar-prefs.ts:10` — change `persistentAtom(.., false, ..)` to `persistentAtom(.., true, ..)` and update the comment
- `apps/desktop/src/store/statusbar-prefs.test.ts` — add tests: default visibility for fresh/upgrading users, stored preference preservation, toggle behavior

## How to Test

1. Clear `localStorage` key `hermes.desktop.statusbarVisible` (DevTools Console)
2. Reload the desktop app — status bar appears by default
3. Right-click bar -> "Hide status bar" — bar unmounts, `hermes.desktop.statusbarVisible` is `false` in localStorage
4. `Ctrl+Shift+S` — bar returns, preference is `true`
5. Repeat step 3-4 from the Command Palette (`Ctrl+K` → "Toggle status bar")

Tested on: Windows 11 Pro (GBK locale)

## Root cause detail

`persistentAtom` reads localStorage first, falls back to the coded default only when no stored value exists. Commit `d399c1644` changed that fallback from `true` to `false` while introducing the new key. Every upgrading user hits the fallback — the bar unmounts, and its own right-click menu (the recovery UI) unmounts with it. Only `Ctrl+Shift+S` or the command palette can recover, neither of which is discoverable.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 11 Pro

### Documentation and Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the fix is a one-line default change. The regression and recovery are described in the issue.
