### PR TITLE
Announce date changes to long-running sessions without touching the prompt cache (port from kimi-code)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -130,6 +130,43 @@ def extract_api_content_sidecar(msg: Mapping[str, Any]) -> Optional[str]:
     return v if isinstance(v, str) else None
 
 
+def maybe_date_change_note(agent: Any, now: Any = None) -> str:
+    """Return a one-line date-change note when the session crossed midnight.
+
+    The system prompt bakes in ``Conversation started: <date>`` and is
+    byte-stable for the life of a conversation (prompt-cache invariant), so a
+    session that runs past midnight leaves the model with a stale idea of
+    today's date. This helper tracks the last date the model was told about
+    on ``agent._last_known_date`` and, when the wall-clock date has moved on,
+    emits a note for the current user message's API-bound copy (the
+    ``api_content`` sidecar channel — persisted and replayed byte-for-byte,
+    so the cache prefix never diverges).
+
+    Seeding is quiet: the first call on a fresh or restored agent records
+    today without announcing (matching the source behavior in
+    MoonshotAI/kimi-code#2564 — a profile with no recorded date seeds
+    silently so only genuine rollovers announce).
+    """
+    try:
+        from datetime import datetime
+
+        current = (now or datetime.now()).strftime("%A, %B %d, %Y")
+    except Exception:
+        return ""
+    last = getattr(agent, "_last_known_date", None)
+    try:
+        agent._last_known_date = current
+    except Exception:
+        pass
+    if last is None or last == current:
+        return ""
+    return (
+        f"[System note: the date has changed since this conversation's "
+        f"context was established. It is now {current} (was {last}). "
+        f"Use the new date for any date-sensitive reasoning.]"
+    )
+
+
 def consume_gateway_turn_context_notes(agent: Any) -> str:
     """Pop the gateway's per-turn must-deliver notes off the agent (one-shot).
 
@@ -1117,6 +1154,15 @@ def build_turn_context(
     # Multimodal (list) content can't take the string sidecar — append a
     # durable text part instead of dropping the fact.
     _gateway_notes = consume_gateway_turn_context_notes(agent)
+    # Date-change note (ported from MoonshotAI/kimi-code#2564): the system
+    # prompt's "Conversation started:" date is byte-stable for cache
+    # integrity, so announce midnight rollovers on the same per-turn user-
+    # message channel instead of touching the prompt.
+    _date_note = maybe_date_change_note(agent)
+    if _date_note:
+        _gateway_notes = (
+            _gateway_notes + "\n\n" + _date_note if _gateway_notes else _date_note
+        )
     if _gateway_notes:
         _gw_turn_content = (
             messages[current_turn_user_idx].get("content")

--- a/tests/agent/test_date_change_note.py
+++ b/tests/agent/test_date_change_note.py
@@ -1,0 +1,58 @@
+"""Tests for the date-change note (ported from MoonshotAI/kimi-code#2564).
+
+The system prompt bakes in "Conversation started: <date>" and stays
+byte-stable for prompt-cache integrity, so a session that crosses midnight
+leaves the model with a stale date. ``maybe_date_change_note`` tracks the
+last announced date on the agent and emits a note (delivered via the
+api_content sidecar channel) only on genuine rollovers.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from agent.turn_context import maybe_date_change_note
+
+
+def _agent():
+    return SimpleNamespace()
+
+
+class TestMaybeDateChangeNote:
+    def test_first_call_seeds_quietly(self):
+        agent = _agent()
+        note = maybe_date_change_note(agent, now=datetime(2026, 8, 6, 23, 50))
+        assert note == ""
+        assert agent._last_known_date == "Thursday, August 06, 2026"
+
+    def test_same_day_no_note(self):
+        agent = _agent()
+        maybe_date_change_note(agent, now=datetime(2026, 8, 6, 9, 0))
+        note = maybe_date_change_note(agent, now=datetime(2026, 8, 6, 23, 59))
+        assert note == ""
+
+    def test_midnight_rollover_announces(self):
+        agent = _agent()
+        maybe_date_change_note(agent, now=datetime(2026, 8, 6, 23, 50))
+        note = maybe_date_change_note(agent, now=datetime(2026, 8, 7, 0, 10))
+        assert "Friday, August 07, 2026" in note
+        assert "Thursday, August 06, 2026" in note
+        assert note.startswith("[System note:")
+
+    def test_announces_once_then_quiet(self):
+        agent = _agent()
+        maybe_date_change_note(agent, now=datetime(2026, 8, 6, 12, 0))
+        assert maybe_date_change_note(agent, now=datetime(2026, 8, 7, 12, 0)) != ""
+        assert maybe_date_change_note(agent, now=datetime(2026, 8, 7, 18, 0)) == ""
+
+    def test_multi_day_gap_announces_current_date(self):
+        agent = _agent()
+        maybe_date_change_note(agent, now=datetime(2026, 8, 1, 12, 0))
+        note = maybe_date_change_note(agent, now=datetime(2026, 8, 6, 12, 0))
+        assert "Thursday, August 06, 2026" in note
+        assert "Saturday, August 01, 2026" in note
+
+    def test_updates_tracker_on_rollover(self):
+        agent = _agent()
+        maybe_date_change_note(agent, now=datetime(2026, 8, 6, 12, 0))
+        maybe_date_change_note(agent, now=datetime(2026, 8, 7, 12, 0))
+        assert agent._last_known_date == "Friday, August 07, 2026"


### PR DESCRIPTION
## Summary
Sessions that run past midnight now get a one-line date-change note on the next turn, so the model stops reasoning with a stale date. The system prompt bakes in `Conversation started: <date>` and is deliberately byte-stable for the life of a conversation (prompt-cache invariant) — this port announces rollovers on the per-turn user-message channel instead of ever touching the prompt.

Ported from MoonshotAI/kimi-code#2564 (their `date_change` context-injection provider), adapted to Hermes' existing gateway-notes / `api_content` sidecar mechanism in the turn prologue.

## Changes
- `agent/turn_context.py`: new `maybe_date_change_note(agent, now=None)` — tracks the last announced date on `agent._last_known_date`; first call seeds quietly (fresh/restored agents announce only genuine rollovers, matching the source's quiet-seed behavior); on rollover returns a `[System note: ... it is now <date> (was <date>) ...]` line. Wired into `build_turn_context` alongside the gateway must-deliver notes, so it rides the existing `api_content` sidecar (persisted and replayed byte-for-byte — the cache prefix never diverges) and the multimodal text-part fallback for free.
- `tests/agent/test_date_change_note.py`: 6 tests (quiet seed, same-day silence, rollover announce, announce-once, multi-day gap, tracker update).

## Validation
| | Before | After |
|---|---|---|
| Session crosses midnight | model keeps stale "Conversation started" date | next turn carries a date-change note |
| Prompt cache | — | prompt untouched; note rides the api_content sidecar |
| Tests | — | test_date_change_note (6) + test_gateway_turn_sidecar + test_api_content_sidecar: 41/41 pass |

## Infographic

![Date-change note](https://v3b.fal.media/files/b/0aa55374/bXz_3iY2kmNs964REOMcn_vdNa7IAb.png)
