### PR TITLE
fix(whatsapp): preserve sender identity across text batches

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -285,7 +285,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
-from gateway.whatsapp_identity import to_whatsapp_jid
+from gateway.whatsapp_identity import canonical_whatsapp_identifier, to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -1339,7 +1339,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # asyncio.create_task pattern for mark_read).
                                 asyncio.create_task(self._send_read_receipt(msg_data))
                                 if event.message_type == MessageType.TEXT:
-                                    self._enqueue_text_event(event)
+                                    await self._enqueue_text_event(event)
                                 else:
                                     await self.handle_message(event)
             except asyncio.CancelledError:
@@ -1392,15 +1392,67 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             profile=event.source.profile,
         )
 
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
+    @staticmethod
+    def _text_batch_sender(event: MessageEvent) -> Optional[str]:
+        """Return the stable sender identity that is safe to batch together."""
+        source = event.source
+        sender_id = source.user_id_alt or source.user_id
+        if sender_id:
+            return canonical_whatsapp_identifier(str(sender_id)) or str(sender_id)
+        if source.chat_type in {"dm", "private"} and source.chat_id:
+            return canonical_whatsapp_identifier(str(source.chat_id)) or str(source.chat_id)
+        return None
+
+    def _can_merge_text_batch_events(
+        self,
+        existing: MessageEvent,
+        incoming: MessageEvent,
+    ) -> bool:
+        """Only merge events whose verified WhatsApp sender is identical."""
+        existing_sender = self._text_batch_sender(existing)
+        incoming_sender = self._text_batch_sender(incoming)
+        return existing_sender is not None and existing_sender == incoming_sender
+
+    async def _flush_text_batch_now(self, key: str) -> bool:
+        """Cancel one debounce timer and dispatch its buffered event immediately."""
+        event = self._pending_text_batches.pop(key, None)
+        if event is None:
+            # The timer may already have claimed this event and entered
+            # handle_message(). Do not cancel it mid-dispatch: wait so a
+            # sender transition cannot overtake or lose the earlier batch.
+            task = self._pending_text_batch_tasks.get(key)
+            if task and task is not asyncio.current_task() and not task.done():
+                await asyncio.gather(task, return_exceptions=True)
+            return False
+        task = self._pending_text_batch_tasks.pop(key, None)
+        if task and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await self.handle_message(event)
+        return True
+
+    async def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
         When WhatsApp delivers rapid-fire messages (e.g. forwarded
         batches), this concatenates them and waits for a short quiet
-        period before dispatching the combined message.
+        period before dispatching the combined message. In a shared group,
+        a sender change flushes the earlier sender first so attribution and
+        chronological order are preserved.
         """
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        if existing is None:
+            # A timer removes its event immediately before dispatch. If that
+            # dispatch is still in flight, let it finish before a later sender
+            # can start a new batch or cancel the task below.
+            in_flight = self._pending_text_batch_tasks.get(key)
+            if in_flight and in_flight is not asyncio.current_task() and not in_flight.done():
+                await asyncio.gather(in_flight, return_exceptions=True)
+                existing = self._pending_text_batches.get(key)
+        if existing is not None and not self._can_merge_text_batch_events(existing, event):
+            await self._flush_text_batch_now(key)
+            existing = None
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -9,6 +9,7 @@ Batch delays are read from ``config.extra`` (config.yaml), not env vars.
 """
 
 import asyncio
+from unittest.mock import AsyncMock, call
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
@@ -22,13 +23,20 @@ def _make_adapter(**extra):
     return WhatsAppAdapter(PlatformConfig(enabled=True, extra=base))
 
 
-def _event(text):
+def _event(
+    text,
+    *,
+    chat_id="chat123",
+    chat_type="dm",
+    user_id="user1",
+    user_name="tester",
+):
     src = SessionSource(
         platform=Platform.WHATSAPP,
-        chat_id="chat123",
-        chat_type="dm",
-        user_id="user1",
-        user_name="tester",
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name=user_name,
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=src)
 
@@ -51,3 +59,142 @@ def test_invalid_config_value_falls_back_to_default():
     assert adapter._text_batch_split_delay_seconds == 10.0
 
 
