### PR TITLE
Inspired by Cursor: .hermesignore project-level agent file-access blocking

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2156,6 +2156,14 @@ DEFAULT_CONFIG = {
         # for restricted networks, audited environments, or air-gapped
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
+        # Honor a project-level `.hermesignore` file (gitignore syntax at the
+        # workspace root) that blocks the agent's FILE TOOLS — read_file,
+        # write_file, patch, search_files — from touching matched paths
+        # (Cursor .cursorignore parity). Search results under ignored paths
+        # are filtered out. Does NOT gate the terminal tool or MCP servers —
+        # shell commands run as the same OS user and can still read matched
+        # files. Set to false to disable the guard entirely.
+        "hermesignore_enabled": True,
     },
 
     "cron": {

--- a/tests/tools/test_hermesignore.py
+++ b/tests/tools/test_hermesignore.py
@@ -1,0 +1,225 @@
+"""Tests for project-level `.hermesignore` agent file-access blocking.
+
+`.hermesignore` is a gitignore-syntax file at the workspace root that blocks
+the agent's file tools (read_file / write_file / patch / search_files) from
+touching matched paths. See ``tools/hermesignore.py``.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+import tools.file_tools as file_tools
+import tools.hermesignore as hermesignore
+from tools.hermesignore import check_hermesignore
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """Force the guard on and clear the spec cache around every test."""
+    monkeypatch.setattr(hermesignore, "_enabled", lambda: True)
+    hermesignore._spec_cache.clear()
+    yield
+    hermesignore._spec_cache.clear()
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A fake workspace root (with .git) that discovery resolves to."""
+    root = tmp_path.resolve() / "repo"
+    (root / ".git").mkdir(parents=True)
+    monkeypatch.setattr(
+        file_tools, "_authoritative_workspace_root", lambda task_id="default": str(root)
+    )
+    return root
+
+
+def _write_ignore(root: Path, text: str) -> Path:
+    ignore = root / ".hermesignore"
+    ignore.write_text(text, encoding="utf-8")
+    return ignore
+
+
+class TestMatching:
+    def test_no_ignore_file_allows_everything(self, repo):
+        target = repo / "secrets.txt"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is None
+
+    def test_glob_pattern_blocks_matching_file(self, repo):
+        _write_ignore(repo, "*.pem\n")
+        target = repo / "server.pem"
+        target.write_text("x", encoding="utf-8")
+        err = check_hermesignore(str(target))
+        assert err is not None
+        assert ".hermesignore" in err
+
+    def test_non_matching_file_allowed(self, repo):
+        _write_ignore(repo, "*.pem\n")
+        target = repo / "readme.md"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is None
+
+    def test_comments_and_blank_lines_skipped(self, repo):
+        _write_ignore(repo, "# a comment\n\n   \n# *.md would match if not a comment\n")
+        target = repo / "notes.md"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is None
+
+    def test_trailing_slash_directory_pattern(self, repo):
+        _write_ignore(repo, "secrets/\n")
+        target = repo / "secrets" / "key.txt"
+        target.parent.mkdir()
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is not None
+
+    def test_bare_name_blocks_directory_subtree(self, repo):
+        _write_ignore(repo, "build\n")
+        target = repo / "build" / "out" / "artifact.bin"
+        target.parent.mkdir(parents=True)
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is not None
+
+    def test_double_star_glob(self, repo):
+        _write_ignore(repo, "docs/**/*.md\n")
+        target = repo / "docs" / "internal" / "plan.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is not None
+
+    def test_negation_last_match_wins(self, repo):
+        _write_ignore(repo, "*.env\n!example.env\n")
+        blocked = repo / "prod.env"
+        allowed = repo / "example.env"
+        blocked.write_text("x", encoding="utf-8")
+        allowed.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(blocked)) is not None
+        assert check_hermesignore(str(allowed)) is None
+
+    def test_ignore_file_never_hides_itself(self, repo):
+        ignore = _write_ignore(repo, "*\n")
+        assert check_hermesignore(str(ignore)) is None
+
+    def test_path_outside_workspace_not_affected(self, repo, tmp_path):
+        _write_ignore(repo, "*.txt\n")
+        outside = tmp_path.resolve() / "elsewhere.txt"
+        outside.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(outside)) is None
+
+    def test_discovery_from_target_parent_without_workspace_root(
+        self, tmp_path, monkeypatch
+    ):
+        """Absolute-path access into a repo the terminal never cd'ed into."""
+        monkeypatch.setattr(
+            file_tools, "_authoritative_workspace_root", lambda task_id="default": None
+        )
+        monkeypatch.chdir(tmp_path)
+        other = tmp_path.resolve() / "other-repo"
+        (other / ".git").mkdir(parents=True)
+        _write_ignore(other, "*.key\n")
+        target = other / "signing.key"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is not None
+
+    def test_walk_stops_at_git_root(self, tmp_path, monkeypatch):
+        """An ignore file ABOVE the git root must not leak into the repo."""
+        outer = tmp_path.resolve()
+        _write_ignore(outer, "*.txt\n")
+        inner = outer / "project"
+        (inner / ".git").mkdir(parents=True)
+        monkeypatch.setattr(
+            file_tools, "_authoritative_workspace_root", lambda task_id="default": str(inner)
+        )
+        target = inner / "notes.txt"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is None
+
+
+class TestKillSwitchAndCache:
+    def test_disabled_via_config_allows_everything(self, repo, monkeypatch):
+        _write_ignore(repo, "*.pem\n")
+        target = repo / "server.pem"
+        target.write_text("x", encoding="utf-8")
+        monkeypatch.setattr(hermesignore, "_enabled", lambda: False)
+        assert check_hermesignore(str(target)) is None
+
+    def test_enabled_reads_security_config(self, monkeypatch):
+        monkeypatch.undo()  # drop the autouse _enabled override for this test
+        import tools.hermesignore as hi
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"hermesignore_enabled": False}},
+        )
+        assert hi._enabled() is False
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        assert hi._enabled() is True
+
+    def test_cache_invalidated_on_mtime_change(self, repo):
+        ignore = _write_ignore(repo, "*.pem\n")
+        target = repo / "server.pem"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is not None
+
+        # Rewrite the ignore file to no longer match; bump mtime explicitly so
+        # the (mtime_ns, size) cache key changes even on coarse filesystems.
+        ignore.write_text("*.nothing\n", encoding="utf-8")
+        future = time.time() + 10
+        os.utime(ignore, (future, future))
+        assert check_hermesignore(str(target)) is None
+
+    def test_empty_ignore_file_blocks_nothing(self, repo):
+        _write_ignore(repo, "# only comments\n\n")
+        target = repo / "anything.txt"
+        target.write_text("x", encoding="utf-8")
+        assert check_hermesignore(str(target)) is None
+
+
+class TestFileToolChokePoints:
+    def test_read_file_tool_refuses_ignored_path(self, repo):
+        _write_ignore(repo, "vault/**\n")
+        target = repo / "vault" / "creds.txt"
+        target.parent.mkdir()
+        target.write_text("top secret", encoding="utf-8")
+        result = json.loads(file_tools.read_file_tool(str(target)))
+        assert ".hermesignore" in result.get("error", "")
+        assert "top secret" not in json.dumps(result)
+
+    def test_write_choke_point_refuses_ignored_path(self, repo):
+        _write_ignore(repo, "generated/\n")
+        target = repo / "generated" / "out.txt"
+        target.parent.mkdir()
+        err = file_tools._check_sensitive_path(str(target))
+        assert err is not None and ".hermesignore" in err
+
+    def test_search_tool_refuses_ignored_root(self, repo):
+        _write_ignore(repo, "vault/\n")
+        vault = repo / "vault"
+        vault.mkdir()
+        (vault / "creds.txt").write_text("top secret", encoding="utf-8")
+        result = json.loads(
+            file_tools.search_tool("secret", target="content", path=str(vault))
+        )
+        assert ".hermesignore" in result.get("error", "")
+
+    def test_read_file_tool_allows_unmatched_path(self, repo):
+        _write_ignore(repo, "vault/**\n")
+        target = repo / "open.txt"
+        target.write_text("hello world", encoding="utf-8")
+        result = json.loads(file_tools.read_file_tool(str(target)))
+        assert "error" not in result
+        assert "hello world" in result.get("content", "")
+
+    def test_wrapper_fails_open_on_module_error(self, repo, monkeypatch):
+        _write_ignore(repo, "*.pem\n")
+        target = repo / "server.pem"
+        target.write_text("x", encoding="utf-8")
+        monkeypatch.setattr(
+            hermesignore,
+            "check_hermesignore",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        assert file_tools._check_hermesignore_path(str(target)) is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -588,6 +588,24 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
+def _check_hermesignore_path(resolved_path: str, task_id: str = "default") -> str | None:
+    """Return an error when *resolved_path* matches the project's ``.hermesignore``.
+
+    Thin wrapper around :func:`tools.hermesignore.check_hermesignore` that
+    fails open on import/runtime errors — this is a project-convenience
+    guard layered on top of the hard sensitive-path denylist, not a
+    replacement for it. See ``tools/hermesignore.py`` for syntax and the
+    terminal/MCP limitation.
+    """
+    try:
+        from tools.hermesignore import check_hermesignore
+
+        return check_hermesignore(resolved_path, task_id)
+    except Exception:
+        logger.debug("hermesignore check failed for %s", resolved_path, exc_info=True)
+        return None
+
+
 def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
     """Return the read-safety error for a search result path.
 
@@ -599,8 +617,11 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     try:
         resolved = _resolve_path_for_task(path, task_id)
     except (OSError, ValueError, RuntimeError):
-        return get_read_block_error(path)
-    return get_read_block_error(str(resolved))
+        return get_read_block_error(path) or _check_hermesignore_path(path, task_id)
+    return (
+        get_read_block_error(str(resolved))
+        or _check_hermesignore_path(str(resolved), task_id)
+    )
 
 
 def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
@@ -699,6 +720,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    # Project-level .hermesignore (gitignore syntax at the workspace root)
+    # blocks agent writes the same way it blocks reads/searches. Checked here
+    # so write_file_tool and patch_tool share one choke point. See
+    # tools/hermesignore.py for syntax and the terminal/MCP limitation.
+    ignore_error = _check_hermesignore_path(resolved, task_id)
+    if ignore_error:
+        return ignore_error
     return None
 
 
@@ -1356,6 +1384,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         block_error = get_read_block_error(str(_resolved))
         if block_error:
             return tool_error(block_error)
+
+        # ── .hermesignore guard ───────────────────────────────────────
+        # Project-level agent file-access ignore file (gitignore syntax,
+        # committed at the workspace root). See tools/hermesignore.py.
+        ignore_error = _check_hermesignore_path(str(_resolved), task_id)
+        if ignore_error:
+            return tool_error(ignore_error)
 
         # ── Negative-result cache ─────────────────────────────────────
         # If we already discovered this path doesn't exist (within TTL),
@@ -2086,6 +2121,11 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
         if block_error:
             return tool_error(block_error)
+        ignore_error = _check_hermesignore_path(
+            str(resolved_path) if resolved_path else path, task_id
+        )
+        if ignore_error:
+            return tool_error(ignore_error)
 
         # ── Negative-result cache ─────────────────────────────────────
         # Search returns "Path not found: <path>" when the search root
@@ -2115,7 +2155,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if omitted:
             result_dict["_omitted"] = (
                 f"{omitted} result(s) omitted because they target credential, "
-                "token, cache, or secret-bearing environment files."
+                "token, cache, or secret-bearing environment files, or paths "
+                "excluded by the project's .hermesignore."
             )
 
         # Populate negative cache when search root was missing. No early

--- a/tools/hermesignore.py
+++ b/tools/hermesignore.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Project-level agent file-access ignore file (``.hermesignore``).
+
+Inspired by Cursor's ``.cursorignore``: a gitignore-syntax file committed at
+the workspace root that blocks the agent's FILE TOOLS (``read_file``,
+``write_file``, ``patch``, ``search_files``) from touching matched paths.
+Unlike the hardcoded sensitive-path denylist in ``tools/file_tools.py``,
+``.hermesignore`` is repo-scoped: a team can commit one file and every Hermes
+session working in that checkout honors it.
+
+Syntax (parsed with ``pathspec``'s gitwildmatch — real gitignore semantics):
+
+* ``#`` comments and blank lines are skipped
+* ``*`` and ``**`` globs (``*.pem``, ``docs/**/*.md``)
+* trailing-slash directory patterns (``secrets/``)
+* bare names match files AND directory subtrees (``build`` blocks ``build/x``)
+* ``!`` negation, last match wins (``*.env`` then ``!example.env``)
+
+Discovery walks UP from the resolved terminal cwd (and from the target file's
+own directory, so worktree/subdir sessions still resolve the repo root) to the
+git root — the first directory containing ``.hermesignore``, stopping at the
+directory that contains ``.git`` or at the filesystem root. Parsed specs are
+cached per ``(path, mtime)`` so the file is re-read only when it changes.
+
+Scope and limitations (same tradeoff Cursor documents for ``.cursorignore``):
+this gates the in-process FILE TOOLS ONLY. The ``terminal`` tool runs shell
+commands as the same OS user and can still ``cat`` a matched file, and MCP
+servers perform their own I/O. Defense-in-depth and a clear stop signal for
+the model — not a sandbox for a hostile agent.
+
+Kill switch: ``security.hermesignore_enabled`` (default ``true``) in
+``~/.hermes/config.yaml``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+IGNORE_FILENAME = ".hermesignore"
+
+# Bound the walk-up so a pathological cwd (or symlink loop survivor) cannot
+# spin forever. 64 levels is far deeper than any real checkout.
+_MAX_WALK_UP = 64
+
+# path -> (mtime_ns, size, PathSpec | None). ``None`` spec means the file
+# existed but parsed to zero usable patterns — cached to skip re-parsing.
+_spec_cache: dict[str, tuple[int, int, object | None]] = {}
+_cache_lock = threading.Lock()
+
+
+def _enabled() -> bool:
+    """Return the ``security.hermesignore_enabled`` toggle (default True).
+
+    Fails OPEN on config errors: this is a project-convenience guard, not a
+    security boundary, and a broken config should not lock the agent out of
+    every repo that happens to contain a ``.hermesignore``.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        security = load_config().get("security") or {}
+        return bool(security.get("hermesignore_enabled", True))
+    except Exception:
+        return True
+
+
+def _load_spec(ignore_path: str):
+    """Parse *ignore_path* into a ``pathspec.PathSpec``, cached by (mtime, size).
+
+    Returns ``None`` when the file vanished, is unreadable, or contains no
+    usable patterns.
+    """
+    try:
+        st = os.stat(ignore_path)
+    except OSError:
+        with _cache_lock:
+            _spec_cache.pop(ignore_path, None)
+        return None
+
+    key = (st.st_mtime_ns, st.st_size)
+    with _cache_lock:
+        cached = _spec_cache.get(ignore_path)
+        if cached is not None and (cached[0], cached[1]) == key:
+            return cached[2]
+
+    try:
+        import pathspec
+
+        with open(ignore_path, "r", encoding="utf-8", errors="replace") as fh:
+            lines = fh.read().splitlines()
+        # The parser itself skips comments/blank lines; pre-filtering just
+        # lets us cache "no usable patterns" as None.
+        usable = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+        # GitIgnoreSpec implements real gitignore semantics (negation with
+        # last-match-wins, dir patterns); fall back to the older gitwildmatch
+        # factory for pathspec versions that predate it.
+        if not usable:
+            spec = None
+        elif hasattr(pathspec, "GitIgnoreSpec"):
+            spec = pathspec.GitIgnoreSpec.from_lines(lines)
+        else:
+            spec = pathspec.PathSpec.from_lines("gitwildmatch", lines)
+    except Exception:
+        logger.debug("failed to parse %s", ignore_path, exc_info=True)
+        spec = None
+
+    with _cache_lock:
+        _spec_cache[ignore_path] = (st.st_mtime_ns, st.st_size, spec)
+    return spec
+
+
+def _find_ignore_file(start_dir: str) -> str | None:
+    """Walk up from *start_dir* to the git root looking for ``.hermesignore``.
+
+    Returns the ignore file's absolute path, or ``None``. The walk stops
+    after checking the first directory that contains ``.git`` (the workspace
+    root for our purposes) or on reaching the filesystem root.
+    """
+    try:
+        current = Path(start_dir).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not current.is_dir():
+        current = current.parent
+
+    for _ in range(_MAX_WALK_UP):
+        candidate = current / IGNORE_FILENAME
+        try:
+            if candidate.is_file():
+                return str(candidate)
+            at_git_root = (current / ".git").exists()
+        except OSError:
+            return None
+        if at_git_root:
+            return None  # Reached the repo root without finding one.
+        parent = current.parent
+        if parent == current:
+            return None  # Filesystem root.
+        current = parent
+    return None
+
+
+def _candidate_start_dirs(resolved_path: str, task_id: str = "default") -> list[str]:
+    """Start points for ignore-file discovery, most authoritative first.
+
+    1. The resolved terminal cwd (``_authoritative_workspace_root`` — the
+       directory the agent is actually working in, e.g. a git worktree).
+    2. The target file's own parent directory — covers absolute-path access
+       into a repo the terminal has not cd'ed into yet.
+    """
+    dirs: list[str] = []
+    try:
+        from tools.file_tools import _authoritative_workspace_root
+
+        root = _authoritative_workspace_root(task_id)
+    except Exception:
+        root = None
+    if root:
+        dirs.append(root)
+    else:
+        dirs.append(os.getcwd())
+    try:
+        parent = str(Path(resolved_path).parent)
+    except (OSError, ValueError):
+        parent = None
+    if parent and parent not in dirs:
+        dirs.append(parent)
+    return dirs
+
+
+def check_hermesignore(resolved_path: str, task_id: str = "default") -> str | None:
+    """Return an error string when *resolved_path* is blocked by ``.hermesignore``.
+
+    *resolved_path* must already be resolved against the task's cwd (callers
+    in ``tools/file_tools.py`` pass the output of ``_resolve_path_for_task``).
+    Returns ``None`` when no ignore file applies, the path does not match, or
+    the ``security.hermesignore_enabled`` kill switch is off.
+    """
+    if not _enabled():
+        return None
+
+    seen_ignore_files: set[str] = set()
+    for start_dir in _candidate_start_dirs(resolved_path, task_id):
+        ignore_path = _find_ignore_file(start_dir)
+        if not ignore_path or ignore_path in seen_ignore_files:
+            continue
+        seen_ignore_files.add(ignore_path)
+
+        spec = _load_spec(ignore_path)
+        if spec is None:
+            continue
+
+        root = Path(ignore_path).parent
+        try:
+            rel = Path(resolved_path).resolve().relative_to(root)
+        except (ValueError, OSError, RuntimeError):
+            continue  # Target is outside this ignore file's tree.
+        rel_posix = rel.as_posix()
+        if rel_posix in (".", ""):
+            continue
+        # Never let the ignore file hide itself — the agent should always be
+        # able to read the policy that is blocking it.
+        if rel_posix == IGNORE_FILENAME:
+            continue
+        try:
+            # Directory targets (e.g. a search root) must be tested with a
+            # trailing slash too — gitignore dir patterns like ``secrets/``
+            # only match the slash-suffixed form.
+            candidates = [rel_posix]
+            try:
+                if Path(resolved_path).is_dir():
+                    candidates.append(rel_posix + "/")
+            except OSError:
+                pass
+            if any(spec.match_file(c) for c in candidates):
+                return (
+                    f"Access to '{resolved_path}' is blocked by .hermesignore "
+                    f"({ignore_path}). This project excludes the path from agent "
+                    "file access. Note: .hermesignore gates file tools only — "
+                    "it does not restrict terminal commands or MCP servers."
+                )
+        except Exception:
+            logger.debug("hermesignore match failed for %s", resolved_path, exc_info=True)
+            return None
+    return None

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -316,6 +316,38 @@ Do not ask the agent to `patch` `~/.hermes/cron/jobs.json` directly. Use the `cr
 Write guards apply to `write_file` and `patch` only. The `terminal` tool runs as the same OS user and can still `cat` or overwrite denied paths via shell commands. The denylist reduces accidental damage and gives models a clear stop signal; it does not sandbox a hostile or compromised agent.
 :::
 
+## Project-level `.hermesignore` {#hermesignore}
+
+A `.hermesignore` file committed at the workspace root blocks the agent's file tools — `read_file`, `write_file`, `patch`, and `search_files` — from touching matched paths. Unlike the built-in denylists above, it is **repo-scoped**: a team commits one file and every Hermes session working in that checkout honors it.
+
+The syntax is gitignore syntax:
+
+```gitignore
+# Comments and blank lines are skipped
+*.pem                 # glob patterns
+secrets/              # trailing-slash directory patterns
+docs/internal/**      # ** recursive globs
+build                 # bare names match files AND directory subtrees
+*.env
+!example.env          # ! negation — last match wins
+```
+
+Discovery walks up from the terminal's current working directory (and from the target file's own directory) to the repository root — the first directory containing `.hermesignore` wins, and the walk stops at the directory containing `.git`. Parsed patterns are cached per file and re-read automatically when the file changes.
+
+Blocked access returns an error naming `.hermesignore`, and matched paths are filtered out of `search_files` results. The ignore file itself is never hidden, so the agent can always read the policy blocking it.
+
+Disable the guard entirely with:
+
+```yaml
+# ~/.hermes/config.yaml
+security:
+  hermesignore_enabled: false   # default: true
+```
+
+:::note Same defense-in-depth caveat
+`.hermesignore` gates the file tools only. The `terminal` tool runs shell commands as the same OS user and can still `cat` a matched file, and MCP servers perform their own I/O. Treat it as a clear stop signal for the model and a guard against accidental access — not a sandbox for a hostile agent.
+:::
+
 ## User Authorization (Gateway)
 
 When running the messaging gateway, Hermes controls who can interact with the bot through a layered authorization system.


### PR DESCRIPTION
Adds project-level `.hermesignore` support: a gitignore-syntax file committed at the workspace root that blocks the agent's file tools (`read_file`, `write_file`, `patch`, `search_files`) from touching matched paths — [Cursor `.cursorignore`](https://cursor.com/docs) parity, repo-scoped so a team commits one file and every Hermes session working in that checkout honors it.

## What's in the change

- **New `tools/hermesignore.py`** — discovery walks up from the resolved terminal cwd (via the existing `_authoritative_workspace_root` helper) and from the target's own parent to the git root; first `.hermesignore` found wins, walk stops at the directory containing `.git`.
- **Real gitignore semantics** via `pathspec` (already a dependency): `#` comments, blank lines, `*`/`**` globs, trailing-slash directory patterns, bare-name subtree matches, and `!` negation with last-match-wins (`GitIgnoreSpec`, with `gitwildmatch` fallback for older pathspec).
- **Enforcement at the choke points** in `tools/file_tools.py`: `read_file_tool`, `_check_sensitive_path` (shared by `write_file` + `patch`), and `search_tool`. Blocked access returns a clear error naming `.hermesignore`; search results under ignored paths are filtered with an explanatory omission note.
- **Per-file spec cache** keyed by `(mtime_ns, size)` — the ignore file is re-parsed only when it changes.
- **Config gate**: `security.hermesignore_enabled` (default `true`) in `config.yaml` — no new env vars. Fails open on config/parse errors: this layers on top of the hard sensitive-path denylist, it doesn't replace it.
- **Guardrails**: the ignore file can never hide itself (the agent can always read the policy blocking it); an ignore file above the git root does not leak into the repo; directory search roots are matched against slash-suffixed forms so `secrets/` blocks searching inside `secrets`.
- **Docs**: new "Project-level `.hermesignore`" section in `website/docs/user-guide/security.md`, including the same defense-in-depth caveat as the write-safety guards (terminal/MCP are not gated).

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_hermesignore.py` (21 new tests) | ✅ 21 passed |
| `scripts/run_tests.sh tests/tools/test_file_tools.py tests/tools/test_credential_files.py tests/tools/test_file_write_safety.py` | ✅ all passed |
| `ruff check` on all touched Python files | ✅ All checks passed |
| `scripts/check-windows-footguns.py` on new files | ✅ No footguns |
| `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

Test coverage: matching semantics (globs, `**`, dir patterns, bare names, comments, negation), discovery boundaries (git-root stop, absolute-path access into a foreign repo, paths outside the workspace), kill switch + config read, mtime cache invalidation, choke-point enforcement for read/write/search, and the fail-open wrapper.

## Infographic

![.hermesignore infographic](https://v3b.fal.media/files/b/0aa55634/92EcaDuEqxiIxy7BFR6uH_OOlhfHa1.png)
