### PR TITLE
fix(tui): interrupt active turns with /stop (#80745)

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -679,6 +679,15 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('/stop interrupts the active turn before stopping background processes', () => {
+    patchUiState({ busy: true, sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/stop')).toBe(true)
+    expect(ctx.turn.interrupt).toHaveBeenCalledWith('sid-abc')
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('process.stop', {})
+  })
+
   it('renders browser connect progress messages from the gateway', async () => {
     const rpc = vi.fn(() =>
       Promise.resolve({
@@ -1075,6 +1084,7 @@ const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
   gateway: { ...buildGateway(), ...overrides.gateway },
   local: { ...buildLocal(), ...overrides.local },
   session: { ...buildSession(), ...overrides.session },
+  turn: { interrupt: vi.fn(), ...overrides.turn },
   transcript: { ...buildTranscript(), ...overrides.transcript },
   voice: { ...buildVoice(), ...overrides.voice }
 })
@@ -1139,6 +1149,7 @@ interface Ctx {
   gateway: ReturnType<typeof buildGateway>
   local: ReturnType<typeof buildLocal>
   session: ReturnType<typeof buildSession>
+  turn: { interrupt: ReturnType<typeof vi.fn> }
   transcript: ReturnType<typeof buildTranscript>
   voice: ReturnType<typeof buildVoice>
 }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -529,6 +529,9 @@ export interface SlashHandlerContext {
     resumeById: (id: string) => void
     setSessionStartedAt: StateSetter<number>
   }
+  turn: {
+    interrupt: (sid: string) => void
+  }
   slashFlightRef: MutableRefObject<number>
   transcript: {
     page: (text: string, title?: string) => void

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -66,6 +66,10 @@ export const opsCommands: SlashCommand[] = [
     help: 'stop background processes',
     name: 'stop',
     run: (_arg, ctx) => {
+      if (ctx.ui.busy && ctx.sid) {
+        ctx.turn.interrupt(ctx.sid)
+      }
+
       ctx.gateway
         .rpc<ProcessStopResponse>('process.stop', {})
         .then(

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -898,6 +898,9 @@ export function useMainApp(gw: GatewayClient) {
           resumeById: session.resumeById,
           setSessionStartedAt
         },
+        turn: {
+          interrupt: sid => turnController.interruptTurn({ appendMessage, gw, sid, sys })
+        },
         slashFlightRef,
         transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
         voice: { setVoiceEnabled, setVoiceRecordKey, setVoiceTts }


### PR DESCRIPTION
## Summary
- Make TUI `/stop` interrupt the active turn before stopping background processes.
- Reuse the existing turn-controller interrupt path so the UI and gateway settle consistently.

Closes #80745
