### PR TITLE
fix(tools): reject unresolved explicit send targets instead of silently using the home channel

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -64,3 +64,72 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         force_document=False,
     )
 
+
+def test_unresolved_explicit_target_errors_while_bare_platform_uses_home(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from gateway import channel_directory
+
+    target_id = "19:private-dm@thread.v2"
+    directory_path = tmp_path / "channel_directory.json"
+    directory_path.write_text(
+        json.dumps({
+            "platforms": {
+                "teams": [{"id": target_id, "name": "Private DM", "type": "dm"}]
+            }
+        })
+    )
+    monkeypatch.setattr(channel_directory, "DIRECTORY_PATH", directory_path)
+    monkeypatch.setattr(
+        channel_directory,
+        "CHANNEL_ALIASES_PATH",
+        tmp_path / "channel_aliases.json",
+    )
+
+    teams_platform = Platform("teams")
+    teams_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={teams_platform: teams_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="home-chat"),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch(
+             "tools.send_message_tool._send_to_platform",
+             new=AsyncMock(return_value={"success": True}),
+         ) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        explicit_result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": f"teams:{target_id}",
+                    "message": "confidential",
+                }
+            )
+        )
+        bare_result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "teams",
+                    "message": "status update",
+                }
+            )
+        )
+
+    assert "Could not resolve" in explicit_result["error"]
+    assert bare_result["success"] is True
+    assert bare_result["note"] == "Sent to teams home channel (chat_id: home-chat)"
+    send_mock.assert_awaited_once_with(
+        teams_platform,
+        teams_cfg,
+        "home-chat",
+        "status update",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -391,6 +391,12 @@ def _handle_send(args):
                 f"Try using a numeric channel ID instead."
             )
 
+    if target_ref is not None and not chat_id:
+        return tool_error(
+            f"Could not resolve '{target_ref}' on {platform_name} to a chat ID. "
+            f"Use send_message(action='list') to see available targets."
+        )
+
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")


### PR DESCRIPTION
## Problem

`_handle_send` cannot distinguish *"no target supplied — use the home channel"* from
*"a target was supplied but did not resolve to a chat id"*. Both fall into the same branch:

```python
used_home_channel = False
if not chat_id:
    home = config.get_home_channel(platform)
    ...
    if home:
        chat_id = home.chat_id
        used_home_channel = True
```

So an explicitly specified target that fails to resolve is **silently redirected to the home
channel**, and the call returns `success` with `note: "Sent to <platform> home channel (...)"`.

## Impact

This is a confidentiality problem, not only a usability one.

Where the home channel is a shared or group conversation, a message explicitly addressed to a
private conversation is delivered into that shared channel — and reported as delivered. The only
signal is an easily missed `note` field on a successful result.

It bites on any platform whose targets `_parse_target_ref` does not handle: the target never
becomes a `chat_id`, so *every* explicit target for that platform routes to the home channel.

Found on a live deployment, where three sends addressed to a private 1:1 conversation each landed
in a shared channel and each reported success.

## Reproduction

With a platform configured, a home channel set, and a target the parser does not recognise:

```
hermes send --to <platform>:<some-conversation-id> "message"
→ {"success": true, "note": "Sent to <platform> home channel (chat_id: <home>)"}
```

Expected: an error identifying the unresolved target. Actual: silent delivery elsewhere.

## Fix

Six lines. If a target was supplied but produced no chat id, return an error instead of falling
back to the home channel.

Behaviour deliberately preserved:

- bare platform name (`--to telegram`) still uses the home channel;
- opaque platform-native ids that pass through verbatim still work — they set `chat_id`, so the
  new guard does not fire;
- no change to any supported platform's resolution path.

This PR does **not** add support for any new platform; it only stops silent misdelivery.

## Tests

Adds `tests/tools/test_send_message_target_parse.py::test_unresolved_explicit_target_errors_while_bare_platform_uses_home`,
asserting both halves: the explicit unresolved target errors, and a bare platform name still
reaches the home channel.

- Without the fix: fails (`KeyError: 'error'` — the send succeeded to the home channel).
- With the fix: passes.
- All ten `*send_message*` test files: **45 passed, 1 skipped**.

(Four unrelated collection errors exist in `tests/tools` on my machine — `test_clipboard`,
`test_mcp_oauth*`, `test_mcp_tool` — caused by missing local deps. They reproduce on an unmodified
checkout.)
