### PR TITLE
The desktop's tools reach it on remote and cloud backends too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,45 @@ backends, providers, notifiers), don't merge them one at a time — design an
 ABC + orchestrator, wrap the existing built-in as the first provider, and turn
 the competing PRs into plugins against that interface.
 
+### Surface capability is a property of the SESSION, never of the process env
+
+A tool that only works because of *who is on the other end of the connection* —
+the desktop app's panes, the in-app browser, message reactions, Projects — must
+resolve its availability from the **session's own source**, not from an env var
+on the backend process.
+
+The client and the backend are separate machines on separate clocks. The
+desktop app can be driving a backend Electron spawned locally, one over SSH,
+one behind a plain URL + token, or Hermes Cloud. Only the first two are spawned
+by us and carry `HERMES_DESKTOP=1`. Every env-keyed GUI gate is therefore a
+silent no-op on the other half of the topologies, and the failure is invisible:
+the tool is stripped from the schema before the model ever sees it, on the same
+backend whose platform hint is telling the model it's *"chatting inside the
+Hermes desktop app."*
+
+The pattern that works:
+
+- **The toolset is the surface gate.** Keep the tools off `_HERMES_CORE_TOOLS`
+  (nobody else should pay their schema) and put them in a named toolset —
+  `desktop_ui`, `project`. The GUI gateway's `_load_enabled_toolsets(platform)`
+  folds that toolset in when the session's platform says GUI. One resolver,
+  every topology.
+- **`check_fn` answers reachability or user opt-in, not surface.** "Is the
+  renderer bridge wired?", "did the user enable reactions?" — fine. "Was I
+  spawned by Electron?" — not fine. `check_fn` results are also TTL-cached
+  process-wide (`tools/registry.py`), so a per-session answer does not belong
+  there at all: one process serves many sessions.
+- **Ask which identity you actually mean.** `HERMES_DESKTOP=1` legitimately
+  marks *"this backend process was spawned by the app"* — it gates the cron
+  ticker and web-dist handling correctly. It does NOT mean "a GUI is watching",
+  and the embedded terminal pane (`hermes --tui` against that same backend) is
+  the standing counterexample.
+
+Same test both ways: if the capability would still make sense with the client
+on another machine, it is session-scoped. Cover it with a test that asserts the
+GUI session gets the tool **with the env var absent** — that's the assertion
+the original gate could never have passed.
+
 ## Development Environment
 
 ```bash

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -153,6 +153,14 @@ consumer. Design a shared contract only once more than one real consumer proves
 its shape. "Plugin" means several unrelated things across Hermes — do not assume
 one surface's extension model runs in another.
 
+When the new capability is an **agent-callable** one — a tool that acts on this
+renderer (open a pane, read the in-app browser, react to a message) — it is a
+property of the SESSION's client, not of the backend host. Wire its
+availability off the session source the app already sends on `session.create`
+(`source: 'desktop'`), never off an env var on the backend process: that
+process might be a remote or cloud gateway this app merely connected to. See
+the root AGENTS.md, "Surface capability is a property of the SESSION."
+
 ## Respect the person using it
 
 Design and engineering meet at intent. The user's attention and context are

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -246,17 +246,29 @@ class TestResolveToolsetIncludeRegistry:
     by platform reverse-mapping. Regression harness for issue #49622."""
 
     def test_include_registry_false_excludes_registry_tools(self):
-        from tools.registry import discover_builtin_tools
-        discover_builtin_tools()  # registers read_terminal into 'terminal'
+        from tools.registry import discover_builtin_tools, registry
+        discover_builtin_tools()
 
-        merged = set(resolve_toolset("terminal"))
-        static = set(resolve_toolset("terminal", include_registry=False))
+        # Register a tool into `terminal` at runtime, the way plugins and MCP
+        # servers do, so the split is exercised on the mechanism rather than on
+        # whichever built-in currently happens to live where.
+        registry.register(
+            name="__probe_registry_only_tool__",
+            toolset="terminal",
+            schema={"name": "__probe_registry_only_tool__", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda args, **kw: "",
+        )
+        try:
+            merged = set(resolve_toolset("terminal"))
+            static = set(resolve_toolset("terminal", include_registry=False))
+        finally:
+            registry.deregister("__probe_registry_only_tool__")
 
         assert static == {"terminal", "process"}, static
-        # read_terminal is registered into 'terminal' but is desktop-only and
-        # not part of the static definition — it must only appear in the merged view.
-        assert "read_terminal" in merged
-        assert "read_terminal" not in static
+        # Registered into 'terminal' but not part of the static definition — it
+        # must only appear in the merged view.
+        assert "__probe_registry_only_tool__" in merged
+        assert "__probe_registry_only_tool__" not in static
 
 
     def test_static_view_threads_through_includes(self):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1997,7 +1997,7 @@ def test_load_enabled_toolsets_folds_project_into_focus_posture(monkeypatch):
 
     monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding", "figma"])
 
-    assert server._load_enabled_toolsets() == ["coding", "figma", "project"]
+    assert server._load_enabled_toolsets("tui") == ["coding", "figma", "project"]
 
 
 def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
@@ -3482,7 +3482,7 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
         },
     )
     monkeypatch.setattr("run_agent.AIAgent", fake_agent)
-    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
     agent = server._make_agent("sid", "session-key")
@@ -3503,7 +3503,7 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
         _fallback_chain=chain,
     )
     monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
-    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
     kwargs = server._background_agent_kwargs(agent, "task-id")
@@ -3527,7 +3527,7 @@ def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
             ],
         },
     )
-    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
     kwargs = server._background_agent_kwargs(agent, "task-id")
@@ -13498,7 +13498,7 @@ def _setup_make_agent_mocks(monkeypatch, cfg):
     monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
     monkeypatch.setattr(server, "_load_reasoning_config", lambda model="": None)
     monkeypatch.setattr(server, "_load_service_tier", lambda: None)
-    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_agent_cbs", lambda sid: {})
 
@@ -15496,7 +15496,7 @@ class TestResolveRuntimeWithFallback:
             fake_resolve,
         )
         monkeypatch.setattr("run_agent.AIAgent", fake_agent)
-        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
         monkeypatch.setattr(server, "_get_db", lambda: None)
 
         agent = server._make_agent(

--- a/tests/test_tui_mcp_late_refresh.py
+++ b/tests/test_tui_mcp_late_refresh.py
@@ -41,7 +41,7 @@ def _install(monkeypatch, *, in_flight, join_result, new_defs):
     monkeypatch.setattr(entry, "mcp_discovery_in_flight", lambda: in_flight)
     monkeypatch.setattr(entry, "join_mcp_discovery", lambda timeout=None: join_result)
     monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(new_defs))
-    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: None)
     monkeypatch.setattr(server, "_session_info", lambda agent, session: {"tools_len": len(agent.tools)})
 
     emitted = []

--- a/tests/tools/test_focus_pane_tool.py
+++ b/tests/tools/test_focus_pane_tool.py
@@ -1,10 +1,11 @@
-"""Tests for the desktop-gated ``focus_pane`` tool."""
+"""Tests for the GUI-surface ``focus_pane`` tool."""
 
 import json
 
 import pytest
 
 from tools import desktop_ui, focus_pane_tool as fp
+from tools.registry import registry
 
 
 @pytest.fixture(autouse=True)
@@ -14,12 +15,16 @@ def _reset_emitter():
     desktop_ui.set_emitter(None)
 
 
-def test_gated_on_desktop(monkeypatch):
+def test_lives_in_the_gui_surface_toolset(monkeypatch):
+    """Surface eligibility is the toolset's job, not a process env var — the
+    desktop client can be driving a remote/cloud backend that never sees
+    HERMES_DESKTOP."""
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
-    assert fp.check_focus_pane_requirements() is False
+    entry = registry.get_entry("focus_pane")
 
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    assert fp.check_focus_pane_requirements() is True
+    assert entry is not None
+    assert entry.toolset == "desktop_ui"
+    assert entry.check_fn is None
 
 
 @pytest.mark.parametrize("pane", fp.PANES)

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -1,10 +1,11 @@
-"""Tests for the desktop-gated ``open_preview`` tool."""
+"""Tests for the GUI-surface ``open_preview`` tool."""
 
 import json
 
 import pytest
 
 from tools import desktop_ui, open_preview_tool as op
+from tools.registry import registry
 
 
 @pytest.fixture(autouse=True)
@@ -15,13 +16,15 @@ def _reset_emitter():
     desktop_ui.set_emitter(None)
 
 
-def test_gated_on_desktop(monkeypatch):
-    """Hidden unless HERMES_DESKTOP is set (mirrors read_terminal/close_terminal)."""
+def test_lives_in_the_gui_surface_toolset(monkeypatch):
+    """Reaches a desktop client on ANY backend, including one with no
+    HERMES_DESKTOP in its environment (URL / cloud gateways)."""
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
-    assert op.check_open_preview_requirements() is False
+    entry = registry.get_entry("open_preview")
 
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    assert op.check_open_preview_requirements() is True
+    assert entry is not None
+    assert entry.toolset == "desktop_ui"
+    assert entry.check_fn is None
 
 
 def test_emitter_failure_is_reported():

--- a/tests/tools/test_read_preview_tool.py
+++ b/tests/tools/test_read_preview_tool.py
@@ -1,17 +1,19 @@
-"""Tests for the desktop-gated ``read_preview`` tool."""
+"""Tests for the GUI-surface ``read_preview`` tool."""
 
 import json
 
 from tools import read_preview_tool as rp
+from tools.registry import registry
 
 
-def test_gated_on_desktop(monkeypatch):
-    """Hidden unless HERMES_DESKTOP is set (mirrors read_terminal)."""
+def test_lives_in_the_gui_surface_toolset(monkeypatch):
+    """Mirrors read_terminal: scoped by toolset, not by the backend's env."""
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
-    assert rp.check_read_preview_requirements() is False
+    entry = registry.get_entry("read_preview")
 
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    assert rp.check_read_preview_requirements() is True
+    assert entry is not None
+    assert entry.toolset == "desktop_ui"
+    assert entry.check_fn is None
 
 
 def test_requires_callback():

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -1,0 +1,113 @@
+"""GUI capability follows the SESSION's client, not the backend's process env.
+
+The desktop app is a client. It can drive a backend that Electron spawned
+locally, one reached over SSH, one behind a plain URL+token, or Hermes Cloud —
+and only the first two run with ``HERMES_DESKTOP=1`` in their environment.
+Gating the pane/browser/reaction tools on that env var therefore stripped every
+one of them from URL and cloud gateways, while the same backend still told the
+model "You are chatting inside the Hermes desktop app".
+
+These tests pin the contract that replaced it: eligibility is resolved from the
+session's own ``source`` (``session.create``'s ``source: 'desktop'``), so the
+answer is identical on every connection topology.
+"""
+
+import pytest
+
+import tui_gateway.server as server
+from toolsets import TOOLSETS, resolve_toolset
+
+GUI_TOOLS = {
+    "close_terminal",
+    "focus_pane",
+    "open_preview",
+    "read_preview",
+    "read_terminal",
+    "react_to_message",
+}
+
+
+@pytest.fixture
+def no_desktop_env(monkeypatch):
+    """A backend nobody told about the desktop — i.e. every remote gateway."""
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+    return monkeypatch
+
+
+class TestDesktopUiToolset:
+    def test_holds_exactly_the_gui_affordances(self):
+        assert set(resolve_toolset("desktop_ui")) == GUI_TOOLS
+
+    def test_stays_off_the_core_tool_list(self):
+        """Core ships on every API call — a GUI-only tool must not be there."""
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert GUI_TOOLS.isdisjoint(_HERMES_CORE_TOOLS)
+
+    def test_no_platform_bundle_carries_it(self):
+        """Messaging/CLI bundles must not pick these up by listing them."""
+        for name, spec in TOOLSETS.items():
+            if name == "desktop_ui":
+                continue
+            assert GUI_TOOLS.isdisjoint(set(spec.get("tools") or ())), name
+
+
+class TestSurfaceResolution:
+    def test_desktop_session_gets_them_with_no_desktop_env(self, no_desktop_env):
+        """THE regression: a desktop client on a remote/cloud backend."""
+        assert "desktop_ui" in server._gui_surface_toolsets("desktop")
+
+    def test_tui_session_does_not(self, no_desktop_env):
+        assert "desktop_ui" not in server._gui_surface_toolsets("tui")
+
+    def test_desktop_env_alone_does_not_grant_them(self, no_desktop_env):
+        """A desktop-spawned backend serving a TUI session stays clean.
+
+        The embedded terminal pane runs `hermes --tui` against this same
+        backend; env-keyed gating handed it GUI tools it cannot answer.
+        """
+        no_desktop_env.setenv("HERMES_DESKTOP", "1")
+        assert "desktop_ui" not in server._gui_surface_toolsets("tui")
+
+    def test_project_tools_ride_on_every_gui_surface(self, no_desktop_env):
+        for platform in ("desktop", "tui"):
+            assert "project" in server._gui_surface_toolsets(platform)
+
+
+class TestResolverPlumbing:
+    def test_posture_path_folds_in_the_session_surface(self, no_desktop_env):
+        """Focus-mode returns early — the surface toolsets must survive it."""
+        import agent.coding_context as cc
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+
+        assert server._load_enabled_toolsets("desktop") == [
+            "coding",
+            "desktop_ui",
+            "project",
+        ]
+        assert server._load_enabled_toolsets("tui") == ["coding", "project"]
+
+    def test_config_path_folds_in_the_session_surface(self, no_desktop_env):
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: None)
+        no_desktop_env.setattr(
+            config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
+        )
+
+        desktop = server._load_enabled_toolsets("desktop")
+        tui = server._load_enabled_toolsets("tui")
+
+        assert desktop is not None and tui is not None
+        assert "desktop_ui" in desktop
+        assert "desktop_ui" not in tui
+
+    def test_explicit_env_pin_still_wins(self, no_desktop_env):
+        """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
+        no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")
+
+        assert server._load_enabled_toolsets("desktop") == ["web", "memory"]

--- a/tools/close_terminal_tool.py
+++ b/tools/close_terminal_tool.py
@@ -8,13 +8,11 @@ The output keeps buffering and the user can reopen the tab from the status stack
 
 It routes through the process registry's ``on_close`` sink, which the desktop
 gateway wires to emit a ``terminal.close`` event the renderer handles. Like
-``read_terminal`` it is gated on ``HERMES_DESKTOP`` so it never appears outside
-the GUI.
+``read_terminal`` it lives in the ``desktop_ui`` toolset, which the GUI gateway
+enables only for desktop-sourced sessions, so it never appears outside the GUI.
 """
 
 import json
-
-from utils import env_var_enabled
 
 from tools.process_registry import process_registry
 from tools.registry import registry, tool_error
@@ -27,11 +25,6 @@ def close_terminal_tool(process_id: str) -> str:
         return tool_error("process_id is required (the background process whose tab to close).")
 
     return json.dumps(process_registry.request_close_terminal(pid), ensure_ascii=False)
-
-
-def check_close_terminal_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
 
 
 CLOSE_TERMINAL_SCHEMA = {
@@ -62,9 +55,8 @@ CLOSE_TERMINAL_SCHEMA = {
 
 registry.register(
     name="close_terminal",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=CLOSE_TERMINAL_SCHEMA,
     handler=lambda args, **kw: close_terminal_tool(process_id=args.get("process_id", "")),
-    check_fn=check_close_terminal_requirements,
     emoji="🖥️",
 )

--- a/tools/focus_pane_tool.py
+++ b/tools/focus_pane_tool.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """Reveal/focus a pane in the Hermes desktop GUI.
 
-Gated on ``HERMES_DESKTOP`` (like the other GUI affordances). Emits
-``pane.reveal`` through the shared ``desktop_ui`` bridge; the renderer runs each
-pane's own reveal path and only acts on the active window (a background turn
-never moves the user's focus). To show a URL/file, use ``open_preview``.
+Lives in the ``desktop_ui`` toolset (like the other GUI affordances), which the
+GUI gateway enables only for desktop-sourced sessions. Emits ``pane.reveal``
+through the shared ``desktop_ui`` bridge; the renderer runs each pane's own
+reveal path and only acts on the active window (a background turn never moves
+the user's focus). To show a URL/file, use ``open_preview``.
 """
 
 import json
 
 from tools import desktop_ui
 from tools.registry import registry, tool_error
-from utils import env_var_enabled
 
 PANES = ("chat", "files", "terminal", "review", "sessions")
 
@@ -30,11 +30,6 @@ def focus_pane_tool(pane: str) -> str:
         return tool_error("Pane focus is only available in the Hermes desktop app.")
 
     return json.dumps({"success": True, "pane": name}, ensure_ascii=False)
-
-
-def check_focus_pane_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
 
 
 FOCUS_PANE_SCHEMA = {
@@ -62,9 +57,8 @@ FOCUS_PANE_SCHEMA = {
 
 registry.register(
     name="focus_pane",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=FOCUS_PANE_SCHEMA,
     handler=lambda args, **kw: focus_pane_tool(pane=args.get("pane", "")),
-    check_fn=check_focus_pane_requirements,
     emoji="🪟",
 )

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Open a URL, dev server, or file in the Hermes desktop GUI's preview pane.
 
-Gated on ``HERMES_DESKTOP`` (like ``read_terminal`` / ``close_terminal``) so it
-never appears outside the GUI. Emits ``preview.open`` through the shared
-``desktop_ui`` bridge; the renderer opens the pane beside the chat for the
-window that asked and never steals focus for a background session.
+Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for a
+session whose source is the desktop app — so the schema never reaches a CLI,
+messaging, or cron agent, and it DOES reach a desktop client on a remote/cloud
+backend. Emits ``preview.open`` through the shared ``desktop_ui`` bridge; the
+renderer opens the pane beside the chat for the window that asked and never
+steals focus for a background session.
 """
 
 import json
@@ -12,7 +14,6 @@ import re
 
 from tools import desktop_ui
 from tools.registry import registry, tool_error
-from utils import env_var_enabled
 
 
 def _normalize_target(raw: str) -> str:
@@ -52,11 +53,6 @@ def open_preview_tool(url: str, label: str = "") -> str:
     return json.dumps({"success": True, "url": target, "label": label}, ensure_ascii=False)
 
 
-def check_open_preview_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
-
-
 OPEN_PREVIEW_SCHEMA = {
     "name": "open_preview",
     "description": (
@@ -89,9 +85,8 @@ OPEN_PREVIEW_SCHEMA = {
 
 registry.register(
     name="open_preview",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=OPEN_PREVIEW_SCHEMA,
     handler=lambda args, **kw: open_preview_tool(url=args.get("url", ""), label=args.get("label", "")),
-    check_fn=check_open_preview_requirements,
     emoji="🖼️",
 )

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -4,9 +4,9 @@
 The conversational counterpart to the user's tapback: the same reaction store,
 the same one-per-author semantics, just written with ``author="agent"``.
 
-Gated on ``HERMES_DESKTOP`` (like the other GUI affordances) so it costs nothing
-on every other surface — the platform adapters already expose reactions through
-``send_message(action="react")``, and this is the desktop's equivalent.
+Lives in the ``desktop_ui`` toolset (like the other GUI affordances) so it costs
+nothing on every other surface — the platform adapters already expose reactions
+through ``send_message(action="react")``, and this is the desktop's equivalent.
 
 Defaults to the message that triggered this turn (the photon precedent: the
 model shouldn't have to thread row ids through tool calls), and emits
@@ -90,14 +90,13 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
 
 
 def check_react_requirements() -> bool:
-    """Desktop GUI only, and opt-in.
+    """Opt-in feature flag — surface eligibility is the toolset's job.
 
-    HERMES_DESKTOP is set on the gateway the app spawns; the feature itself is
-    off by default and enabled from Settings → Appearance (the desktop mirrors
-    the toggle into ``display.message_reactions``).
+    ``desktop_ui`` already restricts this to GUI sessions. What's left is the
+    user's own toggle (Settings → Appearance), which the desktop mirrors into
+    ``display.message_reactions`` on the CONNECTED gateway's config — so this
+    reads the right config whether that gateway is local, SSH, URL, or cloud.
     """
-    if not env_var_enabled("HERMES_DESKTOP"):
-        return False
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -155,7 +154,7 @@ REACT_TO_MESSAGE_SCHEMA = {
 
 registry.register(
     name="react_to_message",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=REACT_TO_MESSAGE_SCHEMA,
     handler=lambda args, **kw: react_to_message_tool(
         emoji=args.get("emoji", ""),

--- a/tools/read_preview_tool.py
+++ b/tools/read_preview_tool.py
@@ -7,13 +7,15 @@ bridge — the same one ``read_terminal`` uses: tui_gateway emits
 ``preview.read.request``, the renderer serializes the active preview tab and
 answers with ``preview.read.respond``. This module is just schema + a thin
 dispatcher over the platform-injected callback.
+
+Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for
+desktop-sourced sessions.
 """
 
 import json
 from typing import Callable, Optional
 
 from tools.registry import registry, tool_error
-from utils import env_var_enabled
 
 
 def read_preview_tool(
@@ -49,11 +51,6 @@ def read_preview_tool(
         return json.dumps({"text": str(raw)}, ensure_ascii=False)
 
 
-def check_read_preview_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
-
-
 READ_PREVIEW_SCHEMA = {
     "name": "read_preview",
     "description": (
@@ -86,13 +83,12 @@ READ_PREVIEW_SCHEMA = {
 
 registry.register(
     name="read_preview",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=READ_PREVIEW_SCHEMA,
     handler=lambda args, **kw: read_preview_tool(
         start=args.get("start"),
         count=args.get("count"),
         callback=kw.get("callback"),
     ),
-    check_fn=check_read_preview_requirements,
     emoji="🔍",
 )

--- a/tools/read_terminal_tool.py
+++ b/tools/read_terminal_tool.py
@@ -6,13 +6,15 @@ tool round-trips through the gateway's blocking-prompt bridge — the same one
 `clarify` uses: tui_gateway emits ``terminal.read.request``, the renderer answers
 with ``terminal.read.respond``. This module is just schema + a thin dispatcher
 over the platform-injected callback.
+
+Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for
+desktop-sourced sessions.
 """
 
 import json
 from typing import Callable, Optional
 
 from tools.registry import registry, tool_error
-from utils import env_var_enabled
 
 
 def read_terminal_tool(
@@ -48,11 +50,6 @@ def read_terminal_tool(
         return json.dumps({"text": str(raw)}, ensure_ascii=False)
 
 
-def check_read_terminal_requirements() -> bool:
-    """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return env_var_enabled("HERMES_DESKTOP")
-
-
 READ_TERMINAL_SCHEMA = {
     "name": "read_terminal",
     "description": (
@@ -81,13 +78,12 @@ READ_TERMINAL_SCHEMA = {
 
 registry.register(
     name="read_terminal",
-    toolset="terminal",
+    toolset="desktop_ui",
     schema=READ_TERMINAL_SCHEMA,
     handler=lambda args, **kw: read_terminal_tool(
         start_line=args.get("start_line"),
         count=args.get("count"),
         callback=kw.get("callback"),
     ),
-    check_fn=check_read_terminal_requirements,
     emoji="🖥️",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -33,11 +33,13 @@ _HERMES_CORE_TOOLS = [
     "web_search", "web_extract",
     # Terminal + process management
     "terminal", "process",
-    # Desktop GUI affordances: read the embedded terminal pane, close an agent's
-    # read-only terminal tab, open a URL/file in the preview pane, focus a
-    # pane, and react to a message with an emoji (all gated on HERMES_DESKTOP
-    # via check_fn — hidden outside the GUI).
-    "read_terminal", "close_terminal", "open_preview", "read_preview", "focus_pane", "react_to_message",
+    # NOTE: the desktop GUI affordances (read_terminal, open_preview, …) are
+    # deliberately NOT here, for the same reason as the `project` tools below:
+    # they only work where a GUI renderer can answer them. They live in the
+    # `desktop_ui` toolset and are enabled solely by the GUI gateway for a
+    # session whose SOURCE is the desktop app (tui_gateway/server.py::
+    # _load_enabled_toolsets) — never keyed on a process env var, which is
+    # blind to a desktop client talking to a remote/cloud backend.
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
@@ -256,6 +258,25 @@ TOOLSETS = {
         "tools": ["project_list", "project_create", "project_switch"],
         "includes": []
     },
+
+    # Affordances that only exist because a GUI renderer is on the other end of
+    # the connection: read/close the embedded terminal pane, open and read the
+    # in-app browser, focus a pane, tapback a message.
+    #
+    # Enabled by the GUI gateway for a session whose SOURCE is the desktop app
+    # (tui_gateway/server.py::_load_enabled_toolsets), NOT by a process env var.
+    # The renderer is a CLIENT — it can be driving a local, SSH, URL, or cloud
+    # backend — so "was this process spawned by Electron?" is the wrong
+    # question and silently strips these tools from every remote gateway.
+    "desktop_ui": {
+        "description": "Desktop GUI affordances — in-app terminal/browser panes, pane focus, reactions (GUI sessions only)",
+        "tools": [
+            "read_terminal", "close_terminal",
+            "open_preview", "read_preview",
+            "focus_pane", "react_to_message",
+        ],
+        "includes": []
+    },
     
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
@@ -371,12 +392,16 @@ TOOLSETS = {
     # code workspace; see agent/coding_context.py. Keeps everything you reach
     # for while pairing on code and drops the rest (messaging, tts, image_gen,
     # spotify, home-assistant, cron, computer-use).
+    #
+    # The GUI pane/browser affordances are NOT listed here: they belong to the
+    # client surface, not the posture, so the GUI gateway folds `desktop_ui`
+    # in alongside this selection for a desktop-sourced session (see
+    # tui_gateway/server.py::_load_enabled_toolsets).
     "coding": {
         "description": "Coding-focused toolset: files, terminal, search, web docs, skills, todo, delegate, vision, browser",
         "tools": [
             "web_search", "web_extract",
-            "terminal", "process", "read_terminal", "close_terminal",
-            "open_preview", "read_preview",
+            "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4086,7 +4086,29 @@ def _load_tool_progress_mode() -> str:
     return mode if mode in {"off", "new", "all", "verbose"} else "all"
 
 
-def _load_enabled_toolsets() -> list[str] | None:
+def _gui_surface_toolsets(platform: str) -> set[str]:
+    """Toolsets that exist because of the CLIENT on the other end, not the host.
+
+    Both entries are deliberately off ``_HERMES_CORE_TOOLS`` — every other
+    platform would carry their schema for nothing — so this resolver is the one
+    gate that exposes them.
+
+    ``platform`` is the SESSION's source (``session.create``'s ``source``
+    field), never a process env var. The desktop app is a client: it can be
+    driving a local, SSH, URL, or cloud backend, and only the local/SSH spawn
+    paths run with ``HERMES_DESKTOP=1``. Keying GUI capability off that env var
+    silently stripped every pane/browser tool from URL and cloud gateways while
+    the same backend told the model it was "chatting inside the Hermes desktop
+    app". See the surface-capability rule in AGENTS.md.
+    """
+    surfaces = {"project"}
+    if platform == "desktop":
+        surfaces.add("desktop_ui")
+    return surfaces
+
+
+def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
+    session_platform = platform or _resolve_session_platform()
     explicit = [
         item.strip()
         for item in os.environ.get("HERMES_TUI_TOOLSETS", "").split(",")
@@ -4105,13 +4127,13 @@ def _load_enabled_toolsets() -> list[str] | None:
         try:
             from agent.coding_context import coding_selection
 
-            selection = coding_selection(platform=_resolve_session_platform())
+            selection = coding_selection(platform=session_platform)
             if selection is not None:
-                # Fold in `project` here too: this is a GUI-only resolver, and
-                # the focus-mode coding posture returns before the fallback path
-                # that normally adds it — without this the desktop loses the
-                # project tools exactly when sitting in a repo (see below).
-                return sorted({*selection, "project"})
+                # Fold in the client-surface toolsets here too: the focus-mode
+                # coding posture returns before the fallback path that normally
+                # adds them — without this the desktop loses its pane/project
+                # tools exactly when sitting in a repo (see below).
+                return sorted({*selection, *_gui_surface_toolsets(session_platform)})
         except Exception:
             pass
 
@@ -4222,13 +4244,13 @@ def _load_enabled_toolsets() -> list[str] | None:
             print(fallback_notice, file=sys.stderr, flush=True)
         if not enabled:
             return None
-        # The desktop Project tools are off _HERMES_CORE_TOOLS (every other
+        # The client-surface toolsets are off _HERMES_CORE_TOOLS (every other
         # platform would carry their schema for nothing), so the platform
         # recovery above — which keys off hermes-cli's tool universe — can't
         # surface them. This resolver runs ONLY in the desktop/TUI gateway, so
-        # folding in the `project` toolset here is the gate that exposes them on
-        # exactly the surface that can follow a project move.
-        return sorted(enabled | {"project"})
+        # folding them in here is the gate that exposes them on exactly the
+        # surface that can answer them.
+        return sorted(enabled | _gui_surface_toolsets(session_platform))
     except Exception:
         if fallback_notice is not None:
             print(
@@ -5990,7 +6012,11 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "model": getattr(agent, "model", None) or _resolve_model(),
         "max_iterations": _cfg_max_turns(cfg, 25),
         "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
-        or _load_enabled_toolsets(),
+        # Detached background tasks declare platform="tui" below: they have no
+        # UI session id, so a renderer-routed event has nowhere to land. Resolve
+        # their toolsets against that same platform rather than the gateway
+        # process's, so they never carry GUI schema they cannot use.
+        or _load_enabled_toolsets("tui"),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)
@@ -6485,7 +6511,7 @@ def _make_agent(
             if service_tier_override is not None
             else _load_service_tier()
         ),
-        enabled_toolsets=_load_enabled_toolsets(),
+        enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -8,7 +8,7 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 This page documents Hermes' built-in tools, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts (current registry):** ~82 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 7 terminal tools (`terminal`, `process`, plus desktop-GUI-gated `read_terminal`, `close_terminal`, `open_preview`, `read_preview`, `focus_pane`), 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 12 kanban tools (registered when the kanban dispatcher spawns the agent), 3 project tools (desktop/GUI sessions), 2 Discord tools, 3 video tools (`video_generate`, `xai_video_edit`, `xai_video_extend`), and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `todo`, `computer_use`, `x_search`).
+**Quick counts (current registry):** ~82 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 2 terminal tools (`terminal`, `process`), 6 desktop-GUI tools (`read_terminal`, `close_terminal`, `open_preview`, `read_preview`, `focus_pane`, `react_to_message` — desktop-app sessions only), 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 12 kanban tools (registered when the kanban dispatcher spawns the agent), 3 project tools (desktop/GUI sessions), 2 Discord tools, 3 video tools (`video_generate`, `xai_video_edit`, `xai_video_extend`), and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `todo`, `computer_use`, `x_search`).
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with the prefix `mcp__<server>__` (e.g., `mcp__github__create_issue` for the `github` MCP server). See [MCP Integration](/user-guide/features/mcp) for configuration.
@@ -171,11 +171,21 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
 | `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
