### PR TITLE
docs: re-sync stale file references, regenerate skill docs, and add guards for both

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,14 @@ jobs:
     needs: detect
     uses: ./.github/workflows/infographic-check.yml
 
+  # Intentionally ungated: the diff that breaks a doc reference is a rename in
+  # the code, which does not touch the doc. A path filter would miss the whole
+  # failure class. Pure stdlib, no install step.
+  doc-links:
+    name: Check doc file references
+    needs: detect
+    uses: ./.github/workflows/doc-links.yml
+
   lockfile-diff:
     name: package-lock.json diff
     needs: detect
@@ -252,6 +260,7 @@ jobs:
       - history-check
       - contributor-check
       - uv-lockfile
+      - doc-links
       - lockfile-diff
       - docker-lint
       - supply-chain

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,0 +1,53 @@
+name: Doc Links
+
+# Rejects PRs where a doc cites a repo file that does not exist.
+#
+# Docs rot when *code* moves, not when docs change. When the messaging
+# platforms migrated from `gateway/platforms/<name>.py` to
+# `plugins/platforms/<name>/adapter.py`, ADDING_A_PLATFORM.md kept sending new
+# contributors to files that were already gone, §11 kept describing an opt-in
+# discovery list that had become an opt-out frozenset, and the Matrix E2E
+# README kept telling readers to diff against a deleted symbol. None of it
+# failed anything, because nothing checked.
+#
+# Note there is deliberately NO path filter on this job. Gating it on
+# "markdown changed" would miss the entire failure class above — the diff that
+# breaks a reference is a rename in the code, and it does not touch the doc.
+# The check is pure stdlib over `git ls-files`, so running it every time is
+# cheap (no venv, no install step).
+#
+# The resolver is deliberately generous — repo root, the doc's directory or any
+# ancestor, a directory declared in backticks by the nearest heading, or an
+# explicit `<!-- doc-links: base=... -->` override. A false positive gets a
+# check like this switched off; a missed dead link costs one confused reader.
+# See scripts/ci/check_doc_links.py for the model and the exemption tables.
+
+on:
+  workflow_call:
+    outputs:
+      review_status:
+        description: "JSON array of review_status objects for the synthesizer."
+        value: ${{ jobs.check-doc-links.outputs.review_status }}
+
+permissions:
+  contents: read
+
+jobs:
+  check-doc-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      review_status: ${{ steps.doc-links.outputs.review_status }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: doc-links
+        name: Check documentation file references
+        run: |
+          if python3 scripts/ci/check_doc_links.py --stats; then
+            echo "review_status=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          STATUS='[{"source":"doc links","results":[{"kind":"action_required","title":"Documentation references a file that does not exist","summary":"A doc cites a repo path that is not in the tree — usually because the code moved and the doc did not.","detail":"","how_to_fix":"Run it locally to see the exact doc and line:\n```\npython3 scripts/ci/check_doc_links.py --stats\n```\nThen, in order of preference:\n1. The file moved — update the path in the doc.\n2. The path is correct but addressed from elsewhere — declare a base in the nearest heading, ``## Section (`some/dir/`)``, or add ``<!-- doc-links: base=some/dir -->`` near the top of the doc.\n3. It genuinely lives outside this repo (another repo, a runtime path under HERMES_HOME, a placeholder the reader creates) — add it to `EXEMPT_REFS` in `scripts/ci/check_doc_links.py` with a reason.\n"}]}]'
+          echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
+          exit 1

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -44,6 +44,48 @@ jobs:
       - name: Regenerate per-skill docs pages + catalogs
         run: python3 website/scripts/generate-skill-docs.py
 
+      # The two generators above are the source of truth for the per-skill
+      # pages, the catalogs and the sidebar — but their output is *committed*,
+      # and until now nothing compared the regenerated result against HEAD.
+      # Both this job and deploy-site.yml regenerate before building, so the
+      # published site was always right while the in-repo copies silently
+      # rotted: a skill could be added with no page, no catalog entry and no
+      # sidebar link, and every check stayed green. (Caught 2026-08 with
+      # optional-skills/devops/actual-setup missing entirely and three pages
+      # drifted from their SKILL.md.)
+      #
+      # Safe to gate on: the generators are deterministic — running them twice
+      # over an unchanged tree is byte-identical.
+      - name: Check generated skill docs are committed and current
+        run: |
+          # Scoped to website/: every generator output lands there (docs pages,
+          # both catalogs, sidebars.ts; the static/api/*.json blobs are
+          # gitignored). Diffing the whole tree would blame the generators for
+          # anything else a prior step happened to touch.
+          if git diff --quiet -- website/ && git diff --quiet --cached -- website/ && \
+             [ -z "$(git ls-files --others --exclude-standard website/)" ]; then
+            echo "::notice::Generated skill docs are current."
+            exit 0
+          fi
+          echo "::error::Generated skill docs are out of date — regenerate and commit them."
+          echo ""
+          echo "Modified by the generators:"
+          git --no-pager diff --stat -- website/
+          UNTRACKED="$(git ls-files --others --exclude-standard website/)"
+          if [ -n "$UNTRACKED" ]; then
+            echo ""
+            echo "Missing entirely (generator produced a page with no committed counterpart):"
+            printf '%s\n' "$UNTRACKED" | sed 's/^/  /'
+          fi
+          echo ""
+          echo "To fix, from the repo root:"
+          echo "  python3 website/scripts/extract-skills.py"
+          echo "  python3 website/scripts/generate-skill-docs.py"
+          echo "  git add website/ && git commit -m 'docs: regenerate skill pages'"
+          echo ""
+          echo "Do not hand-edit the generated pages — edit the skill's SKILL.md."
+          exit 1
+
       - name: Lint docs diagrams
         run: npm run lint:diagrams
         working-directory: website

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,10 +268,10 @@ entry points you'll actually edit.
 
 ```
 hermes-agent/
-├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
+├── run_agent.py          # AIAgent class — core conversation loop (~8k LOC)
 ├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
 ├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
-├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)
+├── cli.py                # HermesCLI class — interactive CLI orchestrator (~18k LOC)
 ├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
 ├── hermes_constants.py   # get_hermes_home(), display_hermes_home() — profile-aware paths
 ├── hermes_logging.py     # setup_logging() — agent.log / errors.log / gateway.log (profile-aware)
@@ -281,12 +281,18 @@ hermes-agent/
 ├── tools/                # Tool implementations — auto-discovered via tools/registry.py
 │   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
 ├── gateway/              # Messaging gateway — run.py + session.py + platforms/
-│   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
-│   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
-│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   yuanbao, webhook, api_server, ...). See ADDING_A_PLATFORM.md.
+│   ├── authz_mixin.py    # GatewayAuthorizationMixin — _is_user_authorized + allowlist maps
+│   ├── platform_registry.py  # Plugin-platform registry (adapters, auth env vars, discovery)
+│   ├── platforms/        # BasePlatformAdapter + shared mixins/helpers, and the
+│   │                     #   BUILT-IN adapters ONLY: api_server, bluebubbles,
+│   │                     #   msgraph_webhook, qqbot/, signal, webhook, weixin,
+│   │                     #   whatsapp_cloud, yuanbao. Most platforms are now plugins —
+│   │                     #   see plugins/platforms/ and ADDING_A_PLATFORM.md.
 │   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
 ├── plugins/              # Plugin system (see "Plugins" section below)
+│   ├── platforms/        # Platform adapters, plugin path — the home for most
+│   │                     #   platforms: telegram, discord, slack, matrix, teams,
+│   │                     #   feishu, email, sms, irc, line, whatsapp (Baileys), ...
 │   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
 │   ├── context_engine/   # Context-engine plugins
 │   ├── model-providers/  # Inference backend plugins (openrouter, anthropic, gmi, ...)
@@ -294,7 +300,7 @@ hermes-agent/
 │   ├── hermes-achievements/  # Gamified achievement tracking
 │   ├── observability/    # Metrics / traces / logs plugin
 │   ├── image_gen/        # Image-generation providers
-│   └── <others>/         # disk-cleanup, google_meet, platforms, spotify,
+│   └── <others>/         # disk-cleanup, google_meet, spotify,
 │                         #   strike-freedom-cockpit, ...
 ├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
 ├── skills/               # Built-in skills bundled with the repo
@@ -305,7 +311,7 @@ hermes-agent/
 ├── cron/                 # Scheduler — jobs.py, scheduler.py
 ├── scripts/              # run_tests.sh, release.py, auxiliary scripts
 ├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
+└── tests/                # Pytest suite (~23.5k test functions, ~2.7k files, Aug 2026)
 ```
 
 **User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
@@ -530,16 +536,16 @@ The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes
 
 ### Electron Desktop Chat App (`apps/desktop/`)
 
-A **separate** chat surface from both the classic CLI and the dashboard's embedded TUI. It is an Electron + React + nanostore renderer (`@assistant-ui/react`) that talks to a `tui_gateway` backend over JSON-RPC (`requestGateway(method, params)`). The WebSocket/JSON-RPC transport lives in the framework-agnostic `apps/shared` package (`@hermes/shared` — `JsonRpcGatewayClient` + WS URL helpers), which the web dashboard (`web/`) also consumes; **desktop has no build/runtime dependency on the dashboard frontend** — it spawns a headless `hermes serve` backend server (the same gateway `dashboard` serves, minus the browser UI entirely: `serve` sets `headless_backend=True`, so `cmd_dashboard` skips `_build_web_ui` AND exports `HERMES_SERVE_HEADLESS=1` so `mount_spa()` disables the SPA even if a stray `web_dist/` exists — only the JSON-RPC/WS/API surface is reachable). `dashboard` and `serve` share `cmd_dashboard`/`start_server` but are independent surfaces — neither launches the other. The one exception is a backward-compat *fallback*: `serve` is newer, so the desktop spawn (`electron/backend-command.ts` + `backendSupportsServe()` in `electron/main.ts`) detects whether the resolved runtime registers `serve` and, only when it does not (an older managed install / PATH `hermes` the app hasn't updated yet), rewrites the argv to the legacy `dashboard --no-open`. Without that, a new app against an un-upgraded runtime would crash on an unknown subcommand and brick every mid-upgrade user. It does NOT embed `hermes --tui` — it has its own composer, transcript, and slash-command pipeline. For scoped Desktop architecture, state, resolver, transport, and testing rules, read `apps/desktop/AGENTS.md`.
+A **separate** chat surface from both the classic CLI and the dashboard's embedded TUI. It is an Electron + React + nanostore renderer (`@assistant-ui/react`) that talks to a `tui_gateway` backend over JSON-RPC (`requestGateway(method, params)`). The WebSocket/JSON-RPC transport lives in the framework-agnostic `apps/shared` package (`@hermes/shared` — `JsonRpcGatewayClient` + WS URL helpers), which the web dashboard (`web/`) also consumes; **desktop has no build/runtime dependency on the dashboard frontend** — it spawns a headless `hermes serve` backend server (the same gateway `dashboard` serves, minus the browser UI entirely: `serve` sets `headless_backend=True`, so `cmd_dashboard` skips `_build_web_ui` AND exports `HERMES_SERVE_HEADLESS=1` so `mount_spa()` disables the SPA even if a stray `web_dist/` exists — only the JSON-RPC/WS/API surface is reachable). `dashboard` and `serve` share `cmd_dashboard`/`start_server` but are independent surfaces — neither launches the other. The one exception is a backward-compat *fallback*: `serve` is newer, so the desktop spawn (`apps/desktop/electron/backend-command.ts` + `backendSupportsServe()` in `apps/desktop/electron/main.ts`) detects whether the resolved runtime registers `serve` and, only when it does not (an older managed install / PATH `hermes` the app hasn't updated yet), rewrites the argv to the legacy `dashboard --no-open`. Without that, a new app against an un-upgraded runtime would crash on an unknown subcommand and brick every mid-upgrade user. It does NOT embed `hermes --tui` — it has its own composer, transcript, and slash-command pipeline. For scoped Desktop architecture, state, resolver, transport, and testing rules, read `apps/desktop/AGENTS.md`.
 
 **Slash commands in the desktop app are curated client-side, then dispatched to the backend.** The pipeline:
 
 - **Backend already provides everything.** `tui_gateway/server.py` `commands.catalog` (empty-query list) and `complete.slash` (typed-query completions) both include built-in commands, user `quick_commands`, AND skill-derived commands (`scan_skill_commands()` / `get_skill_commands()`). The desktop app does not need a new RPC to see skills.
 - **The renderer curates via `apps/desktop/src/lib/desktop-slash-commands.ts`.** This is the load-bearing file. It holds `DESKTOP_COMMAND_SPECS` (the built-ins and their Desktop surfaces) plus `NO_DESKTOP_SURFACE` block-lists for terminal-only / messaging-only / picker-owned / settings-owned / advanced commands that should NOT clutter the desktop popover.
   - `isDesktopSlashCommand(name)` — gates **execution**. Returns true for built-ins AND for any non-built-in (skill / quick command), so typed extension commands run.
