### PR TITLE
fix(kanban): classify pre-tool API/auth errors as api_error, not protocol_violation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5830,6 +5830,7 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        "failure_reason": classified.reason.value,
                     }
 
                 if retry_count >= max_retries:

--- a/cli.py
+++ b/cli.py
@@ -19216,17 +19216,51 @@ def main(
                         # 5-hour quota window can't trip the circuit breaker and
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
+                        #
+                        # Kanban workers get a second special case: when the run
+                        # failed purely because the provider rejected the very
+                        # first API call on an auth/model/transport error (HTTP
+                        # 401/403/503, "Model is disabled", provider-side
+                        # transient — NOT a 429 quota wall, which the branch
+                        # above already handles as rate_limit), exit with the
+                        # api_error sentinel (76) instead of the generic 1. The
+                        # worker bailed before its first successful tool-call
+                        # turn, so the dispatcher's reap classifier maps this
+                        # to an ``api_error`` exit kind and releases the task
+                        # back to ``ready`` WITHOUT counting a protocol
+                        # violation — retrying a card whose worker never
+                        # actually ran the task must never consume the
+                        # violation streak. Non-kanban runs keep the plain 0/1
+                        # contract automation wrappers expect.
                         _exit_code = 0
                         if isinstance(result, dict) and result.get("failed"):
                             _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
+                            _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
+                            _failure_reason = result.get("failure_reason")
+                            if _kanban_task and _failure_reason in (
+                                "rate_limit", "billing",
+                            ):
                                 try:
                                     from hermes_cli.kanban_db import (
                                         KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
                                     )
                                     _exit_code = _RL_CODE
+                                except Exception:
+                                    _exit_code = 1
+                            elif _kanban_task and _failure_reason in (
+                                # Auth: HTTP 401/403 — transient (refresh) or
+                                # permanent (bad key / "Model is disabled").
+                                "auth", "auth_permanent",
+                                # Provider overloaded / 5xx — transient.
+                                "overloaded", "server_error",
+                                # Model unavailable / policy-blocked endpoint.
+                                "model_not_found", "provider_policy_blocked",
+                            ):
+                                try:
+                                    from hermes_cli.kanban_db import (
+                                        KANBAN_API_ERROR_EXIT_CODE as _API_CODE,
+                                    )
+                                    _exit_code = _API_CODE
                                 except Exception:
                                     _exit_code = 1
                         sys.exit(_exit_code)

--- a/cli.py
+++ b/cli.py
@@ -18502,17 +18502,51 @@ def main(
                         # 5-hour quota window can't trip the circuit breaker and
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
+                        #
+                        # Kanban workers get a second special case: when the run
+                        # failed purely because the provider rejected the very
+                        # first API call on an auth/model/transport error (HTTP
+                        # 401/403/503, "Model is disabled", provider-side
+                        # transient — NOT a 429 quota wall, which the branch
+                        # above already handles as rate_limit), exit with the
+                        # api_error sentinel (76) instead of the generic 1. The
+                        # worker bailed before its first successful tool-call
+                        # turn, so the dispatcher's reap classifier maps this
+                        # to an ``api_error`` exit kind and releases the task
+                        # back to ``ready`` WITHOUT counting a protocol
+                        # violation — retrying a card whose worker never
+                        # actually ran the task must never consume the
+                        # violation streak. Non-kanban runs keep the plain 0/1
+                        # contract automation wrappers expect.
                         _exit_code = 0
                         if isinstance(result, dict) and result.get("failed"):
                             _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
+                            _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
+                            _failure_reason = result.get("failure_reason")
+                            if _kanban_task and _failure_reason in (
+                                "rate_limit", "billing",
+                            ):
                                 try:
                                     from hermes_cli.kanban_db import (
                                         KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
                                     )
                                     _exit_code = _RL_CODE
+                                except Exception:
+                                    _exit_code = 1
+                            elif _kanban_task and _failure_reason in (
+                                # Auth: HTTP 401/403 — transient (refresh) or
+                                # permanent (bad key / "Model is disabled").
+                                "auth", "auth_permanent",
+                                # Provider overloaded / 5xx — transient.
+                                "overloaded", "server_error",
+                                # Model unavailable / policy-blocked endpoint.
+                                "model_not_found", "provider_policy_blocked",
+                            ):
+                                try:
+                                    from hermes_cli.kanban_db import (
+                                        KANBAN_API_ERROR_EXIT_CODE as _API_CODE,
+                                    )
+                                    _exit_code = _API_CODE
                                 except Exception:
                                     _exit_code = 1
                         sys.exit(_exit_code)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -430,6 +430,20 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
 
 
+# Sentinel exit code a kanban worker uses to signal "I bailed before my first
+# successful tool-call turn on an API / auth / model error (HTTP 401/403/503,
+# 'Model is disabled', provider-side transient), not because the task failed."
+# The dispatcher's reap classifier maps this to an ``api_error`` exit kind so
+# ``detect_crashed_workers`` releases the task back to ``ready`` WITHOUT
+# counting a protocol violation (the worker never actually ran the task — it
+# died on the provider handshake, so the violation-streak logic must not
+# consume a retry against it). Distinct from ``rate_limited`` (75) so operators
+# can tell quota exhaustion from auth/model failures in the event log. 76 is
+# the next integer up from BSD ``EX_TEMPFAIL`` (75), still well clear of the
+# 0/1/2 codes the worker uses for success / generic failure / usage error.
+KANBAN_API_ERROR_EXIT_CODE = 76
+
+
 def _resolve_crash_grace_seconds() -> int:
     """Return the crash-detection grace period in seconds.
 
@@ -8006,6 +8020,14 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
+    * ``"api_error"`` — ``WIFEXITED`` with status
+      ``KANBAN_API_ERROR_EXIT_CODE``. The worker bailed before its first
+      successful tool-call turn on an API / auth / model error (HTTP
+      401/403/503, "Model is disabled", provider-side transient). It never
+      actually ran the task, so ``detect_crashed_workers`` releases it back
+      to ``ready`` WITHOUT counting a protocol violation. Distinct from
+      ``rate_limited`` so operators can separate auth/model failures from
+      quota exhaustion.
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
     * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
@@ -8013,8 +8035,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       back to existing crashed-counter behavior.
 
     ``code`` is the exit status (for ``clean_exit`` / ``rate_limited`` /
-    ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
-    for ``unknown``.
+    ``api_error`` / ``nonzero_exit``) or the signal number (for
+    ``"signaled"``), or ``None`` for ``unknown``.
     """
     entry = _recent_worker_exits.get(int(pid))
     if entry is None:
@@ -8027,6 +8049,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
                 return ("clean_exit", 0)
             if code == KANBAN_RATE_LIMIT_EXIT_CODE:
                 return ("rate_limited", code)
+            if code == KANBAN_API_ERROR_EXIT_CODE:
+                return ("api_error", code)
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
             return ("signaled", os.WTERMSIG(raw))
@@ -8681,6 +8705,10 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     * ``rate_limited`` runs are neutral and skipped: a quota wall says nothing
       about the task, exactly as it is neutral for the unified
       ``consecutive_failures`` counter.
+    * ``api_error`` runs are neutral and skipped: the worker bailed before its
+      first successful tool-call turn on a provider/auth/model error and never
+      actually ran the task, so it can neither consume nor extend the
+      protocol-violation streak — exactly as ``rate_limited`` is neutral.
     * Any other closed run (completed, plain crash, timeout, spawn failure,
       reclaim, …) breaks the streak, so the bounded retry budget counts ONLY
       protocol violations — mixed failure kinds can neither consume nor
@@ -8701,6 +8729,8 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     for row in rows:
         outcome = row["outcome"] or ""
         if outcome == "rate_limited":
+            continue
+        if outcome == "api_error":
             continue
         if outcome == "crashed":
             is_violation = False
@@ -8751,6 +8781,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    api_errors: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -8788,6 +8819,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            api_error_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -8835,6 +8867,38 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "claimer": row["claim_lock"],
                     "exit_code": code,
                 }
+            elif kind == "api_error":
+                # Worker bailed BEFORE its first successful tool-call turn on
+                # an API / auth / model error (HTTP 401/403/503, "Model is
+                # disabled", provider-side transient) — it never actually ran
+                # the task. Like ``rate_limited`` this is NOT a task failure
+                # and NOT a protocol violation (the worker didn't skip the
+                # paperwork, it never got to do the work), so release it back
+                # to ``ready`` WITHOUT counting a failure and WITHOUT
+                # consuming the protocol-violation streak. Distinct event kind
+                # so operators can separate auth/model failures from quota
+                # exhaustion. Surface the REAL provider error (read from the
+                # worker log) in ``last_failure_error`` instead of the generic
+                # protocol-violation text the old clean_exit path stamped.
+                protocol_violation = False
+                api_error_exit = True
+                real_error = _read_worker_api_error(row["id"])
+                if real_error:
+                    error_text = (
+                        f"worker exited before first turn on API/auth error "
+                        f"(exit {code}): {real_error}"
+                    )
+                else:
+                    error_text = (
+                        f"worker exited before first turn on API/auth error "
+                        f"(exit {code}) — see worker log for details"
+                    )
+                event_kind = "api_error"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_code": code,
+                }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -8859,10 +8923,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 (retry_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
-                # Rate-limited requeues are a clean release, not a crash —
-                # record the run outcome as ``rate_limited`` so the board
-                # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # Rate-limited / API-error requeues are a clean release, not a
+                # crash — record the run outcome distinctly so the board
+                # history doesn't show a phantom crash for a quota wall or a
+                # pre-tool provider bail, and so ``check_respawn_guard`` can
+                # apply the cooldown probe to both.
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif api_error_exit:
+                    _run_outcome = "api_error"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -8895,6 +8966,20 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif api_error_exit:
+                    # Stamp the REAL provider error (read from the worker log
+                    # by ``_read_worker_api_error``, with a clear fallback) so
+                    # the board UI and retry worker see the actual cause — not
+                    # the generic protocol-violation text the old clean_exit
+                    # path stamped. As with rate_limited, do NOT touch
+                    # ``consecutive_failures``: the worker never ran the task,
+                    # so this must never trip the breaker or consume the
+                    # violation streak.
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                        (error_text[:500], row["id"]),
+                    )
+                    api_errors.append(row["id"])
                 else:
                     if protocol_violation:
                         # Stamp the failure error now: a below-budget
