### PR TITLE
feat(skills): add dyad-integration optional skill

### DIFF
--- a/optional-skills/devops/dyad-integration/SKILL.md
+++ b/optional-skills/devops/dyad-integration/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: dyad-integration
+description: Sync Hermes and Dyad projects, context, and MCP tools.
+version: 1.0.0
+author: Arthur Talley (Ambientmuse Studios LLC)
+license: MIT
+platforms: [macos, linux, windows]
+metadata:
+  hermes:
+    tags: [dyad, integration, mcp, ai-rules, sync, app-builder]
+    category: devops
+    related_skills: []
+---
+
+# Dyad ↔ Hermes Integration
+
+Connect Hermes to [Dyad](https://dyad.sh) — the local, open-source AI app builder.
+Sync project context, read Dyad's chat history, write `AI_RULES.md` files that Dyad
+treats as authoritative, register MCP servers so Dyad can call Hermes tools, and
+manage Dyad projects programmatically.
+
+## When to Use
+
+- The user wants to synchronize project work between Hermes and Dyad.
+- The user wants to send context, specs, or task state to a Dyad project so Dyad's
+  AI chat picks it up automatically.
+- The user wants to list, inspect, or manage Dyad projects from Hermes.
+- The user wants Dyad's AI to call Hermes tools (web search, file ops, terminal,
+  memory) during its app-building chats — via MCP.
+- The user asks about connecting Dyad to Hermes or "sending work to Dyad."
+
+## Architecture Overview
+
+Dyad is an **Electron app** (`com.electron.dyad`) that stores all state in a single
+SQLite database. Projects live as plain directories on disk with git repos. Dyad
+loads a per-project `AI_RULES.md` file and injects it as authoritative context into
+every AI chat turn. Dyad is also an **MCP client** — it can connect to external MCP
+servers.
+
+Three integration paths:
+
+| Path | Direction | Mechanism | Risk |
+|------|-----------|-----------|------|
+| 1. AI_RULES.md + filesystem | Hermes → Dyad | Write context files into `~/dyad-apps/<name>/AI_RULES.md`; Dyad auto-loads them | Very low |
+| 2. MCP bridge | Dyad → Hermes | Register a Hermes MCP server in Dyad's `mcp_servers` table; Dyad calls Hermes tools | Medium |
+| 3. SQLite + filesystem | Bidirectional | Read/write Dyad's DB and project dirs directly from Hermes | Low (reads safe with WAL) |
+
+## Prerequisites
+
+- Dyad installed (`/Applications/dyad.app` on macOS).
+- Dyad SQLite DB at `~/Library/Application Support/dyad/sqlite.db` (WAL mode —
+  concurrent reads are safe while Dyad runs; writes should be cautious).
+- Dyad projects stored at `~/dyad-apps/<project-name>/`.
+- Python 3 with `sqlite3` (stdlib) for the bridge script.
+
+## Key Paths
+
+```
+Dyad app:           /Applications/dyad.app
+Dyad Electron DB:   ~/Library/Application Support/dyad/sqlite.db
+Dyad projects dir:  ~/dyad-apps/<project-name>/
+AI_RULES.md:        ~/dyad-apps/<project-name>/AI_RULES.md  (per-project, Dyad auto-loads)
+Dyad deep link:     dyad://  (registered URL scheme — OAuth callbacks only)
+Dyad config env:   DYAD_LANGUAGE_MODEL_CATALOG_URL  (override model catalog)
+```
+
+## Procedure
+
+### 1. List Dyad Projects
+
+Run the bridge script to list all Dyad projects:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list
+```
+
+Output: id, name, path, created_at, github_repo for each Dyad app.
+
+### 2. Read Dyad Chat History
+
+List chats for a project:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py chats <app_id>
+```
+
+Read messages from a chat:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py messages <chat_id>
+```
+
+### 3. Write AI_RULES.md (Hermes → Dyad context sync)
+
+This is the primary integration. Write project context, specs, architecture
+decisions, or task state into a Dyad project's `AI_RULES.md`. Dyad loads this file
+and injects it as authoritative context into every AI chat turn.
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py write-rules \
+  <project-name-or-id> --file /path/to/context.md
+```
+
+Or pipe content directly:
+
+```bash
+echo "# Project Context\n\nBuild a React dashboard with..." | \
+  python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py write-rules \
+    <project-name-or-id> --stdin
+```
+
+Dyad's own system instructions say:
+> "Treat AI_RULES.md as authoritative project context, unless it conflicts with the
+> user's current request. Edit AI_RULES.md only when the user explicitly asks to
+> remember something across conversations. Keep AI_RULES.md concise and easy to
+> scan."
+
+So keep the file focused — specs, decisions, conventions — not scratchpads.
+
+### 4. Sync Files Between Hermes and a Dyad Project
+
+Since Dyad projects are plain git repos on disk, Hermes can read, write, and
+diff them directly. Use `read_file`, `write_file`, `patch`, `search_files`, and
+`terminal` (git) against `~/dyad-apps/<project-name>/`.
+
+Example — see what Dyad changed:
+
+```bash
+cd ~/dyad-apps/<project-name> && git log --oneline -10
+```
+
+Example — write a file into a Dyad project from Hermes:
+
+Use `write_file` with `path=~/dyad-apps/<project-name>/src/utils/api.ts`.
+
+Dyad's file watcher picks up external changes. The next chat turn will see them.
+
+### 5. Register an MCP Server (Dyad → Hermes tools)
+
+Register an MCP server in Dyad's `mcp_servers` table so Dyad's AI can call
+external tools during app-building chats. Dyad supports `stdio` and `sse`
+transports.
+
+For a stdio MCP server (e.g., a Hermes tool bridge):
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
+  --name "Hermes Bridge" \
+  --transport stdio \
+  --command python3 \
+  --args "/path/to/mcp_server.py" \
+  --env '{"HERMES_HOME": "/Users/ambientmuse/.hermes"}'
+```
+
+For an SSE/URL-based MCP server:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
+  --name "Remote Tools" \
+  --transport sse \
+  --url "http://localhost:8082/sse"
+```
+
+List registered MCP servers:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list-mcp
+```
+
+Remove an MCP server:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py remove-mcp <server_id>
+```
+
+**Note:** After adding an MCP server via the DB, Dyad needs to be restarted (or the
+MCP connections reloaded) to pick up the new server. Dyad's UI also has an MCP
+settings page — changes there write to the same `mcp_servers` table.
+
+### 6. Manage Reusable Prompts
+
+Dyad stores reusable prompts in the `prompts` table. Add one from Hermes:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-prompt \
+  --title "Build Dashboard" \
+  --description "Standard dashboard scaffold prompt" \
+  --content "Create a React dashboard with chart.js, dark theme, responsive layout..."
+```
+
+List prompts:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list-prompts
+```
+
+### 7. Create a New Dyad Project
+
+Create the project directory and register it in Dyad's DB:
+
+```bash
+python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py create-project \
+  --name "my-new-app" \
+  --path ~/dyad-apps/my-new-app
+```
+
+This creates the directory, initializes a git repo, writes a starter
+`AI_RULES.md`, and inserts a row into Dyad's `apps` table. The project will appear
+in Dyad's project list on next launch.
+
+## Full Dyad DB Schema
+
+See `references/dyad-db-schema.md` for the complete SQLite schema — all tables,
+columns, types, and foreign keys. Use it for advanced queries or custom
+integrations.
+
+## Pitfalls
+
+- **Dyad must be closed for DB writes** — WAL mode makes concurrent reads safe,
+  but writes while Dyad's Electron process holds a write transaction can still
+  conflict. If a write fails with "database is locked", close Dyad and retry.
+- **`mcp_servers` inserts need restart** — Dyad loads MCP servers at startup.
+  After inserting a row via the bridge script, restart Dyad for it to connect.
+- **AI_RULES.md must be concise** — Dyad's instructions say to keep it scannable,
+  not a scratchpad. Don't dump raw logs or chatty notes. Specs, decisions, and
+  conventions only.
+- **Project path is relative in DB** — the `apps.path` column stores the project
+  name (relative to `~/dyad-apps/`), not an absolute path. The bridge script
+  resolves it. If you query the DB directly, prepend `~/dyad-apps/`.
+- **Dyad version drift** — schema was extracted from Dyad v1.6.2 (Aug 2026). Future
+  versions may add columns or tables. The bridge script uses `SELECT *` and is
+  resilient to new columns, but if Dyad changes the schema fundamentally,
+  re-extract with `sqlite3 ~/Library/Application\ Support/dyad/sqlite.db .schema`.
+- **`chat_mode` column** — Dyad chats have a `chat_mode` field (values seen in
+  source: build, agent, etc.). This affects how Dyad processes the chat. When
+  creating chats via the bridge, leave this null unless you know the mode.
+- **No HTTP API in shipping Dyad** — the `rkendel1/Dyad` GitHub fork claims a REST
+  API, but the official `dyad-sh/dyad` shipping build does NOT expose one. All
+  integration is via SQLite + filesystem. Do not expect `curl localhost:PORT` to
+  work.
+
+## Verification
+
+### Running the test suite
+
+```bash
+cd ~/.hermes/skills/devops/dyad-integration
+python3 scripts/test_bridge.py
+```
+
+40 tests covering every bridge command: list, chats, messages, write-rules
+(file + stdin + overwrite + missing dir + error cases), read-rules, create-project
+(dir + DB registration + starter files + custom path), add/list/remove MCP servers
+(stdio + sse + error cases), add/list prompts, versions, schema, and project
+resolution by name/ID/path. Includes 3 live DB smoke tests that auto-skip if Dyad
+isn't installed.
+
+Also compatible with pytest:
+
+```bash
+pytest scripts/test_bridge.py -v
+```
+
+### Manual verification
+
+- **List projects:** `python3 scripts/dyad_bridge.py list` — should show your
+  Dyad apps.
+- **AI_RULES.md:** write one, then open the project in Dyad and start a chat —
+  Dyad should reference the context.
+- **MCP server:** after registering one and restarting Dyad, check Dyad's MCP
+  settings UI — your server should appear.
+- **SQLite reads:** all bridge read commands work while Dyad is running (WAL mode).
+- **Schema freshness:** `sqlite3 ~/Library/Application\ Support/dyad/sqlite.db .schema`
+  should match `references/dyad-db-schema.md`.
+
+## References
+
+- `references/dyad-db-schema.md` — complete Dyad SQLite schema (all tables, columns,
+  types, foreign keys, indexes).
+- `scripts/dyad_bridge.py` — Python bridge implementing all operations (list,
+  chats, messages, write-rules, create-project, add-mcp, list-mcp, remove-mcp,
+  add-prompt, list-prompts).

