### PR TITLE
fix(desktop): persist onboarding model change against the picked model's provider

### DIFF
--- a/apps/desktop/src/components/onboarding/flow.tsx
+++ b/apps/desktop/src/components/onboarding/flow.tsx
@@ -319,8 +319,17 @@ function ConfirmingModelPanel({
         currentModel={flow.currentModel}
         currentProvider={flow.providerSlug}
         onOpenChange={setPickerOpen}
-        onSelect={({ model }) => {
-          void setOnboardingModel(model)
+        onSelect={({ model, provider }) => {
+          // The picker lists models from every configured provider, not just
+          // the one the user just signed in with. Persist the assignment
+          // against the provider that actually serves the picked model (and
+          // sync the card label to it) — otherwise a foreign model gets
+          // paired with the sign-in provider and chat errors out.
+          const picked = options.data?.providers?.find(
+            p => String(p.slug).toLowerCase() === String(provider).toLowerCase()
+          )
+
+          void setOnboardingModel(model, provider, picked?.name)
           setPickerOpen(false)
         }}
         open={pickerOpen}

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -10,6 +10,7 @@ import {
   refreshOnboarding,
   requestDesktopOnboarding,
   saveOnboardingLocalEndpoint,
+  setOnboardingModel,
   submitOnboardingCode
 } from './onboarding'
 
@@ -589,5 +590,142 @@ describe('saveOnboardingLocalEndpoint', () => {
     expect(result.ok).toBe(false)
     expect(result.message).toContain('No provider can serve the selected model.')
     expect($desktopOnboarding.get().configured).not.toBe(true)
+  })
+})
+
+describe('setOnboardingModel', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+    vi.restoreAllMocks()
+  })
+
+  function confirmingModelState(overrides: Partial<Extract<DesktopOnboardingState['flow'], { status: 'confirming_model' }>> = {}) {
+    return baseState({
+      flow: {
+        status: 'confirming_model',
+        currentModel: 'gpt-5.6-terra',
+        label: 'OpenAI OAuth (ChatGPT)',
+        providerSlug: 'openai',
+        saving: false,
+        ...overrides
+      }
+    })
+  }
+
+  it('persists a cross-provider pick against the picked model provider, not the sign-in provider', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    const api = vi.fn(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'nous', model: 'deepseek/deepseek-v4-flash-0731' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    $desktopOnboarding.set(confirmingModelState())
+
+    // The user signed in with OpenAI OAuth but picked a deepseek model that
+    // Nous Portal serves. The assignment must target `nous`, never `openai`.
+    await setOnboardingModel('deepseek/deepseek-v4-flash-0731', 'nous', 'Nous Portal')
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({
+      scope: 'main',
+      provider: 'nous',
+      model: 'deepseek/deepseek-v4-flash-0731'
+    })
+
+    const flow = $desktopOnboarding.get().flow
+    expect(flow.status).toBe('confirming_model')
+
+    if (flow.status === 'confirming_model') {
+      expect(flow.currentModel).toBe('deepseek/deepseek-v4-flash-0731')
+      expect(flow.providerSlug).toBe('nous')
+      expect(flow.label).toBe('Nous Portal')
+      expect(flow.saving).toBe(false)
+    }
+  })
+
+  it('keeps the sign-in provider when the picked model belongs to it', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    const api = vi.fn(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'openai', model: 'gpt-5.2' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    $desktopOnboarding.set(confirmingModelState())
+
+    await setOnboardingModel('gpt-5.2', 'openai', 'OpenAI OAuth (ChatGPT)')
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({ provider: 'openai', model: 'gpt-5.2' })
+
+    const flow = $desktopOnboarding.get().flow
+    expect(flow.status).toBe('confirming_model')
+
+    if (flow.status === 'confirming_model') {
+      expect(flow.providerSlug).toBe('openai')
+      expect(flow.label).toBe('OpenAI OAuth (ChatGPT)')
+    }
+  })
+
+  it('falls back to the flow provider when the caller passes no provider', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    const api = vi.fn(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'openai', model: 'gpt-5.2' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    $desktopOnboarding.set(confirmingModelState())
+
+    // Legacy call shape (model only) must keep persisting under the sign-in
+    // provider rather than writing an empty provider.
+    await setOnboardingModel('gpt-5.2')
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({ provider: 'openai', model: 'gpt-5.2' })
+  })
+
+  it('reverts the model, provider and label when persistence fails', async () => {
+    installApiMock(async () => {
+      throw new Error('backend down')
+    })
+    $desktopOnboarding.set(confirmingModelState())
+
+    await setOnboardingModel('deepseek/deepseek-v4-flash-0731', 'nous', 'Nous Portal')
+
+    const flow = $desktopOnboarding.get().flow
+    expect(flow.status).toBe('confirming_model')
+
+    if (flow.status === 'confirming_model') {
+      expect(flow.currentModel).toBe('gpt-5.6-terra')
+      expect(flow.providerSlug).toBe('openai')
+      expect(flow.label).toBe('OpenAI OAuth (ChatGPT)')
+      expect(flow.saving).toBe(false)
+    }
   })
 })

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -871,34 +871,47 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
 
 // User picked a different model from the dropdown on the confirm card.
 // Persists immediately so the displayed value is always what's on disk.