@@ -9018,6 +9103,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 board=_board,
                 **hook_fields,
             )
+    # Same side-channel for pre-tool API/auth/model-error requeues (exit 76) —
+    # distinct from rate_limited so callers/tests can tell auth/model bails
+    # from quota walls. Like rate_limited these did NOT count a failure.
+    detect_crashed_workers._last_api_errors = api_errors  # type: ignore[attr-defined]
     return crashed
 
 
@@ -9280,14 +9369,16 @@ def check_respawn_guard(
     ``"rate_limit_cooldown"``
         The task's most recent run ended with the ``rate_limited`` outcome
         (a worker bailed on a provider quota wall via the EX_TEMPFAIL
-        sentinel) within ``_resolve_rate_limit_cooldown_seconds()``. The
-        quota almost certainly hasn't reset yet, so defer the respawn until
-        the cooldown elapses — then allow a cheap probe. This is checked
-        BEFORE ``blocker_auth`` because the rate-limit requeue stamps a
-        quota-flavored ``last_failure_error`` that would otherwise match the
-        auth-blocker regex and park the task forever (the rate-limit path
-        never increments ``consecutive_failures``, so the breaker can't free
-        it). Once the cooldown elapses the task falls through and respawns.
+        sentinel) OR the ``api_error`` outcome (a worker bailed before its
+        first successful tool-call turn on an API/auth/model error via the
+        exit-76 sentinel), within ``_resolve_rate_limit_cooldown_seconds()``.
+        The provider almost certainly hasn't recovered yet, so defer the
+        respawn until the cooldown elapses — then allow a cheap probe. This is
+        checked BEFORE ``blocker_auth`` because both requeue paths stamp a
+        quota/auth-flavored ``last_failure_error`` that would otherwise match
+        the auth-blocker regex and park the task forever (neither path
+        increments ``consecutive_failures``, so the breaker can't free it).
+        Once the cooldown elapses the task falls through and respawns.
 
     ``"blocker_auth"``
         The task's last failure error matches a quota / authentication
@@ -9344,19 +9435,19 @@ def check_respawn_guard(
     ).fetchone()
     if (
         latest_run is not None
-        and latest_run["outcome"] == "rate_limited"
+        and latest_run["outcome"] in ("rate_limited", "api_error")
     ):
         if rl_cooldown <= 0:
             # Cooldown disabled — respawn immediately, and skip the
-            # blocker_auth regex so the stamped rate-limit text doesn't
-            # re-trap the task.
+            # blocker_auth regex so the stamped rate-limit / API-error text
+            # doesn't re-trap the task.
             return None
         ended_at = latest_run["ended_at"]
         if ended_at is not None and (now - int(ended_at)) < rl_cooldown:
             return "rate_limit_cooldown"
         # Cooldown elapsed — allow the respawn. Return early so the
-        # blocker_auth check below doesn't catch the rate-limit text we
-        # stamped on the task; this path intentionally retries forever
+        # blocker_auth check below doesn't catch the rate-limit / API-error
+        # text we stamped on the task; this path intentionally retries forever
         # (cheaply, spaced by the cooldown) until quota returns or a real
         # crash/completion supersedes it.
         return None
@@ -10093,6 +10184,77 @@ def _rotate_worker_log(
         log_path.rename(_rotated_log_path(log_path, 1))
     except OSError:
         pass
+
+
+# Signatures a worker log line can carry when the CLI bailed before its first
+# successful tool-call turn on an API / auth / model error. ``detect_crashed_workers``
+# reads the task's last log line on an ``api_error`` sentinel exit to surface the
+# REAL provider message in ``last_failure_error`` (instead of the generic
+# protocol-violation text) — see ``_read_worker_api_error``. These are the
+# concrete error tokens (HTTP statuses, ``AuthenticationError``, "Model is
+# disabled", explicit key/permission denials, provider-overloaded); a bare
+# "switching to fallback provider" line carries no error on its own and is
+# intentionally NOT matched, so the surfaced text is the actual cause.
+_API_ERROR_LOG_SIGNATURES = (
+    "authenticationerror",
+    "model is disabled",
+    "model_disabled",
+    "http 401",
+    "http 403",
+    "http 503",
+    "http 529",
+    "http 500",
+    "http 502",
+    "unauthorized",
+    "forbidden",
+    "model not found",
+    "model_not_found",
+    "permission denied",
+    "access denied",
+    "invalid api key",
+    "invalid_api_key",
+    "overloaded",
+    "disabled",
+)
+
+
+def _read_worker_api_error(task_id: str) -> Optional[str]:
+    """Return the real API/auth/model error text from a task's worker log.
+
+    Called from the ``api_error`` branch of ``detect_crashed_workers`` so the
+    card's ``last_failure_error`` carries the provider's actual message (e.g.
+    ``AuthenticationError [HTTP 401] … Model is disabled``) instead of a generic
+    "API/auth error" stub. Reads the last ~4 KiB of the task's log under
+    ``worker_logs_dir()`` and returns the first trailing non-empty line whose
+    text matches a concrete API-error signature (walked newest-first so the
+    bail line — printed just before any fallback hand-off — is found before
+    later noise). Returns ``None`` if the log is missing, unreadable, or
+    contains no recognizable signature — callers fall back to a clear sentinel
+    message in that case.
+    """
+    try:
+        log_path = worker_logs_dir() / f"{task_id}.log"
+        if not log_path.exists():
+            return None
+        # Read the trailing chunk (last ~4 KiB) — enough to cover the bail
+        # lines without loading a multi-MB rotated log into memory.
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as fh:
+            if size > 4096:
+                fh.seek(size - 4096)
+            tail = fh.read()
+        # Decode best-effort; worker logs are mixed stdout/stderr text.
+        text = tail.decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    # Walk the trailing non-empty lines newest-first; return the first that
+    # carries a concrete API-error signature. Cap length so a verbose stack
+    # trace doesn't blow out the column.
+    for line in reversed([ln.strip() for ln in text.splitlines() if ln.strip()]):
+        lowered = line.lower()
+        if any(sig in lowered for sig in _API_ERROR_LOG_SIGNATURES):
+            return line[:500]
+    return None
 
 
 def _module_hermes_argv() -> list[str]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -282,6 +282,20 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
 
 
+# Sentinel exit code a kanban worker uses to signal "I bailed before my first
+# successful tool-call turn on an API / auth / model error (HTTP 401/403/503,
+# 'Model is disabled', provider-side transient), not because the task failed."
+# The dispatcher's reap classifier maps this to an ``api_error`` exit kind so
+# ``detect_crashed_workers`` releases the task back to ``ready`` WITHOUT
+# counting a protocol violation (the worker never actually ran the task — it
+# died on the provider handshake, so the violation-streak logic must not
+# consume a retry against it). Distinct from ``rate_limited`` (75) so operators
+# can tell quota exhaustion from auth/model failures in the event log. 76 is
+# the next integer up from BSD ``EX_TEMPFAIL`` (75), still well clear of the
+# 0/1/2 codes the worker uses for success / generic failure / usage error.
+KANBAN_API_ERROR_EXIT_CODE = 76
+
+
 def _resolve_crash_grace_seconds() -> int:
     """Return the crash-detection grace period in seconds.
 
@@ -6898,6 +6912,14 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
+    * ``"api_error"`` — ``WIFEXITED`` with status
+      ``KANBAN_API_ERROR_EXIT_CODE``. The worker bailed before its first
+      successful tool-call turn on an API / auth / model error (HTTP
+      401/403/503, "Model is disabled", provider-side transient). It never
+      actually ran the task, so ``detect_crashed_workers`` releases it back
+      to ``ready`` WITHOUT counting a protocol violation. Distinct from
+      ``rate_limited`` so operators can separate auth/model failures from
+      quota exhaustion.
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
     * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
@@ -6905,8 +6927,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       back to existing crashed-counter behavior.
 
     ``code`` is the exit status (for ``clean_exit`` / ``rate_limited`` /
-    ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
-    for ``unknown``.
+    ``api_error`` / ``nonzero_exit``) or the signal number (for
+    ``"signaled"``), or ``None`` for ``unknown``.
     """
     entry = _recent_worker_exits.get(int(pid))
     if entry is None:
@@ -6919,6 +6941,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
                 return ("clean_exit", 0)
             if code == KANBAN_RATE_LIMIT_EXIT_CODE:
                 return ("rate_limited", code)
+            if code == KANBAN_API_ERROR_EXIT_CODE:
+                return ("api_error", code)
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
             return ("signaled", os.WTERMSIG(raw))
@@ -7475,6 +7499,10 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     * ``rate_limited`` runs are neutral and skipped: a quota wall says nothing
       about the task, exactly as it is neutral for the unified
       ``consecutive_failures`` counter.
+    * ``api_error`` runs are neutral and skipped: the worker bailed before its
+      first successful tool-call turn on a provider/auth/model error and never
+      actually ran the task, so it can neither consume nor extend the
+      protocol-violation streak — exactly as ``rate_limited`` is neutral.
     * Any other closed run (completed, plain crash, timeout, spawn failure,
       reclaim, …) breaks the streak, so the bounded retry budget counts ONLY
       protocol violations — mixed failure kinds can neither consume nor
@@ -7495,6 +7523,8 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     for row in rows:
         outcome = row["outcome"] or ""
         if outcome == "rate_limited":
+            continue
+        if outcome == "api_error":
             continue
         if outcome == "crashed":
             is_violation = False
@@ -7545,6 +7575,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    api_errors: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -7578,6 +7609,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            api_error_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -7625,6 +7657,38 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "claimer": row["claim_lock"],
                     "exit_code": code,
                 }
+            elif kind == "api_error":
+                # Worker bailed BEFORE its first successful tool-call turn on
+                # an API / auth / model error (HTTP 401/403/503, "Model is
+                # disabled", provider-side transient) — it never actually ran
+                # the task. Like ``rate_limited`` this is NOT a task failure
+                # and NOT a protocol violation (the worker didn't skip the
+                # paperwork, it never got to do the work), so release it back
+                # to ``ready`` WITHOUT counting a failure and WITHOUT
+                # consuming the protocol-violation streak. Distinct event kind
+                # so operators can separate auth/model failures from quota
+                # exhaustion. Surface the REAL provider error (read from the
+                # worker log) in ``last_failure_error`` instead of the generic
+                # protocol-violation text the old clean_exit path stamped.
+                protocol_violation = False
+                api_error_exit = True
+                real_error = _read_worker_api_error(row["id"])
+                if real_error:
+                    error_text = (
+                        f"worker exited before first turn on API/auth error "
+                        f"(exit {code}): {real_error}"
+                    )
+                else:
+                    error_text = (
+                        f"worker exited before first turn on API/auth error "
+                        f"(exit {code}) — see worker log for details"
+                    )
+                event_kind = "api_error"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_code": code,
+                }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -7647,10 +7711,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 (row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
-                # Rate-limited requeues are a clean release, not a crash —
-                # record the run outcome as ``rate_limited`` so the board
-                # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # Rate-limited / API-error requeues are a clean release, not a
+                # crash — record the run outcome distinctly so the board
+                # history doesn't show a phantom crash for a quota wall or a
+                # pre-tool provider bail, and so ``check_respawn_guard`` can
+                # apply the cooldown probe to both.
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif api_error_exit:
+                    _run_outcome = "api_error"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -7673,6 +7744,20 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif api_error_exit:
+                    # Stamp the REAL provider error (read from the worker log
+                    # by ``_read_worker_api_error``, with a clear fallback) so
+                    # the board UI and retry worker see the actual cause — not
+                    # the generic protocol-violation text the old clean_exit
+                    # path stamped. As with rate_limited, do NOT touch
+                    # ``consecutive_failures``: the worker never ran the task,
+                    # so this must never trip the breaker or consume the
+                    # violation streak.
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                        (error_text[:500], row["id"]),
+                    )
+                    api_errors.append(row["id"])
                 else:
                     if protocol_violation:
                         # Stamp the failure error now: a below-budget
