### PR TITLE
fix(api): forward MoA progress events on /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6265,6 +6265,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "text": preview or "",
                 })
+            elif event_type == "moa.progress":
+                _push({
+                    "event": "moa.progress",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "label": tool_name or "",
+                    "refs_done": kwargs.get("moa_refs_done"),
+                    "refs_total": kwargs.get("moa_refs_total"),
+                })
+            elif event_type == "moa.phase":
+                _push({
+                    "event": "moa.phase",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "phase": kwargs.get("moa_phase"),
+                    "refs_done": kwargs.get("moa_refs_done"),
+                    "refs_total": kwargs.get("moa_refs_total"),
+                    "aggregator": tool_name or "",
+                })
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
                     "event": event_type,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -625,6 +625,43 @@ class TestDisconnectedAgentReap:
 class TestRunEventCallback:
 
     @pytest.mark.asyncio
+    async def test_moa_progress_events_are_forwarded(self, adapter):
+        """The runs stream exposes live MoA progress and phase transitions."""
+        run_id = "run_moa_progress"
+        loop = asyncio.get_running_loop()
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        adapter._run_statuses.pop(run_id, None)
+
+        callback = adapter._make_run_event_callback(run_id, loop)
+        callback(
+            "moa.progress",
+            "reference-model",
+            moa_refs_done=1,
+            moa_refs_total=2,
+        )
+        callback(
+            "moa.phase",
+            "aggregator-model",
+            moa_phase="aggregator",
+            moa_refs_done=2,
+            moa_refs_total=2,
+        )
+
+        progress = await asyncio.wait_for(queue.get(), timeout=1.0)
+        phase = await asyncio.wait_for(queue.get(), timeout=1.0)
+
+        assert progress["event"] == "moa.progress"
+        assert progress["refs_done"] == 1
+        assert progress["refs_total"] == 2
+        assert progress["label"] == "reference-model"
+        assert phase["event"] == "moa.phase"
+        assert phase["phase"] == "aggregator"
+        assert phase["refs_done"] == 2
+        assert phase["refs_total"] == 2
+        assert phase["aggregator"] == "aggregator-model"
+
+    @pytest.mark.asyncio
     async def test_subagent_events_redact_secrets_and_carry_child_session(self, adapter):
         """Free-text fields (goal/summary/output_tail/preview) must pass the
         forced secret redaction before hitting the public /v1/runs stream,
@@ -2859,4 +2896,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-


### PR DESCRIPTION
## What does this PR do?

The MoA runtime already emits `moa.progress` as each reference completes and `moa.phase` when the aggregator phase begins. The TUI gateway forwards both events, but `APIServerAdapter._make_run_event_callback` silently drops them, so `/v1/runs/{run_id}/events` clients cannot show live fan-out progress or the phase transition.

This adds the missing Runs API mapping with the same payload fields used by the TUI gateway: `label`, `refs_done`, `refs_total`, `phase`, and `aggregator`.

This intentionally does not duplicate `moa.reference` or `moa.aggregating`: #71130 already covers those content-bearing events. It complements #71796, which improves the progress event source and native UI consumers but does not wire the events into the API server.

## Related Issue

Related to #2971. Complements #71130 and #71796.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — forward `moa.progress` and `moa.phase` through the `/v1/runs` SSE callback.
- `tests/gateway/test_api_server.py` — verify both structured event payloads with model-agnostic labels.

## How to Test

1. Start a MoA-backed run with `POST /v1/runs`.
2. Subscribe to `GET /v1/runs/{run_id}/events`.
3. Confirm that reference completion emits `moa.progress` and the aggregator transition emits `moa.phase` with the structured counters and labels.

Automated verification:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py -q
100 passed

ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
All checks passed!

python3 scripts/check-windows-footguns.py gateway/platforms/api_server.py tests/gateway/test_api_server.py
No Windows footguns found.
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the complete affected API server file passes (100 tests); the repository-wide suite is left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this extends the existing MoA run-event family
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral event forwarding; checker passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — structured SSE event forwarding is covered by the regression test above.