--- a/optional-skills/devops/dyad-integration/SKILL.md
+++ b/optional-skills/devops/dyad-integration/SKILL.md
@@ -71,7 +71,7 @@ Dyad config env:   DYAD_LANGUAGE_MODEL_CATALOG_URL  (override model catalog)
 Run the bridge script to list all Dyad projects:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py list
 ```
 
 Output: id, name, path, created_at, github_repo for each Dyad app.
@@ -81,13 +81,13 @@ Output: id, name, path, created_at, github_repo for each Dyad app.
 List chats for a project:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py chats <app_id>
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py chats <app_id>
 ```
 
 Read messages from a chat:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py messages <chat_id>
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py messages <chat_id>
 ```
 
 ### 3. Write AI_RULES.md (Hermes → Dyad context sync)
@@ -97,7 +97,7 @@ decisions, or task state into a Dyad project's `AI_RULES.md`. Dyad loads this fi
 and injects it as authoritative context into every AI chat turn.
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py write-rules \
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py write-rules \
   <project-name-or-id> --file /path/to/context.md
 ```
 
@@ -105,7 +105,7 @@ Or pipe content directly:
 
 ```bash
 echo "# Project Context\n\nBuild a React dashboard with..." | \
-  python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py write-rules \
+  python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py write-rules \
     <project-name-or-id> --stdin
 ```
 
@@ -144,7 +144,7 @@ transports.
 For a stdio MCP server (e.g., a Hermes tool bridge):
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py add-mcp \
   --name "Hermes Bridge" \
   --transport stdio \
   --command python3 \
@@ -155,7 +155,7 @@ python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
 For an SSE/URL-based MCP server:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py add-mcp \
   --name "Remote Tools" \
   --transport sse \
   --url "http://localhost:8082/sse"