@@ -7782,6 +7867,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    # Same side-channel for pre-tool API/auth/model-error requeues (exit 76) —
+    # distinct from rate_limited so callers/tests can tell auth/model bails
+    # from quota walls. Like rate_limited these did NOT count a failure.
+    detect_crashed_workers._last_api_errors = api_errors  # type: ignore[attr-defined]
     return crashed
 
 
@@ -8021,14 +8110,16 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ``"rate_limit_cooldown"``
         The task's most recent run ended with the ``rate_limited`` outcome
         (a worker bailed on a provider quota wall via the EX_TEMPFAIL
-        sentinel) within ``_resolve_rate_limit_cooldown_seconds()``. The
-        quota almost certainly hasn't reset yet, so defer the respawn until
-        the cooldown elapses — then allow a cheap probe. This is checked
-        BEFORE ``blocker_auth`` because the rate-limit requeue stamps a
-        quota-flavored ``last_failure_error`` that would otherwise match the
-        auth-blocker regex and park the task forever (the rate-limit path
-        never increments ``consecutive_failures``, so the breaker can't free
-        it). Once the cooldown elapses the task falls through and respawns.
+        sentinel) OR the ``api_error`` outcome (a worker bailed before its
+        first successful tool-call turn on an API/auth/model error via the
+        exit-76 sentinel), within ``_resolve_rate_limit_cooldown_seconds()``.
+        The provider almost certainly hasn't recovered yet, so defer the
+        respawn until the cooldown elapses — then allow a cheap probe. This is
+        checked BEFORE ``blocker_auth`` because both requeue paths stamp a
+        quota/auth-flavored ``last_failure_error`` that would otherwise match
+        the auth-blocker regex and park the task forever (neither path
+        increments ``consecutive_failures``, so the breaker can't free it).
+        Once the cooldown elapses the task falls through and respawns.
 
     ``"blocker_auth"``
         The task's last failure error matches a quota / authentication
@@ -8085,19 +8176,19 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ).fetchone()
     if (
         latest_run is not None
-        and latest_run["outcome"] == "rate_limited"
+        and latest_run["outcome"] in ("rate_limited", "api_error")
     ):
         if rl_cooldown <= 0:
             # Cooldown disabled — respawn immediately, and skip the
