### PR TITLE
fix(mcp): treat null args as empty list in stdio bridge (#80652)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2384,7 +2384,7 @@ class MCPServerTask:
             )
 
         command = config.get("command")
-        args = config.get("args", [])
+        args = config.get("args") or []
         user_env = config.get("env")
 
         if not command:


### PR DESCRIPTION
fix(mcp): treat null args as empty list in stdio bridge

Fixes #80652

## Root cause

`config.get("args", [])` returns `None` (not `[]`) when the YAML key exists but the value is null — e.g. `args:` or `args: null`. The `*args` unpacking in the stdio watchdog wrapper then crashes with `TypeError: Value after * must be an iterable, not NoneType`.

The MCP server enters a `connecting -> parked` loop, logging the error every ~5 minutes.

## Fix

Change `config.get("args", [])` to `config.get("args") or []`, matching the pattern already used in `tools/mcp_schema_cache.py:35`.

## Testing

- Verified syntax with `py_compile`
- The `or []` coalesce correctly handles: `args: null`, `args:` (YAML null), and missing `args` key (defaults via `get()` to `None`, then `or []`)
