### PR TITLE
feat(cron): continuity=true — cron jobs carry their previous run's output across runs

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5436,6 +5436,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
   const [name, setName] = useState('')
   const [instruction, setInstruction] = useState('')
   const [sched, setSched] = useState(defaultScheduleState())
+  const [continuity, setContinuity] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(null)
   const activeProfile = useValue(host.state.profile)
@@ -5445,6 +5446,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
     setName('')
     setInstruction('')
     setSched(defaultScheduleState())
+    setContinuity(false)
     setBusy(false)
     setError(null)
   }
@@ -5477,7 +5479,8 @@ function CreateRoutineDialog({ bot, open, onClose }) {
         schedule: schedule.trim(),
         prompt: routinePrompt(bot, title, task, activeProfile),
         ...(bot ? { profile: bot } : {}),
-        ...(repeatN ? { repeat: repeatN } : {})
+        ...(repeatN ? { repeat: repeatN } : {}),
+        ...(continuity ? { continuity: true } : {})
       })
       await invalidateRoutineOwner(bot)
       host.notify({ kind: 'success', message: `Cronjob "${title}" scheduled` })
@@ -5530,6 +5533,18 @@ function CreateRoutineDialog({ bot, open, onClose }) {
               })
             ),
             labeled('When to run', jsx(SchedulePicker, { state: sched, setState: setSched })),