+def test_same_sender_messages_share_one_batch():
+    async def run():
+        adapter = _make_adapter(text_batch_delay_seconds=60)
+        adapter.handle_message = AsyncMock()
+
+        await adapter._enqueue_text_event(_event("first"))
+        await adapter._enqueue_text_event(_event("second"))
+
+        assert adapter.handle_message.await_count == 0
+        pending = next(iter(adapter._pending_text_batches.values()))
+        assert pending.text == "first\nsecond"
+        await adapter._flush_text_batch_now(adapter._text_batch_key(pending))
+        adapter.handle_message.assert_awaited_once_with(pending)
+        assert not adapter._pending_text_batches
+        assert not adapter._pending_text_batch_tasks
+
+    asyncio.run(run())
+
+
+def test_sender_change_flushes_before_starting_next_batch():
+    async def run():
+        adapter = _make_adapter(
+            group_sessions_per_user=False,
+            text_batch_delay_seconds=60,
+        )
+        adapter.handle_message = AsyncMock()
+        first = _event(
+            "from Alice",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id="15550000001@s.whatsapp.net",
+            user_name="Alice",
+        )
+        second = _event(
+            "from Bob",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id="15550000002@s.whatsapp.net",
+            user_name="Bob",
+        )
+
+        assert adapter._text_batch_key(first) == adapter._text_batch_key(second)
+        await adapter._enqueue_text_event(first)
+        await adapter._enqueue_text_event(second)
+
+        adapter.handle_message.assert_awaited_once_with(first)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        assert pending is second
+        assert pending.source.user_name == "Bob"
+        await adapter._flush_text_batch_now(adapter._text_batch_key(second))
+        assert adapter.handle_message.await_args_list == [call(first), call(second)]
+        assert not adapter._pending_text_batches
+        assert not adapter._pending_text_batch_tasks
+
+    asyncio.run(run())
+
+
+def test_sender_change_waits_for_in_flight_flush_without_cancelling_it():
+    async def run():
+        adapter = _make_adapter(
+            group_sessions_per_user=False,
+            text_batch_delay_seconds=0,
+        )
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        handled = []
+
+        async def handle(event):
+            handled.append(event)
+            if len(handled) == 1:
+                first_started.set()
+                await release_first.wait()
+
+        adapter.handle_message = AsyncMock(side_effect=handle)
+        first = _event(
+            "from Alice",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id="15550000001@s.whatsapp.net",
+            user_name="Alice",
+        )
+        second = _event(
+            "from Bob",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id="15550000002@s.whatsapp.net",
+            user_name="Bob",
+        )
+
+        await adapter._enqueue_text_event(first)
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        adapter._text_batch_delay_seconds = 60
+        enqueue_second = asyncio.create_task(adapter._enqueue_text_event(second))
+        await asyncio.sleep(0)
+        assert not enqueue_second.done()
+
+        release_first.set()
+        await asyncio.wait_for(enqueue_second, timeout=1)
+        assert handled == [first]
+        assert next(iter(adapter._pending_text_batches.values())) is second
+        await adapter._flush_text_batch_now(adapter._text_batch_key(second))
+        assert handled == [first, second]
+
+    asyncio.run(run())
+
+
+def test_unknown_group_senders_are_not_merged():
+    async def run():
+        adapter = _make_adapter(
+            group_sessions_per_user=False,
+            text_batch_delay_seconds=60,
+        )
+        adapter.handle_message = AsyncMock()
+        first = _event(
+            "first",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id=None,
+            user_name=None,
+        )
+        second = _event(
+            "second",
+            chat_id="shared@g.us",
+            chat_type="group",
+            user_id=None,
+            user_name=None,
+        )
+
+        await adapter._enqueue_text_event(first)
+        await adapter._enqueue_text_event(second)
+
+        adapter.handle_message.assert_awaited_once_with(first)
+        assert next(iter(adapter._pending_text_batches.values())) is second
+        await adapter._flush_text_batch_now(adapter._text_batch_key(second))
+        assert adapter.handle_message.await_args_list == [call(first), call(second)]
+        assert not adapter._pending_text_batches
+        assert not adapter._pending_text_batch_tasks
+
+    asyncio.run(run())


### PR DESCRIPTION
## What does this PR do?

Prevents WhatsApp text-debounce batching from merging rapid messages from different participants in a shared group into one `MessageEvent` whose `source` still belongs to the first participant.

The adapter now:
- derives a stable canonical sender identity for each event
- flushes the pending batch immediately when the sender changes
- preserves same-sender debounce batching
- fails closed when a group sender cannot be verified
- waits for an in-flight flush so a newer sender cannot cancel or overtake the earlier batch

This protects downstream authorization, privacy boundaries, and tool gating that depend on `event.source`; adding an author label only to the merged text would not correct the metadata.

This is an alternative to #47794. Related sender-isolation work: #63056 and #63163.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing

- [x] Added regression coverage for same-sender batching
- [x] Added regression coverage for sender transitions and dispatch order
- [x] Added fail-closed coverage for missing group sender IDs
- [x] Added coverage for the in-flight flush cancellation race
- [x] `scripts/run_tests.sh tests/gateway/test_whatsapp_text_batching.py` — 6 passed
- [x] All WhatsApp gateway tests in the upstream worktree — 128 passed
- [x] Ruff and `git diff --check` passed

## Checklist

- [x] The public diff contains no private participant data or credentials
- [x] Existing same-sender batching behavior remains intact
