### PR TITLE
fix(cron): recover jobs a sibling process wrote during unlocked jobs.json save (#80624)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -286,6 +286,11 @@ def _jobs_lock():
     Nested calls in the same thread reuse the held lock so legacy callers that
     invoke save_jobs() inside a broader mutation section don't deadlock or try
     to reacquire the advisory file lock.
+
+    Whenever the cross-process flock could not actually be acquired (timeout,
+    OSError, or neither fcntl/msvcrt available), ``_jobs_lock_state.degraded``
+    is set so ``_save_jobs_unlocked`` can detect and recover from a sibling
+    process writing jobs.json during the unprotected window (#80624).
     """
     depth = getattr(_jobs_lock_state, "depth", 0)
     if depth:
@@ -298,7 +303,11 @@ def _jobs_lock():
 
     with _jobs_file_lock:
         _jobs_lock_state.depth = 1
+        _jobs_lock_state.degraded = False
+        _jobs_lock_state.load_stamp = None
+        _jobs_lock_state.load_ids = None
         lock_fd = None
+        locked = False
         try:
             try:
                 ensure_dirs()
@@ -323,6 +332,7 @@ def _jobs_lock():
                     while True:
                         try:
                             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            locked = True
                             break
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
@@ -343,11 +353,13 @@ def _jobs_lock():
                             time.sleep(0.1)
                 elif msvcrt is not None:
                     getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    locked = True
             except (OSError, IOError) as e:
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
                                "proceeding with in-process lock only", e)
+            _jobs_lock_state.degraded = not locked
             try:
                 yield
             finally:
@@ -363,6 +375,9 @@ def _jobs_lock():
                         lock_fd.close()
         finally:
             _jobs_lock_state.depth = 0
+            _jobs_lock_state.degraded = False
+            _jobs_lock_state.load_stamp = None
+            _jobs_lock_state.load_ids = None
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -1010,11 +1025,31 @@ def get_ticker_last_error() -> Optional[str]:
 # Job CRUD Operations
 # =============================================================================
 
+def _record_load_stamp(jobs_file: Path, jobs: List[Dict[str, Any]]) -> None:
+    """Snapshot the file state + job IDs a load_jobs() call observed.
+
+    Only meaningful inside a _jobs_lock() critical section (depth > 0); lets
+    _save_jobs_unlocked() detect a sibling process writing jobs.json during a
+    degraded (unlocked) window and recover any job it added instead of
+    silently discarding it (#80624).
+    """
+    if not getattr(_jobs_lock_state, "depth", 0):
+        return
+    try:
+        st = jobs_file.stat()
+        stamp = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        stamp = None
+    _jobs_lock_state.load_stamp = stamp
+    _jobs_lock_state.load_ids = {j["id"] for j in jobs if isinstance(j, dict) and "id" in j}
+
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     if not jobs_file.exists():
+        _record_load_stamp(jobs_file, [])
         return []
 
     _strict_retry = False  # track whether we used the strict=False fallback
@@ -1048,6 +1083,7 @@ def load_jobs() -> List[Dict[str, Any]]:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)
             logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+        _record_load_stamp(jobs_file, jobs)
         return jobs
     if isinstance(data, list):
         # Bare array — likely saved/edited outside save_jobs(). Wrap it back
@@ -1055,6 +1091,7 @@ def load_jobs() -> List[Dict[str, Any]]:
         if data:
             save_jobs(data)
             logger.warning("Auto-repaired jobs.json (bare list wrapped as dict)")
+        _record_load_stamp(jobs_file, data)
         return data
 
     raise RuntimeError(
@@ -1062,10 +1099,71 @@ def load_jobs() -> List[Dict[str, Any]]:
     )
 
 
+def _reconcile_degraded_write(
+    jobs_file: Path, jobs: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Recover jobs a sibling process wrote since this critical section loaded.
+
+    When the cross-process flock in _jobs_lock() times out or is unavailable
+    (#60703), two processes can run a load->modify->save cycle concurrently
+    with no mutual exclusion. If a sibling process created a job in that
+    window, this critical section never saw it, and a plain overwrite would
+    silently discard it — the exact symptom in #80624 (CLI-created jobs
+    vanishing from jobs.json while the gateway is running).
+
+    Runs on every save, not just ones this process saw as degraded: a
+    *healthy* lock holder can still clobber a sibling's degraded write if
+    that sibling raced in and out while this process's own (properly
+    exclusive) critical section was open — the flock only stops other
+    processes from *also* getting exclusive access, it does nothing to stop
+    a process that gave up on getting it. The stat check below is a single
+    cheap syscall that is always a no-op when nothing raced (the overwhelming
+    common case), so this costs nothing on the healthy path. Any job ID
+    present on disk right now but absent from both what we loaded and what
+    we're about to write is unioned back in — favoring a resurrected job over
+    a silently lost one, matching the liveness-over-strict-consistency
+    tradeoff #60703 already accepted for this lock.
+    """
+    load_stamp = getattr(_jobs_lock_state, "load_stamp", None)
+    load_ids = getattr(_jobs_lock_state, "load_ids", None)
+    if load_ids is None:
+        return jobs
+    try:
+        st = jobs_file.stat()
+        current_stamp = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        current_stamp = None
+    if current_stamp == load_stamp:
+        return jobs
+    try:
+        current_jobs = load_jobs()
+    except RuntimeError:
+        return jobs
+    result_ids = {j["id"] for j in jobs if isinstance(j, dict) and "id" in j}
+    recovered = [
+        j
+        for j in current_jobs
+        if isinstance(j, dict)
+        and j.get("id") not in load_ids
+        and j.get("id") not in result_ids
+    ]
+    if recovered:
+        logger.error(
+            "jobs.json changed on disk since this process loaded it — "
+            "recovering %d job(s) a sibling process wrote that this write "
+            "would otherwise have discarded (#80624): %s",
+            len(recovered),
+            [j.get("id") for j in recovered],
+        )
+        jobs = jobs + recovered
+    return jobs
+
+
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
+    jobs = _reconcile_degraded_write(jobs_file, jobs)
     # Snapshot the current owner BEFORE the atomic replace so a privileged
     # writer (root CLI in Docker) can hand ownership back to the gateway user
     # afterwards instead of locking its ticker out (#68483). When the file is

--- a/tests/cron/test_jobs_crossprocess_lock.py
+++ b/tests/cron/test_jobs_crossprocess_lock.py
@@ -125,3 +125,117 @@ def test_jobs_lock_excludes_another_process(tmp_path, monkeypatch):
     # Once the child has released, the lock is freely acquirable again.
     with jobs._jobs_lock():
         pass
+
+
+def test_degraded_lock_recovers_concurrently_created_job(tmp_path, monkeypatch):
+    """#80624: a job a sibling process wrote during a degraded (unlocked)
+    window must not be silently discarded by this process's own save.
+
+    ``_jobs_lock()`` intentionally falls through to in-process-only locking
+    when the cross-process flock times out or is unavailable (#60703) — that
+    is a deliberate liveness tradeoff, not a bug. But before this fix, a save
+    made during that window would blindly overwrite jobs.json with whatever
+    stale list this process last loaded, discarding any job a sibling process
+    (e.g. the CLI) wrote in between. Reproduces that exact race in-process by
+    forcing ``_jobs_lock_state`` into the degraded state _jobs_lock() would
+    have left it in, without depending on OS-specific flock timing.
+    """
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+
+    job_a = {"id": "aaaaaaaaaaaa", "name": "existing"}
+    job_b = {"id": "bbbbbbbbbbbb", "name": "cli-created"}
+
+    try:
+        jobs.save_jobs([job_a])
+
+        # This process enters a degraded critical section (as _jobs_lock()
+        # does after a flock timeout) and loads the current, job_b-less state.
+        jobs._jobs_lock_state.depth = 1
+        jobs._jobs_lock_state.degraded = True
+        assert jobs.load_jobs() == [job_a]
+        stale_stamp = jobs._jobs_lock_state.load_stamp
+        stale_ids = jobs._jobs_lock_state.load_ids
+
+        # A sibling process (e.g. the CLI) creates job_b concurrently, via its
+        # own independent, fully-scoped _jobs_lock() cycle.
+        jobs._jobs_lock_state.depth = 0
+        jobs.save_jobs([job_a, job_b])
+
+        # This process resumes its degraded section with the stale view it
+        # actually observed (no job_b) and saves — pre-fix, this silently
+        # wiped job_b out of jobs.json.
+        jobs._jobs_lock_state.depth = 1
+        jobs._jobs_lock_state.degraded = True
+        jobs._jobs_lock_state.load_stamp = stale_stamp
+        jobs._jobs_lock_state.load_ids = stale_ids
+        jobs._save_jobs_unlocked([job_a])
+    finally:
+        jobs._jobs_lock_state.depth = 0
+        jobs._jobs_lock_state.degraded = False
+        jobs._jobs_lock_state.load_stamp = None
+        jobs._jobs_lock_state.load_ids = None
+
+    on_disk_ids = {j["id"] for j in jobs.load_jobs()}
+    assert on_disk_ids == {job_a["id"], job_b["id"]}, (
+        "sibling-created job was clobbered by a degraded-lock write (#80624)"
+    )
+
+
+def test_healthy_lock_write_recovers_sibling_degraded_create(tmp_path, monkeypatch):
+    """#80624 reverse direction: a *healthy* lock holder can still clobber a
+    sibling's degraded write if that sibling raced in and out while this
+    process's own critical section was open. flock only excludes other
+    processes that also hold it — it does nothing to stop a process that
+    gave up waiting for it. The reconcile check must not be gated on this
+    process's own ``degraded`` flag, or this direction of the race reopens
+    the exact #80624 symptom.
+    """
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+
+    job_a = {"id": "aaaaaaaaaaaa", "name": "existing"}
+    job_b = {"id": "bbbbbbbbbbbb", "name": "cli-created"}
+
+    try:
+        jobs.save_jobs([job_a])
+
+        # This process opens a *healthy* critical section (real flock held)
+        # and loads the current, job_b-less state.
+        jobs._jobs_lock_state.depth = 1
+        jobs._jobs_lock_state.degraded = False
+        assert jobs.load_jobs() == [job_a]
+        stale_stamp = jobs._jobs_lock_state.load_stamp
+        stale_ids = jobs._jobs_lock_state.load_ids
+
+        # A sibling process couldn't get the flock, degraded, and created
+        # job_b anyway via its own independent _jobs_lock() cycle. (This
+        # nested call shares the same thread-local as the outer section only
+        # because the test simulates two processes in one thread — real
+        # processes each have their own _jobs_lock_state, so this reset
+        # doesn't happen in production; restored below to keep the test
+        # faithful to the real per-process state.)
+        jobs._jobs_lock_state.depth = 0
+        jobs.save_jobs([job_a, job_b])
+
+        # This process resumes its still-healthy section with the stale view
+        # it actually observed (no job_b) and saves.
+        jobs._jobs_lock_state.depth = 1
+        jobs._jobs_lock_state.degraded = False
+        jobs._jobs_lock_state.load_stamp = stale_stamp
+        jobs._jobs_lock_state.load_ids = stale_ids
+        jobs._save_jobs_unlocked([job_a])
+    finally:
+        jobs._jobs_lock_state.depth = 0
+        jobs._jobs_lock_state.degraded = False
+        jobs._jobs_lock_state.load_stamp = None
+        jobs._jobs_lock_state.load_ids = None
+
+    on_disk_ids = {j["id"] for j in jobs.load_jobs()}
+    assert on_disk_ids == {job_a["id"], job_b["id"]}, (
+        "sibling's degraded create was clobbered by a healthy-lock write (#80624)"
+    )


### PR DESCRIPTION
## Summary

`no_agent` CLI-created cron jobs disappear from `jobs.json` while the gateway is running. Root cause confirmed by code inspection (not the issue's own in-memory-cache hypothesis, which is false — the scheduler has no cache): `_jobs_lock()`'s cross-process `flock` deliberately degrades to in-process-only locking on timeout/unavailability (#60703's liveness tradeoff). In that window two processes can run `load -> mutate -> save` concurrently with no mutual exclusion, and whichever writes last silently discards the other's concurrently created job.

## Fix

`_save_jobs_unlocked()` now stat()s `jobs.json` against a `(mtime_ns, size)` stamp recorded when this critical section called `load_jobs()`. On mismatch, it reloads the file and unions back any job id present on disk but absent from both the original load and the payload about to be written, before the atomic replace.

Deliberately **not** gated on this process's own degraded flag: a *healthy* lock holder can just as easily clobber a sibling's degraded write if that sibling raced in and out while this process's own critical section was open (flock only excludes other processes that also hold it, not ones that gave up waiting for it). Running the stat check unconditionally closes both directions of the race for the cost of one syscall — a no-op whenever nothing actually raced.

No public signatures changed, no call sites touched.



## Testing

- `tests/cron/test_jobs_crossprocess_lock.py`: two new regression tests — degraded-writer-clobbers-sibling-create, and the reverse healthy-lock-clobbers-degraded-sibling-create.
- Full `tests/cron/` + `tests/tools/test_cronjob_tools.py`: 443 passed, 0 failed, 19 skipped (pre-existing POSIX-only skips on Windows, verified present on unmodified `main` too).

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[⚡ Process A: load jobs.json] -->|stamp t0, ids I0| B[🔒 _jobs_lock critical section]
    C[⚡ Process B: sibling] -->|flock timeout #60703| D[🌀 Degraded, unlocked write]
    D -->|creates job X, writes jobs.json| E[💾 Disk: jobs.json @ t1]
    B -->|about to save stale payload without X| F{🔎 Reconcile: stat jobs.json}
    F -->|t1 != t0, changed| G[♻️ Reload + union missing ids]
    G -->|X present on disk, absent from load and payload| H[✅ Job X merged back]
    F -->|t1 == t0, unchanged| I[🚀 Fast path: no-op, single syscall]
    H --> J[🔐 Atomic replace jobs.json]
    I --> J
    J --> K[✔️ No silent job loss]
```

## Infographic :

<img width="1024" height="1024" alt="cron_bug_infographic" src="https://github.com/user-attachments/assets/4ae85eac-2246-4809-a3fa-2949505b07b1" />
