### PR TITLE
fix(cron): parse and resolve named Telegram private-DM topic targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1408,6 +1408,74 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _resolve_telegram_named_dm_topic(
+    runtime_adapter: Any,
+    chat_id: str,
+    topic_name: str,
+    loop: Any,
+    job_id: str,
+) -> Optional[str]:
+    """Resolve a named Telegram private-DM topic to a numeric thread_id via the
+    LIVE adapter's ``ensure_dm_topic`` — the same resolver the gateway
+    DeliveryRouter uses for live named-topic sends (#80483).
+
+    Cron's media helper sends directly through adapter media methods (bypassing
+    the DeliveryRouter), so it cannot rely on the router's named-topic
+    resolution. This helper reuses the adapter's single ``ensure_dm_topic``
+    method so text and media share ONE resolver instead of growing parallel
+    Telegram routing rules in each send helper.
+
+    Mirrors the DeliveryRouter's retry contract: if the first resolution returns
+    nothing (a stale/missing topic mapping), refresh it once via
+    ``force_create=True`` before giving up (#80483 contract #3).
+
+    Returns the resolved numeric thread_id as a string, or ``None`` when no live
+    adapter is available, the adapter cannot create named topics, or resolution
+    fails — callers MUST fail closed (skip delivery) on ``None`` rather than
+    silently delivering into the General topic.
+    """
+    ensure_dm_topic = getattr(type(runtime_adapter), "ensure_dm_topic", None)
+    if not callable(ensure_dm_topic):
+        logger.error(
+            "Job '%s': named Telegram DM topic '%s' for chat %s cannot be "
+            "resolved — live adapter has no ensure_dm_topic; skipping delivery "
+            "(fail closed, not delivered into General)",
+            job_id, topic_name, chat_id,
+        )
+        return None
+    from agent.async_utils import safe_schedule_threadsafe
+
+    def _call(force_create: bool) -> Optional[str]:
+        future = safe_schedule_threadsafe(
+            ensure_dm_topic(runtime_adapter, str(chat_id), topic_name, force_create=force_create),
+            loop,
+        )
+        if future is None:
+            return None
+        try:
+            thread_id = future.result(timeout=30)
+        except Exception as exc:
+            logger.error(
+                "Job '%s': ensure_dm_topic raised for chat %s topic '%s': %s; "
+                "skipping delivery (fail closed)",
+                job_id, chat_id, topic_name, exc,
+            )
+            return None
+        return str(thread_id) if thread_id else None
+
+    resolved = _call(force_create=False)
+    if resolved:
+        return resolved
+    # Retry once by refreshing the topic mapping (force_create), mirroring the
+    # DeliveryRouter's thread-not-found refresh+retry.
+    logger.info(
+        "Job '%s': named Telegram DM topic '%s' for chat %s not resolved on "
+        "first attempt; refreshing mapping and retrying once",
+        job_id, topic_name, chat_id,
+    )
+    return _call(force_create=True)
+
+
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -1736,6 +1804,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
+        # Named Telegram private-DM topic flag is computed here (before the
+        # live-adapter block) so the standalone fail-closed branch below can
+        # reference it even when no live adapter/loop is available (#80483). It
+        # only depends on (platform, chat_id, thread_id), not on adapter
+        # availability. The two delivery helpers are imported at module use time
+        # by the live block below; import them here too for this detection.
+        from gateway.delivery import (
+            _looks_like_int as _delivery_looks_like_int,
+            looks_like_telegram_private_chat_id as _looks_like_telegram_private_chat_id,
+        )
+        is_named_telegram_private_topic = (
+            platform == Platform.TELEGRAM
+            and thread_id is not None
+            and _looks_like_telegram_private_chat_id(str(chat_id))
+            and not _delivery_looks_like_int(str(thread_id))
+        )
         if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
@@ -1760,6 +1844,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 and looks_like_telegram_private_chat_id(str(chat_id))
                 and _looks_like_int(str(thread_id))
             )
