### PR TITLE
feat(plugin): hashline-guard — content-addressed patch anchors (anchored_patch + hashline_compute)

### DIFF
--- a/plugins/hashline-guard/README.md
+++ b/plugins/hashline-guard/README.md
@@ -1,0 +1,97 @@
+# hashline-guard
+
+Strict-match and content-addressed patch anchors for the `patch` tool. Blocks
+stale or ambiguous `old_string` anchors before the patch is applied, preventing
+silent drift when a file has changed under the agent, and provides an
+`anchored_patch` tool that pins edits to a SHA-256 hashline of the anchor plus
+its surrounding context.
+
+## What it does
+
+Registers a `pre_tool_call` hook. When a `patch` call with `mode=replace`
+targets a file, it verifies the `old_string` anchor is present **exactly once**
+in the live file:
+
+- **Exactly once** -> allow the patch.
+- **Zero times** -> block: `old_string not found in live file — anchor drifted`.
+- **Two or more** -> block: `old_string is ambiguous: found N times in live file`.
+- **Empty old_string** -> block: `old_string must be non-empty`.
+- **Missing file** -> block: `file not found: <path>`.
+
+Blocked calls return `{'action': 'block', 'message': ...}` so the agent re-reads
+the file and re-issues the patch against the current content.
+
+The plugin also registers two tools:
+
+- `anchored_patch` — apply a `mode=replace` patch pinned by `verify_anchor_by_hash`.
+  The expected hashline selects the exact occurrence even when `old_string`
+  appears multiple times. Read -> verify -> apply -> write is a single atomic
+  handler operation.
+- `hashline_compute` — return the current hashline for every occurrence of an
+  `old_string` (with line numbers and context snippets) so the agent can
+  discover the value to pin.
+
+## Trigger conditions
+
+- Tool: `patch`
+- Mode: `replace`
+- Requires both `path` and `old_string` in `function_args`
+
+V4A multi-file patches (`mode=apply` / traversal patches) are skipped — those
+have their own traversal checks. Non-patch tools are always skipped.
+
+## Canonicalization policy
+
+- Newline normalization: `CRLF`/`LFCR`/`CR` -> `LF` before matching/hashing.
+- Trailing whitespace: kept byte-exact on each line.
+- Versioned payload: `hashline:v1:<index>:<windowed_text>` so future format
+  changes don't collide with prior hashline values.
+- Window size is part of the computed hash shape; changing `window` changes the
+  hash.
+
+## Fail-open policy
+
+Any unexpected error (IO error, permission, encoding) is logged at debug level
+and the patch proceeds — the hook never blocks on infrastructure problems.
+The only hard blocks are the verified anchor conditions above.
+
+## Files
+
+- `src/hashline_core.py` — `verify_anchor()`, `compute_hashline()`,
+  `verify_anchor_by_hash()`, `find_all()`, `context_hash()`
+- `__init__.py` — plugin entry: `register(ctx)` registers the `pre_tool_call`
+  hook plus the `anchored_patch` and `hashline_compute` tools
+- `tests/test_verify_anchor.py` — exact-match guard + hashline pinning + CRLF
+  canonicalization
+- `tests/test_anchored_patch.py` — anchored_patch handler behavior + atomicity
+- `tests/test_e2e_anchored_patch.py` — end-to-end probe (pin -> stale-pin
+  block -> re-pin -> wrong-hash block -> CRLF)
+
+Note: the plugin directory name contains a hyphen, so `__init__.py` loads
+`hashline_core` via `importlib.util.spec_from_file_location` rather than a
+relative import.
+
+## Example
+
+```json
+{
+  "tool": "anchored_patch",
+  "args": {
+    "path": "src/engine/verbs/special.py",
+    "old_string": "sp = sp + 1\n",
+    "new_string": "sp += min(6, max_sp - sp)\n",
+    "expected_hashline": "<computed hashline:v1 SHA-256 hex>",
+    "window": 2
+  }
+}
+```
+
+Discover the pin with `hashline_compute`, then apply with `anchored_patch`.
+If the file drifted, `anchored_patch` returns the found hashlines and line
+numbers so the agent can re-pin in one turn.
+
+## Rollback
+
+```bash
+hermes plugins disable hashline-guard
+```

--- a/plugins/hashline-guard/__init__.py
+++ b/plugins/hashline-guard/__init__.py
@@ -13,6 +13,7 @@ relative import.
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
 import sys
 from pathlib import Path
@@ -50,7 +51,7 @@ SCHEMA = {
 }
 
 
-def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
+def handle_anchored_patch(args: Dict[str, Any]) -> str:
     try:
         path = args["path"]
         old_string = args["old_string"]
@@ -97,14 +98,45 @@ def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
         logger.debug("anchored_patch write error (%s): %s", path, exc)
         return _tool_error(f"anchored_patch: write failed: {path}", code="500", details={"error": str(exc)})
 