-export async function setOnboardingModel(model: string) {
+//
+// The picker can surface models from ANY configured provider, not just the
+// one the user just authenticated. The selection therefore carries the
+// model's real provider slug — persist against that, or a foreign model
+// gets paired with the sign-in provider (config says provider A serves a
+// model only provider B has; chat errors "provider doesn't have the
+// selected model"). Also keep the flow's providerSlug/label in sync so the
+// confirm card shows the provider that actually serves the picked model.
+export async function setOnboardingModel(model: string, providerSlug?: string, label?: string) {
   const { flow } = $desktopOnboarding.get()
 
   if (flow.status !== 'confirming_model') {
     return
   }
 
+  // Fall back to the sign-in provider when the caller doesn't know the
+  // model's provider (back-compat) — the confirm card always has both.
+  const provider = (providerSlug || flow.providerSlug).trim() || flow.providerSlug
+  const displayLabel = label || flow.label
+
   // Optimistic update so the dropdown feels instant; revert on failure.
-  const previous = flow.currentModel
-  setFlow({ ...flow, currentModel: model, saving: true })
+  const previous = { currentModel: flow.currentModel, label: flow.label, providerSlug: flow.providerSlug }
+  setFlow({ ...flow, currentModel: model, providerSlug: provider, label: displayLabel, saving: true })
 
   try {
     await setModelAssignment({
       scope: 'main',
-      provider: flow.providerSlug,
+      provider,
       model
     })
     const current = $desktopOnboarding.get().flow
 
     if (current.status === 'confirming_model') {
-      setFlow({ ...current, currentModel: model, saving: false })
+      setFlow({ ...current, currentModel: model, providerSlug: provider, label: displayLabel, saving: false })
     }
   } catch (error) {
     notifyError(error, 'Could not change model')
     const current = $desktopOnboarding.get().flow
 
     if (current.status === 'confirming_model') {
-      setFlow({ ...current, currentModel: previous, saving: false })
+      setFlow({ ...current, ...previous, saving: false })
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Fixes the desktop first-run onboarding flow writing a provider/model mismatch when the user changes the default model on the confirm screen to one served by a different provider.

The confirm-model step's **Change** picker lists models from every configured provider, but the `onSelect` handler dropped the picked model's provider slug, and `setOnboardingModel` persisted the assignment against the just-signed-in provider. Adding OpenAI OAuth and then picking `deepseek/deepseek-v4-flash-0731` (served by Nous Portal) wrote `provider: openai` + `model: deepseek/...` to config. New sessions then failed with "provider doesn't have the selected model", and Settings → Model showed the mismatched pair.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #80762

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- **`components/onboarding/flow.tsx`** — forward the picker selection's `provider` (and resolved display name) into `setOnboardingModel` instead of discarding it.
- **`store/onboarding.ts`** — persist the assignment against the picked model's provider (falling back to the flow provider for the legacy call shape), and keep the confirm card's `providerSlug`/`label` in sync so the screen reflects the provider that actually serves the model. Reverts model/provider/label on a failed persist.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure a new provider in the model onboarding screen.
2. Change the default model in the confirmation screen to a model from a provider other than the one you just setup
3. See new sessions fail and see the provider/model mismatch in Setting -> Model

## Checklist

<!-- Complete these before requesting review. -->
- [x] Ready for review

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
These screenshots show the previous flow and resultant provider/model mismatch that is fixed in this PR:
<img width="1637" height="1013" alt="Screenshot 2026-08-06 143449" src="https://github.com/user-attachments/assets/4a713bb5-5862-400f-9f37-0bc433569577" />
<img width="1637" height="1013" alt="Screenshot 2026-08-06 144150" src="https://github.com/user-attachments/assets/5e8fbf08-fab8-4dc1-bae9-7d14acb52b5e" />
<img width="1637" height="1013" alt="Screenshot 2026-08-06 144208" src="https://github.com/user-attachments/assets/0fa9f3c2-2592-4ed2-82ae-26af660074e5" />
<img width="1637" height="1013" alt="Screenshot 2026-08-06 144427" src="https://github.com/user-attachments/assets/f222f8e5-2451-450d-8a12-21357da86854" />
