### PR TITLE
fix(security): make persisted-result writes private across backends

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -76,7 +76,7 @@ class TestWriteToSandbox:
         assert "[ ! -L" in cmd
         assert "[ -O" in cmd
         assert "chmod 700" in cmd
-        assert f"-mtime +{RESULT_TTL_DAYS}" in cmd
+        assert f"-mtime +{RESULT_TTL_DAYS - 1}" in cmd
         assert "rm -f" in cmd
         # Content travels through stdin, NOT inside the command string —
         # otherwise large content would hit Linux's 128 KB MAX_ARG_STRLEN
@@ -126,7 +126,7 @@ class TestWriteToSandbox:
         assert "'/tmp/x; rm -rf /; echo .txt'" in cmd
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
-    def test_real_write_is_private_and_cleans_expired_results(self, tmp_path):
+    def test_real_write_is_private_and_enforces_ttl_boundary(self, tmp_path):
         from tools.environments.local import LocalEnvironment
 
         env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
@@ -134,8 +134,13 @@ class TestWriteToSandbox:
         storage_dir.mkdir(mode=0o755)
         expired = storage_dir / "expired.txt"
         expired.write_text("old", encoding="utf-8")
-        expired_at = time.time() - ((RESULT_TTL_DAYS + 1) * 24 * 60 * 60)
+        retained = storage_dir / "retained.txt"
+        retained.write_text("recent", encoding="utf-8")
+        now = time.time()
+        expired_at = now - ((RESULT_TTL_DAYS * 24 + 1) * 60 * 60)
+        retained_at = now - ((RESULT_TTL_DAYS * 24 - 1) * 60 * 60)
         os.utime(expired, (expired_at, expired_at))
+        os.utime(retained, (retained_at, retained_at))
 
         target = storage_dir / "fresh.txt"
         assert _write_to_sandbox("private content", str(target), env) is True
@@ -144,6 +149,7 @@ class TestWriteToSandbox:
         assert stat.S_IMODE(storage_dir.stat().st_mode) == 0o700
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
         assert not expired.exists()
