### PR TITLE
fix: read_file false-positive binary on UTF-8 truncation at byte 1000

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,25 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_truncation_artifact_not_flagged(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # The binary-detection sample is taken with `head -c 1000` (byte-based).
+        # When byte 1000 splits a multi-byte UTF-8 char, the truncated tail
+        # decodes to up to 3 U+FFFD at the END of the sample only. That is a
+        # truncation artifact, not evidence of a binary file — legitimate
+        # UTF-8 text cut mid-character must still read as text.
+        sample = "网络" * 500 + "学"  # ends mid-UTF-8-char after byte cut
+        raw = sample.encode("utf-8")[:1000]
+        lossy_tail = raw.decode("utf-8", errors="replace")
+        assert lossy_tail.endswith("\ufffd")
+        assert ops._is_likely_binary("notes.txt", lossy_tail) is False
+
+    def test_replacement_char_in_body_still_binary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # U+FFFD inside the body (not just the trailing truncation artifact)
+        # must still be flagged binary — scattered replacement chars mean the
+        # file really is undecodable, and returning it as text could lead to a
+        # read→edit→write round-trip that overwrites the original bytes.
+        scattered = "前缀" + "\ufffd" * 10 + "后缀" + "\ufffd" * 5 + "尾部"
+        assert ops._is_likely_binary("notes.txt", scattered) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,11 +903,22 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # Exception: the sample is taken with `head -c 1000` (byte-based).
+            # When byte 1000 lands mid-way through a multi-byte UTF-8 char,
+            # the truncated tail decodes to at most 3 U+FFFD at the END of
+            # the sample only (UTF-8 chars are ≤4 bytes; a cut splits one
+            # char into ≤3 replacement chars). A genuinely binary file has
+            # replacement chars scattered through the whole sample. So ignore
+            # only the trailing ≤3 chars (truncation artifact) before testing
+            # — preserves the guard while letting legitimate UTF-8 text
+            # through.
+            sample = content_sample[:1000]
+            if "\ufffd" in sample[:-3]:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(sample), 1000) > 0.30
         
         return False
     


### PR DESCRIPTION
## Problem
`read_file` misflags legitimate UTF-8 text as binary. The binary-detection sample is taken with `head -c 1000` (byte-based); when byte 1000 splits a multi-byte UTF-8 character, the truncated tail decodes to up to 3 U+FFFD (replacement chars) at the END of the sample. `_is_likely_binary` sees any U+FFFD and returns binary — so e.g. a 2.9KB Chinese markdown file fails to read, and cron jobs reading it fall back to slow workarounds.

## Fix
Ignore only the trailing ≤3 chars (truncation artifact) before the U+FFFD test. Replacement chars scattered through the body still count as binary, preserving the original read-only guard against mojibake round-trips.

## Tests
- Existing: `test_replacement_char_sample_flagged_binary` (body U+FFFD still flagged) still passes.
- Added regression tests: trailing truncation artifact reads as text; body replacement chars still flagged binary.
- `pytest tests/tools/test_file_operations.py` — 69 passed.

- [x] I've tested on my platform: Ubuntu 24.04 (OrbStack container), Chinese UTF-8 markdown file
- [x] I've tested the skill end-to-end