-| `read_terminal` | Read what's currently shown in the in-app terminal pane of the Hermes desktop GUI (the embedded shell beside this chat). Desktop-app only. | — |
-| `close_terminal` | Close the read-only terminal tab for a background process in the Hermes desktop GUI. Does NOT kill the process — only drops the tab/view; use process(action='kill') to stop it. Desktop-app only. | — |
-| `open_preview` | Open a web URL, localhost dev-server URL, or file path in the preview pane beside the chat in the Hermes desktop app. Desktop-app only. | — |
-| `read_preview` | Read what's currently shown in the preview pane of the Hermes desktop GUI — the in-app Browser's page text (URL + title + rendered text, pageable with `start`/`count`), or a file/artifact tab's identity. Desktop-app only. | — |
-| `focus_pane` | Reveal and focus a pane in the Hermes desktop app (chat, files, terminal, review, sessions). Desktop-app only. | — |
+
+## `desktop_ui` toolset
+
+Enabled for sessions whose source is the Hermes desktop app, on any backend it
+is connected to (local, SSH, URL, or Hermes Cloud). Absent from CLI, TUI,
+messaging, and cron sessions.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `read_terminal` | Read what's currently shown in the in-app terminal pane of the Hermes desktop GUI (the embedded shell beside this chat). | — |
+| `close_terminal` | Close the read-only terminal tab for a background process in the Hermes desktop GUI. Does NOT kill the process — only drops the tab/view; use process(action='kill') to stop it. | — |
+| `open_preview` | Open a web URL, localhost dev-server URL, or file path in the preview pane beside the chat in the Hermes desktop app. | — |
+| `read_preview` | Read what's currently shown in the preview pane of the Hermes desktop GUI — the in-app Browser's page text (URL + title + rendered text, pageable with `start`/`count`), or a file/artifact tab's identity. | — |
+| `focus_pane` | Reveal and focus a pane in the Hermes desktop app (chat, files, terminal, review, sessions). | — |
+| `react_to_message` | React to a message with a single emoji, iMessage-tapback style. Opt-in via Settings → Appearance (`display.message_reactions`). | — |
 
 ## `todo` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -71,13 +71,14 @@ Or in-session:
 | `video_gen` | `video_generate`, `xai_video_edit`, `xai_video_extend` | Text-to-video and image-to-video via plugin-registered backends (xAI Grok-Imagine, FAL.ai Veo 3.1 / Pixverse v6 / Kling O3). Pass `image_url` to animate an image; omit it for text-to-video. `xai_video_edit` / `xai_video_extend` are provider-specific edit/extend tools, gated on xAI Imagine credentials. |
 | `kanban` | `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_block`, `kanban_comment`, `kanban_complete`, `kanban_create`, `kanban_heartbeat`, `kanban_link`, `kanban_list`, `kanban_show`, `kanban_unblock` | Multi-agent coordination tools. Registered for dispatcher-spawned task workers (`HERMES_KANBAN_TASK`) and for profiles that explicitly list the `kanban` toolset by name (the `all`/`*` wildcard does **not** enable it). Workers mark tasks done, block, heartbeat, comment, and create/link follow-up tasks; orchestrator profiles additionally get board-routing tools like list/unblock. `delegate_task` children are not Kanban run owners: their schema strips/disables this toolset and runtime guards reject direct board mutations, even if parent `HERMES_KANBAN_*` env vars are present. |
 | `memory` | `memory` | Persistent cross-session memory management. |
