### PR TITLE
fix(whatsapp): add _wenv fallback for group_allow_from (#80660)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -449,7 +449,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom") or _wenv("WHATSAPP_GROUP_ALLOWED_USERS"))
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
             read_receipts if isinstance(read_receipts, bool)


### PR DESCRIPTION
fix(whatsapp): add _wenv fallback for group_allow_from

Fixes #80660

## Root cause

The WhatsApp adapter reads `group_policy` from both `config.extra` AND `_wenv()` (`.env`), but reads `group_allow_from` from `config.extra` **only** — with no `_wenv("WHATSAPP_GROUP_ALLOWED_USERS")` fallback.

When a user sets `WHATSAPP_GROUP_POLICY=allowlist` and `WHATSAPP_GROUP_ALLOWED_USERS=<gid>@g.us` in `.env` (the documented config path), the group policy loads correctly but the allowlist stays empty. Every group message is silently dropped by `_is_group_allowed()` returning `False`.

## Fix

Add `_wenv("WHATSAPP_GROUP_ALLOWED_USERS")` fallback to the `group_allow_from` initialization, matching the pattern used by `group_policy` on the preceding line. One-line change.

## Testing

- Verified syntax with `py_compile`
- The `_coerce_allow_list()` already handles `None` gracefully (returns `set()`), so the `_wenv()` return value flows through the same parsing path as `config.extra` values
