### PR TITLE
fix(mcp): isolate runtime ownership by profile

### DIFF
--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tools.mcp_tool import MCPServerTask, _register_server_tools
+from tools.mcp_tool import (
+    MCPServerTask,
+    _canonical_profile_home,
+    _register_server_tools,
+)
 from tools.registry import ToolRegistry
 
 
@@ -46,7 +50,8 @@ class TestRefreshTools:
     @pytest.mark.asyncio
     async def test_nuke_and_repave(self, mock_registry):
         """Old tools are removed and new tools registered on refresh."""
-        server = MCPServerTask("live_srv")
+        profile_home = _canonical_profile_home()
+        server = MCPServerTask("live_srv", profile_home=profile_home)
         server._refresh_lock = asyncio.Lock()
         server._config = {}
         from toolsets import resolve_toolset
@@ -55,7 +60,7 @@ class TestRefreshTools:
         mock_registry.register(
             name="mcp__live_srv__old_tool", toolset="mcp-live_srv", schema={},
             handler=lambda x: x, check_fn=lambda: True, is_async=False,
-            description="", emoji="",
+            description="", emoji="", profile_home=profile_home,
         )
         server._registered_tool_names = ["mcp__live_srv__old_tool"]
 

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -152,8 +152,10 @@ class TestLazyFirstUseConnect:
 
         connected = self._connected_server()
 
-        def _connect(name):
-            mcp._servers["playwright"] = connected
+        server_key = mcp._server_key("playwright")
+
+        def _connect(key):
+            mcp._servers[key] = connected
             return True
 
         with patch.object(mcp, "_ensure_lazy_server_connected", side_effect=_connect) as mock_connect, \
@@ -161,7 +163,7 @@ class TestLazyFirstUseConnect:
             handler = mcp._make_tool_handler("playwright", "browser_navigate", 5)
             out = handler({}, task_id="t1")
 
-        mock_connect.assert_called_once_with("playwright")
+        mock_connect.assert_called_once_with(server_key)
         payload = json.loads(out)
         assert "error" not in payload
         assert payload.get("result") == ""
@@ -176,8 +178,10 @@ class TestLazyFirstUseConnect:
         connected = self._connected_server()
         connected.session.list_resources = AsyncMock()
 
-        def _connect(name):
-            mcp._servers["playwright"] = connected
+        server_key = mcp._server_key("playwright")
+
+        def _connect(key):
+            mcp._servers[key] = connected
             return True
 
         async def _fake_paginate(list_method, items_attr, server_name):
@@ -189,7 +193,7 @@ class TestLazyFirstUseConnect:
             handler = mcp._make_list_resources_handler("playwright", 5)
             out = handler({})
 
-        mock_connect.assert_called_once_with("playwright")
+        mock_connect.assert_called_once_with(server_key)
         payload = json.loads(out)
         assert "error" not in payload
         assert payload["resources"][0]["uri"] == "file:///a"
@@ -203,8 +207,10 @@ class TestLazyFirstUseConnect:
             return_value=SimpleNamespace(messages=[])
         )
 
-        def _connect(name):
-            mcp._servers["playwright"] = connected
+        server_key = mcp._server_key("playwright")
+
+        def _connect(key):
+            mcp._servers[key] = connected
             return True
 
         with patch.object(mcp, "_ensure_lazy_server_connected", side_effect=_connect) as mock_connect, \
@@ -212,7 +218,7 @@ class TestLazyFirstUseConnect:
             handler = mcp._make_get_prompt_handler("playwright", 5)
             out = handler({"name": "greeting"})
 
-        mock_connect.assert_called_once_with("playwright")
+        mock_connect.assert_called_once_with(server_key)
         payload = json.loads(out)
         assert "error" not in payload
 
@@ -285,7 +291,10 @@ class TestLazyFirstUseConnect:
              patch.object(registry, "deregister") as mock_dereg:
             assert mcp._ensure_lazy_server_connected("playwright") is True
 
-        mock_dereg.assert_called_once_with("mcp_playwright_tool_x")
+        mock_dereg.assert_called_once_with(
+            "mcp_playwright_tool_x",
+            profile_home=mcp._server_key("playwright")[0],
+        )
 
     def test_lazy_connect_failure_records_cooldown(self):
         mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
@@ -300,7 +309,7 @@ class TestLazyFirstUseConnect:
              patch.object(mcp, "_record_connect_failure") as mock_record:
             assert mcp._ensure_lazy_server_connected("playwright") is False
 
-        mock_record.assert_called_once_with("playwright")
+        mock_record.assert_called_once_with(mcp._server_key("playwright"))
         # Config retained so a later call can retry after cooldown.
         assert "playwright" in mcp._lazy_server_configs
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -10,6 +10,7 @@ import os
 import sys
 import threading
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -299,6 +300,52 @@ class TestMCPStatus:
         assert statuses["failed"]["error"] == "Connection closed"
         assert statuses["disabled"]["status"] == "disabled"
         assert statuses["disabled"]["disabled"] is True
+        from hermes_constants import get_hermes_home
+
+        assert {
+            entry["profile_home"]
+            for entry in statuses.values()
+        } == {str(Path(get_hermes_home()).expanduser().resolve())}
+
+    def test_connected_owner_survives_home_override_switch(self, tmp_path, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        first_home = (tmp_path / "first").resolve()
+        second_home = (tmp_path / "second").resolve()
+        server = mcp_tool.MCPServerTask("connected")
+        server.profile_home = str(first_home)
+        server.session = object()
+        server._tools = []
+
+        monkeypatch.setattr(
+            mcp_tool,
+            "_load_mcp_config",
+            lambda: {"connected": {"command": "mock"}},
+        )
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            mcp_tool._servers.clear()
+            mcp_tool._servers["connected"] = server
+        try:
+            first_token = set_hermes_home_override(first_home)
+            try:
+                first_status = mcp_tool.get_mcp_status()
+            finally:
+                reset_hermes_home_override(first_token)
+
+            second_token = set_hermes_home_override(second_home)
+            try:
+                second_status = mcp_tool.get_mcp_status()
+            finally:
+                reset_hermes_home_override(second_token)
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+
+        assert first_status[0]["profile_home"] == str(first_home)
+        assert second_status[0]["profile_home"] == str(first_home)
 
 
 class TestLifecycleConfig:
@@ -735,6 +782,134 @@ class TestDiscoverAndRegister:
         assert "mcp__fs__write_file" in mock_registry.get_all_tool_names()
 
         _servers.pop("fs", None)
+
+    def test_eager_registration_captures_profile_home(self, tmp_path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import ToolRegistry
+        import tools.mcp_tool as mcp_tool
+        from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+
+        mock_registry = ToolRegistry()
+        mock_tools = [_make_mcp_tool("read_file", "Read a file")]
+        mock_session = MagicMock()
+        profile_home = (tmp_path / "eager").resolve()
+
+        async def fake_connect(name, config):
+            server = MCPServerTask(name)
+            server.session = mock_session
+            server._tools = mock_tools
+            return server
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+                 patch("tools.registry.registry", mock_registry):
+                registered = asyncio.run(
+                    _discover_and_register_server(
+                        "eager",
+                        {
+                            "command": "mock",
+                            "tools": {"resources": False, "prompts": False},
+                        },
+                    )
+                )
+        finally:
+            reset_hermes_home_override(token)
+
+        try:
+            assert registered == ["mcp__eager__read_file"]
+            assert mock_registry.get_profile_home_for_tool(registered[0]) == str(profile_home)
+        finally:
+            _servers.pop("eager", None)
+            with mcp_tool._lock:
+                mcp_tool._server_profile_homes.pop("eager", None)
+
+    def test_dynamic_refresh_keeps_original_profile_home(self, tmp_path):
+        import tools.mcp_tool as mcp_tool
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import ToolRegistry
+
+        first_home = (tmp_path / "first").resolve()
+        second_home = (tmp_path / "second").resolve()
+        config = {"tools": {"resources": False, "prompts": False}}
+        mock_registry = ToolRegistry()
+
+        first_token = set_hermes_home_override(first_home)
+        try:
+            # The server is created in profile A; registration happens after
+            # switching to profile B, like a list_changed refresh on the
+            # shared MCP loop.
+            server = mcp_tool.MCPServerTask(
+                "refresh", profile_home=mcp_tool._canonical_profile_home()
+            )
+            server.session = MagicMock()
+            server._tools = [_make_mcp_tool("read_file", "Read a file")]
+        finally:
+            reset_hermes_home_override(first_token)
+
+        second_token = set_hermes_home_override(second_home)
+        try:
+            with patch("tools.registry.registry", mock_registry):
+                registered = mcp_tool._register_server_tools("refresh", server, config)
+        finally:
+            reset_hermes_home_override(second_token)
+
+        assert registered == ["mcp__refresh__read_file"]
+        assert mock_registry.get_profile_home_for_tool(registered[0]) == str(first_home)
+        with mcp_tool._lock:
+            mcp_tool._server_profile_homes.pop("refresh", None)
+
+    def test_lazy_registration_captures_profile_home(self, tmp_path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import ToolRegistry
+        import tools.mcp_tool as mcp_tool
+
+        mock_registry = ToolRegistry()
+        profile_home = (tmp_path / "lazy").resolve()
+        config = {"command": "mock", "args": [], "lazy": True}
+        entry = {
+            "fingerprint": "unused",
+            "tools": [{
+                "name": "read_file",
+                "description": "Read a file",
+                "inputSchema": {"type": "object", "properties": {}},
+            }],
+            "utility_tools": [],
+        }
+        with mcp_tool._lock:
+            saved_configs = dict(mcp_tool._lazy_server_configs)
+            saved_fingerprints = dict(mcp_tool._lazy_server_fingerprints)
+            saved_names = dict(mcp_tool._lazy_server_tool_names)
+            saved_profile_homes = dict(mcp_tool._lazy_server_profile_homes)
+            saved_server_profile_homes = dict(mcp_tool._server_profile_homes)
+            mcp_tool._lazy_server_configs.clear()
+            mcp_tool._lazy_server_fingerprints.clear()
+            mcp_tool._lazy_server_tool_names.clear()
+            mcp_tool._lazy_server_profile_homes.clear()
+            mcp_tool._server_profile_homes.clear()
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            with patch("tools.registry.registry", mock_registry):
+                registered = mcp_tool._register_from_cache_sync("lazy", config, entry)
+        finally:
+            reset_hermes_home_override(token)
+
+        try:
+            assert registered == ["mcp__lazy__read_file"]
+            assert mock_registry.get_profile_home_for_tool(registered[0]) == str(profile_home)
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._lazy_server_configs.clear()
+                mcp_tool._lazy_server_configs.update(saved_configs)
+                mcp_tool._lazy_server_fingerprints.clear()
+                mcp_tool._lazy_server_fingerprints.update(saved_fingerprints)
+                mcp_tool._lazy_server_tool_names.clear()
+                mcp_tool._lazy_server_tool_names.update(saved_names)
+                mcp_tool._lazy_server_profile_homes.clear()
+                mcp_tool._lazy_server_profile_homes.update(saved_profile_homes)
+                mcp_tool._server_profile_homes.clear()
+                mcp_tool._server_profile_homes.update(saved_server_profile_homes)
 
 
     def test_same_server_normalization_collision_skips_all_ambiguous_tools(self, caplog):

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1014,6 +1014,63 @@ class TestDiscoverAndRegister:
                         mcp_tool._servers.pop(key, None)
                         mcp_tool._server_connect_errors.pop(key, None)
 
+    def test_same_named_server_trust_gate_isolated_across_profiles(self, tmp_path):
+        import tools.mcp_tool as mcp_tool
+        from tools.registry import ToolRegistry
+
+        home_a = str((tmp_path / "profile-a").resolve())
+        home_b = str((tmp_path / "profile-b").resolve())
+        registry = ToolRegistry()
+        tool_name = "mcp__shared__write"
+
+        def server_for(home):
+            server = mcp_tool.MCPServerTask("shared", profile_home=home)
+            server._tools = [_make_mcp_tool("write", "write data")]
+            return server
+
+        with patch.dict(mcp_tool._server_trust_levels, {}, clear=True), patch.dict(
+            mcp_tool._tool_read_only_hints, {}, clear=True
+        ), patch.dict(mcp_tool._servers, {}, clear=True), patch.dict(
+            mcp_tool._lazy_server_configs, {}, clear=True
+        ), patch.dict(mcp_tool._server_error_counts, {}, clear=True), patch.dict(
+            mcp_tool._server_breaker_opened_at, {}, clear=True
+        ), patch("tools.registry.registry", registry), patch(
+            "tools.mcp_tool._track_mcp_tool_server"
+        ):
+            assert mcp_tool._register_server_tools(
+                "shared",
+                server_for(home_a),
+                {
+                    "trust": "full",
+                    "tools": {"resources": False, "prompts": False},
+                },
+            ) == [tool_name]
+            assert mcp_tool._register_server_tools(
+                "shared",
+                server_for(home_b),
+                {
+                    "trust": "untrusted",
+                    "tools": {"resources": False, "prompts": False},
+                },
+            ) == [tool_name]
+            handler_a = registry.get_entry(
+                tool_name, profile_home=home_a
+            ).handler
+            handler_b = registry.get_entry(
+                tool_name, profile_home=home_b
+            ).handler
+
+            with patch(
+                "tools.approval.request_elicitation_consent",
+                return_value="decline",
+            ) as consent:
+                result_a = json.loads(handler_a({}))
+                result_b = json.loads(handler_b({}))
+
+            assert "not connected" in result_a["error"]
+            assert "did not approve" in result_b["error"]
+            consent.assert_called_once()
+
 
     def test_same_server_normalization_collision_skips_all_ambiguous_tools(self, caplog):
         from tools.mcp_tool import _register_server_tools

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -307,7 +307,7 @@ class TestMCPStatus:
             for entry in statuses.values()
         } == {str(Path(get_hermes_home()).expanduser().resolve())}
 
-    def test_connected_owner_survives_home_override_switch(self, tmp_path, monkeypatch):
+    def test_connected_status_is_scoped_to_owner_profile(self, tmp_path, monkeypatch):
         import tools.mcp_tool as mcp_tool
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
@@ -326,7 +326,9 @@ class TestMCPStatus:
         with mcp_tool._lock:
             saved_servers = dict(mcp_tool._servers)
             mcp_tool._servers.clear()
-            mcp_tool._servers["connected"] = server
+            mcp_tool._servers[
+                mcp_tool._server_key("connected", str(first_home))
+            ] = server
         try:
             first_token = set_hermes_home_override(first_home)
             try:
@@ -345,7 +347,31 @@ class TestMCPStatus:
                 mcp_tool._servers.update(saved_servers)
 
         assert first_status[0]["profile_home"] == str(first_home)
-        assert second_status[0]["profile_home"] == str(first_home)
+        assert first_status[0]["status"] == "connected"
+        assert second_status[0]["profile_home"] == str(second_home)
+        assert second_status[0]["status"] == "configured"
+
+    def test_unscoped_multiplex_runtime_queries_fail_closed(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+
+        monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home_override",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            mcp_tool,
+            "_load_mcp_config",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("unscoped status must not read profile config")
+            ),
+        )
+
+        assert mcp_tool.get_mcp_status() == []
+        assert mcp_tool.has_registered_mcp_tools() is False
+        assert mcp_tool.get_registered_mcp_server_names() == set()
+        assert mcp_tool.is_mcp_tool_parallel_safe("mcp__shared__echo") is False
+        assert mcp_tool.reconnect_mcp_server("shared") is False
 
 
 class TestLifecycleConfig:
@@ -818,11 +844,11 @@ class TestDiscoverAndRegister:
 
         try:
             assert registered == ["mcp__eager__read_file"]
-            assert mock_registry.get_profile_home_for_tool(registered[0]) == str(profile_home)
+            assert mock_registry.get_profile_home_for_tool(
+                registered[0], profile_home=str(profile_home)
+            ) == str(profile_home)
         finally:
             _servers.pop("eager", None)
-            with mcp_tool._lock:
-                mcp_tool._server_profile_homes.pop("eager", None)
 
     def test_dynamic_refresh_keeps_original_profile_home(self, tmp_path):
         import tools.mcp_tool as mcp_tool
@@ -855,9 +881,9 @@ class TestDiscoverAndRegister:
             reset_hermes_home_override(second_token)
 
         assert registered == ["mcp__refresh__read_file"]
-        assert mock_registry.get_profile_home_for_tool(registered[0]) == str(first_home)
-        with mcp_tool._lock:
-            mcp_tool._server_profile_homes.pop("refresh", None)
+        assert mock_registry.get_profile_home_for_tool(
+            registered[0], profile_home=str(first_home)
+        ) == str(first_home)
 
     def test_lazy_registration_captures_profile_home(self, tmp_path):
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
@@ -880,13 +906,9 @@ class TestDiscoverAndRegister:
             saved_configs = dict(mcp_tool._lazy_server_configs)
             saved_fingerprints = dict(mcp_tool._lazy_server_fingerprints)
             saved_names = dict(mcp_tool._lazy_server_tool_names)
-            saved_profile_homes = dict(mcp_tool._lazy_server_profile_homes)
-            saved_server_profile_homes = dict(mcp_tool._server_profile_homes)
             mcp_tool._lazy_server_configs.clear()
             mcp_tool._lazy_server_fingerprints.clear()
             mcp_tool._lazy_server_tool_names.clear()
-            mcp_tool._lazy_server_profile_homes.clear()
-            mcp_tool._server_profile_homes.clear()
 
         token = set_hermes_home_override(profile_home)
         try:
@@ -897,7 +919,9 @@ class TestDiscoverAndRegister:
 
         try:
             assert registered == ["mcp__lazy__read_file"]
-            assert mock_registry.get_profile_home_for_tool(registered[0]) == str(profile_home)
+            assert mock_registry.get_profile_home_for_tool(
+                registered[0], profile_home=str(profile_home)
+            ) == str(profile_home)
         finally:
             with mcp_tool._lock:
                 mcp_tool._lazy_server_configs.clear()
@@ -906,10 +930,89 @@ class TestDiscoverAndRegister:
                 mcp_tool._lazy_server_fingerprints.update(saved_fingerprints)
                 mcp_tool._lazy_server_tool_names.clear()
                 mcp_tool._lazy_server_tool_names.update(saved_names)
-                mcp_tool._lazy_server_profile_homes.clear()
-                mcp_tool._lazy_server_profile_homes.update(saved_profile_homes)
-                mcp_tool._server_profile_homes.clear()
-                mcp_tool._server_profile_homes.update(saved_server_profile_homes)
+
+    def test_same_named_server_isolated_across_profiles_and_reloads(self, tmp_path):
+        import tools.mcp_tool as mcp_tool
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import ToolRegistry
+
+        home_a = (tmp_path / "profile-a").resolve()
+        home_b = (tmp_path / "profile-b").resolve()
+        registry = ToolRegistry()
+        sessions = {}
+
+        async def fake_connect(name, config):
+            owner = mcp_tool._canonical_profile_home()
+            label = "a" if owner == str(home_a) else "b"
+            session = MagicMock()
+            session.call_tool = AsyncMock(return_value=SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(text=label)],
+                structuredContent=None,
+            ))
+            server = mcp_tool.MCPServerTask(name, profile_home=owner)
+            server.session = session
+            server._tools = [_make_mcp_tool("echo", f"profile {label}")]
+            sessions[label] = session
+            return server
+
+        config = {
+            "command": "mock",
+            "tools": {"resources": False, "prompts": False},
+        }
+        tool_name = "mcp__shared__echo"
+        keys = {
+            mcp_tool._server_key("shared", str(home_a)),
+            mcp_tool._server_key("shared", str(home_b)),
+        }
+
+        with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), patch(
+            "tools.registry.registry", registry
+        ), patch(
+            "tools.mcp_tool._load_mcp_config", return_value={"shared": config}
+        ), patch(
+            "tools.mcp_tool._run_on_mcp_loop",
+            side_effect=lambda coroutine_factory, timeout=None: asyncio.run(
+                coroutine_factory()
+            ),
+        ):
+            for home in (home_a, home_b):
+                token = set_hermes_home_override(home)
+                try:
+                    assert asyncio.run(
+                        mcp_tool._discover_and_register_server("shared", config)
+                    ) == [tool_name]
+                finally:
+                    reset_hermes_home_override(token)
+
+            try:
+                assert keys.issubset(mcp_tool._servers)
+                for home, label in ((home_a, "a"), (home_b, "b"), (home_a, "a")):
+                    token = set_hermes_home_override(home)
+                    try:
+                        status = mcp_tool.get_mcp_status()
+                        assert status == [{
+                            "name": "shared",
+                            "transport": "stdio",
+                            "tools": 1,
+                            "connected": True,
+                            "disabled": False,
+                            "status": "connected",
+                            "profile_home": str(home),
+                        }]
+                        assert registry.get_schema(tool_name)["description"] == f"profile {label}"
+                        assert json.loads(registry.dispatch(tool_name, {})) == {
+                            "result": label
+                        }
+                    finally:
+                        reset_hermes_home_override(token)
+                sessions["a"].call_tool.assert_awaited_with("echo", arguments={})
+                sessions["b"].call_tool.assert_awaited_once_with("echo", arguments={})
+            finally:
+                with mcp_tool._lock:
+                    for key in keys:
+                        mcp_tool._servers.pop(key, None)
+                        mcp_tool._server_connect_errors.pop(key, None)
 
 
     def test_same_server_normalization_collision_skips_all_ambiguous_tools(self, caplog):
