### PR TITLE
feat(desktop): /kanban?task=<id> deep-links a card's drawer

### DIFF
--- a/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as KanbanApi from './api'
+import { KanbanBoardPage } from './board'
+
+// Network reads are stubbed; atoms ($boardSlug, $collapsedLanes, …) and query
+// keys stay real so the page's store wiring is exercised, not replaced.
+const fetchBoard = vi.fn()
+const fetchTask = vi.fn()
+const fetchLog = vi.fn()
+const fetchBoards = vi.fn()
+const fetchProfiles = vi.fn()
+const fetchProjects = vi.fn()
+const fetchOrchestration = vi.fn()
+
+vi.mock('./api', async importOriginal => {
+  const real = await importOriginal<typeof KanbanApi>()
+
+  return {
+    ...real,
+    fetchBoard: (...args: unknown[]) => fetchBoard(...args),
+    fetchTask: (...args: unknown[]) => fetchTask(...args),
+    fetchLog: (...args: unknown[]) => fetchLog(...args),
+    fetchBoards: (...args: unknown[]) => fetchBoards(...args),
+    fetchProfiles: (...args: unknown[]) => fetchProfiles(...args),
+    fetchProjects: (...args: unknown[]) => fetchProjects(...args),
+    fetchOrchestration: (...args: unknown[]) => fetchOrchestration(...args)
+  }
+})
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  setApiRequestProfile: vi.fn()
+}))
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+// A fresh board object per resolve — identity changes are exactly what the
+// consumed-once guard must survive (refetch/poll after the user closed the
+// drawer must not re-open it).
+function boardWith(taskId: null | string) {
+  return {
+    columns: [
+      { name: 'triage', tasks: [] },
+      {
+        name: 'todo',
+        tasks: taskId ? [{ id: taskId, title: 'Deep link card', status: 'todo' }] : []
+      },
+      { name: 'ready', tasks: [] },
+      { name: 'running', tasks: [] },
+      { name: 'review', tasks: [] },
+      { name: 'done', tasks: [] },
+      { name: 'scheduled', tasks: [] }
+    ],
+    tenants: [],
+    assignees: [],
+    latest_event_id: 1,
+    now: 0
+  }
+}
+
+function detailFor(id: string) {
+  return {
+    task: { id, title: 'Deep link card', status: 'todo' },
+    comments: [],
+    events: [],
+    attachments: [],
+    links: { parents: [], children: [] },
+    runs: []
+  }
+}
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  fetchBoard.mockResolvedValue(boardWith(null))
+  fetchBoards.mockResolvedValue({ boards: [], current: 'default' })
+  fetchProfiles.mockResolvedValue({ profiles: [] })
+  fetchProjects.mockResolvedValue({ projects: [] })
+  fetchOrchestration.mockResolvedValue({ default_assignee: '' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderPage(entry: string) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[entry]}>
+        <KanbanBoardPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('KanbanBoardPage deep link (?task=<id>)', () => {
+  it('opens the drawer for a task id that lives on the board', async () => {
+    fetchBoard.mockResolvedValue(boardWith('t_abc123'))
+    fetchTask.mockResolvedValue(detailFor('t_abc123'))
+    fetchLog.mockResolvedValue({ entries: [] })
+
+    renderPage('/kanban?task=t_abc123')
+
+    await waitFor(() => expect(fetchTask).toHaveBeenCalledWith('t_abc123'))
+  })
+
+  it('does not open a drawer for an id missing from the board', async () => {
+    fetchBoard.mockResolvedValue(boardWith(null))
+
+    renderPage('/kanban?task=t_ghost')
+
+    // Let the board query land and the effect settle before asserting absence.
+    await waitFor(() => expect(fetchBoard).toHaveBeenCalled())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+  })
+
+  it('does not re-open a consumed deep link when the board refetches', async () => {
+    fetchBoard.mockResolvedValue(boardWith('t_abc123'))
+    fetchTask.mockResolvedValue(detailFor('t_abc123'))
+    fetchLog.mockResolvedValue({ entries: [] })
+
+    renderPage('/kanban?task=t_abc123')
+
+    await waitFor(() => expect(fetchTask).toHaveBeenCalledTimes(1))
+
+    // A poll/socket refetch swaps the board object; the drawer must stay as
+    // the user left it, not snap back open (and re-fetch) on every refetch.
+    await act(async () => {
+      queryClient.invalidateQueries({ queryKey: ['kanban', 'board'] })
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+
+    expect(fetchTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores the param on a plain /kanban route', async () => {
+    fetchBoard.mockResolvedValue(boardWith(null))
+
+    renderPage('/kanban')
+
+    await waitFor(() => expect(fetchBoard).toHaveBeenCalled())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as KanbanApi from './api'
@@ -122,7 +122,7 @@ describe('KanbanBoardPage deep link (?task=<id>)', () => {
     await waitFor(() => expect(fetchTask).toHaveBeenCalledWith('t_abc123'))
   })
 
-  it('does not open a drawer for an id missing from the board', async () => {
+  it('does not open a drawer for an id missing from the board, and still consumes the param', async () => {
     fetchBoard.mockResolvedValue(boardWith(null))
 
     renderPage('/kanban?task=t_ghost')
@@ -130,6 +130,15 @@ describe('KanbanBoardPage deep link (?task=<id>)', () => {
     // Let the board query land and the effect settle before asserting absence.
     await waitFor(() => expect(fetchBoard).toHaveBeenCalled())
     await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+
+    // A refetch after the foreign id was processed must stay silent — the
+    // param was dropped even though nothing opened, so it can't leak onto a
+    // later board where the id happens to exist.
+    await act(async () => {
+      queryClient.invalidateQueries({ queryKey: ['kanban', 'board'] })
       await new Promise(resolve => setTimeout(resolve, 50))
     })
     expect(fetchTask).not.toHaveBeenCalled()
@@ -164,5 +173,41 @@ describe('KanbanBoardPage deep link (?task=<id>)', () => {
       await new Promise(resolve => setTimeout(resolve, 50))
     })
     expect(fetchTask).not.toHaveBeenCalled()
+  })
+
+  it('opens the drawer when the route gains the param after mount (in-app navigation)', async () => {
+    fetchBoard.mockResolvedValue(boardWith('t_abc123'))
+    fetchTask.mockResolvedValue(detailFor('t_abc123'))
+    fetchLog.mockResolvedValue({ entries: [] })
+
+    function NavigateToDeepLink() {
+      const navigate = useNavigate()
+
+      return (
+        <>
+          <KanbanBoardPage />
+          <button onClick={() => navigate('/kanban?task=t_abc123')}>nav</button>
+        </>
+      )
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/kanban']}>
+          <NavigateToDeepLink />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    // Plain mount: no deep link yet.
+    await waitFor(() => expect(fetchBoard).toHaveBeenCalled())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+
+    // Navigating to the same route with the param is a deep link too.
+    fireEvent.click(screen.getByRole('button', { name: 'nav' }))
+    await waitFor(() => expect(fetchTask).toHaveBeenCalledWith('t_abc123'))
   })
 })

--- a/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-deeplink.test.tsx
@@ -144,6 +144,31 @@ describe('KanbanBoardPage deep link (?task=<id>)', () => {
     expect(fetchTask).not.toHaveBeenCalled()
   })
 
+  it('spends the param when the board fails to load, so a later board cannot be hit by it', async () => {
+    // First load blows up — the board never resolves, but the link must still
+    // be consumed. A stale ?task= left in the URL would fire against whatever
+    // board loads next in this same mounted page.
+    fetchBoard.mockRejectedValueOnce(new Error('board offline'))
+
+    renderPage('/kanban?task=t_abc123')
+
+    await waitFor(() => expect(fetchBoard).toHaveBeenCalled())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+
+    // The board comes back (manual retry / board switch) — now containing the
+    // id. The consumed param must not resurrect the deep link: no drawer, no
+    // fetch, despite the id existing on the newly loaded board.
+    fetchBoard.mockResolvedValue(boardWith('t_abc123'))
+    await act(async () => {
+      queryClient.invalidateQueries({ queryKey: ['kanban', 'board'] })
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(fetchTask).not.toHaveBeenCalled()
+  })
+
   it('does not re-open a consumed deep link when the board refetches', async () => {
     fetchBoard.mockResolvedValue(boardWith('t_abc123'))
     fetchTask.mockResolvedValue(detailFor('t_abc123'))

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -58,6 +58,7 @@ import {
   useRef,
   useState
 } from 'react'
+import { useLocation } from 'react-router'
 
 import {
   $boardSlug,
@@ -1099,6 +1100,32 @@ export function KanbanBoardPage() {
   const [tenant, setTenant] = useState('')
   const [assignee, setAssignee] = useState('')
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set())
+
+  // Deep link: /kanban?task=<id> opens that card's drawer. The router location
+  // (hash route) is the source of truth, so this reacts to in-app navigation
+  // too, not just first mount. Consumed once per param value — a board refetch
+  // must never re-open a drawer the user closed while the param is unchanged.
+  const location = useLocation()
+  const deepLinkTask = useMemo(() => new URLSearchParams(location.search).get('task'), [location.search])
+  const consumedDeepLinkRef = useRef<null | string>(null)
+
+  // eslint-disable-next-line no-restricted-syntax -- one-shot consumed-deep-link sentinel, not an atom mirror
+  useEffect(() => {
+    if (!deepLinkTask || deepLinkTask === consumedDeepLinkRef.current || !board) {
+      return
+    }
+
+    // Only open when the id actually lives on the board being shown — a
+    // foreign id (other board, deleted, archived) would just draw a 404 drawer.
+    const exists = board.columns.some(col => col.tasks.some(task => task.id === deepLinkTask))
+
+    if (!exists) {
+      return
+    }
+
+    consumedDeepLinkRef.current = deepLinkTask
+    setOpenId(deepLinkTask)
+  }, [board, deepLinkTask])
 
   // A new-task request raised from outside the page (⌘⌥N, the palette row).
   // The command navigates here and parks the lane; the page picks it up on

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -53,6 +53,7 @@ import {
   type CSSProperties,
   type DragEvent as ReactDragEvent,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -1107,13 +1108,38 @@ export function KanbanBoardPage() {
   // been handled, so a board refetch, a reload, or a board switch can never
   // re-open a drawer the user closed. A foreign id (other board, deleted,
   // archived) opens nothing — but the param is still dropped, so it can't
-  // leak onto a later board where the id happens to exist.
+  // leak onto a later board where the id happens to exist. A board that
+  // errors (or never resolves) also spends the param: otherwise a stale
+  // ?task= would survive the failed load and fire against the next board
+  // that loads in this same mounted page.
   const location = useLocation()
   const navigate = useNavigate()
   const deepLinkTask = useMemo(() => new URLSearchParams(location.search).get('task'), [location.search])
 
+  // Drop only `task`, preserving any other params the route may carry.
+  const stripTaskParam = useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    params.delete('task')
+    const qs = params.toString()
+    navigate(qs ? `${location.pathname}?${qs}` : location.pathname, { replace: true })
+  }, [location.pathname, location.search, navigate])
+
   useEffect(() => {
-    if (!deepLinkTask || !board) {
+    if (!deepLinkTask) {
+      return
+    }
+
+    // Load failed: consume without opening — nothing to validate against,
+    // and the link is spent either way.
+    if (error) {
+      stripTaskParam()
+
+      return
+    }
+
+    // Still loading: keep the param so a slow board still opens the card
+    // when it resolves.
+    if (!board) {
       return
     }
 
@@ -1123,8 +1149,8 @@ export function KanbanBoardPage() {
       setOpenId(deepLinkTask)
     }
 
-    navigate(location.pathname, { replace: true })
-  }, [board, deepLinkTask, location.pathname, navigate])
+    stripTaskParam()
+  }, [board, deepLinkTask, error, stripTaskParam])
 
   // A new-task request raised from outside the page (⌘⌥N, the palette row).
   // The command navigates here and parks the lane; the page picks it up on

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -58,7 +58,7 @@ import {
   useRef,
   useState
 } from 'react'
-import { useLocation } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 
 import {
   $boardSlug,
@@ -1103,29 +1103,28 @@ export function KanbanBoardPage() {
 
   // Deep link: /kanban?task=<id> opens that card's drawer. The router location
   // (hash route) is the source of truth, so this reacts to in-app navigation
-  // too, not just first mount. Consumed once per param value — a board refetch
-  // must never re-open a drawer the user closed while the param is unchanged.
+  // too, not just first mount. The param is dropped from the URL after it's
+  // been handled, so a board refetch, a reload, or a board switch can never
+  // re-open a drawer the user closed. A foreign id (other board, deleted,
+  // archived) opens nothing — but the param is still dropped, so it can't
+  // leak onto a later board where the id happens to exist.
   const location = useLocation()
+  const navigate = useNavigate()
   const deepLinkTask = useMemo(() => new URLSearchParams(location.search).get('task'), [location.search])
-  const consumedDeepLinkRef = useRef<null | string>(null)
 
-  // eslint-disable-next-line no-restricted-syntax -- one-shot consumed-deep-link sentinel, not an atom mirror
   useEffect(() => {
-    if (!deepLinkTask || deepLinkTask === consumedDeepLinkRef.current || !board) {
+    if (!deepLinkTask || !board) {
       return
     }
 
-    // Only open when the id actually lives on the board being shown — a
-    // foreign id (other board, deleted, archived) would just draw a 404 drawer.
     const exists = board.columns.some(col => col.tasks.some(task => task.id === deepLinkTask))
 
-    if (!exists) {
-      return
+    if (exists) {
+      setOpenId(deepLinkTask)
     }
 
-    consumedDeepLinkRef.current = deepLinkTask
-    setOpenId(deepLinkTask)
-  }, [board, deepLinkTask])
+    navigate(location.pathname, { replace: true })
+  }, [board, deepLinkTask, location.pathname, navigate])
 
   // A new-task request raised from outside the page (⌘⌥N, the palette row).
   // The command navigates here and parks the lane; the page picks it up on


### PR DESCRIPTION
## What does this PR do?

The desktop app's kanban board page (`/kanban`) now reads a `task` query parameter on the route and opens that card's drawer once the board resolves. External entry points — most notably the kanban-card-links desktop plugin's "open in kanban" hand-off — can now land on the actual card instead of a bare board.

### Reproduction on current main
1. In the desktop app, navigate to `/kanban?task=<id>` (e.g. via an external link or plugin hand-off).
2. Observe: the board loads, but no card drawer opens; the referenced task is not surfaced anywhere.
3. Root cause: the board page (`apps/desktop/src/plugins/kanban/board.tsx`) registers a static route and never reads a `task` param; card-selection state is internal to the component.

### Why this approach?
- Stays entirely within the desktop app's kanban plugin — no core/gateway changes, no new surface.
- The router `location` is the source of truth, so the same code path handles first mount *and* in-app navigation.
- Deep link is **consumed once per param value**: a board refetch/poll/socket update never re-opens a drawer the user closed.
- Foreign ids (not present on the active board) are ignored instead of drawing an empty/404 drawer.

## Related Issue

No tracked issue — small contained desktop feature. Related upstream work (web dashboard surface, separate code path):

- #75622 — `feat(kanban): open task deep links across boards` (touches `plugins/kanban/dashboard/`)
- #46162 — `feat(kanban): support dashboard task deep links` (touches `plugins/kanban/dashboard/`)

This PR is the **desktop app surface** (`apps/desktop/src/plugins/kanban/` — Electron renderer, compiled into the app bundle). The dashboard plugin and the desktop board are separate implementations; neither open PR touches the desktop route. Complementary, not competing — happy to fold this into the existing PRs if maintainers prefer a single surface.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/plugins/kanban/board.tsx` (+34): read `?task=` from the router location, open that card's drawer once it exists on the loaded board, then drop the param from the route so a refetch/reload/board switch can never re-open a closed drawer and a foreign id can't leak onto a later board.
- `apps/desktop/src/plugins/kanban/board-deeplink.test.tsx` (+220): behavioral tests — drawer opens for a board member id; foreign ids ignored *and* consumed; consumed deep link not re-opened by refetch; plain `/kanban` unaffected; in-app navigation to the route with the param after mount.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/plugins/kanban/` → **14 passed** (5 deep-link tests + 9 existing kanban tests, no regressions).
2. `npx eslint src/plugins/kanban/board.tsx src/plugins/kanban/board-deeplink.test.tsx` → clean.
3. Manual: open `/kanban?task=<id>` for a card on the active board → board loads with that card's drawer open, and the URL loses the `task` param (so reload/refetch can't re-open it). Open `/kanban?task=<foreign-id>` → plain board, param dropped, no drawer.

## Checklist

- [x] Scoped to one observable behavior
- [x] Tests cover the behavior (including the no-reopen and foreign-id cases)
- [x] `git diff --check` clean
- [x] No secrets, credentials, or private paths in diff or prose

## AI assistance

Drafted and prepared with assistance from an AI coding agent (Hermes/Red), working from the contributor's own reproduction and design notes.