-  - `isDesktopSlashSuggestion(name)` — gates **discovery/completion**. Used by BOTH completion paths in `app/chat/composer/hooks/use-slash-completions.ts` (empty-query catalog filter + typed-query `complete.slash` filter) and by `filterDesktopCommandsCatalog`.
+  - `isDesktopSlashSuggestion(name)` — gates **discovery/completion**. Used by BOTH completion paths in `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts` (empty-query catalog filter + typed-query `complete.slash` filter) and by `filterDesktopCommandsCatalog`.
   - `isDesktopSlashExtensionCommand(name)` — true when the command is NOT a known Hermes built-in (i.e. a skill or user quick command). Both suggestion and catalog-filter paths allow extensions through so skill commands surface in the palette. (Added when fixing "skill commands missing from the desktop slash palette" — the curated allow-list was silently dropping every skill/quick command from completions even though they executed fine when typed.)
-- **Dispatch** lives in `app/session/hooks/use-prompt-actions/slash.ts` (`runSlash`): built-ins that the desktop owns (`/skin`, `/help`, `/new`, …) are handled locally or via `commands.catalog`; everything else goes to `slash.exec`, falling back to `command.dispatch` (which the gateway resolves into skill / alias / exec directives). A skill command resolves to `{type: "skill", message}` and is submitted as a normal prompt.
+- **Dispatch** lives in `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` (`runSlash`): built-ins that the desktop owns (`/skin`, `/help`, `/new`, …) are handled locally or via `commands.catalog`; everything else goes to `slash.exec`, falling back to `command.dispatch` (which the gateway resolves into skill / alias / exec directives). A skill command resolves to `{type: "skill", message}` and is submitted as a normal prompt.
 
 **Rule:** the desktop slash palette's curation is about hiding noise (terminal-only / messaging-only built-ins), NOT about hiding user-activated extensions. Skill commands and `quick_commands` are extensions the backend surfaces — they belong in completions. If you tighten `desktop-slash-commands.ts`, keep `isDesktopSlashExtensionCommand` flowing into both the suggestion and catalog-filter paths. Tests: from `apps/desktop`, run `npx vitest run src/lib/desktop-slash-commands.test.ts` (workspace dependencies are installed at the repo root).
 

--- a/docs/chronos-managed-cron-contract.md
+++ b/docs/chronos-managed-cron-contract.md
@@ -132,7 +132,7 @@ public HTTP surface on hosted deployments (the gateway may be idle/scaled down);
 it is in `PUBLIC_API_PATHS` so the dashboard cookie gate lets the bearer-JWT
 callback through to the verifier. (Also registered on the optional
 `APIServerAdapter` for self-host API-server deployments.) The verifier is
-`plugins/cron/chronos/verify.py`.
+`plugins/cron_providers/chronos/verify.py`.
 
 - **Auth:** `Authorization: Bearer <NAS-minted JWT>`. The agent verifies:
   - signature against the NAS JWKS (`cron.chronos.nas_jwks_url`),

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -56,9 +56,13 @@ orphans) and the developer-guide page for the prose walkthrough.
 two transport modes the user picks between — unofficial vs official
 APIs, polling vs websocket, library A vs library B — the right
 structure is two adapters that share a behavior mixin. WhatsApp does
-this: `gateway/platforms/whatsapp.py` (Baileys bridge) and
+this: `plugins/platforms/whatsapp/adapter.py` (Baileys bridge) and
 `gateway/platforms/whatsapp_cloud.py` (Meta Cloud API) both inherit
 from `WhatsAppBehaviorMixin` in `gateway/platforms/whatsapp_common.py`.
+Note that these two now live on opposite sides of the plugin/built-in
+split — the mixin stays in `gateway/platforms/` and the plugin imports
+it directly. Sharing a core mixin from a plugin adapter is supported and
+is the intended way to avoid duplicating protocol-agnostic behavior.
 The mixin owns gating, allow-lists, mention parsing, broadcast
 filters, and the WhatsApp-flavored markdown conversion — everything
 that's platform-protocol-agnostic. Each adapter owns its transport.
@@ -122,7 +126,10 @@ If your platform supports interactive button/menu messages, implement these for 
 | `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram and Discord. |
 | `send_choice_picker(...)` | Flat single-level picker for finite-choice commands (`/reasoning`, `/fast`). Implemented by Telegram (inline keyboard), Discord (select menu), and Matrix (reactions). Platforms without it fall back to the text status card automatically. |
 
-See `gateway/platforms/telegram.py`, `discord.py`, and `whatsapp_cloud.py` for reference implementations. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`) is shared across adapters — match it so the gateway-side resolvers work without modification.
+For reference implementations see `plugins/platforms/telegram/adapter.py` and
+`plugins/platforms/discord/adapter.py` (both migrated to the plugin path, and
+both still the richest examples of interactive UX), and
+`gateway/platforms/whatsapp_cloud.py` for a built-in adapter. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`) is shared across adapters — match it so the gateway-side resolvers work without modification.
 
 ### Required function
 
@@ -187,9 +194,17 @@ elif platform == Platform.YOUR_PLATFORM:
 
 ---
 
-## 4. Authorization Maps (`gateway/run.py`)
+## 4. Authorization Maps (`gateway/authz_mixin.py`)
 
-Add to BOTH dicts in `_is_user_authorized()`:
+> **Plugin path: skip this section.** `_is_user_authorized()` falls back to
+> `gateway/platform_registry.py` for any platform not in the maps below and
+> picks up `allowed_users_env` / `allow_all_env` from your `plugin.yaml`
+> automatically. Only built-in adapters need to hand-edit these dicts.
+
+Authorization lives on `GatewayAuthorizationMixin`, which `gateway/run.py`
+mixes into the runner — the maps are **not** in `run.py` itself.
+
+Add to BOTH dicts in `GatewayAuthorizationMixin._is_user_authorized()`:
 
 ```python
 platform_env_map = {
@@ -301,14 +316,25 @@ platform as a delivery option.
 
 ---
 
-## 11. Channel Directory (`gateway/channel_directory.py`)
+## 11. Channel Directory (`gateway/channel_directory.py`) — usually nothing to do
 
-If your platform can't enumerate chats (most can't), add it to the
-session-based discovery list:
+This used to be an opt-**in** list. It is now opt-**out**: every platform in
+the `Platform` enum (and every plugin in the registry) gets session-based
+discovery automatically when it can't enumerate chats directly. You only act
+here if you need to *suppress* it:
 
 ```python
-for plat_name in ("telegram", "whatsapp", "signal", "your_platform"):
+_SKIP_SESSION_DISCOVERY = frozenset({"local", "api_server", "webhook"})
 ```
+
+Discovery is additionally gated on the platform being **connected in this
+gateway process** — historical sessions from a disabled or decommissioned
+platform are deliberately not resurrected as send targets, because stale
+entries make `send_message` route somewhere that can no longer deliver.
+
+So: if your platform is connected and can't enumerate chats, you get the
+directory for free. Add it to `_SKIP_SESSION_DISCOVERY` only if session
+origins are not valid send targets for it.
 
 ---
 
