### PR TITLE
fix(run_agent): release owned SessionDB connection on agent close

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1588,6 +1588,13 @@ def init_agent(
     # background skill/memory review fork so its harness turn can't leak into
     # the user's real session and hijack the next live turn. Default False.
     agent._persist_disabled = False
+    # Whether this agent OWNS its session_db handle and must close the SQLite
+    # connection on close(). The CLI/gateway pass a long-lived shared handle
+    # they keep open for the process; the TUI/serve backend hands a fresh
+    # dedicated handle per profile-scoped agent build, and the recall fallback
+    # self-creates one. Only the owner closes it — closing a shared handle
+    # would break concurrent users.
+    agent._owns_session_db = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/run_agent.py
+++ b/run_agent.py
@@ -613,6 +613,9 @@ class AIAgent:
             from hermes_state import SessionDB
 
             self._session_db = SessionDB()
+            # The agent self-created this handle, so it owns it and must
+            # release the connection on close() (see AIAgent.close()).
+            self._owns_session_db = True
             return self._session_db
         except Exception:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
@@ -4330,6 +4333,21 @@ class AIAgent:
                 session_id = getattr(self, "session_id", None)
                 if session_db and session_id:
                     session_db.end_session(session_id, "agent_close")
+        except Exception:
+            pass
+
+        # 8b. Release an OWNED session_db connection. The CLI/gateway pass a
+        # long-lived shared handle they keep for the process; the TUI/serve
+        # backend hands a fresh dedicated handle per profile-scoped agent
+        # build, and the recall fallback self-creates one. Only the owner
+        # closes it — closing a shared handle would break concurrent users
+        # and corrupt the tracked-connection ledger. Without this, long-lived
+        # serve backends leaked 2 fds per agent build and exhausted the fd
+        # table (OSError 24) after ~2 days.
+        try:
+            if getattr(self, "_owns_session_db", False) and self._session_db is not None:
+                self._session_db.close()
+                self._session_db = None
         except Exception:
             pass
 

--- a/tests/run_agent/test_session_db_closed_on_agent_close.py
+++ b/tests/run_agent/test_session_db_closed_on_agent_close.py
@@ -1,0 +1,135 @@
+"""Regression: AIAgent.close() must release an owned SessionDB connection.
+
+Observed in the Desktop/`serve --isolated` backend (#fd-leak): every profile-
+scoped agent build hands the agent a dedicated ``SessionDB(db_path=.../state.db)``
+handle, but ``AIAgent.close()`` only finalized the session ROW (``end_session``)
+and never closed the SQLite CONNECTION. After ~2 days the backend hit the
+1024-fd soft limit (``OSError: [Errno 24] Too many open files``) and stopped
+doing new work.
+
+Contract: after ``agent.close()``, no file descriptor may remain open on an
+OWNED session database (state.db or its WAL). Borrowed/shared handles (the
+CLI/gateway long-lived SessionDB) must NOT be closed by the agent.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SESSION_ID = "test-session-db-close"
+
+
+def _open_fds_to(db_path: Path) -> int:
+    """Count this process's open fds on ``db_path`` (including its WAL)."""
+    target = str(db_path.resolve())
+    count = 0
+    try:
+        for fd in os.listdir("/proc/self/fd"):
+            try:
+                link = os.readlink(f"/proc/self/fd/{fd}")
+            except OSError:
+                continue
+            if link == target or link.startswith(target):
+                count += 1
+    except FileNotFoundError:
+        pass
+    return count
+
+
+def _make_agent(session_db=None, *, owns=False):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=SESSION_ID,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    if owns:
+        # Mirrors tui_gateway.server._make_agent, which marks agents handed a
+        # dedicated profile-scoped handle this way.
+        agent._owns_session_db = True
+    agent._ensure_db_session()
+    return agent
+
+
+def test_agent_close_releases_owned_session_db_connection():
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(SESSION_ID, "cli")
+            agent = _make_agent(db, owns=True)
+
+            # The write connection must actually be open before close(), or the
+            # assertion proves nothing.
+            agent._session_db.flush_token_counts()
+            assert _open_fds_to(db_path) > 0
+
+            agent.close()
+
+            assert _open_fds_to(db_path) == 0
+        finally:
+            db.close()
+
+
+def test_agent_close_does_not_close_borrowed_session_db():
+    """The CLI/gateway pass a long-lived shared handle; close() must not release it."""
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(SESSION_ID, "cli")
+            agent = _make_agent(db, owns=False)
+
+            agent._session_db.flush_token_counts()
+            assert _open_fds_to(db_path) > 0
+
+            agent.close()
+
+            # Borrowed handle stays open — the process owner keeps using it.
+            assert _open_fds_to(db_path) > 0
+        finally:
+            db.close()
+
+
+def test_agent_close_releases_recall_fallback_session_db():
+    """The recall fallback self-creates a SessionDB; close() must release it.
+
+    This path sets ``_owns_session_db`` inside real production code
+    (``AIAgent._get_session_db_for_recall``), so it exercises the full
+    flag + close machinery end-to-end.
+    """
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "state.db"
+        # Seed the canonical default db (no path) so the fallback resolves here.
+        seed = SessionDB(db_path=db_path)
+        seed.create_session(SESSION_ID, "cli")
+        seed.close()
+
+        agent = _make_agent(None)
+        # Forces the recall fallback to self-create a SessionDB (resolved to
+        # the hermetic test home by the live-DB isolation guard).
+        recalled = agent._get_session_db_for_recall()
+        assert recalled is not None
+        assert getattr(agent, "_owns_session_db", False) is True
+
+        # Resolve the path the fallback actually opened and confirm it leaks today.
+        target = Path(recalled.db_path)
+        assert _open_fds_to(target) > 0
+
+        agent.close()
+
+        assert _open_fds_to(target) == 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6485,7 +6485,7 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
-    return AIAgent(
+    agent = AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
@@ -6532,6 +6532,16 @@ def _make_agent(
         fallback_model=_load_fallback_model(),
         **_agent_cbs(sid),
     )
+
+    # A dedicated profile-scoped session_db handle is owned by this agent and
+    # must be closed on teardown (AIAgent.close()); the launch-profile shared
+    # handle (_get_db()) stays open for the whole process.
+    if session_db is not None and session_db is not _get_db():
+        try:
+            agent._owns_session_db = True
+        except Exception:
+            pass
+    return agent
 
 
 def _init_session(


### PR DESCRIPTION
## Summary

Fixes an fd leak in the Desktop/`serve --isolated` backend (and any other long-lived surface that hands an agent a dedicated profile-scoped `SessionDB`): `AIAgent.close()` finalized the session **row** (`end_session`) but never closed the SQLite **connection**. Observed live: ~490 leaked handles (state.db + WAL = 2 fds per agent build) over ~2 days pushed the backend to the 1024-fd soft limit (`OSError: [Errno 24] Too many open files`) and it stopped doing new work.

## Root cause

Every profile-scoped agent build in `tui_gateway/server.py` (`_make_agent`, `methods_session.resume`, compute-host path) creates a dedicated `SessionDB(db_path=.../profiles/<p>/state.db)` and hands it to the agent. `AIAgent.close()` (run_agent.py) ran `session_db.end_session(...)` but never `session_db.close()`, so the connection (and its WAL fd) leaked until process exit. The launch-profile shared handle (`_get_db()`) is intentionally long-lived and must NOT be closed.

## Fix

Explicit ownership flag, mirroring the existing `_end_session_on_close` / `_persist_disabled` lifecycle flags:

- `agent/agent_init.py` — seed `_owns_session_db = False` (the CLI/gateway shared handle is never closed by an agent).
- `run_agent.py` — `_get_session_db_for_recall()` marks the handle it self-creates as owned; `AIAgent.close()` closes and drops an owned handle after `end_session`.
- `tui_gateway/server.py` — `_make_agent()` marks agents handed a dedicated profile-scoped handle (identity check against the shared `_get_db()` singleton).

Borrowed/shared handles (CLI, gateway runner, launch profile) are untouched — the agent only closes what it owns.

## Test plan

- New regression tests (RED first — reproduced the leak deterministically: 1 fd remained open after `close()`):
  - owned handle is released on `close()`;
  - borrowed handle is NOT closed by `close()`;
  - recall-fallback self-created handle is released end-to-end.
- Full suites vs unchanged main (identical pre-existing env failures only, zero new):
  - `tests/run_agent/`: 1406 passed (7 pre-existing, anthropic pkg missing in CI env)
  - `tests/agent/`: 3695 passed (109 pre-existing, byte-identical failure set on main)
  - `tests/tui_gateway/`: 342 passed
  - `tests/test_tui_gateway_server.py`: 518 passed (includes the real `_make_agent` fallback-chain test)
- Ruff clean.
- Canary: 25 real `_make_agent` → `AIAgent.close()` cycles against an isolated temp home; fd count flat at baseline.