@@ -164,13 +164,13 @@ python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-mcp \
 List registered MCP servers:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list-mcp
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py list-mcp
 ```
 
 Remove an MCP server:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py remove-mcp <server_id>
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py remove-mcp <server_id>
 ```
 
 **Note:** After adding an MCP server via the DB, Dyad needs to be restarted (or the
@@ -182,7 +182,7 @@ settings page — changes there write to the same `mcp_servers` table.
 Dyad stores reusable prompts in the `prompts` table. Add one from Hermes:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-prompt \
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py add-prompt \
   --title "Build Dashboard" \
   --description "Standard dashboard scaffold prompt" \
   --content "Create a React dashboard with chart.js, dark theme, responsive layout..."
@@ -191,7 +191,7 @@ python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py add-prompt \
 List prompts:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list-prompts
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py list-prompts
 ```
 
 ### 7. Create a New Dyad Project
@@ -199,7 +199,7 @@ python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py list-prompts
 Create the project directory and register it in Dyad's DB:
 
 ```bash
-python3 ~/.hermes/skills/dyad-integration/scripts/dyad_bridge.py create-project \
+python3 ~/.hermes/skills/devops/dyad-integration/scripts/dyad_bridge.py create-project \
   --name "my-new-app" \
   --path ~/dyad-apps/my-new-app
 ```

--- a/optional-skills/devops/dyad-integration/references/dyad-db-schema.md
+++ b/optional-skills/devops/dyad-integration/references/dyad-db-schema.md
@@ -1,0 +1,241 @@
+# Dyad SQLite Database Schema
+
+Extracted from Dyad v1.6.2 (Aug 2026). The DB lives at
+`~/Library/Application Support/dyad/sqlite.db` and runs in **WAL mode**
+(concurrent reads are safe while Dyad runs; writes should be done with caution).
+
+## Tables
+
+### `apps` — Dyad projects
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `name` | text | | Project name |
+| `path` | text | | Relative path (name only, resolves under `~/dyad-apps/`) |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+| `github_org` | text | | GitHub org for repo sync |
+| `github_repo` | text | | GitHub repo name |
+| `supabase_project_id` | text | | Supabase project reference |
+| `chat_context` | text | | Additional context for chats |
+| `github_branch` | text | | Active GitHub branch |
+| `vercel_project_id` | text | | Vercel deployment project |
+| `vercel_project_name` | text | | Vercel project name |
+| `vercel_team_id` | text | | Vercel team |
+| `vercel_deployment_url` | text | | Live deployment URL |
+| `neon_project_id` | text | | Neon DB project |
+| `neon_development_branch_id` | text | | Neon dev branch |
+| `neon_preview_branch_id` | text | | Neon preview branch |
+| `install_command` | text | | Custom install command |
+| `start_command` | text | | Custom start command |
+| `is_favorite` | integer | 0 | Favorite flag |
+| `supabase_parent_project_id` | text | | Supabase parent (branching) |
+| `supabase_organization_slug` | text | | Supabase org slug |
+| `theme_id` | text | | Applied theme |
+| `neon_active_branch_id` | text | | Active Neon branch |
+| `needs_app_blueprint` | integer | 0 | Blueprint pending flag |
+| `neon_production_auth_cookie_secret` | text | | Neon prod auth |
+| `neon_development_auth_cookie_secret` | text | | Neon dev auth |
+| `collection_id` | integer | | FK → `app_collections(id)` |
+| `selected_database_branch_type` | text | | DB branch type |
+
+### `chats` — Chat sessions per project
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `app_id` | integer | | FK → `apps(id)` ON DELETE CASCADE |
+| `title` | text | | Chat title |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `initial_commit_hash` | text | | Git commit at chat start |
+| `compacted_at` | integer | | When compaction happened |
+| `compaction_backup_path` | text | | Path to compaction backup |
+| `pending_compaction` | integer | | Compaction pending flag |
+| `chat_mode` | text | | Chat mode (e.g. "build", "agent") |
+
+### `messages` — Individual chat messages
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `chat_id` | integer | | FK → `chats(id)` ON DELETE CASCADE |
+| `role` | text | | "user", "assistant", etc. |
+| `content` | text | | Message content (may contain markdown, code) |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `approval_state` | text | | Approval status for code proposals |
+| `commit_hash` | text | | Git commit associated with message |
+| `request_id` | text | | LLM request ID |
+| `source_commit_hash` | text | | Source commit for this message |
+| `max_tokens_used` | integer | | Token usage |
+| `ai_messages_json` | text | | Full AI message JSON |
+| `model` | text | | Model used (e.g. "claude-3.5-sonnet") |
+| `using_free_agent_mode_quota` | integer | | Free tier flag |
+| `is_compaction_summary` | integer | | Compaction summary flag |
+
+### `mcp_servers` — MCP server registrations
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `name` | text | | Display name |
+| `transport` | text | | "stdio" or "sse" |
+| `command` | text | | Command to run (stdio transport) |
+| `args` | text | | Arguments (space-separated or JSON) |
+| `env_json` | text | | JSON object of env vars |
+| `url` | text | | URL (sse transport) |
+| `enabled` | integer | 0 | Whether server is active |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+| `headers_json` | text | | JSON headers (sse transport) |
+| `oauth_enabled` | integer | 0 | OAuth flag |
+| `oauth_state` | text | | OAuth state token |
+| `oauth_client_id` | text | | OAuth client ID |
+| `oauth_client_secret` | text | | OAuth client secret |
+| `oauth_scope` | text | | OAuth scopes |
+| `oauth_callback_port` | integer | | OAuth callback port |
+
+### `mcp_tool_consents` — Per-tool approval settings
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `server_id` | integer | | FK → `mcp_servers(id)` ON DELETE CASCADE |
+| `tool_name` | text | | MCP tool name |
+| `consent` | text | `'ask'` | "ask", "allow", or "deny" |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+
+**Unique index:** `uniq_mcp_consent` on `(server_id, tool_name)`
+
+### `prompts` — Reusable prompt templates
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `title` | text | | Prompt title |
+| `description` | text | | Description |
+| `content` | text | | Prompt content |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+| `slug` | text | | URL slug |
+
+**Unique index:** `prompts_slug_unique` on `(slug)`
+
+### `versions` — Git commit versions per project
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `app_id` | integer | | FK → `apps(id)` ON DELETE CASCADE |
+| `commit_hash` | text | | Git commit hash |
+| `neon_db_timestamp` | text | | Neon DB timestamp |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+| `is_favorite` | integer | 0 | Favorite flag |
+| `note` | text | | Version note |
+
+**Unique index:** `versions_app_commit_unique` on `(app_id, commit_hash)`
+
+### `app_collections` — Project collections/folders
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `name` | text | | Collection name |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+
+**Unique index:** `app_collections_name_unique` on `(name)`
+
+### `language_model_providers` — Custom LLM providers
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | text PK | | Provider ID (string) |
+| `name` | text | | Display name |
+| `api_base_url` | text | | API endpoint |
+| `env_var_name` | text | | Env var for API key |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+
+### `language_models` — Custom model definitions
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `display_name` | text | | Model display name |
+| `api_name` | text | | API model name |
+| `builtin_provider_id` | text | | Reference to builtin provider |
+| `custom_provider_id` | text | | FK → `language_model_providers(id)` ON DELETE CASCADE |
+| `description` | text | | Model description |
+| `max_output_tokens` | integer | | Max output tokens |
+| `context_window` | integer | | Context window size |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+
+### `custom_themes` — User-created UI themes
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | integer PK | AUTOINCREMENT | Primary key |
+| `name` | text | | Theme name |
+| `description` | text | | Theme description |
+| `prompt` | text | | Theme generation prompt |
+| `created_at` | integer | `unixepoch()` | Unix timestamp |
+| `updated_at` | integer | `unixepoch()` | Unix timestamp |
+
+### `__drizzle_migrations` — Schema migration tracking
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | serial PK | Migration ID |
+| `hash` | text | Migration hash |
+| `created_at` | numeric | When applied |
+
+## Useful Queries
+
+### List all projects with chat counts
+
+```sql
+SELECT a.id, a.name, a.path, a.github_repo,
+       COUNT(DISTINCT c.id) AS chat_count,
+       COUNT(DISTINCT m.id) AS message_count
+FROM apps a
+LEFT JOIN chats c ON c.app_id = a.id
+LEFT JOIN messages m ON m.chat_id = c.id
+GROUP BY a.id
+ORDER BY a.created_at DESC;
+```
+
+### Recent messages across all projects
+
+```sql
+SELECT m.id, m.role, m.model, m.created_at,
+       c.title AS chat_title, a.name AS project_name
+FROM messages m
+JOIN chats c ON m.chat_id = c.id
+JOIN apps a ON c.app_id = a.id
+ORDER BY m.created_at DESC
+LIMIT 20;
+```
+
+### All MCP servers with consent counts
+
+```sql
+SELECT s.id, s.name, s.transport, s.enabled,
+       COUNT(tc.id) AS tool_count,
+       SUM(CASE WHEN tc.consent = 'allow' THEN 1 ELSE 0 END) AS auto_approved
+FROM mcp_servers s
+LEFT JOIN mcp_tool_consents tc ON tc.server_id = s.id
+GROUP BY s.id;
+```
+
+### Project versions (git history)
+
+```sql
+SELECT v.commit_hash, v.note, v.is_favorite, v.created_at, a.name
+FROM versions v
+JOIN apps a ON v.app_id = a.id
+ORDER BY v.created_at DESC
+LIMIT 30;
+```

--- a/optional-skills/devops/dyad-integration/scripts/dyad_bridge.py
+++ b/optional-skills/devops/dyad-integration/scripts/dyad_bridge.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Dyad ↔ Hermes Bridge — manage Dyad projects, context, and MCP servers from Hermes.
+
+Usage:
+    python3 dyad_bridge.py list
+    python3 dyad_bridge.py chats <app_id>
+    python3 dyad_bridge.py messages <chat_id> [--limit N]
+    python3 dyad_bridge.py write-rules <project_name_or_id> [--file PATH | --stdin]
+    python3 dyad_bridge.py read-rules <project_name_or_id>
+    python3 dyad_bridge.py create-project --name NAME [--path PATH]
+    python3 dyad_bridge.py add-mcp --name NAME --transport stdio --command CMD [--args ARGS] [--env JSON]
+    python3 dyad_bridge.py add-mcp --name NAME --transport sse --url URL [--headers JSON]
+    python3 dyad_bridge.py list-mcp
+    python3 dyad_bridge.py remove-mcp <server_id>
+    python3 dyad_bridge.py add-prompt --title T --content C [--description D]
+    python3 dyad_bridge.py list-prompts
+    python3 dyad_bridge.py versions <app_id>
+    python3 dyad_bridge.py schema
+
+All read operations are safe to run while Dyad is open (WAL mode).
+Write operations (create-project, add-mcp, remove-mcp, add-prompt) should be done
+with Dyad closed to avoid lock conflicts. If you get "database is locked", close
+Dyad and retry.
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+# Env overrides allow tests to point at a temp DB + temp projects dir.
+DYAD_DB = Path(os.environ.get("DYAD_DB_PATH", str(Path.home() / "Library" / "Application Support" / "dyad" / "sqlite.db")))
+DYAD_PROJECTS_DIR = Path(os.environ.get("DYAD_PROJECTS_DIR", str(Path.home() / "dyad-apps")))
+
+
+def connect_db():
+    """Connect to the Dyad SQLite DB in read-only mode by default."""
+    if not DYAD_DB.exists():
+        print(f"Error: Dyad DB not found at {DYAD_DB}", file=sys.stderr)
+        print("Is Dyad installed? Download from https://dyad.sh", file=sys.stderr)
+        sys.exit(1)
+    conn = sqlite3.connect(str(DYAD_DB), timeout=10)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def connect_db_write():
+    """Connect to the Dyad SQLite DB in read-write mode with retry."""
+    if not DYAD_DB.exists():
+        print(f"Error: Dyad DB not found at {DYAD_DB}", file=sys.stderr)
+        sys.exit(1)
+    for attempt in range(3):
+        try:
+            conn = sqlite3.connect(str(DYAD_DB), timeout=15)
+            conn.row_factory = sqlite3.Row
+            # Test we can write
+            conn.execute("BEGIN IMMEDIATE")
+            conn.rollback()
+            return conn
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e) and attempt < 2:
+                print(f"Database locked (attempt {attempt+1}/3), retrying in 2s...", file=sys.stderr)
+                time.sleep(2)
+            else:
+                print(f"Error: Cannot acquire write lock on Dyad DB: {e}", file=sys.stderr)
+                print("Close Dyad and retry.", file=sys.stderr)
+                sys.exit(1)
+
+
+def resolve_project(identifier):
+    """Resolve a project name or numeric ID to a row dict."""
+    conn = connect_db()
+    try:
+        if identifier.isdigit():
+            row = conn.execute("SELECT * FROM apps WHERE id = ?", (int(identifier),)).fetchone()
+        else:
+            row = conn.execute("SELECT * FROM apps WHERE name = ? OR path = ?", (identifier, identifier)).fetchone()
+    finally:
+        conn.close()
+    if not row:
+        print(f"Error: No Dyad project matching '{identifier}'", file=sys.stderr)
+        print(f"Available projects:", file=sys.stderr)
+        cmd_list()
+        sys.exit(1)
+    return dict(row)
+
+
+def project_dir(app_row):
+    """Get the absolute filesystem path for a Dyad project."""
+    path = app_row["path"]
+    # Dyad stores relative path (name only) — resolve under ~/dyad-apps/
+    abs_path = DYAD_PROJECTS_DIR / path
+    if abs_path.exists():
+        return abs_path
+    # Fallback: maybe it's already absolute
+    p = Path(path)
+    if p.is_absolute() and p.exists():
+        return p
+    # If nothing exists, return the ~/dyad-apps/<path> path anyway
+    return abs_path
+
+
+def fmt_ts(ts):
+    """Format a Unix timestamp to ISO date string."""
+    if ts is None:
+        return ""
+    try:
+        from datetime import datetime
+        return datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return str(ts)
+
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+def cmd_list():
+    """List all Dyad projects."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, name, path, created_at, updated_at, github_repo, vercel_deployment_url "
+            "FROM apps ORDER BY created_at DESC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print("No Dyad projects found. Create one with: dyad_bridge.py create-project --name <name>")
+        return
+
+    print(f"{'ID':>4}  {'Name':<24}  {'Path':<20}  {'Created':<18}  {'GitHub':<20}  {'Deployed'}")
+    print("-" * 100)
+    for r in rows:
+        print(f"{r['id']:>4}  {r['name']:<24}  {r['path']:<20}  {fmt_ts(r['created_at']):<18}  "
+              f"{(r['github_repo'] or ''):<20}  {r['vercel_deployment_url'] or ''}")
+
+
+def cmd_chats(app_id):
+    """List chats for a project."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, app_id, title, created_at, chat_mode, pending_compaction "
+            "FROM chats WHERE app_id = ? ORDER BY created_at DESC",
+            (app_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print(f"No chats found for app_id={app_id}")
+        return
+
+    print(f"{'ID':>4}  {'Title':<30}  {'Created':<18}  {'Mode':<10}  {'Pending Compaction'}")
+    print("-" * 85)
+    for r in rows:
+        title = (r["title"] or "(untitled)")[:30]
+        print(f"{r['id']:>4}  {title:<30}  {fmt_ts(r['created_at']):<18}  "
+              f"{r['chat_mode'] or '':<10}  {bool(r['pending_compaction'])}")
+
+
+def cmd_messages(chat_id, limit=50):
+    """Read messages from a chat."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, role, content, created_at, model, approval_state, commit_hash "
+            "FROM messages WHERE chat_id = ? ORDER BY created_at ASC LIMIT ?",
+            (chat_id, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print(f"No messages found for chat_id={chat_id}")
+        return
+
+    for r in rows:
+        print(f"\n{'─' * 80}")
+        print(f"[{r['id']}] {r['role'].upper()} · {fmt_ts(r['created_at'])} · model={r['model'] or '?'}")
+        if r["approval_state"]:
+            print(f"  approval: {r['approval_state']}")
+        if r["commit_hash"]:
+            print(f"  commit: {r['commit_hash']}")
+        print()
+        # Truncate very long messages for terminal display
+        content = r["content"]
+        if len(content) > 2000:
+            print(content[:1800])
+            print(f"\n... ({len(content)} chars total, truncated)")
+        else:
+            print(content)
+
+
+def cmd_write_rules(identifier, file_path=None, use_stdin=False):
+    """Write AI_RULES.md into a Dyad project."""
+    app = resolve_project(identifier)
+    pdir = project_dir(app)
+
+    if use_stdin:
+        content = sys.stdin.read()
+    elif file_path:
+        content = Path(file_path).read_text()
+    else:
+        print("Error: provide --file PATH or --stdin", file=sys.stderr)
+        sys.exit(1)
+
+    rules_path = pdir / "AI_RULES.md"
+
+    # Create project dir if it doesn't exist
+    pdir.mkdir(parents=True, exist_ok=True)
+
+    # Write the file
+    rules_path.write_text(content)
+
+    print(f"✓ Wrote {len(content)} bytes to {rules_path}")
+    print(f"  Project: {app['name']} (id={app['id']})")
+    print(f"  Dyad will load this as authoritative context on the next chat turn.")
+
+
+def cmd_read_rules(identifier):
+    """Read the current AI_RULES.md from a Dyad project."""
+    app = resolve_project(identifier)
+    pdir = project_dir(app)
+    rules_path = pdir / "AI_RULES.md"
+
+    if not rules_path.exists():
+        print(f"No AI_RULES.md found in {pdir}")
+        print(f"Create one with: dyad_bridge.py write-rules {app['name']} --file <path>")
+        return
+
+    content = rules_path.read_text()
+    print(f"┌─ AI_RULES.md — {app['name']} ({len(content)} bytes) ─────────────────────────")
+    print(content)
+    print(f"└─────────────────────────────────────────────────────────────")
+
+
+def cmd_create_project(name, path=None):
+    """Create a new Dyad project directory and register it in the DB."""
+    if path is None:
+        path = DYAD_PROJECTS_DIR / name
+    else:
+        path = Path(path).expanduser()
+
+    # Create directory
+    path.mkdir(parents=True, exist_ok=True)
+
+    # Init git repo
+    subprocess.run(["git", "init"], cwd=str(path), capture_output=True, check=True)
+
+    # Create .gitignore
+    gitignore = path / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("node_modules/\ndist/\n.env\n*.local\n")
+
+    # Create starter AI_RULES.md
+    rules = path / "AI_RULES.md"
+    if not rules.exists():
+        rules.write_text(f"# {name}\n\n## Project Context\n\n<!-- This file is loaded by Dyad as authoritative project context. -->\n<!-- Keep it concise: specs, decisions, conventions. No scratchpads. -->\n\n## Architecture\n\n<!-- Describe the tech stack and key architectural decisions -->\n\n## Conventions\n\n<!-- Naming, file structure, coding conventions -->\n")
+
+    # Create package.json stub
+    pkg = path / "package.json"
+    if not pkg.exists():
+        pkg.write_text(json.dumps({
+            "name": name,
+            "version": "0.0.1",
+            "private": True,
+            "type": "module",
+            "scripts": {
+                "dev": "vite",
+                "build": "vite build",
+                "preview": "vite preview"
+            }
+        }, indent=2))
+
+    # Register in Dyad DB
+    conn = connect_db_write()
+    try:
+        conn.execute(
+            "INSERT INTO apps (name, path, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            (name, name, int(time.time()), int(time.time())),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError as e:
+        print(f"Error: Could not insert into Dyad DB: {e}", file=sys.stderr)
+        print(f"  The project dir is created at {path}", file=sys.stderr)
+        print(f"  You may need to add it manually in Dyad's UI, or a project named '{name}' already exists.", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    print(f"✓ Created Dyad project '{name}'")
+    print(f"  Directory: {path}")
+    print(f"  Registered in Dyad DB (apps table)")
+    print(f"  AI_RULES.md: {rules}")
+    print(f"  The project will appear in Dyad on next launch.")
+
+
+def cmd_add_mcp(name, transport, command=None, args=None, env_json=None,
+                url=None, headers_json=None):
+    """Register an MCP server in Dyad's mcp_servers table."""
+    if transport not in ("stdio", "sse"):
+        print("Error: --transport must be 'stdio' or 'sse'", file=sys.stderr)
+        sys.exit(1)
+
+    if transport == "stdio" and not command:
+        print("Error: --command is required for stdio transport", file=sys.stderr)
+        sys.exit(1)
+    if transport == "sse" and not url:
+        print("Error: --url is required for sse transport", file=sys.stderr)
+        sys.exit(1)
+
+    conn = connect_db_write()
+    try:
+        conn.execute(
+            """INSERT INTO mcp_servers
+               (name, transport, command, args, env_json, url, enabled, created_at, updated_at, headers_json)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)""",
+            (name, transport, command, args, env_json, url,
+             int(time.time()), int(time.time()), headers_json),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT id, name, transport, enabled FROM mcp_servers ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    print(f"✓ Registered MCP server '{name}' (id={row['id']})")
+    print(f"  Transport: {transport}")
+    if transport == "stdio":
+        print(f"  Command: {command} {args or ''}")
+    else:
+        print(f"  URL: {url}")
+    print(f"  Enabled: {bool(row['enabled'])}")
+    print(f"  ⚠ Restart Dyad for it to connect to this server.")
+
+
+def cmd_list_mcp():
+    """List all registered MCP servers."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, name, transport, command, args, url, enabled, created_at "
+            "FROM mcp_servers ORDER BY created_at DESC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print("No MCP servers registered.")
+        print("Add one with: dyad_bridge.py add-mcp --name <name> --transport <stdio|sse> ...")
+        return
+
+    print(f"{'ID':>4}  {'Name':<24}  {'Transport':<10}  {'Enabled':<8}  {'Command/URL'}")
+    print("-" * 90)
+    for r in rows:
+        endpoint = r["command"] if r["transport"] == "stdio" else r["url"]
+        print(f"{r['id']:>4}  {r['name']:<24}  {r['transport']:<10}  "
+              f"{'✓' if r['enabled'] else '✗':<8}  {endpoint or ''}")
+
+
+def cmd_remove_mcp(server_id):
+    """Remove an MCP server from Dyad's DB."""
+    conn = connect_db_write()
+    try:
+        row = conn.execute("SELECT name FROM mcp_servers WHERE id = ?", (server_id,)).fetchone()
+        if not row:
+            print(f"Error: No MCP server with id={server_id}", file=sys.stderr)
+            sys.exit(1)
+        conn.execute("DELETE FROM mcp_servers WHERE id = ?", (server_id,))
+        conn.commit()
+    finally:
+        conn.close()
+    print(f"✓ Removed MCP server '{row['name']}' (id={server_id})")
+    print(f"  ⚠ Restart Dyad for the change to take effect.")
+
+
+def cmd_add_prompt(title, content, description=None):
+    """Add a reusable prompt to Dyad's prompts table."""
+    conn = connect_db_write()
+    try:
+        conn.execute(
+            "INSERT INTO prompts (title, description, content, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (title, description, content, int(time.time()), int(time.time())),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT id, title FROM prompts ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    print(f"✓ Added prompt '{title}' (id={row['id']})")
+
+
+def cmd_list_prompts():
+    """List all reusable prompts."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, title, description, created_at FROM prompts ORDER BY created_at DESC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print("No reusable prompts found.")
+        return
+
+    print(f"{'ID':>4}  {'Title':<30}  {'Description':<40}  {'Created'}")
+    print("-" * 95)
+    for r in rows:
+        print(f"{r['id']:>4}  {r['title'][:30]:<30}  "
+              f"{(r['description'] or '')[:40]:<40}  {fmt_ts(r['created_at'])}")
+
+
+def cmd_versions(app_id):
+    """List git version snapshots for a project."""
+    conn = connect_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, commit_hash, note, is_favorite, created_at "
+            "FROM versions WHERE app_id = ? ORDER BY created_at DESC",
+            (app_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        print(f"No versions found for app_id={app_id}")
+        return
+
+    print(f"{'ID':>4}  {'Commit':<12}  {'Favorite':<10}  {'Created':<18}  {'Note'}")
+    print("-" * 80)
+    for r in rows:
+        commit = (r["commit_hash"] or "")[:10]
+        note = (r["note"] or "")[:30]
+        print(f"{r['id']:>4}  {commit:<12}  {'★' if r['is_favorite'] else '':<10}  "
+              f"{fmt_ts(r['created_at']):<18}  {note}")
+
+
+def cmd_schema():
+    """Print the Dyad DB schema."""
+    conn = connect_db()
+    try:
+        schema = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND sql IS NOT NULL ORDER BY name"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    for row in schema:
+        print(row["sql"])
+        print()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Dyad ↔ Hermes Bridge — manage Dyad from Hermes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="subcommand")
+
+    # list
+    sub.add_parser("list", help="List all Dyad projects")
+
+    # chats
+    p_chats = sub.add_parser("chats", help="List chats for a project")
+    p_chats.add_argument("app_id", type=int)
+
+    # messages
+    p_msgs = sub.add_parser("messages", help="Read messages from a chat")
+    p_msgs.add_argument("chat_id", type=int)
+    p_msgs.add_argument("--limit", type=int, default=50, help="Max messages to show (default 50)")
+
+    # write-rules
+    p_wr = sub.add_parser("write-rules", help="Write AI_RULES.md to a Dyad project")
+    p_wr.add_argument("identifier", help="Project name or numeric ID")
+    p_wr.add_argument("--file", help="Path to file to write as AI_RULES.md")
+    p_wr.add_argument("--stdin", action="store_true", help="Read content from stdin")
+
+    # read-rules
+    p_rr = sub.add_parser("read-rules", help="Read AI_RULES.md from a Dyad project")
+    p_rr.add_argument("identifier", help="Project name or numeric ID")
+
+    # create-project
+    p_cp = sub.add_parser("create-project", help="Create a new Dyad project")
+    p_cp.add_argument("--name", required=True, help="Project name")
+    p_cp.add_argument("--path", help="Project directory (default: ~/dyad-apps/<name>)")
+
+    # add-mcp
+    p_amcp = sub.add_parser("add-mcp", help="Register an MCP server in Dyad")
+    p_amcp.add_argument("--name", required=True, help="Server display name")
+    p_amcp.add_argument("--transport", required=True, choices=["stdio", "sse"])
+    p_amcp.add_argument("--command", help="Command to run (stdio transport)")
+    p_amcp.add_argument("--args", help="Arguments for command (stdio transport)")
+    p_amcp.add_argument("--env", help="JSON env vars (stdio transport)")
+    p_amcp.add_argument("--url", help="Server URL (sse transport)")
+    p_amcp.add_argument("--headers", help="JSON headers (sse transport)")
+
+    # list-mcp
+    sub.add_parser("list-mcp", help="List registered MCP servers")
+
+    # remove-mcp
+    p_rmcp = sub.add_parser("remove-mcp", help="Remove an MCP server")
+    p_rmcp.add_argument("server_id", type=int)
+
+    # add-prompt
+    p_ap = sub.add_parser("add-prompt", help="Add a reusable prompt to Dyad")
+    p_ap.add_argument("--title", required=True)
+    p_ap.add_argument("--description", default=None)
+    p_ap.add_argument("--content", required=True)
+
+    # list-prompts
+    sub.add_parser("list-prompts", help="List reusable prompts")
+
+    # versions
+    p_ver = sub.add_parser("versions", help="List versions for a project")
+    p_ver.add_argument("app_id", type=int)
+
+    # schema
+    sub.add_parser("schema", help="Print the Dyad DB schema")
+
+    args = parser.parse_args()
+
+    if not args.subcommand:
+        parser.print_help()
+        sys.exit(0)
+
+    dispatch = {
+        "list": lambda: cmd_list(),
+        "chats": lambda: cmd_chats(args.app_id),
+        "messages": lambda: cmd_messages(args.chat_id, args.limit),
+        "write-rules": lambda: cmd_write_rules(args.identifier, args.file, args.stdin),
+        "read-rules": lambda: cmd_read_rules(args.identifier),
+        "create-project": lambda: cmd_create_project(args.name, args.path),
+        "add-mcp": lambda: cmd_add_mcp(args.name, args.transport, args.command,
+                                       args.args, args.env, args.url, args.headers),
+        "list-mcp": lambda: cmd_list_mcp(),
+        "remove-mcp": lambda: cmd_remove_mcp(args.server_id),
+        "add-prompt": lambda: cmd_add_prompt(args.title, args.content, args.description),
+        "list-prompts": lambda: cmd_list_prompts(),
+        "versions": lambda: cmd_versions(args.app_id),
+        "schema": lambda: cmd_schema(),
+    }
+
+    dispatch[args.subcommand]()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/devops/dyad-integration/scripts/dyad_bridge.py
+++ b/optional-skills/devops/dyad-integration/scripts/dyad_bridge.py
@@ -91,18 +91,18 @@ def resolve_project(identifier):
 
 
 def project_dir(app_row):
-    """Get the absolute filesystem path for a Dyad project."""
+    """Get the absolute filesystem path for a Dyad project.
+
+    Dyad stores either a bare project name (relative, resolved under
+    DYAD_PROJECTS_DIR) or an absolute path (when --path was used).
+    """
     path = app_row["path"]
-    # Dyad stores relative path (name only) — resolve under ~/dyad-apps/
-    abs_path = DYAD_PROJECTS_DIR / path
-    if abs_path.exists():
-        return abs_path
-    # Fallback: maybe it's already absolute
     p = Path(path)
-    if p.is_absolute() and p.exists():
+    # If it's already absolute, use it directly
+    if p.is_absolute():
         return p
-    # If nothing exists, return the ~/dyad-apps/<path> path anyway
-    return abs_path
+    # Otherwise resolve under DYAD_PROJECTS_DIR
+    return DYAD_PROJECTS_DIR / path
 
 
 def fmt_ts(ts):
@@ -278,12 +278,21 @@ def cmd_create_project(name, path=None):
             }
         }, indent=2))
 
+    # Determine what to store in apps.path:
+    # - If using the default dir (~/dyad-apps/<name>), store the bare name (relative —
+    #   Dyad's own convention, resolved by project_dir() under DYAD_PROJECTS_DIR).
+    # - If using a custom --path, store the absolute path so project_dir() can find it.
+    if path == DYAD_PROJECTS_DIR / name:
+        stored_path = name
+    else:
+        stored_path = str(path)
+
     # Register in Dyad DB
     conn = connect_db_write()
     try:
         conn.execute(
             "INSERT INTO apps (name, path, created_at, updated_at) VALUES (?, ?, ?, ?)",
-            (name, name, int(time.time()), int(time.time())),
+            (name, stored_path, int(time.time()), int(time.time())),
         )
         conn.commit()
     except sqlite3.IntegrityError as e:

--- a/optional-skills/devops/dyad-integration/scripts/test_bridge.py
+++ b/optional-skills/devops/dyad-integration/scripts/test_bridge.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""Test suite for the Dyad ↔ Hermes bridge script.
+
+Creates a temporary Dyad SQLite DB with the real schema, temp project dirs,
+and exercises every bridge command end-to-end.
+
+Run:
+    cd ~/.hermes/skills/devops/dyad-integration
+    python3 scripts/test_bridge.py
+
+Or with pytest:
+    pytest scripts/test_bridge.py -v
+
+No external dependencies — uses only stdlib (unittest, sqlite3, tempfile, subprocess).
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+SKILL_DIR = Path(__file__).resolve().parent.parent
+BRIDGE = SKILL_DIR / "scripts" / "dyad_bridge.py"
+SCHEMA_SQL = SKILL_DIR / "references" / "dyad-db-schema.md"
+
+# Real schema DDL — extracted from Dyad v1.6.2, matches references/dyad-db-schema.md
+SCHEMA_DDL = """
+CREATE TABLE IF NOT EXISTS "apps" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" text NOT NULL,
+    "path" text NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "github_org" text,
+    "github_repo" text,
+    "supabase_project_id" text,
+    "chat_context" text,
+    "github_branch" text,
+    "vercel_project_id" text,
+    "vercel_project_name" text,
+    "vercel_team_id" text,
+    "vercel_deployment_url" text,
+    "neon_project_id" text,
+    "neon_development_branch_id" text,
+    "neon_preview_branch_id" text,
+    "install_command" text,
+    "start_command" text,
+    "is_favorite" integer DEFAULT 0 NOT NULL,
+    "supabase_parent_project_id" text,
+    "supabase_organization_slug" text,
+    "theme_id" text,
+    "neon_active_branch_id" text,
+    "needs_app_blueprint" integer DEFAULT 0 NOT NULL,
+    "neon_production_auth_cookie_secret" text,
+    "neon_development_auth_cookie_secret" text,
+    "collection_id" integer,
+    "selected_database_branch_type" text
+);
+
+CREATE TABLE IF NOT EXISTS "chats" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "app_id" integer NOT NULL,
+    "title" text,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "initial_commit_hash" text,
+    "compacted_at" integer,
+    "compaction_backup_path" text,
+    "pending_compaction" integer,
+    "chat_mode" text,
+    FOREIGN KEY ("app_id") REFERENCES "apps"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "messages" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "chat_id" integer NOT NULL,
+    "role" text NOT NULL,
+    "content" text NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "approval_state" text,
+    "commit_hash" text,
+    "request_id" text,
+    "source_commit_hash" text,
+    "max_tokens_used" integer,
+    "ai_messages_json" text,
+    "model" text,
+    "using_free_agent_mode_quota" integer,
+    "is_compaction_summary" integer,
+    FOREIGN KEY ("chat_id") REFERENCES "chats"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "mcp_servers" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" text NOT NULL,
+    "transport" text NOT NULL,
+    "command" text,
+    "args" text,
+    "env_json" text,
+    "url" text,
+    "enabled" integer DEFAULT 0 NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "headers_json" text,
+    "oauth_enabled" integer DEFAULT 0 NOT NULL,
+    "oauth_state" text,
+    "oauth_client_id" text,
+    "oauth_client_secret" text,
+    "oauth_scope" text,
+    "oauth_callback_port" integer
+);
+
+CREATE TABLE IF NOT EXISTS "mcp_tool_consents" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "server_id" integer NOT NULL,
+    "tool_name" text NOT NULL,
+    "consent" text DEFAULT 'ask' NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    FOREIGN KEY ("server_id") REFERENCES "mcp_servers"("id") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_mcp_consent" ON "mcp_tool_consents" ("server_id","tool_name");
+
+CREATE TABLE IF NOT EXISTS "prompts" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "title" text NOT NULL,
+    "description" text,
+    "content" text NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "slug" text
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "prompts_slug_unique" ON "prompts" ("slug");
+
+CREATE TABLE IF NOT EXISTS "versions" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "app_id" integer NOT NULL,
+    "commit_hash" text NOT NULL,
+    "neon_db_timestamp" text,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "is_favorite" integer DEFAULT 0 NOT NULL,
+    "note" text,
+    FOREIGN KEY ("app_id") REFERENCES "apps"("id") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "versions_app_commit_unique" ON "versions" ("app_id","commit_hash");
+
+CREATE TABLE IF NOT EXISTS "app_collections" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" text NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "app_collections_name_unique" ON "app_collections" ("name");
+
+CREATE TABLE IF NOT EXISTS "language_model_providers" (
+    "id" text PRIMARY KEY NOT NULL,
+    "name" text NOT NULL,
+    "api_base_url" text NOT NULL,
+    "env_var_name" text,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "language_models" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "display_name" text NOT NULL,
+    "api_name" text NOT NULL,
+    "builtin_provider_id" text,
+    "custom_provider_id" text,
+    "description" text,
+    "max_output_tokens" integer,
+    "context_window" integer,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL,
+    FOREIGN KEY ("custom_provider_id") REFERENCES "language_model_providers"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "custom_themes" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" text NOT NULL,
+    "description" text,
+    "prompt" text NOT NULL,
+    "created_at" integer DEFAULT (unixepoch()) NOT NULL,
+    "updated_at" integer DEFAULT (unixepoch()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+    "id" SERIAL PRIMARY KEY,
+    "hash" text NOT NULL,
+    "created_at" numeric
+);
+"""
+
+
+def create_temp_dyad_db(db_path):
+    """Create a temp Dyad SQLite DB with the real schema + WAL mode."""
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(SCHEMA_DDL)
+    # Enable WAL mode like the real Dyad
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+    conn.close()
+
+
+class DyadBridgeTestBase(unittest.TestCase):
+    """Base class — sets up temp DB, temp projects dir, and env vars."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self.tmpdir.name)
+        self.db_path = self.tmp / "sqlite.db"
+        self.projects_dir = self.tmp / "dyad-apps"
+        self.projects_dir.mkdir()
+
+        create_temp_dyad_db(self.db_path)
+
+        self.env = {
+            **os.environ,
+            "DYAD_DB_PATH": str(self.db_path),
+            "DYAD_PROJECTS_DIR": str(self.projects_dir),
+        }
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def run_bridge(self, *args, stdin_data=None):
+        """Run the bridge script with given args, return (returncode, stdout, stderr)."""
+        proc = subprocess.run(
+            [sys.executable, str(BRIDGE), *args],
+            env=self.env,
+            capture_output=True,
+            text=True,
+            input=stdin_data,
+            timeout=30,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+
+
+class TestListProjects(DyadBridgeTestBase):
+    """list command — list all Dyad projects."""
+
+    def test_empty_db(self):
+        """list with no projects should succeed and say so."""
+        rc, out, err = self.run_bridge("list")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No Dyad projects found", out)
+
+    def test_with_project(self):
+        """list with a project in the DB should show it."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        conn.execute(
+            "INSERT INTO apps (name, path, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            ("test-app", "test-app", int(time.time()), int(time.time())),
+        )
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("list")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("test-app", out)
+        self.assertIn("ID", out)
+
+
+class TestChats(DyadBridgeTestBase):
+    """chats command — list chats for a project."""
+
+    def test_no_chats(self):
+        """chats for a project with no chats should say so."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        conn.execute(
+            "INSERT INTO apps (name, path, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            ("test-app", "test-app", int(time.time()), int(time.time())),
+        )
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("chats", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No chats found", out)
+
+    def test_with_chat(self):
+        """chats should show a chat that exists."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('app1', 'app1', ?, ?)", (ts, ts))
+        conn.execute("INSERT INTO chats (app_id, title, created_at, chat_mode) VALUES (1, 'Build app', ?, 'build')", (ts,))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("chats", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Build app", out)
+        self.assertIn("build", out)
+
+
+class TestMessages(DyadBridgeTestBase):
+    """messages command — read messages from a chat."""
+
+    def test_no_messages(self):
+        """messages for a chat with no messages should say so."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('app1', 'app1', ?, ?)", (ts, ts))
+        conn.execute("INSERT INTO chats (app_id, created_at) VALUES (1, ?)", (ts,))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("messages", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No messages found", out)
+
+    def test_with_messages(self):
+        """messages should show user and assistant messages."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('app1', 'app1', ?, ?)", (ts, ts))
+        conn.execute("INSERT INTO chats (app_id, created_at) VALUES (1, ?)", (ts,))
+        conn.execute("INSERT INTO messages (chat_id, role, content, created_at, model) VALUES (1, 'user', 'Build a dashboard', ?, 'user')", (ts,))
+        conn.execute("INSERT INTO messages (chat_id, role, content, created_at, model) VALUES (1, 'assistant', 'I will create...', ?, 'auto')", (ts,))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("messages", "1", "--limit", "10")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("USER", out)
+        self.assertIn("ASSISTANT", out)
+        self.assertIn("Build a dashboard", out)
+        self.assertIn("I will create", out)
+
+    def test_message_truncation(self):
+        """Very long messages should be truncated in terminal output."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('app1', 'app1', ?, ?)", (ts, ts))
+        conn.execute("INSERT INTO chats (app_id, created_at) VALUES (1, ?)", (ts,))
+        long_content = "x" * 3000
+        conn.execute("INSERT INTO messages (chat_id, role, content, created_at) VALUES (1, 'user', ?, ?)", (long_content, ts))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("messages", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("truncated", out)
+
+
+class TestWriteRules(DyadBridgeTestBase):
+    """write-rules command — write AI_RULES.md to a Dyad project."""
+
+    def test_write_from_file(self):
+        """write-rules with --file should create AI_RULES.md in the project dir."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('test-app', 'test-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        # Create project dir
+        proj_dir = self.projects_dir / "test-app"
+        proj_dir.mkdir()
+
+        # Write rules file
+        rules_content = "# Test Project\n\n## Tech Stack\n- React\n"
+        rules_file = self.tmp / "rules.md"
+        rules_file.write_text(rules_content)
+
+        rc, out, err = self.run_bridge("write-rules", "test-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Wrote", out)
+        self.assertIn("AI_RULES.md", out)
+
+        # Verify file on disk
+        rules_path = proj_dir / "AI_RULES.md"
+        self.assertTrue(rules_path.exists(), "AI_RULES.md was not created")
+        self.assertEqual(rules_path.read_text(), rules_content)
+
+    def test_write_from_stdin(self):
+        """write-rules with --stdin should read content from stdin."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('stdin-app', 'stdin-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        proj_dir = self.projects_dir / "stdin-app"
+        proj_dir.mkdir()
+
+        content = "# From Stdin\n\n## Context\n- Test conventions\n"
+        rc, out, err = self.run_bridge("write-rules", "stdin-app", "--stdin", stdin_data=content)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Wrote", out)
+
+        rules_path = proj_dir / "AI_RULES.md"
+        self.assertTrue(rules_path.exists())
+        self.assertEqual(rules_path.read_text(), content)
+
+    def test_write_overwrites_existing(self):
+        """write-rules should overwrite an existing AI_RULES.md."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('overwrite-app', 'overwrite-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        proj_dir = self.projects_dir / "overwrite-app"
+        proj_dir.mkdir()
+        existing = proj_dir / "AI_RULES.md"
+        existing.write_text("# OLD CONTENT\n")
+
+        new_content = "# NEW CONTENT\n"
+        rules_file = self.tmp / "new_rules.md"
+        rules_file.write_text(new_content)
+
+        rc, out, err = self.run_bridge("write-rules", "overwrite-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        self.assertEqual(existing.read_text(), new_content)
+
+    def test_write_creates_project_dir_if_missing(self):
+        """write-rules should create the project dir if it doesn't exist."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('missing-dir-app', 'missing-dir-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        # Don't create the project dir — the script should
+        rules_file = self.tmp / "rules.md"
+        rules_file.write_text("# Test\n")
+
+        rc, out, err = self.run_bridge("write-rules", "missing-dir-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        proj_dir = self.projects_dir / "missing-dir-app"
+        self.assertTrue(proj_dir.exists())
+        self.assertTrue((proj_dir / "AI_RULES.md").exists())
+
+    def test_write_no_file_or_stdin_errors(self):
+        """write-rules without --file or --stdin should error."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('err-app', 'err-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        proj_dir = self.projects_dir / "err-app"
+        proj_dir.mkdir()
+
+        rc, out, err = self.run_bridge("write-rules", "err-app")
+        self.assertNotEqual(rc, 0)
+        self.assertIn("Error", err)
+
+    def test_write_nonexistent_project_errors(self):
+        """write-rules for a nonexistent project should error."""
+        rules_file = self.tmp / "rules.md"
+        rules_file.write_text("# Test\n")
+
+        rc, out, err = self.run_bridge("write-rules", "no-such-project", "--file", str(rules_file))
+        self.assertNotEqual(rc, 0)
+        self.assertIn("No Dyad project matching", err)
+
+
+class TestReadRules(DyadBridgeTestBase):
+    """read-rules command — read AI_RULES.md from a Dyad project."""
+
+    def test_read_existing(self):
+        """read-rules should show the AI_RULES.md content."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('read-app', 'read-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        proj_dir = self.projects_dir / "read-app"
+        proj_dir.mkdir()
+        content = "# Read Test\n\n## Context\n- Something\n"
+        (proj_dir / "AI_RULES.md").write_text(content)
+
+        rc, out, err = self.run_bridge("read-rules", "read-app")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Read Test", out)
+        self.assertIn("Something", out)
+
+    def test_read_missing(self):
+        """read-rules for a project with no AI_RULES.md should say so."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('no-rules', 'no-rules', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        proj_dir = self.projects_dir / "no-rules"
+        proj_dir.mkdir()
+
+        rc, out, err = self.run_bridge("read-rules", "no-rules")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No AI_RULES.md found", out)
+
+
+class TestCreateProject(DyadBridgeTestBase):
+    """create-project command — create a new Dyad project."""
+
+    def test_create_default_path(self):
+        """create-project with default path should create dir + register in DB."""
+        rc, out, err = self.run_bridge("create-project", "--name", "new-app")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Created Dyad project", out)
+
+        # Verify dir
+        proj_dir = self.projects_dir / "new-app"
+        self.assertTrue(proj_dir.exists())
+        self.assertTrue((proj_dir / ".git").exists())
+        self.assertTrue((proj_dir / "AI_RULES.md").exists())
+        self.assertTrue((proj_dir / "package.json").exists())
+        self.assertTrue((proj_dir / ".gitignore").exists())
+
+    def test_create_custom_path(self):
+        """create-project with --path should use the custom path."""
+        custom = self.tmp / "custom-location" / "my-app"
+        rc, out, err = self.run_bridge("create-project", "--name", "custom-app", "--path", str(custom))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertTrue(custom.exists())
+        self.assertTrue((custom / ".git").exists())
+
+    def test_create_registers_in_db(self):
+        """create-project should insert a row into the apps table."""
+        rc, out, err = self.run_bridge("create-project", "--name", "db-app")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        row = conn.execute("SELECT name, path FROM apps WHERE name = 'db-app'").fetchone()
+        conn.close()
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], "db-app")
+        self.assertEqual(row[1], "db-app")
+
+    def test_create_starter_ai_rules(self):
+        """create-project should write a starter AI_RULES.md with project name."""
+        rc, out, err = self.run_bridge("create-project", "--name", "starter-app")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        rules = (self.projects_dir / "starter-app" / "AI_RULES.md").read_text()
+        self.assertIn("starter-app", rules)
+        self.assertIn("Project Context", rules)
+
+    def test_create_package_json(self):
+        """create-project should write a valid package.json."""
+        import json
+        rc, out, err = self.run_bridge("create-project", "--name", "pkg-app")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        pkg = json.loads((self.projects_dir / "pkg-app" / "package.json").read_text())
+        self.assertEqual(pkg["name"], "pkg-app")
+        self.assertIn("dev", pkg["scripts"])
+
+
+class TestMcpServer(DyadBridgeTestBase):
+    """MCP server commands — add, list, remove."""
+
+    def test_add_stdio_server(self):
+        """add-mcp with stdio transport should register in DB."""
+        rc, out, err = self.run_bridge(
+            "add-mcp", "--name", "Test Bridge",
+            "--transport", "stdio",
+            "--command", "python3",
+            "--args", "/path/to/server.py",
+            "--env", '{"TEST": "true"}',
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Registered MCP server", out)
+        self.assertIn("stdio", out)
+
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        row = conn.execute("SELECT name, transport, command FROM mcp_servers").fetchone()
+        conn.close()
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], "Test Bridge")
+        self.assertEqual(row[1], "stdio")
+
+    def test_add_sse_server(self):
+        """add-mcp with sse transport should register with URL."""
+        rc, out, err = self.run_bridge(
+            "add-mcp", "--name", "Remote SSE",
+            "--transport", "sse",
+            "--url", "http://localhost:8082/sse",
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Remote SSE", out)
+        self.assertIn("http://localhost:8082/sse", out)
+
+    def test_add_stdio_without_command_errors(self):
+        """add-mcp stdio without --command should error."""
+        rc, out, err = self.run_bridge(
+            "add-mcp", "--name", "Bad", "--transport", "stdio",
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("command is required", err)
+
+    def test_add_sse_without_url_errors(self):
+        """add-mcp sse without --url should error."""
+        rc, out, err = self.run_bridge(
+            "add-mcp", "--name", "Bad", "--transport", "sse",
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("url is required", err)
+
+    def test_list_mcp_empty(self):
+        """list-mcp with no servers should say so."""
+        rc, out, err = self.run_bridge("list-mcp")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No MCP servers registered", out)
+
+    def test_list_mcp_with_server(self):
+        """list-mcp should show registered servers."""
+        self.run_bridge("add-mcp", "--name", "Visible", "--transport", "sse", "--url", "http://x")
+        rc, out, err = self.run_bridge("list-mcp")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Visible", out)
+        self.assertIn("sse", out)
+
+    def test_remove_mcp(self):
+        """remove-mcp should delete the server from DB."""
+        self.run_bridge("add-mcp", "--name", "To Remove", "--transport", "sse", "--url", "http://x")
+
+        rc, out, err = self.run_bridge("remove-mcp", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Removed MCP server", out)
+
+        # Verify it's gone
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        count = conn.execute("SELECT COUNT(*) FROM mcp_servers").fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 0)
+
+    def test_remove_nonexistent_mcp_errors(self):
+        """remove-mcp with invalid ID should error."""
+        rc, out, err = self.run_bridge("remove-mcp", "999")
+        self.assertNotEqual(rc, 0)
+        self.assertIn("No MCP server with id", err)
+
+
+class TestPrompts(DyadBridgeTestBase):
+    """Prompt commands — add, list."""
+
+    def test_add_prompt(self):
+        """add-prompt should insert into the prompts table."""
+        rc, out, err = self.run_bridge(
+            "add-prompt", "--title", "Build Dashboard",
+            "--description", "Standard dashboard",
+            "--content", "Create a React dashboard...",
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Added prompt", out)
+
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        row = conn.execute("SELECT title, content FROM prompts").fetchone()
+        conn.close()
+        self.assertEqual(row[0], "Build Dashboard")
+        self.assertEqual(row[1], "Create a React dashboard...")
+
+    def test_list_prompts_empty(self):
+        """list-prompts with no prompts should say so."""
+        rc, out, err = self.run_bridge("list-prompts")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No reusable prompts found", out)
+
+    def test_list_prompts_with_data(self):
+        """list-prompts should show existing prompts."""
+        self.run_bridge("add-prompt", "--title", "My Prompt", "--content", "Do stuff")
+        rc, out, err = self.run_bridge("list-prompts")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("My Prompt", out)
+
+
+class TestVersions(DyadBridgeTestBase):
+    """versions command — list git versions for a project."""
+
+    def test_no_versions(self):
+        """versions for a project with no versions should say so."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('ver-app', 'ver-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("versions", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("No versions found", out)
+
+    def test_with_version(self):
+        """versions should show existing version entries."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('ver-app', 'ver-app', ?, ?)", (ts, ts))
+        conn.execute("INSERT INTO versions (app_id, commit_hash, note, created_at, updated_at) VALUES (1, 'abc123def456', 'Initial version', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        rc, out, err = self.run_bridge("versions", "1")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("abc123def", out)
+        self.assertIn("Initial version", out)
+
+
+class TestSchema(DyadBridgeTestBase):
+    """schema command — print the Dyad DB schema."""
+
+    def test_schema_output(self):
+        """schema should print CREATE TABLE statements."""
+        rc, out, err = self.run_bridge("schema")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("CREATE TABLE", out)
+        self.assertIn("apps", out)
+        self.assertIn("mcp_servers", out)
+        self.assertIn("messages", out)
+
+
+class TestProjectResolution(DyadBridgeTestBase):
+    """Test project resolution by name vs ID."""
+
+    def test_resolve_by_name(self):
+        """write-rules should resolve a project by name."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('named-app', 'named-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        (self.projects_dir / "named-app").mkdir()
+
+        rules_file = self.tmp / "r.md"
+        rules_file.write_text("# Test\n")
+        rc, out, err = self.run_bridge("write-rules", "named-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertTrue((self.projects_dir / "named-app" / "AI_RULES.md").exists())
+
+    def test_resolve_by_id(self):
+        """write-rules should resolve a project by numeric ID."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('id-app', 'id-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        (self.projects_dir / "id-app").mkdir()
+
+        rules_file = self.tmp / "r.md"
+        rules_file.write_text("# Test\n")
+        rc, out, err = self.run_bridge("write-rules", "1", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertTrue((self.projects_dir / "id-app" / "AI_RULES.md").exists())
+
+    def test_resolve_by_path(self):
+        """write-rules should resolve a project by path value."""
+        import sqlite3, time
+        conn = sqlite3.connect(str(self.db_path))
+        ts = int(time.time())
+        conn.execute("INSERT INTO apps (name, path, created_at, updated_at) VALUES ('path-app', 'path-app', ?, ?)", (ts, ts))
+        conn.commit()
+        conn.close()
+
+        (self.projects_dir / "path-app").mkdir()
+
+        rules_file = self.tmp / "r.md"
+        rules_file.write_text("# Test\n")
+        rc, out, err = self.run_bridge("write-rules", "path-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertTrue((self.projects_dir / "path-app" / "AI_RULES.md").exists())
+
+
+class TestLiveDbSmokeTest(unittest.TestCase):
+    """Smoke test against the real live Dyad DB (if installed).
+
+    These are read-only and safe to run while Dyad is open.
+    Skipped if Dyad is not installed.
+    """
+
+    def setUp(self):
+        self.db_path = Path.home() / "Library" / "Application Support" / "dyad" / "sqlite.db"
+        if not self.db_path.exists():
+            self.skipTest("Dyad not installed — skipping live DB smoke test")
+
+    def run_bridge_live(self, *args):
+        proc = subprocess.run(
+            [sys.executable, str(BRIDGE), *args],
+            capture_output=True, text=True, timeout=30,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+
+    def test_live_list(self):
+        """list should work against the live DB."""
+        rc, out, err = self.run_bridge_live("list")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_live_schema(self):
+        """schema should work against the live DB."""
+        rc, out, err = self.run_bridge_live("schema")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("CREATE TABLE", out)
+
+    def test_live_list_mcp(self):
+        """list-mcp should work against the live DB."""
+        rc, out, err = self.run_bridge_live("list-mcp")
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/optional-skills/devops/dyad-integration/scripts/test_bridge.py
+++ b/optional-skills/devops/dyad-integration/scripts/test_bridge.py
@@ -529,12 +529,49 @@ class TestCreateProject(DyadBridgeTestBase):
         self.assertTrue((proj_dir / ".gitignore").exists())
 
     def test_create_custom_path(self):
-        """create-project with --path should use the custom path."""
+        """create-project with --path should use the custom path and store it in DB."""
         custom = self.tmp / "custom-location" / "my-app"
         rc, out, err = self.run_bridge("create-project", "--name", "custom-app", "--path", str(custom))
         self.assertEqual(rc, 0, f"stderr: {err}")
         self.assertTrue(custom.exists())
         self.assertTrue((custom / ".git").exists())
+
+        # Verify the DB stores the absolute path, not the project name
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        row = conn.execute("SELECT path FROM apps WHERE name = 'custom-app'").fetchone()
+        conn.close()
+        self.assertIsNotNone(row, "Project not found in DB")
+        self.assertEqual(row[0], str(custom), f"DB path should be '{custom}' but got '{row[0]}'")
+
+    def test_create_custom_path_then_write_rules(self):
+        """write-rules should resolve to the custom path after create-project."""
+        custom = self.tmp / "custom-loc" / "rules-app"
+        self.run_bridge("create-project", "--name", "rules-app", "--path", str(custom))
+
+        # Write rules to the project — should land in the custom dir, not ~/dyad-apps/
+        rules_file = self.tmp / "rules.md"
+        rules_file.write_text("# Custom Path Rules\n")
+        rc, out, err = self.run_bridge("write-rules", "rules-app", "--file", str(rules_file))
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+        # AI_RULES.md must be in the custom directory
+        self.assertTrue((custom / "AI_RULES.md").exists(),
+                        f"AI_RULES.md not in custom dir {custom}")
+        # And NOT in ~/dyad-apps/rules-app/
+        self.assertFalse((self.projects_dir / "rules-app" / "AI_RULES.md").exists(),
+                         "AI_RULES.md wrongly created in default dyad-apps dir")
+
+    def test_create_default_path_stores_name(self):
+        """create-project without --path should store the bare name in apps.path."""
+        self.run_bridge("create-project", "--name", "default-path-app")
+
+        import sqlite3
+        conn = sqlite3.connect(str(self.db_path))
+        row = conn.execute("SELECT path FROM apps WHERE name = 'default-path-app'").fetchone()
+        conn.close()
+        self.assertEqual(row[0], "default-path-app",
+                         f"Default path should store bare name, got '{row[0]}'")
 
     def test_create_registers_in_db(self):
         """create-project should insert a row into the apps table."""


### PR DESCRIPTION
## What

Connects Hermes to [Dyad](https://dyad.sh) — the local, open-source AI app builder (21k★, TypeScript/Electron). Dyad stores all state in a single SQLite DB, projects live as plain git repos on disk, and it loads a per-project `AI_RULES.md` file as authoritative context for every AI chat turn. Dyad is also an MCP client.

## Three integration paths

| Path | Direction | Mechanism |
|------|-----------|-----------|
| **AI_RULES.md** | Hermes → Dyad | Write context files into `~/dyad-apps/<name>/AI_RULES.md`; Dyad auto-loads them as authoritative context |
| **MCP bridge** | Dyad → Hermes | Register MCP servers in Dyad's `mcp_servers` table; Dyad's AI calls external tools during app-building chats |
| **SQLite + filesystem** | Bidirectional | Read/write Dyad's DB (WAL mode) and project dirs directly from Hermes |

## Files

- `SKILL.md` — full procedures for 7 operations, pitfalls, verification steps
- `references/dyad-db-schema.md` — complete Dyad v1.6.2 SQLite schema (13 tables, all columns, types, FKs, indexes, useful queries)
- `scripts/dyad_bridge.py` — Python bridge implementing 13 commands (list, chats, messages, write-rules, read-rules, create-project, add-mcp, list-mcp, remove-mcp, add-prompt, list-prompts, versions, schema). Env-var overridable (`DYAD_DB_PATH`, `DYAD_PROJECTS_DIR`) for testing. No external dependencies — stdlib only.
- `scripts/test_bridge.py` — 40-test suite using stdlib `unittest`. Creates temp Dyad DB with real schema, exercises every command. Includes 3 live DB smoke tests that auto-skip if Dyad isn't installed.

## Category

`optional-skills/devops/` — sits alongside existing devops skills (docker-management, pinggy-tunnel, watchers, cli, hermes-s6-container-supervision).

## Verification

```
40 tests, all passing:

cd optional-skills/devops/dyad-integration
python3 scripts/test_bridge.py

Ran 40 tests in 1.838s
OK
```

## Notes

- Dyad is Electron (not Tauri as I initially guessed). Confirmed by inspecting `/Applications/dyad.app/Contents/Info.plist` — `com.electron.dyad`, v1.6.2.
- The shipping Dyad build does **not** expose an HTTP REST API (a community fork claims one, but the official `dyad-sh/dyad` does not). All integration is via SQLite + filesystem + MCP.
- Schema extracted from the live `sqlite.db` on a real Dyad install. The bridge script uses `SELECT *` and is resilient to new columns being added in future Dyad versions.
- `AI_RULES.md` is Dyad's own mechanism — its system prompt instructs the AI to treat it as authoritative project context. This skill leverages that existing mechanism; it doesn't modify Dyad.