@@ -394,11 +420,14 @@ Optional but valuable:
 After implementing everything, verify with:
 
 ```bash
-# All tests pass
-python -m pytest tests/ -q
+# All tests pass. Use the runner, not pytest directly — it enforces CI parity
+# (unset credential vars, TZ=UTC, per-file subprocess isolation). See AGENTS.md
+# § Testing; direct pytest has caused repeated works-locally/fails-in-CI splits.
+scripts/run_tests.sh
 
 # Grep for your platform name to find any missed integration points
-grep -r "telegram\|discord\|whatsapp\|slack" gateway/ tools/ agent/ cron/ hermes_cli/ toolsets.py \
+grep -r "telegram\|discord\|whatsapp\|slack" \
+  gateway/ plugins/platforms/ tools/ agent/ cron/ hermes_cli/ toolsets.py \
   --include="*.py" -l | sort -u
 # Check each file in the output — if it mentions other platforms but not yours, you missed it
 ```

--- a/scripts/ci/check_doc_links.py
+++ b/scripts/ci/check_doc_links.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Verify that repo file paths cited in tracked Markdown still exist.
+
+Why this exists
+---------------
+Docs rot silently when *code* moves, not when docs change. When the messaging
+platforms migrated from ``gateway/platforms/<name>.py`` to
+``plugins/platforms/<name>/adapter.py``, `ADDING_A_PLATFORM.md` kept pointing
+new contributors at files that no longer existed, and
+`tests/e2e/matrix_xsign_bootstrap/README.md` kept telling readers to diff
+against a symbol that had been deleted. Nothing failed, because nothing checks.
+
+That is also why this check is **not** gated on "markdown changed" — the diff
+that breaks a doc reference usually does not touch the doc at all.
+
+Resolution model
+----------------
+A reference resolves if ANY of these lands on a real tracked path:
+
+1. repo-root relative                    — ``gateway/run.py``
+2. relative to the doc's own directory, or any ancestor of it up to the repo
+   root. This is what makes ``app/chat/perf-probe.tsx`` resolve from
+   ``apps/desktop/src/debug/README.md``.
+3. relative to a **section base** — the nearest preceding heading that names a
+   directory in backticks, e.g.::
+
+       ### Slash command subsystem (`src/app/slash/`)
+
+       - `commands/core.ts` — general TUI commands
+
+   The base itself is resolved with rules 1 and 2, so both repo-root-anchored
+   and doc-relative section bases work.
+4. relative to an explicit per-file override::
+
+       <!-- doc-links: base=apps/desktop/src -->
+
+The model is deliberately generous. A false positive costs a contributor real
+time and gets the check disabled; a missed dead link costs the next reader one
+confused search. Tune toward silence.
+
+Exemptions live in the tables at the top of this file, each with a reason —
+if you add one, say why.
+
+Usage
+-----
+    python3 scripts/ci/check_doc_links.py            # check the repo
+    python3 scripts/ci/check_doc_links.py --stats    # + coverage summary
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# ── Which docs are in scope ──────────────────────────────────────────────
+#
+# Excluded trees are excluded for a *reason*, not for convenience. Dated plan
+# documents and investigation logs are historical records: they describe the
+# tree as it was, and "fixing" their paths to match today's code destroys the
+# thing that makes them worth keeping.
+
+EXCLUDED_DOC_GLOBS: tuple[str, ...] = (
+    # Historical records — accurate as of their date, deliberately not updated.
+    "docs/plans/*",
+    ".plans/*",
+    "apps/desktop/scripts/profile-typing-lag.md",  # self-declared investigation log
+    # The Docusaurus site has its own link checking in docs-site-checks.yml.
+    "website/*",
+    # Skill docs address paths relative to an installed skill directory, which
+    # is not this repo's layout. Out of scope until that's modeled properly.
+    "skills/*",
+    "optional-skills/*",
+    "locales/*",
+    # Vendored / generated.
+    "node_modules/*",
+)
+
+# ── Reference exemptions ─────────────────────────────────────────────────
+#
+# (doc_glob, ref, reason). doc_glob "*" applies everywhere.
+# These are NOT dead links — they are references that correctly point outside
+# this repo's working tree.
+
+EXEMPT_REFS: tuple[tuple[str, str, str], ...] = (
+    (
+        "AGENTS.md",
+        "tools/your_tool.py",
+        "tutorial placeholder — the file the reader is being told to create",
+    ),
+    (
+        "AGENTS.md",
+        "references/new-skill-pr-salvage.md",
+        "lives in the hermes-agent-dev skill, not this repo (stated in context)",
+    ),
+    (
+        "docs/relay-connector-contract.md",
+        "src/core/relayBus.ts",
+        "connector repo: NousResearch/gateway-gateway",
+    ),
+    (
+        "docs/relay-connector-contract.md",
+        "src/core/relayAuthToken.ts",
+        "connector repo: NousResearch/gateway-gateway",
+    ),
+    (
+        "docs/relay-connector-contract.md",
+        "docs/capability-trust-boundary.md",
+        "connector repo — the doc says so inline",
+    ),
+    (
+        "docs/relay-connector-contract.md",
+        "docs/connector-gateway-auth-design.md",
+        "connector repo — the doc says so inline",
+    ),
+    (
+        "docs/chronos-managed-cron-contract.md",
+        "src/server/agent-cron/instance-auth.ts",
+        "NAS repo (nous-account-service) — this doc's audience is its implementer",
+    ),
+    (
+        "docs/observability/relay-shared-metrics.md",
+        "skills/.usage.json",
+        "runtime path under HERMES_HOME, not a repo file",
+    ),
+    (
+        "plugins/hermes-achievements/docs/*",
+        "dashboard/perf_scan_coordinator.py",
+        "forward-looking spec — file is to be created by the described refactor",
+    ),
+    (
+        "plugins/hermes-achievements/docs/*",
+        "dashboard/perf_snapshot.py",
+        "forward-looking spec — file is to be created by the described refactor",
+    ),
+)
+
+# Paths under these prefixes are runtime locations (user's HERMES_HOME, editor
+# config), never repo files.
+RUNTIME_PREFIXES: tuple[str, ...] = (".hermes/", ".claude/", "~/")
+
+# Path segments that mean "generated output" — never tracked, so a reference
+# through one is describing a build artifact, not a source file.
+_GENERATED_SEGMENTS = frozenset({"dist", "build", "web_dist", "node_modules", "__pycache__"})
+
+# Extensions we treat as "a path to a file in this repo".
+CODE_EXTS = (
+    "py", "ts", "tsx", "js", "jsx", "mjs", "cjs",
+    "yaml", "yml", "json", "toml", "sh", "ps1", "md", "rs",
+)
+
+_REF_RE = re.compile(r"`([^`\s]+\.(?:" + "|".join(CODE_EXTS) + r"))`")
+_HEADING_BASE_RE = re.compile(r"^#{1,6}\s.*?`([A-Za-z0-9_./-]+/)`")
+_BASE_DIRECTIVE_RE = re.compile(r"<!--\s*doc-links:\s*base=([A-Za-z0-9_./-]+)\s*-->")
+_EXT_LIST_SEG_RE = re.compile(r"^\.[a-z0-9]+$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    doc: str
+    line: int
+    ref: str
+
+
+def is_pathlike(ref: str) -> bool:
+    """Filter out backticked tokens that look like paths but aren't.
+
+    Each rejection below is a *class* of non-path token seen in this repo's
+    docs, not a one-off. Keeping them here rather than in EXEMPT_REFS means a
+    new doc using the same idiom doesn't have to re-litigate it.
+    """
+    if not ref or "/" not in ref:  # bare filenames are too ambiguous to resolve
+        return False
+    if ref.startswith(("/", "~", "@")):
+        # absolute path, home-relative path, or an npm scoped package
+        # specifier (`@spectrum-ts/imessage/dist/index.js`)
+        return False
+    if "://" in ref:  # any URL scheme — http, viking://, etc.
+        return False
+    if ref.startswith(RUNTIME_PREFIXES):
+        return False
+    if "$" in ref or "{" in ref or "}" in ref:
+        # env-var or template interpolation: `$HERMES_HOME/mem0.json`,
+        # `{sessions_dir}/sessions.json` — a runtime path, not a repo file
+        return False
+    if "*" in ref or "<" in ref or ">" in ref:  # globs / placeholders
+        return False
+    segs = ref.split("/")
+    if all(_EXT_LIST_SEG_RE.match(s) for s in segs):
+        return False  # ".md/.txt/.rst" — an extension list, not a path
+    if any(s in _GENERATED_SEGMENTS for s in segs):
+        return False  # build output isn't tracked; `ui-tui/dist/entry.js`
+    return True
+
+
+def extract_refs(text: str) -> list[tuple[str, int]]:
+    """Return ``(ref, line_number)`` for every path-like backticked token."""
+    out: list[tuple[str, int]] = []
+    in_fence = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue  # code blocks are illustrative, not assertions about the tree
+        for m in _REF_RE.finditer(line):
+            ref = m.group(1)
+            if is_pathlike(ref):
+                out.append((ref, lineno))
+    return out
+
+
+def section_base_at(text: str, line: int) -> str | None:
+    """Directory declared by the nearest heading at or above ``line``."""
+    base = None
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if lineno > line:
+            break
+        m = _HEADING_BASE_RE.match(raw)
+        if m:
+            base = m.group(1).rstrip("/")
+    return base
+
+
+def explicit_base(text: str) -> str | None:
+    m = _BASE_DIRECTIVE_RE.search(text)
+    return m.group(1).rstrip("/") if m else None
+
+
+def ancestors(doc: str) -> list[str]:
+    """The doc's own directory and every ancestor, nearest first, then root."""
+    out = []
+    d = os.path.dirname(doc)
+    while d:
+        out.append(d)
+        d = os.path.dirname(d)
+    out.append("")
+    return out
+
+
+def candidates(ref: str, doc: str, base: str | None, override: str | None) -> list[str]:
+    """Every path this reference could legitimately mean, most likely first."""
+    anchors = ancestors(doc)
+    out = [ref]  # repo-root relative
+    out += [os.path.normpath(os.path.join(a, ref)) for a in anchors if a]
+    for b in (override, base):
+        if not b:
+            continue
+        # The section base itself may be repo-root- or doc-relative.
+        for a in anchors:
+            out.append(os.path.normpath(os.path.join(a, b, ref)) if a
+                       else os.path.normpath(os.path.join(b, ref)))
+    seen, uniq = set(), []
+    for c in out:
+        if c not in seen:
+            seen.add(c)
+            uniq.append(c)
+    return uniq
+
+
+def exemption_reason(doc: str, ref: str) -> str | None:
+    for doc_glob, exempt_ref, reason in EXEMPT_REFS:
+        if ref == exempt_ref and (doc_glob == "*" or fnmatch.fnmatch(doc, doc_glob)):
+            return reason
+    return None
+
+
+def in_scope(doc: str) -> bool:
+    return not any(fnmatch.fnmatch(doc, g) for g in EXCLUDED_DOC_GLOBS)
+
+
+def check_doc(doc: str, text: str, exists) -> tuple[list[Finding], int, int]:
+    """Check one doc. Returns ``(findings, checked, exempted)``.
+
+    ``exists`` is injected so this is testable without a filesystem.
+    """
+    override = explicit_base(text)
+    findings: list[Finding] = []
+    checked = exempted = 0
+    for ref, lineno in extract_refs(text):
+        if exemption_reason(doc, ref):
+            exempted += 1
+            continue
+        checked += 1
+        base = section_base_at(text, lineno)
+        if not any(exists(c) for c in candidates(ref, doc, base, override)):
+            findings.append(Finding(doc, lineno, ref))
+    return findings, checked, exempted
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stats", action="store_true", help="print coverage summary")
+    ap.add_argument("--json", action="store_true", help="emit findings as JSON")
+    args = ap.parse_args()
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], capture_output=True, text=True, check=True
+    ).stdout.split("\n")
+    tracked_set = {p for p in tracked if p}
+    docs = sorted(p for p in tracked_set if p.endswith(".md") and in_scope(p))
+
+    def exists(p: str) -> bool:
+        return p in tracked_set or os.path.exists(p)
+
+    findings: list[Finding] = []
+    total_checked = total_exempt = 0
+    for doc in docs:
+        try:
+            text = open(doc, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        f, c, e = check_doc(doc, text, exists)
+        findings += f
+        total_checked += c
+        total_exempt += e
+
+    if args.json:
+        print(json.dumps([f.__dict__ for f in findings], indent=2))
+
+    if args.stats or not findings:
+        print(
+            f"doc-links: {total_checked} references checked across {len(docs)} docs "
+            f"({total_exempt} exempted, {len(EXCLUDED_DOC_GLOBS)} doc globs out of scope)"
+        )
+
+    if findings:
+        print()
+        print(f"::error::{len(findings)} documentation reference(s) point at files that do not exist.")
+        print()
+        by_doc: dict[str, list[Finding]] = {}
+        for f in findings:
+            by_doc.setdefault(f.doc, []).append(f)
+        for doc, items in sorted(by_doc.items()):
+            print(f"  {doc}")
+            for f in items:
+                print(f"    line {f.line}: `{f.ref}`")
+        print()
+        print("A reference resolves against the repo root, the doc's own directory or any")
+        print("ancestor of it, or a directory named in backticks by the nearest heading.")
+        print()
+        print("To fix, in order of preference:")
+        print("  1. The file moved   -> update the path (that is the whole point of this check).")
+        print("  2. The path is right but addressed from somewhere else -> add a section base:")
+        print("       ## Section title (`some/dir/`)")
+        print("     or a per-file override near the top of the doc:")
+        print("       <!-- doc-links: base=some/dir -->")
+        print("  3. It genuinely lives outside this repo (another repo, a runtime path under")
+        print("     HERMES_HOME, a placeholder the reader will create) -> add it to")
+        print("     EXEMPT_REFS in scripts/ci/check_doc_links.py *with a reason*.")
+        print()
+        print("Run locally: python3 scripts/ci/check_doc_links.py --stats")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_doc_links.py
+++ b/tests/ci/test_doc_links.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/ci/check_doc_links.py.
+
+The resolver is exercised as pure logic with an injected ``exists`` predicate —
+no filesystem, no reading of real repo files. A test that walked the real tree
+would fail every time a doc legitimately changed, which is exactly the
+change-detector antipattern AGENTS.md bans.
+
+The bias under test: **resolve generously, report rarely.** A false positive
+gets the check disabled; a missed dead link costs one confused reader.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "check_doc_links.py"
+_spec = importlib.util.spec_from_file_location("check_doc_links", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load check_doc_links.py")
+_mod = importlib.util.module_from_spec(_spec)
+# Register before exec: @dataclass resolves its own module out of sys.modules,
+# and blows up with AttributeError on None if the module isn't there yet.
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+is_pathlike = _mod.is_pathlike
+extract_refs = _mod.extract_refs
+section_base_at = _mod.section_base_at
+candidates = _mod.candidates
+check_doc = _mod.check_doc
+in_scope = _mod.in_scope
+exemption_reason = _mod.exemption_reason
+
+
+def _exists(*present: str):
+    """Build an ``exists`` predicate over a fixed set of paths."""
+    known = set(present)
+    return lambda p: p in known
+
+
+# ── What counts as a repo path ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "gateway/run.py",
+        "plugins/platforms/telegram/adapter.py",
+        ".github/workflows/ci.yml",  # dotdir is a real repo path
+        "src/components/markdown.tsx",
+    ],
+)
+def test_pathlike_accepts_repo_paths(ref):
+    assert is_pathlike(ref)
+
+
+@pytest.mark.parametrize(
+    "ref,why",
+    [
+        ("run_agent.py", "bare filename — too ambiguous to resolve"),
+        ("/.well-known/agent.json", "absolute/URL path"),
+        ("~/.hermes/config.yaml", "home-relative runtime path"),
+        (".hermes/security-guidance.md", "runtime path under HERMES_HOME"),
+        ("$HERMES_HOME/mem0.json", "env-var interpolation"),
+        ("{sessions_dir}/sessions.json", "template placeholder"),
+        ("viking://user/memories/profile.md", "custom URL scheme"),
+        ("https://example.com/a.json", "http URL"),
+        ("@spectrum-ts/imessage/dist/index.js", "npm scoped package specifier"),
+        ("ui-tui/dist/entry.js", "build artifact, never tracked"),
+        ("web/node_modules/foo/index.js", "vendored dependency"),
+        (".md/.txt/.rst/.json/.yaml", "extension list, not a path"),
+        ("tools/*.py", "glob"),
+        ("gateway/platforms/<platform>.py", "placeholder"),
+    ],
+)
+def test_pathlike_rejects_non_repo_tokens(ref, why):
+    assert not is_pathlike(ref), why
+
+
+# ── Extraction ───────────────────────────────────────────────────────────
+
+
+def test_extract_skips_fenced_code_blocks():
+    text = "\n".join([
+        "Real ref: `gateway/run.py`",
+        "```python",
+        "from a.b import c  # `illustrative/only.py`",
+        "```",
+        "Another: `tools/registry.py`",
+    ])
+    assert [r for r, _ in extract_refs(text)] == ["gateway/run.py", "tools/registry.py"]
+
+
+def test_extract_reports_line_numbers():
+    text = "line one\n\nsee `gateway/run.py` here\n"
+    assert extract_refs(text) == [("gateway/run.py", 3)]
+
+
+# ── Section bases ────────────────────────────────────────────────────────
+
+
+def test_section_base_from_nearest_heading():
+    text = "\n".join([
+        "# Title",                                    # 1
+        "### Slash commands (`src/app/slash/`)",      # 2
+        "- `commands/core.ts` — stuff",               # 3
+    ])
+    assert section_base_at(text, 3) == "src/app/slash"
+
+
+def test_section_base_is_nearest_preceding_not_any():
+    text = "\n".join([
+        "## A (`src/one/`)",     # 1
+        "- `x.ts`",              # 2
+        "## B (`src/two/`)",     # 3
+        "- `y.ts`",              # 4
+    ])
+    assert section_base_at(text, 2) == "src/one"
+    assert section_base_at(text, 4) == "src/two"
+
+
+def test_no_base_before_first_declaring_heading():
+    assert section_base_at("## Plain heading\n- `a/b.ts`\n", 2) is None
+
+
+# ── Resolution ───────────────────────────────────────────────────────────
+
+
+def test_resolves_from_repo_root():
+    found, _, _ = check_doc(
+        "docs/x.md", "see `gateway/run.py`", _exists("gateway/run.py")
+    )
+    assert found == []
+
+
+def test_resolves_via_ancestor_directory():
+    """`app/chat/probe.tsx` cited from apps/desktop/src/debug/README.md."""
+    found, _, _ = check_doc(
+        "apps/desktop/src/debug/README.md",
+        "see `app/chat/probe.tsx`",
+        _exists("apps/desktop/src/app/chat/probe.tsx"),
+    )
+    assert found == []
+
+
+def test_resolves_via_section_base():
+    text = "### Slash (`src/app/slash/`)\n- `commands/core.ts`\n"
+    found, _, _ = check_doc(
+        "ui-tui/README.md", text, _exists("ui-tui/src/app/slash/commands/core.ts")
+    )
+    assert found == []
+
+
+def test_resolves_via_explicit_base_directive():
+    text = "<!-- doc-links: base=apps/desktop/src -->\nsee `lib/thing.ts`\n"
+    found, _, _ = check_doc(
+        "docs/desktop.md", text, _exists("apps/desktop/src/lib/thing.ts")
+    )
+    assert found == []
+
+
+def test_reports_a_genuinely_missing_file():
+    found, _, _ = check_doc(
+        "docs/x.md", "see `gateway/platforms/telegram.py`", _exists("nothing/else.py")
+    )
+    assert len(found) == 1
+    assert found[0].ref == "gateway/platforms/telegram.py"
+    assert found[0].line == 1
+
+
+def test_the_regression_this_check_exists_for():
+    """An adapter moves; the doc still names the old path and is not edited."""
+    doc = "See `gateway/platforms/telegram.py` for a reference implementation."
+    after_move = _exists("plugins/platforms/telegram/adapter.py")
+    found, _, _ = check_doc("gateway/platforms/ADDING_A_PLATFORM.md", doc, after_move)
+    assert [f.ref for f in found] == ["gateway/platforms/telegram.py"]
+
+
+# ── Exemptions and scope ─────────────────────────────────────────────────
+
+
+def test_exempt_ref_is_not_reported_and_is_counted_separately():
+    text = "checklist lives at `references/new-skill-pr-salvage.md`"
+    found, checked, exempted = check_doc("AGENTS.md", text, _exists())
+    assert found == []
+    assert (checked, exempted) == (0, 1)
+
+
+def test_exemption_is_scoped_to_its_doc():
+    ref = "references/new-skill-pr-salvage.md"
+    assert exemption_reason("AGENTS.md", ref)
+    assert exemption_reason("docs/unrelated.md", ref) is None
+
+
+def test_every_exemption_carries_a_reason():
+    for doc_glob, ref, reason in _mod.EXEMPT_REFS:
+        assert reason.strip(), f"{doc_glob}:{ref} exempted without a reason"
+
+
+@pytest.mark.parametrize(
+    "doc,expected",
+    [
+        ("AGENTS.md", True),
+        ("gateway/platforms/ADDING_A_PLATFORM.md", True),
+        ("docs/plans/2026-06-09-003-fix-telegram.md", False),  # historical record
+        (".plans/streaming-support.md", False),                # historical record
+        ("website/docs/user-guide/x.md", False),               # docs-site owns this
+        ("skills/github/SKILL.md", False),                     # installed-skill layout
+    ],
+)
+def test_doc_scope(doc, expected):
+    assert in_scope(doc) is expected
+
+
+def test_candidates_are_deduplicated():
+    got = candidates("a/b.py", "docs/x.md", "a", None)
+    assert len(got) == len(set(got))

