### PR TITLE
fix(tools): return zero-match probe paths

### DIFF
--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -26,6 +27,10 @@ class TestZeroMatchProbe:
         r = json.loads(search_tool("token_alpha", path=str(proj / "proj"), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "case-insensitive" in r.get("warning", "")
+        assert {
+            Path(match["path"]).name: match["count"]
+            for match in r["case_insensitive_matches"]
+        } == {"a.py": 1, "b.py": 1}
 
     def test_regex_metachar_literal_hint(self, proj):
         d = proj / "proj"
@@ -33,6 +38,10 @@ class TestZeroMatchProbe:
         r = json.loads(search_tool("lookup[key+1]", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "literal match" in r.get("warning", "")
+        assert [
+            {"path": Path(match["path"]).name, "count": match["count"]}
+            for match in r["literal_matches"]
+        ] == [{"path": "meta.py", "count": 1}]
 
     def test_true_zero_match_no_hint(self, proj):
         r = json.loads(search_tool("zzz_totally_absent_zzz", path=str(proj / "proj"), task_id="t-zm"))
@@ -46,6 +55,18 @@ class TestZeroMatchProbe:
         r = json.loads(search_tool("HIDDEN_ONLY_TOKEN", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "hidden or gitignored" in r.get("warning", "")
+        assert [
+            {"path": Path(match["path"]).name, "count": match["count"]}
+            for match in r["hidden_matches"]
+        ] == [{"path": "conf.cfg", "count": 1}]
+
+    def test_probe_paths_respect_read_block(self, proj):
+        d = proj / "proj"
+        (d / ".env").write_text("HIDDEN_SECRET_TOKEN=value\n", encoding="utf-8")
+        r = json.loads(search_tool("HIDDEN_SECRET_TOKEN", path=str(d), task_id="t-zm"))
+        assert r["total_count"] == 0
+        assert "hidden_matches" not in r
+        assert "1 result(s) omitted" in r.get("_omitted", "")
 
     def test_matching_search_unaffected(self, proj):
         r = json.loads(search_tool("TOKEN_ALPHA", path=str(proj / "proj"), task_id="t-zm"))
@@ -129,7 +150,11 @@ class TestZeroMatchProbeEngineParity:
             return _real(cmd)
 
         monkeypatch.setattr(ops, "_has_command", only)
-        monkeypatch.setattr(ops, "_zero_match_probe", lambda *a, **k: "SENTINEL_HINT")
+        monkeypatch.setattr(
+            ops,
+            "_zero_match_probe",
+            lambda *a, **k: ("SENTINEL_HINT", "case_insensitive_matches", []),
+        )
         r = ops.search("token_alpha", path=str(proj / "proj"), target="content")
         assert r.total_count == 0
         assert "SENTINEL_HINT" in (r.warning or ""), (
@@ -140,7 +165,11 @@ class TestZeroMatchProbeEngineParity:
         from tools.file_tools import _get_file_ops
 
         ops = _get_file_ops(task_id="t-parity-hit")
-        monkeypatch.setattr(ops, "_zero_match_probe", lambda *a, **k: "SENTINEL_HINT")
+        monkeypatch.setattr(
+            ops,
+            "_zero_match_probe",
+            lambda *a, **k: ("SENTINEL_HINT", "case_insensitive_matches", []),
+        )
         r = ops.search("TOKEN_ALPHA", path=str(proj / "proj"), target="content")
         assert r.total_count > 0
         assert "SENTINEL_HINT" not in (r.warning or "")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -253,6 +253,13 @@ class SearchMatch:
 
 
 @dataclass
+class SearchProbeMatch:
+    """A path and match count found by a zero-match recovery probe."""
+    path: str
+    count: int
+
+
+@dataclass
 class SearchResult:
     """Result from searching."""
     matches: List[SearchMatch] = field(default_factory=list)
@@ -262,6 +269,9 @@ class SearchResult:
     truncated: bool = False
     limit_reason: Optional[str] = None
     warning: Optional[str] = None
+    case_insensitive_matches: List[SearchProbeMatch] = field(default_factory=list)
+    hidden_matches: List[SearchProbeMatch] = field(default_factory=list)
+    literal_matches: List[SearchProbeMatch] = field(default_factory=list)
     error: Optional[str] = None
     
     # Densify content-mode matches into a path-grouped text block above this
@@ -324,6 +334,17 @@ class SearchResult:
             result["limit_reason"] = self.limit_reason
         if self.warning:
             result["warning"] = self.warning
+        for field_name in (
+            "case_insensitive_matches",
+            "hidden_matches",
+            "literal_matches",
+        ):
+            probe_matches = getattr(self, field_name)
+            if probe_matches:
+                result[field_name] = [
+                    {"path": match.path, "count": match.count}
+                    for match in probe_matches
+                ]
         if self.error:
             result["error"] = self.error
         return result
@@ -2683,9 +2704,23 @@ class ShellFileOperations(FileOperations):
         merged.warning = note
         return merged
 
-    def _zero_match_probe(self, pattern: str, path: str,
-                          file_glob: Optional[str]) -> Optional[str]:
-        """Return a hint for a 0-match content search, or None.
+    @staticmethod
+    def _parse_probe_matches(output: str) -> List[SearchProbeMatch]:
+        """Parse bounded ``rg --count-matches`` output without losing drive colons."""
+        matches = []
+        for line in output.strip().splitlines():
+            match_path, separator, count = line.rpartition(":")
+            if separator and match_path and count.isdigit():
+                matches.append(SearchProbeMatch(path=match_path, count=int(count)))
+        return matches
+
+    def _zero_match_probe(
+        self,
+        pattern: str,
+        path: str,
+        file_glob: Optional[str],
+    ) -> Optional[tuple[str, str, List[SearchProbeMatch]]]:
+        """Return a warning, result field, and paths for a 0-match search.
 
         13.9% of production content searches return zero matches and give
         the model nothing to steer by. Run ONE cheap case-insensitive count
@@ -2702,17 +2737,16 @@ class ShellFileOperations(FileOperations):
             f"2>/dev/null | head -50",
             timeout=30,
         )
-        ci_total = 0
-        ci_files = 0
-        for line in (probe.stdout or "").strip().splitlines():
-            _p, _sep, n = line.rpartition(":")
-            if n.isdigit():
-                ci_total += int(n)
-                ci_files += 1
+        ci_matches = self._parse_probe_matches(probe.stdout or "")
+        ci_total = sum(match.count for match in ci_matches)
         if ci_total > 0:
             return (
-                f"0 exact matches, but {ci_total} case-insensitive match(es) "
-                f"in {ci_files} file(s) — the pattern's casing may be wrong."
+                (
+                    f"0 exact matches, but {ci_total} case-insensitive match(es) "
+                    f"in {len(ci_matches)} file(s) — the pattern's casing may be wrong."
+                ),
+                "case_insensitive_matches",
+                ci_matches,
             )
         # Hidden/ignored probe: rg skips dotdirs and .gitignore'd files by
         # default. When the pattern exists only there, say so instead of
@@ -2724,18 +2758,17 @@ class ShellFileOperations(FileOperations):
             f"2>/dev/null | head -50",
             timeout=30,
         )
-        h_total = 0
-        h_files = 0
-        for line in (hidden.stdout or "").strip().splitlines():
-            _p, _sep, n = line.rpartition(":")
-            if n.isdigit():
-                h_total += int(n)
-                h_files += 1
+        hidden_matches = self._parse_probe_matches(hidden.stdout or "")
+        h_total = sum(match.count for match in hidden_matches)
         if h_total > 0:
             return (
-                f"0 matches in visible files, but {h_total} match(es) in "
-                f"{h_files} hidden or gitignored file(s) — these are excluded "
-                "by default. Search the hidden path explicitly to include them."
+                (
+                    f"0 matches in visible files, but {h_total} match(es) in "
+                    f"{len(hidden_matches)} hidden or gitignored file(s) — these are "
+                    "excluded by default. Search the hidden path explicitly to include them."
+                ),
+                "hidden_matches",
+                hidden_matches,
             )
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
@@ -2744,16 +2777,17 @@ class ShellFileOperations(FileOperations):
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
-            f_total = sum(
-                int(line.rpartition(":")[2])
-                for line in (fixed.stdout or "").strip().splitlines()
-                if line.rpartition(":")[2].isdigit()
-            )
+            literal_matches = self._parse_probe_matches(fixed.stdout or "")
+            f_total = sum(match.count for match in literal_matches)
             if f_total > 0:
                 return (
-                    f"0 regex matches, but {f_total} literal match(es) — the "
-                    "pattern contains regex metacharacters that likely need "
-                    "escaping (or pass a simpler substring)."
+                    (
+                        f"0 regex matches, but {f_total} literal match(es) — the "
+                        "pattern contains regex metacharacters that likely need "
+                        "escaping (or pass a simpler substring)."
+                    ),
+                    "literal_matches",
+                    literal_matches,
                 )
         return None
 
@@ -2915,11 +2949,13 @@ class ShellFileOperations(FileOperations):
         if (not result.error and result.total_count == 0
                 and not result.matches and not result.files and not result.counts):
             try:
-                hint = self._zero_match_probe(pattern, path, file_glob)
+                probe_result = self._zero_match_probe(pattern, path, file_glob)
             except Exception:
-                hint = None
-            if hint:
+                probe_result = None
+            if probe_result:
+                hint, field_name, probe_matches = probe_result
                 result.warning = hint if not result.warning else f"{result.warning} {hint}"
+                setattr(result, field_name, probe_matches)
 
         # rg auto-enables --multiline for \n patterns, so the line-oriented
         # explanation only applies to the grep fallback engine.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -635,6 +635,22 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
             allowed_counts[file_path] = count
         result.counts = allowed_counts
 
+    for field_name in (
+        "case_insensitive_matches",
+        "hidden_matches",
+        "literal_matches",
+    ):
+        probe_matches = getattr(result, field_name, None)
+        if not probe_matches:
+            continue
+        allowed_probe_matches = []
+        for match in probe_matches:
+            if _search_result_read_block_error(match.path, task_id):
+                omitted += 1
+                continue
+            allowed_probe_matches.append(match)
+        setattr(result, field_name, allowed_probe_matches)
+
     return omitted
 
 


### PR DESCRIPTION
## What / Why

A zero-result content search already runs bounded recovery probes, but those probes reduce ripgrep per-file counts to warning text and discard the paths. The model therefore learns that differently-cased, hidden/ignored, or literal matches exist without receiving an actionable location.

This change preserves the bounded path/count rows in structured result fields while keeping the primary exact-search result at `total_count=0`.

Fixes #80522

## Product impact path

User/model invokes the supported core `search_files` tool -> `tools.file_tools.search_tool` -> `ShellFileOperations.search` -> `_search_content` -> `_zero_match_probe` -> `SearchResult.to_dict(densify=True)` -> tool JSON returned to the model.

On the base commit, searching for `token_alpha` against files containing `TOKEN_ALPHA` reports two case-insensitive matches but omits both paths. On this head, the same public entry returns `case_insensitive_matches` with each path and count. Hidden/ignored and literal recovery probes receive equivalent structured fields.

## Root cause and scope

`_zero_match_probe` parsed every ripgrep `path:count` row, summed the counts, and discarded the path variable before returning a warning string. The fix introduces a small `SearchProbeMatch` value, parses those already-bounded rows once, attaches the relevant structured field, serializes it, and applies the existing credential/read-block filter before model delivery.

The existing `head -50` bound remains in place. No additional searches are introduced.

## Commit evidence

- Base: `c0106e50e7ecedb3ce34e785d949725dc4e0e457` (`upstream/main` fetched immediately before rebase)
- Head: `51cffe422bacc3c71ba3719b8c040fbbfea1a302`
- History: one commit whose sole parent is the stated base
- `git range-diff` reports the pre-rebase `a24988f6` patch and this head as equivalent

## Main / head / mutation proof

Canonical command:

```text
scripts/run_tests.sh tests/tools/test_search_zero_match_and_multipath.py -q
```

- Exact base production files plus the new tests: **4 failed, 12 passed**. The case-insensitive, literal, and hidden fields were absent, and the `.env` probe path never reached the read-block omission path.
- PR head: **16 passed**.
- Mutation proof: after temporarily removing only the production `setattr` that attaches probe matches, while leaving warnings and search commands intact, **4 failed, 12 passed** for the same four contracts.
- Restoring that line returned the suite to **16 passed**. The final tree was verified identical to the rebased head.

The base production-file state was checked with:

```text
git diff --exit-code upstream/main -- tools/file_operations.py tools/file_tools.py
```

## Additional verification

- `scripts/run_tests.sh tests/agent/test_file_safety_credentials.py -q`: **9 passed**
- `scripts/run_tests.sh tests/tools/test_file_operations.py -k TestSearchResult -q`: **5 passed**
- `scripts/run_tests.sh tests/tools/test_file_tools.py -k TestSearch -q`: **4 passed**
- `ruff 0.15.10 check` on all three changed files: passed
- `python scripts/check-windows-footguns.py --all`: passed, 944 files scanned
- `git diff --check`: passed

## Checks not passing or not run

- Full `ty 0.0.21 check` did not complete: Ty panicked in unmodified `tools/checkpoint_manager.py` (`too many cycle iterations`) and reported missing optional dependencies throughout the repository.
- A three-file Ty run reported 21 existing/environment diagnostics (including unresolved `pytest`/`yaml` and pre-existing `None` annotations); none points to an added line. This is not represented as a passing type check.
- Not run: the full Python test suite or live production gateway traffic.

## Platform and test harness

Windows NT 10.0.26200.0; Windows PowerShell 5.1.26100.7920; Python 3.12.2; Git 2.52.0.windows.1.

The focused public-entry tests used the official ripgrep 15.1.0 portable binary through a temporary, non-repository Git Bash shim that only cleared Hermes' `MSYS_NO_PATHCONV` / `MSYS2_ARG_CONV_EXCL` variables before launching native `rg.exe`. The initial attempts without that shim were invalid environment failures and are not counted as code evidence. All temporary files were removed afterward.

## Independent review and overlapping work

`monerostar` independently exercised the live public `search_tool` entry on Ubuntu 26.04 with ripgrep 15.1.0 against the pre-rebase head `a24988f6`: main returned warning counts only; the PR returned all three structured path/count fields, and the `.env` credential filter omitted the field while setting `_omitted`. Their focused suite passed 16/16. That review is attached to the old commit; despite the equivalent `range-diff`, this PR does not claim a current formal approval and may need review refresh.

- #80525 is an open competing fix for #80522 that places probe paths in warning text. This PR intentionally keeps structured fields and routes them through the existing read-block filter for tool JSON consumers.
- #79605 and #77157 remain open but address grep fallback and/or Windows native-rg path handling. This PR does not integrate or build on either branch.

## Non-goals

This does not change exact regex matching, automatically include hidden/ignored files, alter pagination, add probe invocations, change search engine selection, or solve the separate Windows native-rg path issue.

Prepared with Codex assistance; evidence verified against the stated commits.