+| `desktop_ui` | `close_terminal`, `focus_pane`, `open_preview`, `react_to_message`, `read_preview`, `read_terminal` | Affordances that act on the Hermes desktop app itself — read/close the embedded terminal pane, open and read the in-app browser, reveal a pane, react to a message. Enabled for sessions whose source is the desktop app, whichever backend it's connected to (local, SSH, URL, or Hermes Cloud). Never present on CLI, TUI, messaging, or cron sessions. |
 | `project` | `project_create`, `project_list`, `project_switch` | Create and switch desktop [Projects](../user-guide/cli.md) (named, multi-folder workspaces). GUI / desktop sessions only. |
 | `safe` | `image_generate`, `vision_analyze`, `web_extract`, `web_search` (via `includes`) | Read-only research + media generation. No file writes, no terminal, no code execution. |
 | `search` | `web_search` | Web search only (without extract). |
 | `session_search` | `session_search` | Search past conversation sessions. |
 | `skills` | `skill_manage`, `skill_view`, `skills_list` | Skill CRUD and browsing. |
 | `spotify` | `spotify_albums`, `spotify_devices`, `spotify_library`, `spotify_playback`, `spotify_playlists`, `spotify_queue`, `spotify_search` | Native Spotify control (playback, queue, search, playlists, albums, library). Registered by the bundled `spotify` plugin. |
