### PR TITLE
fix(agent): stray .git debris must not manufacture a code workspace

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli._subprocess_compat import bounded_git_probe
+from utils import find_git_root
 
 logger = logging.getLogger("hermes.coding_context")
 
@@ -388,11 +389,13 @@ def _resolve_cwd(cwd: Optional[str | Path]) -> Path:
 
 
 def _git_root(cwd: Path) -> Optional[Path]:
-    current = cwd.resolve()
-    for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
-    return None
+    """Nearest ancestor that is a git repo root, or ``None``.
+
+    Thin alias over :func:`utils.find_git_root` — the shared chokepoint that
+    rejects ``.git`` debris and skips the world-writable temp root, for the
+    same reason :func:`_marker_root` below skips it for stray manifests.
+    """
+    return find_git_root(cwd)
 
 
 def _home() -> Optional[Path]:

--- a/agent/lsp/workspace.py
+++ b/agent/lsp/workspace.py
@@ -22,7 +22,13 @@ import os
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
 
+# The one non-stdlib import in this module. ``utils`` is itself stdlib + yaml
+# with no project imports, so this stays cycle-free and cheap even on the lint
+# hook path — worth it to keep git-root detection answered in exactly one place.
+from utils import find_git_root
+
 logger = logging.getLogger("agent.lsp.workspace")
+
 
 # Cache: cwd → (worktree_root, is_git) so repeated calls don't re-stat.
 # Cleared on shutdown.  Keyed by absolute resolved path so symlink
@@ -42,13 +48,20 @@ def normalize_path(path: str) -> str:
 
 
 def find_git_worktree(start: str) -> Optional[str]:
-    """Walk up from ``start`` looking for a ``.git`` entry (file or dir).
+    """Walk up from ``start`` looking for a git repo root.
 
-    Returns the directory containing ``.git``, or ``None`` if no git
-    root is found before hitting the filesystem root.
+    Returns the repo root as a string, or ``None`` if none is found before
+    hitting the filesystem root. A ``.git`` *file* (rather than directory)
+    means we're inside a worktree from ``git worktree add`` — both forms
+    count; an empty directory named ``.git`` does not.
 
-    A ``.git`` *file* (not directory) means we're inside a git
-    worktree set up via ``git worktree add`` — both forms count.
+    Resolution is delegated to :func:`utils.find_git_root`, the shared
+    chokepoint. This gate is what keeps a gateway user sitting in their home
+    directory from spawning language-server daemons, so a phantom root
+    directly defeats its purpose.
+
+    Kept local to this function: the result cache and the ``str`` return
+    contract that the rest of the LSP layer depends on.
     """
     try:
         start_path = Path(normalize_path(start))
@@ -65,27 +78,12 @@ def find_git_worktree(start: str) -> Optional[str]:
         root, _is_git = cached
         return root
 
-    cur = start_path
-    # Defensive cap: the deepest reasonable monorepo is well under 64
-    # levels.  Caps the walk so a pathological cwd or a symlink cycle
-    # we somehow traverse can't keep us looping.
-    for _ in range(64):
-        git_marker = cur / ".git"
-        try:
-            if git_marker.exists():
-                resolved = str(cur)
-                _workspace_cache[str(start_path)] = (resolved, True)
-                return resolved
-        except OSError:
-            # Permission error on a parent dir — bail out cleanly.
-            break
-        parent = cur.parent
-        if parent == cur:
-            break
-        cur = parent
-
-    _workspace_cache[str(start_path)] = (None, False)
-    return None
+    # resolve=False: normalize_path() above deliberately leaves symlinks
+    # unfolded, and the returned root must stay in those terms.
+    root_path = find_git_root(start_path, resolve=False)
+    resolved = str(root_path) if root_path is not None else None
+    _workspace_cache[str(start_path)] = (resolved, resolved is not None)
+    return resolved
 
 
 def is_inside_workspace(path: str, workspace_root: str) -> bool:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -35,7 +35,7 @@ from agent.skill_utils import (
     skill_matches_platform,
     skill_matches_platform_list,
 )
-from utils import atomic_json_write
+from utils import atomic_json_write, find_git_root
 
 logger = logging.getLogger(__name__)
 
@@ -80,16 +80,21 @@ def _scan_context_content(content: str, filename: str) -> str:
 
 
 def _find_git_root(start: Path) -> Optional[Path]:
-    """Walk *start* and its parents looking for a ``.git`` directory.
+    """Walk *start* and its parents looking for a git repo root.
 
-    Returns the directory containing ``.git``, or ``None`` if we hit the
-    filesystem root without finding one.
+    Returns the repo root, or ``None`` if we hit the filesystem root without
+    finding one. Delegates to :func:`utils.find_git_root`, which rejects an
+    empty ``.git`` directory and skips the shared temp root.
+
+    That matters twice over here. This bounds the ``.hermes.md`` search below —
+    and ``_find_hermes_md`` deliberately refuses to walk parents when there is
+    no git root, precisely so a file planted in ``/tmp`` or ``/home`` can't be
+    picked up. A stray ``.git`` in one of those directories used to make this
+    return a root, which re-enabled the very walk that guard exists to prevent.
+    It also feeds the system prompt's workspace snapshot, so a phantom root is
+    something the model is told and acts on.
     """
