### PR TITLE
Pin as many sessions as you want, and they stay where you put them

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -419,16 +419,35 @@ export function ChatSidebar({
     return out
   }, [pinnedSessionIds, sessionByAnyId])
 
-  const pinnedRealIdSet = useMemo(() => new Set(pinnedSessions.map(s => s.id)), [pinnedSessions])
-  const pinnedIdSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
+  // Every id a pin is reachable under: the raw stored ids, plus BOTH identities
+  // of each session we resolved one to. A pin is stored on the durable lineage
+  // root, but the lists that must filter it out are fed from three independent
+  // fetches (recents, the messaging slice, the backend project tree) and each
+  // can surface the same conversation under either its live tip or its root.
+  // Comparing one identity against the other is how a pinned session ended up
+  // rendered twice — once in Pinned, once in its project group.
+  const pinnedIdentitySet = useMemo(() => {
+    const ids = new Set(pinnedSessionIds)
+
+    for (const session of pinnedSessions) {
+      ids.add(session.id)
+
+      if (session._lineage_root_id) {
+        ids.add(session._lineage_root_id)
+      }
+    }
+
+    return ids
+  }, [pinnedSessionIds, pinnedSessions])
 
   // A pinned session belongs to the Pinned section and nowhere else, so every
-  // other list filters it out (the flat recents already did). Match on the live
-  // id AND the durable pin id — a backend snapshot can surface either side of a
-  // compression tip rotation.
+  // other list filters it out. Match on either identity the row carries — a
+  // backend snapshot can surface either side of a compression tip rotation.
   const isPinnedSession = useCallback(
-    (session: SessionInfo) => pinnedRealIdSet.has(session.id) || pinnedIdSet.has(sessionPinId(session)),
-    [pinnedRealIdSet, pinnedIdSet]
+    (session: SessionInfo) =>
+      pinnedIdentitySet.has(session.id) ||
+      (session._lineage_root_id != null && pinnedIdentitySet.has(session._lineage_root_id)),
+    [pinnedIdentitySet]
   )
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
@@ -519,10 +538,11 @@ export function ChatSidebar({
     }
   }, [agentOrderIds, agentOrderManual, unpinnedAgentSessions])
 
-  const agentSessions = useMemo(
-    () => (agentOrderManual ? orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds) : unpinnedAgentSessions),
-    [unpinnedAgentSessions, agentOrderIds, agentOrderManual]
-  )
+  // Recents render in recency order. The hand-picked order is layered on per
+  // date group inside the section (orderRowsWithinGroups) rather than baked
+  // into the list here, so a drag ranks a row among its own day's chats
+  // instead of flattening the whole sidebar into an undated manual mode.
+  const agentSessions = unpinnedAgentSessions
 
   // Recents are local-only: messaging-platform sessions are fetched as their
   // own slice ($messagingSessions) and rendered in self-managed per-platform
@@ -1304,7 +1324,7 @@ export function ChatSidebar({
                   // virtualized long list, which must keep its own scroller.
                   !recentsVirtualizes && COMPACT_FLAT
                 )}
-                dateGrouped={inProject || !agentOrderManual}
+                dateGrouped
                 dndSensors={dndSensors}
                 emptyState={
                   showSessionSkeletons ? (
@@ -1419,6 +1439,7 @@ export function ChatSidebar({
                   ) : undefined
                 }
                 liveSessions={inProject ? agentSessions : undefined}
+                manualOrderIds={agentOrderManual ? agentOrderIds : undefined}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1288,7 +1288,7 @@ export function ChatSidebar({
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex max-h-[50vh] flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
+                contentClassName="flex flex-col gap-px rounded-lg pb-2 pt-1"
                 dndSensors={dndSensors}
                 emptyState={<SidebarPinnedEmptyState />}
                 label={s.pinned}

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import type { SidebarListRow } from '@/lib/session-date-groups'
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  orderByIds,
+  orderRowsWithinGroups,
+  reconcileOrderIds,
+  reorderableRowIds,
+  resolveManualSessionOrderIds,
+  sameIds
+} from './order'
 
 describe('resolveManualSessionOrderIds', () => {
   it('clears legacy auto-seeded order until the user manually reorders sessions', () => {
@@ -30,12 +40,27 @@ describe('orderByIds', () => {
 
   it('reorders by the given ids and drops missing ones', () => {
     const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
-    expect(orderByIds(items, id, ['c', 'gone', 'a'])).toEqual([{ id: 'b' }, { id: 'c' }, { id: 'a' }])
+    // 'b' isn't in the order and sits after 'a' (the first ordered item), so
+    // it's an older row: it sinks below the hand-picked pair, not above it.
+    expect(orderByIds(items, id, ['c', 'gone', 'a'])).toEqual([{ id: 'c' }, { id: 'a' }, { id: 'b' }])
   })
 
   it('surfaces items absent from the order first', () => {
     const items = [{ id: 'fresh' }, { id: 'a' }, { id: 'b' }]
     expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'fresh' }, { id: 'b' }, { id: 'a' }])
+  })
+
+  it('keeps a newly-loaded older page below the hand-picked order', () => {
+    // Callers pass recency-sorted lists, so an unknown id BELOW the ordered
+    // ones is an older page that just loaded — hoisting it to the top was
+    // dumping 50 stale sessions above the user's arrangement.
+    const items = [{ id: 'a' }, { id: 'b' }, { id: 'old1' }, { id: 'old2' }]
+    expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'b' }, { id: 'a' }, { id: 'old1' }, { id: 'old2' }])
+  })
+
+  it('splits unknown ids either side of the order by their own position', () => {
+    const items = [{ id: 'new' }, { id: 'a' }, { id: 'b' }, { id: 'old' }]
+    expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'new' }, { id: 'b' }, { id: 'a' }, { id: 'old' }])
   })
 })
 