-| `terminal` | `close_terminal`, `focus_pane`, `open_preview`, `process`, `read_preview`, `read_terminal`, `terminal` | Shell command execution and background process management. `read_terminal`, `close_terminal`, `open_preview`, `read_preview`, and `focus_pane` drive the desktop GUI's embedded panes and are check_fn-gated — they only register in desktop-app sessions. |
+| `terminal` | `process`, `terminal` | Shell command execution and background process management. |
 | `todo` | `todo` | Task list management within a session. |
 | `tts` | `text_to_speech` | Text-to-speech audio generation. |
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
@@ -92,9 +93,9 @@ Platform toolsets define the complete tool configuration for a deployment target
 
 | Toolset | Differences from `hermes-cli` |
 |---------|-------------------------------|
-| `hermes-cli` | Full toolset — the default for interactive CLI sessions. Includes file, terminal (plus the desktop-GUI pane tools `read_terminal`, `close_terminal`, `open_preview`, `read_preview`, `focus_pane`), web, browser, memory, skills, vision, image_gen, todo, tts, delegation, code_execution, cronjob, session_search, clarify, computer_use, Home Assistant, and the kanban tools (all check_fn-gated at runtime). |
-| `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `text_to_speech`, `computer_use`, all four Home Assistant tools, the kanban tools, and the desktop-GUI pane tools. Focused on coding tasks in IDE context. |
-| `hermes-api-server` | Drops `clarify`, `text_to_speech`, `computer_use`, the kanban tools, and the desktop-GUI pane tools. Keeps everything else — suitable for programmatic access where user interaction isn't possible. |
+| `hermes-cli` | Full toolset — the default for interactive CLI sessions. Includes file, terminal, web, browser, memory, skills, vision, image_gen, todo, tts, delegation, code_execution, cronjob, session_search, clarify, computer_use, Home Assistant, and the kanban tools (all check_fn-gated at runtime). |
+| `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `text_to_speech`, `computer_use`, all four Home Assistant tools, and the kanban tools. Focused on coding tasks in IDE context. |
+| `hermes-api-server` | Drops `clarify`, `text_to_speech`, `computer_use`, and the kanban tools. Keeps everything else — suitable for programmatic access where user interaction isn't possible. |
 | `hermes-cron` | Same as `hermes-cli`. |
 | `hermes-telegram` | Same as `hermes-cli`. |
 | `hermes-discord` | Adds `discord` and `discord_admin` on top of `hermes-cli`. |


