### PR TITLE
Keep elapsed status text from overlapping

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -31,7 +31,7 @@ const StatusRow: FC<{ children: ReactNode; label: string } & React.ComponentProp
     aria-label={label}
     aria-live="polite"
     className={cn(
-      'flex max-w-full items-center gap-1.5 self-start leading-(--conversation-line-height)',
+      'flex min-w-0 max-w-full items-center gap-1.5 self-start leading-(--conversation-line-height)',
       'text-(--conversation-scaffold-text)',
       className
     )}
@@ -47,7 +47,7 @@ const StatusRow: FC<{ children: ReactNode; label: string } & React.ComponentProp
 const COMPACTION_LABEL = 'Summarizing thread'
 
 const HintText: FC<{ children: ReactNode }> = ({ children }) => (
-  <span className={cn(SCAFFOLD_LABEL_CLASS, 'shimmer min-w-0 truncate')}>{children}</span>
+  <span className={cn(SCAFFOLD_LABEL_CLASS, 'shimmer min-w-0 flex-1 truncate')}>{children}</span>
 )
 
 /** These indicators render inside whichever transcript mounted them, so every

--- a/apps/desktop/src/components/chat/disclosure-row.tsx
+++ b/apps/desktop/src/components/chat/disclosure-row.tsx
@@ -14,11 +14,10 @@ import { cn } from '@/lib/utils'
 //     title text, NOT the full row — and reaches just past the chevron with
 //     `-mx-1.5 px-1.5` so it reads as a soft hit-target rather than a slab
 //     stretching to the message edge.
-//   - `trailing` overlays the right edge (absolute) and must stay
-//     non-interactive (e.g. a duration timer) — an opacity-0-but-clickable
-//     control there steals clicks from the caret. Interactive controls go in
-//     `action`, which lays out *in flow* at the far right so it never sits on
-//     top of the caret's hit-target, no matter how long the title is.
+//   - `trailing` stays in flow (e.g. a duration timer), so the title always
+//     reserves space for it instead of painting underneath it. Interactive
+//     controls go in `action`, which lays out *in flow* at the far right so it
+//     never sits on top of the caret's hit-target.
 export function DisclosureRow({
   action,
   children,
@@ -68,7 +67,7 @@ export function DisclosureRow({
         </span>
       )}
       {trailing && (
-        <span className="absolute right-1 top-0 flex h-(--conversation-line-height) items-center">{trailing}</span>
+        <span className="flex h-(--conversation-line-height) shrink-0 items-center pl-1.5">{trailing}</span>
       )}
     </div>
   )

--- a/apps/desktop/src/components/chat/scaffold-row.tsx
+++ b/apps/desktop/src/components/chat/scaffold-row.tsx
@@ -24,7 +24,7 @@ export const SCAFFOLD_META_CLASS = 'shrink-0 text-[0.625rem] tabular-nums text-(
 
 /**
  * One scaffold line. `children` is the label and whatever trails it in flow
- * (meta, diff counts); `trailing` overlays the right edge for a live timer.
+ * (meta, diff counts); `trailing` reserves a right-side slot for a live timer.
  */
 export function ScaffoldRow({
   children,


### PR DESCRIPTION
## Summary
- Keep the running-status label and elapsed timer in separate flex slots so the timer cannot paint over the label.
- Allow the status label to shrink and truncate when the transcript is narrow.

## Test plan
- [ ] Open the desktop transcript with a running process and confirm the label stays readable as the timer updates.
- [ ] Check a narrow transcript width and confirm the label truncates before the elapsed timer.
