### PR TITLE
fix(docker): include unzip for Composio installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev libatomic1 procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev libatomic1 procps git openssh-client docker-cli xz-utils unzip && \
     rm -rf /var/lib/apt/lists/*
 
 # Prefer the fixed SQLite over Debian's vulnerable libsqlite3.so.0. Keep the


### PR DESCRIPTION
## Summary
- Add `unzip` to the Hermes Docker image package list.
- The Composio CLI installer needs `unzip` to unpack its release artifact.
- Keeps Composio setup reproducible after image builds without mounting Docker into the Hermes runtime container.

## Verification
- `git diff --check -- Dockerfile`
- `scripts/run_tests.sh tests/tools/test_dockerfile_immutable_install.py tests/tools/test_dockerfile_pid1_reaping.py tests/docker`

## Notes
- Full Docker image build verification should run in GitHub Actions via `.github/workflows/docker.yml`, not inside the Hermes container.