@@ -1248,8 +1351,13 @@ class TestShutdown:
                 "parameters": {"type": "object", "properties": {}},
             },
             handler=lambda *_args, **_kwargs: "{}",
+            profile_home=mcp_mod._canonical_profile_home(),
         )
-        registry.register_toolset_alias("test", "mcp-test")
+        registry.register_toolset_alias(
+            "test",
+            "mcp-test",
+            profile_home=mcp_mod._canonical_profile_home(),
+        )
 
         server = MCPServerTask("test")
         server._registered_tool_names = ["mcp__test__ping"]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -33,6 +33,39 @@ class TestRegisterAndDispatch:
         result = json.loads(reg.dispatch("alpha", {}))
         assert result == {"ok": True}
 
+    def test_builtin_registration_has_no_profile_home_provenance(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="alpha", toolset="core", schema=_make_schema("alpha"),
+            handler=_dummy_handler,
+        )
+
+        assert reg.get_profile_home_for_tool("alpha") is None
+
+    def test_reregister_updates_profile_home_provenance(self, tmp_path):
+        reg = ToolRegistry()
+        first_home = str((tmp_path / "first").resolve())
+        second_home = str((tmp_path / "second").resolve())
+
+        reg.register(
+            name="mcp__shared__search",
+            toolset="mcp-shared",
+            schema=_make_schema("mcp__shared__search"),
+            handler=_dummy_handler,
+            profile_home=first_home,
+        )
+        assert reg.get_profile_home_for_tool("mcp__shared__search") == first_home
+
+        reg.register(
+            name="mcp__shared__search",
+            toolset="mcp-shared",
+            schema=_make_schema("mcp__shared__search"),
+            handler=_dummy_handler,
+            profile_home=second_home,
+        )
+
+        assert reg.get_profile_home_for_tool("mcp__shared__search") == second_home
+
 
     def test_cross_mcp_toolsets_do_not_overwrite_atomically(self, caplog):
         """Parallel MCP registrations with one name leave exactly one owner."""

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -54,7 +54,12 @@ class TestRegisterAndDispatch:
             handler=_dummy_handler,
             profile_home=first_home,
         )
-        assert reg.get_profile_home_for_tool("mcp__shared__search") == first_home
+        assert (
+            reg.get_profile_home_for_tool(
+                "mcp__shared__search", profile_home=first_home
+            )
+            == first_home
+        )
 
         reg.register(
             name="mcp__shared__search",
@@ -64,7 +69,12 @@ class TestRegisterAndDispatch:
             profile_home=second_home,
         )
 
-        assert reg.get_profile_home_for_tool("mcp__shared__search") == second_home
+        assert (
+            reg.get_profile_home_for_tool(
+                "mcp__shared__search", profile_home=second_home
+            )
+            == second_home
+        )
 
 
     def test_cross_mcp_toolsets_do_not_overwrite_atomically(self, caplog):
@@ -117,6 +127,168 @@ class TestRegisterAndDispatch:
             and "mcp__foo_bar__search" in record.message
             for record in caplog.records
         )
+
+    def test_mcp_same_public_name_is_scoped_by_profile(self, tmp_path):
+        reg = ToolRegistry()
+        home_a = str((tmp_path / "profile-a").resolve())
+        home_b = str((tmp_path / "profile-b").resolve())
+        name = "mcp__shared__echo"
+
+        def handler_a(args, **kwargs):
+            return json.dumps({"owner": "a"})
+
+        def handler_b(args, **kwargs):
+            return json.dumps({"owner": "b"})
+
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema=_make_schema(name),
+            handler=handler_a,
+            profile_home=home_a,
+        )
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema={**_make_schema(name), "description": "profile b"},
+            handler=handler_b,
+            profile_home=home_b,
+        )
+
+        entry_a = reg.get_entry(name, profile_home=home_a)
+        entry_b = reg.get_entry(name, profile_home=home_b)
+        assert entry_a is not None and entry_a.profile_home == home_a
+        assert entry_b is not None and entry_b.profile_home == home_b
+        assert reg.get_schema(name, profile_home=home_a)["description"] == f"A {name}"
+        assert reg.get_schema(name, profile_home=home_b)["description"] == "profile b"
+        assert json.loads(reg.dispatch(name, {}, profile_home=home_a))["owner"] == "a"
+        assert json.loads(reg.dispatch(name, {}, profile_home=home_b))["owner"] == "b"
+
+        defs_a = reg.get_definitions({name}, profile_home=home_a)
+        defs_b = reg.get_definitions({name}, profile_home=home_b)
+        assert [item["function"]["name"] for item in defs_a] == [name]
+        assert [item["function"]["name"] for item in defs_b] == [name]
+        assert defs_a[0]["function"]["description"] == f"A {name}"
+        assert defs_b[0]["function"]["description"] == "profile b"
+
+    def test_mcp_same_profile_cross_toolset_collision_fails_closed(self, tmp_path):
+        reg = ToolRegistry()
+        home = str((tmp_path / "profile").resolve())
+        name = "mcp__shared__echo"
+
+        def first(args, **kwargs):
+            return json.dumps({"owner": "first"})
+
+        def second(args, **kwargs):
+            return json.dumps({"owner": "second"})
+
+        reg.register(
+            name=name,
+            toolset="mcp-first",
+            schema=_make_schema(name),
+            handler=first,
+            profile_home=home,
+        )
+        reg.register(
+            name=name,
+            toolset="mcp-second",
+            schema=_make_schema(name),
+            handler=second,
+            profile_home=home,
+        )
+
+        assert reg.get_toolset_for_tool(name, profile_home=home) == "mcp-first"
+        assert json.loads(reg.dispatch(name, {}, profile_home=home))["owner"] == "first"
+
+    def test_mcp_deregister_is_scoped_to_one_profile(self, tmp_path):
+        reg = ToolRegistry()
+        home_a = str((tmp_path / "profile-a").resolve())
+        home_b = str((tmp_path / "profile-b").resolve())
+        name = "mcp__shared__echo"
+
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema=_make_schema(name),
+            handler=lambda args, **kwargs: json.dumps({"owner": "a"}),
+            profile_home=home_a,
+        )
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema=_make_schema(name),
+            handler=lambda args, **kwargs: json.dumps({"owner": "b"}),
+            profile_home=home_b,
+        )
+
+        reg.deregister(name, profile_home=home_a)
+
+        assert reg.get_entry(name, profile_home=home_a) is None
+        assert json.loads(reg.dispatch(name, {}, profile_home=home_b))["owner"] == "b"
+        assert reg.get_definitions({name}, profile_home=home_a) == []
+        assert len(reg.get_definitions({name}, profile_home=home_b)) == 1
+
+    def test_mcp_unscoped_lookup_uses_current_canonical_profile(self, tmp_path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        reg = ToolRegistry()
+        home_a = (tmp_path / "profile-a").resolve()
+        home_b = (tmp_path / "profile-b").resolve()
+        name = "mcp__shared__echo"
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema=_make_schema(name),
+            handler=lambda args, **kwargs: json.dumps({"owner": "a"}),
+            profile_home=home_a,
+        )
+        reg.register(
+            name=name,
+            toolset="mcp-shared",
+            schema=_make_schema(name),
+            handler=lambda args, **kwargs: json.dumps({"owner": "b"}),
+            profile_home=home_b,
+        )
+
+        token = set_hermes_home_override(home_a)
+        try:
+            assert json.loads(reg.dispatch(name, {}))["owner"] == "a"
+            assert reg.get_profile_home_for_tool(name) == str(home_a)
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(home_b)
+        try:
+            assert json.loads(reg.dispatch(name, {}))["owner"] == "b"
+            assert reg.get_profile_home_for_tool(name) == str(home_b)
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_mcp_unscoped_lookup_fails_closed_in_multiplex_without_override(
+        self, tmp_path
+    ):
+        reg = ToolRegistry()
+        name = "mcp__shared__echo"
+        for profile in ("profile-a", "profile-b"):
+            home = str((tmp_path / profile).resolve())
+            reg.register(
+                name=name,
+                toolset="mcp-shared",
+                schema=_make_schema(name),
+                handler=lambda args, profile=profile, **kwargs: json.dumps(
+                    {"owner": profile}
+                ),
+                profile_home=home,
+            )
+
+        with patch("agent.secret_scope.is_multiplex_active", return_value=True), patch(
+            "hermes_constants.get_hermes_home_override", return_value=None
+        ):
+            assert reg.get_entry(name) is None
+            assert reg.get_schema(name) is None
+            assert reg.get_toolset_for_tool(name) is None
+            assert reg.get_definitions({name}) == []
+            assert "Unknown tool" in reg.dispatch(name, {})
 
 class TestGetDefinitions:
     def test_returns_openai_format(self):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -110,6 +110,7 @@ import shutil
 import sys
 import threading
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
@@ -119,6 +120,37 @@ from urllib.parse import urlparse
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
+
+
+def _canonical_profile_home() -> str:
+    """Return the active profile home as a normalized absolute path.
+
+    MCP discovery can run on a shared background loop while callers switch
+    the context-local Hermes home between turns. Callers must capture this
+    value at discovery/registration time and retain it as provenance rather
+    than resolving it again from a later mutable context.
+    """
+    from hermes_constants import get_hermes_home
+
+    return str(Path(get_hermes_home()).expanduser().resolve())
+
+
+def _normalize_profile_home(profile_home: str) -> str:
+    """Normalize a captured profile-home value without consulting context."""
+    return str(Path(profile_home).expanduser().resolve())
+
+
+def _server_profile_home(server: "MCPServerTask") -> str:
+    """Return and, when needed, capture a server's stable profile owner."""
+    profile_home = getattr(server, "profile_home", None)
+    if profile_home:
+        normalized = _normalize_profile_home(profile_home)
+        if normalized != profile_home:
+            server.profile_home = normalized
+        return normalized
+    profile_home = _canonical_profile_home()
+    server.profile_home = profile_home
+    return profile_home
 
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
@@ -1910,6 +1942,7 @@ class MCPServerTask:
 
     __slots__ = (
         "name", "session", "tool_timeout",
+        "profile_home",
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_elicitation",
@@ -1922,10 +1955,13 @@ class MCPServerTask:
         "_reconnect_retries", "_session_proven", "_was_parked",
     )
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, profile_home: Optional[str] = None):
         self.name = name
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
+        self.profile_home: Optional[str] = (
+            _normalize_profile_home(profile_home) if profile_home else None
+        )
         self._task: Optional[asyncio.Task] = None
         self._ready = asyncio.Event()
         self._shutdown_event = asyncio.Event()
