### PR TITLE
fix(desktop): drop duplicate gateway statusbar pill left by plugin migration

### DIFF
--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -78,7 +78,7 @@ export const StatusbarSurface = memo(function StatusbarSurface({
 }) {
   const gatewayState = useStore($gatewayState)
   const freshDraftReady = useStore($freshDraftReady)
-  const { inferenceStatus, statusSnapshot } = useStatusSnapshot(gatewayState, actions.requestGateway)
+  const { statusSnapshot } = useStatusSnapshot(gatewayState, actions.requestGateway)
   const extraLeftItems = useStatusbarContributions('left')
   const extraRightItems = useStatusbarContributions('right')
 
@@ -90,9 +90,7 @@ export const StatusbarSurface = memo(function StatusbarSurface({
     extraRightItems,
     freshDraftReady,
     gatewayState,
-    inferenceStatus,
     openAgents: actions.openAgents,
-    openCommandCenterSection: actions.openCommandCenterSection,
     requestGateway: actions.requestGateway,
     statusSnapshot,
     toggleCommandCenter: actions.toggleCommandCenter

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,17 +1,13 @@
 import { useStore } from '@nanostores/react'
 import { useCallback, useMemo } from 'react'
 
-import type { CommandCenterSection } from '@/app/command-center'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
-import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { $paneVisible, togglePaneVisible } from '@/components/pane-shell/tree/store'
 import { Codicon } from '@/components/ui/codicon'
-import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { displayPath, pathLeaf } from '@/lib/display-path'
-import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
-import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -36,7 +32,6 @@ import {
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
-import { $gatewayRestarting } from '@/store/system-actions'
 import {
   $backendUpdateApply,
   $backendUpdateStatus,
@@ -59,9 +54,7 @@ interface StatusbarItemsOptions {
   extraLeftItems: readonly StatusbarItem[]
   extraRightItems: readonly StatusbarItem[]
   gatewayState: string
-  inferenceStatus: RuntimeReadinessResult | null
   openAgents: () => void
-  openCommandCenterSection: (section: CommandCenterSection) => void
   freshDraftReady: boolean
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   statusSnapshot: StatusResponse | null
@@ -75,9 +68,7 @@ export function useStatusbarItems({
   extraLeftItems,
   extraRightItems,
   gatewayState,
-  inferenceStatus,
   openAgents,
-  openCommandCenterSection,
   requestGateway,
   statusSnapshot,
   toggleCommandCenter
@@ -97,7 +88,6 @@ export function useStatusbarItems({
   // own cwd in `$sessionStates` and must not paint the primary's workspace.
   const primaryCwd = useStore($currentCwd)
   const primaryUsage = useStore($currentUsage)
-  const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
 
@@ -235,40 +225,6 @@ export function useStatusbarItems({
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 
-  const gatewayMenuContent = useMemo(
-    () => (close: () => void) => (
-      <GatewayMenuPanel
-        gatewayState={gatewayState}
-        inferenceStatus={inferenceStatus}
-        onClose={close}
-        onOpenSystem={() => openCommandCenterSection('system')}
-        statusSnapshot={statusSnapshot}
-      />
-    ),
-    [gatewayState, inferenceStatus, openCommandCenterSection, statusSnapshot]
-  )
-
-  const gatewayOpen = gatewayState === 'open'
-  const gatewayConnecting = gatewayState === 'connecting'
-  const inferenceReady = gatewayOpen && inferenceStatus?.ready === true
-  const gatewayDegraded = gatewayOpen || gatewayConnecting
-
-  const gatewayDetail = gatewayOpen
-    ? inferenceStatus?.ready
-      ? copy.gatewayReady
-      : inferenceStatus
-        ? copy.gatewayNeedsSetup
-        : copy.gatewayChecking
-    : gatewayConnecting
-      ? copy.gatewayConnecting
-      : copy.gatewayOffline
-
-  const gatewayClassName = inferenceReady
-    ? undefined
-    : gatewayDegraded
-      ? 'text-amber-600 hover:text-amber-600'
-      : 'text-destructive hover:text-destructive'
-
   const clientVersionItem = useMemo<StatusbarItem>(() => {
     const applying = updateApply.applying || updateApply.stage === 'restart'
 
@@ -395,25 +351,6 @@ export function useStatusbarItems({
         variant: 'action'
       },
       {
-        className: gatewayRestarting ? undefined : gatewayClassName,
-        detail: gatewayRestarting ? copy.gatewayRestarting : gatewayDetail,
-        icon: gatewayRestarting ? (
-          <GlyphSpinner ariaLabel={copy.gatewayRestarting} className="size-3" />
-        ) : inferenceReady ? (
-          <Activity className="size-3" />
-        ) : (
-          <AlertCircle className="size-3" />
-        ),
-        id: 'gateway-health',
-        label: copy.gateway,
-        menuClassName: 'w-72',
-        menuContent: gatewayMenuContent,
-        // Tip only when there's a real status reason — not "gateway status" restating the label.
-        title: inferenceStatus?.reason || undefined,
-        toggleLabel: copy.gateway,
-        variant: 'menu'
-      },
-      {
         hidden: !currentCwd,
         icon: <FolderOpen className="size-3" />,
         id: 'workspace-cwd',
@@ -499,12 +436,6 @@ export function useStatusbarItems({
       fileMenu.copyPath,
       fileMenu.revealFileManager,
       fileMenu.revealInSidebar,
-      gatewayMenuContent,
-      gatewayClassName,
-      gatewayDetail,
-      gatewayRestarting,
-      inferenceReady,
-      inferenceStatus?.reason,
       openAgents,
       projectName,
       subagentsFailed,


### PR DESCRIPTION
## What does this PR do?

The desktop statusbar renders **two identical gateway pills** ("Gateway" / "Ready"). The gateway-health statusbar item was migrated to a plugin (`gateway-pill`, `area: 'statusBar.right'`), but the legacy built-in implementation was never removed — both register with different ids (`gateway-health` vs `gateway-pill`), so the contribution registry (which dedupes by `(area, id)`) cannot collapse them. Both buttons open the same `GatewayMenuPanel`; only the built-in one exposes a `toggleLabel`, so the duplicate can't even be hidden from the statusbar context menu.

This PR removes the legacy built-in `gateway-health` item and its now-dead helpers, leaving the plugin as the single source of the gateway status pill.

## Related Issue

Fixes #77556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx`
  - Remove the `gateway-health` statusbar item (id `'gateway-health'`).
  - Remove now-unused helpers: `gatewayMenuContent`, `gatewayOpen` / `gatewayConnecting` / `inferenceReady` / `gatewayDegraded`, `gatewayDetail`, `gatewayClassName`, and the `gatewayRestarting` store read.
  - Remove dead imports (`GatewayMenuPanel`, `GlyphSpinner`, `Activity`, `RuntimeReadinessResult`, `$gatewayRestarting`, `CommandCenterSection`).
  - Drop the now-unused `inferenceStatus` / `openCommandCenterSection` params from `StatusbarItemsOptions`.
- `apps/desktop/src/app/contrib/surfaces.tsx`
  - Stop passing `inferenceStatus` / `openCommandCenterSection` to `useStatusbarItems`.

The `gateway-pill` plugin (`apps/desktop/src/plugins/gateway-pill/plugin.tsx`) already covers the feature 1:1 — same `GatewayMenuPanel`, same readiness logic via `evaluateRuntimeReadiness`, same i18n label — so this is purely a dedup, no behavior loss.

## How to Test

1. Launch the desktop app against a local backend.
2. Observe the bottom statusbar right cluster: exactly **one** gateway pill ("网关" / "Gateway" + "Ready").
3. Click it — the gateway menu panel opens (connection/inference rows, restart, messaging platforms).
4. Right-click the statusbar — the gateway item appears once in the visibility menu.

Verified locally: `tsc -p . --noEmit` clean, `vitest run` on statusbar/approval-mode/contrib tests passes (27 tests), eslint reports 0 errors on the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (TypeScript-only change; vitest + tsc run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — existing `statusbar-visibility.test.tsx` covers the render path with the `gateway-health` id as a generic fixture; updated coverage not needed since the item itself is removed
- [x] I've tested on my platform: macOS 26.5.2 (Apple M1, arm64)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or architecture changes