-    current = start.resolve()
-    for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
-    return None
+    return find_git_root(start)
 
 
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")

--- a/tests/agent/lsp/test_broken_set.py
+++ b/tests/agent/lsp/test_broken_set.py
@@ -35,6 +35,7 @@ def _make_git_workspace(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     (repo / "pyproject.toml").write_text("[project]\nname='t'\n")
     return repo
 
@@ -51,6 +52,7 @@ def test_unrelated_project_not_affected_by_broken(tmp_path, monkeypatch):
     repo_b = tmp_path / "repo-b"
     repo_b.mkdir()
     (repo_b / ".git").mkdir()
+    (repo_b / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     (repo_b / "pyproject.toml").write_text("[project]\nname='b'\n")
     a_src = repo_a / "x.py"
     a_src.write_text("")

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -66,6 +66,7 @@ def mock_pyright(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     (repo / "pyproject.toml").write_text("")  # so pyright's root resolver finds it
     monkeypatch.chdir(str(repo))
     gen = _install_mock_server(monkeypatch, "errors", "pyright")

--- a/tests/agent/lsp/test_stale_diagnostics.py
+++ b/tests/agent/lsp/test_stale_diagnostics.py
@@ -118,6 +118,7 @@ def stale_repo(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     (repo / "pyproject.toml").write_text("")
     monkeypatch.chdir(str(repo))
     idx, original = _install_mock_server("stale")

--- a/tests/agent/lsp/test_workspace.py
+++ b/tests/agent/lsp/test_workspace.py
@@ -29,9 +29,50 @@ def test_find_git_worktree_finds_dotgit(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     sub = repo / "src" / "deep"
     sub.mkdir(parents=True)
     assert find_git_worktree(str(sub)) == str(repo)
+
+
+def test_shared_temp_root_is_not_a_worktree(tmp_path: Path, monkeypatch):
+    """A stray `.git` in the shared temp dir must not make every path under it
+    look like a workspace.
+
+    `/tmp` is world-writable, so any process can leave a `.git` behind. Without
+    this guard the gate opens for paths that have no project at all, and Hermes
+    spawns language servers for them — the failure mode the workspace gate
+    exists to prevent.
+    """
+    fake_tmp = tmp_path / "shared-tmp"
+    (fake_tmp / ".git").mkdir(parents=True)
+    (fake_tmp / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    work = fake_tmp / "scratch"
+    work.mkdir()
+    # Patched on utils, not this module: find_git_worktree delegates the
+    # walk (and the temp-root guard) to utils.find_git_root.
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+    # Asserts the temp root is not *claimed* rather than asserting ``None``:
+    # ``tmp_path`` itself lives under the machine's real temp dir, and a host
+    # with its own stray ``/tmp/.git`` would resolve to that instead — making an
+    # ``is None`` assertion pass or fail on ambient state rather than on the
+    # behavior under test. (That ambient sensitivity is the very bug this guard
+    # fixes; the test must not inherit it.)
+    assert find_git_worktree(str(work)) != str(fake_tmp)
+
+
+def test_real_repo_under_the_temp_root_still_resolves(tmp_path: Path, monkeypatch):
+    """Only the temp root itself is skipped, not everything beneath it —
+    otherwise every `tmp_path`-based workspace test would go blind."""
+    fake_tmp = tmp_path / "shared-tmp"
+    repo = fake_tmp / "checkout"
+    repo.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    # Patched on utils, not this module: find_git_worktree delegates the
+    # walk (and the temp-root guard) to utils.find_git_root.
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+    assert find_git_worktree(str(repo)) == str(repo)
 
 
 
@@ -56,6 +97,7 @@ def test_nearest_root_finds_first_marker(tmp_path: Path):
 def test_resolve_workspace_for_file_uses_cwd_first(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     (repo / ".git").mkdir(parents=True)
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
     file_path = repo / "x.py"
     file_path.write_text("")
     # cwd is inside the repo

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -201,6 +201,60 @@ class TestHomeDotfilesGuard:
         assert cc.is_coding_context(platform="cli", cwd=proj, config=cfg) is True
 
 
+class TestStrayGitDebrisGuard:
+    """`.git` debris must not manufacture a workspace.
+
+    These assert on `_git_root` directly rather than through
+    `is_coding_context`, because the end-to-end path only misbehaves when the
+    *real* temp dir happens to be polluted — which is true on some machines and
+    not on CI. Testing the helper makes the contract hold everywhere.
+    """
+
+    def test_empty_git_directory_is_not_a_repo(self, tmp_path):
+        # `git rev-parse` exits 128 on this tree; `.git/`.exists() does not.
+        (tmp_path / ".git").mkdir()
+        assert cc._git_root(tmp_path) is None
+
+    def test_git_directory_with_head_is_a_repo(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+        assert cc._git_root(tmp_path) == tmp_path.resolve()
+
+    def test_git_file_worktree_is_a_repo(self, tmp_path):
+        # Linked worktrees and submodules use a `.git` *file* holding `gitdir:`.
+        (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n")
+        assert cc._git_root(tmp_path) == tmp_path.resolve()
+
+    def test_shared_temp_root_is_never_a_repo_root(self, tmp_path, monkeypatch):
+        """A `.git` in the shared temp dir must not claim every path under it.
+
+        Same guard `_marker_root` already applies to stray manifests: anything
+        world-writable is not somebody's workspace.
+        """
+        fake_tmp = tmp_path / "shared-tmp"
+        (fake_tmp / "work").mkdir(parents=True)
+        real_git = fake_tmp / ".git"
+        real_git.mkdir()
+        (real_git / "HEAD").write_text("ref: refs/heads/main\n")
+        # Patch utils, where the walk actually lives — cc._git_root delegates.
+        monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+        assert cc._git_root(fake_tmp / "work") is None
+
+    def test_real_repo_under_the_temp_root_still_counts(self, tmp_path, monkeypatch):
+        """Only the temp root itself is skipped — not everything beneath it.
+
+        Pytest's own `tmp_path` lives under the temp root, so over-broad
+        skipping here would blind every workspace test in the suite.
+        """
+        fake_tmp = tmp_path / "shared-tmp"
+        repo = fake_tmp / "projects" / "app"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+        (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+        # Patch utils, where the walk actually lives — cc._git_root delegates.
+        monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+        assert cc._git_root(repo) == repo.resolve()
+
 
 # ── prompt assembly integration ─────────────────────────────────────────────
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -456,6 +456,7 @@ class TestBuildContextFilesPrompt:
         # git-root AGENTS.md + intermediate + cwd are all merged, root first
         # and cwd last so deeper guidance takes precedence.
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         (tmp_path / "AGENTS.md").write_text("Root: use Ruff.")
         pkg = tmp_path / "packages"
         pkg.mkdir()
@@ -478,6 +479,7 @@ class TestBuildContextFilesPrompt:
     def test_agents_md_chain_skips_gaps(self, tmp_path):
         # Intermediate dirs without AGENTS.md contribute nothing.
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         (tmp_path / "AGENTS.md").write_text("Root rules.")
         deep = tmp_path / "a" / "b" / "c"
         deep.mkdir(parents=True)
@@ -487,6 +489,7 @@ class TestBuildContextFilesPrompt:
 
     def test_agents_md_chain_dedupes_identical_content(self, tmp_path):
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         (tmp_path / "AGENTS.md").write_text("Same rules everywhere.")
         sub = tmp_path / "sub"
         sub.mkdir()
@@ -500,6 +503,7 @@ class TestBuildContextFilesPrompt:
         from agent.prompt_builder import _load_agents_md
 
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         sub = tmp_path / "sub"
         sub.mkdir()
         (sub / "AGENTS.md").write_text("Only file.")
@@ -598,6 +602,7 @@ class TestFindHermesMd:
 
     def test_walks_to_git_root(self, tmp_path):
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         (tmp_path / ".hermes.md").write_text("root rules")
         sub = tmp_path / "a" / "b"
         sub.mkdir(parents=True)
@@ -629,10 +634,12 @@ class TestFindHermesMd:
 class TestFindGitRoot:
     def test_finds_git_dir(self, tmp_path):
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         assert _find_git_root(tmp_path) == tmp_path
 
     def test_finds_from_subdirectory(self, tmp_path):
         (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         sub = tmp_path / "src" / "lib"
         sub.mkdir(parents=True)
         assert _find_git_root(sub) == tmp_path

--- a/tests/test_utils_git_root.py
+++ b/tests/test_utils_git_root.py
@@ -1,0 +1,142 @@
+"""Tests for the shared git-root detection helpers in utils.py.
+
+These cover the chokepoint itself. Four call sites route through it
+(``agent.coding_context``, ``agent.prompt_builder``, ``agent.lsp.workspace``,
+``tools.checkpoint_manager``), and each previously answered "is this a repo?"
+on its own with ``(parent / ".git").exists()`` — a check that accepts an empty
+directory ``git`` itself rejects.
+
+Note these assert on the helpers directly and stub ``gettempdir`` rather than
+going through the callers. The end-to-end failure only reproduces when the
+machine's real temp dir happens to hold ``.git`` debris — true on some hosts,
+not on CI — so caller-level tests pass with the bug present and prove nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils import find_git_root, is_git_root
+
+
+# ── is_git_root: what counts as a repo ───────────────────────────────────
+
+
+def test_empty_git_directory_is_not_a_repo(tmp_path: Path):
+    """`git rev-parse` exits 128 on this tree; `.exists()` says yes anyway."""
+    (tmp_path / ".git").mkdir()
+    assert is_git_root(tmp_path) is False
+
+
+def test_git_directory_with_head_is_a_repo(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    assert is_git_root(tmp_path) is True
+
+
+def test_git_file_worktree_is_a_repo(tmp_path: Path):
+    """Linked worktrees and submodules use a `.git` *file* holding `gitdir:`."""
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n")
+    assert is_git_root(tmp_path) is True
+
+
+def test_no_git_entry_at_all(tmp_path: Path):
+    assert is_git_root(tmp_path) is False
+
+
+def test_accepts_str_paths(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    assert is_git_root(str(tmp_path)) is True
+
+
+# ── find_git_root: the walk ──────────────────────────────────────────────
+
+
+def _repo(at: Path) -> Path:
+    at.mkdir(parents=True, exist_ok=True)
+    (at / ".git").mkdir()
+    (at / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    return at
+
+
+def test_finds_root_from_a_subdirectory(tmp_path: Path):
+    repo = _repo(tmp_path / "repo")
+    deep = repo / "src" / "pkg"
+    deep.mkdir(parents=True)
+    assert find_git_root(deep) == repo.resolve()
+
+
+def test_returns_none_when_no_repo_above(tmp_path: Path, monkeypatch):
+    # Stub the temp root to tmp_path so the walk stops before reaching the
+    # machine's real temp dir, which may hold its own .git debris.
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(tmp_path))
+    work = tmp_path / "not-a-repo"
+    work.mkdir()
+    assert find_git_root(work) is None
+
+
+def test_empty_git_dir_does_not_stop_the_walk(tmp_path: Path):
+    """Debris must be skipped over, not merely rejected at that level."""
+    repo = _repo(tmp_path / "repo")
+    inner = repo / "scratch"
+    inner.mkdir()
+    (inner / ".git").mkdir()  # debris, no HEAD
+    assert find_git_root(inner) == repo.resolve()
+
+
+def test_shared_temp_root_is_never_a_repo_root(tmp_path: Path, monkeypatch):
+    """A `.git` in the world-writable temp dir must not claim everything under it."""
+    fake_tmp = _repo(tmp_path / "shared-tmp")
+    work = fake_tmp / "work"
+    work.mkdir()
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+    assert find_git_root(work) != fake_tmp.resolve()
+
+
+def test_real_repo_under_the_temp_root_still_counts(tmp_path: Path, monkeypatch):
+    """Only the temp root itself is skipped, not everything beneath it.
+
+    pytest's own `tmp_path` lives under the temp root, so over-broad skipping
+    would blind every workspace test in the suite.
+    """
+    fake_tmp = tmp_path / "shared-tmp"
+    repo = _repo(fake_tmp / "projects" / "app")
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+    assert find_git_root(repo) == repo.resolve()
+
+
+def test_temp_root_guard_is_not_sidesteppable_via_symlink(tmp_path: Path, monkeypatch):
+    """The guard compares resolved forms, so a symlink to the temp root is caught."""
+    fake_tmp = _repo(tmp_path / "shared-tmp")
+    link = tmp_path / "link-to-tmp"
+    try:
+        link.symlink_to(fake_tmp, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+    monkeypatch.setattr("utils.tempfile.gettempdir", lambda: str(fake_tmp))
+    assert find_git_root(link) != fake_tmp.resolve()
+
+
+# ── resolve=False: the LSP contract ──────────────────────────────────────
+
+
+def test_resolve_false_keeps_the_path_as_given(tmp_path: Path):
+    """agent.lsp.workspace needs unfolded symlinks — some language servers key
+    workspace identity on the exact path the user opened."""
+    real = _repo(tmp_path / "real-repo")
+    link = tmp_path / "via-link"
+    try:
+        link.symlink_to(real, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+
+    assert find_git_root(link, resolve=True) == real.resolve()
+    assert find_git_root(link, resolve=False) == link.absolute()
+
+
+def test_bad_input_returns_none_rather_than_raising():
+    """Callers sit on the lint and prompt-build paths; they must not crash."""
+    assert find_git_root("\0invalid") is None

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -318,6 +318,7 @@ class TestWorkingDirResolution:
         git_proj = tmp_path / "myproject"
         (git_proj / "src").mkdir(parents=True)
         (git_proj / ".git").mkdir()
+        (git_proj / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
         (git_proj / "src" / "main.py").write_text("x\n")
         assert m.get_working_dir_for_path(
             str(git_proj / "src" / "main.py")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -61,7 +61,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Dict, List, Optional, Set, Tuple
 
-from utils import env_int
+from utils import env_int, is_git_root
 
 logger = logging.getLogger(__name__)
 
@@ -981,11 +981,16 @@ class CheckpointManager:
         else:
             candidate = path.parent
 
-        markers = {".git", "pyproject.toml", "package.json", "Cargo.toml",
+        # ``.git`` is validated rather than merely stat'd: an empty directory
+        # named ``.git`` is debris, and accepting it here sends every checkpoint
+        # for the edited file to whatever ancestor happens to hold it — commonly
+        # a shared temp or scratch dir, i.e. not the user's project at all.
+        # The other markers are ordinary files, so existence is the right test.
+        markers = {"pyproject.toml", "package.json", "Cargo.toml",
                     "go.mod", "Makefile", "pom.xml", ".hg", "Gemfile"}
         check = candidate
         while check != check.parent:
-            if any((check / m).exists() for m in markers):
+            if is_git_root(check) or any((check / m).exists() for m in markers):
                 return str(check)
             check = check.parent
 

--- a/utils.py
+++ b/utils.py
@@ -524,6 +524,82 @@ def fast_safe_load(stream: Any) -> Any:
     return yaml.load(stream, Loader=_get_fast_yaml_loader())
 
 
+# ─── Git Workspace Detection ─────────────────────────────────────────────────
+#
+# One chokepoint for "is this directory a git repo?" and "which ancestor is the
+# repo root?". Four call sites used to answer this independently with
+# ``(parent / ".git").exists()``, and every one of them could be fooled the same
+# way — so the answer lives here now and they all route through it.
+#
+# Two failure modes are closed:
+#
+#   1. ``.exists()`` accepts an *empty directory* named ``.git``. ``git`` itself
+#      does not — ``rev-parse`` exits 128 on such a tree. Scratch dirs collect
+#      exactly this debris.
+#   2. The shared temp root is world-writable, so any process can drop a ``.git``
+#      there and strand every path beneath it in a phantom repo.
+#
+# Real-world impact when this went wrong: the agent's system prompt claimed a
+# workspace rooted at ``/tmp``, the LSP gate spawned language servers for files
+# with no project, checkpoints were taken against the wrong directory, and
+# interactive sessions flipped into the coding posture anywhere under the temp
+# dir.
+
+
+def is_git_root(directory: Union[str, Path]) -> bool:
+    """Whether ``directory`` holds a real git repo marker — not just the name.
+
+    A real marker is a ``.git`` directory containing ``HEAD``, or a ``.git``
+    *file* holding ``gitdir: …`` (linked worktree or submodule). An empty
+    directory named ``.git`` is debris, not a repo.
+    """
+    dot_git = Path(directory) / ".git"
+    try:
+        if dot_git.is_file():
+            return True
+        return (dot_git / "HEAD").exists()
+    except OSError:
+        return False
+
+
+def find_git_root(start: Union[str, Path], *, resolve: bool = True) -> "Path | None":
+    """Nearest ancestor of ``start`` that is a git repo root, or ``None``.
+
+    Walks ``start`` and its parents. The shared temp root itself is skipped —
+    only that one directory, so a real checkout *under* it (CI scratch space,
+    ``git worktree add /tmp/...``, pytest ``tmp_path`` fixtures) still resolves
+    normally.
+
+    ``resolve`` controls symlink handling of the *returned* path. The default
+    resolves, matching what the workspace/posture callers have always done.
+    Pass ``resolve=False`` to walk the path as given and return the ancestor
+    unresolved — the LSP layer needs this because some language servers key
+    their workspace identity on the exact path the user opened, and folding a
+    symlink changes that identity. The temp-root comparison still uses resolved
+    forms either way, so the guard can't be sidestepped through a symlink.
+    """
+    try:
+        current = Path(start)
+        current = current.resolve() if resolve else current.absolute()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    try:
+        temp_root = Path(tempfile.gettempdir()).resolve()
+    except Exception:
+        temp_root = None
+    for parent in [current, *current.parents]:
+        try:
+            if temp_root is not None and parent.resolve() == temp_root:
+                continue
+            if is_git_root(parent):
+                return parent
+        except OSError:
+            # Permission error partway up — stop rather than crash a caller
+            # that may be on a lint or prompt-build path.
+            break
+    return None
+
+
 # ─── Environment Variable Helpers ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What and why

Four call sites decided "am I in a git repo?" independently, and all four
answered it the same wrong way:

```python
if (parent / ".git").exists():   # an EMPTY directory satisfies this
```

`git` itself does not — `rev-parse` exits 128 on such a tree. Shared,
world-writable temp and scratch directories collect exactly this debris, so one
stray `/tmp/.git` makes every path underneath resolve to a repo rooted at
`/tmp`.

What that breaks, per site:

| Site | Consequence |
|---|---|
| `agent/coding_context.py` | interactive sessions flip into the coding posture anywhere under the temp dir |
| `agent/prompt_builder.py` | the system prompt's workspace snapshot claims a repo that isn't there |
| `agent/lsp/workspace.py` | the workspace gate opens for files with no project — the exact case it exists to prevent |
| `tools/checkpoint_manager.py` | checkpoints for an edited file are taken against whatever ancestor holds the debris |

The `prompt_builder` one is worth calling out. `_find_hermes_md` deliberately
refuses to walk parents when there is **no** git root, specifically so a
`.hermes.md` planted in `/tmp` or `/home` can't be picked up. A phantom root
made `stop_at` truthy and re-enabled that walk — so the bug defeats an existing
guard, on the path that builds the system prompt.

`_marker_root` in `coding_context` already carried a temp-root guard with a
comment explaining this exact risk ("Shared world-writable temp roots are never
project roots: a stray manifest in /tmp … must not flip every session"). Its
immediate neighbour never got it. That asymmetry is what makes this a class
rather than a bug.

## Approach

Rather than patch each site, the answer now lives in one place.
`utils.is_git_root()` / `utils.find_git_root()` close two failure modes:

1. a `.git` must actually be a repo — a directory containing `HEAD`, or a
   *file* holding `gitdir:` (linked worktree / submodule);
2. the shared temp root itself is skipped — only that one directory, so a real
   checkout under it (CI scratch space, `git worktree add /tmp/...`, pytest
   `tmp_path`) still resolves normally.

`utils` is the right home on structure, not taste: it is stdlib + yaml with no
project imports, so no cycle is possible, and three of the four call sites
already import from it.

Two details this had to get right:

- **`agent/lsp/workspace.py` must not fold symlinks.** `normalize_path`'s
  comment notes that some servers (rust-analyzer) key workspace identity on the
  path as opened. `find_git_root` resolves by default, so that caller passes
  `resolve=False`. The temp-root comparison still uses resolved forms either
  way, so the guard cannot be sidestepped through a symlink — there is a test
  for that specifically.
- **`checkpoint_manager` needs the predicate, not the walk**, since it checks
  `.git` alongside `pyproject.toml`, `Cargo.toml` and friends. Those are
  ordinary files, so plain existence remains the right test for them.

`hermes_cli/config.py:detect_install_method` is **not** part of this class
despite matching a `.git`-plus-`.parents` search: its check is a single stat on
a known install root, not an ancestor walk. Left untouched.

## On the twelve changed test fixtures

Making the predicate uniform breaks fixtures that create a bare
`(repo / ".git").mkdir()`. Twelve of them across five files now also write a
`HEAD`.

That churn was worth questioning, and I did: an earlier revision of this fix
applied the strict check only to `coding_context` and left the LSP path with a
temp-root guard alone, precisely to avoid touching those tests. That was the
wrong call. The debris actually observed included an empty `.git` *outside* the
temp root (a tool's scratch dir under `$HOME`), which a temp-guard-only fix
misses entirely. The fixtures are also more faithful now — a bare directory
named `.git` is not a repo, and `git` agrees.

## How to test

```bash
scripts/run_tests.sh tests/test_utils_git_root.py
scripts/run_tests.sh tests/agent/ tests/tools/ tests/hermes_cli/
```

To reproduce the original behavior, drop an empty `.git` in the shared temp dir
and compare the old walk against the new helper:

```bash
mkdir -p /tmp/.git /tmp/scratch-demo      # empty dir — not a repo
git -C /tmp rev-parse --show-toplevel     # exits 128: git agrees it is not one

# the old walk, verbatim
python3 -c "
from pathlib import Path
p = Path('/tmp/scratch-demo').resolve()
for parent in [p, *p.parents]:
    if (parent / '.git').exists(): print('naive walk ->', parent); break
else: print('naive walk -> None')
"                                          # -> /tmp

python3 -c "from utils import find_git_root; print(find_git_root('/tmp/scratch-demo'))"
                                           # -> None

rmdir /tmp/.git /tmp/scratch-demo
```

Output above is from an actual run on a host that had accumulated a stray
`/tmp/.git` — which is how this was found in the first place.

`tests/test_utils_git_root.py` asserts on the helpers directly and stubs
`gettempdir` rather than going through the callers — deliberately. The
end-to-end failure only reproduces on a host whose real temp dir holds debris,
which is true on some machines and not on CI, so caller-level tests pass with
the bug present and prove nothing. I verified the new tests discriminate by
swapping the naive `.exists()` implementation back in: 3 of 13 fail, as they
must.

## Platforms tested

Linux (Kali 6.19, x86_64), Python 3.11.14, pytest 9.1.1.

Full `scripts/run_tests.sh`: see the run below. The single failure,
`tests/agent/test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`,
fails identically on unmodified `main` and is unrelated to this change —
reported rather than folded in, since whether the test or the rotation logic
encodes the intended behavior is a maintainer call.

`ruff check .` clean. The four `ty` diagnostics in `prompt_builder.py` are
pre-existing (identical count with this change stashed) and sit in code this PR
does not touch.