+        assert retained.read_text(encoding="utf-8") == "recent"
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
     def test_real_retry_replaces_permissive_target_mode(self, tmp_path):

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,10 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import os
+import stat
+import sys
+import time
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +17,7 @@ from tools.tool_result_storage import (
     HEREDOC_MARKER,
     PERSISTED_OUTPUT_TAG,
     PERSISTED_OUTPUT_CLOSING_TAG,
+    RESULT_TTL_DAYS,
     STORAGE_DIR,
     _build_persisted_message,
     _heredoc_marker,
@@ -66,6 +72,12 @@ class TestWriteToSandbox:
         env.execute.assert_called_once()
         cmd = env.execute.call_args[0][0]
         assert "mkdir -p" in cmd
+        assert "umask 077" in cmd
+        assert "[ ! -L" in cmd
+        assert "[ -O" in cmd
+        assert "chmod 700" in cmd
+        assert f"-mtime +{RESULT_TTL_DAYS}" in cmd
+        assert "rm -f" in cmd
         # Content travels through stdin, NOT inside the command string —
         # otherwise large content would hit Linux's 128 KB MAX_ARG_STRLEN
         # ceiling on `bash -c <cmd>` (#22906).
@@ -112,6 +124,59 @@ class TestWriteToSandbox:
         cmd = env.execute.call_args[0][0]
         # The semicolons must be inside quotes, not acting as command separators
         assert "'/tmp/x; rm -rf /; echo .txt'" in cmd
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_real_write_is_private_and_cleans_expired_results(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.mkdir(mode=0o755)
+        expired = storage_dir / "expired.txt"
+        expired.write_text("old", encoding="utf-8")
+        expired_at = time.time() - ((RESULT_TTL_DAYS + 1) * 24 * 60 * 60)
+        os.utime(expired, (expired_at, expired_at))
+
+        target = storage_dir / "fresh.txt"
+        assert _write_to_sandbox("private content", str(target), env) is True
+
+        assert target.read_text(encoding="utf-8") == "private content"
+        assert stat.S_IMODE(storage_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert not expired.exists()
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_real_retry_replaces_permissive_target_mode(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.mkdir(mode=0o700)
+        target = storage_dir / "retry.txt"
+        target.write_text("stale", encoding="utf-8")
+        target.chmod(0o644)
+
+        assert _write_to_sandbox("replacement", str(target), env) is True
+
+        assert target.read_text(encoding="utf-8") == "replacement"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX symlink semantics",
+    )
+    def test_real_write_rejects_symlinked_storage_dir(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.symlink_to(outside, target_is_directory=True)
+
+        target = storage_dir / "escaped.txt"
+        assert _write_to_sandbox("private content", str(target), env) is False
+        assert not (outside / "escaped.txt").exists()
 
 
 class TestResolveStorageDir:

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,12 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +23,7 @@ from tools.tool_result_storage import (
     _resolve_storage_dir,
     _safe_result_filename,
     _write_to_sandbox,
+    _write_to_spillover,
     cleanup_spillover_cache,
     enforce_turn_budget,
     generate_preview,
@@ -98,6 +106,140 @@ class TestWriteToSandbox:
         cmd = env.execute.call_args[0][0]
         # The semicolons must be inside quotes, not acting as command separators
         assert "'/tmp/x; rm -rf /; echo .txt'" in cmd
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_real_write_is_private(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.mkdir(mode=0o755)
+        target = storage_dir / "fresh.txt"
+        assert _write_to_sandbox("private content", str(target), env) is True
+
+        assert target.read_text(encoding="utf-8") == "private content"
+        assert stat.S_IMODE(storage_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_real_retry_replaces_permissive_target_mode(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.mkdir(mode=0o700)
+        target = storage_dir / "retry.txt"
+        target.write_text("stale", encoding="utf-8")
+        target.chmod(0o644)
+
+        assert _write_to_sandbox("replacement", str(target), env) is True
+
+        assert target.read_text(encoding="utf-8") == "replacement"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="requires POSIX shell semantics")
+    def test_real_write_fails_when_required_acl_removal_fails(self, tmp_path):
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        chmod = fake_bin / "chmod"
+        chmod.write_text(
+            "#!/bin/sh\n"
+            "if [ \"$1\" = -N ]; then exit 42; fi\n"
+            "exec /bin/chmod \"$@\"\n",
+            encoding="utf-8",
+        )
+        chmod.chmod(0o755)
+        setfacl = fake_bin / "setfacl"
+        setfacl.write_text("#!/bin/sh\nexit 42\n", encoding="utf-8")
+        setfacl.chmod(0o755)
+        class ShellEnv:
+            def execute(self, command, timeout, stdin_data):
+                result = subprocess.run(
+                    ["bash", "-c", command],
+                    input=stdin_data,
+                    text=True,
+                    capture_output=True,
+                    timeout=timeout,
+                    env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+                    cwd=tmp_path,
+                    check=False,
+                )
+                return {"output": result.stdout + result.stderr, "returncode": result.returncode}
+
+        target = tmp_path / "hermes-results" / "private.txt"
+        assert _write_to_sandbox("private content", str(target), ShellEnv()) is False
+        assert not target.exists()
+
+    @pytest.mark.macos_only
+    def test_real_write_removes_inherited_acl(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.mkdir(mode=0o700)
+        subprocess.run(
+            [
+                "chmod",
+                "+a",
+                "everyone allow read,write,execute,file_inherit,directory_inherit",
+                str(storage_dir),
+            ],
+            check=True,
+        )
+
+        target = storage_dir / "private.txt"
+        assert _write_to_sandbox("private content", str(target), env) is True
+
+        directory_acl = subprocess.run(
+            ["ls", "-lde", str(storage_dir)],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        file_acl = subprocess.run(
+            ["ls", "-le", str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert "group:everyone" not in directory_acl
+        assert "group:everyone" not in file_acl
+
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX symlink semantics",
+    )
+    def test_real_write_rejects_symlinked_storage_dir(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), env={"TMPDIR": str(tmp_path)})
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        storage_dir = tmp_path / "hermes-results"
+        storage_dir.symlink_to(outside, target_is_directory=True)
+
+        target = storage_dir / "escaped.txt"
+        assert _write_to_sandbox("private content", str(target), env) is False
+        assert not (outside / "escaped.txt").exists()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 class TestResolveStorageDir:
@@ -223,7 +365,7 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         cmd = env.execute.call_args[0][0]
-        target = cmd.split("cat > ", 1)[1].split(" <<", 1)[0]
+        target = cmd.split("cat > ", 1)[1].split(" &&", 1)[0]
 
         assert "Full output saved to: /tmp/hermes-results/outside_whoami_x_" in result
         assert "/tmp/hermes-results/../" not in result
@@ -345,6 +487,78 @@ class TestSpillover:
         assert spill_file.read_text(encoding="utf-8") == content
         assert str(spill_file) in result
 
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows"
+    )
+    def test_spillover_write_is_private_and_symlink_safe(self):
+        spill_dir = get_spillover_dir()
+        spill_dir.parent.mkdir(parents=True)
+        os.chmod(spill_dir.parent, 0o755)
+        spill_dir.mkdir()
+        if sys.platform == "darwin":
+            subprocess.run(
+                [
+                    "chmod",
+                    "+a",
+                    "everyone allow read,write,execute,file_inherit,directory_inherit",
+                    str(spill_dir),
+                ],
+                check=True,
+            )
+
+        assert _write_to_spillover("secret", "result.txt") == str(
+            spill_dir / "result.txt"
+        )
+
+        target = spill_dir / "result.txt"
+        assert stat.S_IMODE(spill_dir.parent.stat().st_mode) == 0o755
+        assert stat.S_IMODE(spill_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        if sys.platform == "darwin":
+            acl = subprocess.run(
+                ["ls", "-lde", str(spill_dir), str(target)],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+            assert "group:everyone" not in acl
+
+        outside = spill_dir.parent / "outside.txt"
+        outside.write_text("unchanged", encoding="utf-8")
+        target.unlink()
+        target.symlink_to(outside)
+
+        assert _write_to_spillover("replacement", "result.txt") == str(target)
+        assert target.read_text(encoding="utf-8") == "replacement"
+        assert not target.is_symlink()
+        assert outside.read_text(encoding="utf-8") == "unchanged"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX directory symlinks",
+    )
+    def test_spillover_write_refuses_symlinked_shared_root(self):
+        spill_dir = get_spillover_dir()
+        spill_dir.parent.parent.mkdir(parents=True)
+        outside = spill_dir.parent.parent / "outside-root"
+        outside.mkdir()
+        spill_dir.parent.symlink_to(outside, target_is_directory=True)
+
+        assert _write_to_spillover("secret", "result.txt") is None
+        assert not (outside / "tool-results" / "result.txt").exists()
+
+    def test_spillover_security_setup_failure_falls_back(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.spill_safety.ensure_spill_dir",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(1, ["chmod", "-N"])
+            ),
+        )
+
+        assert _write_to_spillover("secret", "result.txt") is None
+
     def test_local_env_persists_to_spillover_not_sandbox(self):
         """LocalEnvironment routes host-side: no env.execute() shell-out."""
         from tools.environments.local import LocalEnvironment
@@ -428,16 +642,75 @@ class TestSpillover:
         spill_dir.mkdir(parents=True, exist_ok=True)
         old = spill_dir / "old.txt"
         new = spill_dir / "new.txt"
+        legacy = spill_dir.parent / "legacy.txt"
         old.write_text("old")
         new.write_text("new")
+        legacy.write_text("legacy")
         stale = _time.time() - (48 * 3600)
         os.utime(old, (stale, stale))
+        os.utime(legacy, (stale, stale))
 
         removed = cleanup_spillover_cache(max_age_hours=24)
 
-        assert removed == 1
+        assert removed == 2
         assert not old.exists()
+        assert not legacy.exists()
         assert new.exists()
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX symlink timestamps",
+    )
+    def test_cleanup_ages_symlink_artifact_without_following_target(self):
+        spill_dir = get_spillover_dir()
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        outside = spill_dir.parent / "outside.txt"
+        outside.write_text("keep", encoding="utf-8")
+        alias = spill_dir / "expired.txt"
+        alias.symlink_to(outside)
+        stale = time.time() - (48 * 3600)
+        os.utime(alias, (stale, stale), follow_symlinks=False)
+
+        assert cleanup_spillover_cache(max_age_hours=24) == 1
+        assert not alias.is_symlink()
+        assert outside.read_text(encoding="utf-8") == "keep"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX directory symlinks",
+    )
+    def test_cleanup_refuses_symlinked_private_directory(self):
+        spill_dir = get_spillover_dir()
+        spill_dir.parent.mkdir(parents=True)
+        outside = spill_dir.parent.parent / "outside"
+        outside.mkdir()
+        victim = outside / "victim.txt"
+        victim.write_text("keep", encoding="utf-8")
+        stale = time.time() - (48 * 3600)
+        os.utime(victim, (stale, stale))
+        spill_dir.symlink_to(outside, target_is_directory=True)
+
+        assert cleanup_spillover_cache(max_age_hours=24) == 0
+        assert victim.read_text(encoding="utf-8") == "keep"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or not hasattr(os, "symlink"),
+        reason="requires POSIX directory symlinks",
+    )
+    def test_cleanup_refuses_symlinked_shared_root(self):
+        spill_dir = get_spillover_dir()
+        spill_dir.parent.parent.mkdir(parents=True)
+        outside = spill_dir.parent.parent / "outside-root"
+        private_outside = outside / "tool-results"
+        private_outside.mkdir(parents=True)
+        victim = private_outside / "victim.txt"
+        victim.write_text("keep", encoding="utf-8")
+        stale = time.time() - (48 * 3600)
+        os.utime(victim, (stale, stale))
+        spill_dir.parent.symlink_to(outside, target_is_directory=True)
+
+        assert cleanup_spillover_cache(max_age_hours=24) == 0
+        assert victim.read_text(encoding="utf-8") == "keep"
 
     def test_cleanup_missing_dir_returns_zero(self):
         assert cleanup_spillover_cache() == 0

--- a/tools/spill_safety.py
+++ b/tools/spill_safety.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import os
 import stat
+import subprocess
+import sys
 from pathlib import Path
 from typing import IO
 
@@ -17,6 +19,17 @@ __all__ = ["ensure_spill_dir", "open_exclusive", "write_text_exclusive"]
 
 # O_NOFOLLOW is POSIX-only; on Windows O_EXCL alone already refuses every pre-existing path.
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+def _strip_private_acl(path: Path) -> None:
+    """Remove macOS ACL entries that can override private mode bits."""
+    if sys.platform == "darwin":
+        subprocess.run(
+            ["chmod", "-N", os.fspath(path)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
 
 
 def ensure_spill_dir(path: Path, *, private: bool = True) -> Path:
@@ -28,8 +41,10 @@ def ensure_spill_dir(path: Path, *, private: bool = True) -> Path:
     st = os.lstat(path)
     if not stat.S_ISDIR(st.st_mode):
         raise OSError(f"spill dir is not a directory (symlink?): {path}")
-    if private and stat.S_IMODE(st.st_mode) != 0o700:
-        os.chmod(path, 0o700)
+    if private:
+        _strip_private_acl(path)
+        if stat.S_IMODE(st.st_mode) != 0o700:
+            os.chmod(path, 0o700)
     return path
 
 
@@ -52,9 +67,15 @@ def open_exclusive(path: Path, *, private: bool = True, overwrite: bool = False,
     mode = 0o600 if private else 0o666  # non-private honors umask
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW, mode)
     try:
+        if private:
+            _strip_private_acl(path)
         return os.fdopen(fd, "w", encoding=encoding, errors=errors)
     except Exception:
         os.close(fd)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
         raise
 
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
+RESULT_TTL_DAYS = 7
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -111,7 +112,23 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     the exec-arg ceiling.
     """
     storage_dir = os.path.dirname(remote_path)
-    cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)}"
+    quoted_dir = shlex.quote(storage_dir)
+    quoted_path = shlex.quote(remote_path)
+    # Persisted results can contain credentials or private session history.
+    # Create them under a private directory with a restrictive umask, and
+    # remove the target before a retry so an older permissive mode cannot
+    # survive shell redirection. Reject a symlinked or foreign-owned leaf
+    # directory before writing beneath a shared temp root. Cleanup is
+    # deliberately best-effort: a backend without a compatible `find` must
+    # still be able to persist.
+    cmd = (
+        "umask 077 && "
+        f"[ ! -L {quoted_dir} ] && mkdir -p {quoted_dir} && "
+        f"[ -O {quoted_dir} ] && chmod 700 {quoted_dir} && "
+        f"(find {quoted_dir} -type f -name '*.txt' -mtime +{RESULT_TTL_DAYS} "
+        "-exec rm -f {} + 2>/dev/null || true) && "
+        f"rm -f {quoted_path} && cat > {quoted_path}"
+    )
     result = env.execute(cmd, timeout=30, stdin_data=content)
     return result.get("returncode", 1) == 0
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -125,7 +125,7 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
         "umask 077 && "
         f"[ ! -L {quoted_dir} ] && mkdir -p {quoted_dir} && "
         f"[ -O {quoted_dir} ] && chmod 700 {quoted_dir} && "
-        f"(find {quoted_dir} -type f -name '*.txt' -mtime +{RESULT_TTL_DAYS} "
+        f"(find {quoted_dir} -type f -name '*.txt' -mtime +{RESULT_TTL_DAYS - 1} "
         "-exec rm -f {} + 2>/dev/null || true) && "
         f"rm -f {quoted_path} && cat > {quoted_path}"
     )

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -1,15 +1,53 @@
-"""Tool result persistence -- preserves large outputs instead of truncating. Layers against
-context overflow: (1) per-tool caps inside each tool; (2) ``maybe_persist_tool_result`` —
-output over the tool's threshold is persisted and replaced by a preview + path; canonical home
-is ALWAYS host-side ``$HERMES_HOME/cache/spillover/{id}.txt`` (works for sessions that never
-ran a terminal), remote backends get the translated in-sandbox path (probed for readability)
-else a copy in the sandbox temp dir; (3) ``enforce_turn_budget``."""
+"""Tool result persistence -- preserves large outputs instead of truncating.
+
+Defense against context-window overflow operates at three levels:
+
+1. **Per-tool output cap** (inside each tool): Tools like search_files
+   pre-truncate their own output before returning. This is the first line
+   of defense and the only one the tool author controls.
+
+2. **Per-result persistence** (maybe_persist_tool_result): After a tool
+   returns, if its output exceeds the tool's registered threshold
+   (registry.get_max_result_size), the full output is persisted and the
+   in-context content is replaced with a preview + file path reference.
+
+   The canonical home is ALWAYS host-side:
+   ``$HERMES_HOME/cache/spillover/tool-results/{tool_use_id}.txt`` — alongside
+   the other Hermes-owned caches (images, audio, documents, ...) instead of
+   the OS temp dir. This needs no sandbox environment, so it also works for
+   sessions that never ran a terminal command (MCP-only, cron, gateway) —
+   previously those hit the inline-truncate fallback because
+   ``get_active_env()`` returned None until the first terminal call created
+   an environment.
+
+   What the model sees depends on the backend:
+
+   - **Local backend (or no active env):** the host path itself.
+   - **Remote backends (docker/ssh/modal/daytona):** ``cache/spillover`` is
+     in the auto-mounted/synced cache-dir list (tools/credential_files.py),
+     so the reference is the translated in-sandbox path (probed for
+     readability first). When the sandbox can't see it (e.g. a persistent
+     container created before spillover joined the mount list), fall back
+     to writing a copy into the sandbox temp dir via env.execute().
+
+   The spillover dir is pruned two ways: the gateway housekeeping loop
+   sweeps it hourly with the other media caches, and a once-per-process
+   best-effort prune runs on the first spill so CLI-only installs (which
+   never run gateway housekeeping) self-clean too.
+
+3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
+   results in a single assistant turn are collected, if the total exceeds
+   MAX_TURN_BUDGET_CHARS (200K), the largest non-persisted results are
+   spilled to disk until the aggregate is under budget. This catches cases
+   where many medium-sized results combine to overflow context.
+"""
 
 import hashlib
 import logging
 import os
 import re
 import shlex
+import stat
 import threading
 import time
 
@@ -20,6 +58,7 @@ PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 SPILLOVER_SUBDIR = "cache/spillover"
+PERSISTED_SPILLOVER_SUBDIR = "tool-results"
 SPILLOVER_MAX_AGE_HOURS = 24
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -29,10 +68,15 @@ _spillover_prune_lock = threading.Lock()
 _spillover_pruned_once = False
 
 
-def get_spillover_dir():
-    """Return $HERMES_HOME/cache/spillover as a Path (not created)."""
+def get_spillover_root():
+    """Return the shared ``$HERMES_HOME/cache/spillover`` root."""
     from hermes_constants import get_hermes_home
     return get_hermes_home() / SPILLOVER_SUBDIR
+
+
+def get_spillover_dir():
+    """Return the private tool-result spill directory (not created)."""
+    return get_spillover_root() / PERSISTED_SPILLOVER_SUBDIR
 
 
 def cleanup_spillover_cache(max_age_hours: int = SPILLOVER_MAX_AGE_HOURS) -> int:
@@ -40,13 +84,33 @@ def cleanup_spillover_cache(max_age_hours: int = SPILLOVER_MAX_AGE_HOURS) -> int
     contract as the ``cleanup_*_cache`` helpers the gateway housekeeping loop runs hourly)."""
     cutoff = time.time() - (max_age_hours * 3600)
     removed = 0
+    entries = []
+    spillover_root = get_spillover_root()
     try:
-        entries = list(get_spillover_dir().iterdir())
+        root_stat = os.lstat(spillover_root)
     except OSError:
         return 0
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return 0
+    for directory in (spillover_root, get_spillover_dir()):
+        try:
+            directory_stat = os.lstat(directory)
+            if not stat.S_ISDIR(directory_stat.st_mode):
+                continue
+            entries.extend(directory.iterdir())
+        except OSError:
+            continue
     for f in entries:
         try:
-            if f.is_file() and f.stat().st_mtime < cutoff:
+            # Inspect the directory entry itself. ``Path.is_file()`` and
+            # ``Path.stat()`` follow symlinks, which both leaves dangling
+            # result aliases behind forever and applies retention using the
+            # target's timestamp rather than the artifact's timestamp.
+            entry_stat = os.lstat(f)
+            is_result_artifact = stat.S_ISREG(entry_stat.st_mode) or stat.S_ISLNK(
+                entry_stat.st_mode
+            )
+            if is_result_artifact and entry_stat.st_mtime < cutoff:
                 f.unlink()
                 removed += 1
         except OSError:
@@ -68,6 +132,8 @@ def _prune_spillover_once() -> None:
         logger.debug("Spillover prune failed: %s", exc)
 
 
+
+
 def _is_host_side_env(env) -> bool:
     """True when this process should write the spill file directly: ``env=None`` (no sandbox
     yet) or the local backend. Remote backends resolve ``read_file`` inside the sandbox."""
@@ -81,13 +147,31 @@ def _is_host_side_env(env) -> bool:
 
 
 def _write_to_spillover(content: str, filename: str):
-    """Write host-side to $HERMES_HOME/cache/spillover; returns path str or None."""
+    """Write content privately to ``$HERMES_HOME/cache/spillover``.
+
+    Returns the absolute path string on success, None on failure. Existing
+    targets are replaced via a symlink-refusing exclusive create.
+    """
+    if os.path.basename(filename) != filename:
+        logger.warning("Spillover write refused unsafe filename: %s", filename)
+        return None
     try:
-        spill_dir = get_spillover_dir()
-        spill_dir.mkdir(parents=True, exist_ok=True)
+        from tools.spill_safety import ensure_spill_dir, write_text_exclusive
+
+        spill_root = ensure_spill_dir(get_spillover_root(), private=False)
+        spill_dir = ensure_spill_dir(
+            spill_root / PERSISTED_SPILLOVER_SUBDIR,
+            private=True,
+        )
         path = spill_dir / filename
-        path.write_text(content, encoding="utf-8", errors="replace")
-    except OSError as exc:
+        write_text_exclusive(
+            path,
+            content,
+            private=True,
+            overwrite=True,
+            errors="replace",
+        )
+    except Exception as exc:
         logger.warning("Spillover write failed for %s: %s", filename, exc)
         return None
     _prune_spillover_once()
@@ -120,14 +204,18 @@ def _sandbox_visible_spillover_path(host_path: str, env) -> str | None:
 
 def _resolve_storage_dir(env) -> str:
     """Return the best temp-backed storage dir for this environment."""
-    get_temp_dir = getattr(env, "get_temp_dir", None)
-    temp_dir = None
-    if callable(get_temp_dir):
-        try:
-            temp_dir = get_temp_dir()
-        except Exception as exc:
-            logger.debug("Could not resolve env temp dir: %s", exc)
-    return f"{temp_dir.rstrip('/') or '/'}/hermes-results" if temp_dir else STORAGE_DIR
+    if env is not None:
+        get_temp_dir = getattr(env, "get_temp_dir", None)
+        if callable(get_temp_dir):
+            try:
+                temp_dir = get_temp_dir()
+            except Exception as exc:
+                logger.debug("Could not resolve env temp dir: %s", exc)
+            else:
+                if isinstance(temp_dir, str) and temp_dir:
+                    temp_dir = temp_dir.rstrip("/") or "/"
+                    return f"{temp_dir}/hermes-results"
+    return STORAGE_DIR
 
 
 def _safe_result_filename(tool_use_id: str) -> str:
@@ -156,8 +244,40 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     stdin, not the command string: Linux ``MAX_ARG_STRLEN`` caps one argv element at 128 KB,
     so a heredoc-in-command silently failed for exactly the oversized results this handles."""
     storage_dir = os.path.dirname(remote_path)
-    cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)}"
+    quoted_dir = shlex.quote(storage_dir)
+    quoted_path = shlex.quote(remote_path)
+    # Persisted results can contain credentials or private session history.
+    # Create them under a private directory with a restrictive umask, and
+    # remove the target before a retry so an older permissive mode cannot
+    # survive shell redirection. On systems with NFSv4-style ACLs (notably
+    # macOS), chmod alone does not revoke inherited grants, so strip those
+    # ACLs before applying and verifying the private mode. POSIX ACLs are
+    # constrained by the mode bits, and setfacl removes any residual entries
+    # where available. Reject a symlinked or foreign-owned leaf directory
+    # before writing beneath a shared temp root.
+    cmd = (
+        "umask 077 && "
+        f"[ ! -L {quoted_dir} ] && mkdir -p {quoted_dir} && "
+        f"[ -O {quoted_dir} ] && "
+        f"if [ \"$(uname -s 2>/dev/null)\" = Darwin ]; then "
+        f"chmod -N {quoted_dir}; "
+        "elif command -v setfacl >/dev/null 2>&1; then "
+        f"setfacl -b -k {quoted_dir}; fi && "
+        f"chmod 700 {quoted_dir} && "
+        f"rm -f {quoted_path} && cat > {quoted_path} && "
+        f"if [ \"$(uname -s 2>/dev/null)\" = Darwin ]; then "
+        f"chmod -N {quoted_path}; "
+        "elif command -v setfacl >/dev/null 2>&1; then "
+        f"setfacl -b {quoted_path}; fi && "
+        f"chmod 600 {quoted_path} && "
+        f"mode=$(stat -c '%a' {quoted_path} 2>/dev/null || "
+        f"stat -f '%Lp' {quoted_path} 2>/dev/null) && [ \"$mode\" = 600 ]"
+    )
     return env.execute(cmd, timeout=30, stdin_data=content).get("returncode", 1) == 0
+
+
+
+
 
 
 def _build_persisted_message(preview: str, has_more: bool, original_size: int,


### PR DESCRIPTION
## Scope: write-time confidentiality only
Split in response to the review-size request and an independent review. This PR now keeps all host and sandbox writers together, but **does not claim read-time TTL enforcement**.

- Private host `tool-results` directory, exclusive result replacement, restrictive file modes, and macOS ACL removal.
- Sandbox directory ownership/symlink checks, restrictive umask, ACL removal, and explicit verified private file mode.
- Preserve existing host housekeeping for the old shared and new private directory during migration, including safe symlink-artifact handling.
- The real macOS ACL regression uses `pytest.mark.macos_only` so its CI lane can discover it.

**Retention-only follow-up:** https://github.com/tachyon-r/hermes-agent/pull/1
Its review base is this branch at `94ae1bcd763006b46ce03dc43d36247891d74f80`, not upstream main. Merge order: upstream #80760 first; then rebase/present retention upstream. Do not merge the fork-local retention PR into this branch, which would recombine the split. No merge performed.

## Verification
`scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/tools/test_spill_safety.py`: **55 passed** on this write-only head, macOS.
`git diff --check`: passed. Write-only diff: three files, 442 additions / 28 deletions; production portion 167 additions / 26 deletions.

The combined retention stack additionally passed 128 focused tests. Those are not a substitute for this PR's independent 55-test result. Fresh CI must be evaluated for this rewritten head. Ruff is not installed in the existing environment; no dependencies were installed.

## Attribution and limits
Recomposed from the existing tachyon-r authored #80760 series. Mixed write/retention commits could not be retained unchanged while producing independent review diffs; the original authored history and repair are preserved locally at `maintenance/security-combined-80760`. Credit @spfcraze for the TTL-boundary finding and @egilewski for ACL, retention and review-size feedback.

An independent review found a real read-time deletion bug in the old combined version; the retention follow-up proves it with a real filesystem regression and repairs it before inclusion. This write-only PR has no new read-time deletion gate. No claims of live remote-backend or race-free filesystem verification. Native Linux/Windows and full-suite runs remain for CI.