--- a/tests/e2e/matrix_xsign_bootstrap/README.md
+++ b/tests/e2e/matrix_xsign_bootstrap/README.md
@@ -1,7 +1,9 @@
 # Matrix cross-signing bootstrap — E2E test
 
-Self-contained end-to-end test for the auto-bootstrap behavior added in
-`gateway/platforms/matrix.py`. Spins up a real Continuwuity homeserver
+Self-contained end-to-end test for the auto-bootstrap behavior in the Matrix
+adapter, `plugins/platforms/matrix/adapter.py` (this moved out of the old
+gateway-builtin location when Matrix became a plugin).
+Spins up a real Continuwuity homeserver
 in Docker, registers a fresh bot, runs the patched bootstrap path
 against it, and asserts:
 
@@ -35,12 +37,19 @@ busy locally.
 ## What the test exercises
 
 The test mirrors the bootstrap snippet from
-`gateway/platforms/matrix.py` (the "if MATRIX_RECOVERY_KEY else
-get_own_cross_signing_public_keys / generate_recovery_key" branch)
-inline so it runs without importing the entire hermes gateway and its
-many dependencies. **If the source diverges from what's in
-`_connect_with_bootstrap`, this test must be updated to match.** A
-small price for not requiring the full hermes-agent runtime in CI.
+`MatrixAdapter.connect()` in `plugins/platforms/matrix/adapter.py` (the
+"if MATRIX_RECOVERY_KEY else get_own_cross_signing_public_keys /
+generate_recovery_key" branch) inline so it runs without importing the
+entire hermes gateway and its many dependencies. The copy lives in this
+test's own `_connect_with_bootstrap()` helper — that name exists **only
+here**, not in production. **If `connect()` diverges from the mirrored
+snippet, this test must be updated to match.** A small price for not
+requiring the full hermes-agent runtime in CI.
+
+> **Known gap:** nothing mechanically enforces the mirror. The production
+> bootstrap has already moved once (module → plugin, and out of a dedicated
+> method into `connect()`) without this test noticing, so treat drift here
+> as likely rather than hypothetical.
 
 ## Skipped when
 

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -94,14 +94,15 @@ npm run test:watch
 ### Slash command subsystem (`src/app/slash/`)
 
 - `types.ts` — `SlashCommand` interface and `SlashRunCtx` execution context (gateway rpc, transcript helpers, session refs, stale-guard)
-- `registry.ts` — assembles `SLASH_COMMANDS` from all command files in registration order (core → billing → credits → session → ops → setup → debug) and exposes `findSlashCommand(name)` for case-insensitive lookup
-- `commands/core.ts` — general TUI commands
-- `commands/billing.ts` — `/billing`: manage Nous remote spending — buy credits, auto-reload, limits
-- `commands/credits.ts` — `/credits`
-- `commands/session.ts` — session and agent commands
-- `commands/ops.ts` — operations commands
+- `registry.ts` — assembles `SLASH_COMMANDS` from all command files in registration order (core → topup → session → subscription → ops → wake → setup → debug) and exposes `findSlashCommand(name)` for case-insensitive lookup
+- `commands/core.ts` — general TUI commands (`/help`, `/quit`, `/clear`, `/status`, `/copy`, `/paste`, `/logs`, `/queue`, `/steer`, `/undo`, `/retry`, …)
+- `commands/topup.ts` — `/topup`: buy Nous credits
+- `commands/session.ts` — session and agent commands (`/model`, `/sessions`, `/compress`, `/branch`, `/skin`, `/reasoning`, `/usage`, …)
+- `commands/subscription.ts` — `/subscription`: manage the Nous subscription
+- `commands/ops.ts` — operations commands (`/stop`, `/reload`, `/reload-mcp`, `/browser`, `/agents`, `/replay`, `/skills`, `/plugins`, `/tools`, …)
+- `commands/wake.ts` — `/wake`: wake-word control
 - `commands/setup.ts` — `/setup`
-- `commands/debug.ts` — `/heapdump`, `/mem`
+- `commands/debug.ts` — `/heapdump`, `/mem`, `/widgets-reload`, `/theme-info`
 
 The top-level `app.tsx` composes these into the Ink tree with `Static` transcript output, a live streaming assistant row, prompt overlays, queue preview, status rule, input line, and completion list.
 
@@ -122,7 +123,7 @@ The intro panel is driven by `session.info` and rendered through `branding.tsx`.
 
 ## Hotkeys and interactions
 
-Current input behavior is split across `app.tsx`, `components/textInput.tsx`, and the prompt/picker components.
+Current input behavior is split across `src/app.tsx`, `src/components/textInput.tsx`, and the prompt/picker components.
 
 ### Main chat input
 
@@ -179,7 +180,7 @@ Notes:
 
 Notes:
 
-- Clarify free-text mode and masked prompts use `ink-text-input`, so text editing there follows the library's default bindings rather than `components/textInput.tsx`.
+- Clarify free-text mode and masked prompts use `ink-text-input`, so text editing there follows the library's default bindings rather than `src/components/textInput.tsx`.
 - When a blocking prompt is open, the main chat input hotkeys are suspended.
 - Clarify mode has no dedicated cancel shortcut in the current client. Sudo and secret prompts only expose `Ctrl+C` cancellation from the app-level blocked handler.
 
@@ -201,7 +202,7 @@ Notes:
 Assistant output is rendered in one of two ways:
 
 - if the payload already contains ANSI, `messageLine.tsx` prints it directly
-- otherwise `components/markdown.tsx` renders a small Markdown subset into Ink components
+- otherwise `src/components/markdown.tsx` renders a small Markdown subset into Ink components
 
 The Markdown renderer handles headings, lists, block quotes, tables, fenced code blocks, diff coloring, inline code, emphasis, links, and plain URLs.
 

--- a/web/README.md
+++ b/web/README.md
@@ -76,7 +76,7 @@ Read before adding or editing UI styles. These rules keep the dashboard legible 
 
 - The dashboard preserves the Nous brand uppercase aesthetic, but it is **opt-in per element, not global**.
 - Apply uppercase via the DS utility `text-display` on **brand chrome only** — page titles, nav section headings, badges, brand wordmark. DS components (`Button`, `Badge`, `Tabs`, `Segmented`, etc.) already self-apply `text-display`.
-- **Do not introduce new `uppercase`** (the literal Tailwind class) in `hermes-agent/web/src`. Prefer `text-display` for new brand chrome. Legacy `uppercase` call sites (e.g. `components/ui/label.tsx`, `card.tsx`) remain until migrated.
+- **Do not introduce new `uppercase`** (the literal Tailwind class) in `hermes-agent/web/src`. Prefer `text-display` for new brand chrome. Legacy `uppercase` call sites remain until migrated — the densest are `src/pages/SystemPage.tsx`, `src/pages/ChannelsPage.tsx`, and `src/pages/ModelsPage.tsx`. (This list previously cited label/card components under `web/src/components/ui/`; that directory is now empty and those files are gone.)
 - The app shell no longer forces uppercase globally, so blanket `normal-case` opt-outs are unnecessary. Use `normal-case` only where a DS component applies `text-display` but the label should stay sentence case — e.g. dynamic user content (model slugs, theme names) **or** fixed UI copy that is not brand chrome (EnvPage “not configured” toggle, sidebar “New chat”).
 
 ### Fonts

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -79,6 +79,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**actual-setup**](/docs/user-guide/skills/optional/devops/devops-actual-setup) | Set up Actual Computer (actual.inc) inference in Hermes. |
 | [**inference-sh-cli**](/docs/user-guide/skills/optional/devops/devops-cli) | Run 150+ AI apps (image, video, LLM) via inference.sh CLI. |
 | [**docker-management**](/docs/user-guide/skills/optional/devops/devops-docker-management) | Manage Docker containers, images, volumes, and Compose. |
 | [**hermes-s6-container-supervision**](/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision) | Modify or debug s6 services in the Hermes Docker image. |

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
@@ -117,8 +117,9 @@ screenshot in the same tool call. All actions that target an element
 accept `modifiers=[…]` for held keys.
 
 The input actions (`click`, `double_click`, `right_click`, `middle_click`,
-`drag`, `scroll`, `type`, `key`) also accept `delivery_mode` and
-`bring_to_front` — see "The verify → escalate ladder" below.
+`drag`, `scroll`, `type`, `key`) also accept `delivery_mode`. The optional
+`bring_to_front=True` request invokes a separately approved standalone focus
+tool before foreground input; it is never an input-action property.
 
 ## The verify → escalate ladder (background-first)
 
