### PR TITLE
fix(desktop): recover transitive compression continuations

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1209,26 +1209,52 @@ def _adopt_live_compression_child(
     session_db: Any,
     parent_session_id: str,
 ) -> Optional[List[Dict[str, Any]]]:
-    """Move a stale compression contender onto the unique durable child.
+    """Move a stale compression contender onto the durable live tip.
 
     Resolve and load first, then mutate the live agent. This ordering keeps the
     stale contender fail-closed when lineage is ambiguous or the compacted
-    handoff cannot be read.
+    handoff cannot be read. The canonical tip resolver is transitive because an
+    already-open Desktop runtime can miss more than one durable-id rotation.
     """
     finder = getattr(type(session_db), "find_live_compression_child", None)
     loader = getattr(type(session_db), "get_messages_as_conversation", None)
-    if not callable(finder) or not callable(loader):
+    tip_resolver = getattr(type(session_db), "get_compression_tip", None)
+    session_loader = getattr(type(session_db), "get_session", None)
+    if not callable(loader):
         return None
-    child = finder(session_db, parent_session_id)
+
+    if callable(tip_resolver) and callable(session_loader):
+        tip_id = tip_resolver(session_db, parent_session_id)
+        child = (
+            session_loader(session_db, tip_id)
+            if tip_id and tip_id != parent_session_id
+            else None
+        )
+        if child and child.get("ended_at") is not None:
+            child = None
+    else:
+        if not callable(finder):
+            return None
+        child = finder(session_db, parent_session_id)
     if not child or not child.get("id"):
         return None
     child_session_id = str(child["id"])
     recovered = loader(session_db, child_session_id)
     if not isinstance(recovered, list) or not recovered:
         return None
-    # Revalidate after loading: the child may have rotated or a competing
+    # Revalidate after loading: the tip may have rotated or a competing
     # continuation may have appeared between the two DB reads.
-    confirmed = finder(session_db, parent_session_id)
+    if callable(tip_resolver) and callable(session_loader):
+        confirmed_id = tip_resolver(session_db, parent_session_id)
+        confirmed = (
+            session_loader(session_db, confirmed_id) if confirmed_id else None
+        )
+        if confirmed and confirmed.get("ended_at") is not None:
+            confirmed = None
+    else:
+        if not callable(finder):
+            return None
+        confirmed = finder(session_db, parent_session_id)
     if not confirmed or str(confirmed.get("id") or "") != child_session_id:
         return None
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3651,8 +3651,8 @@ class AIAgent:
                 prefix
                 + "the turn was stopped because session storage could not be "
                 "written (the transcript would have been lost on restart). "
-                "This is often a full disk — free some space (or fix state.db "
-                "permissions), then send your message again."
+                "Check Hermes logs for the exact storage error, fix it, then "
+                "send your message again."
             )
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -36,6 +36,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -573,6 +574,56 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     assert db.get_compression_lock_holder(parent_sid) is None, (
         "Compression lock leaked: still held after both paths completed."
     )
+
+
+def test_turn_start_recovery_follows_multiple_compression_rotations(
+    tmp_path: Path,
+) -> None:
+    """An already-open runtime may lag more than one continuation behind.
+
+    Desktop tabs keep a stable runtime id while compression rotates the durable
+    session id. If the renderer misses two rotation events, the next turn still
+    arrives on the runtime whose agent points at the root. Recovery must adopt
+    the live tip, not only a live direct child of that root.
+    """
+    from agent.conversation_compression import recover_rotated_compression_session
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    root = "desktop-stale-root"
+    middle = "desktop-ended-middle"
+    tip = "desktop-live-tip"
+    db.create_session(root, source="desktop")
+    db.append_message(root, "user", "pre-compression turn")
+    db.end_session(root, "compression")
+    db.create_session(middle, source="desktop", parent_session_id=root)
+    db.append_message(middle, "user", "first compacted handoff")
+    db.end_session(middle, "compression")
+    db.create_session(tip, source="desktop", parent_session_id=middle)
+    db.append_message(tip, "user", "second compacted handoff")
+
+    switches = []
+    agent = SimpleNamespace(
+        _gateway_session_key="desktop-runtime",
+        _memory_manager=None,
+        _session_db=db,
+        context_compressor=SimpleNamespace(
+            on_session_start=lambda *args, **kwargs: switches.append((args, kwargs))
+        ),
+        platform="desktop",
+        session_id=root,
+    )
+
+    try:
+        recovered = recover_rotated_compression_session(agent)
+    finally:
+        db.close()
+
+    assert agent.session_id == tip
+    assert [
+        (message["role"], message["content"]) for message in recovered or []
+    ] == [("user", "second compacted handoff")]
+    assert switches and switches[0][0] == (tip,)
+    assert switches[0][1]["old_session_id"] == root
 
 
 def test_durable_message_committed_before_lease_is_adopted(

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -241,6 +241,12 @@ def test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects():
     assert result["failed"] is True
     assert result["completed"] is False
     assert result["turn_exit_reason"] == "session_persistence_failed"
+    assert result["error"] == (
+        "⚠️ No reply: the turn was stopped because session storage could not be "
+        "written (the transcript would have been lost on restart). Check Hermes "
+        "logs for the exact storage error, fix it, then send your message again."
+    )
+    assert "disk" not in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import subprocess
@@ -5122,6 +5123,48 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         assert created == [], "session.create should not persist an empty DB row"
     finally:
         server._sessions.pop(sid, None)
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code", "expected_text"),
+    [
+        (OSError(errno.ENOSPC, "No space left on device"), 5070, "disk full"),
+        (
+            PermissionError("state row is closed"),
+            5071,
+            "session storage could not be written",
+        ),
+    ],
+)
+def test_prompt_submit_distinguishes_disk_full_from_other_persistence_failures(
+    monkeypatch, failure, expected_code, expected_text
+):
+    """Desktop notification routing depends on these persistence error classes."""
+    server._sessions["sid"] = _session()
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_ensure_session_db_row",
+        lambda _session: (_ for _ in ()).throw(failure),
+    )
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "request",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response is not None
+    assert "error" in response
+    assert response["error"]["code"] == expected_code
+    assert expected_text in response["error"]["message"].lower()
+    if expected_code == 5071:
+        assert "disk full" not in response["error"]["message"].lower()
 
 
 def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):


### PR DESCRIPTION
## Root cause

Desktop runtimes keep a stable runtime identity while compression rotates durable session IDs. Turn-start recovery only looked for a live direct child. After multiple compression rotations, that direct child is already ended, so a stale runtime could miss the transitive live tip and fail persistence on its next turn.

## Implementation

- Resolve the canonical compression tip transitively, load it, and revalidate it before mutating the live agent.
- Preserve the existing direct-child fallback for compatible database stand-ins.
- Keep storage failures accurately classified: explicit `ENOSPC` remains error `5070`, while generic persistence failures remain `5071` with neutral recovery guidance.
- Add regression coverage for multi-rotation recovery and the `5070`/`5071` distinction.

## Verification

- `scripts/run_tests.sh tests/agent/test_compression_concurrent_fork.py` — 43 passed
- `scripts/run_tests.sh tests/run_agent/test_tool_call_incremental_persistence.py` — 11 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'session_resume_follows_compression_tip or prompt_submit_distinguishes_disk_full_from_other_persistence_failures'` — 3 passed
- `scripts/run_tests.sh tests/test_hermes_state.py -k 'get_compression_tip_walks_full_chain'` — 1 passed
- `cd apps/desktop && NODE_OPTIONS='--localstorage-file=<temporary-file>' npx vitest run src/store/session-states.test.ts src/app/session/hooks/use-session-state-cache.test.tsx src/store/notifications.test.ts src/store/native-notifications.test.ts src/app/session/hooks/use-message-stream` — 138 passed
- `cd apps/desktop && npm run typecheck` — passed
- `cd apps/desktop && npm run lint` — passed with no errors
- `python -m py_compile agent/conversation_compression.py run_agent.py tests/agent/test_compression_concurrent_fork.py tests/run_agent/test_tool_call_incremental_persistence.py tests/test_tui_gateway_server.py` — passed
- `git diff --check origin/main...HEAD` — passed