@@ -3629,6 +3665,14 @@ _server_connect_errors: Dict[str, str] = {}
 _lazy_server_configs: Dict[str, dict] = {}
 _lazy_server_fingerprints: Dict[str, str] = {}
 _lazy_server_tool_names: Dict[str, List[str]] = {}
+# Profile provenance captured when a lazy manifest is registered. This is
+# separate from the config snapshot because the same server name may be
+# explicitly re-registered under another profile in this name-keyed runtime.
+_lazy_server_profile_homes: Dict[str, str] = {}
+# Owner for connecting/failed servers that do not yet have an MCPServerTask.
+# Connected ownership lives on MCPServerTask itself; this map is status
+# bookkeeping for the pre-task lifecycle states.
+_server_profile_homes: Dict[str, str] = {}
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -4373,7 +4417,8 @@ _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
 
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
-# _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
+# profile-owner maps, _parallel_safe_servers, _mcp_tool_server_names, and
+# _stdio_pids.
 _lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
@@ -4941,7 +4986,11 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         ImportError: if HTTP transport is needed but not available.
         Exception: on connection or initialization failure.
     """
-    server = MCPServerTask(name)
+    # Capture the active profile before the long-lived task is started. The
+    # task may later reconnect on a shared event loop after the caller's
+    # context-local home has changed, so deriving ownership during refresh
+    # would be incorrect.
+    server = MCPServerTask(name, profile_home=_canonical_profile_home())
     claim = _connect_server_claim.get()
     claim_token = None
     if claim is not None:
@@ -5044,6 +5093,13 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             return False
         if server_name in _server_connecting:
             return False
+        profile_home = _lazy_server_profile_homes.get(server_name)
+        if profile_home is None:
+            # Defensive fallback for old in-memory state created before this
+            # provenance map existed. Capture it once and retain it for the
+            # lifetime of this lazy registration.
+            profile_home = _canonical_profile_home()
+            _lazy_server_profile_homes[server_name] = profile_home
         _server_connecting.add(server_name)
         _server_connect_errors.pop(server_name, None)
 
@@ -5054,7 +5110,17 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     async def _connect():
         return await _discover_and_register_server(server_name, config)
 
+    override_token = None
+    reset_home_override = None
     try:
+        # A lazy manifest may have been registered under profile A while the
+        # first tool call arrives under profile B. Re-establish A around the
+        # shared-loop scheduling boundary so discovery and the new task retain
+        # the manifest's original owner.
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        reset_home_override = reset_hermes_home_override
+        override_token = set_hermes_home_override(profile_home)
         _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
     except BaseException as exc:
         message = _format_connect_error(exc)
@@ -5066,6 +5132,9 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             "Lazy MCP connect failed for '%s': %s", server_name, message,
         )
         return False
+    finally:
+        if override_token is not None and reset_home_override is not None:
+            reset_home_override(override_token)
 
     with _lock:
         _server_connecting.discard(server_name)
@@ -6100,6 +6169,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
+    profile_home = _server_profile_home(server)
+    with _lock:
+        _server_profile_homes[name] = profile_home
+        # A live/eager publication supersedes any stale lazy-manifest owner
+        # for this name. The server task now carries the authoritative owner.
+        _lazy_server_profile_homes.pop(name, None)
 
     # Selective tool loading: honour include/exclude lists from config.
     # Rules (matching issue #690 spec, extended with glob support):
@@ -6250,6 +6325,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=candidate["check_fn"],
             is_async=False,
             description=candidate["schema"]["description"],
+            profile_home=profile_home,
         )
 
         # The pre-check above is advisory only. Multiple servers connect in
@@ -6334,6 +6410,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
+    profile_home = _canonical_profile_home()
     fingerprint = config_fingerprint(config)
     tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
     tools_filter = config.get("tools") or {}
@@ -6401,6 +6478,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            profile_home=profile_home,
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
@@ -6434,6 +6512,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
+            profile_home=profile_home,
         )
         if registry.get_toolset_for_tool(util_name) != toolset_name:
             continue
@@ -6446,6 +6525,8 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             _lazy_server_configs[name] = dict(config)
             _lazy_server_fingerprints[name] = fingerprint
             _lazy_server_tool_names[name] = list(registered_names)
+            _lazy_server_profile_homes[name] = profile_home
+            _server_profile_homes[name] = profile_home
         logger.info(
             "MCP server '%s' (lazy): registered %d tool(s) from schema cache",
             name, len(registered_names),
@@ -6458,6 +6539,9 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     Returns list of registered tool names.
     """
     connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    discovery_profile_home = _canonical_profile_home()
+    with _lock:
+        _server_profile_homes[name] = discovery_profile_home
     # List-based claim (not a ``nonlocal`` rebind): the claim callback runs
     # inside ``_connect_server`` while this frame is suspended, and appending
     # keeps type narrowing intact for the module's other ``server`` locals.
@@ -6500,6 +6584,11 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     with _lock:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
+        # Test/probe adapters may return a task constructed without the
+        # production connection helper. Preserve an existing owner, otherwise
+        # bind this server before any registry publication.
+        if not getattr(server, "profile_home", None):
+            server.profile_home = discovery_profile_home
         _servers[name] = server
 
     registered_names = _register_server_tools(name, server, config)
@@ -6534,6 +6623,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("MCP SDK not available -- skipping explicit MCP registration")
         return []
 
+    # Capture the request's profile once. This owner is used for connecting
+    # and failed status rows even if the caller's context changes while the
+    # background discovery batch is in flight.
+    registration_profile_home = _canonical_profile_home()
     servers = _filter_suspicious_mcp_servers(servers)
     if not servers:
         logger.debug("No explicit MCP servers provided")
@@ -6575,6 +6668,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _server_connecting.update(new_servers)
         for srv_name in new_servers:
             _server_connect_errors.pop(srv_name, None)
+            _server_profile_homes[srv_name] = registration_profile_home
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -6838,9 +6932,9 @@ def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
     Returns a list of dicts with keys: name, transport, tools, connected,
-    disabled, and status. Includes connected servers, disabled servers,
-    in-flight connection attempts, recorded failures, and servers that are
-    configured but have not been started in this process yet.
+    disabled, status, and profile_home. Includes connected servers, disabled
+    servers, in-flight connection attempts, recorded failures, and servers
+    that are configured but have not been started in this process yet.
     """
     result: List[dict] = []
 
@@ -6848,11 +6942,14 @@ def get_mcp_status() -> List[dict]:
     configured = _load_mcp_config()
     if not configured:
         return result
+    status_profile_home = _canonical_profile_home()
 
     with _lock:
         active_servers = dict(_servers)
         connecting = set(_server_connecting)
         connect_errors = dict(_server_connect_errors)
+        profile_homes = dict(_server_profile_homes)
+        lazy_profile_homes = dict(_lazy_server_profile_homes)
 
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
@@ -6866,6 +6963,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": True,
                 "disabled": False,
                 "status": "connected",
+                "profile_home": _server_profile_home(server),
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
@@ -6881,6 +6979,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": True,
                 "status": "disabled",
+                "profile_home": status_profile_home,
             })
         elif name in connecting:
             result.append({
@@ -6890,6 +6989,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "connecting",
+                "profile_home": profile_homes.get(name, status_profile_home),
             })
         elif name in connect_errors:
             result.append({
@@ -6900,6 +7000,7 @@ def get_mcp_status() -> List[dict]:
                 "disabled": False,
                 "status": "failed",
                 "error": connect_errors[name],
+                "profile_home": profile_homes.get(name, status_profile_home),
             })
         else:
             result.append({
@@ -6909,6 +7010,13 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "configured",
+                "profile_home": (
+                    lazy_profile_homes.get(name, status_profile_home)
+                    if name in lazy_profile_homes
+                    else profile_homes.get(name, status_profile_home)
+                    if name in active_servers
+                    else status_profile_home
+                ),
             })
 
     return result
@@ -7228,6 +7336,8 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _server_profile_homes.clear()
+            _lazy_server_profile_homes.clear()
         _stop_mcp_loop()
         return
 
@@ -7248,6 +7358,8 @@ def shutdown_mcp_servers():
             # stale per-server backoff from before the restart (#50394).
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _server_profile_homes.clear()
+            _lazy_server_profile_homes.clear()
 
     with _lock:
         loop = _mcp_loop
@@ -7271,6 +7383,8 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _server_profile_homes.clear()
+        _lazy_server_profile_homes.clear()
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3913,8 +3913,8 @@ _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 # Classification happens at CALL TIME from data captured at DISCOVERY —
 # no toolset or schema mutation, so the conversation's toolset stays
 # byte-stable and prompt caching is preserved.
-_server_trust_levels: Dict[str, str] = {}
-_tool_read_only_hints: Dict[str, Dict[str, bool]] = {}
+_server_trust_levels: Dict[MCPServerKey, str] = _ProfileServerDict()
+_tool_read_only_hints: Dict[MCPServerKey, Dict[str, bool]] = _ProfileServerDict()
 
 _TRUST_FULL = "full"
 _TRUST_UNTRUSTED = "untrusted"
@@ -3960,31 +3960,40 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
 
 
 def _record_tool_trust_metadata(
-    server_name: str, config: dict, tools: List[Any]
+    server_name: str,
+    config: dict,
+    tools: List[Any],
+    profile_home: Optional[str] = None,
 ) -> None:
     """Capture per-server trust and per-tool readOnlyHint at discovery."""
+    server_key = _server_key(server_name, profile_home)
     with _lock:
-        _server_trust_levels[server_name] = _normalize_server_trust(
+        _server_trust_levels[server_key] = _normalize_server_trust(
             (config or {}).get("trust")
         )
-        hints = _tool_read_only_hints.setdefault(server_name, {})
+        hints = _tool_read_only_hints.setdefault(server_key, {})
         for tool in tools:
             name = getattr(tool, "name", None)
             if name:
                 hints[name] = _annotation_read_only_hint(tool)
 
 
-def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
+def _trust_gate_check(
+    server_name: str,
+    tool_name: str,
+    profile_home: Optional[str] = None,
+) -> Optional[str]:
     """Consult the approval path for write-capable tools on untrusted servers.
 
     Returns None when the call may proceed, or an error string (already
     formatted via ``tool_error``) when the call is blocked. Fail-closed:
     approval-system errors block the call.
     """
-    trust = _server_trust_levels.get(server_name, _TRUST_FULL)
+    server_key = _server_key(server_name, profile_home)
+    trust = _server_trust_levels.get(server_key, _TRUST_FULL)
     if trust != _TRUST_UNTRUSTED:
         return None
-    if _tool_read_only_hints.get(server_name, {}).get(tool_name) is True:
+    if _tool_read_only_hints.get(server_key, {}).get(tool_name) is True:
         return None
 
     # Lazy import mirrors the elicitation handler's pattern: tools.approval
@@ -5351,7 +5360,11 @@ def _make_tool_handler(
         # servers configured ``trust: untrusted`` must be approved by the
         # user before ANY transport work happens — including the lazy
         # first-use spawn below. A denied call never touches the server.
-        gate_error = _trust_gate_check(server_name, tool_name)
+        gate_error = _trust_gate_check(
+            server_name,
+            tool_name,
+            profile_home=profile_home,
+        )
         if gate_error is not None:
             return gate_error
 
@@ -6382,7 +6395,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     # configured trust tier and each tool's readOnlyHint annotation NOW,
     # at discovery, so the call-time gate in _make_tool_handler classifies
     # from data we control rather than re-reading server-supplied state.
-    _record_tool_trust_metadata(name, config, server._tools)
+    _record_tool_trust_metadata(name, config, server._tools, profile_home)
 
     for mcp_tool in server._tools:
         if not _should_register(mcp_tool.name):
@@ -6631,7 +6644,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         for raw in tools_from_cache_entry(entry)
         if isinstance(raw, dict) and raw.get("name")
     ]
-    _record_tool_trust_metadata(name, config, cached_tool_objs)
+    _record_tool_trust_metadata(name, config, cached_tool_objs, profile_home)
     for raw in tools_from_cache_entry(entry):
         if not isinstance(raw, dict):
             continue

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -135,9 +135,137 @@ def _canonical_profile_home() -> str:
     return str(Path(get_hermes_home()).expanduser().resolve())
 
 
+def _active_profile_home_or_none() -> Optional[str]:
+    """Return the active owner, or None for an unscoped multiplex caller."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        if is_multiplex_active():
+            from hermes_constants import get_hermes_home_override
+
+            override = get_hermes_home_override()
+            if not override:
+                return None
+            return _normalize_profile_home(override)
+        return _canonical_profile_home()
+    except Exception:
+        # An unresolved owner must never fall back to another profile's
+        # process-default MCP runtime.
+        return None
+
+
 def _normalize_profile_home(profile_home: str) -> str:
     """Normalize a captured profile-home value without consulting context."""
     return str(Path(profile_home).expanduser().resolve())
