### PR TITLE
fix(cli): keep the --replace restart watcher in the replacement's waitpid chain

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -864,7 +864,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         if sys.platform == "win32":
             try:
                 _popen_kwargs["creationflags"] = windows_detach_flags()
-                subprocess.Popen(cmd, **_popen_kwargs)
+                _replacement = subprocess.Popen(cmd, **_popen_kwargs)
             except OSError:
                 # CREATE_BREAKAWAY_FROM_JOB can be rejected with
                 # ERROR_ACCESS_DENIED when the parent's job object refuses
@@ -872,10 +872,26 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
                 # alone are enough in most setups. Mirrors the canonical
                 # fallback in gateway_windows._spawn_detached.
                 _popen_kwargs["creationflags"] = windows_detach_flags_without_breakaway()
-                subprocess.Popen(cmd, **_popen_kwargs)
+                _replacement = subprocess.Popen(cmd, **_popen_kwargs)
         else:
             _popen_kwargs["start_new_session"] = True
-            subprocess.Popen(cmd, **_popen_kwargs)
+            _replacement = subprocess.Popen(cmd, **_popen_kwargs)
+
+        # Stay alive as the replacement's parent for its whole lifetime.
+        #
+        # Without this the watcher returns from Popen and exits immediately,
+        # so the gateway it just started loses its parent and is reparented
+        # to PID 1.  On a systemd-supervised host that orphan sits OUTSIDE
+        # the unit's cgroup: systemd never tracks it, never stops it, and
+        # never reaps it, so it races the supervised gateway for the
+        # duplicate-instance guard and keeps holding platform sessions (in
+        # #73480, Telegram's getUpdates long poll) open indefinitely.
+        #
+        # Blocking in wait() keeps the replacement inside a live waitpid
+        # chain: it always has a real parent, its exit status is collected
+        # rather than left as a zombie, and the whole restart chain
+        # terminates with the gateway instead of outliving it.
+        _replacement.wait()
         """
     ).strip().format(
         respawn_cwd_literal=respawn_cwd_literal,

--- a/tests/hermes_cli/test_gateway_restart_watcher_reap.py
+++ b/tests/hermes_cli/test_gateway_restart_watcher_reap.py
@@ -1,0 +1,167 @@
+"""Reap semantics of the ``--replace`` detached restart watcher (#73480).
+
+``hermes_cli.gateway._spawn_gateway_restart_watcher`` builds a tiny Python
+watcher *as a source string* and launches it detached.  The watcher polls the
+outgoing gateway's PID and then respawns the gateway.
+
+The bug: the respawn used to be a bare ``subprocess.Popen(cmd, ...)`` whose
+handle was dropped, after which the watcher script simply ran off the end and
+exited.  The replacement gateway therefore lost its parent the instant it
+started and was reparented to PID 1.  On a systemd-supervised host that orphan
+lives *outside* the unit's cgroup: systemd never tracks it, never stops it and
+never reaps it, so it races the supervised gateway for the duplicate-instance
+guard and keeps platform sessions (Telegram's ``getUpdates`` long poll, in the
+filed incident) open indefinitely.
+
+Because the watcher is only a string, it can be exercised end-to-end in-process
+against a short-lived stub child — no gateway, no systemd, no privileges.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import hermes_cli.gateway as gateway
+
+# Stand-in for the respawned gateway.  Announces itself, blocks until the test
+# releases it, then records who its parent is at exit time.
+REPLACEMENT_SOURCE = """
+import os
+import pathlib
+import sys
+import time
+
+started = pathlib.Path(sys.argv[1])
+release = pathlib.Path(sys.argv[2])
+parent_record = pathlib.Path(sys.argv[3])
+
+started.write_text(str(os.getpid()), encoding="utf-8")
+deadline = time.monotonic() + 60
+while time.monotonic() < deadline and not release.exists():
+    time.sleep(0.02)
+parent_record.write_text(str(os.getppid()), encoding="utf-8")
+"""
+
+
+def _generated_watcher_source(old_pid: int, run_argv: list) -> str:
+    """Return the watcher source ``_spawn_gateway_restart_watcher`` builds.
+
+    The real function is called (so the source under test is the real one,
+    including its ``.format()`` escaping); only the detached launch is
+    intercepted, so the test can run the watcher itself under its own control.
+    """
+    captured = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        return mock.MagicMock()
+
+    with mock.patch.object(gateway.subprocess, "Popen", _fake_popen):
+        assert gateway._spawn_gateway_restart_watcher(old_pid, list(run_argv)) is True
+
+    watcher_argv = captured["argv"]
+    # [sys.executable, "-c", <watcher source>, str(old_pid), *run_argv]
+    assert watcher_argv[1] == "-c"
+    assert watcher_argv[3] == str(old_pid)
+    assert watcher_argv[4:] == list(run_argv)
+    return watcher_argv[2]
+
+
+def _reaped_pid() -> int:
+    """A PID that has already exited *and been reaped*, so it no longer exists.
+
+    The watcher's poll loop must fall through immediately rather than burn its
+    120s deadline.
+    """
+    finished = subprocess.Popen([sys.executable, "-c", ""])
+    finished.wait()
+    return finished.pid
+
+
+def _wait_for(path: Path, message: str, timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.02)
+    raise AssertionError(message)
+
+
+class TestRestartWatcherReapsReplacement:
+    """The generated watcher must stay in the replacement's ``waitpid`` chain."""
+
+    def test_generated_watcher_source_is_valid_python(self):
+        """The watcher body is interpolated through ``str.format()``.
+
+        Every literal brace in it has to be doubled; a single missed ``{``
+        yields either a ``KeyError`` at build time or syntactically broken
+        source that only fails once a user's gateway tries to restart.
+        """
+        source = _generated_watcher_source(
+            _reaped_pid(), [sys.executable, "-c", "pass"]
+        )
+        compile(source, "<restart-watcher>", "exec")
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="asserts POSIX waitpid-chain/reparenting semantics",
+    )
+    def test_watcher_waits_for_and_reaps_a_short_lived_replacement(self, tmp_path):
+        """Regression guard for #73480.
+
+        Before the fix the watcher dropped the ``Popen`` handle and exited as
+        soon as the replacement was spawned, so the replacement was orphaned to
+        PID 1.  The watcher must instead remain the replacement's parent for
+        its whole lifetime and collect its exit status.
+        """
+        started = tmp_path / "replacement-started"
+        release = tmp_path / "replacement-release"
+        parent_record = tmp_path / "replacement-parent"
+
+        run_argv = [
+            sys.executable,
+            "-c",
+            REPLACEMENT_SOURCE,
+            str(started),
+            str(release),
+            str(parent_record),
+        ]
+        old_pid = _reaped_pid()
+        source = _generated_watcher_source(old_pid, run_argv)
+
+        watcher = subprocess.Popen(
+            [sys.executable, "-c", source, str(old_pid), *run_argv],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for(started, "the watcher never spawned the replacement")
+
+            # The replacement is alive; the watcher must not have exited.
+            with pytest.raises(subprocess.TimeoutExpired):
+                watcher.wait(timeout=5)
+
+            release.write_text("go", encoding="utf-8")
+
+            # wait() returning is exactly "the child was reaped by this
+            # process" — the watcher only gets here once it has collected the
+            # replacement's exit status.
+            assert watcher.wait(timeout=30) == 0
+        finally:
+            if not release.exists():
+                release.write_text("go", encoding="utf-8")
+            if watcher.poll() is None:
+                watcher.kill()
+                watcher.wait(timeout=30)
+
+        replacement_pid = int(started.read_text(encoding="utf-8").strip())
+        assert replacement_pid > 0
+        assert replacement_pid != watcher.pid
+
+        # The parent the replacement saw at exit is the watcher itself, not
+        # PID 1 — i.e. it never left the waitpid chain.
+        assert parent_record.read_text(encoding="utf-8").strip() == str(watcher.pid)

--- a/tests/hermes_cli/test_gateway_restart_watcher_reap.py
+++ b/tests/hermes_cli/test_gateway_restart_watcher_reap.py
@@ -82,7 +82,14 @@ def _reaped_pid() -> int:
     return finished.pid
 
 
-def _wait_for(path: Path, message: str, timeout: float = 60.0) -> None:
+def _wait_for(path: Path, message: str, timeout: float = 20.0) -> None:
+    """Block until ``path`` appears.
+
+    The watcher breaks out of its poll loop as soon as it sees the (already
+    reaped) old PID is gone, so the replacement appears in well under a
+    second; 20s is a large margin for a loaded runner while still surfacing a
+    genuine regression quickly.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if path.exists():

--- a/tests/hermes_cli/test_gateway_restart_watcher_reap.py
+++ b/tests/hermes_cli/test_gateway_restart_watcher_reap.py
@@ -47,7 +47,7 @@ parent_record.write_text(str(os.getppid()), encoding="utf-8")
 """
 
 
-def _generated_watcher_source(old_pid: int, run_argv: list) -> str:
+def _generated_watcher_source(old_pid: int, run_argv: list[str]) -> str:
     """Return the watcher source ``_spawn_gateway_restart_watcher`` builds.
 
     The real function is called (so the source under test is the real one,


### PR DESCRIPTION
## What does this PR do?

Fixes the `--replace` detached restart watcher leaking an unreapable `ppid=1`
gateway on every restart.

`_spawn_gateway_restart_watcher` (`hermes_cli/gateway.py:762`) builds a tiny
Python watcher **as a source string** and launches it detached. The watcher
polls the outgoing gateway's PID, then respawns the gateway. The respawn was a
bare `subprocess.Popen(cmd, **_popen_kwargs)` whose handle was dropped, after
which the watcher script simply ran off the end and exited.

So the replacement gateway lost its parent the instant it started and was
reparented to PID 1. On a systemd-supervised host that orphan lives **outside**
the unit's cgroup: systemd never tracks it, never stops it and never reaps it.
It then races the supervised gateway for the duplicate-instance guard and keeps
platform sessions open.

In #73480 that orphan held Telegram's `getUpdates` long poll open, so the live
gateway exhausted its 5-retry polling-conflict recovery and hit the
deliberately-fatal `RestartPreventExitStatus=78`. systemd correctly refused to
auto-restart — but the leaked watcher chain kept respawning a fresh orphan, so
the alert's own suggested remedy (`systemctl --user reload-or-restart`) would
have raced the same orphan and failed identically. The reporter observed 5
discrete orphan-kill cycles over ~55 minutes.

Blast radius is wider than a hand-typed `--replace`: `hermes update`'s
restart-all-profiles pass goes through this same watcher, so an ordinary user
hits it just by updating.

**The fix:** retain the `Popen` handle in all three respawn branches and
`wait()` on it. The watcher stays the replacement's parent for its whole
lifetime, so the replacement never leaves a live `waitpid` chain, its exit
status is collected rather than left as a zombie, and the restart chain
terminates with the gateway instead of outliving it.

### Supersedes #73718

@webtecnica diagnosed this bug and opened #73718 — the root-cause analysis
there and in #73480 is theirs. That PR was reviewed on 2026-07-30 with two
stated problems:

1. **Unrelated changes beyond the restart watcher** — an in-tree Hetzner
   provider (flagged as conflicting with the standalone-plugin policy), an
   AgentKey manifest, Himalaya skill docs, an `agent/tool_executor.py` change
   and a stray `.bytecode-fingerprint` file.
2. **"The watcher change has no regression test."**

The suggested change was to keep the watcher fix as a focused, salvageable
change and to *"test that the generated watcher waits for and reaps a
short-lived replacement process."* #73718 has had no commits since
2026-07-29T00:25Z — before that review — and no force-pushes.

This PR is exactly that requested split-out: watcher-only, plus the named
regression test.

| Review request | Status here |
| --- | --- |
| Keep only the focused watcher change | ✅ 1 production file, 1 hunk, +19/−3 |
| Drop the Hetzner provider / AgentKey / Himalaya / tool_executor changes | ✅ none carried over |
| Test that the generated watcher waits for and reaps a short-lived replacement | ✅ `test_watcher_waits_for_and_reaps_a_short_lived_replacement` |

## Related Issue

Fixes #73480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — in the watcher source generated by
  `_spawn_gateway_restart_watcher`, bind the respawn's `Popen` handle to
  `_replacement` in **all three** branches and `_replacement.wait()` on it:
  - win32 with `CREATE_BREAKAWAY_FROM_JOB`
  - win32 no-breakaway `OSError` fallback
  - POSIX `start_new_session=True`

  All three previously dropped the handle, so all three are covered — the
  `wait()` sits after the branch so it applies once, whichever path ran.
- `tests/hermes_cli/test_gateway_restart_watcher_reap.py` — new. Because the
  watcher is only a string, it can be exercised end-to-end in-process against a
  short-lived stub child: no gateway, no systemd, no privileges, no sleeps as
  assertions.
  - `test_watcher_waits_for_and_reaps_a_short_lived_replacement` — the test the
    review asked for.
  - `test_generated_watcher_source_is_valid_python` — the watcher body is
    interpolated through `str.format()`, so every literal brace must be
    doubled; a single missed `{` would otherwise only surface when a real
    user's gateway tries to restart.

### Scope notes

- **Sibling sweep.** `textwrap.dedent`-generated watcher sources under
  `hermes_cli/` return exactly one site — `hermes_cli/gateway.py:821`, the one
  fixed here. `gateway/run.py` hosts a *separate* `/restart` watcher built by a
  different mechanism (in-process asyncio tasks plus its own restart path); it
  does not share this generated-source root cause and is deliberately left
  alone.
- **Not touched:** `_reap_unsupervised_gateway_orphans`. Its
  `if supports_systemd_services(): return False` short-circuit is deliberate —
  removing it would let the sweep SIGTERM live management processes on systemd
  hosts.
- Issue #73480 also suggests gating the detached-watcher path against
  service-managed profiles. That is **not** attempted here: `_is_service_installed()`
  takes no `profile` argument and resolves through
  `get_systemd_unit_path()` / `get_launchd_plist_path()`, which are scoped to
  the *current process's* `HERMES_HOME` rather than the profile being
  restarted, so gating on it naively reads the wrong profile. Threading a
  profile through would widen a hot API and re-create exactly the
  unrelated-scope problem this PR exists to avoid. The reap leg is
  self-contained and fixes the leak on its own.

## How to Test

Regression guard, verified in both directions:

```bash
# Green with the fix
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_gateway_restart_watcher_reap.py -v
# 2 passed

# Revert only the production hunk, keep the test:
git checkout origin/main -- hermes_cli/gateway.py
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_gateway_restart_watcher_reap.py -v
# FAILED test_watcher_waits_for_and_reaps_a_short_lived_replacement
#   Failed: DID NOT RAISE TimeoutExpired
```

The failure message is the bug stated precisely: with the handle dropped, the
watcher has already exited while the replacement is still running.

The test asserts three things, none of them timing-based:

1. Once the stub replacement signals that it started, `watcher.wait(timeout=5)`
   must raise `TimeoutExpired` — the watcher has **not** exited. (Before the
   fix it has already exited, so nothing is raised.)
2. After the test releases the replacement, the watcher exits `0`. `wait()`
   returning *is* "this process reaped the child".
3. The replacement records `os.getppid()` at exit; it must equal the watcher's
   PID, i.e. it never left the `waitpid` chain and was never reparented to
   PID 1.

Also run, all green (251 passed), including the static text-scan guards over
the exact heredoc block this PR edits:

```
tests/tools/test_windows_native_support.py      # incl. test_watcher_threads_hidden_console_spec_into_respawn
tests/hermes_cli/test_gateway_restart_loop.py
tests/hermes_cli/test_gateway_service.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the focused and adjacent suites listed under "How to Test" (251 passed), not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavioural fix inside a generated watcher; the rationale is documented inline at the change site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — all three respawn branches are fixed, including both Windows detach paths. The behavioural test asserts POSIX `waitpid`/reparenting semantics and is `skipif`-guarded on `win32`, matching the existing static-only approach for the Windows detach flags in `tests/tools/test_windows_native_support.py`. The source-validity test runs everywhere.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

Dedup was run on two independent nets immediately before opening, and again
right before pushing:

- **By changed file** (`gh pr list --json files`, newest 300 open PRs): the only
  other open PRs touching `hermes_cli/gateway.py` are #80748 (launchd
  `RLIMIT_NOFILE`) and #80528 (systemd/launchd write atomicity) — both
  hunk-disjoint from the watcher. #78873 also touches the file, at
  `generate_launchd_plist` (~`:4096`), and #69956 at `_gateway_command_inner`
  (~`:7044`); both are far from the heredoc at `:821-882`.
- **By text** (`gh search prs`, corpus-wide) on `_spawn_gateway_restart_watcher`,
  `unreapable`, `73480`, `ppid=1`, `restart watcher`, `waitpid`: **#73718 is the
  only PR naming this bug**, and it is the one this supersedes.
- The nearby restart-watcher PRs — #42338, #16621, #29619 — all target
  `gateway/run.py`'s separate `/restart` watcher and are file-disjoint from
  this change. #77721 targets `hermes_cli/web_server.py`.
