### PR TITLE
feat: reclaim backoff to prevent thundering-herd re-spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4557,12 +4557,16 @@ def release_stale_claims(
             )
             continue
         with write_txn(conn):
+            # Calculate reclaim backoff to prevent thundering-herd re-spawn.
+            # First reclaim: 0s (immediate), 2nd: 60s, 3rd: 300s, 4th+: 1800s.
+            backoff = _reclaim_backoff_seconds(row["id"], conn)
+            new_claim_expires = now + backoff if backoff > 0 else None
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = ?, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                (new_claim_expires, row["id"], row["claim_lock"], now),
             )
             if cur.rowcount != 1:
                 continue
@@ -4586,6 +4590,8 @@ def release_stale_claims(
                 "now": now,
                 "host_local": host_local,
                 "heartbeat_stale": bool(heartbeat_stale),
+                "backoff_seconds": backoff,
+                "backoff_until": new_claim_expires,
             }
             payload.update(termination)
             _append_event(
@@ -7304,6 +7310,40 @@ def enforce_max_runtime(
 # to match the original spec (">4h started + no commits in 1h").
 _STALE_HEARTBEAT_GAP_SECONDS = 3600
 
+# Reclaim backoff — exponential backoff after stale reclaim to prevent
+# thundering-herd re-spawn.  Steps are (attempt, delay_seconds):
+#   1st reclaim:  60s  (1 min)
+#   2nd reclaim: 300s  (5 min)
+#   3rd reclaim: 1800s (30 min)
+#   4th+ reclaim: kept at 1800s (cap)
+# If the task succeeds between reclaims, the counter resets.
+_RECLAIM_BACKOFF_STEPS = [60, 300, 1800]
+_RECLAIM_BACKOFF_CAP = 1800
+
+
+def _reclaim_backoff_seconds(task_id: str, conn: sqlite3.Connection) -> int:
+    """Return backoff delay (seconds) based on consecutive reclaim count.
+
+    Counts 'reclaimed' events since the last 'completed' event for this
+    task.  Returns 0 if no prior reclaims found (first reclaim → immediate
+    re-spawn allowed, matching current behavior).
+    """
+    rows = conn.execute(
+        "SELECT kind FROM task_events "
+        "WHERE task_id = ? AND kind IN ('completed', 'reclaimed') "
+        "ORDER BY created_at DESC LIMIT 20",
+        (task_id,),
+    ).fetchall()
+    consecutive = 0
+    for row in rows:
+        if row["kind"] == "completed":
+            break
+        consecutive += 1
+    if consecutive == 0:
+        return 0
+    idx = min(consecutive - 1, len(_RECLAIM_BACKOFF_STEPS) - 1)
+    return _RECLAIM_BACKOFF_STEPS[idx]
+
 
 def detect_stale_running(
     conn: sqlite3.Connection,
@@ -8360,7 +8400,9 @@ def _dispatch_once_locked(
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (claim_expires IS NULL OR claim_expires <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (now,),
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,


### PR DESCRIPTION
## What

Adds exponential backoff to automatic task reclaim (heartbeat-based stale detection).

After a stale task is reclaimed, it stays in 'ready' status but is invisible to the task picker for a calculated backoff period:

| Consecutive reclaims | Backoff delay |
|---|---|
| 1st | 0s (immediate, current behavior) |
| 2nd | 60s |
| 3rd | 300s (5 min) |
| 4th+ | 1800s (30 min, cap) |

Backoff resets when the task successfully completes.

## Why

In resource-constrained environments (local LLMs, limited API quotas, rate-limited providers), a task that repeatedly times out triggers repeated immediate re-spawns. Each re-spawn consumes tokens/quotas, potentially hitting rate limits and creating a thundering-herd pattern:

```
task times out → reclaim → immediately re-spawn → times out → reclaim → immediately re-spawn → ...
```

With backoff:

```
task times out → reclaim (1st, immediate) → re-spawn → times out → reclaim (2nd, wait 60s) → re-spawn → times out → reclaim (3rd, wait 5min) → ...
```

## How

- New helper `_reclaim_backoff_seconds(task_id, conn)` counts consecutive 'reclaimed' events since the last 'completed' event for that task (O(1) query, capped at 20 rows)
- In `release_stale_claims()`: sets `claim_expires = now + backoff` instead of `NULL`, so the task stays in 'ready' status but is invisible to the task picker until the backoff elapses
- Task picker query gains: `AND (claim_expires IS NULL OR claim_expires <= now)`
- Backoff metadata (`backoff_seconds`, `backoff_until`) recorded in task_events payload for observability
- Manual `reclaim_task()` is NOT affected (user-initiated = no backoff needed)
- Backoff resets on successful completion

## Changes

- `hermes_cli/kanban_db.py`: +45/-3 lines
  - `_RECLAIM_BACKOFF_STEPS` constant
  - `_reclaim_backoff_seconds()` helper
  - Modified `release_stale_claims()` to use backoff
  - Modified task picker query to respect backoff
  - Added backoff fields to reclaim event payload

## Testing

```bash
# Simulate: 3 consecutive stale reclaims should show increasing backoff
# 1st reclaim: backoff=0, claim_expires=NULL (immediate)
# 2nd reclaim: backoff=60, claim_expires=now+60
# 3rd reclaim: backoff=300, claim_expires=now+300
```

## Related

- PR #80737 (hermes sessions optimize --retention-days)
- This is PR 2 of 5 from the 5-Agent system contribution (see INTEGRATION.md §6)