### PR DESCRIPTION
The desktop app's pane, in-app browser, and reaction tools were gated on `HERMES_DESKTOP=1` — an env var that only exists on backends Electron spawns itself. Connect the app to a plain URL gateway or Hermes Cloud and all six vanish: stripped from the schema before the model sees them, on the same backend whose platform hint is telling it *"you are chatting inside the Hermes desktop app."* Nothing errors. The capability just isn't there.

| connection | backend spawned by | `HERMES_DESKTOP` | GUI tools |
|---|---|---|---|
| local | `electron/main.ts` | yes | worked |
| remote / SSH | `electron/remote-lifecycle.ts` | yes | worked |
| remote / URL+token | someone else's `hermes serve` | **no** | **missing** |
| cloud | hosted backend | **no** | **missing** |

## Why the gate was wrong

The client and the backend are separate machines. `HERMES_DESKTOP=1` honestly means *"Electron spawned this process"* — which is what correctly gates the cron ticker and packaged web-dist handling. It does **not** mean "a GUI is watching," and the embedded terminal pane is the standing counterexample: it runs `hermes --tui` against a desktop-spawned backend, so the env var is set while the session is not a GUI chat surface at all. The old gate handed *that* session tools it could never answer, and denied them to real GUI sessions on remote backends.

Nothing else about the feature was remote-hostile. `_wire_desktop_ui()` installs the emitter on every gateway, and `desktop_ui.emit` routes by `HERMES_UI_SESSION_ID` over whatever transport the session holds. Only the availability probe was asking the wrong question.