+
+
+MCPServerKey = Tuple[str, str]
+
+
+def _server_key(
+    server_name: str,
+    profile_home: Optional[str] = None,
+) -> MCPServerKey:
+    """Return the canonical runtime owner for one profile's named server."""
+    owner = (
+        _normalize_profile_home(profile_home)
+        if profile_home is not None
+        else _canonical_profile_home()
+    )
+    return owner, server_name
+
+
+class _ProfileServerDict(dict):
+    """Tuple-keyed runtime map with an active-profile string convenience API."""
+
+    @staticmethod
+    def _key(key):
+        return _server_key(key) if isinstance(key, str) else key
+
+    def __contains__(self, key):
+        return super().__contains__(self._key(key))
+
+    def __getitem__(self, key):
+        return super().__getitem__(self._key(key))
+
+    def __setitem__(self, key, value):
+        return super().__setitem__(self._key(key), value)
+
+    def get(self, key, default=None):
+        return super().get(self._key(key), default)
+
+    def pop(self, key, *args):
+        return super().pop(self._key(key), *args)
+
+    def setdefault(self, key, default=None):
+        return super().setdefault(self._key(key), default)
+
+    def update(self, *args, **kwargs):
+        incoming = dict(*args, **kwargs)
+        return super().update({self._key(k): v for k, v in incoming.items()})
+
+
+class _ProfileServerSet(set):
+    """Tuple-keyed runtime set with active-profile string membership helpers."""
+
+    @staticmethod
+    def _key(key):
+        return _server_key(key) if isinstance(key, str) else key
+
+    def __contains__(self, key):
+        return super().__contains__(self._key(key))
+
+    def add(self, key):
+        return super().add(self._key(key))
+
+    def discard(self, key):
+        return super().discard(self._key(key))
+
+    def update(self, *iterables):
+        for iterable in iterables:
+            super().update(self._key(item) for item in iterable)
+
+    def difference_update(self, *iterables):
+        for iterable in iterables:
+            super().difference_update(self._key(item) for item in iterable)
+
+
+class _ProfileToolServerDict(dict):
+    """Profile-keyed MCP tool provenance with active-profile string helpers."""
+
+    @staticmethod
+    def _key(key):
+        if isinstance(key, str):
+            return _canonical_profile_home(), key
+        return key
+
+    @staticmethod
+    def _value(value):
+        if isinstance(value, str):
+            return _server_key(value)
+        return value
+
+    def __contains__(self, key):
+        return super().__contains__(self._key(key))
+
+    def __getitem__(self, key):
+        return super().__getitem__(self._key(key))
+
+    def __setitem__(self, key, value):
+        return super().__setitem__(self._key(key), self._value(value))
+
+    def get(self, key, default=None):
+        return super().get(self._key(key), default)
+
+    def pop(self, key, *args):
+        return super().pop(self._key(key), *args)
+
+    def update(self, *args, **kwargs):
+        incoming = dict(*args, **kwargs)
+        return super().update({
+            self._key(k): self._value(v)
+            for k, v in incoming.items()
+        })
 
 
 def _server_profile_home(server: "MCPServerTask") -> str:
@@ -2229,6 +2357,7 @@ class MCPServerTask:
             # notifications. Tools absent from the fresh list are no longer
             # callable, so remove only those stale registry entries first.
             toolset_name = f"mcp-{self.name}"
