### PR TITLE
Show earlier messages no longer hides most of a session

### DIFF
--- a/apps/desktop/src/app/chat/transcript-window.ts
+++ b/apps/desktop/src/app/chat/transcript-window.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from '@/lib/chat-messages'
-import { messageRenderWeight } from '@/lib/render-weight'
+import { messageStoreWeight } from '@/lib/render-weight'
 
 /**
  * Bound what reaches assistant-ui at all.
@@ -88,7 +88,7 @@ export function selectTranscriptWindow(messages: readonly ChatMessage[], pages =
   let weight = 0
 
   for (let i = messages.length - 1; i >= 0; i--) {
-    weight += messageRenderWeight(messages[i].parts)
+    weight += messageStoreWeight(messages[i].parts)
     start = i
 
     if (weight >= budget && messages.length - i >= TRANSCRIPT_WINDOW_MIN_MESSAGES) {

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-import { messageRenderWeight, RENDER_WEIGHT_CHARS } from '@/lib/render-weight'
-
 import {
   buildGroups,
   firstVisibleGroupIndex,
@@ -136,49 +134,19 @@ describe('firstVisibleGroupIndex', () => {
   it('returns groups.length for an empty list', () => {
     expect(firstVisibleGroupIndex([], 60)).toBe(0)
   })
-})
 
-describe('messageRenderWeight', () => {
-  it('charges large text and tool results by character cost, not only part count', () => {
-    const text = [{ type: 'text', text: 'x'.repeat(RENDER_WEIGHT_CHARS * 3) }]
+  it('keeps a floor of turns visible however heavy they are', () => {
+    // Without the floor a session of enormous turns puts "Show earlier" two
+    // turns from the bottom, which reads as broken rather than as paging.
+    const groups = Array.from({ length: 20 }, (_, i) => group(`g${i}`, 5_000))
 
-    const tool = [
-      {
-        type: 'tool-call',
-        toolName: 'skill_view',
-        args: { name: 'hermes-agent' },
-        result: { content: 'x'.repeat(RENDER_WEIGHT_CHARS * 100) }
-      }
-    ]
-
-    expect(messageRenderWeight(text)).toBe(4)
-    expect(messageRenderWeight(tool)).toBeGreaterThanOrEqual(101)
+    expect(firstVisibleGroupIndex(groups, 600, 8)).toBe(groups.length - 8)
   })
 
-  it('makes repeated 51KB tool outputs exceed the normal transcript page', () => {
-    const toolOutput = () => [
-      {
-        type: 'tool-call',
-        toolName: 'skill_view',
-        result: { content: 'x'.repeat(51_236) }
-      }
-    ]
+  it('does not force the floor to hide turns the budget already showed', () => {
+    const groups = Array.from({ length: 20 }, (_, i) => group(`g${i}`, 1))
 
-    const groups = Array.from({ length: 5 }, (_, index) => ({
-      id: `tool-${index}`,
-      index,
-      kind: 'standalone' as const,
-      weight: messageRenderWeight(toolOutput())
-    }))
-
-    expect(firstVisibleGroupIndex(groups, 300)).toBeGreaterThan(0)
-  })
-
-  it('handles circular tool payloads without recursing forever', () => {
-    const result: { content: string; self?: unknown } = { content: 'ok' }
-    result.self = result
-
-    expect(messageRenderWeight([{ type: 'tool-call', result }])).toBe(2)
+    expect(firstVisibleGroupIndex(groups, 600, 8)).toBe(0)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -16,7 +16,7 @@ import {
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
-import { messageRenderWeight } from '@/lib/render-weight'
+import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
 import {
   onScrollToBottomRequest,
@@ -37,19 +37,37 @@ export type MessageGroup = { id: string; weight: number } & (
   { index: number; kind: 'standalone' } | { indices: number[]; kind: 'turn' }
 )
 
-// DOM is bounded by a render-cost budget, not a message/turn count. Every part
-// costs one unit, and large strings add another unit per 512 characters. Parts
-// approximate component/node count; characters approximate markdown parsing,
-// text-node allocation, and tool-result formatting. Counting only parts badly
-// underpriced a 51KB tool result as "1", so a handful of huge results let a
-// 600KB transcript through the old 300-part cap and could drive Chromium's renderer
-// into a GC crash.
+// DOM is bounded by a render-cost budget, not a message/turn count. The
+// currency is `messagePaintWeight`: what a turn actually MOUNTS, which is what
+// the grouping decides rather than what the payload weighs. A settled run of
+// twelve reads is one grey summary line, a thought is one collapsed
+// disclosure, a hoisted `todo` is nothing — while a diff, an image card or a
+// wall of markdown really does build DOM and is charged for it.
+//
+// Pricing by payload instead had the budget counting work that never mounts:
+// one tool-heavy turn measured 84-281 units of tool JSON that painted as a
+// dozen one-line summaries, so a session spent the whole page in two or three
+// turns and offered "Show earlier" over a screen and a half of transcript.
 //
 // "Show earlier" prepends another page; whole turns stay intact so the sticky
 // human bubble never loses its turn. This is the long-session perf lever WITHOUT
 // a virtualizer — pure rendering, never touches scrollTop, so it can't fight
 // use-stick-to-bottom (the single scroll owner).
-const RENDER_BUDGET = 300
+//
+// 600 units ≈ 10-20 agentic turns on measured real sessions (a tool-heavy turn
+// prices at 30-90, a plain exchange at 5-10), and a whole session of ordinary
+// work now fits one page instead of paging three times to reach its start.
+// What the DOM can hold is bounded above by the store window regardless
+// (TRANSCRIPT_WINDOW_BUDGET), so this cannot admit more than one window's
+// content.
+const RENDER_BUDGET = 600
+// Never offer "Show earlier" over fewer turns than this, however heavy they
+// are. A weight-only cut on a session of enormous turns put the button two
+// turns from the bottom, where it reads as broken rather than as paging — the
+// user has not been given enough transcript to have gone looking for more. The
+// store window caps what the DOM can reach at all, so a floor here stays
+// bounded.
+const MIN_VISIBLE_GROUPS = 8
 // On session switch, paint a small budget first (enough for the bottom turn(s)
 // the user actually sees after scroll-to-bottom), then bump to the full budget
 // in a requestAnimationFrame — defers the heavy markdown+syntax-highlight render
@@ -125,9 +143,13 @@ export function buildGroups(signature: string): MessageGroup[] {
 }
 
 // Walk turns newest-first, summing their render weights until the budget is met;
-// everything before the first kept turn is hidden. Returns the index of that
-// first visible group.
-export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: number): number {
+// everything before the first kept turn is hidden. `minVisible` turns are kept
+// regardless of weight. Returns the index of that first visible group.
+export function firstVisibleGroupIndex(
+  groups: readonly MessageGroup[],
+  budget: number,
+  minVisible = 0
+): number {
   let firstVisible = groups.length
 
   for (let i = groups.length - 1, weight = 0; i >= 0; i--) {
@@ -139,7 +161,7 @@ export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: 
     }
   }
 
-  return firstVisible
+  return Math.min(firstVisible, Math.max(0, groups.length - minVisible))
 }
 
 // content-visibility:auto skips off-screen turns for perf, but with
@@ -231,7 +253,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   )
 
   const weightSignature = useAuiState(s =>
-    s.thread.messages.map(message => messageRenderWeight(message.content)).join(',')
+    s.thread.messages.map(message => messagePaintWeight(message.content)).join(',')
   )
 
   const { t } = useI18n()
@@ -337,7 +359,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   // Weights (part count + visible character cost) fold into the BUDGET only.
   // Group identity stays structural, so a streaming append re-runs this cheap
-  // sum — not the row JSX. Settled content hits messageRenderWeight's WeakMap.
+  // sum — not the row JSX. Settled content hits messagePaintWeight's WeakMap.
   const weightedGroups = useMemo(() => {
     const weights = weightSignature.split(',').map(w => Number(w) || 1)
 
@@ -350,7 +372,15 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }))
   }, [groups, weightSignature])
 
-  const hiddenCount = firstVisibleGroupIndex(weightedGroups, renderBudget)
+  // The turn floor applies to a real page only. During the first-paint budget
+  // the point is a small synchronous commit; forcing 8 turns into it would put
+  // back exactly the freeze FIRST_PAINT_BUDGET exists to avoid, and the rAF
+  // backfill a frame later fills them in anyway.
+  const hiddenCount = firstVisibleGroupIndex(
+    weightedGroups,
+    renderBudget,
+    renderBudget >= RENDER_BUDGET ? MIN_VISIBLE_GROUPS : 0
+  )
   const visibleGroups = hiddenCount > 0 ? groups.slice(hiddenCount) : groups
 
   // Where the always-rendered live tail begins. Derived from the WEIGHTED

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -2,6 +2,7 @@ import { type ToolTitleKey, translateNow } from '@/i18n'
 import { normalizeExternalUrl } from '@/lib/external-link'
 import { summarizeShellCommand } from '@/lib/summarize-command'
 import { capitalize, normalize } from '@/lib/text'
+import { isCardTool, isFileEditTool, isSilentTool } from '@/lib/tool-render-class'
 import { extractToolErrorMessage, formatToolResultSummary } from '@/lib/tool-result-summary'
 
 import {
@@ -31,11 +32,10 @@ export * from './format'
 export * from './targets'
 export * from './types'
 
-const FILE_EDIT_TOOL_NAMES = new Set(['edit_file', 'patch', 'write_file'])
-
-export function isFileEditTool(toolName: string): boolean {
-  return FILE_EDIT_TOOL_NAMES.has(toolName)
-}
+// The transcript's render budget prices a turn by the same classification, so
+// it lives in `@/lib/tool-render-class` where both sides can reach it without
+// pulling this module's formatting/i18n weight into the cost path.
+export { isCardTool, isFileEditTool, isSilentTool }
 
 export interface DiffLineStats {
   added: number

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { isCardTool, splitRunItems, technicalTrace } from './fallback'
+import { isCardTool, isSilentTool } from '@/lib/tool-render-class'
+
+import { splitRunItems, technicalTrace } from './fallback'
 
 describe('isCardTool', () => {
   it('keeps what the user has to look at out of a summary', () => {
@@ -16,6 +18,16 @@ describe('isCardTool', () => {
     for (const toolName of ['read_file', 'search_files', 'terminal', 'execute_code', 'web_search']) {
       expect(isCardTool(toolName)).toBe(false)
     }
+  })
+})
+
+describe('isSilentTool', () => {
+  it('names the rows that render nothing in the transcript', () => {
+    // `todo` is hoisted to its own panel; a reaction's UI is the emoji on the
+    // bubble. The render budget must not charge for either.
+    expect(isSilentTool('todo')).toBe(true)
+    expect(isSilentTool('react_to_message')).toBe(true)
+    expect(isSilentTool('terminal')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -53,6 +53,7 @@ import {
   cleanVisibleText,
   countDiffLineStats,
   inlineDiffFromResult,
+  isCardTool,
   isFileEditTool,
   isPreviewableTarget,
   looksRedundant,
@@ -738,22 +739,9 @@ function TerminalTranscript({ command, exitCode }: TerminalTranscriptProps) {
 }
 
 // Tools that draw their own surface and must never be folded into a run's
-// summary. Two kinds, for the same reason — the thing on screen IS the point:
-//
-//   - File edits are the deliverable, not scaffolding. The diff is what the
-//     user reviews, so it stays visible at its place in the turn, live and
-//     settled, the way a PR shows its changes.
-//   - `clarify`, `image_generate` and `delegate_task` bypass ToolEntry to
-//     render their own markup: a question the user has to answer, an image
-//     they asked for, the several agents a fan-out is running.
-//
-// Everything else is ephemeral activity — reads, searches, commands — which is
-// what a run summarizes and what the live ticker cycles through.
-const CARD_TOOLS = new Set(['clarify', 'delegate_task', 'image_generate'])
-
-export function isCardTool(toolName: string): boolean {
-  return CARD_TOOLS.has(toolName) || isFileEditTool(toolName)
-}
+// summary live in `fallback-model` (`isCardTool`) — the DOM render budget
+// prices a turn by the same rule, so both sides have to agree on which rows
+// collapse into a summary line and which mount their own markup.
 
 export type RunItem = { end: number; kind: 'run'; start: number } | { index: number; kind: 'card' }
 

--- a/apps/desktop/src/lib/render-weight.test.ts
+++ b/apps/desktop/src/lib/render-weight.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { messagePaintWeight, messageStoreWeight, RENDER_WEIGHT_CHARS } from './render-weight'
+
+const bigResult = (chars: number) => ({
+  type: 'tool-call',
+  toolName: 'skill_view',
+  args: { name: 'hermes-agent' },
+  result: { content: 'x'.repeat(chars) }
+})
+
+describe('messageStoreWeight', () => {
+  it('charges large text and tool results by character cost, not only part count', () => {
+    const text = [{ type: 'text', text: 'x'.repeat(RENDER_WEIGHT_CHARS * 3) }]
+
+    expect(messageStoreWeight(text)).toBe(4)
+    expect(messageStoreWeight([bigResult(RENDER_WEIGHT_CHARS * 100)])).toBeGreaterThanOrEqual(101)
+  })
+
+  it('prices a 51KB tool output well above a plain exchange', () => {
+    const heavy = messageStoreWeight([bigResult(51_236)])
+    const light = messageStoreWeight([{ type: 'text', text: 'ok' }])
+
+    expect(heavy).toBeGreaterThan(light * 50)
+  })
+
+  it('handles circular tool payloads without recursing forever', () => {
+    const result: { content: string; self?: unknown } = { content: 'ok' }
+    result.self = result
+
+    expect(messageStoreWeight([{ type: 'tool-call', result }])).toBe(2)
+  })
+
+  it('bounds a single enormous payload', () => {
+    const enormous = messageStoreWeight([bigResult(RENDER_WEIGHT_CHARS * 10_000)])
+
+    expect(enormous).toBeLessThanOrEqual(302)
+  })
+})
+
+describe('messagePaintWeight', () => {
+  it('prices a settled activity row as the one line it renders, not its payload', () => {
+    const heavy = messagePaintWeight([bigResult(RENDER_WEIGHT_CHARS * 100)])
+
+    // The whole point: a collapsed tool row costs the same whether it wraps
+    // 200 bytes or 50KB, because the payload sits behind a closed disclosure.
+    expect(heavy).toBe(messagePaintWeight([bigResult(200)]))
+    expect(heavy).toBeLessThan(messageStoreWeight([bigResult(RENDER_WEIGHT_CHARS * 100)]))
+  })
+
+  it('charges a reasoning block one collapsed header', () => {
+    const thought = [{ type: 'reasoning', text: 'x'.repeat(RENDER_WEIGHT_CHARS * 20) }]
+
+    expect(messagePaintWeight(thought)).toBe(1)
+  })
+
+  it('charges rendered markdown its real character cost', () => {
+    const text = [{ type: 'text', text: 'x'.repeat(RENDER_WEIGHT_CHARS * 3) }]
+
+    expect(messagePaintWeight(text)).toBe(4)
+  })
+
+  it('charges a diff by size — FileDiffPanel really does mount a row per line', () => {
+    const diff = Array.from({ length: 400 }, (_, i) => `+line ${i}`).join('\n')
+
+    const patch = messagePaintWeight([
+      { type: 'tool-call', toolName: 'patch', args: { path: 'a.ts' }, result: { inline_diff: diff } }
+    ])
+
+    expect(patch).toBeGreaterThan(5)
+  })
+
+  it('prices an image card flat, however long its data URL', () => {
+    const card = (chars: number) => [
+      { type: 'tool-call', toolName: 'image_generate', args: {}, result: { image: `data:image/png;base64,${'A'.repeat(chars)}` } }
+    ]
+
+    expect(messagePaintWeight(card(10_000_000))).toBe(messagePaintWeight(card(80)))
+  })
+
+  it('charges nothing for a row that renders nothing', () => {
+    const hoisted = [
+      { type: 'tool-call', toolName: 'todo', args: { todos: Array.from({ length: 40 }, (_, i) => ({ content: `t${i}` })) } },
+      { type: 'tool-call', toolName: 'react_to_message', args: { emoji: '❤️' } }
+    ]
+
+    // Floors at 1: a message always occupies at least a row of the transcript.
+    expect(messagePaintWeight(hoisted)).toBe(1)
+  })
+
+  it('keeps a tool-heavy turn far cheaper to paint than to hold', () => {
+    // The measured shape behind the bad threshold: a dozen collapsed activity
+    // rows and a little prose. It paints as ~a dozen lines and used to be
+    // priced as an entire DOM page.
+    const parts = Array.from({ length: 12 }, () => bigResult(4_000)).concat([
+      { type: 'text', text: 'x'.repeat(600) } as unknown as ReturnType<typeof bigResult>
+    ])
+
+    expect(messagePaintWeight(parts)).toBeLessThan(messageStoreWeight(parts) / 5)
+  })
+
+  it('bounds a message of many enormous parts', () => {
+    const parts = Array.from({ length: 50 }, () => ({
+      type: 'text',
+      text: 'x'.repeat(RENDER_WEIGHT_CHARS * 500)
+    }))
+
+    // One ceiling for the whole message — not one per part.
+    expect(messagePaintWeight(parts)).toBeLessThanOrEqual(350)
+  })
+})

--- a/apps/desktop/src/lib/render-weight.ts
+++ b/apps/desktop/src/lib/render-weight.ts
@@ -1,3 +1,5 @@
+import { isCardTool, isFileEditTool, isSilentTool } from '@/lib/tool-render-class'
+
 /**
  * Render cost of one message's content parts, in budget units.
  *
@@ -6,12 +8,24 @@
  * budget (how many of those actually render). Neither can be a message COUNT —
  * counting only parts underpriced a 51KB tool result as "1", so a handful of
  * huge results let a 600KB transcript through the old 300-part cap and drove
- * Chromium's renderer into a GC crash. Characters approximate markdown
- * parsing, text-node allocation, and tool-result formatting; parts approximate
- * component/node count.
+ * Chromium's renderer into a GC crash (#55191). Characters approximate
+ * markdown parsing, text-node allocation, and tool-result formatting; parts
+ * approximate component/node count.
  *
- * Shared so a heavy-but-short session is bounded by the same rule as a
- * long-but-light one (#55191).
+ * The two layers do NOT price a part the same way, because they protect
+ * different things:
+ *
+ *   - The STORE window protects the heap. Every message it admits is
+ *     normalized into the runtime repository whether or not the transcript
+ *     collapses it, so it prices the payload it has to hold: `messageStoreWeight`.
+ *   - The DOM budget protects the paint, and what a turn paints is decided by
+ *     the GROUPING, not by the bytes behind it. A settled run of twelve reads
+ *     is one grey summary line, a thought is one collapsed disclosure, a
+ *     `todo` is hoisted out of the transcript entirely, and a generated image
+ *     is one `<img>` however long its data URL. Charging those their payload
+ *     had the budget counting hundreds of units of work that never mounts, so
+ *     "Show earlier" appeared after two or three tool-heavy turns of a session
+ *     that was painting almost nothing: `messagePaintWeight`.
  */
 
 export const RENDER_WEIGHT_CHARS = 512
