### PR TITLE
fix(desktop): guard only the last chat window on close

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,7 +159,7 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
-import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor, shouldGuardWindowClose } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -8773,6 +8773,8 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
   })
 
+  registerChatWindow(win)
+
   if (IS_MAC) {
     win.setWindowButtonPosition?.(WINDOW_BUTTON_POSITION)
   }
@@ -8853,6 +8855,7 @@ function createInstanceWindow() {
     webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
   })
 
+  registerChatWindow(win)
   instanceWindows.add(win)
 
   if (IS_MAC) {
@@ -9272,6 +9275,8 @@ function createWindow() {
     webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
   })
 
+  registerChatWindow(mainWindow)
+
   if (IS_MAC) {
     mainWindow.setWindowButtonPosition?.(WINDOW_BUTTON_POSITION)
 
@@ -9347,6 +9352,9 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
+  // Persist geometry on close. The quit guard is installed centrally by
+  // registerChatWindow so primary, session, and instance windows share the
+  // same last-chat-window behavior.
   mainWindow.on('close', () => schedulePersistWindowState.flush())
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
@@ -10583,6 +10591,18 @@ ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWat
 // Each renderer reports the turns it has in flight; the quit guard reads the
 // merged picture. Keyed by webContents id so a closed window stops counting.
 const activeWorkByWebContents = new Map<number, ActiveWork>()
+
+const chatWindows = new Set<any>()
+
+function registerChatWindow(window: any) {
+  chatWindows.add(window)
+  window.on('close', (event: Electron.Event) => heldCloseForActiveWork(event, window))
+  window.once('closed', () => chatWindows.delete(window))
+}
+
+function hasOtherChatWindows(window: any): boolean {
+  return [...chatWindows].some(candidate => candidate !== window && !candidate.isDestroyed())
+}
 
 // The same merged picture drives background throttling: chat windows run
 // unthrottled while any turn is in flight (streaming must paint while hidden)
@@ -11945,6 +11965,53 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
     })
     .catch(() => {
       // A dialog we can't show must not become a quit we can't perform.
+      quitPromptOpen = false
+      quitConfirmedWithActiveWork = true
+      app.quit()
+    })
+
+  return true
+}
+
+function heldCloseForActiveWork(event: Electron.Event, window: BrowserWindow): boolean {
+  const work = mergeActiveWork(activeWorkByWebContents.values())
+
+  if (
+    !shouldGuardWindowClose(work, isQuittingForHandoff, IS_MAC, hasOtherChatWindows(window)) ||
+    SKIP_QUIT_CONFIRM ||
+    quitConfirmedWithActiveWork ||
+    quitPromptOpen
+  ) {
+    return false
+  }
+
+  const prompt = quitPromptFor(work, isQuittingForHandoff)
+
+  if (!prompt) {
+    return false
+  }
+
+  event.preventDefault()
+  quitPromptOpen = true
+
+  void dialog
+    .showMessageBox(window, {
+      buttons: ['Keep Running', 'Quit Anyway'],
+      cancelId: 0,
+      defaultId: 0,
+      detail: prompt.detail,
+      message: prompt.message,
+      type: 'question'
+    })
+    .then(({ response }) => {
+      quitPromptOpen = false
+
+      if (response === 1) {
+        quitConfirmedWithActiveWork = true
+        app.quit()
+      }
+    })
+    .catch(() => {
       quitPromptOpen = false
       quitConfirmedWithActiveWork = true
       app.quit()

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { mergeActiveWork, normalizeActiveWork, quitPromptFor, shouldGuardWindowClose } from './quit-guard'
 
 test('normalizeActiveWork drops junk and keeps the count at least the title count', () => {
   assert.deepEqual(normalizeActiveWork(null), { count: 0, titles: [] })
@@ -59,4 +59,29 @@ test('quitPromptFor speaks singular for one chat', () => {
   assert.ok(prompt)
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
   assert.ok(prompt.detail.includes('mid-turn'))
+})
+
+// -- shouldGuardWindowClose -------------------------------------------------
+
+test('shouldGuardWindowClose returns true for active work on Windows/Linux', () => {
+  assert.equal(shouldGuardWindowClose({ count: 1, titles: ['Fix login'] }, false, false, false), true)
+  assert.equal(shouldGuardWindowClose({ count: 3, titles: ['a', 'b', 'c'] }, false, false, false), true)
+})
+
+test('shouldGuardWindowClose returns false when no work is active', () => {
+  assert.equal(shouldGuardWindowClose({ count: 0, titles: [] }, false, false, false), false)
+})
+
+test('shouldGuardWindowClose returns false on macOS', () => {
+  // macOS closing the primary window is a "stay in Dock" gesture, not a quit.
+  assert.equal(shouldGuardWindowClose({ count: 2, titles: ['Fix login'] }, false, true, false), false)
+})
+
+test('shouldGuardWindowClose returns false during a handoff', () => {
+  // Update / swap / uninstall relaunch: the app is replacing itself.
+  assert.equal(shouldGuardWindowClose({ count: 2, titles: ['Fix login'] }, true, false, false), false)
+})
+
+test('shouldGuardWindowClose returns false when another chat window remains open', () => {
+  assert.equal(shouldGuardWindowClose({ count: 1, titles: ['Fix login'] }, false, false, true), false)
 })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -90,3 +90,31 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
     message: work.count === 1 ? 'Hermes is still working on 1 chat.' : `Hermes is still working on ${work.count} chats.`
   }
 }
+
+/**
+ * Whether a window's 'close' event should be intercepted to show the
+ * active-work confirmation.
+ *
+ * On Windows and Linux, closing the last window triggers app.quit() →
+ * before-quit, but by then the renderer's webContents is already destroyed
+ * and its entry has been removed from the active-work map — so the existing
+ * before-quit guard finds nothing and the app exits silently. Intercepting
+ * 'close' instead catches the guard while the work data is still live.
+ *
+ * macOS is excluded: closing the primary window there is the standard
+ * "window stays in Dock" gesture, not a quit, and prompting on it would
+ * block a normal workflow. Chat windows other than the final one are also
+ * excluded because closing them does not stop the application or its work.
+ */
+export function shouldGuardWindowClose(
+  work: ActiveWork,
+  quittingForHandoff: boolean,
+  isMac: boolean,
+  hasOtherChatWindows: boolean
+): boolean {
+  if (isMac || quittingForHandoff || hasOtherChatWindows || work.count < 1) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## What does this PR do?

Adds a close confirmation when the final Hermes Desktop chat window is closed while a conversation is mid-turn.

Closing a secondary/session/instance window while another chat window remains open closes immediately. Closing the final real chat window now warns before interrupting active work. The guard runs during the native `close` event, before the renderer and its active-work report are destroyed.

## Related Issue

No linked issue. This addresses the reported desktop bug where closing during an active conversation gives no warning.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.ts`
  - Registers the primary, standalone session, and full instance windows as chat windows.
  - Guards only the final real chat window; helper windows are excluded.
- `apps/desktop/electron/quit-guard.ts`
  - Adds the pure `shouldGuardWindowClose()` decision function.
- `apps/desktop/electron/quit-guard.test.ts`
  - Covers active work, no work, macOS, handoff, and additional chat windows.

## How to Test

Automated checks run on Windows:

```bash
cd apps/desktop
npx tsc -p tsconfig.electron.json --noEmit
npx eslint electron/main.ts electron/quit-guard.ts electron/quit-guard.test.ts --max-warnings 0
npx vitest run --project electron electron/quit-guard.test.ts electron/session-windows.test.ts
```

Results:

- TypeScript: passed.
- Changed-file ESLint: passed.
- Focused Electron tests: 29/29 passed.

Manual Windows verification completed:

- Closing a non-final chat window during an active turn closes without a prompt.
- Closing the final chat window during an active turn shows the confirmation.
- **Keep Running** preserves the window and conversation.
- **Quit Anyway** exits the application.

The full Python suite was also attempted with `pytest`, but did not pass and timed out after 600 seconds on this Windows environment. This PR changes only the Electron/TypeScript desktop app.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for existing PRs to make sure this isn't a duplicate — related PRs were found, including #73046, #80226, and #73312; maintainers should compare and consolidate as appropriate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — attempted, but the full Python suite did not pass and timed out; the relevant Electron checks are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation — added explanatory comments/docstrings; no user-facing documentation change is needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot is included. Manual Windows verification was completed, and the automated results are listed above.

## Review Note

This PR overlaps with #73046 on the Windows/Linux final-window problem. Its additional scope is multi-window ownership: it registers all real chat windows, excludes helper windows, and guards the final real chat window rather than counting all Electron windows. Maintainers should compare and consolidate this work with the related PRs.
