### PR TITLE
fix(gateway): raise launchd RLIMIT_NOFILE to 10240 via SoftResourceLimits

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4173,6 +4173,24 @@ def generate_launchd_plist() -> str:
     <key>ThrottleInterval</key>
     <integer>30</integer>
 
+    <!-- macOS launchd defaults RLIMIT_NOFILE to 256, which is too low for a
+         long-running gateway: a burst of outbound connections (agent runs,
+         platform polling, model streaming) can exhaust the descriptor limit
+         in minutes, after which every open() in the process raises
+         OSError: [Errno 24] Too many open files and the gateway wedges
+         (existing #37011 / #14210 issue class). Raise the soft+hard limit
+         to 10240 so the keepalive HTTP pools have ample headroom. -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>10240</integer>
+    </dict>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>10240</integer>
+    </dict>
+
     <key>ExitTimeOut</key>
     <integer>25</integer>
 


### PR DESCRIPTION
## Problem

On macOS, `launchd` defaults `RLIMIT_NOFILE` to **256**. A long-running Hermes gateway can exhaust that in minutes during a burst of outbound connections (agent runs, platform polling, model streaming). Once exhausted, every `open()` in the process raises `OSError: [Errno 24] Too many open files` and the gateway wedges — this is the issue class behind #37011 and #14210.

## Fix

The generated launchd plist (`generate_launchd_plist`) now sets:

```xml
<key>SoftResourceLimits</key>
<dict>
    <key>NumberOfFiles</key>
    <integer>10240</integer>
</dict>
<key>HardResourceLimits</key>
<dict>
    <key>NumberOfFiles</key>
    <integer>10240</integer>
</dict>
```

`10240` gives the keepalive HTTP pools (configured with `max_connections=100` per pool) ample headroom — 40x the previous ceiling.

## Why the generated template (not just the installed plist)

`launchd_plist_is_current()` compares the installed plist against `generate_launchd_plist()`. If the template doesn't include the resource limits, `hermes update`'s `refresh_launchd_plist_if_needed()` would overwrite any manual edit and silently drop the fix. Putting it in the generator makes it durable across updates.

## Notes

- macOS launchd uses `SoftResourceLimits`/`HardResourceLimits` (not Linux systemd's `LimitNOFILE` key).
- Value chosen conservatively: `kern.maxfilesperproc` on default macOS is 138240, so 10240 is well within system limits.