## The fix

Availability now resolves from the session's own source, which `session.create` already sends as `source: 'desktop'`.

- The six tools move into a **`desktop_ui` toolset**, kept off `_HERMES_CORE_TOOLS` so no other platform pays their schema.
- **`_gui_surface_toolsets(platform)`** folds it in (alongside the existing `project` tools) when the session's platform is the desktop app. One resolver, one answer, every topology. All five `_make_agent` call sites — create, resume, branch, lazy upgrade, `/new`, compute-host — already thread the platform, so every entry point agrees.
- **`check_fn` drops the env probe.** It keeps only what is genuinely a config fact: `react_to_message`'s `display.message_reactions` opt-in. That one was doubly broken — it read the toggle from *behind* the env gate, so a remote session could never see it regardless of your setting.

`check_fn` was structurally the wrong home for this anyway: results are TTL-cached **process-wide** (`tools/registry.py`), and one gateway process serves many sessions.

## Verified against a real remote gateway

Not an in-process function call. `scripts/probe_remote_gui_tools.py` launches `hermes serve` in a subprocess with **`HERMES_DESKTOP` scrubbed from its environment** — which is exactly what a URL-token or cloud backend looks like — then speaks JSON-RPC over the same WebSocket the desktop app uses, creates a session with each `source`, forces the deferred agent build, and asks the gateway which tools that session's agent actually resolved.