+            # Named Telegram private-DM topic (``telegram:<chat>:<topic_name>``)
+            # — #80483. The topic is a human name, not a numeric thread id, so it
+            # must be resolved/created/refreshed through the LIVE adapter's
+            # ``ensure_dm_topic`` before delivery. Text routes through the
+            # DeliveryRouter, which already detects this named shape and calls
+            # ``ensure_dm_topic`` itself — so we pass the NAME as target.thread_id
+            # and deliberately OMIT ``thread_id`` from route_metadata (otherwise
+            # the router's named-topic detection is short-circuited and the name
+            # would be sent as a raw thread_id). Media bypasses the router, so it
+            # resolves the name to a numeric thread_id via the SAME ensure_dm_topic
+            # resolver (one resolver for text+media, no parallel routing rules).
+            # Resolved numeric thread_id for the named topic (media path only).
+            named_topic_resolved_thread_id: Optional[str] = None
+            named_topic_resolution_failed = False
             route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
                 runtime_adapter, chat_id, loop, job["id"],
             )
@@ -1774,6 +1872,35 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
                 media_metadata = {"direct_messages_topic_id": str(thread_id)}
+            elif is_named_telegram_private_topic:
+                # Named private-DM topic (#80483): pass the NAME to the router via
+                # target.thread_id (set below) and keep thread_id OUT of metadata
+                # so the router's named-topic detection resolves it via
+                # ensure_dm_topic (with its own retry-once on thread-not-found).
+                route_thread_id = str(thread_id)
+                route_metadata = {"job_id": job["id"]}
+                # Media bypasses the router — resolve the name to a numeric
+                # thread_id here via the same ensure_dm_topic resolver (which
+                # retries once with force_create on a stale/empty mapping,
+                # mirroring the router's thread-not-found refresh+retry).
+                named_topic_resolved_thread_id = _resolve_telegram_named_dm_topic(
+                    runtime_adapter, chat_id, str(thread_id), loop, job["id"],
+                )
+                if named_topic_resolved_thread_id:
+                    media_metadata = {"thread_id": named_topic_resolved_thread_id}
+                else:
+                    # Fail closed for media: do NOT deliver attachments into the
+                    # General topic just because the named topic could not be
+                    # resolved. Text may still succeed via the router (which has
+                    # its own fail-closed raise); media is skipped with a log.
+                    named_topic_resolution_failed = True
+                    media_metadata = None
+                    logger.error(
+                        "Job '%s': could not resolve named Telegram DM topic '%s' "
+                        "for chat %s; media delivery skipped (fail closed, not "
+                        "delivered into General)",
+                        job["id"], thread_id, chat_id,
+                    )
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -1946,7 +2073,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # payload is already assumed delivered (#38922).  Record the
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
-                if adapter_ok and not timed_out and media_files:
+                if adapter_ok and not timed_out and media_files and not named_topic_resolution_failed:
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
@@ -1969,6 +2096,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     msg = (
                         f"{len(media_files)} media attachment(s) not delivered to "
                         f"{platform_name}:{chat_id} (live adapter confirmation timed out)"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                elif adapter_ok and media_files and named_topic_resolution_failed:
+                    # Named Telegram DM topic could not be resolved for media —
+                    # fail closed rather than delivering attachments into General.
+                    msg = (
+                        f"{len(media_files)} media attachment(s) not delivered to "
+                        f"{platform_name}:{chat_id} (named DM topic '{thread_id}' "
+                        f"could not be resolved)"
                     )
                     logger.warning("Job '%s': %s", job["id"], msg)
                     delivery_errors.append(msg)
@@ -2022,6 +2159,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     target_errors.append(
                         f"relay delivery to {platform_name}:{chat_id} failed"
                     )
+                delivery_errors.extend(target_errors)
+                continue
+            # Named Telegram private-DM topic with no live adapter resolution
+            # (#80483): the standalone ``_send_to_platform`` path cannot resolve
+            # a topic NAME into a thread_id (it has no ``ensure_dm_topic``), so
+            # sending would either be rejected by the Bot API or silently land
+            # in the General topic. Fail closed instead.
+            if is_named_telegram_private_topic:
+                msg = (
+                    f"named Telegram DM topic '{thread_id}' for {platform_name}:"
+                    f"{chat_id} cannot be resolved without a live adapter; "
+                    "skipping delivery (fail closed, not delivered into General)"
+                )
+                logger.error("Job '%s': %s", job["id"], msg)
+                target_errors.append(msg)
                 delivery_errors.extend(target_errors)
                 continue
             # If the interpreter is finalizing (gateway SIGTERM / restart /

--- a/tests/cron/test_cron_telegram_named_topic.py
+++ b/tests/cron/test_cron_telegram_named_topic.py
@@ -1,0 +1,429 @@
+"""Cron named Telegram private-DM topic delivery (#80483).
+
+Behavior contracts for ``telegram:<private_chat_id>:<topic_name>`` cron targets:
+
+- ``_parse_target_ref`` splits the named private topic into chat_id + topic_name
+  (numeric thread-id behavior is unchanged).
+- ``_resolve_delivery_target`` returns the split shape (the exact repro from
+  the issue).
+- Cron text + media delivery resolve the named topic through the LIVE
+  ``TelegramAdapter.ensure_dm_topic`` (one resolver for both), use the returned
+  thread_id for both text and media, retry once on thread-not-found, and fail
+  closed when no live adapter is available.
+- Numeric / group / forum / non-Telegram targets are unchanged (non-regression).
+
+Tests use the real ``_parse_target_ref`` and ``_deliver_result`` over a stub
+adapter that exposes the real ``ensure_dm_topic`` coroutine signature, per
+AGENTS.md's E2E-over-mocks guidance. No test writes to ``~/.hermes/`` — a temp
+``HERMES_HOME`` is pinned.
+"""
+
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.scheduler import (
+    _deliver_result,
+    _resolve_delivery_target,
+    _resolve_telegram_named_dm_topic,
+)
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from tools.send_message_tool import _parse_target_ref
+
+
+@pytest.fixture(autouse=True)
+def _temp_hermes_home(tmp_path, monkeypatch):
+    """Pin a temp HERMES_HOME so no test reads or writes ~/.hermes/."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    yield
+
+
+class RecordingTelegramAdapter:
+    """Live Telegram adapter double with a real ``ensure_dm_topic`` coroutine.
+
+    Mirrors the contract in tests/gateway/test_delivery.py: ``send`` records the
+    routed metadata so tests can assert the resolved thread_id lands in BOTH the
+    text send and the media send. ``ensure_dm_topic`` is a real coroutine method
+    on the CLASS (not an instance attribute) because the cron resolver and the
+    DeliveryRouter both probe ``type(adapter).ensure_dm_topic``.
+    """
+
+    def __init__(self, send_success=True, thread_id_for_name="38049",
+                 force_create_thread_id="38064", send_error_first=None):
+        self.calls = []
+        self.ensure_dm_topic_calls = []
+        self.send_calls = []
+        self.media_calls = []
+        self._send_success = send_success
+        self._thread_id_for_name = thread_id_for_name
+        self._force_create_thread_id = force_create_thread_id
+        self._send_error_first = send_error_first
+        self._send_count = 0
+        self.platform = Platform.TELEGRAM
+
+    async def ensure_dm_topic(self, chat_id, topic_name, force_create=False):
+        self.ensure_dm_topic_calls.append(
+            {"chat_id": str(chat_id), "topic_name": topic_name,
+             "force_create": force_create}
+        )
+        if force_create:
+            return self._force_create_thread_id
+        return self._thread_id_for_name
+
+    async def send(self, chat_id, content, metadata=None):
+        self._send_count += 1
+        self.send_calls.append(
+            {"chat_id": str(chat_id), "content": content, "metadata": dict(metadata or {})}
+        )
+        if self._send_error_first is not None and self._send_count == 1:
+            return SendResult(success=False, error=self._send_error_first)
+        return SendResult(success=self._send_success, message_id="m1")
+
+    # Media methods used by _send_media_via_adapter.
+    async def send_image_file(self, chat_id, image_path, metadata=None):
+        self.media_calls.append(
+            {"method": "send_image_file", "chat_id": str(chat_id),
+             "image_path": image_path, "metadata": dict(metadata or {})}
+        )
+        return SendResult(success=True)
+
+    async def send_document(self, chat_id, file_path, metadata=None):
+        self.media_calls.append(
+            {"method": "send_document", "chat_id": str(chat_id),
+             "file_path": file_path, "metadata": dict(metadata or {})}
+        )
+        return SendResult(success=True)
+
+    async def send_voice(self, chat_id, audio_path, metadata=None):
+        self.media_calls.append(
+            {"method": "send_voice", "chat_id": str(chat_id),
+             "audio_path": audio_path, "metadata": dict(metadata or {})}
+        )
+        return SendResult(success=True)
+
+    async def send_video(self, chat_id, video_path, metadata=None):
+        self.media_calls.append(
+            {"method": "send_video", "chat_id": str(chat_id),
+             "video_path": video_path, "metadata": dict(metadata or {})}
+        )
+        return SendResult(success=True)
+
+
+def _run_coro_factory():
+    """Build a fake ``asyncio.run_coroutine_threadsafe`` that actually runs the
+    coroutine (so the real DeliveryRouter + adapter execute) and returns a
+    completed concurrent.futures.Future — matching the real scheduling contract.
+    """
+    import asyncio
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    return fake_run_coro
+
+
+def _telegram_config(home_chat_id="722341991"):
+    """A GatewayConfig with an enabled Telegram platform + home channel."""
+    return GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id=home_chat_id,
+                    name="Owner DM",
+                ),
+            ),
+        },
+    )
+
+
+class TestParseNamedTelegramTopic:
+    """``_parse_target_ref`` splits ``telegram:<chat>:<topic_name>`` (#80483)."""
+
+    def test_named_private_topic_splits_chat_id_and_topic_name(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "722341991:Debug")
+        assert (chat_id, thread_id, is_explicit) == ("722341991", "Debug", True)
+
+    def test_named_topic_with_underscore_name(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "telegram", "722341991:Hermes_API_Test"
+        )
+        assert (chat_id, thread_id, is_explicit) == ("722341991", "Hermes_API_Test", True)
+
+    def test_numeric_thread_id_unchanged_negative_chat(self):
+        """Numeric topic on a group/supergroup chat: byte-identical to before."""
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "telegram", "-1003724596514:17"
+        )
+        assert (chat_id, thread_id, is_explicit) == ("-1003724596514", "17", True)
+
+    def test_numeric_thread_id_unchanged_positive_chat(self):
+        """Numeric topic on a private (positive) chat: still numeric, not named."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "722341991:42")
+        assert (chat_id, thread_id, is_explicit) == ("722341991", "42", True)
+
+    def test_bare_chat_id_unchanged(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "722341991")
+        assert (chat_id, thread_id, is_explicit) == ("722341991", None, True)
+
+    def test_bare_negative_chat_id_unchanged(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "-1003724596514")
+        assert (chat_id, thread_id, is_explicit) == ("-1003724596514", None, True)
+
+
+class TestResolveNamedTelegramTopic:
+    """``_resolve_delivery_target`` returns the split shape (issue repro)."""
+
+    def test_issue_repro_named_private_topic(self):
+        # Exact reproduction from issue #80483.
+        assert _resolve_delivery_target({"deliver": "telegram:722341991:Debug"}) == {
+            "platform": "telegram",
+            "chat_id": "722341991",
+            "thread_id": "Debug",
+        }
+
+    def test_numeric_topic_non_regression(self):
+        assert _resolve_delivery_target({"deliver": "telegram:-1003724596514:17"}) == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "17",
+        }
+
+    def test_numeric_positive_chat_topic_non_regression(self):
+        assert _resolve_delivery_target({"deliver": "telegram:722341991:42"}) == {
+            "platform": "telegram",
+            "chat_id": "722341991",
+            "thread_id": "42",
+        }
+
+    def test_group_forum_target_unchanged(self):
+        # A supergroup forum topic target: negative chat, numeric thread.
+        assert _resolve_delivery_target({"deliver": "telegram:-100456:9"}) == {
+            "platform": "telegram",
+            "chat_id": "-100456",
+            "thread_id": "9",
+        }
+
+    def test_non_telegram_target_unchanged(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "987654")
+        assert _resolve_delivery_target({"deliver": "discord:987654:55"}) == {
+            "platform": "discord",
+            "chat_id": "987654",
+            "thread_id": "55",
+        }
+
+
+class TestResolveTelegramNamedDmTopicHelper:
+    """The named-topic resolver reuses the live adapter's ensure_dm_topic."""
+
+    def test_resolves_via_ensure_dm_topic(self):
+        adapter = RecordingTelegramAdapter(thread_id_for_name="38049")
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coro_factory()):
+            resolved = _resolve_telegram_named_dm_topic(
+                adapter, "722341991", "Debug", loop, "job-1",
+            )
+        assert resolved == "38049"
+        assert adapter.ensure_dm_topic_calls == [
+            {"chat_id": "722341991", "topic_name": "Debug", "force_create": False},
+        ]
+
+    def test_retries_once_with_force_create(self):
+        adapter = RecordingTelegramAdapter(
+            thread_id_for_name=None,  # first resolution returns nothing
+            force_create_thread_id="38064",
+        )
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coro_factory()):
+            resolved = _resolve_telegram_named_dm_topic(
+                adapter, "722341991", "Debug", loop, "job-1",
+            )
+        # First call normal, then a force_create retry; second resolution wins.
+        assert resolved == "38064"
+        assert adapter.ensure_dm_topic_calls == [
+            {"chat_id": "722341991", "topic_name": "Debug", "force_create": False},
+            {"chat_id": "722341991", "topic_name": "Debug", "force_create": True},
+        ]
+
+    def test_fail_closed_when_no_live_adapter(self):
+        # An adapter instance whose CLASS has no ensure_dm_topic coroutine.
+        class BareAdapter:
+            platform = Platform.TELEGRAM
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        resolved = _resolve_telegram_named_dm_topic(
+            BareAdapter(), "722341991", "Debug", loop, "job-1",
+        )
+        assert resolved is None
+
+
+class TestCronNamedTopicDelivery:
+    """E2E: cron ``_deliver_result`` for a named Telegram private-DM topic."""
+
+    def _media_path(self, tmp_path, monkeypatch, name="img.png", data=b"png"):
+        root = tmp_path / "media-cache"
+        media_file = root / name
+        media_file.parent.mkdir(parents=True, exist_ok=True)
+        media_file.write_bytes(data)
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (root,),
+        )
+        return media_file.resolve()
+
+    def test_named_topic_resolved_for_text_and_media(self, tmp_path, monkeypatch):
+        """Text routes via DeliveryRouter (which calls ensure_dm_topic) and media
+        routes via the cron resolver — both use the SAME ensure_dm_topic, and the
+        resolved thread_id is used for both text and media metadata."""
+        adapter = RecordingTelegramAdapter(thread_id_for_name="38049")
+        config = _telegram_config()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        media_path = self._media_path(tmp_path, monkeypatch)
+
+        job = {
+            "id": "named-topic-job",
+            "deliver": "telegram:722341991:Debug",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe",
+                   side_effect=_run_coro_factory()):
+            result = _deliver_result(
+                job,
+                f"summary\nMEDIA:{media_path}",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None, f"expected successful delivery, got: {result!r}"
+
+        # The named topic was resolved via ensure_dm_topic (text path through the
+        # DeliveryRouter; media path through the cron resolver). At least one
+        # resolution happened.
+        assert adapter.ensure_dm_topic_calls, (
+            "ensure_dm_topic must be called to resolve the named topic"
+        )
+        # Every resolution targeted the right chat + topic name.
+        for call in adapter.ensure_dm_topic_calls:
+            assert call["chat_id"] == "722341991"
+            assert call["topic_name"] == "Debug"
+
+        # Text send: the resolved numeric thread_id (38049) is in metadata, NOT
+        # the bare name "Debug".
+        assert adapter.send_calls, "text must be sent via the live adapter"
+        text_metadata = adapter.send_calls[0]["metadata"]
+        assert text_metadata.get("thread_id") == "38049", (
+            f"text must carry the resolved thread_id, got {text_metadata!r}"
+        )
+        assert text_metadata.get("thread_id") != "Debug"
+
+        # Media send: the resolved numeric thread_id is in media metadata.
+        assert adapter.media_calls, "media must be sent via the live adapter"
+        media_metadata = adapter.media_calls[0]["metadata"]
+        assert media_metadata.get("thread_id") == "38049", (
+            f"media must carry the resolved thread_id, got {media_metadata!r}"
+        )
+
+    def test_retry_once_on_thread_not_found_for_text(self, tmp_path, monkeypatch):
+        """When the first text send fails with 'thread not found', the
+        DeliveryRouter refreshes the topic mapping via ensure_dm_topic
+        (force_create) and retries the send once (#80483 contract #3)."""
+        adapter = RecordingTelegramAdapter(
+            send_success=True,
+            thread_id_for_name="38049",
+            force_create_thread_id="38064",
+            # First send fails with thread-not-found; router refreshes + retries.
+            send_error_first="Bad Request: message thread not found",
+        )
+        config = _telegram_config()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "retry-job", "deliver": "telegram:722341991:Debug"}
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe",
+                   side_effect=_run_coro_factory()):
+            result = _deliver_result(
+                job, "hello", adapters={Platform.TELEGRAM: adapter}, loop=loop,
+            )
+
+        # Delivery ultimately succeeds after the refresh+retry.
+        assert result is None, f"expected delivery after retry, got: {result!r}"
+        # Two text sends (initial + retry).
+        assert len(adapter.send_calls) == 2, (
+            f"expected initial + retry send, got {len(adapter.send_calls)}"
+        )
+        # ensure_dm_topic called with force_create during the refresh.
+        assert any(c["force_create"] for c in adapter.ensure_dm_topic_calls), (
+            "retry must refresh the topic mapping via force_create"
+        )
+
+    def test_no_live_adapter_fails_closed(self, monkeypatch):
+        """With no live adapter/loop, a named topic cannot be resolved — fail
+        closed instead of delivering into General via the standalone path."""
+        config = _telegram_config()
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        job = {"id": "no-adapter-job", "deliver": "telegram:722341991:Debug"}
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(job, "hello", adapters=None, loop=None)
+
+        # Fail closed: an error is returned (not None), and the standalone path
+        # must NOT have delivered a raw "Debug" thread_id into General.
+        assert result is not None, "fail closed must return an error, not None"
+        assert "Debug" in result or "named" in result.lower() or "fail closed" in result.lower()
+        standalone_send.assert_not_awaited()
+
+    def test_numeric_topic_unchanged_via_live_adapter(self, tmp_path, monkeypatch):
+        """Numeric Telegram topic on a private chat still routes via the
+        existing ambiguous-topic path (non-regression for #80483 contract #5)."""
+        adapter = RecordingTelegramAdapter(thread_id_for_name="38049")
+        # get_chat_info on the CLASS so _is_channel_dm_topic can probe; return a
+        # non-channel so routing stays on message_thread_id (forum-style).
+        async def _get_chat_info(chat_id):
+            return {"type": "private"}
+        adapter.get_chat_info = _get_chat_info  # instance attr is fine for the probe
+
+        config = _telegram_config()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "numeric-job", "deliver": "telegram:722341991:42"}
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe",
+                   side_effect=_run_coro_factory()):
+            result = _deliver_result(
+                job, "hello", adapters={Platform.TELEGRAM: adapter}, loop=loop,
+            )
+
+        assert result is None, f"expected successful delivery, got: {result!r}"
+        # Numeric topic must NOT trigger ensure_dm_topic (named-topic resolver).
+        assert adapter.ensure_dm_topic_calls == [], (
+            "numeric topic must not call ensure_dm_topic (non-regression)"
+        )
+        # The numeric thread_id 42 is routed (in metadata via the ambiguous-topic
+        # branch), not treated as a name.
+        assert adapter.send_calls, "text must be sent"
+        text_metadata = adapter.send_calls[0]["metadata"]
+        assert text_metadata.get("thread_id") == "42" or (
+            "direct_messages_topic_id" in text_metadata
+        ), f"numeric thread_id 42 must be routed, got {text_metadata!r}"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -18,6 +18,10 @@ from agent.secret_scope import get_secret
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
+# Named Telegram private-DM topic target: ``<private_chat_id>:<topic_name>``
+# where the topic is a human name (non-numeric), e.g. ``722341991:Debug``. The
+# numeric thread-id form above is matched first, so this only fires for names.
+_TELEGRAM_NAMED_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+):([^\s:]+)\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 # Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
 # Must be uppercase alphanumeric, 9+ chars. User IDs (U...) are parsed as