@@ -140,11 +141,17 @@ Walk it in order:
 
 1. **Element, background (default).** `click(element=N)`. If `effect:"confirmed"`,
    you're done.
-2. **Pixel, background.** On `escalation.recommended == "px"` (or a `degraded`
-   capture with an empty element list), click by `coordinate=[x,y]` read off the
-   screenshot instead of `element`.
-3. **Foreground.** On `escalation.recommended == "foreground"`,
-   `code:"background_unavailable"`, or a pixel click that still didn't land,
+2. **Fresh verification.** `effect:"unverifiable"` means inspect a fresh
+   capture/state before any retry. Do this even when `escalation.recommended`
+   is present; it is advisory, not proof that successful input should repeat.
+3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
+   refusal recommends `"px"` (or a `degraded` capture has no elements), click
+   by `coordinate=[x,y]` instead of `element`.
+4. **Typed page.** When `escalation.recommended == "page"` and the exact
+   browser-page contract below is available, use the namespaced typed route
+   before native foreground. This is not the legacy `page` workflow.
+5. **Foreground.** After `effect:"suspected_noop"`,
+   `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
    for a short sequence to avoid per-call flashes. It needs its own approval
@@ -160,11 +167,47 @@ computer_use(action="click", element=7, delivery_mode="foreground")
 ```
 
 **Escalate to foreground as a REACTION to a returned signal, never as a
