### PR TITLE
fix(gateway): bound Slack channel-directory startup resolution

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -18,6 +18,11 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+# Max number of raw Slack channel/DM IDs resolved via conversations.info /
+# users.info per directory build.  Prevents a large session history from
+# serially blocking gateway startup for minutes (see startup-restore gate).
+_SLACK_DIRECTORY_RESOLVE_LIMIT = 50
+
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
 # Throttle window for repeated Slack channel-directory refresh failures.
 # The directory rebuilds on a timer, so a persistent workspace error (e.g.
@@ -370,8 +375,19 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             seen_ids.add(eid)
 
     # Resolve remaining raw-ID entries (DMs, private channels not in bot scope)
-    # by calling conversations.info + users.info for each.
+    # by calling conversations.info + users.info for each.  BOUNDED: a large
+    # session history can produce hundreds of raw IDs, and uncapped serial
+    # API resolution blocks gateway startup (holding the inbound gate) for
+    # minutes.  Raw IDs remain valid delivery targets without friendly names.
     unresolved = [ch for ch in channels if ch.get("name", "").startswith(("C0", "D0", "G0"))]
+    if len(unresolved) > _SLACK_DIRECTORY_RESOLVE_LIMIT:
+        logger.info(
+            "Channel directory: %d unresolved Slack IDs; resolving first %d only "
+            "(rest keep raw IDs, which remain valid delivery targets)",
+            len(unresolved),
+            _SLACK_DIRECTORY_RESOLVE_LIMIT,
+        )
+        unresolved = unresolved[:_SLACK_DIRECTORY_RESOLVE_LIMIT]
     if unresolved and team_clients:
         client = next(iter(team_clients.values()))
         for entry in unresolved:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11385,9 +11385,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Build initial channel directory for send_message name resolution
         try:
             from gateway.channel_directory import build_channel_directory
-            directory = await build_channel_directory(self.adapters)
+            # BOUNDED: directory enrichment must never hold the startup
+            # restore gate (inbound queue) indefinitely.  On timeout the
+            # gateway continues with raw IDs, which are valid targets.
+            directory = await asyncio.wait_for(
+                build_channel_directory(self.adapters), timeout=30.0
+            )
             ch_count = sum(len(chs) for chs in directory.get("platforms", {}).values())
             logger.info("Channel directory built: %d target(s)", ch_count)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Channel directory build timed out after 30s; continuing startup "
+                "with raw IDs (name resolution remains best-effort)"
+            )
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
         

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -355,3 +355,35 @@ class TestChannelAliases:
                  if e["id"] == "120363@g.us"]
         assert names == ["general"]
 
+
+
+class TestSlackResolveLimit:
+    def test_unresolved_raw_id_resolution_is_capped(self, monkeypatch):
+        """A large session history must not trigger unbounded serial
+        conversations.info calls during startup (startup-restore gate)."""
+        from gateway import channel_directory as cd
+
+        async def _run():
+            return await cd._build_slack(adapter)
+
+        raw_entries = [
+            {"id": f"D0{i:08X}", "name": f"D0{i:08X}", "type": "dm"}
+            for i in range(cd._SLACK_DIRECTORY_RESOLVE_LIMIT + 25)
+        ]
+        monkeypatch.setattr(cd, "_build_from_sessions", lambda platform: raw_entries)
+
+        client = MagicMock()
+        client.users_conversations = AsyncMock(
+            return_value={"ok": True, "channels": [], "response_metadata": {}}
+        )
+        client.conversations_info = AsyncMock(
+            return_value={"ok": True, "channel": {"is_im": False, "name": "x"}}
+        )
+        adapter = SimpleNamespace(_team_clients={"T0TEST": client})
+
+        result = asyncio.run(_run())
+
+        assert client.conversations_info.await_count == cd._SLACK_DIRECTORY_RESOLVE_LIMIT
+        # All entries are still present — unresolved ones keep raw IDs,
+        # which remain valid delivery targets.
+        assert len(result) == len(raw_entries)


### PR DESCRIPTION
## Problem

On gateway startup, `build_channel_directory` resolves friendly names for every Slack channel/DM ID seen in session history via **serial, uncapped** `conversations.info` / `users.info` calls. For long-lived installations this list grows into the hundreds (our production install: **911 IDs**), so the startup-restore gate is held for 5–11+ minutes on every boot.

Observable symptom: Slack authenticates and Socket Mode connects (`✓ slack connected`), but inbound messages only appear as `Queued inbound message during gateway startup restore` and never drain — the gateway looks healthy while processing nothing.

## Fix

- Cap name resolution at **50 IDs per build** (`_SLACK_DIRECTORY_RESOLVE_LIMIT`). Raw IDs past the cap remain valid delivery targets — friendly names are best-effort enrichment, not correctness.
- Wrap the initial directory build in `asyncio.wait_for(..., 30)` so it can never hold the global startup gate indefinitely.

## Measured impact (production)

| | before | after |
|---|---|---|
| unresolved Slack IDs | 911 | 911 |
| directory build time | >5–11 min (gate held) | ~21s |
| startup gate release | minutes | 39s after process start |

## Tests

- Includes a regression test asserting the `conversations_info` call count is capped when session history contains more IDs than the limit.
- `venv/bin/python -m pytest tests/gateway/test_channel_directory.py -q` → **20 passed**