@@ -533,6 +537,14 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+        # Named private-DM topic (``<chat_id>:<topic_name>`` with a non-numeric
+        # topic). Split chat_id and topic_name so callers can resolve the name
+        # into a real thread_id via the live Telegram adapter (#80483). Numeric
+        # thread ids are handled by the regex above; this branch only adds
+        # named-topic support and leaves numeric/group/forum behavior intact.
+        named_match = _TELEGRAM_NAMED_TOPIC_TARGET_RE.fullmatch(target_ref)
+        if named_match:
+            return named_match.group(1), named_match.group(2), True
         from plugins.platforms.telegram.telegram_ids import (
             parse_telegram_username_target,
         )


### PR DESCRIPTION
@## Fixes #80483

Cron delivery did not support the named Telegram private-DM topic target form `deliver: telegram:722341991:Debug`. The same target works in the live gateway path, but cron misparsed it and its text/media/standalone paths did not share one named-topic-resolution contract.

## Reproduction

On current `main`:

```python
from cron.scheduler import _resolve_delivery_target
print(_resolve_delivery_target({"deliver": "telegram:722341991:Debug"}))
```

Actual (before):
```python
{"platform": "telegram", "chat_id": "722341991:Debug", "thread_id": None}
```

Expected (after this PR):
```python
{"platform": "telegram", "chat_id": "722341991", "thread_id": "Debug"}
```