-prediction** from the app being Electron/Chromium/GTK. Different controls in
+prediction** from the app being Electron/Chromium/GTK. A confirmed effect is
+done and must not be duplicated. Different controls in
 the same app behave differently. Do NOT silently retry the same rung, and do
 NOT conclude "cua-driver can't drive this app" — climb the ladder. If
-`delivery_mode="foreground"` returns `code:"foreground_unsupported"`, the
-driver is too old; tell the user to update cua-driver.
+`delivery_mode="foreground"` returns `code:"foreground_unsupported"`, the live
+action schema lacks that property; choose another verified rung without
+inferring support from the executable's reported version.
+
+## Typed browser page rung
+
+For page content in a supported GUI browser, the same `computer_use` tool
+exposes namespaced `cua_browser_*` actions. They do not collide with other
+browser tools. The contract is capability-based:
+
+1. Discover the exact native browser `(pid, window_id)` with `list_windows` or
+   native capture, then call `cua_browser_state` with both values.
+2. Continue only when it returns `status:"ok"`, `binding_quality:"exact"`, and
+   `mutation_allowed:true`. Select an opaque `tab_id` from that response.
+3. Call `cua_browser_state` with the `tab_id` for a fresh `semantic_v2`
+   snapshot. Use only refs from that newest snapshot and only for their
+   declared actions.
+4. Use the matching namespaced action (`cua_browser_click`,
+   `cua_browser_type`, `cua_browser_navigate`, or `cua_browser_pointer`).
+   Trusted input is the default. `input_route="dom_event"` is an explicit
+   trust downgrade; never choose it silently after a refusal.
+5. Every mutation invalidates refs. Take a fresh state snapshot before another
+   typed action. Never chain actions from remembered refs.
+
+`cua_browser_prepare` is a separate approved setup action. Driver-owned
+`isolated_new`/`isolated_named` profiles require explicit `allow_launch=true`.
+An `existing_profile` is decided by cua-driver's immutable permission mode.
+Normal Hermes sessions use `standard`, which requires a certified protected
+host and fails closed when Hermes has none. Explicit Hermes YOLO (`--yolo`,
+`/yolo`, or `approvals.mode: off`) launches a private embedded cua-driver in
+`unrestricted` after that risk acceptance, so there are no runtime Cua
+approval prompts. Never invent, store, log, or reuse a grant token.
+
+Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
+permission UI, OS prompts, native dialogs, extension surfaces, unsupported
+engines, and any typed route that cannot prove exact binding or mutation
+permission. `cua_browser_dialog` covers page JavaScript dialogs only.
 
 ### Key shortcuts vary per platform
 
@@ -270,14 +313,14 @@ in your conversation context.
 | `cua-driver not installed` | Run `hermes computer-use install`, or `hermes tools` and enable Computer Use |
 | Captures consistently return empty / "no on-screen window" | On Linux: DISPLAY may not be set (X11) or you're on pure Wayland — ask the user to run `hermes computer-use doctor`. On Windows: you may be in Session 0 (SSH session) instead of the interactive desktop — see the cua-driver `WINDOWS.md` deep-dive |
 | Element index stale ("Element N not in cache") | SOM indices are only valid until the next `capture`. Re-capture before clicking. The wrapper carries opaque `element_token`s for stale-detection; you'll see an explicit error rather than a wrong click |
-| Click had no effect | Read the structured verdict, don't just recapture. `effect:"unverifiable"` → re-capture and confirm yourself. `effect:"suspected_noop"` / `code:"background_unavailable"` / `escalation.recommended` → climb the ladder: try `coordinate=[x,y]` (px), then `delivery_mode="foreground"`. A modal (e.g. an Electron consent dialog) may be blocking input — foreground delivery is how you dismiss it. Don't conclude the app is undrivable |
+| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |
 
 ## When NOT to use `computer_use`
 
-- **Web automation you can do via `browser_*` tools** — those use a
+- **Web automation you can do via separate headless `browser_*` tools** — those use a
   real headless Chromium and are more reliable than driving the user's
   GUI browser. Reach for `computer_use` specifically when the task
   needs the user's actual native apps (Finder/Explorer/Files, Mail/

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-ocr-and-documents.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-ocr-and-documents.md
@@ -36,6 +36,8 @@ For PPTX: see the `powerpoint` skill (full create/read/edit support).
 For PDF manipulation (merge, split, forms, watermarks, creation): see the `pdf` skill.
 This skill covers **text extraction from PDFs and scanned documents**.
 