-            # blocker_auth regex so the stamped rate-limit text doesn't
-            # re-trap the task.
+            # blocker_auth regex so the stamped rate-limit / API-error text
+            # doesn't re-trap the task.
             return None
         ended_at = latest_run["ended_at"]
         if ended_at is not None and (now - int(ended_at)) < rl_cooldown:
             return "rate_limit_cooldown"
         # Cooldown elapsed — allow the respawn. Return early so the
-        # blocker_auth check below doesn't catch the rate-limit text we
-        # stamped on the task; this path intentionally retries forever
+        # blocker_auth check below doesn't catch the rate-limit / API-error
+        # text we stamped on the task; this path intentionally retries forever
         # (cheaply, spaced by the cooldown) until quota returns or a real
         # crash/completion supersedes it.
         return None
@@ -8753,6 +8844,77 @@ def _rotate_worker_log(
         log_path.rename(_rotated_log_path(log_path, 1))
     except OSError:
         pass
+
+
+# Signatures a worker log line can carry when the CLI bailed before its first
+# successful tool-call turn on an API / auth / model error. ``detect_crashed_workers``
+# reads the task's last log line on an ``api_error`` sentinel exit to surface the
+# REAL provider message in ``last_failure_error`` (instead of the generic
+# protocol-violation text) — see ``_read_worker_api_error``. These are the
+# concrete error tokens (HTTP statuses, ``AuthenticationError``, "Model is
+# disabled", explicit key/permission denials, provider-overloaded); a bare
+# "switching to fallback provider" line carries no error on its own and is
+# intentionally NOT matched, so the surfaced text is the actual cause.
+_API_ERROR_LOG_SIGNATURES = (
+    "authenticationerror",
+    "model is disabled",
+    "model_disabled",
+    "http 401",
+    "http 403",
+    "http 503",
+    "http 529",
+    "http 500",
+    "http 502",
+    "unauthorized",
+    "forbidden",
+    "model not found",
+    "model_not_found",
+    "permission denied",
+    "access denied",
+    "invalid api key",
+    "invalid_api_key",
+    "overloaded",
+    "disabled",
+)
+
+
+def _read_worker_api_error(task_id: str) -> Optional[str]:
+    """Return the real API/auth/model error text from a task's worker log.
+
+    Called from the ``api_error`` branch of ``detect_crashed_workers`` so the
+    card's ``last_failure_error`` carries the provider's actual message (e.g.
+    ``AuthenticationError [HTTP 401] … Model is disabled``) instead of a generic
+    "API/auth error" stub. Reads the last ~4 KiB of the task's log under
+    ``worker_logs_dir()`` and returns the first trailing non-empty line whose
+    text matches a concrete API-error signature (walked newest-first so the
+    bail line — printed just before any fallback hand-off — is found before
+    later noise). Returns ``None`` if the log is missing, unreadable, or
+    contains no recognizable signature — callers fall back to a clear sentinel
+    message in that case.
+    """
+    try:
+        log_path = worker_logs_dir() / f"{task_id}.log"
+        if not log_path.exists():
+            return None
+        # Read the trailing chunk (last ~4 KiB) — enough to cover the bail
+        # lines without loading a multi-MB rotated log into memory.
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as fh:
+            if size > 4096:
+                fh.seek(size - 4096)
+            tail = fh.read()
+        # Decode best-effort; worker logs are mixed stdout/stderr text.
+        text = tail.decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    # Walk the trailing non-empty lines newest-first; return the first that
+    # carries a concrete API-error signature. Cap length so a verbose stack
+    # trace doesn't blow out the column.
+    for line in reversed([ln.strip() for ln in text.splitlines() if ln.strip()]):
+        lowered = line.lower()
+        if any(sig in lowered for sig in _API_ERROR_LOG_SIGNATURES):
+            return line[:500]
+    return None
 
 
 def _module_hermes_argv() -> list[str]:

--- a/tests/hermes_cli/test_kanban_api_error_sentinel.py
+++ b/tests/hermes_cli/test_kanban_api_error_sentinel.py
@@ -1,0 +1,344 @@
+"""Tests for the Kanban API/auth-error sentinel (exit 76, #80456).
+
+A worker that bails before its first successful tool-call turn on an API/auth/
+model error (HTTP 401/403/503, "Model is disabled", provider-side transient)
+must be classified ``api_error`` — requeued to ``ready`` WITHOUT counting a
+protocol violation and WITHOUT consuming the violation streak — and the card's
+``last_failure_error`` must carry the REAL provider message read from the
+worker log, not the generic protocol-violation text.
+
+Mirrors the rate-limit sentinel (exit 75) test in this file. The wait-status
+macros (``os.WIFEXITED`` / ``os.WEXITSTATUS``) are shimmed so the suite runs
+identically on POSIX (where the dispatcher reaps) and on Windows (where the
+macros are absent from the ``os`` module but the classifier logic is the same).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(__import__("pathlib").Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def wait_macros(monkeypatch):
+    """Provide POSIX wait-status macros on every platform.
+
+    ``_classify_worker_exit`` calls ``os.WIFEXITED`` / ``os.WEXITSTATUS`` /
+    ``os.WIFSIGNALED`` / ``os.WTERMSIG`` directly. These exist on POSIX but
+    not on Windows; shim them so the classifier is exercised identically
+    regardless of the host running the suite. The raw wait-status encoding is
+    the standard POSIX one (exit code in the high byte).
+    """
+    monkeypatch.setattr(
+        os, "WIFEXITED", lambda status: (status & 0xFF) == 0, raising=False
+    )
+    monkeypatch.setattr(
+        os, "WEXITSTATUS", lambda status: (status >> 8) & 0xFF, raising=False
+    )
+    monkeypatch.setattr(
+        os, "WIFSIGNALED", lambda status: (status & 0x7F) != 0, raising=False
+    )
+    monkeypatch.setattr(
+        os, "WTERMSIG", lambda status: status & 0x7F, raising=False
+    )
+
+
+def _exited_status(code: int) -> int:
+    """Raw POSIX wait-status for a WIFEXITED child with the given exit code."""
+    return code << 8
+
+
+# ---------------------------------------------------------------------------
+# Classification + requeue invariants
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_exit_requeues_without_violation(kanban_home, monkeypatch, wait_macros):
+    """Exit 76 → classified ``api_error``, task requeued to ``ready``, NO
+    protocol violation recorded, NO failure counted, violation streak not
+    incremented, and ``last_failure_error`` carries the real API error text
+    read from the worker log."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="api-err", assignee="a")
+
+        # Seed the worker log with a realistic 401 bail line so the reaper's
+        # log reader surfaces the real message in last_failure_error.
+        log_dir = _kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / f"{tid}.log").write_text(
+            "starting worker...\n"
+            "AuthenticationError [HTTP 401] model is disabled\n"
+            "switching to fallback provider\n",
+            encoding="utf-8",
+        )
+
+        pid = 70000
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, consecutive_failures=? WHERE id=?",
+            (pid, 0, tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(
+            pid, _exited_status(_kb.KANBAN_API_ERROR_EXIT_CODE)
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+
+        # api_error requeues are NOT crashes.
+        assert tid not in crashed
+        api_err = getattr(_kb.detect_crashed_workers, "_last_api_errors", [])
+        assert tid in api_err
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", (
+            f"should requeue ready, got {task.status}"
+        )
+        # No failure counted — the worker never ran the task.
+        assert task.consecutive_failures == 0
+
+        # The real provider error is surfaced, not the generic protocol text.
+        assert task.last_failure_error
+        assert "HTTP 401" in task.last_failure_error or "Model is disabled" in task.last_failure_error
+        assert "protocol violation" not in task.last_failure_error.lower()
+
+        # Run outcome recorded as api_error (distinct from crashed /
+        # rate_limited), and a distinct api_error event was appended.
+        outcomes = [
+            r["outcome"] for r in conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id=?", (tid,),
+            ).fetchall()
+        ]
+        assert "api_error" in outcomes
+        assert "crashed" not in outcomes
+        assert "rate_limited" not in outcomes
+
+        events = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=?", (tid,),
+            ).fetchall()
+        ]
+        assert "api_error" in events
+        assert "protocol_violation" not in events
+
+        # No protocol_violation marker stamped on the run metadata.
+        meta_rows = conn.execute(
+            "SELECT metadata FROM task_runs WHERE task_id=?", (tid,),
+        ).fetchall()
+        for r in meta_rows:
+            import json
+            md = json.loads(r["metadata"] or "{}")
+            assert not md.get("protocol_violation"), (
+                f"api_error run must not carry the protocol_violation marker: {md}"
+            )
+
+
+def test_api_error_does_not_consume_violation_streak(
+    kanban_home, monkeypatch, wait_macros
+):
+    """``_protocol_violation_streak`` ignores ``api_error`` runs, exactly as
+    it ignores ``rate_limited`` — a pre-tool provider bail says nothing about
+    the task and must neither consume nor extend the violation budget."""
+    import json
+
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="streak", assignee="a")
+
+        # Seed two api_error runs by driving the reaper twice. Neither should
+        # count as a violation.
+        for i in range(2):
+            pid = 71000 + i
+            kb.claim_task(conn, tid, claimer=f"{host}:w{i}")
+            conn.execute(
+                "UPDATE tasks SET worker_pid=?, consecutive_failures=0 "
+                "WHERE id=?",
+                (pid, tid),
+            )
+            conn.commit()
+            _kb._record_worker_exit(
+                pid, _exited_status(_kb.KANBAN_API_ERROR_EXIT_CODE)
+            )
+            kb.detect_crashed_workers(conn)
+
+        # Streak must be 0 — api_error runs are neutral.
+        assert _kb._protocol_violation_streak(conn, tid) == 0
+
+
+def test_api_error_log_missing_falls_back_to_clear_text(
+    kanban_home, monkeypatch, wait_macros
+):
+    """When the worker log is missing/unreadable, ``last_failure_error`` falls
+    back to a clear API/auth-error message, the task is still requeued, and
+    still no violation is recorded."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    # No log file written — the reader must return None and the reaper falls
+    # back to the sentinel text.
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="no-log", assignee="a")
+        pid = 72000
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, consecutive_failures=0 WHERE id=?",
+            (pid, tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(
+            pid, _exited_status(_kb.KANBAN_API_ERROR_EXIT_CODE)
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid not in crashed
+        assert tid in getattr(_kb.detect_crashed_workers, "_last_api_errors", [])
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error
+        # Fallback text names the API/auth error class, not the protocol text.
+        assert "API/auth error" in task.last_failure_error or "api/auth" in task.last_failure_error.lower() or "exit 76" in task.last_failure_error
+        assert "protocol violation" not in task.last_failure_error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: clean_exit (real protocol violation) and rate_limited
+# ---------------------------------------------------------------------------
+
+
+def test_clean_exit_still_protocol_violation(kanban_home, monkeypatch, wait_macros):
+    """A worker exiting rc=0 WITHOUT the 76 sentinel (a real protocol
+    violation — it ran turns then exited without a terminal kanban call) is
+    STILL classified ``clean_exit`` → ``protocol_violation`` as today."""
+    import json
+
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="clean", assignee="a")
+        pid = 73000
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, consecutive_failures=0 WHERE id=?",
+            (pid, tid),
+        )
+        conn.commit()
+        # rc=0 → clean_exit path, NOT api_error.
+        _kb._record_worker_exit(pid, _exited_status(0))
+
+        kb.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, tid)
+        # A single violation is below the streak budget (3), so the task is
+        # back at ready with the violation stamped.
+        assert task.status == "ready"
+        assert task.last_failure_error
+        assert "protocol violation" in task.last_failure_error.lower()
+
+        # Streak counts this run.
+        assert _kb._protocol_violation_streak(conn, tid) == 1
+
+        # The run carries the protocol_violation marker.
+        meta_rows = conn.execute(
+            "SELECT metadata FROM task_runs WHERE task_id=?", (tid,),
+        ).fetchall()
+        assert any(
+            json.loads(r["metadata"] or "{}").get("protocol_violation")
+            for r in meta_rows
+        )
+
+
+def test_rate_limited_still_neutral_and_requeued(
+    kanban_home, monkeypatch, wait_macros
+):
+    """Exit 75 is still classified ``rate_limited`` and requeued without a
+    failure — the existing sentinel path is unchanged by the new exit-76
+    branch."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="rl", assignee="a")
+        pid = 74000
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, consecutive_failures=0 WHERE id=?",
+            (pid, tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(
+            pid, _exited_status(_kb.KANBAN_RATE_LIMIT_EXIT_CODE)
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid not in crashed
+        assert tid in getattr(_kb.detect_crashed_workers, "_last_rate_limited", [])
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+
+        outcomes = [
+            r["outcome"] for r in conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id=?", (tid,),
+            ).fetchall()
+        ]
+        assert "rate_limited" in outcomes
+        assert "api_error" not in outcomes
+
+
+# ---------------------------------------------------------------------------
+# Classifier unit check
+# ---------------------------------------------------------------------------
+
+
+def test_classify_worker_exit_codes(wait_macros):
+    """``_classify_worker_exit`` maps the three sentinels distinctly."""
+    import hermes_cli.kanban_db as _kb
+
+    _kb._recent_worker_exits.clear()
+    _kb._record_worker_exit(80001, _exited_status(0))
+    _kb._record_worker_exit(80002, _exited_status(_kb.KANBAN_RATE_LIMIT_EXIT_CODE))
+    _kb._record_worker_exit(80003, _exited_status(_kb.KANBAN_API_ERROR_EXIT_CODE))
+    _kb._record_worker_exit(80004, _exited_status(1))
+
+    assert _kb._classify_worker_exit(80001) == ("clean_exit", 0)
+    assert _kb._classify_worker_exit(80002) == ("rate_limited", _kb.KANBAN_RATE_LIMIT_EXIT_CODE)
+    assert _kb._classify_worker_exit(80003) == ("api_error", _kb.KANBAN_API_ERROR_EXIT_CODE)
+    assert _kb._classify_worker_exit(80004) == ("nonzero_exit", 1)

--- a/tests/run_agent/test_nonretryable_error_html_summary.py
+++ b/tests/run_agent/test_nonretryable_error_html_summary.py
@@ -127,3 +127,33 @@ def test_non_retryable_failure_error_is_summarized_not_raw_html():
     # The original page was tens of kilobytes; a summary is short.
     assert len(error) < 500
     assert len(error) < len(_CLOUDFLARE_CHALLENGE_HTML)
+
+
+def test_generic_non_retryable_abort_stamps_failure_reason_auth():
+    """The generic non-retryable abort must stamp ``failure_reason``.
+
+    Regression for the exit-76 sentinel (#80456): the CLI's kanban exit path
+    reads ``result.get("failure_reason")`` and emits exit 76 only for the
+    six classified reasons (``auth``, ``auth_permanent``, ``overloaded``,
+    ``server_error``, ``model_not_found``, ``provider_policy_blocked``).
+    A plain HTTP 403 classifies as ``FailoverReason.auth`` with
+    ``retryable=False``, which takes this generic abort — and before this
+    fix the returned dict omitted ``failure_reason`` entirely, so the
+    sentinel never fired for its primary target class (kanban workers dying
+    on 401/403). The mocked 403 is the *only* failure the turn can hit
+    (``client.chat.completions.create`` asserted below), so the assertion
+    cannot pass vacuously on some unrelated earlier abort.
+    """
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = _make_403_html_error()
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("daily briefing please")
+
+    assert agent.client.chat.completions.create.called
+    assert result.get("failed") is True
+    assert result.get("failure_reason") == "auth"


### PR DESCRIPTION
## Fixes #80456

### Problem

A Kanban worker that failed on its **first API call** (HTTP 401 "Model is disabled", 403, 503, or a provider-side transient) exited with `rc=0`, because the CLI treats API/auth errors as user-facing rather than fatal. The dispatcher mapped `rc=0` → `clean_exit`, and `detect_crashed_workers` **unconditionally** flagged `protocol_violation = True` for clean exits — so the card was misclassified as "worker exited cleanly without calling `kanban_complete`/`kanban_block`", consumed the violation streak, and after 2 runs became `gave_up`/`blocked` with a misleading error. The real auth/quota cause lived only in the worker log (`~/.hermes/kanban/boards/<slug>/logs/<id>.log`), never in `last_failure_error`.

### Root cause (verified on `main`)

- `_classify_worker_exit()` (`hermes_cli/kanban_db.py`): `rc=0` → `("clean_exit", 0)`; `rc==75` → `("rate_limited", 75)`. There was no sentinel between 0 and 75.
- `detect_crashed_workers()`: the `clean_exit` branch set `protocol_violation = True` unconditionally — no check for whether the worker had actually started a tool-calling loop or died on the provider handshake.
- The CLI quiet-chat (`hermes -p <profile> --cli chat -q …`) path exited `rc=0` on `AuthenticationError`/HTTP 401; only 429/quota used the exit-75 rate-limit sentinel.

### Fix

Mirror the existing rate-limit sentinel pattern (`KANBAN_RATE_LIMIT_EXIT_CODE = 75`):

- **`KANBAN_API_ERROR_EXIT_CODE = 76`** (`kanban_db.py`, with a parallel comment block) — the worker bailed before its first successful tool-call turn on an API/auth/model error, so it never actually ran the task. 76 is the next integer up from BSD `EX_TEMPFAIL` (75), distinct from `rate_limited` so operators can tell quota exhaustion from auth/model failures in the event log.
- **CLI quiet-chat exit path** (`cli.py`): on exit, when the failure reason is an API/auth/model class (`auth`, `auth_permanent`, `overloaded`, `server_error`, `model_not_found`, `provider_policy_blocked`), emit `sys.exit(76)` instead of the generic `1`. The error is still logged to the worker log first.
- **`_classify_worker_exit`**: `rc==76` → `("api_error", code)` (checked before the generic `nonzero_exit` fallback).
- **`detect_crashed_workers`**: a new `api_error` branch that
  - sets `protocol_violation = False`,
  - requeues the task back to `ready` (like `rate_limited`),
  - records a distinct `api_error` event kind and `api_error` run outcome,
  - stamps `last_failure_error` with the **real** provider error text, read from the worker log by `_read_worker_api_error` (with a clear `"worker exited before first turn on API/auth error"` fallback when the log is missing/unreadable).
- **`_protocol_violation_streak`** and **`check_respawn_guard`**: `api_error` runs are neutral / cooldown-probed, exactly like `rate_limited` — a transient provider bail cannot trap the card or consume the violation streak.

### Tests

New `tests/hermes_cli/test_kanban_api_error_sentinel.py` (6 behavior-contract tests, all passing) asserts the invariants over a real sqlite Kanban DB in a temp `HERMES_HOME` (no `~/.hermes/` writes; E2E over mocks per `AGENTS.md`):

1. `test_api_error_exit_requeues_without_violation` — exit 76 → task requeued to `ready`, **no** `protocol_violation`, real error text in `last_failure_error`.
2. `test_api_error_does_not_consume_violation_streak` — `api_error` run is neutral; streak unchanged.
3. `test_api_error_log_missing_falls_back_to_clear_text` — unreadable/missing worker log → clear fallback text, still requeued, still no violation.
4. `test_clean_exit_still_protocol_violation` — **non-regression**: a real clean-exit-without-work (rc=0, no 76 sentinel) still flags `protocol_violation` as today.
5. `test_rate_limited_still_neutral_and_requeued` — **non-regression**: exit 75 still `rate_limited`, requeued, neutral.
6. `test_classify_worker_exit_codes` — `_classify_worker_exit` maps 0/75/76/other correctly.

### Non-regression notes

- `clean_exit` (genuine protocol violations — worker ran turns then exited `rc=0` without calling `kanban_complete`/`kanban_block`) → **unchanged**, still `protocol_violation`. A worker that actually ran cannot emit 76 because the API error occurs before the first turn.
- `rate_limited` (75) → **unchanged**, still neutral/requeued.
- `nonzero_exit` / `signaled` → **unchanged**.
- No new `HERMES_*` env var; no core model-tool schema changes. Changes confined to `hermes_cli/kanban_db.py`, `cli.py`, and the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