## Root cause

`tools/send_message_tool.py::_parse_target_ref()` only recognized NUMERIC Telegram thread IDs, so `<private_chat_id>:<topic_name>` was treated as one chat_id. Even after parsing, cron`s media helper sent directly through adapter media methods rather than resolving the topic name through `TelegramAdapter.ensure_dm_topic()`, and the standalone path could not safely honor a named private topic.

## Contract implemented (all 5 points from the issue)

For `telegram:<private_chat_id>:<topic_name>` cron targets:

1. **Parse separately.** `_parse_target_ref` now splits `<chat_id>:<non-numeric_topic_name>` into `(chat_id, topic_name)` via a new `_TELEGRAM_NAMED_TOPIC_TARGET_RE`, matched only after the numeric regex fails — so numeric behavior is byte-identical.
2. **Resolve via the live adapter for text AND media.** Text routes through the `DeliveryRouter`, which already detects the named shape and calls `ensure_dm_topic` (the live resolver established by #32270/#50023). Cron passes the NAME as `target.thread_id` and deliberately omits `thread_id` from `route_metadata` so the router`s named-topic detection fires. Media bypasses the router, so a new `_resolve_telegram_named_dm_topic` helper calls the SAME `ensure_dm_topic` method — one resolver for both, no parallel routing rules.
3. **Retry once on a stale mapping.** The router retries text on a thread-not-found send error (refresh via `force_create=True`). The media helper retries once with `force_create=True` when the first resolution returns nothing — mirroring the same refresh+retry contract.
4. **Fail closed without a live adapter.** When no live adapter/loop is available, a named topic cannot be resolved, so delivery is skipped with a clear error log — never silently delivered into General. Media that cannot be resolved is also skipped (fail closed), not routed to General.
5. **Non-regression.** Numeric Telegram topics, group/forum targets, channel DM topics (#22773), and non-Telegram platforms are unchanged.

## Tests

New `tests/cron/test_cron_telegram_named_topic.py` (18 tests, all passing) asserts the invariants over the real `_parse_target_ref`, `_resolve_delivery_target`, and `_deliver_result` with a stub adapter exposing the real `ensure_dm_topic` coroutine signature (E2E over mocks per AGENTS.md; temp `HERMES_HOME`, no writes to `~/.hermes/`):

- Issue repro: `telegram:722341991:Debug` splits into `chat_id=722341991, thread_id=Debug`.
- Numeric topic (negative and positive chat) unchanged — exact current behavior asserted.
- Group/forum and Discord (non-Telegram) targets unchanged.
- Named topic resolution calls `ensure_dm_topic` and the returned thread_id is used for BOTH text and media metadata (not the bare name).
- Retry-once: first `ensure_dm_topic` returning empty triggers a `force_create` retry; a thread-not-found text send triggers the router`s refresh+retry.
- No live adapter -> fail closed (error returned, standalone send not invoked).

Verification:
- `python -m pytest tests/cron/test_cron_telegram_named_topic.py tests/gateway/test_delivery.py tests/gateway/test_dm_topics.py` -> all green (18 + 25 live delivery/DM-topic tests).
- `import cron.scheduler, tools.send_message_tool` imports clean.
- The issue repro snippet now returns the expected split shape.

## Non-regression notes

- Numeric `telegram:<chat>:<numeric_id>` (private, group, supergroup) — unchanged, parsed by the pre-existing numeric regex first.
- Channel DM topic routing (`#22773` `direct_messages_topic_id`) — unchanged; the named branch is mutually exclusive with the ambiguous-numeric-topic branch.
- Forum-style `message_thread_id` routing (`#52060`) — unchanged.
- Non-Telegram platforms — untouched.

## Scope

This is split from the narrower numeric-target fix #69952 as the issue requested — it ONLY adds named-topic support and does not refactor numeric behavior. Touches `tools/send_message_tool.py` (parse), `cron/scheduler.py` (one shared resolver + routing + fail-closed), and tests only; the Telegram adapter is reused as-is (`ensure_dm_topic` already existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@