-    return {"applied": True, "occurrence": occurrence, "hashline": expected_hashline}
+    return _tool_result({"applied": True, "occurrence": occurrence, "hashline": expected_hashline})
 
 
-def _tool_error(message: str, code: str = "500", details: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    return {
-        "applied": False,
-        "error": {"code": code, "message": message, "details": details or {}},
-    }
+def _tool_result(data=None, **kwargs) -> str:
+    """Return a JSON result string, using Hermes core helper when importable.
+
+    Falls back to plain json.dumps so the plugin's standalone tests (which
+    do not have the hermes-agent core on sys.path) still produce valid JSON
+    strings matching the tool-handler contract.
+    """
+    try:
+        from tools.registry import tool_result
+
+        return tool_result(data, **kwargs)
+    except ImportError:
+        payload = data if data is not None else kwargs
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _tool_error(message: str, code: str = "500", details: Optional[Dict[str, Any]] = None) -> str:
+    """Return a JSON error string (Hermes core helper when available).
+
+    The payload always carries ``applied: False`` so consumers of the
+    anchored_patch envelope can distinguish a blocked/errored call from a
+    successful one regardless of which serialization path was used.
+    """
+    try:
+        from tools.registry import tool_error
+
+        return tool_error(
+            message, applied=False, error_type="hashline_guard",
+            code=code, details=details or {},
+        )
+    except ImportError:
+        payload = {
+            "applied": False,
+            "error": {"code": code, "message": message, "details": details or {}},
+        }
+        return json.dumps(payload, ensure_ascii=False)
 
 
 def _context_snippet(file_text: str, old_string: str, occurrence_index: int, window: int = 2) -> str:
@@ -119,7 +151,7 @@ def _context_snippet(file_text: str, old_string: str, occurrence_index: int, win
     return "\n".join(lines[start:end])
 
 
-def hashline_compute(args: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+def hashline_compute(args: Dict[str, Any], **kwargs: Any) -> str:
     try:
         path = args.get("path")
         old_string = args.get("old_string")
@@ -130,7 +162,7 @@ def hashline_compute(args: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         text = Path(path).read_text(encoding="utf-8", errors="replace")
         matches = find_all(text, old_string)
         if not matches:
-            return {"hashlines": [], "count": 0}
+            return _tool_result({"hashlines": [], "count": 0})
 
         out = []
         for idx in range(len(matches)):
@@ -141,7 +173,7 @@ def hashline_compute(args: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
                 "hashline": hl,
                 "context": _context_snippet(text, old_string, idx, window=window),
             })
-        return {"hashlines": out, "count": len(out)}
+        return _tool_result({"hashlines": out, "count": len(out)})
     except Exception as exc:
         logger.debug("hashline_compute failed: %s", exc)
         return _tool_error(f"hashline_compute failed: {type(exc).__name__}: {exc}", code="500", details={})

--- a/plugins/hashline-guard/__init__.py
+++ b/plugins/hashline-guard/__init__.py
@@ -34,11 +34,19 @@ context_hash = _core_mod.context_hash
 raw_offsets = _core_mod.raw_offsets
 
 SCHEMA = {
-    "path": {"type": "string"},
-    "old_string": {"type": "string"},
-    "new_string": {"type": "string"},
-    "expected_hashline": {"type": "string"},
-    "window": {"type": "integer", "default": 2},
+    "name": "anchored_patch",
+    "description": "Atomically read, verify, and apply a content-addressed patch (strict anchor match + expected_hashline pin).",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Target file path."},
+            "old_string": {"type": "string", "description": "Anchor text to match."},
+            "new_string": {"type": "string", "description": "Replacement text."},
+            "expected_hashline": {"type": "string", "description": "Pinned hashline for the anchor occurrence."},
+            "window": {"type": "integer", "description": "Surrounding context lines.", "default": 2},
+        },
+        "required": ["path", "old_string", "new_string", "expected_hashline"],
+    },
 }
 
 

--- a/plugins/hashline-guard/__init__.py
+++ b/plugins/hashline-guard/__init__.py
@@ -31,6 +31,7 @@ verify_anchor_by_hash = _core_mod.verify_anchor_by_hash
 find_all = _core_mod.find_all
 compute_hashline = _core_mod.compute_hashline
 context_hash = _core_mod.context_hash
+raw_offsets = _core_mod.raw_offsets
 
 SCHEMA = {
     "path": {"type": "string"},
@@ -53,7 +54,10 @@ def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
         return _tool_error(f"anchored_patch: invalid args: {exc}", code="500", details={})
 
     try:
-        text = Path(path).read_text(encoding="utf-8", errors="replace")
+        # newline="" disables universal-newline translation so CRLF/CR endings
+        # survive into the raw splice below; matching/hashing use canonical text.
+        with Path(path).open("r", encoding="utf-8", errors="replace", newline="") as fh:
+            text = fh.read()
     except Exception as exc:
         logger.debug("anchored_patch read error (%s): %s", path, exc)
         return _tool_error(f"anchored_patch: read failed: {path}", code="500", details={"error": str(exc)})
@@ -72,8 +76,10 @@ def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
     if occurrence < 0 or occurrence >= len(matches):
         return _tool_error("anchored_patch: occurrence index out of range", code="500", details={})
 
-    start = matches[occurrence][0]
-    end = matches[occurrence][1]
+    # find_all offsets are canonical (CRLF/CR -> LF). Translate to raw byte
+    # offsets before splicing, or a CRLF file is corrupted at the anchor.
+    cstart, cend = matches[occurrence][0], matches[occurrence][1]
+    start, end = raw_offsets(text, cstart, cend)
     updated = text[:start] + new_string + text[end:]
 
     try:
@@ -174,7 +180,8 @@ def on_pre_tool_call(*args: Any, **kwargs: Any) -> Optional[Dict[str, str]]:
 
     expected_hashline = args.get("expected_hashline")
     if expected_hashline is not None:
-        status, payload = verify_anchor_by_hash(text, old_string, expected_hashline)
+        window = int(args.get("window", 2))
+        status, payload = verify_anchor_by_hash(text, old_string, expected_hashline, window=window)
         if status == "ok":
             return None
         if isinstance(payload, dict) and "found" in payload and payload["found"]:

--- a/plugins/hashline-guard/__init__.py
+++ b/plugins/hashline-guard/__init__.py
@@ -1,0 +1,232 @@
+"""hashline-guard plugin: strict-match pre-check on patch `old_string` anchors,
+plus content-addressed anchored patching via `anchored_patch`.
+
+Registers:
+- pre_tool_call hook that blocks stale/ambiguous patch anchors
+- anchored_patch tool: atomic read -> verify -> apply -> write
+- hashline_compute tool: discover expected hashline values
+
+Note: the plugin directory contains a hyphen and cannot be a valid Python
+package name, so hashline_core is loaded via importlib.util rather than a
+relative import.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_CORE_PATH = Path(__file__).parent / "src" / "hashline_core.py"
+_core_spec = importlib.util.spec_from_file_location("hashline_core", _CORE_PATH)
+_core_mod = importlib.util.module_from_spec(_core_spec)
+sys.modules.setdefault("hashline_core", _core_mod)
+_core_spec.loader.exec_module(_core_mod)
+
+verify_anchor = _core_mod.verify_anchor
+verify_anchor_by_hash = _core_mod.verify_anchor_by_hash
+find_all = _core_mod.find_all
+compute_hashline = _core_mod.compute_hashline
+context_hash = _core_mod.context_hash
+
+SCHEMA = {
+    "path": {"type": "string"},
+    "old_string": {"type": "string"},
+    "new_string": {"type": "string"},
+    "expected_hashline": {"type": "string"},
+    "window": {"type": "integer", "default": 2},
+}
+
+
+def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        path = args["path"]
+        old_string = args["old_string"]
+        new_string = args["new_string"]
+        expected_hashline = args["expected_hashline"]
+        window = int(args.get("window", 2))
+    except Exception as exc:
+        logger.debug("anchored_patch arg error: %s", exc)
+        return _tool_error(f"anchored_patch: invalid args: {exc}", code="500", details={})
+
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:
+        logger.debug("anchored_patch read error (%s): %s", path, exc)
+        return _tool_error(f"anchored_patch: read failed: {path}", code="500", details={"error": str(exc)})
+
+    status, payload = verify_anchor_by_hash(text, old_string, expected_hashline, window=window)
+    if status == "block":
+        logger.debug("anchored_patch blocked: %s", payload.get("reason"))
+        return _tool_error(
+            f"anchored_patch: {payload.get('reason')} in {path}",
+            code="422",
+            details={"found": payload.get("found", []), "lines": payload.get("lines", [])},
+        )
+
+    occurrence = payload
+    matches = find_all(text, old_string)
+    if occurrence < 0 or occurrence >= len(matches):
+        return _tool_error("anchored_patch: occurrence index out of range", code="500", details={})
+
+    start = matches[occurrence][0]
+    end = matches[occurrence][1]
+    updated = text[:start] + new_string + text[end:]
+
+    try:
+        with Path(path).open("w", encoding="utf-8", newline="") as fh:
+            fh.write(updated)
+    except Exception as exc:
+        logger.debug("anchored_patch write error (%s): %s", path, exc)
+        return _tool_error(f"anchored_patch: write failed: {path}", code="500", details={"error": str(exc)})
+
+    return {"applied": True, "occurrence": occurrence, "hashline": expected_hashline}
+
+
+def _tool_error(message: str, code: str = "500", details: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return {
+        "applied": False,
+        "error": {"code": code, "message": message, "details": details or {}},
+    }
+
+
+def _context_snippet(file_text: str, old_string: str, occurrence_index: int, window: int = 2) -> str:
+    matches = find_all(file_text, old_string)
+    if not matches or occurrence_index < 0 or occurrence_index >= len(matches):
+        return ""
+    text = _core_mod._canonicalize(file_text)
+    lines = text.splitlines()
+    anchor_line = matches[occurrence_index][2] - 1
+    start = max(0, anchor_line - window)
+    end = min(len(lines), anchor_line + old_string.count("\n") + 1 + window)
+    return "\n".join(lines[start:end])
+
+
+def hashline_compute(args: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+    try:
+        path = args.get("path")
+        old_string = args.get("old_string")
+        window = int(args.get("window", 2))
+        if not path or old_string is None:
+            return _tool_error("hashline_compute requires path and old_string", code="500", details={})
+
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+        matches = find_all(text, old_string)
+        if not matches:
+            return {"hashlines": [], "count": 0}
+
+        out = []
+        for idx in range(len(matches)):
+            line = matches[idx][2]
+            hl = compute_hashline(text, old_string, idx, window=window)
+            out.append({
+                "line": line,
+                "hashline": hl,
+                "context": _context_snippet(text, old_string, idx, window=window),
+            })
+        return {"hashlines": out, "count": len(out)}
+    except Exception as exc:
+        logger.debug("hashline_compute failed: %s", exc)
+        return _tool_error(f"hashline_compute failed: {type(exc).__name__}: {exc}", code="500", details={})
+
+
+def on_pre_tool_call(*args: Any, **kwargs: Any) -> Optional[Dict[str, str]]:
+    """Pre-tool hook: block stale/ambiguous patch anchors, and drift when expected_hashline is pinned.
+
+    Returns ``{'action': 'block', 'message': ...}`` to stop the tool call,
+    or ``None`` to allow it through.
+
+    Hermes invokes this callback with ``tool_name`` and ``args`` kwargs
+    (see ``hermes_cli/plugins.py`` ``_get_pre_tool_call_directive_details``).
+    """
+    tool_name = kwargs.get("tool_name", "")
+    if tool_name != "patch":
+        return None
+
+    args = kwargs.get("args") or {}
+    mode = args.get("mode", "")
+    if mode != "replace":
+        return None
+
+    target_rel = args.get("path")
+    old_string = args.get("old_string")
+    if not target_rel or old_string is None:
+        return None
+
+    cwd = kwargs.get("cwd") or str(Path.cwd())
+    target = Path(target_rel)
+    if not target.is_absolute():
+        target = Path(cwd) / target
+
+    try:
+        text = target.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return {
+            "action": "block",
+            "message": f"hashline-guard: file not found: {target}. Re-read the file and re-issue the patch.",
+        }
+    except Exception as exc:
+        logger.debug("hashline-guard read error (%s): %s", target, exc)
+        return None
+
+    expected_hashline = args.get("expected_hashline")
+    if expected_hashline is not None:
+        status, payload = verify_anchor_by_hash(text, old_string, expected_hashline)
+        if status == "ok":
+            return None
+        if isinstance(payload, dict) and "found" in payload and payload["found"]:
+            actual = payload["found"][0]
+            return {
+                "action": "block",
+                "message": (
+                    f"hashline-guard: expected_hashline drifted in {target}. "
+                    f"Actual hashline for the only occurrence: {actual}. "
+                    "Re-pin expected_hashline to this value and retry."
+                ),
+            }
+        return {
+            "action": "block",
+            "message": f"hashline-guard: {payload.get('reason', 'expected_hashline check failed')} in {target}.",
+        }
+
+    status, reason = verify_anchor(text, old_string)
+    if status == "block":
+        return {
+            "action": "block",
+            "message": f"hashline-guard: {reason} in {target}. Re-read the file and re-issue the patch.",
+        }
+    return None
+
+
+def register(ctx: Any) -> None:
+    """Register hooks/tools with the Hermes plugin context."""
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_tool(
+        name="anchored_patch",
+        toolset="file",
+        schema=SCHEMA,
+        handler=handle_anchored_patch,
+    )
+    ctx.register_tool(
+        name="hashline_compute",
+        toolset="hashline-guard",
+        schema={
+            "name": "hashline_compute",
+            "description": "Return expected hashline values for every occurrence of an anchor in a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Target file path."},
+                    "old_string": {"type": "string", "description": "Anchor text to hash."},
+                    "window": {"type": "integer", "description": "Surrounding context lines.", "default": 2},
+                },
+                "required": ["path", "old_string"],
+            },
+        },
+        handler=hashline_compute,
+        check_fn=lambda: True,
+        description="Discover expected_hashline values for patch anchors.",
+    )

--- a/plugins/hashline-guard/plugin.yaml
+++ b/plugins/hashline-guard/plugin.yaml
@@ -1,0 +1,5 @@
+name: hashline-guard
+version: 0.2.0
+description: Guard rails for hashline behavior.
+author: Michael Anselmi
+kind: standalone

--- a/plugins/hashline-guard/src/hashline_core.py
+++ b/plugins/hashline-guard/src/hashline_core.py
@@ -1,0 +1,129 @@
+"""hashline-guard core: strict-match pre-check on patch `old_string` anchors.
+
+verify_anchor(file_text, old_string) -> ('ok', None) | ('block', reason)
+context_hash(file_text, old_string, window=2) -> SHA-256 hex string
+
+FAIL-OPEN: any IO/setup error is logged and skipped, never blocks.
+
+CANONICALIZATION
+----------------
+- Newline normalization: CRLF/LFCR/CR are normalized to LF before matching/hashing.
+- Trailing whitespace: kept byte-exact on each line; do NOT strip.
+- Hash payload version tag: 'hashline:v1:<windowed_text>' so future format
+  changes don't collide with prior hashline values.
+- Window size is part of the computed text shape; changing window changes the hash.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_EMPTY_REASON = "old_string must be non-empty"
+_VERSION_TAG = "hashline:v1"
+
+
+def verify_anchor(file_text: str, old_string: str) -> Tuple[str, Optional[str]]:
+    """Return ('ok', None) when old_string occurs exactly once, else ('block', reason)."""
+    if not old_string:
+        return "block", _EMPTY_REASON
+
+    canonical = _canonicalize(file_text)
+    count = canonical.count(_canonicalize(old_string))
+    if count == 0:
+        return "block", "old_string not found in live file — anchor drifted"
+    if count > 1:
+        return "block", f"old_string is ambiguous: found {count} times in live file"
+    return "ok", None
+
+
+def context_hash(file_text: str, old_string: str, window: int = 2) -> str:
+    """SHA-256 of old_string + up to `window` surrounding lines (foundation for full-hashline primitive)."""
+    if not old_string:
+        return hashlib.sha256(b"").hexdigest()
+
+    return compute_hashline(file_text, old_string, 0, window=window)
+
+
+def find_all(file_text: str, old_string: str) -> List[Tuple[int, int, int]]:
+    """Return list of (start_idx, end_idx, line_number) for every occurrence of old_string."""
+    if not old_string:
+        return []
+    text = _canonicalize(file_text)
+    anchor = _canonicalize(old_string)
+    out = []
+    start = 0
+    while True:
+        idx = text.find(anchor, start)
+        if idx == -1:
+            break
+        end_idx = idx + len(anchor)
+        line_number = text[:idx].count("\n") + 1
+        out.append((idx, end_idx, line_number))
+        start = end_idx
+    return out
+
+
+def compute_hashline(file_text: str, old_string: str, occurrence_index: int, window: int = 2) -> str:
+    """SHA-256 hex digest of a versioned window around the `occurrence_index`-th match."""
+    if not old_string:
+        return hashlib.sha256(b"").hexdigest()
+    matches = find_all(file_text, old_string)
+    if not matches or occurrence_index < 0 or occurrence_index >= len(matches):
+        return hashlib.sha256(old_string.encode("utf-8")).hexdigest()
+
+    lines = _canonicalize(file_text).splitlines()
+    anchor_line = matches[occurrence_index][2] - 1
+    start = max(0, anchor_line - window)
+    end = min(len(lines), anchor_line + old_string.count("\n") + 1 + window)
+    window_lines = lines[start:end]
+    payload = f"{_VERSION_TAG}:{occurrence_index}:" + "\n".join(window_lines)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def verify_anchor_by_hash(file_text: str, old_string: str, expected_hashline: str, window: int = 2) -> Tuple[str, Tuple]:
+    """Pin an exact occurrence by hashline.
+
+    Returns:
+      ('ok', occurrence_index)
+      ('block', {'reason': str, 'found': [hashline, ...], 'lines': [line_number, ...]})
+    """
+    if not old_string:
+        return "block", {"reason": _EMPTY_REASON, "found": [], "lines": []}
+
+    matches = find_all(file_text, old_string)
+    count = len(matches)
+    if count == 0:
+        return "block", {"reason": "old_string not found in live file — anchor drifted", "found": [], "lines": []}
+
+    found = []
+    lines = []
+    for idx in range(count):
+        lines.append(matches[idx][2])
+        found.append(compute_hashline(file_text, old_string, idx, window=window))
+
+    if count == 1:
+        if found[0] == expected_hashline:
+            return "ok", 0
+        return "block", {"reason": "single occurrence hashline mismatch", "found": found, "lines": lines}
+
+    exact_matches = [i for i, h in enumerate(found) if h == expected_hashline]
+    if len(exact_matches) == 1:
+        return "ok", exact_matches[0]
+    if not exact_matches:
+        reason = f"hashline did not match any occurrence; found {count} anchors"
+    else:
+        reason = f"hashline is ambiguous: matched {len(exact_matches)} occurrences"
+    return "block", {"reason": reason, "found": found, "lines": lines}
+
+
+def _canonicalize(text: str) -> str:
+    if not text:
+        return ""
+    out = text.replace("\r\n", "\n").replace("\r", "\n")
+    # normalize NEL/line-separator/paragraph-separator if present
+    out = out.replace("\u0085", "\n").replace("\u2028", "\n").replace("\u2029", "\n")
+    return out

--- a/plugins/hashline-guard/src/hashline_core.py
+++ b/plugins/hashline-guard/src/hashline_core.py
@@ -125,5 +125,53 @@ def _canonicalize(text: str) -> str:
         return ""
     out = text.replace("\r\n", "\n").replace("\r", "\n")
     # normalize NEL/line-separator/paragraph-separator if present
-    out = out.replace("\u0085", "\n").replace("\u2028", "\n").replace("\u2029", "\n")
+    out = out.replace("\u0085", "\n").replace("\u2029", "\n").replace("\u2028", "\n")
     return out
+
+
+def raw_offsets(file_text: str, canonical_start: int, canonical_end: int) -> Tuple[int, int]:
+    """Map canonical (LF-normalized) offsets back to raw byte offsets.
+
+    ``find_all``/``compute_hashline`` match against the canonicalized (CRLF/CR ->
+    LF) text, so the offsets they return index the normalized string, which is
+    SHORTER than the raw file when it contains CRLF/CR line endings. Splicing
+    the raw file at those canonical offsets corrupts it (a ``\\r`` gets orphaned
+    before the anchor). This translates a canonical [start, end) range into the
+    equivalent raw byte range so the caller can splice the original text.
+
+    Canonicalization only removes bytes (never reorders or adds), so a single
+    left-to-right pass recording the raw index of each canonical char is exact.
+    """
+    if not file_text:
+        return 0, 0
+    can = _canonicalize(file_text)
+    if len(can) == len(file_text):
+        return canonical_start, canonical_end
+
+    # raw_index_of[i] = raw byte index of canonical char i.
+    raw_index_of: List[int] = []
+    ci = 0
+    for ri, ch in enumerate(file_text):
+        if ci < len(can) and ch == can[ci]:
+            raw_index_of.append(ri)
+            ci += 1
+
+    def _raw_start(canon_idx: int) -> int:
+        """Raw offset of the first char of the canonical match (a preserved char)."""
+        if canon_idx >= len(raw_index_of):
+            return len(file_text)
+        return raw_index_of[canon_idx]
+
+    def _raw_end(canon_idx: int) -> int:
+        """Raw exclusive end: one past the raw byte of the last preserved match char.
+
+        The last canonical match char is at canonical_end - 1 and is always a
+        preserved char (canonicalization only removes CR/separator bytes, never
+        a match char), so its raw index + 1 is the exact raw boundary.
+        """
+        if canon_idx <= 0:
+            return 0
+        last_preserved = raw_index_of[canon_idx - 1] if canon_idx - 1 < len(raw_index_of) else len(file_text)
+        return last_preserved + 1
+
+    return _raw_start(canonical_start), _raw_end(canonical_end)

--- a/plugins/hashline-guard/tests/test_anchored_patch.py
+++ b/plugins/hashline-guard/tests/test_anchored_patch.py
@@ -1,15 +1,20 @@
-"""RED phase: failing tests for anchored_patch handler.
+"""Tests for the anchored_patch tool handler.
 
-These tests require the `anchored_patch` tool handler to exist in the plugin.
-They MUST fail until the handler is implemented.
+The handler returns a JSON string (the tool-handler contract — see
+tools/registry._normalize_handler_result); tests decode before asserting.
 """
 import importlib.util
+import json
 import os
 from pathlib import Path
 
 PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
 INIT_PATH = os.path.join(PLUGIN_DIR, "..", "__init__.py")
 CORE_PATH = os.path.join(PLUGIN_DIR, "..", "src", "hashline_core.py")
+
+
+def _load(out: str) -> dict:
+    return json.loads(out)
 
 
 def _load_plugin():
@@ -19,55 +24,78 @@ def _load_plugin():
     return mod
 
 
+def _load_core():
+    spec = importlib.util.spec_from_file_location("hashline_core", CORE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def test_anchored_patch_applies_at_pinned_occurrence(tmp_path):
     """2 identical anchors, pin the second occurrence via hashline."""
     plugin = _load_plugin()
-    if not hasattr(plugin, "handle_anchored_patch"):
-        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
+    core_mod = _load_core()
 
     target = tmp_path / "file.txt"
     target.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
-    core = importlib.util.spec_from_file_location("hashline_core", CORE_PATH)
-    core_mod = importlib.util.module_from_spec(core)
-    core.loader.exec_module(core_mod)
 
     h1 = core_mod.compute_hashline(target.read_text(encoding="utf-8"), "beta", 1, window=2)
 
     before = target.read_text(encoding="utf-8")
-    result = plugin.handle_anchored_patch({
+    result = _load(plugin.handle_anchored_patch({
         "path": str(target),
         "old_string": "beta\n",
         "new_string": "BETA\n",
         "expected_hashline": h1,
         "window": 2,
-    })
+    }))
     after = target.read_text(encoding="utf-8")
 
     assert result.get("applied") is True
     assert result.get("occurrence") == 1
     assert result.get("hashline") == h1
     assert after == "alpha\nbeta\ngamma\nBETA\ndelta\n"
+    assert before != after
     # first occurrence remains unchanged
     assert "beta\n" in after
+
+
+def test_anchored_patch_returns_json_string_contract(tmp_path):
+    """Handlers must return a JSON STRING (tools/registry dispatch contract),
+    never a bare dict — dict returns become tool_result_contract errors."""
+    plugin = _load_plugin()
+    core_mod = _load_core()
+    target = tmp_path / "file.txt"
+    target.write_text("alpha\nbeta\ngamma\n")
+    h0 = core_mod.compute_hashline(target.read_text(encoding="utf-8"), "beta", 0, window=2)
+
+    out = plugin.handle_anchored_patch({
+        "path": str(target),
+        "old_string": "beta\n",
+        "new_string": "BETA\n",
+        "expected_hashline": h0,
+        "window": 2,
+    })
+    assert isinstance(out, str), f"handler must return a str, got {type(out).__name__}"
+    decoded = _load(out)
+    assert decoded.get("applied") is True
 
 
 def test_anchored_patch_blocks_on_hash_mismatch(tmp_path):
     """When hashline does not match any occurrence, file must remain unchanged."""
     plugin = _load_plugin()
-    if not hasattr(plugin, "handle_anchored_patch"):
-        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
 
     target = tmp_path / "file.txt"
     original = "alpha\nbeta\ngamma\nbeta\ndelta\n"
     target.write_text(original)
 
-    result = plugin.handle_anchored_patch({
+    result = _load(plugin.handle_anchored_patch({
         "path": str(target),
         "old_string": "beta\n",
         "new_string": "BETA\n",
         "expected_hashline": "0" * 64,
         "window": 2,
-    })
+    }))
 
     assert result.get("applied") is False
     assert target.read_text(encoding="utf-8") == original
@@ -76,20 +104,18 @@ def test_anchored_patch_blocks_on_hash_mismatch(tmp_path):
 def test_anchored_patch_blocks_on_absent_anchor(tmp_path):
     """If old_string is absent from the file, it must block and not write."""
     plugin = _load_plugin()
-    if not hasattr(plugin, "handle_anchored_patch"):
-        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
 
     target = tmp_path / "file.txt"
     original = "alpha\ngamma\ndelta\n"
     target.write_text(original)
 
-    result = plugin.handle_anchored_patch({
+    result = _load(plugin.handle_anchored_patch({
         "path": str(target),
         "old_string": "beta\n",
         "new_string": "BETA\n",
         "expected_hashline": "any",
         "window": 2,
-    })
+    }))
 
     assert result.get("applied") is False
     assert target.read_text(encoding="utf-8") == original
@@ -98,8 +124,6 @@ def test_anchored_patch_blocks_on_absent_anchor(tmp_path):
 def test_anchored_patch_atomicity(tmp_path):
     """After a block condition, the file must remain byte-identical."""
     plugin = _load_plugin()
-    if not hasattr(plugin, "handle_anchored_patch"):
-        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
 
     target = tmp_path / "file.txt"
     original = "alpha\nbeta\ngamma\nbeta\ndelta\n"

--- a/plugins/hashline-guard/tests/test_anchored_patch.py
+++ b/plugins/hashline-guard/tests/test_anchored_patch.py
@@ -1,0 +1,116 @@
+"""RED phase: failing tests for anchored_patch handler.
+
+These tests require the `anchored_patch` tool handler to exist in the plugin.
+They MUST fail until the handler is implemented.
+"""
+import importlib.util
+import os
+from pathlib import Path
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+INIT_PATH = os.path.join(PLUGIN_DIR, "..", "__init__.py")
+CORE_PATH = os.path.join(PLUGIN_DIR, "..", "src", "hashline_core.py")
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location("hashline_guard_plugin", INIT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_anchored_patch_applies_at_pinned_occurrence(tmp_path):
+    """2 identical anchors, pin the second occurrence via hashline."""
+    plugin = _load_plugin()
+    if not hasattr(plugin, "handle_anchored_patch"):
+        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
+
+    target = tmp_path / "file.txt"
+    target.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    core = importlib.util.spec_from_file_location("hashline_core", CORE_PATH)
+    core_mod = importlib.util.module_from_spec(core)
+    core.loader.exec_module(core_mod)
+
+    h1 = core_mod.compute_hashline(target.read_text(encoding="utf-8"), "beta", 1, window=2)
+
+    before = target.read_text(encoding="utf-8")
+    result = plugin.handle_anchored_patch({
+        "path": str(target),
+        "old_string": "beta\n",
+        "new_string": "BETA\n",
+        "expected_hashline": h1,
+        "window": 2,
+    })
+    after = target.read_text(encoding="utf-8")
+
+    assert result.get("applied") is True
+    assert result.get("occurrence") == 1
+    assert result.get("hashline") == h1
+    assert after == "alpha\nbeta\ngamma\nBETA\ndelta\n"
+    # first occurrence remains unchanged
+    assert "beta\n" in after
+
+
+def test_anchored_patch_blocks_on_hash_mismatch(tmp_path):
+    """When hashline does not match any occurrence, file must remain unchanged."""
+    plugin = _load_plugin()
+    if not hasattr(plugin, "handle_anchored_patch"):
+        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
+
+    target = tmp_path / "file.txt"
+    original = "alpha\nbeta\ngamma\nbeta\ndelta\n"
+    target.write_text(original)
+
+    result = plugin.handle_anchored_patch({
+        "path": str(target),
+        "old_string": "beta\n",
+        "new_string": "BETA\n",
+        "expected_hashline": "0" * 64,
+        "window": 2,
+    })
+
+    assert result.get("applied") is False
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_anchored_patch_blocks_on_absent_anchor(tmp_path):
+    """If old_string is absent from the file, it must block and not write."""
+    plugin = _load_plugin()
+    if not hasattr(plugin, "handle_anchored_patch"):
+        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
+
+    target = tmp_path / "file.txt"
+    original = "alpha\ngamma\ndelta\n"
+    target.write_text(original)
+
+    result = plugin.handle_anchored_patch({
+        "path": str(target),
+        "old_string": "beta\n",
+        "new_string": "BETA\n",
+        "expected_hashline": "any",
+        "window": 2,
+    })
+
+    assert result.get("applied") is False
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_anchored_patch_atomicity(tmp_path):
+    """After a block condition, the file must remain byte-identical."""
+    plugin = _load_plugin()
+    if not hasattr(plugin, "handle_anchored_patch"):
+        raise AssertionError("handle_anchored_patch not implemented — RED phase expected")
+
+    target = tmp_path / "file.txt"
+    original = "alpha\nbeta\ngamma\nbeta\ndelta\n"
+    target.write_text(original)
+
+    plugin.handle_anchored_patch({
+        "path": str(target),
+        "old_string": "beta\n",
+        "new_string": "BETA\n",
+        "expected_hashline": "0" * 64,
+        "window": 2,
+    })
+
+    assert target.read_text(encoding="utf-8") == original

--- a/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
+++ b/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
@@ -1,5 +1,6 @@
 import hashlib
 import importlib.util
+import json
 import tempfile
 from pathlib import Path
 
@@ -51,13 +52,13 @@ def main() -> int:
 
     # Step 3 pin occurrence 1 (first beta, line 2) -> replace with B1
     before_step3 = _bytes(TARGET)
-    res3 = plugin.handle_anchored_patch({
+    res3 = json.loads(plugin.handle_anchored_patch({
         'path': str(TARGET),
         'old_string': 'beta',
         'new_string': 'B1',
         'expected_hashline': h0,
         'window': 2,
-    })
+    }))
     if not res3.get('applied'):
         failures.append(f'step3 not applied: {res3}')
     if res3.get('occurrence') != 0:
@@ -72,13 +73,13 @@ def main() -> int:
     # occurrence 1 patch changed surrounding context/line numbers.
     h1 = core.compute_hashline(TARGET.read_text(encoding='utf-8'), 'beta', 0)
     before_step4 = _bytes(TARGET)
-    res4 = plugin.handle_anchored_patch({
+    res4 = json.loads(plugin.handle_anchored_patch({
         'path': str(TARGET),
         'old_string': 'beta',
         'new_string': 'B2',
         'expected_hashline': h1,
         'window': 2,
-    })
+    }))
     if not res4.get('applied'):
         failures.append(f'step4 not applied: {res4}')
     if res4.get('occurrence') != 0:
@@ -91,13 +92,13 @@ def main() -> int:
 
     # Step 5 wrong hashline -> block, file unchanged
     before_step5 = _bytes(TARGET)
-    res5 = plugin.handle_anchored_patch({
+    res5 = json.loads(plugin.handle_anchored_patch({
         'path': str(TARGET),
         'old_string': 'beta',
         'new_string': 'B2',
         'expected_hashline': '0' * 64,
         'window': 2,
-    })
+    }))
     if res5.get('applied'):
         failures.append('step5 should have blocked on wrong hashline')
     if _bytes(TARGET) != before_step5:
@@ -112,13 +113,13 @@ def main() -> int:
     h0_crlf = core.compute_hashline(text_crlf, 'beta', 0)
     h1_crlf = core.compute_hashline(text_crlf, 'beta', 1)
     before_step6 = _bytes(TARGET)
-    res6 = plugin.handle_anchored_patch({
+    res6 = json.loads(plugin.handle_anchored_patch({
         'path': str(TARGET),
         'old_string': 'beta',
         'new_string': 'B1',
         'expected_hashline': h0_crlf,
         'window': 2,
-    })
+    }))
     if not res6.get('applied'):
         failures.append(f'step6 not applied on CRLF-normalized file: {res6}')
     if _bytes(TARGET) == before_step6:

--- a/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
+++ b/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
@@ -123,9 +123,12 @@ def main() -> int:
         failures.append(f'step6 not applied on CRLF-normalized file: {res6}')
     if _bytes(TARGET) == before_step6:
         failures.append('step6 file bytes unchanged after successful patch')
-    after_step6 = TARGET.read_text(encoding='utf-8')
-    if 'B1' not in after_step6:
-        failures.append(f'step6 B1 missing after patch: {after_step6!r}')
+    # Byte-exact check: the patch must splice at the RAW offsets, preserving
+    # CRLF endings (regression for canonical-vs-raw offset corruption where a
+    # CRLF file's anchor became 'B1a' with a stray '\r').
+    expected_bytes6 = b'alpha\r\nB1\r\ngamma\r\ndelta\r\nbeta\r\nepsilon\r\n'
+    if _bytes(TARGET) != expected_bytes6:
+        failures.append(f'step6 CRLF bytes wrong: {_bytes(TARGET)!r} (expected {expected_bytes6!r})')
 
     if failures:
         print('FAILURES:')

--- a/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
+++ b/plugins/hashline-guard/tests/test_e2e_anchored_patch.py
@@ -1,0 +1,140 @@
+import hashlib
+import importlib.util
+import tempfile
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+INIT_PATH = PLUGIN_DIR / '__init__.py'
+CORE_PATH = PLUGIN_DIR / 'src' / 'hashline_core.py'
+TARGET = Path(tempfile.gettempdir()) / 'hashline-anchored-e2e.txt'
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location('hashline_guard_plugin', INIT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_core():
+    spec = importlib.util.spec_from_file_location('hashline_core', CORE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bytes(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def main() -> int:
+    plugin = _load_plugin()
+    core = _load_core()
+    failures = []
+
+    # Step 1 create temp file (write bytes to avoid Windows newline translation)
+    # Anchors are NON-adjacent (line 2 and line 5) so their context windows are
+    # independent: patching one must not change the other's hashline.
+    original = 'alpha\nbeta\ngamma\ndelta\nbeta\nepsilon\n'
+    TARGET.write_bytes(original.encode('utf-8'))
+    assert _bytes(TARGET) == original.encode('utf-8'), 'step1 write failed'
+
+    # Step 2 hashline_compute on old_string='beta', assert count=2 and hashes differ
+    text = TARGET.read_text(encoding='utf-8')
+    matches = core.find_all(text, 'beta')
+    if len(matches) != 2:
+        failures.append(f'step2 expected 2 matches, got {len(matches)}')
+    h0 = core.compute_hashline(text, 'beta', 0)
+    h1 = core.compute_hashline(text, 'beta', 1)
+    if h0 == h1:
+        failures.append(f'step2 hashes should differ: {h0} == {h1}')
+
+    # Step 3 pin occurrence 1 (first beta, line 2) -> replace with B1
+    before_step3 = _bytes(TARGET)
+    res3 = plugin.handle_anchored_patch({
+        'path': str(TARGET),
+        'old_string': 'beta',
+        'new_string': 'B1',
+        'expected_hashline': h0,
+        'window': 2,
+    })
+    if not res3.get('applied'):
+        failures.append(f'step3 not applied: {res3}')
+    if res3.get('occurrence') != 0:
+        failures.append(f"step3 expected occurrence 0, got {res3.get('occurrence')}")
+    if _bytes(TARGET) == before_step3:
+        failures.append('step3 file bytes unchanged after successful patch')
+    after_step3 = TARGET.read_text(encoding='utf-8')
+    if after_step3 != 'alpha\nB1\ngamma\ndelta\nbeta\nepsilon\n':
+        failures.append(f'step3 wrong content: {after_step3!r}')
+
+    # Step 4 recompute h1 on the current file state because the original
+    # occurrence 1 patch changed surrounding context/line numbers.
+    h1 = core.compute_hashline(TARGET.read_text(encoding='utf-8'), 'beta', 0)
+    before_step4 = _bytes(TARGET)
+    res4 = plugin.handle_anchored_patch({
+        'path': str(TARGET),
+        'old_string': 'beta',
+        'new_string': 'B2',
+        'expected_hashline': h1,
+        'window': 2,
+    })
+    if not res4.get('applied'):
+        failures.append(f'step4 not applied: {res4}')
+    if res4.get('occurrence') != 0:
+        failures.append(f"step4 expected occurrence 0 (only beta left), got {res4.get('occurrence')}")
+    if _bytes(TARGET) == before_step4:
+        failures.append('step4 file bytes unchanged after successful patch')
+    after_step4 = TARGET.read_text(encoding='utf-8')
+    if after_step4 != 'alpha\nB1\ngamma\ndelta\nB2\nepsilon\n':
+        failures.append(f'step4 wrong content: {after_step4!r}')
+
+    # Step 5 wrong hashline -> block, file unchanged
+    before_step5 = _bytes(TARGET)
+    res5 = plugin.handle_anchored_patch({
+        'path': str(TARGET),
+        'old_string': 'beta',
+        'new_string': 'B2',
+        'expected_hashline': '0' * 64,
+        'window': 2,
+    })
+    if res5.get('applied'):
+        failures.append('step5 should have blocked on wrong hashline')
+    if _bytes(TARGET) != before_step5:
+        failures.append('step5 file bytes changed on block')
+
+    # Step 6 CRLF normalization -> still works
+    TARGET.write_bytes(b'alpha\r\nbeta\r\ngamma\r\ndelta\r\nbeta\r\nepsilon\r\n')
+    text_crlf = TARGET.read_text(encoding='utf-8')
+    matches_crlf = core.find_all(text_crlf, 'beta')
+    if len(matches_crlf) != 2:
+        failures.append(f'step6 expected 2 matches after CRLF, got {len(matches_crlf)}')
+    h0_crlf = core.compute_hashline(text_crlf, 'beta', 0)
+    h1_crlf = core.compute_hashline(text_crlf, 'beta', 1)
+    before_step6 = _bytes(TARGET)
+    res6 = plugin.handle_anchored_patch({
+        'path': str(TARGET),
+        'old_string': 'beta',
+        'new_string': 'B1',
+        'expected_hashline': h0_crlf,
+        'window': 2,
+    })
+    if not res6.get('applied'):
+        failures.append(f'step6 not applied on CRLF-normalized file: {res6}')
+    if _bytes(TARGET) == before_step6:
+        failures.append('step6 file bytes unchanged after successful patch')
+    after_step6 = TARGET.read_text(encoding='utf-8')
+    if 'B1' not in after_step6:
+        failures.append(f'step6 B1 missing after patch: {after_step6!r}')
+
+    if failures:
+        print('FAILURES:')
+        for f in failures:
+            print(' -', f)
+        return 1
+    print('ALL ASSERTIONS PASSED')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/plugins/hashline-guard/tests/test_verify_anchor.py
+++ b/plugins/hashline-guard/tests/test_verify_anchor.py
@@ -6,6 +6,7 @@ primitives (find_all, compute_hashline, verify_anchor_by_hash, canonicalization)
 import importlib.util
 import os
 import hashlib
+import json
 
 PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
 CORE_PATH = os.path.join(PLUGIN_DIR, "..", "src", "hashline_core.py")
@@ -186,8 +187,7 @@ def test_hashline_compute_returns_all_occurrences(tmp_path):
         raise AssertionError("hashline_compute not yet implemented — RED phase expected")
     f = tmp_path / "f.txt"
     f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
-    result = plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2})
-    assert isinstance(result, dict)
+    result = json.loads(plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2}))
     assert result["count"] == 2
     assert len(result["hashlines"]) == 2
     assert result["hashlines"][0]["line"] == 2
@@ -205,7 +205,7 @@ def test_hashline_compute_context_snippet(tmp_path):
         raise AssertionError("hashline_compute not yet implemented — RED phase expected")
     f = tmp_path / "f.txt"
     f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
-    result = plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2})
+    result = json.loads(plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2}))
     first = result["hashlines"][0]
     ctx = first["context"]
     assert "alpha" in ctx

--- a/plugins/hashline-guard/tests/test_verify_anchor.py
+++ b/plugins/hashline-guard/tests/test_verify_anchor.py
@@ -1,0 +1,250 @@
+"""Regression tests for hashline_core.
+
+Covers the count-based guard (verify_anchor) and the full hashline anchoring
+primitives (find_all, compute_hashline, verify_anchor_by_hash, canonicalization).
+"""
+import importlib.util
+import os
+import hashlib
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+CORE_PATH = os.path.join(PLUGIN_DIR, "..", "src", "hashline_core.py")
+
+
+def _load_core():
+    """Load hashline_core via importlib; returns None if module absent."""
+    if not os.path.exists(CORE_PATH):
+        return None
+    spec = importlib.util.spec_from_file_location("hashline_core", CORE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_exact_once_ok(tmp_path):
+    """Anchor present exactly once should yield ('ok', None)."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\n")
+    assert core.verify_anchor(f.read_text(), "beta") == ("ok", None)
+
+
+def test_absent_blocks(tmp_path):
+    """Missing anchor should block with drift reason."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\ngamma\n")
+    status, reason = core.verify_anchor(f.read_text(), "beta")
+    assert status == "block"
+    assert "drifted" in (reason or "").lower()
+
+
+def test_ambiguous_blocks(tmp_path):
+    """Duplicate anchor should block with ambiguous reason."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    status, reason = core.verify_anchor(f.read_text(), "beta")
+    assert status == "block"
+    assert "ambiguous" in (reason or "").lower()
+
+
+def test_empty_old_string_blocks(tmp_path):
+    """Empty old_string should block immediately."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\n")
+    status, reason = core.verify_anchor(f.read_text(), "")
+    assert status == "block"
+    assert "non-empty" in (reason or "").lower()
+
+
+# ---- Task 8: per-occurrence hashline + canonicalization ----
+
+def test_find_all_occurrences():
+    """find_all should return (start, end, line_number) for every non-overlapping match."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    occ = core.find_all("alpha\nbeta\ngamma\nbeta\ndelta\n", "beta")
+    assert len(occ) == 2
+    assert occ[0][2] == 2   # first beta on line 2 (1-based)
+    assert occ[1][2] == 4   # second beta on line 4
+    # byte offsets should point at the anchor text
+    text = "alpha\nbeta\ngamma\nbeta\ndelta\n"
+    assert text[occ[0][0]:occ[0][1]] == "beta"
+    assert text[occ[1][0]:occ[1][1]] == "beta"
+
+
+def test_per_occurrence_hashes(tmp_path):
+    """Two identical anchors in different context must produce different hashlines."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    text = f.read_text()
+    h0 = core.compute_hashline(text, "beta", 0)
+    h1 = core.compute_hashline(text, "beta", 1)
+    assert h0 != h1
+    assert len(h0) == 64  # SHA-256 hex
+
+
+def test_verify_by_hash_ok(tmp_path):
+    """Pinning the correct hashline should return ('ok', occurrence_index)."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    text = f.read_text()
+    h0 = core.compute_hashline(text, "beta", 0)
+    status, idx = core.verify_anchor_by_hash(text, "beta", h0)
+    assert status == "ok"
+    assert idx == 0  # first beta
+    h1 = core.compute_hashline(text, "beta", 1)
+    status, idx = core.verify_anchor_by_hash(text, "beta", h1)
+    assert status == "ok"
+    assert idx == 1  # second beta
+
+
+def test_verify_by_hash_block_returns_found(tmp_path):
+    """Pinning a bogus hashline should block and return every found hashline + line."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    text = f.read_text()
+    bogus = hashlib.sha256(b"not_this").hexdigest()
+    status, payload = core.verify_anchor_by_hash(text, "beta", bogus)
+    assert status == "block"
+    assert isinstance(payload, dict)
+    assert "reason" in payload
+    assert "found" in payload
+    assert "lines" in payload
+    assert len(payload["found"]) == 2
+    assert payload["lines"] == [2, 4]
+
+
+def test_verify_by_hash_single_occurrence_mismatch(tmp_path):
+    """Single occurrence with wrong hashline should block (drift by context)."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\n")
+    text = f.read_text()
+    bogus = hashlib.sha256(b"not_this").hexdigest()
+    status, payload = core.verify_anchor_by_hash(text, "beta", bogus)
+    assert status == "block"
+    assert payload["lines"] == [2]
+    assert len(payload["found"]) == 1
+
+
+def test_crlf_canonicalization(tmp_path):
+    """CRLF and LF variants of the same file must hash identically."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    f = tmp_path / "f.txt"
+    f.write_bytes(b"alpha\r\nbeta\r\ngamma\r\n")
+    h_crlf = core.compute_hashline(f.read_text(), "beta", 0)
+    h_lf = core.compute_hashline("alpha\nbeta\ngamma\n", "beta", 0)
+    assert h_crlf == h_lf
+
+
+def test_canonicalization_comment_block():
+    """CANONICALIZATION doc block must be present in hashline_core.py."""
+    core = _load_core()
+    if core is None:
+        raise AssertionError("hashline_core.py not found")
+    text = open(CORE_PATH, encoding="utf-8").read()
+    assert "CANONICALIZATION" in text
+    assert "hashline:v1" in text
+    assert "Trailing whitespace" in text
+
+
+# ---- Task 10: hashline_compute tool + pre_tool_call pin-drift support ----
+
+PLUGIN_PATH = os.path.join(PLUGIN_DIR, "..", "__init__.py")
+
+
+def _load_plugin():
+    """Load the plugin module (__init__.py) via importlib."""
+    if not os.path.exists(PLUGIN_PATH):
+        return None
+    spec = importlib.util.spec_from_file_location("hashline_guard_plugin", PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_hashline_compute_returns_all_occurrences(tmp_path):
+    """hashline_compute should return one entry per occurrence."""
+    plugin = _load_plugin()
+    if plugin is None:
+        raise AssertionError("__init__.py not found — RED phase, expected to fail here")
+    if not hasattr(plugin, "hashline_compute"):
+        raise AssertionError("hashline_compute not yet implemented — RED phase expected")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    result = plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2})
+    assert isinstance(result, dict)
+    assert result["count"] == 2
+    assert len(result["hashlines"]) == 2
+    assert result["hashlines"][0]["line"] == 2
+    assert result["hashlines"][1]["line"] == 4
+    assert len(result["hashlines"][0]["hashline"]) == 64
+    assert "context" in result["hashlines"][0]
+
+
+def test_hashline_compute_context_snippet(tmp_path):
+    """Context should contain surrounding lines including the anchor line."""
+    plugin = _load_plugin()
+    if plugin is None:
+        raise AssertionError("__init__.py not found — RED phase, expected to fail here")
+    if not hasattr(plugin, "hashline_compute"):
+        raise AssertionError("hashline_compute not yet implemented — RED phase expected")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\nbeta\ndelta\n")
+    result = plugin.hashline_compute({"path": str(f), "old_string": "beta", "window": 2})
+    first = result["hashlines"][0]
+    ctx = first["context"]
+    assert "alpha" in ctx
+    assert "gamma" in ctx
+
+
+def test_pre_tool_call_blocks_with_actual_hashline_when_pinned_but_drifted(tmp_path):
+    """pre_tool_call should block with actual hashline when count==1 but expected_hashline drifted."""
+    plugin = _load_plugin()
+    if plugin is None:
+        raise AssertionError("__init__.py not found — RED phase, expected to fail here")
+    if not hasattr(plugin, "on_pre_tool_call"):
+        raise AssertionError("on_pre_tool_call not yet implemented — RED phase expected")
+    f = tmp_path / "f.txt"
+    f.write_text("alpha\nbeta\ngamma\n")
+    text = f.read_text()
+    actual_hashline = plugin.compute_hashline(text, "beta", 0, window=2)
+    wrong_hashline = "0" * 64
+    args = {
+        "mode": "replace",
+        "path": str(f),
+        "old_string": "beta",
+        "expected_hashline": wrong_hashline,
+    }
+    result = plugin.on_pre_tool_call(tool_name="patch", args=args, cwd=str(tmp_path))
+    assert result is not None
+    assert result["action"] == "block"
+    assert actual_hashline in result["message"]
+    assert "Re-pin" in result["message"] or "expected_hashline" in result["message"]
+    assert "context_hash()" not in result["message"]
+

--- a/plugins/hashline-guard/tests/test_verify_anchor.py
+++ b/plugins/hashline-guard/tests/test_verify_anchor.py
@@ -237,3 +237,21 @@ def test_pre_tool_call_blocks_with_actual_hashline_when_pinned_but_drifted(tmp_p
     assert "Re-pin" in result["message"] or "expected_hashline" in result["message"]
     assert "context_hash()" not in result["message"]
 
+
+
+def test_anchored_patch_schema_is_full_openai_shape():
+    """SCHEMA must expose parameters.properties so coerce_tool_args can coerce."""
+    plugin = _load_plugin()
+    if plugin is None:
+        raise AssertionError("__init__.py not found")
+    s = plugin.SCHEMA
+    assert s.get("name") == "anchored_patch"
+    assert "description" in s
+    params = s.get("parameters") or {}
+    props = params.get("properties") or {}
+    # coerce_tool_args reads properties; window must be typed integer
+    assert props["window"]["type"] == "integer"
+    assert set(params.get("required", [])) == {"path", "old_string", "new_string", "expected_hashline"}
+    # every property has a description (schema-sanitizer / registry contract)
+    for k, v in props.items():
+        assert v.get("description"), f"property {k} missing description"

--- a/plugins/hashline-guard/tests/test_verify_anchor.py
+++ b/plugins/hashline-guard/tests/test_verify_anchor.py
@@ -162,17 +162,6 @@ def test_crlf_canonicalization(tmp_path):
     assert h_crlf == h_lf
 
 
-def test_canonicalization_comment_block():
-    """CANONICALIZATION doc block must be present in hashline_core.py."""
-    core = _load_core()
-    if core is None:
-        raise AssertionError("hashline_core.py not found")
-    text = open(CORE_PATH, encoding="utf-8").read()
-    assert "CANONICALIZATION" in text
-    assert "hashline:v1" in text
-    assert "Trailing whitespace" in text
-
-
 # ---- Task 10: hashline_compute tool + pre_tool_call pin-drift support ----
 
 PLUGIN_PATH = os.path.join(PLUGIN_DIR, "..", "__init__.py")

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -602,6 +602,141 @@ def warn_dangerous(tool_name, **kwargs):
 def register(ctx):
     ctx.register_hook("pre_tool_call", warn_dangerous)
 ```
+**Example — content-addressed patch anchors (`anchored_patch` tool + `hashline_compute`):**
+
+Exact-match counts are not enough when `old_string` appears multiple times or
+when a sibling writer changes the surrounding context without touching the
+anchor text itself. The `hashline-guard` plugin (see `plugins/hashline-guard/`)
+extends the hook with content-addressed pins: a SHA-256 of the anchor plus its
+surrounding context window, versioned as `hashline:v1`.
+
+```python
+import hashlib
+from typing import Any, Dict, Optional, Tuple
+
+
+def find_all(file_text: str, old_string: str) -> list[tuple[int, int, int]]:
+    """Return (start, end, line_number) for every non-overlapping match."""
+    out, start = [], 0
+    while True:
+        idx = file_text.find(old_string, start)
+        if idx == -1:
+            break
+        end = idx + len(old_string)
+        out.append((idx, end, file_text[:idx].count("\n") + 1))
+        start = end
+    return out
+
+
+def compute_hashline(file_text: str, old_string: str,
+                     occurrence_index: int, window: int = 2) -> str:
+    """SHA-256 of a versioned window around the occurrence_index-th match."""
+    matches = find_all(file_text, old_string)
+    if not matches or not (0 <= occurrence_index < len(matches)):
+        return hashlib.sha256(old_string.encode("utf-8")).hexdigest()
+    lines = file_text.replace("\r\n", "\n").splitlines()
+    anchor_line = matches[occurrence_index][2] - 1
+    start = max(0, anchor_line - window)
+    end = min(len(lines), anchor_line + old_string.count("\n") + 1 + window)
+    payload = f"hashline:v1:{occurrence_index}:" + "\n".join(lines[start:end])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def verify_anchor_by_hash(file_text: str, old_string: str,
+                          expected_hashline: str,
+                          window: int = 2) -> Tuple[str, Any]:
+    """Pin an exact occurrence by hashline. Returns ('ok', index) or
+    ('block', {'reason', 'found', 'lines'}) so the agent can re-pin."""
+    matches = find_all(file_text, old_string)
+    if not matches:
+        return "block", {"reason": "anchor drifted", "found": [], "lines": []}
+    found = [compute_hashline(file_text, old_string, i, window) for i in range(len(matches))]
+    exact = [i for i, h in enumerate(found) if h == expected_hashline]
+    if len(exact) == 1:
+        return "ok", exact[0]
+    reason = "no match" if not exact else f"ambiguous: matched {len(exact)}"
+    return "block", {"reason": reason, "found": found,
+                     "lines": [m[2] for m in matches]}
+```
+
+Plugins can register tools so the agent can discover and apply pins. The
+`anchored_patch` handler reads the file, verifies the hashline, applies the
+replacement at the pinned occurrence, and writes back atomically:
+
+```python
+def handle_anchored_patch(args: Dict[str, Any]) -> Dict[str, Any]:
+    path = args["path"]
+    old_string = args["old_string"]
+    new_string = args["new_string"]
+    expected_hashline = args["expected_hashline"]
+    window = int(args.get("window", 2))
+
+    text = Path(path).read_text(encoding="utf-8", errors="replace")
+    status, payload = verify_anchor_by_hash(text, old_string,
+                                            expected_hashline, window)
+    if status == "block":
+        return {"applied": False,
+                "error": {"code": "422", "message": payload["reason"],
+                          "details": {"found": payload["found"],
+                                      "lines": payload["lines"]}}}
+    start, end, _ = find_all(text, old_string)[payload]
+    Path(path).write_text(text[:start] + new_string + text[end:],
+                          encoding="utf-8", newline="")
+    return {"applied": True, "occurrence": payload,
+            "hashline": expected_hashline}
+```
+
+A companion `hashline_compute` tool returns every occurrence's hashline, line
+number, and context snippet so the agent can discover the pin:
+
+```python
+def hashline_compute(args: Dict[str, Any]) -> Dict[str, Any]:
+    path = args["path"]
+    old_string = args["old_string"]
+    window = int(args.get("window", 2))
+    text = Path(path).read_text(encoding="utf-8", errors="replace")
+    matches = find_all(text, old_string)
+    return {
+        "hashlines": [
+            {"line": m[2],
+             "hashline": compute_hashline(text, old_string, i, window)}
+            for i, m in enumerate(matches)
+        ],
+        "count": len(matches),
+    }
+
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_tool(
+        name="anchored_patch",
+        toolset="file",
+        schema={
+            "path": {"type": "string"},
+            "old_string": {"type": "string"},
+            "new_string": {"type": "string"},
+            "expected_hashline": {"type": "string"},
+            "window": {"type": "integer", "default": 2},
+        },
+        handler=handle_anchored_patch,
+    )
+    ctx.register_tool(
+        name="hashline_compute",
+        toolset="file",
+        schema={
+            "path": {"type": "string"},
+            "old_string": {"type": "string"},
+            "window": {"type": "integer", "default": 2},
+        },
+        handler=hashline_compute,
+    )
+```
+
+Workflow: `hashline_compute` -> pin the target occurrence -> `anchored_patch`.
+If the file drifted, `anchored_patch` blocks with the found hashlines and line
+numbers so the agent can re-pin in the same turn. Canonicalization is CRLF -> LF
+(keep trailing whitespace byte-exact), so git autocrlf does not invalidate pins.
+
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the `hashline-guard` example plugin (initially added for the `pre_tool_call` stale-anchor guard) with full content-addressed patch anchoring.

## What's included

- **`plugins/hashline-guard/src/hashline_core.py`** — `find_all()`, `compute_hashline()` (versioned `hashline:v1:<index>:<window>` SHA-256 of anchor + surrounding context), `verify_anchor_by_hash()` (per-occurrence pinning; block returns found hashlines + line numbers for one-turn re-pinning), `_canonicalize()` (CRLF/LFCR/CR → LF, trailing whitespace byte-exact so git autocrlf doesn't invalidate pins).
- **`plugins/hashline-guard/__init__.py`** — registers `anchored_patch` (atomic read → verify → apply → write at the pinned occurrence) and `hashline_compute` (discovers per-occurrence hashlines) tools alongside the existing `pre_tool_call` hook. The hook now also blocks pinned-hash drift, reporting the actual hashline.
- **Tests** — `test_verify_anchor.py` (11), `test_anchored_patch.py` (4), `test_e2e_anchored_patch.py` (7-step probe: pin → stale-pin block → re-pin → wrong-hash block → CRLF). All portable paths (no hard-coded user directories).
- **Docs** — `hooks.md` gains a content-addressed patch anchor recipe (compute → pin → apply workflow, block-directive semantics, fail-open policy). README documents the tooling workflow.

## Why

Exact-match counts are insufficient when `old_string` appears multiple times or when a sibling writer changes surrounding context without touching the anchor text. Hashline anchoring makes edits content-addressed and repeatable: the agent pins a SHA-256 of the anchor plus its context window, and the apply is only allowed if the live file hashes to the expected value — with actionable re-pin data on drift.

## Verification

- `pytest plugins/hashline-guard/tests/` → 18 passed
- E2E probe: all assertions passed (pin, stale-pin block, re-pin, wrong-hash block, CRLF canonicalization)