+> **Coming from a `read_file` EXTRACTION COVERAGE WARNING?** `read_file` auto-converts local PDFs but reads the text layer only; the warning footer lists the pages that yielded no text (scanned images). For a handful of pages, render + vision is fastest: `pdftoppm -jpeg -r 150 -f N -l N file.pdf /tmp/page` then `vision_analyze` each image. For bulk OCR of many pages, use marker-pdf below (Step 2).
+
 ## Step 1: Remote URL Available?
 
 If the document has a URL, **always try `web_extract` first**:

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-pdf.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-pdf.md
@@ -175,6 +175,7 @@ Read [forms.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/pr
 
 ## Pitfalls
 
+- `read_file` auto-converts PDFs (via the optional anydoc converter) but reads the **text layer only**. A mostly-scanned PDF converts "successfully" into section headers with empty bodies; when that happens read_file appends an `EXTRACTION COVERAGE WARNING` footer listing the pages that yielded no text. Recover those pages with `pdftoppm -jpeg -r 150 -f N -l N file.pdf /tmp/page` + `vision_analyze`, or bulk-OCR via the `ocr-and-documents` skill.
 - `page.extract_text()` returns `None` on image-only pages — guard with `or ""` and fall back to OCR.
 - pypdf preserves encryption flags: reading an encrypted PDF requires `PdfReader(path, password=...)` before pages are accessible.
 - reportlab coordinates are bottom-left origin, points (1/72″) — not top-left.

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -125,11 +125,9 @@ scripts/run_tests.sh tests/path/to/test_file.py::test_name --trace
 scripts/run_tests.sh tests/path/to/test_file.py --showlocals --tb=long
 ```
 
-Note: `scripts/run_tests.sh` uses xdist (`-n 4`) by default, and pdb does NOT work under xdist. Add `-p no:xdist` or run a single test with `-n 0`:
+Note: `scripts/run_tests.sh` runs each test file in a captured subprocess via `run_tests_parallel.py` (no xdist), so interactive pdb does NOT work under the wrapper. Run pytest directly for `--pdb`:
 
 ```bash
-scripts/run_tests.sh tests/foo_test.py::test_bar --pdb -p no:xdist
-# or
 source .venv/bin/activate
 python -m pytest tests/foo_test.py::test_bar --pdb
 ```
@@ -294,7 +292,7 @@ nc 127.0.0.1 4444
 ## Debugging Hermes-specific Processes
 
 ### Tests
-See Recipe 3. Always add `-p no:xdist` or run single tests without xdist.
+See Recipe 3. The wrapper captures subprocess output, so run pytest directly for interactive pdb.
 
 ### `run_agent.py` / CLI — one-shot
 Easiest: add `breakpoint()` near the suspect line, then run `hermes` normally. Control returns to your terminal at the pause point.
@@ -326,7 +324,7 @@ Long-lived. Use `remote-pdb` at a handler, or `debugpy` with `--wait-for-client`
 
 ## Common Pitfalls
 
-1. **pdb under pytest-xdist silently does nothing.** You won't see the prompt, the test just hangs. Always use `-p no:xdist` or `-n 0`.
+1. **pdb under a parallel/output-capturing runner silently does nothing.** You won't see the prompt, the test just hangs (true of pytest-xdist and of `scripts/run_tests.sh`'s captured per-file subprocesses). Run pytest directly on a single file for interactive debugging.
 
 2. **`breakpoint()` in CI / non-TTY contexts hangs the process.** Safe locally; never commit it. Add a pre-commit grep as a safety net.
 
@@ -351,7 +349,7 @@ Long-lived. Use `remote-pdb` at a handler, or `debugpy` with `--wait-for-client`
 
 - [ ] After `pip install debugpy`, confirm: `python -c "import debugpy; print(debugpy.__version__)"`
 - [ ] For remote debug, confirm the port is actually listening: `ss -tlnp | grep 5678`
-- [ ] First breakpoint actually hits (if it doesn't, you likely have `PYTHONBREAKPOINT=0`, you're under xdist, or execution finished before attach)
+- [ ] First breakpoint actually hits (if it doesn't, you likely have `PYTHONBREAKPOINT=0`, you're under a parallel/capturing runner, or execution finished before attach)
 - [ ] `where` / `w` shows the expected call stack
 - [ ] Post-debug cleanup: no stray `breakpoint()` / `set_trace()` in committed code
   ```bash
@@ -372,10 +370,10 @@ breakpoint()
 
 **"This test passes in isolation but fails in the suite."**
 ```bash
-scripts/run_tests.sh tests/the_test.py --pdb -p no:xdist
-# But if it only fails WITH other tests:
+scripts/run_tests.sh tests/the_test.py   # confirm it fails under the isolated runner first
+# For interactive debugging, or if it only fails WITH other tests:
 source .venv/bin/activate
-python -m pytest tests/ -x --pdb -p no:xdist
+python -m pytest tests/ -x --pdb
 # Now it pdb-traps at the exact failing test after state accumulated.
 ```
 

--- a/website/docs/user-guide/skills/optional/devops/devops-actual-setup.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-actual-setup.md
@@ -1,0 +1,163 @@
+---
+title: "Actual Setup — Set up Actual Computer (actual.inc) inference in Hermes"
+sidebar_label: "Actual Setup"
+description: "Set up Actual Computer (actual.inc) inference in Hermes"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Actual Setup
+
+Set up Actual Computer (actual.inc) inference in Hermes.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/devops/actual-setup` |
+| Path | `optional-skills/devops/actual-setup` |
+| Version | `2.0.0` |
+| Author | shl0ms + Hermes Agent |
+| License | MIT |
+| Tags | `actual`, `actual-inc`, `provider`, `local-inference`, `relay`, `gguf`, `setup` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Actual Computer Setup Skill
+
+Sets up [actual.inc](https://actual.inc) (Actual Computer) as a Hermes inference
+provider. Actual turns the user's own hardware into a private inference cluster
+and exposes an OpenAI-compatible API two ways: a hosted end-to-end-encrypted
+relay at `https://api.actual.inc` (authenticated with an `ac_` key), and a local
+on-device daemon at `http://127.0.0.1:8080` (no auth on loopback). This skill
+does not install the Actual daemon for the user — device authorization requires
+a human in a browser.
+
+## When to Use
+
+- User wants to add actual.inc as an inference provider (cloud relay or local).
+- User has an `ac_` key and wants Hermes routed through their Actual cluster.
+- User wants fully-local, on-device inference via the Actual daemon.
+- Troubleshooting: Actual requests failing with cryptic 400s or empty streams.
+
+## Prerequisites
+
+- Hermes has **first-class `actual` provider support** (provider id `actual`,
+  aliases `actual-computer`, `actualcomputer`, `aci`). Do NOT configure Actual
+  as a `custom_providers` / `providers.actual.*` entry on current Hermes — the
+  built-in provider owns the name and handles base-url normalization, the
+  Responses transport, and local no-auth automatically.
+- Relay mode: an Actual account and an `ac_` inference key from
+  https://actual.inc/user/keys.
+- Local mode: the user has installed the daemon
+  (`curl -fsSL "https://actual.inc/install" | bash`) and completed device
+  authorization by running `actual` once and opening the printed
+  `https://actual.inc/device?code=...` URL in a browser. Relay that URL to the
+  user and WAIT — never invent an email or authorize on their behalf. Codes
+  expire in 5 minutes; re-run `actual` for a fresh one.
+
+## How to Run
+
+### Relay / API mode
+
+1. Put the key in `.env` (secrets only — never config.yaml):
+   append `ACTUAL_API_KEY=ac_...` to `~/.hermes/.env`.
+2. Verify the key and discover models with `terminal`:
+   ```bash
+   curl -s https://api.actual.inc/v1/models -H "Authorization: Bearer $ACTUAL_API_KEY"
+   ```
+3. Select provider + model:
+   ```bash
+   hermes config set model.provider actual
+   hermes config set model.default "MODEL_ID_FROM_DISCOVERY"
+   ```
+4. Verify end-to-end:
+   ```bash
+   hermes chat -Q -q "Reply with exactly: ACTUAL_OK" --provider actual -m MODEL_ID
+   ```
+
+### Local mode
+
+1. Human has installed + authorized the daemon (see Prerequisites).
+2. Download and load a model (scriptable once authorized):
+   ```bash
+   actual models search "qwen2.5 0.5b instruct gguf" --limit 8 --no-prompt
+   # Downloads REQUIRE an explicit quantization (409 ambiguous_model_download otherwise):
+   actual models download "Qwen/Qwen2.5-0.5B-Instruct-GGUF/Q4_K_M"
+   actual models list        # note the INSTALLED name (differs from download id)
+   actual models load "qwen2.5-0.5b-instruct-q4_k_m"   # load by installed name
+   ```
+3. Point Hermes at the daemon. `ACTUAL_BASE_URL` with a loopback host flips the
+   built-in provider into local no-auth mode automatically — no key needed:
+   append `ACTUAL_BASE_URL=http://127.0.0.1:8080` to `~/.hermes/.env`, then:
+   ```bash
+   hermes config set model.provider actual
+   hermes config set model.default "INSTALLED_MODEL_NAME"
+   ```
+4. Verify (reduced toolset — see context-window pitfall below):
+   ```bash
+   hermes chat -Q -q "Reply with exactly: LOCAL_OK" --provider actual -m INSTALLED_NAME -t file,web
+   ```
+
+## Quick Reference
+
+| Thing | Value |
+|---|---|
+| Hosted relay | `https://api.actual.inc/v1` (normalized from bare host automatically) |
+| Local daemon | `http://127.0.0.1:8080/v1` (no auth on loopback) |
+| Key env var | `ACTUAL_API_KEY` (`ac_...`) |
+| Base URL env var | `ACTUAL_BASE_URL` (loopback host ⇒ local no-auth mode) |
+| Provider id / aliases | `actual` / `actual-computer`, `actualcomputer`, `aci` |
+| Transport | Responses API (`codex_responses`) — built-in, do not override |
+| Cluster pinning | `X-Cluster-ID` header via `providers.actual.extra_headers` in config.yaml |
+| Model size guide | 0.5B Q4_K_M ~470MB (toy), 7-8B Q4_K_M ~4.5GB (daily driver), 32B ~20GB |
+
+## Pitfalls
+
+1. **reasoning_effort trap (handled by Hermes since the first-class provider).**
+   Actual's SGLang/vLLM backends accept only `none/low/medium/high/max`;
+   `xhigh`/`ultra` used to fail with a cryptic
+   `Expecting value: line 1 column 1 (char 0)` (a wrapped HTTP 400). The
+   built-in provider clamps `xhigh→high` and `ultra→max` on the wire. If a
+   request still 400s this way on an old Hermes, set a per-model cap:
+   `agent.reasoning_overrides.<model>: high` in config.yaml.
+2. **Context-window overflow on small local models.** Hermes' default toolset
+   is ~26k tokens of schemas plus a ~9k-token system prompt. A model loaded
+   with a 32k context overflows before the first turn, and llama.cpp-family
+   servers emit a bare `data: [DONE]` — Hermes reports
+   `Provider returned an empty stream with no finish_reason`. This is NOT an
+   SSE bug. Fixes: restrict tools (`-t file,web`), load the model with a
+   larger `n_ctx`, or pick a >=64k-context model for the full toolset.
+   Upstream tracking: #51448 (do not file new issues; add evidence there).
+   Related but distinct: #65631 (HTTP-200 SSE carrying a 400), #56516
+   (reasoning-only streams).
+3. **Download ids vs installed names.** `actual models download` takes
+   `repo/QUANT` and 409s without an explicit quantization;
+   `actual models load` takes the INSTALLED name from `actual models list`.
+4. **Reasoning models returning empty content.** GLM/Qwen reasoning variants
+   emit thinking in a separate `reasoning` field and can burn a small
+   `max_tokens` entirely on reasoning. Give generous max_tokens before
+   assuming failure.
+5. **Do not create a custom provider named `actual`.** Older setup guides
+   (pre first-class support) wrote `providers.actual.*` config blocks. On
+   current Hermes the built-in provider wins the name; stale custom blocks
+   are ignored or conflict. Remove them and use the env vars + model.provider
+   flow above.
+
+## Verification
+
+```bash
+# Relay:
+hermes chat -Q -q "Reply with exactly: ACTUAL_OK" --provider actual -m MODEL
+# Local (small model — reduced toolset):
+hermes chat -Q -q "Reply with exactly: LOCAL_OK" --provider actual -m MODEL -t file,web
+# Provider status (local no-auth shows key_source=local-offline):
+hermes status
+```
+
+For other OpenAI-compatible clients (e.g. OpenCode), see
+`references/opencode.md`.

--- a/website/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision.md
@@ -82,7 +82,8 @@ If you're just running the Hermes Agent and want to use Docker, see `website/doc
 
 | Path | Role |
 |---|---|
-| `Dockerfile` | s6-overlay install + cont-init.d wiring + `ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]` |
+| `Dockerfile` | s6-overlay install + cont-init.d wiring + `ENTRYPOINT ["/opt/hermes/docker/entrypoint-dispatch.sh"]` |
+| `docker/entrypoint-dispatch.sh` | PID-1 dispatcher: exec's `/init` + main-wrapper when the image owns PID 1; on wrapped runtimes (Fly Machines, `docker run --init`) falls back to stage2-hook + main-wrapper directly, restoring the s6 helper PATH first (#38349). |
 | `docker/stage2-hook.sh` | The "old entrypoint logic" — UID remap, chown, seed, skills sync. Runs as cont-init.d/01-hermes-setup. |
 | `docker/cont-init.d/02-reconcile-profiles` | Calls `hermes_cli.container_boot` on every boot to restore profile gateway slots from the persistent volume. |
 | `docker/main-wrapper.sh` | The container's CMD. Routes user args, drops to hermes via `s6-setuidgid`, exec's the chosen program. |
@@ -100,7 +101,7 @@ The original plan (v1–v3) called for main hermes to run as a supervised s6-rc 
 1. **cont-init.d scripts receive no CMD args** — so the stage2 hook can't parse `docker run <image> chat -q "hi"` to set `HERMES_ARGS` for a service `run` script to consume.
 2. **`/run/s6/basedir/bin/halt` does NOT propagate the exit code** written to `/run/s6-linux-init-container-results/exitcode`. Containers always exit 143 (SIGTERM) regardless. Confirmed by skarnet (s6 author) in [issue #477](https://github.com/just-containers/s6-overlay/issues/477): _"if you want a container shutdown, you need to either have your CMD exit, or, if you have no CMD, write the container exit code you want then call halt"_.
 
-So we use the s6-overlay-native CMD pattern: `ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]`. /init prepends the wrapper to user args automatically — so `docker run <image> --version` becomes `/init main-wrapper.sh --version`, and `--version` doesn't get intercepted by /init's POSIX shell. The wrapper drops to hermes via `s6-setuidgid`, then exec's the chosen program. The program's exit code becomes the container exit code, exactly matching the pre-s6 tini contract.
+So we use the s6-overlay-native CMD pattern via the dispatcher: `ENTRYPOINT ["/opt/hermes/docker/entrypoint-dispatch.sh"]`, which under PID 1 exec's `/init /opt/hermes/docker/main-wrapper.sh "$@"`. The wrapper is prepended to user args automatically — so `docker run <image> --version` becomes `/init main-wrapper.sh --version`, and `--version` doesn't get intercepted by /init's POSIX shell. The wrapper drops to hermes via `s6-setuidgid`, then exec's the chosen program. The program's exit code becomes the container exit code, exactly matching the pre-s6 tini contract. When the entrypoint is NOT PID 1 (Fly Machines, `docker run --init`), the dispatcher skips `/init` entirely (it would abort with `can only run as pid 1`), restores the s6 helper PATH, runs stage2-hook.sh, and exec's main-wrapper.sh directly — no supervised services on that path (#38349).
 
 Trade-off: main hermes is unsupervised under s6. That exactly matches its behavior under tini (the pre-s6 image). Dashboard supervision is the only **new** guarantee — and per-profile gateways under `/run/service/` get full supervision.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -399,6 +399,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-optional-devops',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/optional/devops/devops-actual-setup',
                     'user-guide/skills/optional/devops/devops-cli',
                     'user-guide/skills/optional/devops/devops-docker-management',
                     'user-guide/skills/optional/devops/devops-hermes-s6-container-supervision',


### PR DESCRIPTION
## What and why

Documentation references rotted when the messaging platforms moved from
`gateway/platforms/<name>.py` to `plugins/platforms/<name>/adapter.py`, and the
committed output of the skill-docs generators drifted from its sources. Nothing
failed, because nothing checks either one. This fixes the current damage and adds
the two checks that would have caught it.

### 1. `ADDING_A_PLATFORM.md` — stale, and in one place inverted

The doc is structurally fine (Plugin path vs Built-in path are two deliberate
sections); its *examples and integration points* had gone stale.

- **§11 Channel Directory had inverted, not merely drifted.** It told contributors
  to add their platform to an opt-**in** session-discovery list. That list no
  longer exists — `gateway/channel_directory.py:172` is now an opt-**out**
  `_SKIP_SESSION_DISCOVERY` frozenset, so discovery is automatic and the
  documented step was a no-op. Also documents the connected-in-this-process gate,
  which is deliberate: stale session origins make `send_message` route to a
  platform that can no longer deliver.
- **§4 Authorization Maps pointed at the wrong file.** `_is_user_authorized()` and
  both allowlist dicts live on `GatewayAuthorizationMixin` in
  `gateway/authz_mixin.py`, not `gateway/run.py`. More useful: `authz_mixin.py`
  now resolves `allowed_users_env` / `allow_all_env` from `platform_registry`, so
  **plugin authors should skip that section entirely** — added as a callout.
- Reference implementations pointed at `gateway/platforms/telegram.py` and
  `discord.py`; both are plugins now.
- The WhatsApp sibling-adapter example cited a moved file. Reframed: the Baileys
  adapter is a *plugin* importing a *core* mixin, which is supported and worth
  stating.
- Quick Verification said `python -m pytest tests/ -q`, contradicting AGENTS.md's
  "ALWAYS use `scripts/run_tests.sh`". Its grep also missed `plugins/platforms/`.

### 2. `AGENTS.md` and other docs

Structure tree listed telegram/discord/slack/matrix under `gateway/platforms/` —
all are in `plugins/platforms/`. Gives `plugins/platforms/` its own entry and
surfaces `authz_mixin.py` / `platform_registry.py`. Refreshed drifted counts
(`cli.py` ~11k→~18k, `run_agent.py` ~12k→~8k, tests ~17k/~900 files→~23.5k
functions/~2.7k files).

Also: `ui-tui/README.md` documented `commands/billing.ts` and `commands/credits.ts`
(neither exists) and omitted `subscription.ts`, `topup.ts`, `wake.ts` (all do);
registration order corrected against `registry.ts`. The Matrix E2E README pointed
at a deleted module and told readers to diff against `_connect_with_bootstrap`, a
symbol that exists only inside the test itself — now names
`MatrixAdapter.connect()` and records that nothing enforces the mirror.
Plus `plugins/cron/chronos` → `plugins/cron_providers/chronos`.

Deliberately untouched: `docs/plans/` and `.plans/` are dated records that
describe the tree as it was.

### 3. New: doc-link guard (`scripts/ci/check_doc_links.py`)

Verifies backticked repo paths in tracked Markdown resolve. Pure stdlib over
`git ls-files` — no venv, no install step.

**Not gated on "markdown changed"** — the diff that breaks a doc reference is a
rename in the *code* and doesn't touch the doc, so a path filter would miss the
entire failure class. Verified by renaming
`plugins/platforms/telegram/adapter.py` with no doc edits: the check fails on
`ADDING_A_PLATFORM.md`, as intended.

The resolver is deliberately generous, because a false positive gets a check like
this switched off while a missed dead link costs one confused reader. A reference
resolves against the repo root, the doc's own directory or any ancestor, a
directory declared in backticks by the nearest heading, or an explicit
`<!-- doc-links: base=... -->` override. Non-path tokens are rejected by class
(`$HERMES_HOME/...`, `{sessions_dir}/...`, `viking://`, npm scoped specifiers,
`dist/`, extension lists). Genuinely-external refs live in `EXEMPT_REFS`, each
with a stated reason; a test asserts none is blank. Historical records and the
Docusaurus site are out of scope.

Currently: 251 references checked across 67 docs, 10 exempted, green.

### 4. Regenerated skill docs + a freshness gate

`optional-skills/devops/actual-setup` had **no page at all** and appeared in
neither the optional-skills catalog nor the sidebar — the skill shipped, its
documentation never did. Three further pages had fallen behind their `SKILL.md`.

Nothing in that commit is hand-written; it is the generators' output, produced by
re-running them on this base rather than replaying an earlier run (replaying would
have collided with the `sidebars.ts` edit in 0957277f2 and could have reverted the
polymarket move — regenerating folds it in instead).

The gate runs right after the generators and diffs `website/`. Scoped there
because every generator output lands there (the `static/api/*.json` blobs are
gitignored). Safe to gate on: the generators are deterministic — two runs over an
unchanged tree are byte-identical, verified by checksum before wiring it up.
Verified in both directions: fails with the file list pre-regeneration, passes
once committed.

## How to test

```bash
# doc-link guard (and its unit tests)
python3 scripts/ci/check_doc_links.py --stats
scripts/run_tests.sh tests/ci/test_doc_links.py

# generated-docs freshness: regenerate, then confirm no diff
python3 website/scripts/extract-skills.py
python3 website/scripts/generate-skill-docs.py
git status --short -- website/     # expect empty

# docs-site lane end to end
cd website && npm ci && npm run lint:diagrams && npm run build
```

To see the doc-link guard actually catch something, rename any file a doc
references (e.g. `plugins/platforms/telegram/adapter.py`) and re-run it without
editing the doc.

## Platforms tested

Linux (Kali 6.19, x86_64), Python 3.11.14, pytest 9.1.1, Node 26.7.0 / npm 12.

Full `scripts/run_tests.sh`: 25,829 passed, 1 failed — the single failure is
`tests/agent/test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`,
which fails identically on unmodified `main` and is unrelated to this PR (it is
not caused by anything here; noted rather than folded in).
JS lane: 10/10 workspace checks, 6,157 tests. Docker lint and image build/test
green. Blocking `ruff check .` and `ty` clean.

## Known limitation

The zh-Hans i18n mirrors of the catalogs are maintained by hand (the generators
do not write `website/i18n/`). This PR widens a pre-existing EN/ZH gap by one row
(29 → 30) by adding `devops-actual-setup` to the English catalog only. I did not
hand-add an untranslated English row to the Chinese catalog — that is a
translation decision, not a mechanical one. The freshness gate cannot cover i18n
for the same reason: the generator never produces those files. Happy to follow up
if you want that mirrored or gated.
