### PR TITLE
fix(tools): stop browser_cdp frame_id path from leaking secrets in OOPIF CDP results

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -188,13 +188,14 @@ def test_websockets_missing_returns_error(monkeypatch):
 
 def test_browser_level_redacts_secret_result(cdp_server):
     fake_secret = "sk-" + "CDPSECRETRESULT1234567890"
+    colliding_secret = "sk-" + "CDPCOLLIDINGRESULT1234567890"
     cdp_server.on(
         "Runtime.evaluate",
         lambda params, sid: {
             "result": {
                 "type": "string",
                 "value": fake_secret,
-                "nested": {fake_secret: "safe"},
+                "nested": {fake_secret: "first", colliding_secret: "second"},
             }
         },
     )
@@ -204,9 +205,12 @@ def test_browser_level_redacts_secret_result(cdp_server):
     assert result["success"] is True
     serialized = json.dumps(result)
     assert "CDPSECRETRESULT" not in serialized
+    assert "CDPCOLLIDINGRESULT" not in serialized
     assert result["result"]["result"]["value"].startswith("sk-")
-    redacted_key = next(iter(result["result"]["result"]["nested"]))
-    assert redacted_key.startswith("sk-")
+    redacted_keys = result["result"]["result"]["nested"]
+    assert len(redacted_keys) == 2
+    assert all(key.startswith("sk-") for key in redacted_keys)
+    assert set(redacted_keys.values()) == {"first", "second"}
 
 
 def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
@@ -219,6 +223,7 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
     import tools.browser_supervisor as browser_supervisor
 
     fake_secret = "sk-" + "CDPSECRETFRAMERESULT1234567890"
+    colliding_secret = "sk-" + "CDPCOLLIDINGFRAMERESULT1234567890"
     frame_id = "oopif-frame-1"
     child_sid = "child-session-1"
 
@@ -247,7 +252,10 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
                     "result": {
                         "type": "string",
                         "value": fake_secret,
-                        "nested": {fake_secret: "safe"},
+                        "nested": {
+                            fake_secret: "first",
+                            colliding_secret: "second",
+                        },
                     }
                 }
             }
@@ -273,9 +281,12 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
     assert result["session_id"] == child_sid
     serialized = json.dumps(result)
     assert "CDPSECRETFRAMERESULT" not in serialized
+    assert "CDPCOLLIDINGFRAMERESULT" not in serialized
     assert result["result"]["result"]["value"].startswith("sk-")