+            jsxs('label', {
+              className: 'flex items-center gap-2 text-xs text-(--ui-text-tertiary) cursor-pointer select-none',
+              children: [
+                jsx('input', {
+                  type: 'checkbox',
+                  className: 'accent-(--ui-accent)',
+                  checked: continuity,
+                  onChange: event => setContinuity(event.target.checked)
+                }),
+                'Continuity: each run sees the previous run\u2019s output (dedupe, continue where it left off)'
+              ]
+            }),
             error
               ? jsx('div', {
                   className: 'rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-accent)',

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2513,6 +2513,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
+            # "self" resolves to the job's own id: the job wakes up with its
+            # most recent output injected, giving recurring jobs continuity
+            # across runs (dedupe against what was already reported, continue
+            # where the last run left off) without touching session history.
+            is_self = False
+            if isinstance(source_job_id, str) and source_job_id.strip().lower() == "self":
+                source_job_id = str(job.get("id") or "")
+                is_self = True
+            elif source_job_id == job.get("id"):
+                is_self = True
             # Guard against path traversal — valid job IDs are 12-char hex strings
             if not source_job_id or not all(c in "0123456789abcdef" for c in source_job_id):
                 logger.warning(
@@ -2540,13 +2550,24 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
                     latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
                 if latest_output:
-                    prompt = (
-                        f"## Output from job '{source_job_id}'\n"
-                        "The following is the most recent output from a preceding "
-                        "cron job. Use it as context for your analysis.\n\n"
-                        f"```\n{latest_output}\n```\n\n"
-                        f"{prompt}"
-                    )
+                    if is_self:
+                        prompt = (
+                            "## Your previous run's output\n"
+                            "The following is this job's most recent output from its "
+                            "previous run. Use it for continuity: avoid repeating what "
+                            "was already reported, and continue where the last run "
+                            "left off.\n\n"
+                            f"```\n{latest_output}\n```\n\n"
+                            f"{prompt}"
+                        )
+                    else:
+                        prompt = (
+                            f"## Output from job '{source_job_id}'\n"
+                            "The following is the most recent output from a preceding "
+                            "cron job. Use it as context for your analysis.\n\n"
+                            f"```\n{latest_output}\n```\n\n"
+                            f"{prompt}"
+                        )
                     has_injected_data = True
                 else:
                     continue  # silent skip — empty output

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3508,6 +3508,16 @@ def _build_job_prompt(
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
+            # "self" resolves to the job's own id: the job wakes up with its
+            # most recent output injected, giving recurring jobs continuity
+            # across runs (dedupe against what was already reported, continue
+            # where the last run left off) without touching session history.
+            is_self = False
+            if isinstance(source_job_id, str) and source_job_id.strip().lower() == "self":
+                source_job_id = str(job.get("id") or "")
+                is_self = True
+            elif source_job_id == job.get("id"):
+                is_self = True
             # Guard against path traversal — valid job IDs are 12-char hex strings
             if not source_job_id or not all(c in "0123456789abcdef" for c in source_job_id):
                 logger.warning(
@@ -3535,13 +3545,24 @@ def _build_job_prompt(
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
                     latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
                 if latest_output:
-                    prompt = (
-                        f"## Output from job '{source_job_id}'\n"
-                        "The following is the most recent output from a preceding "
-                        "cron job. Use it as context for your analysis.\n\n"
-                        f"```\n{latest_output}\n```\n\n"
-                        f"{prompt}"
-                    )
+                    if is_self:
+                        prompt = (
+                            "## Your previous run's output\n"
+                            "The following is this job's most recent output from its "
+                            "previous run. Use it for continuity: avoid repeating what "
+                            "was already reported, and continue where the last run "
+                            "left off.\n\n"
+                            f"```\n{latest_output}\n```\n\n"
+                            f"{prompt}"
+                        )
+                    else:
+                        prompt = (
+                            f"## Output from job '{source_job_id}'\n"
+                            "The following is the most recent output from a preceding "
+                            "cron job. Use it as context for your analysis.\n\n"
+                            f"```\n{latest_output}\n```\n\n"
+                            f"{prompt}"
+                        )
                     has_injected_data = True
                 else:
                     continue  # silent skip — empty output

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -364,6 +364,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        continuity=getattr(args, "continuity", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -382,6 +383,8 @@ def cron_create(args):
         print(f"  Monitor: {job_data['monitor_url']} (agent runs only on output change)")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    if job_data.get("continuity"):
+        print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
     print(f"  Next run: {result['next_run_at']}")
@@ -435,6 +438,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        continuity=getattr(args, "continuity", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -456,6 +460,8 @@ def cron_edit(args):
         print(f"  Monitor: {updated['monitor_url']} (agent runs only on output change)")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    if updated.get("continuity"):
+        print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
     return 0

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -105,6 +105,19 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    cron_create.add_argument(
+        "--continuity",
+        dest="continuity",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Each run wakes up with the job's own previous output injected "
+            "into its prompt, so it can dedupe against what was already "
+            "reported and continue where the last run left off (scouts, "
+            "monitors, incremental digests). First run is unchanged."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -164,6 +177,27 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--continuity",
+        dest="continuity",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Turn on run-to-run continuity: each run sees the job's own "
+            "previous output (dedupe, continue where it left off)."
+        ),
+    )
+    cron_edit.add_argument(
+        "--no-continuity",
+        dest="continuity",
+        action="store_const",
+        const=False,
+        help=(
+            "Turn off run-to-run continuity (other context_from job refs "
+            "are preserved)."
+        ),
     )
     cron_edit.add_argument(
         "--monitor-script",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12087,6 +12087,11 @@ def _validate_dashboard_cron_context_from(
     if not refs:
         return
     for ref in refs:
+        # "self" (the continuity toggle) resolves to the job's own id at run
+        # time — it can't be validated against the store (create precedes the
+        # job's existence).
+        if isinstance(ref, str) and ref.strip().lower() == "self":
+            continue
         if not _call_cron_for_profile(profile_name, "get_job", ref):
             raise HTTPException(
                 status_code=400,

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -217,3 +217,103 @@ class TestUpdateContextFrom:
         assert reloaded["context_from"] == [job_a["id"]]
 
 
+class TestSelfContext:
+    """The special 'self' value injects the job's OWN previous output.
+
+    Inspired by Amp's "Right on Schedule" (agents wake up with their saved
+    context and continue where they left off): recurring jobs get run-to-run
+    continuity without touching session history.
+    """
+
+    def test_self_injects_own_previous_output(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(
+            prompt="Scan for news", schedule="every 1h", context_from="self"
+        )
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            "Reported: story A, story B", encoding="utf-8"
+        )
+
+        prompt = _build_job_prompt(job)
+        assert "Reported: story A, story B" in prompt
+        assert "previous run" in prompt.lower()
+        # Self-context uses continuity framing, not the upstream-job framing.
+        assert f"Output from job '{job['id']}'" not in prompt
+
+    def test_self_case_insensitive(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(
+            prompt="Scan", schedule="every 1h", context_from="SELF"
+        )
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text("prev", encoding="utf-8")
+        prompt = _build_job_prompt(job)
+        assert "prev" in prompt
+
+    def test_self_silent_skip_on_first_run(self, cron_env):
+        from cron.jobs import create_job
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(
+            prompt="Scan for news", schedule="every 1h", context_from="self"
+        )
+        # No output yet (first run) — base prompt intact, no placeholder.
+        prompt = _build_job_prompt(job)
+        assert "Scan for news" in prompt
+        assert "previous run" not in prompt.lower()
+
+    def test_own_id_treated_as_self(self, cron_env):
+        """Passing the job's literal id gets the continuity framing too."""
+        from cron.jobs import create_job, update_job, get_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="Scan", schedule="every 1h")
+        update_job(job["id"], {"context_from": [job["id"]]})
+        job = get_job(job["id"])
+        assert job is not None
+
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text("prev output", encoding="utf-8")
+
+        prompt = _build_job_prompt(job)
+        assert "prev output" in prompt
+        assert "previous run" in prompt.lower()
+
+    def test_tool_create_accepts_self(self, cron_env):
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+        import json
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Scan for news",
+            schedule="every 1h",
+            context_from="self",
+        ))
+        assert result["success"] is True
+        job_id = result["job_id"]
+        assert get_job(job_id)["context_from"] == ["self"]
+
+    def test_tool_update_accepts_self(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        job = create_job(prompt="Scan", schedule="every 1h")
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job["id"],
+            context_from="self",
+        ))
+        assert result["success"] is True
+        assert get_job(job["id"])["context_from"] == ["self"]
+
+

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -317,3 +317,126 @@ class TestSelfContext:
         assert get_job(job["id"])["context_from"] == ["self"]
 
 
+class TestContinuityFlag:
+    """continuity=true/false is the user-facing surface for self-context.
+
+    It translates to the reserved 'self' entry in context_from internally.
+    """
+
+    def test_create_with_continuity_true(self, cron_env):
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+        import json
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Scan for news",
+            schedule="every 1h",
+            continuity=True,
+        ))
+        assert result["success"] is True
+        assert get_job(result["job_id"])["context_from"] == ["self"]
+
+    def test_create_continuity_false_is_noop(self, cron_env):
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+        import json
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Scan",
+            schedule="every 1h",
+            continuity=False,
+        ))
+        assert result["success"] is True
+        assert get_job(result["job_id"]).get("context_from") is None
+
+    def test_create_continuity_combines_with_context_from(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        upstream = create_job(prompt="Collect", schedule="every 1h")
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Digest",
+            schedule="every 2h",
+            context_from=upstream["id"],
+            continuity=True,
+        ))
+        assert result["success"] is True
+        stored = get_job(result["job_id"])["context_from"]
+        assert upstream["id"] in stored
+        assert "self" in stored
+
+    def test_update_continuity_true_adds_self(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        job = create_job(prompt="Scan", schedule="every 1h")
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job["id"],
+            continuity=True,
+        ))
+        assert result["success"] is True
+        assert get_job(job["id"])["context_from"] == ["self"]
+
+    def test_update_continuity_false_removes_self_preserves_others(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        upstream = create_job(prompt="Collect", schedule="every 1h")
+        job = create_job(
+            prompt="Digest",
+            schedule="every 2h",
+            context_from=["self", upstream["id"]],
+        )
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job["id"],
+            continuity=False,
+        ))
+        assert result["success"] is True
+        assert get_job(job["id"])["context_from"] == [upstream["id"]]
+
+    def test_update_continuity_true_idempotent(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        job = create_job(prompt="Scan", schedule="every 1h", context_from="self")
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job["id"],
+            continuity=True,
+        ))
+        assert result["success"] is True
+        assert get_job(job["id"])["context_from"] == ["self"]
+
+    def test_continuity_job_gets_previous_output(self, cron_env):
+        """End-to-end: a continuity-created job injects its own prior output."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+        import json
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Scan for news",
+            schedule="every 1h",
+            continuity=True,
+        ))
+        job = get_job(result["job_id"])
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            "Reported: story A", encoding="utf-8"
+        )
+        prompt = _build_job_prompt(job)
+        assert "Reported: story A" in prompt
+        assert "previous run" in prompt.lower()
+
+

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1141,6 +1141,30 @@ def _try_dispatch_background_run(
     return result
 
 
+def _apply_continuity(
+    context_from: Optional[Union[str, List[str]]],
+    continuity: bool,
+) -> Optional[List[str]]:
+    """Translate the ``continuity`` flag into the ``context_from`` list.
+
+    ``continuity=True`` ensures ``"self"`` is present (the job's own previous
+    output is injected each run); ``continuity=False`` removes any
+    ``"self"``/own-id entry. Other entries are preserved untouched.
+    """
+    if isinstance(context_from, str):
+        refs = [context_from.strip()] if context_from.strip() else []
+    elif context_from:
+        refs = [str(j).strip() for j in context_from if str(j).strip()]
+    else:
+        refs = []
+    has_self = any(r.lower() == "self" for r in refs)
+    if continuity and not has_self:
+        refs.append("self")
+    elif not continuity and has_self:
+        refs = [r for r in refs if r.lower() != "self"]
+    return refs or None
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -1158,6 +1182,7 @@ def cronjob(
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
+    continuity: Optional[bool] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
@@ -1231,6 +1256,11 @@ def cronjob(
                             "Use cronjob(action='list') to see available jobs.",
                             success=False,
                         )
+
+            # continuity=True is sugar for context_from including "self":
+            # the job wakes up with its own previous run's output injected.
+            if continuity is not None:
+                context_from = _apply_continuity(context_from, continuity)
 
             from cron.scheduler import (
                 CronSchedulerRegistrationError,
@@ -1494,14 +1524,20 @@ def cronjob(
                         "clear one before setting the other.",
                         success=False,
                     )
-            if context_from is not None:
+            if context_from is not None or continuity is not None:
                 # Empty string / empty list clears the field; otherwise validate
                 # each referenced job exists before storing. Normalized to a list
                 # (or None) to match the shape stored by create_job().
-                if isinstance(context_from, str):
+                if context_from is None:
+                    # continuity-only update: start from the job's stored refs.
+                    existing = job.get("context_from") or []
+                    refs = [str(j).strip() for j in existing if str(j).strip()]
+                elif isinstance(context_from, str):
                     refs = [context_from.strip()] if context_from.strip() else []
                 else:
                     refs = [str(j).strip() for j in context_from if str(j).strip()]
+                if continuity is not None:
+                    refs = _apply_continuity(refs, continuity) or []
                 if refs:
                     from cron.jobs import get_job as _get_job
                     for ref_id in refs:
@@ -1657,13 +1693,23 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                     "Optional job ID or list of job IDs whose most recent completed output is "
                     "injected into the prompt as context before each run. "
                     "Use this to chain cron jobs: job A collects data, job B processes it. "
-                    "The special value 'self' injects this job's OWN previous output, giving "
-                    "recurring jobs continuity across runs (dedupe against what was already "
-                    "reported, continue where the last run left off). "
-                    "Each other entry must be a valid job ID (from cronjob action='list'). "
+                    "Each entry must be a valid job ID (from cronjob action='list'); "
+                    "for a job's OWN previous output, prefer the `continuity` flag. "
                     "Note: injects the most recent completed output — does not wait for "
                     "upstream jobs running in the same tick. "
                     "On update, pass an empty array to clear."
+                ),
+            },
+            "continuity": {
+                "type": "boolean",
+                "description": (
+                    "When true, this recurring job carries continuity across runs: each run "
+                    "wakes up with the job's own most recent output injected into its prompt, "
+                    "so it can dedupe against what was already reported and continue where the "
+                    "last run left off (scouts, monitors, incremental digests). "
+                    "First run has no previous output and runs unchanged. "
+                    "On update, pass false to turn continuity off (other context_from entries "
+                    "are preserved). Default: false."
                 ),
             },
             "enabled_toolsets": {
@@ -1733,6 +1779,7 @@ registry.register(
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),
+        continuity=args.get("continuity"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -658,6 +658,17 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    stored_refs = job.get("context_from") or []
+    if isinstance(stored_refs, str):
+        stored_refs = [stored_refs]
+    if any(str(r).strip().lower() == "self" or r == job.get("id") for r in stored_refs):
+        result["continuity"] = True
+    external_refs = [
+        r for r in stored_refs
+        if str(r).strip().lower() != "self" and r != job.get("id")
+    ]
+    if external_refs:
+        result["context_from"] = external_refs
     return result
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1220,6 +1220,11 @@ def cronjob(
                 from cron.jobs import get_job as _get_job
                 refs = [context_from] if isinstance(context_from, str) else context_from
                 for ref_id in refs:
+                    # "self" is resolved to the job's own id at run time —
+                    # it can't be validated against the store (the job does
+                    # not exist yet at create time).
+                    if isinstance(ref_id, str) and ref_id.strip().lower() == "self":
+                        continue
                     if not _get_job(ref_id):
                         return tool_error(
                             f"context_from job '{ref_id}' not found. "
@@ -1500,6 +1505,9 @@ def cronjob(
                 if refs:
                     from cron.jobs import get_job as _get_job
                     for ref_id in refs:
+                        # "self" resolves to the job's own id at run time.
+                        if ref_id.lower() == "self":
+                            continue
                         if not _get_job(ref_id):
                             return tool_error(
                                 f"context_from job '{ref_id}' not found. "
@@ -1649,7 +1657,10 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                     "Optional job ID or list of job IDs whose most recent completed output is "
                     "injected into the prompt as context before each run. "
                     "Use this to chain cron jobs: job A collects data, job B processes it. "
-                    "Each entry must be a valid job ID (from cronjob action='list'). "
+                    "The special value 'self' injects this job's OWN previous output, giving "
+                    "recurring jobs continuity across runs (dedupe against what was already "
+                    "reported, continue where the last run left off). "
+                    "Each other entry must be a valid job ID (from cronjob action='list'). "
                     "Note: injects the most recent completed output — does not wait for "
                     "upstream jobs running in the same tick. "
                     "On update, pass an empty array to clear."

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -777,6 +777,11 @@ def cronjob(
                 from cron.jobs import get_job as _get_job
                 refs = [context_from] if isinstance(context_from, str) else context_from
                 for ref_id in refs:
+                    # "self" is resolved to the job's own id at run time —
+                    # it can't be validated against the store (the job does
+                    # not exist yet at create time).
+                    if isinstance(ref_id, str) and ref_id.strip().lower() == "self":
+                        continue
                     if not _get_job(ref_id):
                         return tool_error(
                             f"context_from job '{ref_id}' not found. "
@@ -969,6 +974,9 @@ def cronjob(
                 if refs:
                     from cron.jobs import get_job as _get_job
                     for ref_id in refs:
+                        # "self" resolves to the job's own id at run time.
+                        if ref_id.lower() == "self":
+                            continue
                         if not _get_job(ref_id):
                             return tool_error(
                                 f"context_from job '{ref_id}' not found. "
@@ -1108,7 +1116,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "Optional job ID or list of job IDs whose most recent completed output is "
                     "injected into the prompt as context before each run. "
                     "Use this to chain cron jobs: job A collects data, job B processes it. "
-                    "Each entry must be a valid job ID (from cronjob action='list'). "
+                    "The special value 'self' injects this job's OWN previous output, giving "
+                    "recurring jobs continuity across runs (dedupe against what was already "
+                    "reported, continue where the last run left off). "
+                    "Each other entry must be a valid job ID (from cronjob action='list'). "
                     "Note: injects the most recent completed output — does not wait for "
                     "upstream jobs running in the same tick. "
                     "On update, pass an empty array to clear."

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1711,6 +1711,14 @@ def _(rid, params: dict) -> dict:
                             if str(params.get("repeat", "")).strip().isdigit()
                             else None
                         ),
+                        # Optional continuity toggle: the job's own previous
+                        # output is injected into each run (stored as the
+                        # reserved "self" entry in context_from).
+                        continuity=(
+                            is_truthy_value(params.get("continuity"))
+                            if params.get("continuity") is not None
+                            else None
+                        ),
                     )
                 ),
             )

--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -22,6 +22,7 @@ function form(overrides: Partial<CronJobFormState> = {}): CronJobFormState {
     script: "",
     no_agent: false,
     context_from: "",
+    continuity: false,
     enabled_toolsets: [],
     workdir: "",
     ...overrides,
@@ -53,6 +54,22 @@ describe("buildCronJobPayload", () => {
       context_from: ["upstream-a", "upstream-b"],
       enabled_toolsets: ["web"],
     });
+  });
+
+  it("stores continuity as the reserved self entry", () => {
+    const payload = buildCronJobPayload(
+      form({ continuity: true, context_from: "upstream-a" }),
+    );
+
+    expect(payload.context_from).toEqual(["upstream-a", "self"]);
+  });
+
+  it("continuity off strips any hand-typed self entry", () => {
+    const payload = buildCronJobPayload(
+      form({ continuity: false, context_from: "SELF\nupstream-a" }),
+    );
+
+    expect(payload.context_from).toEqual(["upstream-a"]);
   });
 
   it("keeps clear operations explicit for update payloads", () => {
@@ -101,7 +118,22 @@ describe("cronJobFormFromJob", () => {
     expect(cronJobFormFromJob(job)).toMatchObject({
       schedule: "every 1h",
       context_from: "upstream-a\nupstream-b",
+      continuity: false,
       enabled_toolsets: ["web"],
+    });
+  });
+
+  it("splits the stored self entry into the continuity toggle", () => {
+    const job: CronJob = {
+      id: "abc",
+      enabled: true,
+      schedule_display: "every 1h",
+      context_from: ["self", "upstream-a"],
+    };
+
+    expect(cronJobFormFromJob(job)).toMatchObject({
+      context_from: "upstream-a",
+      continuity: true,
     });
   });
 

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -76,7 +76,11 @@ export function cronJobHasExecutionContent(
 
 export function cronJobFormFromJob(job: CronJob): CronJobFormState {
   const storedRefs = splitCronList(job.context_from);
-  const continuity = storedRefs.some((item) => item.toLowerCase() === "self");
+  // Raw store records carry the reserved "self" entry inside context_from;
+  // tool/RPC-formatted records strip it and set an explicit continuity flag.
+  const continuity =
+    Boolean((job as { continuity?: boolean }).continuity) ||
+    storedRefs.some((item) => item.toLowerCase() === "self");
   const externalRefs = storedRefs.filter((item) => item.toLowerCase() !== "self");
   return {
     name: asString(job.name),

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -12,6 +12,7 @@ export interface CronJobFormState {
   script: string;
   no_agent: boolean;
   context_from: string;
+  continuity: boolean;
   enabled_toolsets: string[];
   workdir: string;
 }
@@ -33,12 +34,6 @@ function optionalText(value: string, stripTrailingSlash = false): string | null 
   return text || null;
 }
 
-/** Coerce a stored list/string field back into the textarea's newline form. */
-function listToText(value: unknown): string {
-  if (Array.isArray(value)) return splitCronList(value).join("\n");
-  return typeof value === "string" ? value : "";
-}
-
 /** Read a stored string field as a plain string ("" when absent). */
 function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -47,7 +42,13 @@ function asString(value: unknown): string {
 /** Build the create/update payload. Optional fields collapse to null so an
  * update explicitly clears them rather than leaving stale values. */
 export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
-  const contextFrom = splitCronList(form.context_from);
+  // The `continuity` toggle is stored as the reserved "self" entry in
+  // context_from (the job's own previous output). Users never type "self" —
+  // the checkbox is the surface; strip any hand-typed variant first.
+  const contextFrom = splitCronList(form.context_from).filter(
+    (item) => item.toLowerCase() !== "self",
+  );
+  if (form.continuity) contextFrom.push("self");
   const enabledToolsets = form.enabled_toolsets.filter(Boolean);
   return {
     name: form.name.trim(),
@@ -74,6 +75,9 @@ export function cronJobHasExecutionContent(
 }
 
 export function cronJobFormFromJob(job: CronJob): CronJobFormState {
+  const storedRefs = splitCronList(job.context_from);
+  const continuity = storedRefs.some((item) => item.toLowerCase() === "self");
+  const externalRefs = storedRefs.filter((item) => item.toLowerCase() !== "self");
   return {
     name: asString(job.name),
     prompt: asString(job.prompt),
@@ -88,7 +92,8 @@ export function cronJobFormFromJob(job: CronJob): CronJobFormState {
     base_url: asString(job.base_url),
     script: asString(job.script),
     no_agent: Boolean(job.no_agent),
-    context_from: listToText(job.context_from),
+    context_from: externalRefs.join("\n"),
+    continuity,
     enabled_toolsets: splitCronList(job.enabled_toolsets),
     workdir: asString(job.workdir),
   };

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -145,6 +145,7 @@ function emptyCronJobForm(): CronJobEditorState {
     script: "",
     no_agent: false,
     context_from: "",
+    continuity: false,
     enabled_toolsets: [],
     workdir: "",
     scheduleState: { ...DEFAULT_SCHEDULE_STATE },
@@ -290,6 +291,16 @@ function CronAdvancedFields({
             placeholder="/absolute/project/path"
           />
         </div>
+
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            className="accent-foreground"
+            checked={form.continuity}
+            onChange={(e) => update("continuity", e.target.checked)}
+          />
+          continuity: each run sees the previous run&apos;s output (dedupe, pick up where it left off)
+        </label>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="grid gap-1">

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -548,14 +548,32 @@ cronjob(
 |--------|---------|
 | Single job ID (string) | `context_from="a1b2c3d4"` |
 | Multiple job IDs (list) | `context_from=["job_a", "job_b"]` |
+| The special value `self` | `context_from="self"` |
 
 Outputs are concatenated in the order listed.
+
+**Self-context: continuity across runs**
+
+`context_from="self"` injects the job's *own* most recent output into each run. Recurring jobs normally start every run with amnesia — a news scout re-reports the same stories, a monitor re-alerts on the same condition. With self-context, the job wakes up seeing what it reported last time and can dedupe and continue where it left off:
+
+```python
+cronjob(
+    action="create",
+    prompt="Scan HN and arXiv for new agent-tooling papers. Report only items NOT already covered in your previous run's output.",
+    schedule="every 6h",
+    context_from="self",
+    name="Agent Tooling Scout",
+)
+```
+
+The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). You can combine it with upstream jobs: `context_from=["self", "<other_job_id>"]`.
 
 **When to use it:**
 
 - Multi-stage pipelines (collect → filter → format → deliver)
 - Dependent tasks where step N's work depends on step N−1's output
 - Fan-out/fan-in patterns where one job aggregates results from several others
+- Recurring scouts/monitors that should dedupe against their own previous report (`context_from="self"`)
 
 ## Provider recovery
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -633,6 +633,8 @@ cronjob(
 
 The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). It combines freely with upstream jobs (`context_from=["<other_job_id>"]` plus `continuity=true`), and `continuity=false` on update turns it off while preserving other `context_from` entries. Internally the flag is stored as the reserved `self` entry in `context_from`.
 
+From the CLI: `hermes cron create "every 6h" "Scan for news" --continuity`, and `hermes cron edit <job_id> --continuity` / `--no-continuity` to toggle it on an existing job. The same toggle appears in the dashboard's cron editor and the desktop Bot Mode routine dialog.
+
 **When to use it:**
 
 - Multi-stage pipelines (collect → filter → format → deliver)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -614,32 +614,31 @@ cronjob(
 |--------|---------|
 | Single job ID (string) | `context_from="a1b2c3d4"` |
 | Multiple job IDs (list) | `context_from=["job_a", "job_b"]` |
-| The special value `self` | `context_from="self"` |
 
 Outputs are concatenated in the order listed.
 
-**Self-context: continuity across runs**
+**Continuity: carry the previous run's output**
 
-`context_from="self"` injects the job's *own* most recent output into each run. Recurring jobs normally start every run with amnesia — a news scout re-reports the same stories, a monitor re-alerts on the same condition. With self-context, the job wakes up seeing what it reported last time and can dedupe and continue where it left off:
+Set `continuity=true` and the job injects its *own* most recent output into each run. Recurring jobs normally start every run with amnesia — a news scout re-reports the same stories, a monitor re-alerts on the same condition. With continuity on, the job wakes up seeing what it reported last time and can dedupe and continue where it left off:
 
 ```python
 cronjob(
     action="create",
     prompt="Scan HN and arXiv for new agent-tooling papers. Report only items NOT already covered in your previous run's output.",
     schedule="every 6h",
-    context_from="self",
+    continuity=True,
     name="Agent Tooling Scout",
 )
 ```
 
-The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). You can combine it with upstream jobs: `context_from=["self", "<other_job_id>"]`.
+The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). It combines freely with upstream jobs (`context_from=["<other_job_id>"]` plus `continuity=true`), and `continuity=false` on update turns it off while preserving other `context_from` entries. Internally the flag is stored as the reserved `self` entry in `context_from`.
 
 **When to use it:**
 
 - Multi-stage pipelines (collect → filter → format → deliver)
 - Dependent tasks where step N's work depends on step N−1's output
 - Fan-out/fan-in patterns where one job aggregates results from several others
-- Recurring scouts/monitors that should dedupe against their own previous report (`context_from="self"`)
+- Recurring scouts/monitors that should dedupe against their own previous report (`continuity=true`)
 
 ## Provider recovery
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -614,14 +614,32 @@ cronjob(
 |--------|---------|
 | Single job ID (string) | `context_from="a1b2c3d4"` |
 | Multiple job IDs (list) | `context_from=["job_a", "job_b"]` |
+| The special value `self` | `context_from="self"` |
 
 Outputs are concatenated in the order listed.
+
+**Self-context: continuity across runs**
+
+`context_from="self"` injects the job's *own* most recent output into each run. Recurring jobs normally start every run with amnesia — a news scout re-reports the same stories, a monitor re-alerts on the same condition. With self-context, the job wakes up seeing what it reported last time and can dedupe and continue where it left off:
+
+```python
+cronjob(
+    action="create",
+    prompt="Scan HN and arXiv for new agent-tooling papers. Report only items NOT already covered in your previous run's output.",
+    schedule="every 6h",
+    context_from="self",
+    name="Agent Tooling Scout",
+)
+```
+
+The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). You can combine it with upstream jobs: `context_from=["self", "<other_job_id>"]`.
 
 **When to use it:**
 
 - Multi-stage pipelines (collect → filter → format → deliver)
 - Dependent tasks where step N's work depends on step N−1's output
 - Fan-out/fan-in patterns where one job aggregates results from several others
+- Recurring scouts/monitors that should dedupe against their own previous report (`context_from="self"`)
 
 ## Provider recovery
 


### PR DESCRIPTION
## Summary

Recurring cron jobs can now carry context across runs: `continuity=true` injects the job's own most recent output into each run, so scouts/monitors dedupe against what they already reported and continue where they left off. (Internally stored as the reserved `self` entry in `context_from`; the boolean flag is the user-facing surface per review.)

Inspired by Amp's ["Right on Schedule"](https://ampcode.com/news/schedule) (Jul 21, 2026) — scheduled Amp agents "wake up with their saved prompt and continue right where they left off, with all of their context and history."

## Their mechanism vs ours

- **Amp:** a schedule re-enters the *same thread* — full context and history persist across wakes.
- **Hermes:** cron runs are deliberately isolated sessions (prompt-cache + alternation invariants; cron deliveries never touch chat history). Replaying full session history per run would grow unboundedly and re-bill the whole transcript every wake.
- **Adaptation:** reuse the existing `context_from` output-injection pipe, pointed at the job itself. The previous run's *final report* (already persisted under `~/.hermes/cron/output/<job_id>/`, already 8K-truncated) is prepended with continuity framing. No session mutation, no new storage, no cache impact — the continuity lands in the fresh prompt.

## Changes

- `cron/scheduler.py`: `_build_job_prompt()` resolves `"self"` (case-insensitive) and the job's own literal id to self-context, with continuity framing ("avoid repeating what was already reported, continue where the last run left off") instead of the upstream-job framing.
- `tools/cronjob_tools.py`: create/update validation allows `"self"` (it can't be validated against the store — the job doesn't exist yet at create time); tool schema documents the value.
- `tests/cron/test_cron_context_from.py`: 6 new tests (injection, case-insensitivity, first-run silent skip, own-id equivalence, tool create/update acceptance).
- `website/docs/user-guide/features/cron.md`: self-context section with example.

## Validation

| Check | Result |
|---|---|
| `tests/cron/test_cron_context_from.py` + `tests/tools/test_cronjob_tools.py` | 84 passed |
| Full `tests/cron/` | 419 passed |
| Sabotage run (fix stashed) | 5/6 new tests fail — the pass is the vacuous first-run skip |

First run has no previous output → silent skip, prompt unchanged (existing `context_from` semantics). Path-traversal guard unchanged: `"self"` resolves to the job's validated 12-hex id before any filesystem access.

## Infographic

![Cron self-context infographic](https://v3b.fal.media/files/b/0aa555f3/Wjbhe6kmK6sIkF5DeKK16_HBTqwrkF.png)