@@ -58,5 +83,76 @@ describe('sameIds', () => {
     expect(sameIds(['a', 'b'], ['a', 'b'])).toBe(true)
     expect(sameIds(['a', 'b'], ['b', 'a'])).toBe(false)
     expect(sameIds(['a'], ['a', 'b'])).toBe(false)
+  })
+})
+
+const session = (id: string, branchStem?: string): SidebarListRow => ({
+  entry: { branchStem, session: { id } as SessionInfo },
+  kind: 'session'
+})
+
+const divider = (key: string): SidebarListRow =>
+  ({ bucket: { key }, key, kind: 'divider' }) as unknown as SidebarListRow
+
+const ids = (rows: SidebarListRow[]): string[] =>
+  rows.map(row => (row.kind === 'divider' ? `--${row.key}--` : `${row.entry.branchStem ?? ''}${row.entry.session.id}`))
+
+describe('orderRowsWithinGroups', () => {
+  it('returns the same rows when no order is given', () => {
+    const rows = [session('a'), session('b')]
+    expect(orderRowsWithinGroups(rows, [])).toBe(rows)
+  })
+
+  it('keeps identity when the order changes nothing', () => {
+    const rows = [session('a'), session('b')]
+    expect(orderRowsWithinGroups(rows, ['a', 'b'])).toBe(rows)
+  })
+
+  it('reorders within a group without moving the dividers', () => {
+    const rows = [session('a'), session('b'), divider('yesterday'), session('c'), session('d')]
+
+    expect(ids(orderRowsWithinGroups(rows, ['b', 'a', 'd', 'c']))).toEqual([
+      'b',
+      'a',
+      '--yesterday--',
+      'd',
+      'c'
+    ])
+  })
+
+  it('never moves a row across a date divider', () => {
+    // 'd' is ranked first overall, but it lives below the divider and must
+    // stay there — chronology owns the groups, the drag only ranks inside one.
+    const rows = [session('a'), session('b'), divider('lastWeek'), session('c'), session('d')]
+
+    expect(ids(orderRowsWithinGroups(rows, ['d', 'c', 'b', 'a']))).toEqual([
+      'b',
+      'a',
+      '--lastWeek--',
+      'd',
+      'c'
+    ])
+  })
+
+  it('leaves rows the order does not name in their recency slot', () => {
+    // Only 'a' and 'c' are ranked; 'b' never moves, and the ranked pair swap
+    // into the two slots they already occupied.
+    const rows = [session('a'), session('b'), session('c')]
+
+    expect(ids(orderRowsWithinGroups(rows, ['c', 'a']))).toEqual(['c', 'b', 'a'])
+  })
+
+  it('carries branch children with their parent', () => {
+    const rows = [session('parent'), session('child', '└─ '), session('other')]
+
+    expect(ids(orderRowsWithinGroups(rows, ['other', 'parent']))).toEqual(['other', 'parent', '└─ child'])
+  })
+})
+
+describe('reorderableRowIds', () => {
+  it('lists root session ids in render order, skipping dividers and branches', () => {
+    const rows = [session('a'), session('branch', '├─ '), divider('yesterday'), session('b')]
+
+    expect(reorderableRowIds(rows)).toEqual(['a', 'b'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,10 +1,44 @@
-/** New ids first, then ids still present in the persisted order. */
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+/**
+ * Fold ids absent from the persisted order back in, on the side they belong.
+ *
+ * Callers hand us a recency-sorted `currentIds`, so an id's position relative
+ * to the newest id the saved order still knows about says which side it goes:
+ * ahead of it is genuinely newer (a session created since the last reconcile,
+ * which must not sink), behind it is an older page that just loaded. Hoisting
+ * every unknown id to the top treated those two cases the same, so one "load
+ * more" dropped 50 of the oldest sessions above the hand-ordered list.
+ */
+function mergeFreshByPosition(currentIds: string[], keptIds: string[]): string[] {
+  const kept = new Set(keptIds)
+  const firstKept = currentIds.findIndex(id => kept.has(id))
+  const newer: string[] = []
+  const older: string[] = []
+
+  currentIds.forEach((id, index) => {
+    if (kept.has(id)) {
+      return
+    }
+
+    if (firstKept >= 0 && index < firstKept) {
+      newer.push(id)
+    } else {
+      older.push(id)
+    }
+  })
+
+  return [...newer, ...keptIds, ...older]
+}
+
+/** Ids still present in the persisted order, with new ids folded in by position. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
   const current = new Set(currentIds)
-  const retained = orderIds.filter(id => current.has(id))
-  const retainedSet = new Set(retained)
 
-  return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
+  return mergeFreshByPosition(
+    currentIds,
+    orderIds.filter(id => current.has(id))
+  )
 }
 
 export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
@@ -22,7 +56,12 @@ export function resolveManualSessionOrderIds(currentIds: string[], orderIds: str
   return reconcileFreshFirst(currentIds, orderIds)
 }
 
-/** Reorder `items` by `orderIds`; items missing from the order surface first. */
+/**
+ * Reorder `items` by `orderIds`. Items missing from the order are folded in by
+ * position, same rule as {@link reconcileFreshFirst}: a brand-new session ahead
+ * of everything the order knows stays on top, an older page that just loaded
+ * sinks below the hand-picked list instead of jumping it.
+ */
 export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: string[]): T[] {
   if (!orderIds.length) {
     return items
@@ -41,17 +80,30 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
     }
   }
 
-  // Items missing from the persisted order are new since it was last
-  // reconciled. Callers pass recency-sorted lists (newest first), so surface
-  // these at the TOP instead of burying them beneath the saved order —
-  // otherwise a brand-new session sinks to the bottom of the sidebar and reads
-  // as "my latest session never showed up".
-  const fresh = items.filter(item => !seen.has(getId(item)))
+  if (seen.size === items.length) {
+    return ordered
+  }
 
-  return fresh.length ? [...fresh, ...ordered] : ordered
+  const firstOrdered = items.findIndex(item => seen.has(getId(item)))
+  const newer: T[] = []
+  const older: T[] = []
+
+  items.forEach((item, index) => {
+    if (seen.has(getId(item))) {
+      return
+    }
+
+    if (firstOrdered >= 0 && index < firstOrdered) {
+      newer.push(item)
+    } else {
+      older.push(item)
+    }
+  })
+
+  return [...newer, ...ordered, ...older]
 }
 
-/** Reconcile a persisted order against the live id set (fresh-first). */
+/** Reconcile a persisted order against the live id set. */
 export function reconcileOrderIds(currentIds: string[], orderIds: string[]): string[] {
   if (!currentIds.length) {
     return []
@@ -67,4 +119,88 @@ export function reconcileOrderIds(currentIds: string[], orderIds: string[]): str
 /** True when two id lists are element-for-element identical. */
 export function sameIds(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((item, index) => item === right[index])
+}
+
+/**
+ * Apply a hand-picked order WITHIN each chronological group, never across them.
+ *
+ * A drag used to switch the whole list into a frozen manual mode with no date
+ * dividers at all: one reorder and the sidebar stopped being chronological,
+ * permanently and for every row. Ranking and grouping are separate concerns —
+ * the calendar buckets stay exactly where recency put them, and the manual
+ * order only decides the sequence of rows inside a bucket.
+ *
+ * Rows are permuted as clusters (a parent plus the branch children nested under
+ * it) so a reorder can't strand a branch away from its parent, and clusters the
+ * saved order doesn't know about keep the slot recency gave them — only the
+ * ones it names are re-slotted, into the positions they already occupied.
+ */
+export function orderRowsWithinGroups(rows: SidebarListRow[], orderIds: string[]): SidebarListRow[] {
+  if (!orderIds.length || !rows.length) {
+    return rows
+  }
+
+  const rank = new Map(orderIds.map((id, index) => [id, index]))
+  const out: SidebarListRow[] = []
+  let cluster: SidebarListRow[][] = []
+  let reordered = false
+
+  // Re-slot the clusters the saved order names, leaving every other cluster
+  // (and every divider) exactly where it is.
+  const flushGroup = () => {
+    const ranked = cluster
+      .map((rows_, index) => ({ index, rank: rank.get(clusterId(rows_)) }))
+      .filter((entry): entry is { index: number; rank: number } => entry.rank !== undefined)
+
+    const slots = ranked.map(entry => entry.index)
+    const sorted = [...ranked].sort((a, b) => a.rank - b.rank)
+    const next = [...cluster]
+
+    slots.forEach((slot, i) => {
+      const source = cluster[sorted[i].index]
+
+      reordered ||= source !== next[slot]
+      next[slot] = source
+    })
+
+    for (const rows_ of next) {
+      out.push(...rows_)
+    }
+
+    cluster = []
+  }
+
+  for (const row of rows) {
+    if (row.kind === 'divider') {
+      flushGroup()
+      out.push(row)
+
+      continue
+    }
+
+    // A branch child rides with the parent cluster above it.
+    if (row.entry.branchStem && cluster.length) {
+      cluster[cluster.length - 1].push(row)
+
+      continue
+    }
+
+    cluster.push([row])
+  }
+
+  flushGroup()
+
+  return reordered ? out : rows
+}
+
+/** A cluster's identity: its root row's session id. */
+function clusterId(rows: SidebarListRow[]): string {
+  const root = rows[0]
+
+  return root.kind === 'session' ? root.entry.session.id : ''
+}
+
+/** The reorderable ids of a rendered row list: root sessions, in render order. */
+export function reorderableRowIds(rows: SidebarListRow[]): string[] {
+  return rows.flatMap(row => (row.kind === 'session' && !row.entry.branchStem ? [row.entry.session.id] : []))
 }

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
+import { orderRowsWithinGroups, reorderableRowIds } from './order'
 import {
   EnteredProjectContent,
   ProjectOverviewRow,
@@ -132,6 +133,11 @@ interface SidebarSessionsSectionProps {
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
+  // The persisted drag order, applied WITHIN each date group (see
+  // orderRowsWithinGroups). Chronology decides the groups; this decides the
+  // sequence inside one, so a reorder no longer costs the whole list its
+  // dividers. Pinned passes nothing — its rows arrive in pin order already.
+  manualOrderIds?: string[]
   // The flat session list is the only hand-reorderable surface (grouped/project
   // views sort deterministically), so it owns the one ReorderableList.
   onReorderSessions?: (ids: string[]) => void
@@ -185,6 +191,7 @@ export function SidebarSessionsSection({
   labelIcon,
   collapsible = true,
   sortable = false,
+  manualOrderIds,
   onReorderSessions,
   onReorderProjects,
   projectBackRow,
@@ -214,15 +221,12 @@ export function SidebarSessionsSection({
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
   const sessionsDraggable = sortable && !!onReorderSessions
-  // Pinned and manual-drag lists pass sessions already in the caller's order.
-  // Default recents stay dateGrouped and still re-sort roots by group recency
-  // so partition buckets stay truthful — but NEVER for pins, where a turn
-  // finishing was floating background tasks over the user's fixed ranking.
-  const preserveInputOrder = pinned || (sessionsDraggable && !dateGrouped)
-
+  // Only Pinned arrives pre-ordered as a flat sequence. Recents keeps its
+  // recency sort — the drag order is layered on per date group below, so the
+  // buckets stay truthful and a reorder never costs the list its dividers.
   const displayEntries = useMemo(
-    () => flattenSessionsWithBranches(sessions, { preserveOrder: preserveInputOrder }),
-    [sessions, preserveInputOrder]
+    () => flattenSessionsWithBranches(sessions, { preserveOrder: pinned }),
+    [sessions, pinned]
   )
 
   const renderRow = useCallback(
@@ -294,10 +298,20 @@ export function SidebarSessionsSection({
   )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
-  const flatRows: SidebarListRow[] = useMemo(
-    () => (dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)),
-    [dateGrouped, displayEntries]
-  )
+  // The hand-picked order is then applied INSIDE each date group, so dragging a
+  // row ranks it among its own day's chats instead of freezing the whole list
+  // into an undated manual mode.
+  const flatRows: SidebarListRow[] = useMemo(() => {
+    const rows = dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)
+
+    return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
+  }, [dateGrouped, displayEntries, manualOrderIds])
+
+  // dnd-kit must see exactly the ids it renders, in render order: the sortable
+  // set is derived from the rows, not from `sessions`. Feeding it the unrendered
+  // session order made a drop compute its target index against a list the user
+  // wasn't looking at — the drag that landed a row in the wrong slot.
+  const sortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
 
   const flatVirtualized =
     !showEmptyState &&
@@ -410,7 +424,7 @@ export function SidebarSessionsSection({
 
     inner =
       sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+        <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
           {virtual}
         </ReorderableList>
       ) : (
@@ -418,7 +432,7 @@ export function SidebarSessionsSection({
       )
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
-      <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+      <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
         {flatRows.map(row => renderListRow(row, true))}
       </ReorderableList>
     )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -313,7 +313,11 @@ export function SidebarSessionsSection({
   // wasn't looking at — the drag that landed a row in the wrong slot.
   const sortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
 
+  // Pinned never virtualizes. Virtualization needs a bounded viewport to
+  // measure against, and Pinned deliberately has none — however many chats you
+  // pin, all of them render and the sidebar's own scroll carries the length.
   const flatVirtualized =
+    !pinned &&
     !showEmptyState &&
     !groups?.length &&
     !projectOverview?.length &&

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -262,8 +262,12 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       ...mergeSessionPage(prev.filter(inKey), result.sessions, keep)
     ])
 
-    // A full window back means the profile still has more on disk.
-    const truncated = result.sessions.length >= loaded + SIDEBAR_SESSIONS_PAGE_SIZE
+    // A full window back means the profile still has more on disk — but pinned
+    // rows arrive as a back-fill PAST the limit, so counting them fakes a full
+    // page and the "Load more" never goes away (it re-fetches the same rows
+    // forever). Only unpinned rows count toward the window.
+    const unpinned = result.sessions.filter(s => !s.pinned).length
+    const truncated = unpinned >= loaded + SIDEBAR_SESSIONS_PAGE_SIZE
     setSessionProfilesTruncated(prev => ({ ...prev, [key]: truncated }))
   }, [])
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -370,6 +370,26 @@ export function pluginSocket(pluginId: string, path: string, onMessage: (data: u
   }
 }
 
+/**
+ * Trim a page to its window WITHOUT discarding pinned rows.
+ *
+ * The list endpoints deliberately back-fill pinned conversations past their
+ * LIMIT — a pin means "always reachable", so an aged-out pinned chat is
+ * appended after the recency window. A plain `slice(0, limit)` throws exactly
+ * those rows away again, which is why pins silently stopped rendering past
+ * some count: the sidebar could only ever show the pins that happened to fall
+ * inside the most-recent page.
+ */
+function pageWindow(sessions: SessionInfo[], limit: number): SessionInfo[] {
+  if (sessions.length <= limit) {
+    return sessions
+  }
+
+  const recent = sessions.slice(0, limit)
+
+  return [...recent, ...sessions.slice(limit).filter(session => session.pinned)]
+}
+
 export async function listSessions(
   limit = 40,
   minMessages = 0,
@@ -385,7 +405,7 @@ export async function listSessions(
 
   return {
     ...result,
-    sessions: result.sessions.slice(0, limit),
+    sessions: pageWindow(result.sessions, limit),
     offset: 0
   }
 }
@@ -426,7 +446,7 @@ export async function listAllProfileSessions(
 
   return {
     ...result,
-    sessions: result.sessions.slice(0, limit),
+    sessions: pageWindow(result.sessions, limit),
     offset: 0
   }
 }
@@ -445,14 +465,16 @@ export interface SidebarSessionSlice {
 
 /** Which profiles filled their per-profile window in a returned page. The
  *  legacy per-slice endpoint doesn't report this, so derive it from the rows:
- *  a profile at (or over) the cap still has more on disk. */
+ *  a profile at (or over) the cap still has more on disk. Pinned rows are
+ *  discounted — they're back-filled past the LIMIT, so counting them fakes a
+ *  full page and leaves a "Load more" that can never resolve. */
 function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<string, boolean> {
   const counts = new Map<string, number>()
 
   for (const session of sessions) {
     const key = session.profile || 'default'
 
-    counts.set(key, (counts.get(key) ?? 0) + 1)
+    counts.set(key, (counts.get(key) ?? 0) + (session.pinned ? 0 : 1))
   }
 
   return Object.fromEntries([...counts].map(([name, count]) => [name, count >= cap]))

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -20,6 +20,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import { resetSessionPinMirror } from '@/store/session-pin-sync'
 import { clearAllSessionStates } from '@/store/session-states'
 
 // True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
@@ -43,6 +44,10 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // The next backend is a different runtime — don't carry the old one's
   // "batched sidebar endpoint missing" capability verdict across the switch.
   resetSidebarBatchCapability()
+  // Pins are mirrored per-backend. The next gateway has its own state.db and
+  // has never seen them, so drop the "already pushed" bookkeeping and let the
+  // next reconcile re-assert the whole set against the new backend.
+  resetSessionPinMirror()
   setSessions([])
   setSessionProfilesTruncated({})
   setCronSessions([])

--- a/apps/desktop/src/store/layout-pinned-order.test.ts
+++ b/apps/desktop/src/store/layout-pinned-order.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { $pinnedSessionIds, setPinnedSessionOrder } from './layout'
+
+beforeEach(() => {
+  $pinnedSessionIds.set([])
+})
+
+describe('setPinnedSessionOrder', () => {
+  it('applies a full reorder', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    setPinnedSessionOrder(['c', 'b', 'a'])
+
+    expect($pinnedSessionIds.get()).toEqual(['c', 'b', 'a'])
+  })
+
+  it('reorders a subset in place, leaving unresolved pins alone', () => {
+    // The dragged list only contains pins whose session actually loaded. A pin
+    // whose row hasn't arrived is absent from the drag but must keep its slot
+    // — requiring the two lists to match length discarded the whole reorder.
+    $pinnedSessionIds.set(['loaded1', 'unresolved', 'loaded2'])
+    setPinnedSessionOrder(['loaded2', 'loaded1'])
+
+    expect($pinnedSessionIds.get()).toEqual(['loaded2', 'unresolved', 'loaded1'])
+  })
+
+  it('ignores ids that are not pinned', () => {
+    $pinnedSessionIds.set(['a', 'b'])
+    setPinnedSessionOrder(['b', 'stranger', 'a'])
+
+    expect($pinnedSessionIds.get()).toEqual(['b', 'a'])
+  })
+
+  it('is a no-op when the drag names nothing pinned', () => {
+    const before = ['a', 'b']
+    $pinnedSessionIds.set(before)
+    setPinnedSessionOrder(['ghost'])
+
+    expect($pinnedSessionIds.get()).toBe(before)
+  })
+
+  it('keeps the same array reference when the order is unchanged', () => {
+    const before = ['a', 'b']
+    $pinnedSessionIds.set(before)
+    setPinnedSessionOrder(['a', 'b'])
+
+    expect($pinnedSessionIds.get()).toBe(before)
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -414,17 +414,32 @@ export function unpinSession(sessionId: string) {
   )
 }
 
-// Replace the whole pinned order at once (drag-reorder hands back the new order
-// rather than a single move). Keep only ids that are actually pinned so a stale
-// row can't smuggle an unpinned id into the store.
+// Apply a new pinned order from a drag. The dragged list only holds the pins
+// that currently RESOLVE to a loaded row, so this is a permutation of a subset:
+// re-slot the ids it names into the positions they already occupied, leaving
+// any pin it doesn't mention (row not loaded yet) exactly where it was.
+// Requiring both lists to be the same length instead let one unresolved pin
+// silently discard the whole reorder.
 export function setPinnedSessionOrder(ids: string[]) {
   const prev = $pinnedSessionIds.get()
   const pinned = new Set(prev)
-  const next = ids.filter(id => pinned.has(id))
+  const moving = ids.filter(id => pinned.has(id))
 
-  if (next.length === prev.length && !arraysEqual(prev, next)) {
-    $pinnedSessionIds.set(next)
+  if (!moving.length) {
+    return
   }
+
+  const movingSet = new Set(moving)
+  const next = [...prev]
+  let cursor = 0
+
+  prev.forEach((id, index) => {
+    if (movingSet.has(id)) {
+      next[index] = moving[cursor++]
+    }
+  })
+
+  setOrderIds($pinnedSessionIds, next)
 }
 
 export function bumpSessionsLimit(step: number = SIDEBAR_SESSIONS_PAGE_SIZE) {

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
-import { watchSessionPins } from './session-pin-sync'
+import { resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -30,6 +30,10 @@ beforeAll(() => {
 beforeEach(() => {
   $sessions.set([])
   $pinnedSessionIds.set([])
+  // The mirror/pending/unconfirmed maps are module-global, so one test's
+  // bookkeeping would otherwise suppress the next test's PATCH (or fence out
+  // its page). Same reset the gateway switch uses.
+  resetSessionPinMirror()
   patch.mockClear()
 })
 
@@ -198,14 +202,89 @@ describe('watchSessionPins remote pull', () => {
 
     expect($pinnedSessionIds.get()).toContain('race')
 
-    // Once the write is acked, later server truth is honoured again.
     settle({ ok: true })
     await flush()
     await flush()
 
-    $sessions.set([row('race', { pinned: false }), row('other')])
+    expect($pinnedSessionIds.get()).toContain('race')
+  })
+
+  it('still ignores a pre-write page that lands AFTER the ack (#76919)', async () => {
+    // The ack is not proof: a list request issued before the PATCH is slower
+    // than the PATCH itself, so it can arrive afterwards still carrying the
+    // old value. Reverting on it un-pins the session AND pushes the wrong
+    // value back to the server, making the mistake durable.
+    $sessions.set([row('acked')])
+    $pinnedSessionIds.set(['acked'])
+    await flush()
+    await flush()
+    expect(patch).toHaveBeenCalledWith('acked', true, undefined)
+    patch.mockClear()
+
+    // Post-ack, but this page predates the write.
+    $sessions.set([row('acked', { pinned: false })])
     await flush()
 
-    expect($pinnedSessionIds.get()).not.toContain('race')
+    expect($pinnedSessionIds.get()).toContain('acked')
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('releases the guard once a page confirms the written value', async () => {
+    $sessions.set([row('confirmed')])
+    $pinnedSessionIds.set(['confirmed'])
+    await flush()
+    await flush()
+
+    // The server catches up and echoes our value back.
+    $sessions.set([row('confirmed', { pinned: true })])
+    await flush()
+    patch.mockClear()
+
+    // With the write confirmed, a genuine remote unpin is authoritative again.
+    $sessions.set([row('confirmed', { pinned: false })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('confirmed')
+  })
+
+  it('stops fencing once the guard cooldown expires', async () => {
+    vi.useFakeTimers()
+
+    try {
+      $sessions.set([row('stale')])
+      $pinnedSessionIds.set(['stale'])
+      await flush()
+      await flush()
+
+      // No page ever confirms the write. The guard must not fence forever —
+      // after the cooldown the server's answer wins again.
+      vi.advanceTimersByTime(11_000)
+
+      $sessions.set([row('stale', { pinned: false })])
+      await flush()
+
+      expect($pinnedSessionIds.get()).not.toContain('stale')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the pin and retries when the write itself fails', async () => {
+    patch.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+
+    $sessions.set([row('failed')])
+    $pinnedSessionIds.set(['failed'])
+    await flush()
+    await flush()
+    patch.mockClear()
+
+    // The PATCH never landed, so the server legitimately still says unpinned —
+    // but that's OUR undelivered intent, not a remote decision. The pin stays
+    // and the next reconcile retries it rather than silently dropping it.
+    $sessions.set([row('failed', { pinned: false })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('failed')
+    expect(patch).toHaveBeenCalledWith('failed', true, undefined)
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -17,7 +17,8 @@
  * authoritative: adopt pins this app hasn't seen, and drop local pins the
  * server says are gone. Only rows actually present in the payload are
  * consulted, so a backend predating the flag (`pinned === undefined`) leaves
- * the local set untouched.
+ * the local set untouched — and a page that predates one of our own writes is
+ * fenced out until a later page confirms the value we wrote.
  */
 
 import { setSessionPinnedRemote } from '@/hermes'
@@ -28,11 +29,17 @@ import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
-// Writes we've issued but not yet had acked, id -> value written. A list page
-// already in flight when we PATCH still carries the old value, so it must not
-// be read as the server disagreeing with us. Cleared when the write settles —
-// the request's own lifetime is the guard, so nothing can leave one open.
-const unconfirmed = new Map<string, boolean>()
+// Writes we've issued, id -> the value we wrote and when. A list page already
+// in flight when we PATCH still carries the OLD value, and it can land after
+// our ack — so the ack is not proof the page we're reading is newer than the
+// write. Hold the guard until a page actually CONFIRMS the written value,
+// with a cooldown so a row that never comes back can't fence itself forever.
+const unconfirmed = new Map<string, { at: number; value: boolean }>()
+
+// How long an unconfirmed write outranks a page that contradicts it. Long
+// enough to cover a list request issued just before the PATCH (those are the
+// slow ones), short enough that a genuine server-side change still wins.
+const WRITE_GUARD_MS = 10_000
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
@@ -40,13 +47,18 @@ function profileFor(pinId: string): null | string | undefined {
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
-  unconfirmed.set(id, pinned)
+  unconfirmed.set(id, { at: Date.now(), value: pinned })
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
-      unconfirmed.delete(id)
+      // Deliberately NOT cleared here: a list request issued before this PATCH
+      // can still land after the ack carrying the pre-write value. The guard
+      // is released by pullRemotePins when a page confirms the written value,
+      // or by the cooldown if none ever does.
     },
     (err: unknown) => {
+      // A failed write leaves the server on the old value, so the guard would
+      // be fencing out the truth. Drop it and let the page win.
       unconfirmed.delete(id)
       throw err
     }
@@ -76,11 +88,22 @@ function pullRemotePins(): void {
     const pinId = sessionPinId(row)
     const heldLocally = local.has(pinId) || local.has(row.id)
 
-    // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
+    // A write of ours this page may predate. Confirmed (page agrees) → release
+    // the guard, the server has caught up. Contradicted but still inside the
+    // cooldown → the page was almost certainly issued before our PATCH, so our
+    // write is newer: skip the row. Contradicted past the cooldown → no page
+    // ever confirmed us, so stop fencing and let the server win.
+    const guardKey = unconfirmed.has(pinId) ? pinId : unconfirmed.has(row.id) ? row.id : null
+    const guard = guardKey ? unconfirmed.get(guardKey) : undefined
 
-    if (awaited !== undefined && awaited !== row.pinned) {
-      continue
+    if (guard && guardKey) {
+      if (guard.value === row.pinned) {
+        unconfirmed.delete(guardKey)
+      } else if (Date.now() - guard.at < WRITE_GUARD_MS) {
+        continue
+      } else {
+        unconfirmed.delete(guardKey)
+      }
     }
 
     // Local intent still waiting on its PATCH (row unresolved when the push
@@ -159,4 +182,21 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+}
+
+/**
+ * Forget what we've mirrored, because the backend we mirrored it TO is gone.
+ *
+ * `mirrored` / `pending` / `unconfirmed` all mean "relative to the gateway we
+ * are talking to". After a soft switch the next backend has its own state.db
+ * and has never seen these pins, but `mirrored` would report them as already
+ * pushed and suppress the PATCHes — so the user's pins silently fail to reach
+ * the new gateway (and its auto-archive sweep is free to hide them). Dropping
+ * the bookkeeping makes the next reconcile re-assert the whole set, which is
+ * the same path that migrates pre-existing pins at boot.
+ */
+export function resetSessionPinMirror(): void {
+  mirrored.clear()
+  pending.clear()
+  unconfirmed.clear()
 }

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3205,9 +3205,13 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "_lineage_root_id", "pinned", "archived",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
+        # SQLite stores these as 0/1; clients reconcile against a real boolean.
+        for flag in ("pinned", "archived"):
+            if flag in payload:
+                payload[flag] = bool(payload[flag])
         # Avoid exposing full system prompts/model_config through the client API;
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
@@ -3417,10 +3421,18 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        # `pinned` and `archived` are durable per-session flags the desktop
+        # sidebar owns (the "keep" flag exempts a chat from the auto-archive
+        # sweep). Rejecting them here was silently 400ing every pin the desktop
+        # made, so pins only ever lived in that one app's localStorage.
+        allowed = {"title", "end_reason", "pinned", "archived"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
+
+        for flag in ("pinned", "archived"):
+            if flag in body and not isinstance(body[flag], bool):
+                return web.json_response(_openai_error(f"'{flag}' must be a boolean", code="invalid_session_field"), status=400)
 
         db = await self._ensure_session_db_async()
         if "title" in body:
@@ -3428,6 +3440,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 await asyncio.to_thread(db.set_session_title, session_id, "" if body["title"] is None else str(body["title"]))
             except ValueError as exc:
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
+        if "pinned" in body:
+            await asyncio.to_thread(db.set_session_pinned, session_id, body["pinned"])
+        if "archived" in body:
+            await asyncio.to_thread(db.set_session_archived, session_id, body["archived"])
         if body.get("end_reason"):
             await asyncio.to_thread(db.end_session, session_id, str(body["end_reason"]))
         session = await asyncio.to_thread(db.get_session, session_id) or session

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3279,13 +3279,19 @@ class APIServerAdapter(BasePlatformAdapter):
             offset=offset,
             include_children=include_children,
             order_by_last_active=True,
+            # A pin means "always reachable", so a pinned conversation that has
+            # aged past the recency window is back-filled rather than dropped.
+            include_pinned=True,
         )
+        # Back-filled pins arrive PAST the limit, so counting them would report
+        # another page that doesn't exist. Only the recency window decides.
+        windowed = sum(1 for s in sessions if not s.get("pinned"))
         return web.json_response({
             "object": "list",
             "data": [self._session_response(s) for s in sessions],
             "limit": limit,
             "offset": offset,
-            "has_more": len(sessions) == limit,
+            "has_more": windowed >= limit,
         })
 
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -608,3 +608,56 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
     mock_run.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_patch_session_persists_pinned_and_archived(adapter, session_db):
+    """PATCH must accept the durable pin/archive flags and round-trip them.
+
+    These were rejected as unsupported fields, so every pin the desktop made
+    400'd silently (the client swallows the error) and the pin only ever lived
+    in that one app's localStorage. The auto-archive sweep reads
+    `sessions.pinned` server-side, so an unpersisted pin does not protect the
+    chat it was supposed to keep.
+    """
+    session_id = session_db.create_session("pin-session", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"pinned": True})
+        assert resp.status == 200, await resp.text()
+        assert (await resp.json())["session"]["pinned"] is True
+
+        # The flag is durable, not just echoed back from the request body.
+        assert bool(session_db.get_session(session_id)["pinned"]) is True
+
+        resp = await cli.get(f"/api/sessions/{session_id}")
+        assert (await resp.json())["session"]["pinned"] is True
+
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"pinned": False})
+        assert (await resp.json())["session"]["pinned"] is False
+        assert bool(session_db.get_session(session_id)["pinned"]) is False
+
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"archived": True})
+        assert (await resp.json())["session"]["archived"] is True
+        assert bool(session_db.get_session(session_id)["archived"]) is True
+
+
+@pytest.mark.asyncio
+async def test_patch_session_rejects_non_boolean_pinned(adapter, session_db):
+    session_id = session_db.create_session("pin-type-session", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"pinned": "yes"})
+        assert resp.status == 400, await resp.text()
+        assert (await resp.json())["error"]["code"] == "invalid_session_field"
+
+
+@pytest.mark.asyncio
+async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
+    session_id = session_db.create_session("unknown-field-session", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
+        assert resp.status == 400, await resp.text()
+        assert (await resp.json())["error"]["code"] == "unsupported_session_field"


### PR DESCRIPTION
## Summary

The sidebar's pin and manual-order handling had drifted into a set of separate bugs that all read as "the sidebar rearranged itself, and my pins won't stay." This fixes the logic behind them rather than each symptom.

**Pins never actually persisted.** `PATCH /api/sessions/{id}` accepted only `title` and `end_reason`, so the `pinned` field the desktop sends came back 400 — and the client swallows that error. Every pin lived in one app's localStorage, never reached `state.db`, and the server-side auto-archive sweep was free to hide the chats a pin exists to keep. The `SessionDB` setters were already there; nothing called them.

**There was an effective limit on pins, in two places.** The list endpoints deliberately back-fill pinned conversations past their `LIMIT`, and the client then sliced the response back down to that same limit — discarding exactly the rows the back-fill went and fetched. On top of that the Pinned section was capped at half the viewport by its own nested scroller, so past roughly a dozen pins the rest were reachable only by scrolling inside a scroller. Both are gone: pin as many sessions as you want and every one of them renders, with no count badge, no "show more", and no special treatment. Verified against a 200-session database with 60 pins deliberately chosen as the *oldest* rows and a page size of 10 — all 60 come back.

**Pins showed up twice.** A pin is keyed on the durable lineage root, but recents, the messaging slice and the backend project tree are three independent fetches, and each can surface the same conversation under either its live tip or its root. The filter compared one identity against the other, missed, and the session rendered in both Pinned and its project group.

**Manual sorting broke chronological grouping.** Dragging a single row switched the whole sidebar into a frozen manual mode with no date dividers at all — permanently, for every session — because the hand-picked order replaced the recency sort instead of layering on it. Grouping and ranking are separate concerns now: the calendar buckets stay where recency put them, and the drag order only decides sequence within a bucket. Rows move as clusters so a branch child can't be stranded from its parent, and dnd-kit finally receives the ids it actually renders (it had been handed the unrendered session order, so a drop computed its target index against a list the user wasn't looking at).

**A pin/unpin could still revert itself.** The guard protecting a fresh toggle was released on the PATCH's own ack, but a list request issued just before the write outlives it — landing after the ack with the old value and no guard left. The pin flipped back, and the next reconcile pushed that wrong value to the server, making it durable. The guard now holds until a page confirms the written value, with a cooldown so a row that never returns can't fence itself forever.

Closes #75468, #80013, #76919, #44009, #51685.

## Test plan

- [x] `pytest tests/gateway/test_session_api.py` — 15 passing, including pin/archive round-trip through real HTTP against a real SQLite DB
- [x] `vitest run` on the touched surface — 63 passing, covering subset reorder, the post-ack revert window, guard cooldown/confirmation, and within-group ranking
- [x] 200 sessions / 60 old pins / page size 10 against a real `state.db`: all 60 pins returned, none lost to the window or the client trim
- [x] `tsc --noEmit` clean
- [ ] Pin ~30 sessions; confirm all render with no inner scrollbar and survive a restart
- [ ] Drag a session in Recents; confirm the date dividers stay and the row ranks within its own day
- [ ] Pin a session inside a project; confirm it appears in Pinned only, not twice
