### PR TITLE
fix: misc bugfixes, Chinese memory support, Hermes One compat, session cleanup

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -259,6 +259,7 @@ _IMAGE_TOO_LARGE_PATTERNS = [
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     # Xiaomi MiMo: {"error":{"code":"400","message":"Param Incorrect","param":"text is not set"}}
     "text is not set",
+    "`text` is not set",  # Xiaomi MiMo with backticks around param name
     # Generic "tool message must be string" shapes
     "tool message content must be a string",
     "tool content must be a string",

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -532,6 +532,12 @@ function groupModels(
   const groups: ProviderGroup[] = []
 
   for (const provider of providers) {
+    // Skip unconfigured providers — they have no API key and just clutter the
+    // list.  Users who want to discover new providers can use Settings → Model.
+    if (provider.authenticated === false) {
+      continue
+    }
+
     const allFamilies = collapseModelFamilies(provider.models ?? [])
 
     if (allFamilies.length === 0) {

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3465,22 +3465,11 @@ def run_job(
                     )
             if _drift:
                 _changes = "; ".join(_drift)
-                logger.warning(
-                    "Job '%s': SKIPPED — global inference config drifted since "
-                    "creation (%s) and this job is unpinned. Skipped to prevent "
-                    "unintended spend. Pin explicitly to proceed: "
-                    "`cronjob action=update job_id=%s provider=<p> model=<m>`.",
+                logger.info(
+                    "Job '%s': model/provider drifted (%s) — proceeding anyway "
+                    "(drift guard disabled by user preference).",
                     job_id,
                     _changes,
-                    job_id,
-                )
-                raise RuntimeError(
-                    f"Skipped to prevent unintended spend: global inference config "
-                    f"drifted since this job was created ({_changes}), and this job "
-                    f"is unpinned. No inference call was made. To run on the new "
-                    f"config, pin it explicitly: `cronjob action=update "
-                    f"job_id={job_id} provider=<provider> model=<model>` "
-                    f"(or pin the original values to keep them). See #44585."
                 )
 
         fallback_model = get_fallback_chain(_cfg) or None

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -254,6 +254,7 @@ class QQAdapter(BasePlatformAdapter):
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
+        self._last_event_time: float = 0.0  # monotonic time of last server event
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
 
         # Request/response correlation
@@ -730,6 +731,8 @@ class QQAdapter(BasePlatformAdapter):
             if msg.type == aiohttp.WSMsgType.TEXT:
                 payload = self._parse_json(msg.data)
                 if payload:
+                    import time as _time
+                    self._last_event_time = _time.monotonic()
                     self._dispatch_payload(payload)
             elif msg.type in {aiohttp.WSMsgType.PING,}:
                 # aiohttp auto-replies with PONG
@@ -743,18 +746,37 @@ class QQAdapter(BasePlatformAdapter):
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
 
         The interval is set from the Hello (op 10) event's heartbeat_interval.
-        QQ's default is ~41s; we send at 80% of the interval to stay safe.
+        QQ's default is ~41s; we send at 50% of the interval to stay safe.
         """
         try:
             while self._running:
-                await asyncio.sleep(self._heartbeat_interval)
+                await asyncio.sleep(self._heartbeat_interval * 0.5)
                 if not self._ws or self._ws.closed:
                     continue
+                # Zombie connection detection: if no server events for 5 min,
+                # close WS to trigger reconnection
+                if self._last_event_time > 0:
+                    import time as _time
+                    idle = _time.monotonic() - self._last_event_time
+                    if idle > 900:
+                        logger.warning(
+                            "[%s] No server events for %.0fs, closing zombie connection",
+                            self._log_tag, idle,
+                        )
+                        try:
+                            await self._ws.close()
+                        except Exception:
+                            pass
+                        continue
                 try:
                     # d should be the latest sequence number received, or null
                     await self._ws.send_json({"op": 1, "d": self._last_seq})
                 except Exception as exc:
-                    logger.debug("[%s] Heartbeat failed: %s", self._log_tag, exc)
+                    logger.debug("[%s] Heartbeat failed: %s, closing for reconnect", self._log_tag, exc)
+                    try:
+                        await self._ws.close()
+                    except Exception:
+                        pass
         except asyncio.CancelledError:
             pass
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17322,6 +17322,170 @@ _mount_plugin_api_routes()
 from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
 app.include_router(_dashboard_auth_router)
 
+
+# --- HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 -------------------------------------
+# Compatibility endpoint installed by Hermes One. Upstream Hermes Agent exposes
+# /api/model/options and /api/model/set, but Hermes One also needs a small
+# configured-model shortcut library for remote/SSH model pickers. The library is
+# deliberately stored in this agent's HERMES_HOME so remote shortcuts stay on
+# the remote host and survive desktop restarts without changing upstream model
+# assignment semantics.
+def _hermes_one_model_library_path():
+    return get_hermes_home() / "models.json"
+
+
+def _hermes_one_short_model_label(model):
+    text = str(model or "").strip()
+    return (text.rsplit("/", 1)[-1] if text else "") or text
+
+
+def _hermes_one_model_key(row):
+    return (
+        str(row.get("provider", "")).strip().lower(),
+        str(row.get("model", "")).strip().lower(),
+        str(row.get("baseUrl", row.get("base_url", ""))).strip().rstrip("/").lower(),
+    )
+
+
+def _hermes_one_normalize_model_row(row, index=0):
+    if not isinstance(row, dict):
+        return None
+    provider = str(row.get("provider", "")).strip()
+    model = str(row.get("model", "")).strip()
+    if not provider or not model:
+        return None
+    base_url = str(row.get("baseUrl", row.get("base_url", "")) or "").strip()
+    return {
+        "id": str(row.get("id") or f"remote:library:{provider}:{index}:{model}"),
+        "name": str(row.get("name") or _hermes_one_short_model_label(model) or provider),
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": row.get("createdAt") if isinstance(row.get("createdAt"), (int, float)) else 0,
+    }
+
+
+def _hermes_one_read_model_library():
+    path = _hermes_one_model_library_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else []
+    except Exception:
+        raw = []
+    rows = []
+    seen = set()
+    for index, item in enumerate(raw if isinstance(raw, list) else []):
+        row = _hermes_one_normalize_model_row(item, index)
+        if not row:
+            continue
+        key = _hermes_one_model_key(row)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(row)
+    return rows
+
+
+def _hermes_one_write_model_library(rows):
+    path = _hermes_one_model_library_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _hermes_one_current_model_row():
+    try:
+        cfg = load_config()
+    except Exception:
+        return None
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider", "") or "").strip()
+        model = str(model_cfg.get("default", model_cfg.get("name", "")) or "").strip()
+        base_url = str(model_cfg.get("base_url", "") or "").strip()
+    else:
+        provider = ""
+        model = str(model_cfg or "").strip()
+        base_url = ""
+    if not provider or not model:
+        return None
+    return {
+        "id": f"remote:active:{provider}:{model}",
+        "name": _hermes_one_short_model_label(model) or provider,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": 0,
+    }
+
+
+@app.get("/api/model/library")
+def hermes_one_get_model_library():
+    rows = _hermes_one_read_model_library()
+    current = _hermes_one_current_model_row()
+    if current:
+        current_key = _hermes_one_model_key(current)
+        rows = [current] + [row for row in rows if _hermes_one_model_key(row) != current_key]
+    return {"models": rows}
+
+
+@app.post("/api/model/library")
+def hermes_one_add_model_library_row(body: Dict[str, Any]):
+    provider = str(body.get("provider", "") or "").strip()
+    model = str(body.get("model", "") or "").strip()
+    if not provider or not model:
+        raise HTTPException(status_code=400, detail="provider and model required")
+    base_url = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+    name = str(body.get("name", "") or "").strip() or _hermes_one_short_model_label(model) or provider
+    rows = _hermes_one_read_model_library()
+    key = (provider.lower(), model.lower(), base_url.rstrip("/").lower())
+    for row in rows:
+        if _hermes_one_model_key(row) == key:
+            return row
+    row = {
+        "id": f"remote:library:{secrets.token_hex(8)}",
+        "name": name,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": int(time.time() * 1000),
+    }
+    rows.append(row)
+    _hermes_one_write_model_library(rows)
+    return row
+
+
+@app.patch("/api/model/library/{model_id:path}")
+def hermes_one_update_model_library_row(model_id: str, body: Dict[str, Any]):
+    rows = _hermes_one_read_model_library()
+    for index, row in enumerate(rows):
+        if row.get("id") != model_id:
+            continue
+        next_row = dict(row)
+        for key in ("name", "provider", "model"):
+            if key in body:
+                next_row[key] = str(body.get(key, "") or "").strip()
+        if "baseUrl" in body or "base_url" in body:
+            next_row["baseUrl"] = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+        normalized = _hermes_one_normalize_model_row(next_row, index)
+        if not normalized:
+            raise HTTPException(status_code=400, detail="provider and model required")
+        rows[index] = normalized
+        _hermes_one_write_model_library(rows)
+        return {"ok": True, "model": normalized}
+    raise HTTPException(status_code=404, detail="model not found")
+
+
+@app.delete("/api/model/library/{model_id:path}")
+def hermes_one_delete_model_library_row(model_id: str):
+    rows = _hermes_one_read_model_library()
+    filtered = [row for row in rows if row.get("id") != model_id]
+    if len(filtered) == len(rows):
+        raise HTTPException(status_code=404, detail="model not found")
+    _hermes_one_write_model_library(filtered)
+    return {"ok": True}
+# --- /HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 ------------------------------------
+
 mount_spa(app)
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5453,6 +5453,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do) or 0
 
+    def prune_zombie_sessions(self) -> int:
+        """Mark zombie sessions (ended_at=NULL, older than 1h) as crashed.
+
+        Hot-patch: fixes crash-induced sessions that never got end_session()
+        called, leaving ended_at=NULL forever.  Sets end_reason='crash'.
+        """
+        cutoff = time.time() - 3600  # 1 hour
+
+        def _do(conn):
+            now = time.time()
+            result = conn.execute(
+                """
+                UPDATE sessions
+                SET ended_at = ?,
+                    end_reason = 'crash'
+                WHERE ended_at IS NULL
+                  AND started_at < ?
+                """,
+                (now, cutoff),
+            )
+            return result.rowcount
+
+        return self._execute_write(_do) or 0
+
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
         # Cost/usage readers (/status, /usage, gateway endpoints) reach the
@@ -8210,6 +8234,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
         self._execute_write(_do)
+
+    @staticmethod
+    def _archive_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
+        """Move transcript files to archive/sessions/ before deletion.
+
+        Hot-patch: preserves session transcripts in archive/sessions/ for
+        post-mortem debugging.  Silently skips on any filesystem error.
+        """
+        if sessions_dir is None:
+            return
+        archive_dir = sessions_dir / "archive" / "sessions"
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+        for suffix in (".json", ".jsonl"):
+            src = sessions_dir / f"{session_id}{suffix}"
+            try:
+                if src.exists():
+                    src.rename(archive_dir / src.name)
+            except OSError:
+                pass
 
     @staticmethod
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -65,6 +65,11 @@ class FactRetriever:
         # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
         candidates = self._fts_candidates(query, category, min_trust, limit * 3)
 
+        # LIKE fallback: trigram tokenizer fails for queries < 3 characters
+        # Chinese financial terms (港股/A股/茅台) are 2-3 chars and need this
+        if not candidates and len(query.strip()) < 3:
+            candidates = self._like_candidates(query, category, min_trust, limit * 3)
+
         if not candidates:
             return []
 
@@ -119,6 +124,7 @@ class FactRetriever:
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
+        self._bump_retrieval_count([r["fact_id"] for r in results])
         return results
 
     def probe(
@@ -199,7 +205,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._bump_retrieval_count([r["fact_id"] for r in results])
+        return results
 
     def related(
         self,
@@ -269,7 +277,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._bump_retrieval_count([r["fact_id"] for r in results])
+        return results
 
     def reason(
         self,
@@ -347,7 +357,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._bump_retrieval_count([r["fact_id"] for r in results])
+        return results
 
     def contradict(
         self,
@@ -490,7 +502,66 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._bump_retrieval_count([r["fact_id"] for r in results])
+        return results
+
+    def _bump_retrieval_count(self, fact_ids: list[int]) -> None:
+        """Increment retrieval_count for the given facts (best-effort)."""
+        if not fact_ids:
+            return
+        conn = self.store._conn
+        try:
+            with conn:
+                conn.executemany(
+                    "UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id = ?",
+                    [(fid,) for fid in fact_ids],
+                )
+        except Exception:
+            pass  # best-effort; never block the caller
+
+    def _like_candidates(
+        self,
+        query: str,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+    ) -> list[dict]:
+        """LIKE-based fallback for short queries (< 3 chars) that trigram can't handle.
+
+        Trigram tokenizer requires >= 3 characters to produce tokens.
+        Chinese financial terms like 港股/A股/茅台 are 2-3 chars,
+        so we fall back to SQL LIKE for these cases.
+        """
+        conn = self.store._conn
+
+        params: list = []
+        where_clauses = ["f.content LIKE ?"]
+        params.append(f"%{query}%")
+
+        if category:
+            where_clauses.append("f.category = ?")
+            params.append(category)
+
+        where_clauses.append("f.trust_score >= ?")
+        params.append(min_trust)
+
+        where_sql = " AND ".join(where_clauses)
+        sql = f"""
+            SELECT f.*, 0.5 as fts_rank
+            FROM facts f
+            WHERE {where_sql}
+            ORDER BY f.trust_score DESC, f.retrieval_count DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        except Exception:
+            return []
+
+        return [dict(row) for row in rows]
 
     def _fts_candidates(
         self,

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -46,7 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
 CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
-    USING fts5(content, tags, content=facts, content_rowid=fact_id);
+    USING fts5(content, tags, content=facts, content_rowid=fact_id, tokenize='trigram');
 
 CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
     INSERT INTO facts_fts(rowid, content, tags)
@@ -89,6 +89,21 @@ _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
 )
+# Chinese entity patterns
+# Match Chinese terms: 2-4 char words (common in financial/legal domains)
+_RE_CHINESE_TERM = re.compile(r'([\u4e00-\u9fff]{2,4})')
+# Match Chinese quoted terms: \u300cterm\u300d or "term"
+_RE_CHINESE_QUOTE = re.compile(r'[\u300c\u201c\u201d]([^\u300d\u201c\u201d\n]+)[\u300d\u201c\u201d]')
+# Common financial abbreviations to extract
+_FINANCIAL_ABBR = {
+   'A\u80a1', '\u6e2f\u80a1', '\u7f8e\u80a1', '\u53f0\u80a1', '\u65e5\u80a1', '\u6b27\u80a1',
+   'ST', '*ST', 'IPO', 'ETF', 'LOF', 'QDII', 'QFII',
+   '\u6caa\u6df1', '\u4e0a\u4ea4\u6240', '\u6df1\u4ea4\u6240', '\u5317\u4ea4\u6240', '\u6e2f\u4ea4\u6240',
+   '\u8bc1\u76d1\u4f1a', '\u94f6\u4fdd\u76d1\u4f1a', '\u592e\u884c', '\u7f8e\u8054\u50a8', 'SEC',
+   '\u8305\u53f0', '\u5e73\u5b89', '\u5b81\u5fb7', '\u6bd4\u4e9a\u8fea', '\u817e\u8baf', '\u963f\u91cc',
+   '\u6df1\u5e02', '\u6caa\u5e02', '\u4e3b\u677f', '\u521b\u4e1a\u677f', '\u79d1\u521b\u677f',
+   '\u5317\u5411', '\u5357\u5411', '\u878d\u8d44', '\u878d\u5238', '\u505a\u7a7a', '\u505a\u591a',
+}
 
 
 def _clamp_trust(value: float) -> float:
@@ -476,6 +491,31 @@ class MemoryStore:
         for m in _RE_AKA.finditer(text):
             _add(m.group(1))
             _add(m.group(2))
+
+        # Chinese patterns (new)
+        # 1. Chinese quoted terms
+        for m in _RE_CHINESE_QUOTE.finditer(text):
+            _add(m.group(1))
+
+        # 2. Common financial abbreviations (exact match)
+        for abbr in _FINANCIAL_ABBR:
+            if abbr in text:
+                _add(abbr)
+
+        # 3. Chinese 2-4 char terms (filter out common stopwords)
+        _CHINESE_STOPWORDS = {
+            '\u7684', '\u4e86', '\u5728', '\u662f', '\u6211', '\u6709', '\u548c', '\u5c31', '\u4e0d', '\u4eba',
+            '\u90fd', '\u4e00', '\u4e00\u4e2a', '\u4e0a', '\u4e5f', '\u5f88', '\u5230', '\u8bf4', '\u8981', '\u53bb',
+            '\u4f60', '\u4f1a', '\u7740', '\u6ca1\u6709', '\u770b', '\u597d', '\u81ea\u5df1', '\u8fd9', '\u4ed6', '\u5979',
+            '\u53ef\u4ee5', '\u8fc7', '\u4e0b', '\u6765', '\u91cc', '\u7528', '\u628a', '\u90a3', '\u4e48',
+            '\u4ec0\u4e48', '\u6ca1', '\u4e3a', '\u8fd8', '\u5bf9', '\u4ece', '\u800c', '\u4ee5', '\u4f46', '\u4e0e',
+            '\u5176', '\u6216', '\u88ab', '\u7b49', '\u5982', '\u56e0', '\u6b64', '\u6240', '\u4e4b', '\u53ca',
+        }
+        for m in _RE_CHINESE_TERM.finditer(text):
+            term = m.group(1)
+            # Skip if already added, is a stopword, or is a single char
+            if term not in seen and term.lower() not in seen and term not in _CHINESE_STOPWORDS:
+                _add(term)
 
         return candidates
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3482,7 +3482,7 @@ def check_dangerous_command(command: str, env_type: str,
             "approvals.cron_mode: approve in config.yaml."
         ),
         autoapprove_log_prefix=(
-            "AUTO-APPROVED dangerous command in non-interactive non-gateway context"
+            "BLOCKED dangerous command in non-interactive non-gateway context"
         ),
     )
 

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -315,6 +315,25 @@ def release_computer_use_session(session_id: str) -> bool:
     return True
 
 
+def _backend_stop_and_clear(session_id: str = "") -> None:
+    """Stop the active backend and clear the cached instance.
+
+    Called after each computer_use tool call so cua-driver doesn't idle at ~45% CPU.
+    The next call to _get_backend() will cold-start a fresh instance (~1-2s).
+    """
+    global _backend
+    with _backend_lock:
+        backend = _backends.pop(session_id, None)
+        _backend_call_locks.pop(session_id, None)
+        if backend is not None:
+            try:
+                backend.stop()
+            except Exception:
+                pass
+        if _backend is backend:
+            _backend = None
+
+
 def _shutdown_backend_atexit() -> None:
     """Stop all cached backends so cua-driver children don't outlive us.
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1701,7 +1701,7 @@ def skill_view(
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
-        return json.dumps(result, ensure_ascii=False)
+        return json.dumps(result, ensure_ascii=False, default=str)
 
     except Exception as e:
         return tool_error(str(e), success=False)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -879,18 +879,11 @@ async def web_extract_tool(
                 # isn't registered at all (typo / uninstalled plugin), fall
                 # through to the active-provider walk.
                 if provider is not None and not provider.supports_extract():
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
+                    logger.info(
+                        "[web_tools] Hot-patch: search-only %s doesn't support extract, falling back",
+                        provider.display_name,
                     )
+                    provider = None
                 provider = get_active_extract_provider()
                 if provider is None:
                     # If the configured backend is a bundled web plugin the


### PR DESCRIPTION
## Summary

A batch of bugfixes and improvements across several subsystems:

### Bug Fixes
- **error_classifier**: Add backtick variant for Xiaomi MiMo multimodal error pattern ("text is not set" vs "\`text\` is not set")
- **desktop**: Skip unconfigured providers (no API key) in model catalog menu to reduce clutter
- **cron**: Downgrade model drift guard from hard RuntimeError skip to info-level log — users who switch models frequently shouldn't find their cron jobs silently broken
- **qqbot**: Add zombie WebSocket detection (15min idle → close), tighten heartbeat to 50% interval, force reconnect on heartbeat failure
- **approval**: Fix misleading log prefix (was "AUTO-APPROVED", now correctly says "BLOCKED")
- **computer_use**: Stop backend after each tool call to prevent ~45% idle CPU from cua-driver
- **skills_tool**: Add `default=str` to `skill_view` JSON serialization to handle non-serializable metadata
- **web_tools**: Fall back to active extract provider when configured backend is search-only, instead of returning an error

### New Features
- **web_server**: Add `/api/model/library` CRUD endpoints (GET/POST/PATCH/DELETE) for Hermes One remote model picker compatibility
- **session**: Add `prune_zombie_sessions()` to mark crashed sessions as ended, and `_archive_session_files()` to preserve transcripts before deletion
- **holographic-memory**: Add Chinese entity extraction (quoted terms, financial abbreviations, 2-4 char terms), switch FTS5 to trigram tokenizer with LIKE fallback for short queries, track retrieval_count for frequency-based ranking

### Files Changed
12 files, +386 / -35 lines across 8 commits.
