### PR TITLE
fix(compression): align host and auxiliary timeouts

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -780,11 +780,16 @@ def resolve_context_compression_timeouts(
 
     ``idle_timeout_seconds <= 0`` disables the owned progress-aware wrapper.
     The ceiling is clamped to at least one idle window when the idle budget
-    is positive, matching gateway hygiene semantics.
+    is positive, matching gateway hygiene semantics. Runtime resolution also
+    raises a positive idle budget to the effective auxiliary compression
+    timeout: the host must not abandon a silent-but-still-valid summary call
+    before that call's own deadline. Passing an explicit config mapping keeps
+    this helper deterministic for validation and unit tests.
     """
     idle = DEFAULT_CONTEXT_TIMEOUT_SECONDS
     ceiling = DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS
     cfg = compression_cfg
+    align_with_auxiliary_timeout = cfg is None
     if cfg is None:
         try:
             from hermes_cli.config import load_config
@@ -812,6 +817,21 @@ def resolve_context_compression_timeouts(
             except (TypeError, ValueError):
                 pass
     if idle > 0:
+        if align_with_auxiliary_timeout:
+            try:
+                from agent.auxiliary_client import _effective_aux_timeout
+
+                auxiliary_timeout = float(
+                    _effective_aux_timeout("compression", None)
+                )
+                if auxiliary_timeout > 0:
+                    idle = max(idle, auxiliary_timeout)
+            except Exception:
+                logger.debug(
+                    "Failed to align context compression timeout with "
+                    "auxiliary.compression timeout",
+                    exc_info=True,
+                )
         ceiling = max(ceiling, idle)
     return idle, ceiling
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -648,12 +648,15 @@ DEFAULT_CONFIG = {
                                       # trickle stream. Clamped to >= hygiene_timeout_seconds.
         "hygiene_failure_cooldown_seconds": 300,  # skip repeated failed hygiene attempts for this session
         "context_timeout_seconds": 120,  # inactivity budget for in-agent compress_context
-                                      # (conversation loop, /compress, preflight, etc.).
-                                      # Same progress-aware semantics as hygiene_timeout_seconds:
-                                      # streamed summary tokens extend the wait; only a silent
-                                      # worker is cut off. 0 = disable the owned wrapper
-                                      # (callers that already pass commit_fence, e.g. gateway
-                                      # hygiene, never use this path).
+                                       # (conversation loop, /compress, preflight, etc.).
+                                       # Same progress-aware semantics as hygiene_timeout_seconds:
+                                       # streamed summary tokens extend the wait; only a silent
+                                       # worker is cut off. At runtime a positive value is raised
+                                       # to at least the effective auxiliary.compression timeout,
+                                       # so the host cannot abandon a request before its own
+                                       # provider deadline. 0 = disable the owned wrapper
+                                       # (callers that already pass commit_fence, e.g. gateway
+                                       # hygiene, never use this path).
         "context_total_ceiling_seconds": 600,  # absolute cap on the *pre-commit*
                                       # in-agent compress_context wait (summary /
                                       # stream phase) even while tokens are still

--- a/run_agent.py
+++ b/run_agent.py
@@ -7482,11 +7482,13 @@ class AIAgent:
                 emit = getattr(self, "_emit_warning", None)
                 if callable(emit):
                     emit(
-                        "⚠ Context compression timed out "
-                        f"after {idle:.1f}s with no output from the summary "
-                        "model. No messages were dropped — continuing without "
-                        "compression. Run /compress to retry, /new for a clean "
-                        "session, or check auxiliary.compression."
+                        "⚠ Context compression stopped waiting "
+                        f"after {idle:.1f}s without an observable progress "
+                        "signal. The summary request may have been slow rather "
+                        "than failed; any late result is discarded safely. No "
+                        "messages were dropped — continuing without compression. "
+                        "Run /compress to retry, /new for a clean session, or "
+                        "check auxiliary.compression."
                     )
 
             def _on_commit_overrun(waited, ceiling):

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -44,6 +44,26 @@ class TestResolveContextCompressionTimeouts:
         assert idle == 90.0
         assert ceiling == 90.0
 
+    def test_runtime_idle_cannot_undercut_effective_aux_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "compression": {
+                    "context_timeout_seconds": 120,
+                    "context_total_ceiling_seconds": 600,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._effective_aux_timeout",
+            lambda task, timeout: 180.0,
+        )
+
+        idle, ceiling = resolve_context_compression_timeouts()
+
+        assert idle == 180.0
+        assert ceiling == 600.0
+
 
 class TestRunCompressContextWithProgressTimeout:
     def test_silent_worker_times_out_and_preserves_messages(self):
@@ -424,6 +444,9 @@ class TestCompressContextForwarderOwnsTimeout:
         assert out_prompt == "sys"
         assert calls["n"] == 1
         agent._emit_warning.assert_called_once()
+        warning = agent._emit_warning.call_args.args[0]
+        assert "without an observable progress signal" in warning
+        assert "no output from the summary model" not in warning
         assert agent.context_compressor._consecutive_timeout_failures == 1
         agent.context_compressor._record_compression_failure_cooldown.assert_called_once()
         cooldown_args = (


### PR DESCRIPTION
## What does this PR do?

Prevents the in-agent compression watchdog from abandoning a still-valid auxiliary summary request before that request reaches its own timeout.

The host watchdog defaulted to 120 seconds while the effective auxiliary compression timeout could be longer. A silent first-token interval could therefore make the host revoke the commit fence even though the summary request was still within its valid provider budget and would complete shortly afterward.

Runtime timeout resolution now raises any positive host idle budget to at least the effective auxiliary compression timeout, then preserves the existing total-ceiling clamp. An explicit `context_timeout_seconds: 0` still disables the owned wrapper. The timeout warning now says that Hermes observed no progress signal rather than claiming the summary model produced no output.

## Related Issue

Related to #62452 (long-context auxiliary compression deadlines).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py`
  - Align the production host idle watchdog with the effective `auxiliary.compression` timeout.
  - Preserve the explicit-zero disable behavior and total-ceiling invariant.
- `run_agent.py`
  - Replace the misleading “no output from the summary model” warning with observable-progress semantics and explicit late-result safety.
- `hermes_cli/config_defaults.py`
  - Document the runtime timeout relationship.
- `tests/agent/test_compress_context_progress_timeout.py`
  - Add a regression contract for a 120-second host / 180-second auxiliary mismatch.
  - Assert accurate timeout warning semantics.

## How to Test

1. RED proof on the parent commit behavior:
   - The new timeout-coordination test returned `120.0` instead of the required `180.0`.
   - The warning test found the old `no output from the summary model` wording.
2. Run the CI-parity focused suite:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_compress_context_progress_timeout.py \
     tests/agent/test_aux_progress_streaming.py \
     tests/agent/test_compression_review_76354.py \
     tests/agent/test_auxiliary_client.py \
     tests/hermes_cli/test_config.py \
     tests/hermes_cli/test_config_validation.py
   ```

3. Expected: 6 files, 295 tests passed, 0 failed.
4. Runtime smoke: with `auxiliary.compression.timeout` above the host default, `resolve_context_compression_timeouts()` returns an idle timeout no shorter than the effective auxiliary timeout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 5.15 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline config documentation and function docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no key added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python/config behavior, no platform-specific path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Exact candidate provenance:

- Base: `55505be152e3a18c7338c533c286dac655b701ec`
- Candidate: `182f1b0c28b63804df8d3511d4aaf8775a04c369`
- Stable patch-id: `c004558bc2c566b1d8ca1ce5e1637e95f53fd3e2`

Focused CI-parity suite on candidate `182f1b0c28b63804df8d3511d4aaf8775a04c369`:

```text
=== Summary: 6 files, 295 tests passed, 0 failed (100% complete)
```

A broader `scripts/run_tests.sh tests/agent/ tests/hermes_cli/` run found no failures in changed or compression-related tests. Two unrelated failures were investigated:

- `test_active_sessions.py::test_cross_process_acquire_claims_only_one_last_slot` timed out under the 24-worker load and passed on an isolated canonical rerun (3/3).
- `test_doctor.py::test_doctor_reports_vercel_backend_diagnostics` remains red on the candidate and reproduces unchanged on the exact parent `623d5c93e0901709abc89c8a76126104a9273732`; it is pre-existing and outside this diff.