@@ -22,36 +36,53 @@ export const RENDER_WEIGHT_CHARS = 512
 // payloads.
 const MAX_MEASURED_MESSAGE_CHARS = 300 * RENDER_WEIGHT_CHARS
 
-const contentWeightCache = new WeakMap<object, number>()
+const storeWeightCache = new WeakMap<object, number>()
+const paintWeightCache = new WeakMap<object, number>()
 const NON_RENDERED_CONTENT_FIELDS = new Set(['id', 'role', 'toolCallId', 'toolName', 'type'])
 
 /**
- * Estimate the synchronous renderer cost of one message's content array.
+ * What a collapsed row costs the DOM: one line of scaffolding.
  *
- * A WeakMap keeps settled history O(message count) on later store updates;
- * both assistant-ui and the session store publish a new content array when a
- * streaming message changes, so the live tail still receives a fresh weight.
+ * A settled tool row is an icon, a title and maybe a count; a settled thought
+ * is a "Thought for 12s" header. Either one keeps its payload behind a
+ * disclosure, and an unopened disclosure mounts none of it. History always
+ * mounts collapsed, and history is exactly what "Show earlier" pages back
+ * through.
  */
-export function messageRenderWeight(content: unknown): number {
-  if (!Array.isArray(content)) {
-    return 1
-  }
+const COLLAPSED_ROW_WEIGHT = 1
 
-  const cached = contentWeightCache.get(content)
+/**
+ * What a fixed-size card costs the DOM.
+ *
+ * A generated image is one `<img>` whether its result carries a path or a
+ * multi-megabyte data URL; a clarify question is a prompt and a few buttons; a
+ * delegation is a header over a one-line ticker. None of them scale with the
+ * payload, so charging characters priced a single image at more than a whole
+ * page of real turns.
+ */
+const CARD_WEIGHT = 6
 
-  if (cached !== undefined) {
-    return cached
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
 
+/**
+ * Character cost of an arbitrary payload, bounded and cycle-safe.
+ *
+ * `budget` is the characters still worth measuring. It is threaded through a
+ * whole message rather than reset per part, so a message of many huge parts
+ * cannot walk past the ceiling one part at a time.
+ */
+function payloadCharacters(roots: readonly unknown[], budget: number): number {
   const seen = new WeakSet<object>()
-  const pending: unknown[] = [...content]
+  const pending: unknown[] = [...roots]
   let characters = 0
 
-  while (pending.length > 0 && characters < MAX_MEASURED_MESSAGE_CHARS) {
+  while (pending.length > 0 && characters < budget) {
     const value = pending.pop()
 
     if (typeof value === 'string') {
-      characters += Math.min(value.length, MAX_MEASURED_MESSAGE_CHARS - characters)
+      characters += Math.min(value.length, budget - characters)
 
       continue
     }
@@ -77,8 +108,111 @@ export function messageRenderWeight(content: unknown): number {
     }
   }
 
-  const weight = Math.max(1, content.length) + Math.ceil(characters / RENDER_WEIGHT_CHARS)
-  contentWeightCache.set(content, weight)
+  return characters
+}
+
+/** Payload price: one unit per part, plus one per 512 characters it carries. */
+function payloadWeight(parts: readonly unknown[], budget: number): number {
+  return parts.length + Math.ceil(payloadCharacters(parts, budget) / RENDER_WEIGHT_CHARS)
+}
+
+/**
+ * Estimate the cost of holding one message's content array in the runtime.
+ *
+ * A WeakMap keeps settled history O(message count) on later store updates;
+ * both assistant-ui and the session store publish a new content array when a
+ * streaming message changes, so the live tail still receives a fresh weight.
+ */
+export function messageStoreWeight(content: unknown): number {
+  if (!Array.isArray(content)) {
+    return 1
+  }
+
+  const cached = storeWeightCache.get(content)
+
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const weight = Math.max(1, payloadWeight(content, MAX_MEASURED_MESSAGE_CHARS))
+  storeWeightCache.set(content, weight)
+
+  return weight
+}
+
+/**
+ * What one part mounts, priced the way `message-parts.tsx` renders it.
+ *
+ * `measure` prices a payload against the message's shared character ceiling —
+ * only the parts that actually paint their content spend from it.
+ */
+function partPaintWeight(part: unknown, measure: (parts: readonly unknown[]) => number): number {
+  if (!isRecord(part)) {
+    return 1
+  }
+
+  // A thought mounts its header; the reasoning text sits behind it.
+  if (part.type === 'reasoning') {
+    return COLLAPSED_ROW_WEIGHT
+  }
+
+  if (part.type !== 'tool-call') {
+    // Text is markdown the DOM really builds, so it keeps the payload price.
+    return measure([part])
+  }
+
+  const toolName = typeof part.toolName === 'string' ? part.toolName : ''
+
+  if (isSilentTool(toolName)) {
+    return 0
+  }
+
+  if (!isCardTool(toolName)) {
+    return COLLAPSED_ROW_WEIGHT
+  }
+
+  // A diff is the one card that scales: `FileDiffPanel` mounts a row per line,
+  // and a big patch really is the expensive thing in the turn.
+  return isFileEditTool(toolName) ? measure([part]) : CARD_WEIGHT
+}
+
+/**
+ * Estimate what one message's content array actually MOUNTS in the transcript.
+ *
+ * Cached like the store weight: a settled message keeps its number across
+ * later store updates, and a streaming one publishes a fresh array per delta
+ * so the live tail is always re-measured.
+ */
+export function messagePaintWeight(content: unknown): number {
+  if (!Array.isArray(content)) {
+    return 1
+  }
+
+  const cached = paintWeightCache.get(content)
+
+  if (cached !== undefined) {
+    return cached
+  }
+
+  // One character ceiling for the whole message, not one per part — otherwise a
+  // message of many huge parts walks past it one part at a time.
+  let remaining = MAX_MEASURED_MESSAGE_CHARS
+
+  const measure = (parts: readonly unknown[]) => {
+    const characters = payloadCharacters(parts, remaining)
+    remaining -= characters
+
+    return parts.length + Math.ceil(characters / RENDER_WEIGHT_CHARS)
+  }
+
+  let weight = 0
+
+  for (const part of content) {
+    weight += partPaintWeight(part, measure)
+  }
+
+  weight = Math.max(1, weight)
+  paintWeightCache.set(content, weight)
 
   return weight
 }

--- a/apps/desktop/src/lib/tool-render-class.ts
+++ b/apps/desktop/src/lib/tool-render-class.ts
@@ -1,0 +1,44 @@
+/**
+ * Which surface a tool call renders as.
+ *
+ * Two consumers have to agree on this and they sit on opposite sides of the
+ * app: the transcript decides what to draw, and the DOM render budget decides
+ * how much of the transcript to mount. Pricing a turn correctly means pricing
+ * what the grouping actually renders, so the classification lives on its own
+ * rather than inside either one.
+ */
+
+const FILE_EDIT_TOOL_NAMES = new Set(['edit_file', 'patch', 'write_file'])
+
+/** Renders a diff — the deliverable of the turn, and the one card whose cost scales. */
+export function isFileEditTool(toolName: string): boolean {
+  return FILE_EDIT_TOOL_NAMES.has(toolName)
+}
+
+// Tools that draw their own surface and must never be folded into a run's
+// summary. Two kinds, for the same reason — the thing on screen IS the point:
+//
+//   - File edits are the deliverable, not scaffolding. The diff is what the
+//     user reviews, so it stays visible at its place in the turn, live and
+//     settled, the way a PR shows its changes.
+//   - `clarify`, `image_generate` and `delegate_task` bypass ToolEntry to
+//     render their own markup: a question the user has to answer, an image
+//     they asked for, the several agents a fan-out is running.
+//
+// Everything else is ephemeral activity — reads, searches, commands — which is
+// what a run summarizes and what the live ticker cycles through.
+const CARD_TOOL_NAMES = new Set(['clarify', 'delegate_task', 'image_generate'])
+
+export function isCardTool(toolName: string): boolean {
+  return CARD_TOOL_NAMES.has(toolName) || isFileEditTool(toolName)
+}
+
+// Activity tools that render nothing at all: `todo` parts are hoisted to a
+// dedicated panel above the message content, and a reaction's UI is the emoji
+// landing on the bubble. Both still render when they FAIL, which is a bounded
+// error row either way.
+const SILENT_TOOL_NAMES = new Set(['react_to_message', 'todo'])
+
+export function isSilentTool(toolName: string): boolean {
+  return SILENT_TOOL_NAMES.has(toolName)
+}


### PR DESCRIPTION
"Show earlier messages" was appearing two or three turns from the bottom, hiding a session that had barely painted anything.

The threshold was not really the problem — the accounting under it was. One weight function fed two budgets that protect different things, and the DOM budget was charging for payload rather than for what the transcript mounts. A settled run of twelve reads is one grey summary line, a thought is one collapsed disclosure, a `todo` is hoisted out of the transcript, and an image is one `<img>` however long its data URL. All of it was priced as if fully expanded, so one tool-heavy turn could spend a third of a page while painting a dozen lines.

Now the store window keeps the payload price (it protects the heap — every message it admits is normalized into the runtime repository whether or not the transcript collapses it), and the DOM budget spends a new paint weight that prices what actually mounts. The budget moves to 600 units, with a floor of 8 turns for the session of enormous turns that a weight-only cut still truncates hard.

Measured on four stored sessions, turns visible before the button appears — old config (payload weight, 300, no floor) against new (paint weight, 600, floor 8):

| session | total turns | before | after |
| --- | --- | --- | --- |
| `c5cfe8` | 22 | 3 | 18 |
| `31261a` | 30 | 3 | 10 |
| `a64598` | 57 | 14 | 17 |
| `c10451` | 5 | 3 | 5 — no button |

The store window still caps what the DOM can reach at all, so this cannot admit more than one window's content.

Desktop typecheck clean; `vitest --project ui` green on the touched suites (10 unrelated settings-panel timeouts in the full parallel run pass in isolation).