+            profile_home = _server_profile_home(self)
             stale_tool_names = old_tool_names - {
                 mcp_prefixed_tool_name(self.name, tool.name)
                 for tool in new_mcp_tools
@@ -2236,10 +2365,13 @@ class MCPServerTask:
             for tool_name in stale_tool_names:
                 # Never let one server's refresh remove a colliding name that
                 # is currently owned by another server.
-                if registry.get_toolset_for_tool(tool_name) != toolset_name:
+                if registry.get_toolset_for_tool(
+                    tool_name,
+                    profile_home=profile_home,
+                ) != toolset_name:
                     continue
-                registry.deregister(tool_name)
-                _forget_mcp_tool_server(tool_name)
+                registry.deregister(tool_name, profile_home=profile_home)
+                _forget_mcp_tool_server(tool_name, profile_home)
 
             # 3. Re-register with the fresh list. The helper may skip names that
             # are ambiguous after normalization.
@@ -2254,10 +2386,13 @@ class MCPServerTask:
             # collision-checked registration set no longer owns.
             registered_name_set = set(registered_names)
             for tool_name in old_tool_names - registered_name_set:
-                if registry.get_toolset_for_tool(tool_name) != toolset_name:
+                if registry.get_toolset_for_tool(
+                    tool_name,
+                    profile_home=profile_home,
+                ) != toolset_name:
                     continue
-                registry.deregister(tool_name)
-                _forget_mcp_tool_server(tool_name)
+                registry.deregister(tool_name, profile_home=profile_home)
+                _forget_mcp_tool_server(tool_name, profile_home)
             self._registered_tool_names = registered_names
 
             # 4. Log what changed (user-visible notification)
@@ -2655,7 +2790,7 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    _reset_server_error(_server_key(self.name, _server_profile_home(self)))
                     # A completed handshake alone is NOT proof of health: a
                     # flapping transport can handshake fine and drop moments
                     # later, forever (#62212). The session must prove itself
@@ -3000,7 +3135,7 @@ class MCPServerTask:
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
+                        _reset_server_error(_server_key(self.name, _server_profile_home(self)))
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
                         reason = await self._wait_for_lifecycle_event()
@@ -3063,7 +3198,7 @@ class MCPServerTask:
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
                             # isn't gated on a stale failure count (#16788).
-                            _reset_server_error(self.name)
+                            _reset_server_error(_server_key(self.name, _server_profile_home(self)))
                             # Unproven until keepalive/tool-call success (#62212).
                             self._session_proven = False
                             reason = await self._wait_for_lifecycle_event()
@@ -3101,7 +3236,7 @@ class MCPServerTask:
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
+                        _reset_server_error(_server_key(self.name, _server_profile_home(self)))
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
                         reason = await self._wait_for_lifecycle_event()
@@ -3162,9 +3297,10 @@ class MCPServerTask:
         """
         if self._registered_tool_names:
             return
+        server_key = _server_key(self.name, _server_profile_home(self))
         if not self._ready.is_set():
             with _lock:
-                if _servers.get(self.name) is not self:
+                if _servers.get(server_key) is not self:
                     return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config
@@ -3173,8 +3309,8 @@ class MCPServerTask:
         # recovered: drop its stale connect error so status surfaces stop
         # reporting it as failed.
         with _lock:
-            if _servers.get(self.name) is self:
-                _server_connect_errors.pop(self.name, None)
+            if _servers.get(server_key) is self:
+                _server_connect_errors.pop(server_key, None)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -3628,9 +3764,10 @@ class MCPServerTask:
         """
         from tools.registry import registry
 
+        profile_home = _server_profile_home(self)
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
-            _forget_mcp_tool_server(tool_name)
+            registry.deregister(tool_name, profile_home=profile_home)
+            _forget_mcp_tool_server(tool_name, profile_home)
         self._registered_tool_names = []
 
     async def _wait_for_lazy_reconnect(self) -> None:
@@ -3656,23 +3793,15 @@ class MCPServerTask:
 # Module-level state
 # ---------------------------------------------------------------------------
 
-_servers: Dict[str, MCPServerTask] = {}
-_server_connecting: set[str] = set()
-_server_connect_errors: Dict[str, str] = {}
+_servers: Dict[MCPServerKey, MCPServerTask] = _ProfileServerDict()
+_server_connecting: set[MCPServerKey] = _ProfileServerSet()
+_server_connect_errors: Dict[MCPServerKey, str] = _ProfileServerDict()
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
-_lazy_server_configs: Dict[str, dict] = {}
-_lazy_server_fingerprints: Dict[str, str] = {}
-_lazy_server_tool_names: Dict[str, List[str]] = {}
-# Profile provenance captured when a lazy manifest is registered. This is
-# separate from the config snapshot because the same server name may be
-# explicitly re-registered under another profile in this name-keyed runtime.
-_lazy_server_profile_homes: Dict[str, str] = {}
-# Owner for connecting/failed servers that do not yet have an MCPServerTask.
-# Connected ownership lives on MCPServerTask itself; this map is status
-# bookkeeping for the pre-task lifecycle states.
-_server_profile_homes: Dict[str, str] = {}
+_lazy_server_configs: Dict[MCPServerKey, dict] = _ProfileServerDict()
+_lazy_server_fingerprints: Dict[MCPServerKey, str] = _ProfileServerDict()
+_lazy_server_tool_names: Dict[MCPServerKey, List[str]] = _ProfileServerDict()
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -3700,13 +3829,13 @@ _connect_server_claim: contextvars.ContextVar[
 # server is retried on a backoff schedule instead of on every worker
 # session -- isolating it from the rest of the bridge. A successful
 # connection clears the state.
-_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
-_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
+_server_connect_retry_after: Dict[MCPServerKey, float] = _ProfileServerDict()
+_server_connect_failures: Dict[MCPServerKey, int] = _ProfileServerDict()
 _CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
 _CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
 
 
-def _record_connect_failure(server_name: str) -> None:
+def _record_connect_failure(server_key: MCPServerKey) -> None:
     """Stamp an exponential-backoff cooldown after a failed connect.
 
     Called (under ``_lock``) when a server fails its discovery/connect
@@ -3715,24 +3844,24 @@ def _record_connect_failure(server_name: str) -> None:
     so a permanently-broken server settles into infrequent retries
     rather than a tight respawn loop.
     """
-    n = _server_connect_failures.get(server_name, 0) + 1
-    _server_connect_failures[server_name] = n
+    n = _server_connect_failures.get(server_key, 0) + 1
+    _server_connect_failures[server_key] = n
     backoff = min(
         _CONNECT_RETRY_BASE_BACKOFF_SEC * (2 ** (n - 1)),
         _CONNECT_RETRY_MAX_BACKOFF_SEC,
     )
-    _server_connect_retry_after[server_name] = time.monotonic() + backoff
+    _server_connect_retry_after[server_key] = time.monotonic() + backoff
 
 
-def _clear_connect_failure(server_name: str) -> None:
+def _clear_connect_failure(server_key: MCPServerKey) -> None:
     """Clear the connect-cooldown state after a successful connection."""
-    _server_connect_failures.pop(server_name, None)
-    _server_connect_retry_after.pop(server_name, None)
+    _server_connect_failures.pop(server_key, None)
+    _server_connect_retry_after.pop(server_key, None)
 
 
-def _connect_cooldown_active(server_name: str) -> bool:
+def _connect_cooldown_active(server_key: MCPServerKey) -> bool:
     """Return True if ``server_name`` is still within its retry cooldown."""
-    deadline = _server_connect_retry_after.get(server_name)
+    deadline = _server_connect_retry_after.get(server_key)
     return deadline is not None and time.monotonic() < deadline
 
 # Circuit breaker: consecutive error counts per server.  After
@@ -3752,8 +3881,8 @@ def _connect_cooldown_active(server_name: str) -> bool:
 # the breaker most recently transitioned into the open state. Use the
 # ``_bump_server_error`` / ``_reset_server_error`` helpers to mutate
 # this state — they keep the count and timestamp in sync.
-_server_error_counts: Dict[str, int] = {}
-_server_breaker_opened_at: Dict[str, float] = {}
+_server_error_counts: Dict[MCPServerKey, int] = _ProfileServerDict()
+_server_breaker_opened_at: Dict[MCPServerKey, float] = _ProfileServerDict()
 _CIRCUIT_BREAKER_THRESHOLD = 3
 _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 
@@ -3902,28 +4031,28 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     )
 
 
-def _bump_server_error(server_name: str) -> None:
-    """Increment the consecutive-failure count for ``server_name``.
+def _bump_server_error(server_key: MCPServerKey) -> None:
+    """Increment the consecutive-failure count for ``server_key``.
 
     When the count crosses :data:`_CIRCUIT_BREAKER_THRESHOLD`, stamp the
     breaker-open timestamp so the cooldown clock starts (or re-starts,
     for probe failures in the half-open state).
     """
-    n = _server_error_counts.get(server_name, 0) + 1
-    _server_error_counts[server_name] = n
+    n = _server_error_counts.get(server_key, 0) + 1
+    _server_error_counts[server_key] = n
     if n >= _CIRCUIT_BREAKER_THRESHOLD:
-        _server_breaker_opened_at[server_name] = time.monotonic()
+        _server_breaker_opened_at[server_key] = time.monotonic()
 
 
-def _reset_server_error(server_name: str) -> None:
-    """Fully close the breaker for ``server_name``.
+def _reset_server_error(server_key: MCPServerKey) -> None:
+    """Fully close the breaker for ``server_key``.
 
     Clears both the failure count and the breaker-open timestamp. Call
     this on any unambiguous success signal (successful tool call,
     successful reconnect, manual /mcp refresh).
     """
-    _server_error_counts[server_name] = 0
-    _server_breaker_opened_at.pop(server_name, None)
+    _server_error_counts[server_key] = 0
+    _server_breaker_opened_at.pop(server_key, None)
 
 
 def _signal_reconnect(server: Any) -> bool:
@@ -3955,8 +4084,12 @@ def _signal_reconnect(server: Any) -> bool:
 
 def reconnect_mcp_server(server_name: str) -> bool:
     """Ask a currently-live MCP server to rebuild after external re-auth."""
+    profile_home = _active_profile_home_or_none()
+    if profile_home is None:
+        return False
+    server_key = _server_key(server_name, profile_home)
     with _lock:
-        server = _servers.get(server_name)
+        server = _servers.get(server_key)
     if server is None:
         return False
     return _signal_reconnect(server)
@@ -4116,7 +4249,7 @@ def _is_auth_error(exc: BaseException) -> bool:
 
 
 def _handle_auth_error_and_retry(
-    server_name: str,
+    server_key: MCPServerKey | str,
     exc: BaseException,
     retry_call,
     op_description: str,
@@ -4151,6 +4284,9 @@ def _handle_auth_error_and_retry(
     """
     if not _is_auth_error(exc):
         return None
+    if isinstance(server_key, str):
+        server_key = _server_key(server_key)
+    _profile_home, server_name = server_key
 
     from tools.mcp_oauth_manager import get_manager
     manager = get_manager()
@@ -4169,7 +4305,7 @@ def _handle_auth_error_and_retry(
 
     if recovered:
         with _lock:
-            srv = _servers.get(server_name)
+            srv = _servers.get(server_key)
         reconnected = False
         if srv is not None and hasattr(srv, "_reconnect_event"):
             reconnected = _signal_reconnect_and_wait(
@@ -4187,17 +4323,17 @@ def _handle_auth_error_and_retry(
         # _bump_server_error on failure, so a genuinely broken server will
         # re-trip the breaker as normal.
         if reconnected:
-            _reset_server_error(server_name)
+            _reset_server_error(server_key)
 
         try:
             result = retry_call()
             try:
                 parsed = json.loads(result)
                 if "error" not in parsed:
-                    _reset_server_error(server_name)
+                    _reset_server_error(server_key)
                     return result
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)
+                _reset_server_error(server_key)
                 return result
         except Exception as retry_exc:
             logger.warning(
@@ -4208,7 +4344,7 @@ def _handle_auth_error_and_retry(
     # No recovery available, or retry also failed: surface a structured
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
-    _bump_server_error(server_name)
+    _bump_server_error(server_key)
     return tool_error(
         f"MCP server '{server_name}' requires re-authentication. "
         f"Run `hermes mcp login {server_name}` (or delete the tokens "
@@ -4322,7 +4458,7 @@ def _is_session_expired_error(exc: BaseException) -> bool:
 
 
 def _handle_session_expired_and_retry(
-    server_name: str,
+    server_key: MCPServerKey | str,
     exc: BaseException,
     retry_call,
     op_description: str,
@@ -4352,9 +4488,12 @@ def _handle_session_expired_and_retry(
     """
     if not _is_session_expired_error(exc):
         return None
+    if isinstance(server_key, str):
+        server_key = _server_key(server_key)
+    _profile_home, server_name = server_key
 
     with _lock:
-        srv = _servers.get(server_name)
+        srv = _servers.get(server_key)
     if srv is None or not hasattr(srv, "_reconnect_event"):
         return None
 
@@ -4388,10 +4527,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _reset_server_error(server_name)
+                _reset_server_error(server_key)
                 return result
         except (json.JSONDecodeError, TypeError):
-            _reset_server_error(server_name)
+            _reset_server_error(server_key)
             return result
     except Exception as retry_exc:
         logger.warning(
@@ -4404,13 +4543,13 @@ def _handle_session_expired_and_retry(
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
-_parallel_safe_servers: set = set()
+_parallel_safe_servers: set[MCPServerKey] = _ProfileServerSet()
 
 # Exact MCP tool-name provenance. The generated registry name is lossy because
 # provider-safe normalization maps punctuation to ``_``. Keep the raw server
 # name captured at registration time so policy and capability checks never rely
 # on parsing or re-sanitizing the generated name.
-_mcp_tool_server_names: Dict[str, str] = {}
+_mcp_tool_server_names: Dict[Tuple[str, str], MCPServerKey] = _ProfileToolServerDict()
 
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -4990,7 +5129,9 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
     # task may later reconnect on a shared event loop after the caller's
     # context-local home has changed, so deriving ownership during refresh
     # would be incorrect.
-    server = MCPServerTask(name, profile_home=_canonical_profile_home())
+    profile_home = _canonical_profile_home()
+    server = MCPServerTask(name)
+    server.profile_home = profile_home
     claim = _connect_server_claim.get()
     claim_token = None
     if claim is not None:
@@ -5073,7 +5214,7 @@ def _resolve_server_lazy(name: str, config: dict) -> bool:
     return _parse_boolish(config.get("lazy", False), default=False)
 
 
-def _ensure_lazy_server_connected(server_name: str) -> bool:
+def _ensure_lazy_server_connected(server_key: MCPServerKey | str) -> bool:
     """Connect a lazily-registered MCP server on demand (sync, blocks caller).
 
     Composes with the existing connect machinery: respects the per-server
@@ -5082,26 +5223,22 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     cooldown bookkeeping stays in one place. Returns True when a live
     session is available afterwards.
     """
+    if isinstance(server_key, str):
+        server_key = _server_key(server_key)
+    profile_home, server_name = server_key
     with _lock:
-        server = _servers.get(server_name)
+        server = _servers.get(server_key)
         if server is not None and server.session is not None:
             return True
-        config = _lazy_server_configs.get(server_name)
+        config = _lazy_server_configs.get(server_key)
         if not config:
             return False
-        if _connect_cooldown_active(server_name):
+        if _connect_cooldown_active(server_key):
             return False
-        if server_name in _server_connecting:
+        if server_key in _server_connecting:
             return False
-        profile_home = _lazy_server_profile_homes.get(server_name)
-        if profile_home is None:
-            # Defensive fallback for old in-memory state created before this
-            # provenance map existed. Capture it once and retain it for the
-            # lifetime of this lazy registration.
-            profile_home = _canonical_profile_home()
-            _lazy_server_profile_homes[server_name] = profile_home
-        _server_connecting.add(server_name)
-        _server_connect_errors.pop(server_name, None)
+        _server_connecting.add(server_key)
+        _server_connect_errors.pop(server_key, None)
 
     logger.info("MCP server '%s': lazy start on first use", server_name)
     _ensure_mcp_loop()
@@ -5125,9 +5262,9 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     except BaseException as exc:
         message = _format_connect_error(exc)
         with _lock:
-            _server_connecting.discard(server_name)
-            _server_connect_errors[server_name] = message
-            _record_connect_failure(server_name)
+            _server_connecting.discard(server_key)
+            _server_connect_errors[server_key] = message
+            _record_connect_failure(server_key)
         logger.warning(
             "Lazy MCP connect failed for '%s': %s", server_name, message,
         )
@@ -5137,12 +5274,12 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             reset_home_override(override_token)
 
     with _lock:
-        _server_connecting.discard(server_name)
-        _clear_connect_failure(server_name)
-        _lazy_server_configs.pop(server_name, None)
-        stale_fingerprint = _lazy_server_fingerprints.pop(server_name, None)
-        cached_names = _lazy_server_tool_names.pop(server_name, None) or []
-        server = _servers.get(server_name)
+        _server_connecting.discard(server_key)
+        _clear_connect_failure(server_key)
+        _lazy_server_configs.pop(server_key, None)
+        stale_fingerprint = _lazy_server_fingerprints.pop(server_key, None)
+        cached_names = _lazy_server_tool_names.pop(server_key, None) or []
+        server = _servers.get(server_key)
         live_names = set(
             getattr(server, "_registered_tool_names", []) or []
         )
@@ -5154,8 +5291,8 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         from tools.registry import registry
 
         for tool_name in phantom_names:
-            registry.deregister(tool_name)
-            _forget_mcp_tool_server(tool_name)
+            registry.deregister(tool_name, profile_home=profile_home)
+            _forget_mcp_tool_server(tool_name, profile_home)
         logger.info(
             "MCP server '%s': deregistered %d phantom cached tool(s) not "
             "served live (stale schema-cache fingerprint %s): %s",
@@ -5165,25 +5302,26 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     return server is not None and server.session is not None
 
 
-def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
+def _get_connected_server_for_call(server_key: MCPServerKey) -> Optional[MCPServerTask]:
     """Return a connected server, lazily reconnecting recycled stdio state.
 
     Also the single first-use connect point for lazy (schema-cache
     registered) servers, so raw tool calls AND the resource/prompt utility
     handlers all trigger the deferred spawn (#56832).
     """
+    profile_home, server_name = server_key
     with _lock:
-        server = _servers.get(server_name)
-        is_lazy = server_name in _lazy_server_configs
+        server = _servers.get(server_key)
+        is_lazy = server_key in _lazy_server_configs
     if is_lazy and (server is None or server.session is None):
-        _ensure_lazy_server_connected(server_name)
+        _ensure_lazy_server_connected(server_key)
         with _lock:
-            server = _servers.get(server_name)
+            server = _servers.get(server_key)
         return server
     if server is not None and server.session is None and server._is_recycled_stdio():
         _request_lazy_reconnect(server_name, server)
         with _lock:
-            server = _servers.get(server_name)
+            server = _servers.get(server_key)
     return server
 
 
@@ -5194,12 +5332,19 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+def _make_tool_handler(
+    server_name: str,
+    tool_name: str,
+    tool_timeout: float,
+    profile_home: Optional[str] = None,
+):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
     ``handler(args_dict, **kwargs) -> str``
     """
+
+    server_key = _server_key(server_name, profile_home)
 
     def _handler(args: dict, **kwargs) -> str:
         # Trust-tier gate (security boundary): write-capable tools on
@@ -5220,23 +5365,23 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         # failure the error paths below bump the count again, which
         # re-stamps the open-time via _bump_server_error (re-arming
         # the cooldown).
-        if _server_error_counts.get(server_name, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
-            opened_at = _server_breaker_opened_at.get(server_name, 0.0)
+        if _server_error_counts.get(server_key, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
+            opened_at = _server_breaker_opened_at.get(server_key, 0.0)
             age = time.monotonic() - opened_at
             if age < _CIRCUIT_BREAKER_COOLDOWN_SEC:
                 remaining = max(1, int(_CIRCUIT_BREAKER_COOLDOWN_SEC - age))
                 return tool_error(
                     f"MCP server '{server_name}' is unreachable after "
-                    f"{_server_error_counts[server_name]} consecutive "
+                    f"{_server_error_counts[server_key]} consecutive "
                     f"failures. Auto-retry available in ~{remaining}s. "
                     f"Do NOT retry this tool yet — use alternative "
                     f"approaches or ask the user to check the MCP server."
                 )
             # Cooldown elapsed → fall through as a half-open probe.
 
-        server = _get_connected_server_for_call(server_name)
+        server = _get_connected_server_for_call(server_key)
         if not server:
-            _bump_server_error(server_name)
+            _bump_server_error(server_key)
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         if not server.session:
@@ -5260,7 +5405,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # without burning iterations. The breaker resets once the
                 # fresh session initializes (_run_stdio/_run_http call
                 # _reset_server_error).
-                _bump_server_error(server_name)
+                _bump_server_error(server_key)
                 if _signal_reconnect(server):
                     return tool_error(
                         f"MCP server '{server_name}' transport is down; "
@@ -5376,11 +5521,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    _bump_server_error(server_key)
                 else:
-                    _reset_server_error(server_name)  # success — reset
+                    _reset_server_error(server_key)  # success — reset
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+                _reset_server_error(server_key)  # non-JSON = success
             return result
         except InterruptedError:
             return _interrupted_call_result()
@@ -5389,7 +5534,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.
             recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once,
+                server_key, exc, _call_once,
                 f"tools/call {tool_name}",
             )
             if recovered is not None:
@@ -5399,13 +5544,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # but skips OAuth recovery because the access token is
             # still valid — only the server-side session is stale.
             recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once,
+                server_key, exc, _call_once,
                 f"tools/call {tool_name}",
             )
             if recovered is not None:
                 return recovered
 
-            _bump_server_error(server_name)
+            _bump_server_error(server_key)
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,
@@ -5417,11 +5562,16 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     return _handler
 
 
-def _make_list_resources_handler(server_name: str, tool_timeout: float):
+def _make_list_resources_handler(
+    server_name: str,
+    tool_timeout: float,
+    profile_home: Optional[str] = None,
+):
     """Return a sync handler that lists resources from an MCP server."""
+    server_key = _server_key(server_name, profile_home)
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        server = _get_connected_server_for_call(server_key)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5454,12 +5604,12 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
             return _interrupted_call_result()
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "resources/list",
+                server_key, exc, _call_once, "resources/list",
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "resources/list",
+                server_key, exc, _call_once, "resources/list",
             )
             if recovered is not None:
                 return recovered
@@ -5473,11 +5623,16 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
     return _handler
 
 
-def _make_read_resource_handler(server_name: str, tool_timeout: float):
+def _make_read_resource_handler(
+    server_name: str,
+    tool_timeout: float,
+    profile_home: Optional[str] = None,
+):
     """Return a sync handler that reads a resource by URI from an MCP server."""
+    server_key = _server_key(server_name, profile_home)
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        server = _get_connected_server_for_call(server_key)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5515,12 +5670,12 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             return _interrupted_call_result()
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "resources/read",
+                server_key, exc, _call_once, "resources/read",
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "resources/read",
+                server_key, exc, _call_once, "resources/read",
             )
             if recovered is not None:
                 return recovered
@@ -5534,11 +5689,16 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
     return _handler
 
 
-def _make_list_prompts_handler(server_name: str, tool_timeout: float):
+def _make_list_prompts_handler(
+    server_name: str,
+    tool_timeout: float,
+    profile_home: Optional[str] = None,
+):
     """Return a sync handler that lists prompts from an MCP server."""
+    server_key = _server_key(server_name, profile_home)
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        server = _get_connected_server_for_call(server_key)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5576,12 +5736,12 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
             return _interrupted_call_result()
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "prompts/list",
+                server_key, exc, _call_once, "prompts/list",
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "prompts/list",
+                server_key, exc, _call_once, "prompts/list",
             )
             if recovered is not None:
                 return recovered
@@ -5595,11 +5755,16 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     return _handler
 
 
-def _make_get_prompt_handler(server_name: str, tool_timeout: float):
+def _make_get_prompt_handler(
+    server_name: str,
+    tool_timeout: float,
+    profile_home: Optional[str] = None,
+):
     """Return a sync handler that gets a prompt by name from an MCP server."""
+    server_key = _server_key(server_name, profile_home)
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        server = _get_connected_server_for_call(server_key)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5641,12 +5806,12 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             return _interrupted_call_result()
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "prompts/get",
+                server_key, exc, _call_once, "prompts/get",
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "prompts/get",
+                server_key, exc, _call_once, "prompts/get",
             )
             if recovered is not None:
                 return recovered
@@ -5660,19 +5825,20 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     return _handler
 
 
-def _make_check_fn(server_name: str):
+def _make_check_fn(server_name: str, profile_home: Optional[str] = None):
     """Return a check function that verifies the MCP connection is alive."""
+    server_key = _server_key(server_name, profile_home)
 
     def _check() -> bool:
         with _lock:
-            server = _servers.get(server_name)
+            server = _servers.get(server_key)
             if server is not None and (
                 server.session is not None or server._is_recycled_stdio()
             ):
                 return True
             # Lazy (schema-cache registered) servers are available: the
             # first real call spawns/connects them (#56832).
-            return server_name in _lazy_server_configs
+            return server_key in _lazy_server_configs
 
     return _check
 
@@ -6056,16 +6222,27 @@ _UTILITY_CAPABILITY_ATTRS = {
 }
 
 
-def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
+def _track_mcp_tool_server(
+    tool_name: str,
+    server_name: str,
+    profile_home: Optional[str] = None,
+) -> None:
     """Remember the exact raw MCP server that registered *tool_name*."""
+    server_key = _server_key(server_name, profile_home)
     with _lock:
-        _mcp_tool_server_names[tool_name] = server_name
+        _mcp_tool_server_names[(server_key[0], tool_name)] = server_key
 
 
-def _forget_mcp_tool_server(tool_name: str) -> None:
+def _forget_mcp_tool_server(
+    tool_name: str,
+    profile_home: Optional[str] = None,
+) -> None:
     """Forget MCP server provenance for a deregistered tool."""
     with _lock:
-        _mcp_tool_server_names.pop(tool_name, None)
+        _mcp_tool_server_names.pop(
+            (_server_key("", profile_home)[0], tool_name),
+            None,
+        )
 
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
@@ -6126,9 +6303,14 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
 
 
 def _existing_tool_names() -> List[str]:
-    """Return tool names for all currently connected servers."""
+    """Return tool names owned by the active profile's MCP runtime."""
+    profile_home = _active_profile_home_or_none()
+    if profile_home is None:
+        return []
     names: List[str] = []
-    for _sname, server in _servers.items():
+    for (owner_home, _sname), server in _servers.items():
+        if owner_home != profile_home:
+            continue
         if hasattr(server, "_registered_tool_names"):
             names.extend(server._registered_tool_names)
             continue
@@ -6140,8 +6322,8 @@ def _existing_tool_names() -> List[str]:
     with _lock:
         lazy_names = [
             n
-            for sname, tool_names in _lazy_server_tool_names.items()
-            if sname not in _servers
+            for server_key, tool_names in _lazy_server_tool_names.items()
+            if server_key[0] == profile_home and server_key not in _servers
             for n in tool_names
         ]
     names.extend(lazy_names)
@@ -6170,11 +6352,6 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
     profile_home = _server_profile_home(server)
-    with _lock:
-        _server_profile_homes[name] = profile_home
-        # A live/eager publication supersedes any stale lazy-manifest owner
-        # for this name. The server task now carries the authoritative owner.
-        _lazy_server_profile_homes.pop(name, None)
 
     # Selective tool loading: honour include/exclude lists from config.
     # Rules (matching issue #690 spec, extended with glob support):
@@ -6198,7 +6375,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             return not matches_name_filter(tool_name, exclude_set)
         return True
 
-    check_fn = _make_check_fn(name)
+    check_fn = _make_check_fn(name, profile_home)
     candidates: List[dict] = []
 
     # Trust-tier metadata (security boundary): capture the server's
@@ -6224,7 +6401,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name, mcp_tool.name, server.tool_timeout, profile_home
                 ),
                 "check_fn": check_fn,
             }
@@ -6247,7 +6424,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"generated utility {handler_key!r}",
                 "schema": schema,
                 "handler": handler_factories[handler_key](
-                    name, server.tool_timeout
+                    name, server.tool_timeout, profile_home
                 ),
                 "check_fn": check_fn,
             }
@@ -6295,7 +6472,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         if registry_name in ambiguous_names:
             continue
 
-        existing_toolset = registry.get_toolset_for_tool(registry_name)
+        existing_toolset = registry.get_toolset_for_tool(
+            registry_name,
+            profile_home=profile_home,
+        )
         if existing_toolset and existing_toolset != toolset_name:
             if existing_toolset.startswith("mcp-"):
                 logger.error(
@@ -6330,7 +6510,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         # The pre-check above is advisory only. Multiple servers connect in
         # parallel, so ToolRegistry.register() is the atomic ownership gate.
-        if registry.get_toolset_for_tool(registry_name) != toolset_name:
+        if registry.get_toolset_for_tool(
+            registry_name,
+            profile_home=profile_home,
+        ) != toolset_name:
             logger.error(
                 "MCP server '%s': registration of %s as '%s' was rejected by "
                 "the registry; skipping provenance/count updates",
@@ -6340,11 +6523,15 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             )
             continue
 
-        _track_mcp_tool_server(registry_name, name)
+        _track_mcp_tool_server(registry_name, name, profile_home)
         registered_names.append(registry_name)
 
     if registered_names:
-        registry.register_toolset_alias(name, toolset_name)
+        registry.register_toolset_alias(
+            name,
+            toolset_name,
+            profile_home=profile_home,
+        )
         # Write-through (#56832): refresh the on-disk schema cache after a
         # live connect so the next startup can lazily register this server
         # without spawning it. Cache failures never break registration.
@@ -6428,7 +6615,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             return not matches_name_filter(tool_name, exclude_set)
         return True
 
-    check_fn = _make_check_fn(name)
+    check_fn = _make_check_fn(name, profile_home)
     # Trust-tier metadata for the lazy path: the cached manifest carries
     # each tool's readOnlyHint (written by the live discovery path), and
     # trust comes from operator config. Recording it before registration
@@ -6462,7 +6649,10 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
         schema = _convert_mcp_schema(name, mcp_tool)
         registry_name = schema["name"]
-        existing_toolset = registry.get_toolset_for_tool(registry_name)
+        existing_toolset = registry.get_toolset_for_tool(
+            registry_name,
+            profile_home=profile_home,
+        )
         if existing_toolset and existing_toolset != toolset_name:
             logger.warning(
                 "MCP server '%s' (lazy): cached tool '%s' collides with "
@@ -6474,15 +6664,23 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             name=registry_name,
             toolset=toolset_name,
             schema=schema,
-            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            handler=_make_tool_handler(
+                name,
+                raw_name,
+                tool_timeout,
+                profile_home,
+            ),
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
             profile_home=profile_home,
         )
-        if registry.get_toolset_for_tool(registry_name) != toolset_name:
+        if registry.get_toolset_for_tool(
+            registry_name,
+            profile_home=profile_home,
+        ) != toolset_name:
             continue
-        _track_mcp_tool_server(registry_name, name)
+        _track_mcp_tool_server(registry_name, name, profile_home)
         registered_names.append(registry_name)
 
     handler_factories = {
@@ -6501,32 +6699,45 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         util_name = schema.get("name") or ""
         if not util_name:
             continue
-        existing_toolset = registry.get_toolset_for_tool(util_name)
+        existing_toolset = registry.get_toolset_for_tool(
+            util_name,
+            profile_home=profile_home,
+        )
         if existing_toolset and existing_toolset != toolset_name:
             continue
         registry.register(
             name=util_name,
             toolset=toolset_name,
             schema=schema,
-            handler=handler_factories[handler_key](name, tool_timeout),
+            handler=handler_factories[handler_key](
+                name,
+                tool_timeout,
+                profile_home,
+            ),
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
             profile_home=profile_home,
         )
-        if registry.get_toolset_for_tool(util_name) != toolset_name:
+        if registry.get_toolset_for_tool(
+            util_name,
+            profile_home=profile_home,
+        ) != toolset_name:
             continue
-        _track_mcp_tool_server(util_name, name)
+        _track_mcp_tool_server(util_name, name, profile_home)
         registered_names.append(util_name)
 
     if registered_names:
-        registry.register_toolset_alias(name, toolset_name)
+        registry.register_toolset_alias(
+            name,
+            toolset_name,
+            profile_home=profile_home,
+        )
+        server_key = _server_key(name, profile_home)
         with _lock:
-            _lazy_server_configs[name] = dict(config)
-            _lazy_server_fingerprints[name] = fingerprint
-            _lazy_server_tool_names[name] = list(registered_names)
-            _lazy_server_profile_homes[name] = profile_home
-            _server_profile_homes[name] = profile_home
+            _lazy_server_configs[server_key] = dict(config)
+            _lazy_server_fingerprints[server_key] = fingerprint
+            _lazy_server_tool_names[server_key] = list(registered_names)
         logger.info(
             "MCP server '%s' (lazy): registered %d tool(s) from schema cache",
             name, len(registered_names),
@@ -6540,8 +6751,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """
     connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
     discovery_profile_home = _canonical_profile_home()
-    with _lock:
-        _server_profile_homes[name] = discovery_profile_home
+    server_key = _server_key(name, discovery_profile_home)
     # List-based claim (not a ``nonlocal`` rebind): the claim callback runs
     # inside ``_connect_server`` while this frame is suspended, and appending
     # keeps type narrowing intact for the module's other ``server`` locals.
@@ -6574,7 +6784,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             # Recoverable park: the run task deliberately stays alive to
             # self-probe, so adopt it into the registry for shutdown/revival.
             with _lock:
-                _servers[name] = server
+                _servers[server_key] = server
         elif server is not None:
             await server.shutdown()
         raise
@@ -6582,14 +6792,14 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _connect_server_claim.reset(claim_token)
 
     with _lock:
-        _server_connecting.discard(name)
-        _server_connect_errors.pop(name, None)
+        _server_connecting.discard(server_key)
+        _server_connect_errors.pop(server_key, None)
         # Test/probe adapters may return a task constructed without the
         # production connection helper. Preserve an existing owner, otherwise
         # bind this server before any registry publication.
         if not getattr(server, "profile_home", None):
             server.profile_home = discovery_profile_home
-        _servers[name] = server
+        _servers[server_key] = server
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
@@ -6626,7 +6836,16 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     # Capture the request's profile once. This owner is used for connecting
     # and failed status rows even if the caller's context changes while the
     # background discovery batch is in flight.
-    registration_profile_home = _canonical_profile_home()
+    registration_profile_home = _active_profile_home_or_none()
+    if registration_profile_home is None:
+        logger.error(
+            "MCP registration skipped: multiplex profile owner is unresolved"
+        )
+        return []
+    registration_keys = {
+        name: _server_key(name, registration_profile_home)
+        for name in servers
+    }
     servers = _filter_suspicious_mcp_servers(servers)
     if not servers:
         logger.debug("No explicit MCP servers provided")
@@ -6641,11 +6860,11 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers
-            and k not in connecting
+            if registration_keys[k] not in _servers
+            and registration_keys[k] not in connecting
             # Servers already lazily registered from the schema cache are
             # not re-registered; they connect on first tool use (#56832).
-            and k not in _lazy_server_configs
+            and registration_keys[k] not in _lazy_server_configs
             and _parse_boolish(v.get("enabled", True), default=True)
             # Skip a server still serving its post-failure backoff. Without
             # this, a server that fails to connect (and is therefore never
@@ -6653,7 +6872,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             # session's discovery pass -- the #50394 restart storm. The
             # cooldown is cleared automatically on the next successful
             # connect or by a manual /mcp refresh.
-            and not _connect_cooldown_active(k)
+            and not _connect_cooldown_active(registration_keys[k])
         }
         # Cached entries with no live session are parked or mid-reconnect.
         # Their tools are deregistered, so nothing else can reach
@@ -6661,20 +6880,20 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         # waits up to _PARKED_RETRY_INTERVAL for the next self-probe
         # (#50170). Wake them now so their tools come back promptly.
         stale_cached = [
-            _servers[k]
+            _servers[registration_keys[k]]
             for k in servers
-            if k in _servers and getattr(_servers[k], "session", None) is None
+            if registration_keys[k] in _servers
+            and getattr(_servers[registration_keys[k]], "session", None) is None
         ]
-        _server_connecting.update(new_servers)
+        _server_connecting.update(registration_keys[name] for name in new_servers)
         for srv_name in new_servers:
-            _server_connect_errors.pop(srv_name, None)
-            _server_profile_homes[srv_name] = registration_profile_home
+            _server_connect_errors.pop(registration_keys[srv_name], None)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
-                _parallel_safe_servers.add(srv_name)
+                _parallel_safe_servers.add(registration_keys[srv_name])
             else:
-                _parallel_safe_servers.discard(srv_name)
+                _parallel_safe_servers.discard(registration_keys[srv_name])
 
     for srv in stale_cached:
         _signal_reconnect(srv)
@@ -6703,7 +6922,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             if not entry:
                 continue
             with _lock:
-                _server_connecting.discard(name)
+                _server_connecting.discard(registration_keys[name])
             try:
                 names = _register_from_cache_sync(name, cfg, entry)
             except Exception as exc:
@@ -6711,7 +6930,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                     "Failed lazy MCP registration for '%s': %s", name, exc,
                 )
                 with _lock:
-                    _server_connecting.add(name)
+                    _server_connecting.add(registration_keys[name])
                 continue
             eager_servers.pop(name, None)
             lazy_registered += len(names)
@@ -6746,13 +6965,14 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 command = new_servers.get(name, {}).get("command")
                 message = _format_connect_error(result)
                 with _lock:
-                    _server_connecting.discard(name)
-                    _server_connect_errors[name] = message
+                    server_key = registration_keys[name]
+                    _server_connecting.discard(server_key)
+                    _server_connect_errors[server_key] = message
                     # Arm the per-server backoff so the next discovery pass
                     # doesn't immediately re-spawn this failing server
                     # (#50394). Isolated to this server -- healthy servers
                     # in the same batch are unaffected.
-                    _record_connect_failure(name)
+                    _record_connect_failure(server_key)
                 logger.warning(
                     "Failed to connect to MCP server '%s'%s: %s",
                     name,
@@ -6761,9 +6981,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 )
             else:
                 with _lock:
-                    _server_connecting.discard(name)
-                    _server_connect_errors.pop(name, None)
-                    _clear_connect_failure(name)
+                    server_key = registration_keys[name]
+                    _server_connecting.discard(server_key)
+                    _server_connect_errors.pop(server_key, None)
+                    _clear_connect_failure(server_key)
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
@@ -6783,7 +7004,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         # entries stranded in _server_connecting.  Those stale
         # entries would block future reconnection attempts (#58862).
         with _lock:
-            stale = [n for n in new_servers if n in _server_connecting]
+            stale = [
+                n for n in new_servers
+                if registration_keys[n] in _server_connecting
+            ]
             if stale:
                 logger.warning(
                     "MCP discovery %s while %d server(s) were still "
@@ -6792,10 +7016,12 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                     len(stale),
                     ", ".join(stale),
                 )
-                _server_connecting.difference_update(stale)
+                _server_connecting.difference_update(
+                    registration_keys[n] for n in stale
+                )
                 for _sn in stale:
                     _server_connect_errors.setdefault(
-                        _sn,
+                        registration_keys[_sn],
                         f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery",
                     )
         raise
@@ -6808,10 +7034,15 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         connected = [
             n
             for n in new_servers
-            if n in _servers and n not in _server_connect_errors
+            if registration_keys[n] in _servers
+            and registration_keys[n] not in _server_connect_errors
         ]
         new_tool_count = sum(
-            len(getattr(_servers[n], "_registered_tool_names", []))
+            len(getattr(
+                _servers[registration_keys[n]],
+                "_registered_tool_names",
+                [],
+            ))
             for n in connected
         )
     failed = len(new_servers) - len(connected)
@@ -6841,11 +7072,21 @@ def discover_mcp_tools() -> List[str]:
     if not _MCP_AVAILABLE:
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
+    if _active_profile_home_or_none() is None:
+        logger.error(
+            "MCP discovery skipped: multiplex profile owner is unresolved"
+        )
+        return []
 
     servers = _load_mcp_config()
     if not servers:
         logger.debug("No MCP servers configured")
         return []
+    discovery_profile_home = _canonical_profile_home()
+    discovery_keys = {
+        name: _server_key(name, discovery_profile_home)
+        for name in servers
+    }
 
     # Cross-process discovery guard (#62771). A lock loser waits for
     # the holder, then performs its own process-local discovery. If locking is
@@ -6877,8 +7118,8 @@ def discover_mcp_tools() -> List[str]:
             new_server_names = [
                 name
                 for name, cfg in servers.items()
-                if name not in _servers
-                and name not in connecting
+                if discovery_keys[name] not in _servers
+                and discovery_keys[name] not in connecting
                 and _parse_boolish(cfg.get("enabled", True), default=True)
             ]
 
@@ -6890,10 +7131,15 @@ def discover_mcp_tools() -> List[str]:
             connected_server_names = [
                 name
                 for name in new_server_names
-                if name in _servers and name not in _server_connect_errors
+                if discovery_keys[name] in _servers
+                and discovery_keys[name] not in _server_connect_errors
             ]
             new_tool_count = sum(
-                len(getattr(_servers[name], "_registered_tool_names", []))
+                len(getattr(
+                    _servers[discovery_keys[name]],
+                    "_registered_tool_names",
+                    [],
+                ))
                 for name in connected_server_names
             )
 
@@ -6923,9 +7169,12 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
     """
     if not tool_name.startswith(MCP_TOOL_NAME_PREFIX):
         return False
+    profile_home = _active_profile_home_or_none()
+    if profile_home is None:
+        return False
     with _lock:
-        server_name = _mcp_tool_server_names.get(tool_name)
-        return bool(server_name and server_name in _parallel_safe_servers)
+        server_key = _mcp_tool_server_names.get((profile_home, tool_name))
+        return bool(server_key and server_key in _parallel_safe_servers)
 
 
 def get_mcp_status() -> List[dict]:
@@ -6937,24 +7186,36 @@ def get_mcp_status() -> List[dict]:
     that are configured but have not been started in this process yet.
     """
     result: List[dict] = []
+    status_profile_home = _active_profile_home_or_none()
+    if status_profile_home is None:
+        return result
 
     # Get configured servers from config
     configured = _load_mcp_config()
     if not configured:
         return result
-    status_profile_home = _canonical_profile_home()
 
     with _lock:
-        active_servers = dict(_servers)
-        connecting = set(_server_connecting)
-        connect_errors = dict(_server_connect_errors)
-        profile_homes = dict(_server_profile_homes)
-        lazy_profile_homes = dict(_lazy_server_profile_homes)
+        active_servers = {
+            key: server
+            for key, server in _servers.items()
+            if key[0] == status_profile_home
+        }
+        connecting = {
+            key for key in _server_connecting
+            if key[0] == status_profile_home
+        }
+        connect_errors = {
+            key: error
+            for key, error in _server_connect_errors.items()
+            if key[0] == status_profile_home
+        }
 
     for name, cfg in configured.items():
+        server_key = _server_key(name, status_profile_home)
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
         enabled = _parse_boolish(cfg.get("enabled", True), default=True)
-        server = active_servers.get(name)
+        server = active_servers.get(server_key)
         if server and server.session is not None:
             entry = {
                 "name": name,
@@ -6981,7 +7242,7 @@ def get_mcp_status() -> List[dict]:
                 "status": "disabled",
                 "profile_home": status_profile_home,
             })
-        elif name in connecting:
+        elif server_key in connecting:
             result.append({
                 "name": name,
                 "transport": transport,
@@ -6989,9 +7250,9 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "connecting",
-                "profile_home": profile_homes.get(name, status_profile_home),
+                "profile_home": status_profile_home,
             })
-        elif name in connect_errors:
+        elif server_key in connect_errors:
             result.append({
                 "name": name,
                 "transport": transport,
@@ -6999,8 +7260,8 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "failed",
-                "error": connect_errors[name],
-                "profile_home": profile_homes.get(name, status_profile_home),
+                "error": connect_errors[server_key],
+                "profile_home": status_profile_home,
             })
         else:
             result.append({
@@ -7010,13 +7271,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "configured",
-                "profile_home": (
-                    lazy_profile_homes.get(name, status_profile_home)
-                    if name in lazy_profile_homes
-                    else profile_homes.get(name, status_profile_home)
-                    if name in active_servers
-                    else status_profile_home
-                ),
+                "profile_home": status_profile_home,
             })
 
     return result
@@ -7106,8 +7361,14 @@ def has_registered_mcp_tools() -> bool:
     registered TOOLS, not connected servers, so a server that registers no tools
     doesn't keep the hook firing every turn.
     """
+    profile_home = _active_profile_home_or_none()
+    if profile_home is None:
+        return False
     with _lock:
-        return bool(_mcp_tool_server_names)
+        return any(
+            owner_home == profile_home
+            for owner_home, _tool_name in _mcp_tool_server_names
+        )
 
 
 def get_registered_mcp_server_names() -> set:
@@ -7120,8 +7381,16 @@ def get_registered_mcp_server_names() -> set:
     Slack platform note) to detect an MCP server that provides a given
     platform's capability regardless of what its config key is named.
     """
+    profile_home = _active_profile_home_or_none()
+    if profile_home is None:
+        return set()
     with _lock:
-        return set(_mcp_tool_server_names.values())
+        return {
+            server_key[1]
+            for (owner_home, _tool_name), server_key
+            in _mcp_tool_server_names.items()
+            if owner_home == profile_home
+        }
 
 
 
@@ -7336,8 +7605,6 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
-            _server_profile_homes.clear()
-            _lazy_server_profile_homes.clear()
         _stop_mcp_loop()
         return
 
@@ -7358,8 +7625,6 @@ def shutdown_mcp_servers():
             # stale per-server backoff from before the restart (#50394).
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
-            _server_profile_homes.clear()
-            _lazy_server_profile_homes.clear()
 
     with _lock:
         loop = _mcp_loop
@@ -7383,8 +7648,6 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
-        _server_profile_homes.clear()
-        _lazy_server_profile_homes.clear()
 
     _stop_mcp_loop()
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -163,12 +163,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "profile_home",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 profile_home=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -187,6 +188,10 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # Optional provenance for dynamic tools (currently MCP). Built-in and
+        # plugin registrations leave this unset; callers that own a profile
+        # pass a canonical absolute path captured at registration time.
+        self.profile_home = str(profile_home) if profile_home is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +537,7 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        profile_home: Optional[str] = None,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -591,6 +597,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                profile_home=profile_home,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -820,6 +827,16 @@ class ToolRegistry:
         """Return the toolset a tool belongs to, or None."""
         entry = self.get_entry(name)
         return entry.toolset if entry else None
+
+    def get_profile_home_for_tool(self, name: str) -> Optional[str]:
+        """Return the captured profile home for a dynamic tool, if any.
+
+        Registry entries own this provenance. Reading it never consults the
+        mutable Hermes-home context, so a later profile switch cannot make a
+        previously registered tool appear to belong to another profile.
+        """
+        entry = self.get_entry(name)
+        return entry.profile_home if entry else None
 
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -27,6 +27,57 @@ from typing import Callable, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 
+# ``None`` continues to mean a process-global registration.  A non-empty
+# canonical Hermes home is an owner only for dynamic MCP registrations.  The
+# sentinel lets lookups distinguish an unresolved multiplex profile from a
+# normal global-only snapshot without exposing that implementation detail in
+# the public API.
+_PROFILE_HOME_UNSET = object()
+_PROFILE_SCOPE_UNRESOLVED = object()
+
+
+def _canonical_profile_home(profile_home) -> Optional[str]:
+    """Return the stable absolute key for a profile home, or ``None``."""
+    if profile_home is None:
+        return None
+    value = str(profile_home).strip()
+    if not value:
+        return None
+    try:
+        return str(Path(value).expanduser().resolve())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _current_profile_home():
+    """Resolve the current profile owner, failing closed in multiplex mode."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        if is_multiplex_active():
+            from hermes_constants import get_hermes_home_override
+
+            override = get_hermes_home_override()
+            if not override:
+                return _PROFILE_SCOPE_UNRESOLVED
+
+        from hermes_constants import get_hermes_home
+
+        return _canonical_profile_home(get_hermes_home())
+    except Exception:
+        # Registry is imported very early.  If the profile context cannot be
+        # resolved, expose only process-global entries rather than risking a
+        # lookup against another profile's MCP handler.
+        return _PROFILE_SCOPE_UNRESOLVED
+
+
+def _resolve_profile_home(profile_home=_PROFILE_HOME_UNSET):
+    """Resolve an explicit or context-local owner for registry operations."""
+    if profile_home is not _PROFILE_HOME_UNSET and profile_home is not None:
+        return _canonical_profile_home(profile_home)
+    return _current_profile_home()
+
+
 def _is_registry_register_call(node: ast.AST) -> bool:
     """Return True when *node* is a ``registry.register(...)`` call expression."""
     if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
@@ -379,7 +430,12 @@ class ToolRegistry:
     """Singleton registry that collects tool schemas + handlers from tool files."""
 
     def __init__(self):
+        # Built-in and plugin tools retain the historical process-global map.
+        # MCP entries live in a second dimension keyed by canonical profile
+        # home so identical public names can coexist without replacing one
+        # another's handler or schema.
         self._tools: Dict[str, ToolEntry] = {}
+        self._profile_tools: Dict[str, Dict[str, ToolEntry]] = {}
         # Durable map: plugin module namespace (handler.__globals__["__name__"])
         # -> operator opt-in for built-in override. Populated at plugin load and
         # never cleared, so a plugin's override authorization is bound to the
@@ -387,7 +443,9 @@ class ToolRegistry:
         # happens (sync during load, or a delayed/threaded callback afterwards).
         self._plugin_override_policy: Dict[str, bool] = {}
         self._toolset_checks: Dict[str, Callable] = {}
+        self._profile_toolset_checks: Dict[tuple[str, str], Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
+        self._profile_toolset_aliases: Dict[str, Dict[str, str]] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -399,14 +457,39 @@ class ToolRegistry:
         # long as the generation hasn't changed.
         self._generation: int = 0
 
-    def _snapshot_state(self) -> tuple[List[ToolEntry], Dict[str, Callable]]:
+    def _snapshot_state(
+        self, profile_home=_PROFILE_HOME_UNSET
+    ) -> tuple[List[ToolEntry], Dict[str, Callable]]:
         """Return a coherent snapshot of registry entries and toolset checks."""
         with self._lock:
-            return list(self._tools.values()), dict(self._toolset_checks)
+            entries = list(self._tools.values())
+            toolset_checks = dict(self._toolset_checks)
+            scope = _resolve_profile_home(profile_home)
+            if scope is not _PROFILE_SCOPE_UNRESOLVED and scope is not None:
+                entries.extend(self._profile_tools.get(scope, {}).values())
+                for (home, toolset), check_fn in self._profile_toolset_checks.items():
+                    if home == scope:
+                        toolset_checks.setdefault(toolset, check_fn)
+            return entries, toolset_checks
 
-    def _snapshot_entries(self) -> List[ToolEntry]:
+    def _snapshot_entries(self, profile_home=_PROFILE_HOME_UNSET) -> List[ToolEntry]:
         """Return a stable snapshot of registered tool entries."""
-        return self._snapshot_state()[0]
+        if profile_home is _PROFILE_HOME_UNSET:
+            return self._snapshot_state()[0]
+        return self._snapshot_state(profile_home)[0]
+
+    def _entry_for_name_locked(self, name: str, profile_home=_PROFILE_HOME_UNSET):
+        """Return the selected profile entry, falling back to global tools."""
+        scope = _resolve_profile_home(profile_home)
+        if scope is not _PROFILE_SCOPE_UNRESOLVED and scope is not None:
+            entry = self._profile_tools.get(scope, {}).get(name)
+            if entry is not None:
+                return entry
+        return self._tools.get(name)
+
+    def _profile_entry_exists_locked(self, name: str) -> bool:
+        """Return whether any profile owns *name* (for global collision checks)."""
+        return any(name in entries for entries in self._profile_tools.values())
 
     def _toolset_has_exposable_tools(
         self,
@@ -432,42 +515,91 @@ class ToolRegistry:
                 return True
         return False
 
-    def get_entry(self, name: str) -> Optional[ToolEntry]:
-        """Return a registered tool entry by name, or None."""
+    def get_entry(
+        self, name: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Optional[ToolEntry]:
+        """Return a global or current-profile entry by public name.
+
+        Passing ``profile_home`` explicitly is required by background MCP
+        work that runs outside the profile context.  In a multiplex process,
+        an omitted/implicit profile with no Hermes-home override selects only
+        global entries; it never guesses an MCP owner.
+        """
         with self._lock:
-            return self._tools.get(name)
+            return self._entry_for_name_locked(name, profile_home)
 
-    def get_registered_toolset_names(self) -> List[str]:
+    def get_registered_toolset_names(self, *, profile_home=_PROFILE_HOME_UNSET) -> List[str]:
         """Return sorted unique toolset names present in the registry."""
-        return sorted({entry.toolset for entry in self._snapshot_entries()})
+        return sorted({entry.toolset for entry in self._snapshot_entries(profile_home)})
 
-    def get_tool_names_for_toolset(self, toolset: str) -> List[str]:
+    def get_tool_names_for_toolset(
+        self, toolset: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> List[str]:
         """Return sorted tool names registered under a given toolset."""
         return sorted(
-            entry.name for entry in self._snapshot_entries()
+            entry.name for entry in self._snapshot_entries(profile_home)
             if entry.toolset == toolset
         )
 
-    def register_toolset_alias(self, alias: str, toolset: str) -> None:
-        """Register an explicit alias for a canonical toolset name."""
+    def register_toolset_alias(
+        self, alias: str, toolset: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> None:
+        """Register an explicit global or profile-scoped toolset alias."""
         with self._lock:
-            existing = self._toolset_aliases.get(alias)
+            scope = _resolve_profile_home(profile_home)
+            if scope is _PROFILE_SCOPE_UNRESOLVED:
+                logger.error(
+                    "Toolset alias registration REJECTED: profile scope for %r "
+                    "is unresolved in multiplex mode",
+                    alias,
+                )
+                return
+            explicit_profile = (
+                profile_home is not _PROFILE_HOME_UNSET
+                and _canonical_profile_home(profile_home) is not None
+            )
+            if scope is not None:
+                profile_entries = self._profile_tools.get(scope, {}).values()
+                profile_owns_toolset = any(
+                    entry.toolset == toolset for entry in profile_entries
+                )
+            else:
+                profile_owns_toolset = False
+            aliases = (
+                self._profile_toolset_aliases.setdefault(scope, {})
+                if scope is not None and (explicit_profile or profile_owns_toolset)
+                else self._toolset_aliases
+            )
+            existing = aliases.get(alias)
             if existing and existing != toolset:
                 logger.warning(
                     "Toolset alias collision: '%s' (%s) overwritten by %s",
                     alias, existing, toolset,
                 )
-            self._toolset_aliases[alias] = toolset
+            aliases[alias] = toolset
             self._generation += 1
 
-    def get_registered_toolset_aliases(self) -> Dict[str, str]:
+    def get_registered_toolset_aliases(
+        self, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Dict[str, str]:
         """Return a snapshot of ``{alias: canonical_toolset}`` mappings."""
         with self._lock:
-            return dict(self._toolset_aliases)
+            aliases = dict(self._toolset_aliases)
+            scope = _resolve_profile_home(profile_home)
+            if scope is not _PROFILE_SCOPE_UNRESOLVED and scope is not None:
+                aliases.update(self._profile_toolset_aliases.get(scope, {}))
+            return aliases
 
-    def get_toolset_alias_target(self, alias: str) -> Optional[str]:
+    def get_toolset_alias_target(
+        self, alias: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Optional[str]:
         """Return the canonical toolset name for an alias, or None."""
         with self._lock:
+            scope = _resolve_profile_home(profile_home)
+            if scope is not _PROFILE_SCOPE_UNRESOLVED and scope is not None:
+                target = self._profile_toolset_aliases.get(scope, {}).get(alias)
+                if target is not None:
+                    return target
             return self._toolset_aliases.get(alias)
 
     # ------------------------------------------------------------------
@@ -548,7 +680,56 @@ class ToolRegistry:
         toolset are rejected to prevent accidental overwrites.
         """
         with self._lock:
-            existing = self._tools.get(name)
+            requested_home = _canonical_profile_home(profile_home)
+            # ``profile_home`` is an MCP ownership marker.  Do not let a
+            # built-in/plugin registration accidentally become profile-scoped
+            # merely because a caller forwarded unrelated context metadata.
+            owner_home = (
+                requested_home if requested_home and toolset.startswith("mcp-") else None
+            )
+
+            if owner_home is not None:
+                # A dynamic MCP entry must never shadow a global built-in or
+                # plugin entry.  Allowing both would make the public name
+                # ambiguous for global callers and could route to the wrong
+                # handler during a profile switch.
+                if name in self._tools:
+                    logger.error(
+                        "Tool registration REJECTED: profile-scoped MCP tool %r "
+                        "would shadow global toolset %r",
+                        name,
+                        self._tools[name].toolset,
+                    )
+                    return
+                target_tools = self._profile_tools.setdefault(owner_home, {})
+                existing = target_tools.get(name)
+            else:
+                # Preserve global built-in/plugin behavior and prevent a
+                # global late registration from hiding an already-live MCP
+                # owner under the same public name.
+                if self._profile_entry_exists_locked(name):
+                    logger.error(
+                        "Tool registration REJECTED: global tool %r would "
+                        "shadow a profile-scoped MCP entry",
+                        name,
+                    )
+                    return
+                target_tools = self._tools
+                existing = target_tools.get(name)
+
+            if owner_home is not None and existing and existing.toolset != toolset:
+                # Dynamic MCP ownership is intentionally stricter than the
+                # global plugin override path: two toolsets under one profile
+                # and public name are always ambiguous, even when a caller
+                # passes ``override=True``.
+                logger.error(
+                    "Tool registration REJECTED: '%s' (toolset '%s') would "
+                    "shadow existing profile tool from toolset '%s'",
+                    name,
+                    toolset,
+                    existing.toolset,
+                )
+                return
             if existing and existing.toolset != toolset:
                 if override:
                     _owner = self._plugin_owner_of(handler)
@@ -585,7 +766,7 @@ class ToolRegistry:
                         name, toolset, existing.toolset,
                     )
                     return
-            self._tools[name] = ToolEntry(
+            target_tools[name] = ToolEntry(
                 name=name,
                 toolset=toolset,
                 schema=schema,
@@ -597,7 +778,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
-                profile_home=profile_home,
+                profile_home=owner_home,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -605,11 +786,16 @@ class ToolRegistry:
             # banner.py reads (presence only, never called) to classify an
             # already-unavailable toolset as lazy-init vs disabled. Keep the
             # write path for that classification.
-            if check_fn and toolset not in self._toolset_checks:
-                self._toolset_checks[toolset] = check_fn
+            if check_fn:
+                if owner_home is not None:
+                    self._profile_toolset_checks.setdefault(
+                        (owner_home, toolset), check_fn
+                    )
+                elif toolset not in self._toolset_checks:
+                    self._toolset_checks[toolset] = check_fn
             self._generation += 1
 
-    def deregister(self, name: str) -> None:
+    def deregister(self, name: str, *, profile_home=_PROFILE_HOME_UNSET) -> None:
         """Remove a tool from the registry.
 
         Also cleans up the toolset check if no other tools remain in the
@@ -626,7 +812,37 @@ class ToolRegistry:
         every refresh and has no plugin-override concept.
         """
         with self._lock:
-            entry = self._tools.get(name)
+            explicit_profile = (
+                profile_home is not _PROFILE_HOME_UNSET
+                and _canonical_profile_home(profile_home) is not None
+            )
+            scope = _resolve_profile_home(profile_home)
+            if explicit_profile:
+                # An owner-scoped teardown may remove only that owner's MCP
+                # entry.  It must never fall back to a global or other-profile
+                # entry when its own slot is absent.
+                owner_home = _canonical_profile_home(profile_home)
+                if owner_home is None:  # narrowed by explicit_profile; defensive
+                    return
+                owner_tools = self._profile_tools.get(owner_home, {})
+                entry = owner_tools.get(name)
+                target_tools = owner_tools
+                if entry is None:
+                    return
+            elif scope is not _PROFILE_SCOPE_UNRESOLVED and scope is not None:
+                owner_home = scope
+                owner_tools = self._profile_tools.get(owner_home, {})
+                entry = owner_tools.get(name)
+                if entry is not None:
+                    target_tools = owner_tools
+                else:
+                    owner_home = None
+                    target_tools = self._tools
+                    entry = target_tools.get(name)
+            else:
+                owner_home = None
+                target_tools = self._tools
+                entry = target_tools.get(name)
             if entry is None:
                 return
             if not entry.toolset.startswith("mcp-"):
@@ -660,19 +876,36 @@ class ToolRegistry:
                         f"{name!r} (toolset {entry.toolset!r}) without operator "
                         f"opt-in (allow_tool_override)."
                     )
-            del self._tools[name]
+            del target_tools[name]
             # Drop the toolset check and aliases if this was the last tool in
-            # that toolset.
+            # that owner/toolset.  Profile cleanup is deliberately scoped to
+            # one home; another profile may still expose the same toolset.
             toolset_still_exists = any(
-                e.toolset == entry.toolset for e in self._tools.values()
+                e.toolset == entry.toolset for e in target_tools.values()
             )
             if not toolset_still_exists:
-                self._toolset_checks.pop(entry.toolset, None)
-                self._toolset_aliases = {
-                    alias: target
-                    for alias, target in self._toolset_aliases.items()
-                    if target != entry.toolset
-                }
+                if owner_home is not None:
+                    self._profile_toolset_checks.pop(
+                        (owner_home, entry.toolset), None
+                    )
+                    profile_aliases = self._profile_toolset_aliases.get(owner_home)
+                    if profile_aliases is not None:
+                        self._profile_toolset_aliases[owner_home] = {
+                            alias: target
+                            for alias, target in profile_aliases.items()
+                            if target != entry.toolset
+                        }
+                        if not self._profile_toolset_aliases[owner_home]:
+                            self._profile_toolset_aliases.pop(owner_home, None)
+                    if not target_tools:
+                        self._profile_tools.pop(owner_home, None)
+                else:
+                    self._toolset_checks.pop(entry.toolset, None)
+                    self._toolset_aliases = {
+                        alias: target
+                        for alias, target in self._toolset_aliases.items()
+                        if target != entry.toolset
+                    }
             self._generation += 1
         logger.debug("Deregistered tool: %s", name)
 
@@ -680,7 +913,13 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(
+        self,
+        tool_names: Set[str],
+        quiet: bool = False,
+        *,
+        profile_home=_PROFILE_HOME_UNSET,
+    ) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -696,7 +935,9 @@ class ToolRegistry:
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
         check_results: Dict[Callable, bool] = {}
-        entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
+        entries_by_name = {
+            entry.name: entry for entry in self._snapshot_entries(profile_home)
+        }
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
             if not entry:
@@ -764,7 +1005,14 @@ class ToolRegistry:
             result_type=result_type,
         )
 
-    def dispatch(self, name: str, args: dict, **kwargs) -> str | dict:
+    def dispatch(
+        self,
+        name: str,
+        args: dict,
+        *,
+        profile_home=_PROFILE_HOME_UNSET,
+        **kwargs,
+    ) -> str | dict:
         """Execute a tool handler by name.
 
         * Async handlers are bridged automatically via ``_run_async()``.
@@ -773,7 +1021,7 @@ class ToolRegistry:
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         if not entry:
             return tool_error(f"Unknown tool: {name}")
         try:
@@ -800,9 +1048,15 @@ class ToolRegistry:
     # Query helpers  (replace redundant dicts in model_tools.py)
     # ------------------------------------------------------------------
 
-    def get_max_result_size(self, name: str, default: int | float | None = None) -> int | float:
+    def get_max_result_size(
+        self,
+        name: str,
+        default: int | float | None = None,
+        *,
+        profile_home=_PROFILE_HOME_UNSET,
+    ) -> int | float:
         """Return per-tool max result size, or *default* (or global default)."""
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         if entry and entry.max_result_size_chars is not None:
             return entry.max_result_size_chars
         if default is not None:
@@ -810,65 +1064,91 @@ class ToolRegistry:
         from tools.budget_config import DEFAULT_RESULT_SIZE_CHARS
         return DEFAULT_RESULT_SIZE_CHARS
 
-    def get_all_tool_names(self) -> List[str]:
+    def get_all_tool_names(self, *, profile_home=_PROFILE_HOME_UNSET) -> List[str]:
         """Return sorted list of all registered tool names."""
-        return sorted(entry.name for entry in self._snapshot_entries())
+        return sorted(entry.name for entry in self._snapshot_entries(profile_home))
 
-    def get_schema(self, name: str) -> Optional[dict]:
+    def get_schema(self, name: str, *, profile_home=_PROFILE_HOME_UNSET) -> Optional[dict]:
         """Return a tool's raw schema dict, bypassing check_fn filtering.
 
         Useful for token estimation and introspection where availability
         doesn't matter — only the schema content does.
         """
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         return entry.schema if entry else None
 
-    def get_toolset_for_tool(self, name: str) -> Optional[str]:
+    def get_toolset_for_tool(
+        self, name: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Optional[str]:
         """Return the toolset a tool belongs to, or None."""
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         return entry.toolset if entry else None
 
-    def get_profile_home_for_tool(self, name: str) -> Optional[str]:
+    def get_profile_home_for_tool(
+        self, name: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Optional[str]:
         """Return the captured profile home for a dynamic tool, if any.
 
         Registry entries own this provenance. Reading it never consults the
         mutable Hermes-home context, so a later profile switch cannot make a
         previously registered tool appear to belong to another profile.
         """
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         return entry.profile_home if entry else None
 
-    def get_emoji(self, name: str, default: str = "⚡") -> str:
+    def get_emoji(
+        self, name: str, default: str = "⚡", *, profile_home=_PROFILE_HOME_UNSET
+    ) -> str:
         """Return the emoji for a tool, or *default* if unset."""
-        entry = self.get_entry(name)
+        entry = self.get_entry(name, profile_home=profile_home)
         return (entry.emoji if entry and entry.emoji else default)
 
-    def get_tool_to_toolset_map(self) -> Dict[str, str]:
+    def get_tool_to_toolset_map(
+        self, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Dict[str, str]:
         """Return ``{tool_name: toolset_name}`` for every registered tool."""
-        return {entry.name: entry.toolset for entry in self._snapshot_entries()}
+        return {
+            entry.name: entry.toolset
+            for entry in self._snapshot_entries(profile_home)
+        }
 
-    def is_toolset_available(self, toolset: str) -> bool:
+    def is_toolset_available(
+        self, toolset: str, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> bool:
         """Check if a toolset has at least one exposable tool.
 
         Returns False (rather than crashing) when a per-tool check raises
         an unexpected exception (e.g. network error, missing import, bad config).
         """
-        entries, _ = self._snapshot_state()
+        if profile_home is _PROFILE_HOME_UNSET:
+            entries, _ = self._snapshot_state()
+        else:
+            entries, _ = self._snapshot_state(profile_home)
         return self._toolset_has_exposable_tools(toolset, entries)
 
-    def check_toolset_requirements(self) -> Dict[str, bool]:
+    def check_toolset_requirements(
+        self, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
-        entries, _ = self._snapshot_state()
+        if profile_home is _PROFILE_HOME_UNSET:
+            entries, _ = self._snapshot_state()
+        else:
+            entries, _ = self._snapshot_state(profile_home)
         toolsets = sorted({entry.toolset for entry in entries})
         return {
             toolset: self._toolset_has_exposable_tools(toolset, entries)
             for toolset in toolsets
         }
 
-    def get_available_toolsets(self) -> Dict[str, dict]:
+    def get_available_toolsets(
+        self, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Dict[str, dict]:
         """Return toolset metadata for UI display."""
         toolsets: Dict[str, dict] = {}
-        entries, _ = self._snapshot_state()
+        if profile_home is _PROFILE_HOME_UNSET:
+            entries, _ = self._snapshot_state()
+        else:
+            entries, _ = self._snapshot_state(profile_home)
         for entry in entries:
             ts = entry.toolset
             if ts not in toolsets:
@@ -885,10 +1165,15 @@ class ToolRegistry:
                         toolsets[ts]["requirements"].append(env)
         return toolsets
 
-    def get_toolset_requirements(self) -> Dict[str, dict]:
+    def get_toolset_requirements(
+        self, *, profile_home=_PROFILE_HOME_UNSET
+    ) -> Dict[str, dict]:
         """Build a TOOLSET_REQUIREMENTS-compatible dict for backward compat."""
         result: Dict[str, dict] = {}
-        entries, toolset_checks = self._snapshot_state()
+        if profile_home is _PROFILE_HOME_UNSET:
+            entries, toolset_checks = self._snapshot_state()
+        else:
+            entries, toolset_checks = self._snapshot_state(profile_home)
         for entry in entries:
             ts = entry.toolset
             if ts not in result:
@@ -906,11 +1191,16 @@ class ToolRegistry:
                     result[ts]["env_vars"].append(env)
         return result
 
-    def check_tool_availability(self, quiet: bool = False):
+    def check_tool_availability(
+        self, quiet: bool = False, *, profile_home=_PROFILE_HOME_UNSET
+    ):
         """Return (available_toolsets, unavailable_info) like the old function."""
         available = []
         unavailable = []
-        entries, _ = self._snapshot_state()
+        if profile_home is _PROFILE_HOME_UNSET:
+            entries, _ = self._snapshot_state()
+        else:
+            entries, _ = self._snapshot_state(profile_home)
         for ts in sorted({entry.toolset for entry in entries}):
             ts_entries = [entry for entry in entries if entry.toolset == ts]
             if self._toolset_has_exposable_tools(ts, entries):


### PR DESCRIPTION
## What does this PR do?

Hermes' MCP runtime and central tool registry were process-global by server/tool name. In a multiplex process, two profiles configuring the same MCP server name could overwrite or observe each other's status, schema, handler, lazy state, and reconnect bookkeeping.

This PR makes canonical `(profile_home, server_name)` the runtime owner and scopes MCP registry entries by canonical profile home.

## Changes made

- Key connected, connecting, failed, retry, circuit-breaker, parallel-safety, and lazy MCP state by `(profile_home, server_name)`.
- Scope MCP registry schemas, handlers, toolset checks, aliases, lookups, dispatch, and teardown by canonical profile home.
- Capture the owner in eager, lazy-cache, first-use connect, reconnect, and dynamic refresh paths.
- Keep built-in/plugin registry entries process-global.
- Fail closed for unscoped multiplex status, discovery, registry, reconnect, and provenance queries.
- Preserve explicit owner provenance in every MCP status row and registry entry.
- Add a two-profile duplicate-name regression proving A → B → A status, schema, and dispatch isolation.

This is the Agent-side contract consumed by [Hermes WebUI #6114](https://github.com/nesquena/hermes-webui/pull/6114) at WebUI head `c93c50874f57d5f13fa93ff34494d2dfe4021338`.

## Related issue

- Cross-repository blocker: https://github.com/nesquena/hermes-webui/pull/6114#issuecomment-5214343016

## Type of change

- [x] Bug fix
- [x] Tests

## Verification

Fail-before: the new profile-scoped registry regressions initially reported 4 failures because the API did not accept an owner dimension and an unscoped lookup could select another profile's entry.

Head verification:

```bash
./scripts/run_tests.sh tests/tools/test_registry.py
# 34 passed

./scripts/run_tests.sh tests/tools/test_mcp_tool.py
# 96 passed

./scripts/run_tests.sh tests/tools/test_mcp_*.py tests/tools/test_refresh_agent_mcp_tools.py tests/tools/test_registry.py
# 50 files, 471 passed, 0 failed

./.venv/bin/ruff check tools/registry.py tools/mcp_tool.py tests/tools/test_registry.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_mcp_lazy_start.py
# All checks passed

python3 -m py_compile tools/registry.py tools/mcp_tool.py tests/tools/test_registry.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_mcp_lazy_start.py
git diff --check upstream/main...HEAD
# both exit 0
```

Cross-repository consumer verification:

```bash
HERMES_WEBUI_AGENT_DIR=/path/to/this/worktree ./scripts/test.sh tests/test_issue5619_profile_config_isolation.py tests/test_issue697_mcp_tool_inventory.py
# 47 passed
```

The repository-wide test command was also attempted locally. Its non-green nodes are outside the changed MCP/registry files and include missing optional `acp` / `anthropic` SDKs; no green full-suite claim is made.

## Scope

No config keys, dependencies, visual surfaces, deployment behavior, or WebUI code are changed here. Built-in and plugin tool behavior remains global.