Before (`0957277f2`):

```
backend up on 127.0.0.1:53869  (HERMES_DESKTOP unset in its env)
  source=desktop  total= 40 gui=[]
  source=tui      total= 40 gui=[]
FAIL
```

After:

```
backend up on 127.0.0.1:53747  (HERMES_DESKTOP unset in its env)
  source=desktop  total= 47 gui=['close_terminal', 'focus_pane', 'open_preview',
                                 'react_to_message', 'read_preview', 'read_terminal']
  source=tui      total= 40 gui=[]
PASS
```

The `tui` row is the other half of the contract: a TUI session on a desktop-spawned backend gets none of them, even with `HERMES_DESKTOP=1` set.

## Keeping it fixed

`tests/tui_gateway/test_gui_surface_toolsets.py` asserts the thing the old gate could never have passed — a desktop session gets its tools **with the env var absent** — plus the inverse (env var present + tui session ⇒ none), and a structural invariant that no other toolset can quietly re-list these six.

`AGENTS.md` gains the rule: *surface capability is a property of the session, never of the process env*, with the reasoning about `check_fn`'s process-wide cache. `apps/desktop/AGENTS.md` points at it from the renderer side.

I swept the rest of the codebase for the same class of bug: every other env-reading `check_fn` (`HERMES_INTERACTIVE`, `HERMES_GATEWAY_SESSION`, `HERMES_KANBAN_TASK`) is legitimately host-scoped, set by the process actually serving the session. This was the only instance.