### PR TITLE
fix(desktop): render agent reactions live

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -55,7 +55,6 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
-  setMessages,
   setSessions,
   setTurnStartedAt,
   setYoloActive
@@ -1050,11 +1049,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // keyed by ChatMessage identity.
         const reactedRowId = payload?.row_id
 
-        if (typeof reactedRowId === 'number') {
+        if (typeof reactedRowId === 'number' && sessionId) {
           const nextReactions = Array.isArray(payload?.reactions) ? payload.reactions : []
           const reactedRole = payload?.role === 'assistant' ? 'assistant' : 'user'
 
-          setMessages(messages => {
+          updateSessionState(sessionId, state => {
+            const messages = state.messages
             // Preferred leg: the message already knows its durable row id
             // (rehydrated transcript, or a live row that has round-tripped).
             const byRowId = messages.find(message => message.rowId === reactedRowId)
@@ -1064,9 +1064,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
               // in-memory history that doesn't carry this mid-turn DB write.
               recordAgentReaction(reactedRowId, nextReactions)
 
-              return messages.map(message =>
-                message.rowId === reactedRowId ? { ...message, reactions: nextReactions } : message
-              )
+              return {
+                ...state,
+                messages: messages.map(message =>
+                  message.rowId === reactedRowId ? { ...message, reactions: nextReactions } : message
+                )
+              }
             }
 
             // Live leg: the targeted message is still optimistic (no rowId —
@@ -1079,14 +1082,17 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             )
 
             if (lastIndex === -1) {
-              return messages
+              return state
             }
 
             recordAgentReaction(reactedRowId, nextReactions)
 
-            return messages.map((message, index) =>
-              index === lastIndex ? { ...message, rowId: reactedRowId, reactions: nextReactions } : message
-            )
+            return {
+              ...state,
+              messages: messages.map((message, index) =>
+                index === lastIndex ? { ...message, rowId: reactedRowId, reactions: nextReactions } : message
+              )
+            }
           })
         }
       } else if (event.type === 'status.update') {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/reaction-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/reaction-event.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $messages } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'runtime-session-1'
+let handleGatewayEvent: ((event: RpcEvent) => void) | null = null
+let states: Map<string, ClientSessionState>
+
+type UpdateSessionState = (
+  sessionId: string,
+  updater: (state: ClientSessionState) => ClientSessionState,
+  storedSessionId?: string | null
+) => ClientSessionState
+
+let updateSessionState: ReturnType<typeof vi.fn<UpdateSessionState>>
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(states)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    handleGatewayEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('live agent reaction events', () => {
+  beforeEach(() => {
+    handleGatewayEvent = null
+
+    const state = createClientSessionState('stored-session-1', [
+      {
+        id: 'optimistic-user-message',
+        role: 'user',
+        parts: [textPart('hello')],
+        timestamp: 1
+      }
+    ])
+
+    states = new Map([[SID, state]])
+    updateSessionState = vi.fn((sessionId, updater) => {
+      const next = updater(states.get(sessionId) ?? createClientSessionState())
+      states.set(sessionId, next)
+
+      return next
+    })
+    $messages.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    $messages.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('paints an optimistic message in the owning runtime session', () => {
+    render(<Harness />)
+    expect(handleGatewayEvent).not.toBeNull()
+
+    act(() =>
+      handleGatewayEvent!({
+        type: 'message.reaction',
+        session_id: SID,
+        payload: {
+          row_id: 42,
+          reactions: [{ author: 'agent', emoji: '❤️' }],
+          role: 'user'
+        }
+      })
+    )
+
+    expect(states.get(SID)?.messages).toEqual([
+      {
+        id: 'optimistic-user-message',
+        role: 'user',
+        parts: [textPart('hello')],
+        timestamp: 1,
+        rowId: 42,
+        reactions: [{ author: 'agent', emoji: '❤️' }]
+      }
+    ])
+    expect($messages.get()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- route live `message.reaction` updates through the owning runtime's authoritative session state
- publish the updated state only when that runtime owns the active transcript
- add a regression test covering live reaction rendering without a reload

## Problem

Agent reactions were persisted successfully, but the Desktop renderer did not show them during the active session. Users only saw the emoji after reloading or restoring the conversation, making successful reactions appear to have been lost.

The event handler updated the legacy global message draft while the renderer reads per-runtime session state, so the live event never changed the state that paints the transcript.

## Verification

- `npx vitest run src/app/session/hooks/use-message-stream/reaction-event.test.tsx`
- `npx vitest run src/app/session/hooks/use-message-stream`
- `npx vitest run src/app/session/hooks/use-session-state-cache.test.tsx src/store/reactions.test.ts`
- `npm run typecheck`
- targeted ESLint on changed files

Closes #80678