-    redacted_key = next(iter(result["result"]["result"]["nested"]))
-    assert redacted_key.startswith("sk-")
+    redacted_keys = result["result"]["result"]["nested"]
+    assert len(redacted_keys) == 2
+    assert all(key.startswith("sk-") for key in redacted_keys)
+    assert set(redacted_keys.values()) == {"first", "second"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -187,10 +187,16 @@ def test_websockets_missing_returns_error(monkeypatch):
 
 
 def test_browser_level_redacts_secret_result(cdp_server):
-    fake_key = "sk-" + "CDPSECRETRESULT1234567890"
+    fake_secret = "sk-" + "CDPSECRETRESULT1234567890"
     cdp_server.on(
         "Runtime.evaluate",
-        lambda params, sid: {"result": {"type": "string", "value": fake_key}},
+        lambda params, sid: {
+            "result": {
+                "type": "string",
+                "value": fake_secret,
+                "nested": {fake_secret: "safe"},
+            }
+        },
     )
 
     result = json.loads(browser_cdp_tool.browser_cdp(method="Runtime.evaluate"))
@@ -199,6 +205,8 @@ def test_browser_level_redacts_secret_result(cdp_server):
     serialized = json.dumps(result)
     assert "CDPSECRETRESULT" not in serialized
     assert result["result"]["result"]["value"].startswith("sk-")
+    redacted_key = next(iter(result["result"]["result"]["nested"]))
+    assert redacted_key.startswith("sk-")
 
 
 def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
@@ -210,7 +218,7 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
 
     import tools.browser_supervisor as browser_supervisor
 
-    fake_key = "sk-" + "CDPSECRETFRAMERESULT1234567890"
+    fake_secret = "sk-" + "CDPSECRETFRAMERESULT1234567890"
     frame_id = "oopif-frame-1"
     child_sid = "child-session-1"
 
@@ -234,7 +242,15 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
         coro.close()
         fut = concurrent.futures.Future()
         fut.set_result(
-            {"result": {"result": {"type": "string", "value": fake_key}}}
+            {
+                "result": {
+                    "result": {
+                        "type": "string",
+                        "value": fake_secret,
+                        "nested": {fake_secret: "safe"},
+                    }
+                }
+            }
         )
         return fut
 
@@ -258,6 +274,8 @@ def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
     serialized = json.dumps(result)
     assert "CDPSECRETFRAMERESULT" not in serialized
     assert result["result"]["result"]["value"].startswith("sk-")
+    redacted_key = next(iter(result["result"]["result"]["nested"]))
+    assert redacted_key.startswith("sk-")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -201,6 +201,65 @@ def test_browser_level_redacts_secret_result(cdp_server):
     assert result["result"]["result"]["value"].startswith("sk-")
 
 
+def test_frame_id_supervisor_path_redacts_secret_result(monkeypatch):
+    """frame_id / supervisor success path must redact like the stateless path."""
+    import concurrent.futures
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    import tools.browser_supervisor as browser_supervisor
+
+    fake_key = "sk-" + "CDPSECRETFRAMERESULT1234567890"
+    frame_id = "oopif-frame-1"
+    child_sid = "child-session-1"
+
+    snap = SimpleNamespace(
+        frame_tree={
+            "top": {"frame_id": "top-frame"},
+            "children": [{"frame_id": frame_id, "session_id": child_sid}],
+        }
+    )
+    supervisor = SimpleNamespace(
+        snapshot=lambda: snap,
+        _state_lock=threading.Lock(),
+        _frames={},
+        _loop=SimpleNamespace(is_running=lambda: True),
+    )
+    registry = MagicMock()
+    registry.get.return_value = supervisor
+    monkeypatch.setattr(browser_supervisor, "SUPERVISOR_REGISTRY", registry)
+
+    def fake_schedule(coro, loop):
+        coro.close()
+        fut = concurrent.futures.Future()
+        fut.set_result(
+            {"result": {"result": {"type": "string", "value": fake_key}}}
+        )
+        return fut
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool._browser_cdp_via_supervisor(
+            task_id="task-1",
+            frame_id=frame_id,
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            timeout=5.0,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["frame_id"] == frame_id
+    assert result["session_id"] == child_sid
+    serialized = json.dumps(result)
+    assert "CDPSECRETFRAMERESULT" not in serialized
+    assert result["result"]["result"]["value"].startswith("sk-")
+
+
 # ---------------------------------------------------------------------------
 # Happy-path: target-attached call
 # ---------------------------------------------------------------------------

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -53,7 +53,14 @@ def _redact_cdp_output(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(_redact_cdp_output(item) for item in value)
     if isinstance(value, dict):
-        return {key: _redact_cdp_output(item) for key, item in value.items()}
+        return {
+            (
+                redact_sensitive_text(key, force=True)
+                if isinstance(key, str)
+                else key
+            ): _redact_cdp_output(item)
+            for key, item in value.items()
+        }
     return value
 
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -53,14 +53,20 @@ def _redact_cdp_output(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(_redact_cdp_output(item) for item in value)
     if isinstance(value, dict):
-        return {
-            (
+        redacted = {}
+        for key, item in value.items():
+            redacted_key = (
                 redact_sensitive_text(key, force=True)
                 if isinstance(key, str)
                 else key
-            ): _redact_cdp_output(item)
-            for key, item in value.items()
-        }
+            )
+            unique_key = redacted_key
+            duplicate = 2
+            while unique_key in redacted:
+                unique_key = f"{redacted_key} [duplicate {duplicate}]"
+                duplicate += 1
+            redacted[unique_key] = _redact_cdp_output(item)
+        return redacted
     return value
 
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -386,7 +386,9 @@ def _browser_cdp_via_supervisor(
         "method": method,
         "frame_id": frame_id,
         "session_id": child_sid,
-        "result": result_msg.get("result", {}),
+        # Same redaction as the stateless/target_id path — frame_id routing
+        # must not leak secrets that sibling path would scrub.
+        "result": _redact_cdp_output(result_msg.get("result", {})),
     }
     return json.dumps(payload, ensure_ascii=False)
 


### PR DESCRIPTION
## What does this PR do?

`browser_cdp(..., frame_id=...)` returned raw CDP results from out-of-process iframes, so secret-shaped strings (API keys, tokens) from iframe content could enter the model transcript even though the same call without `frame_id` already scrubbed them. This aligns the supervisor-routed success path with the existing `_redact_cdp_output` contract.

### Symptom

A `browser_cdp` call that targets a cross-origin iframe via `frame_id` can return secret-shaped page content verbatim in the tool JSON result.

### Impact

Secrets from OOPIF content can leak into model context, logs, and trajectories on the `frame_id` path only. Blast radius beyond this path asymmetry was not measured.

### Bug Cause

`_browser_cdp_via_supervisor` assigned `result_msg.get("result", {})` directly into the success payload. The sibling stateless/target_id path already wrapped the result with `_redact_cdp_output`.

### Fix

Apply `_redact_cdp_output` on the supervisor success `result`, and add a regression test that asserts the secret marker is scrubbed while the redacted `sk-` prefix shape is preserved (same contract as the existing browser-level redact test).

## Related Issue

Fixes #80755

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- `tools/browser_cdp_tool.py` - redact supervisor/frame_id CDP success results via `_redact_cdp_output`
- `tests/tools/test_browser_cdp_tool.py` - regression coverage for the frame_id supervisor success path

## How to Test

1. Manual: attach CDP to a page with an OOPIF whose body text includes a secret-shaped string, call `browser_cdp(method='Runtime.evaluate', params={'expression': 'document.body.innerText'}, frame_id='...')`, and confirm the secret marker is absent from the tool result.
2. Automated (already run locally, 13 passed):

```bash
scripts/run_tests.sh tests/tools/test_browser_cdp_tool.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A (redaction helper is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A (behavior matches documented redact contract on the sibling path)
