### PR TITLE
feat(background-review): evidence-grounding rule cuts inferred memory writes 87.5% → 30%

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -168,14 +168,31 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 # the user-message that the forked review agent receives.  AIAgent exposes
 # them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) for back-compat;
 # the actual text lives here so future edits are one-place.
+_MEMORY_EVIDENCE_RULE = (
+    "\n\nEvidence rule — every entry must be GROUNDED, not inferred:\n"
+    "- Save ONLY facts the user explicitly stated or directly demonstrated in this "
+    "conversation. Before writing an entry, identify the specific user message that "
+    "supports it; if you cannot point to one, do not save it.\n"
+    "- Do NOT infer demographics, personality traits, skill level, emotional state, "
+    "motivations, or preferences from indirect signals (topic choice, tone, phrasing, "
+    "tools used). 'User asked about X' does not mean 'user prefers X' or 'user is a "
+    "beginner/expert at X'.\n"
+    "- Do NOT generalize a one-time request into a standing preference. One correction "
+    "in one context is situational unless the user marks it as general "
+    "('always', 'never', 'from now on', 'remember this').\n"
+    "- When uncertain whether something is stated or inferred, leave it out. A missed "
+    "fact can be re-learned; a fabricated one silently corrupts every future session."
+)
+
 _MEMORY_REVIEW_PROMPT = (
     "Review the conversation above and consider saving to memory if appropriate.\n\n"
     "Focus on:\n"
     "1. Has the user revealed things about themselves — their persona, desires, "
     "preferences, or personal details worth remembering?\n"
     "2. Has the user expressed expectations about how you should behave, their work "
-    "style, or ways they want you to operate?\n\n"
-    "If something stands out, save it using the memory tool. "
+    "style, or ways they want you to operate?"
+    + _MEMORY_EVIDENCE_RULE +
+    "\n\nIf something stands out, save it using the memory tool. "
     "If nothing is worth saving, just say 'Nothing to save.' and stop."
 )
 
@@ -309,7 +326,8 @@ _COMBINED_REVIEW_PROMPT = (
     "**Memory**: who the user is. Did the user reveal persona, "
     "desires, preferences, personal details, or expectations about "
     "how you should behave? Save facts about the user and durable "
-    "preferences with the memory tool.\n\n"
+    "preferences with the memory tool."
+    + _MEMORY_EVIDENCE_RULE + "\n\n"
     "**Skills**: how to do this class of task. Be ACTIVE — most "
     "sessions produce at least one skill update. A pass that does "
     "nothing is a missed learning opportunity, not a neutral outcome.\n\n"

--- a/tests/run_agent/test_memory_review_grounding.py
+++ b/tests/run_agent/test_memory_review_grounding.py
@@ -1,0 +1,51 @@
+"""Regression tests for the evidence-grounding rule in memory review prompts.
+
+The background memory review historically saved INFERRED user attributes
+(personality, skill level, generalized preferences) that were never stated in
+the conversation — the over-inference failure mode measured in the Aug 2026
+A/B validation (87.5% inferred/fabricated entries under the un-grounded
+prompt vs 30% with the evidence rule; see PR body for methodology).
+
+These tests pin the invariant that both memory-bearing review prompts carry
+the grounding rule, so a future prompt edit can't silently drop it.
+"""
+
+from agent.background_review import (
+    _COMBINED_REVIEW_PROMPT,
+    _MEMORY_EVIDENCE_RULE,
+    _MEMORY_REVIEW_PROMPT,
+    _SKILL_REVIEW_PROMPT,
+)
+
+
+def test_memory_prompt_carries_evidence_rule():
+    assert _MEMORY_EVIDENCE_RULE in _MEMORY_REVIEW_PROMPT
+
+
+def test_combined_prompt_carries_evidence_rule():
+    assert _MEMORY_EVIDENCE_RULE in _COMBINED_REVIEW_PROMPT
+
+
+def test_skill_prompt_unchanged_by_evidence_rule():
+    # The rule targets memory writes; the skill-only prompt should not carry it.
+    assert _MEMORY_EVIDENCE_RULE not in _SKILL_REVIEW_PROMPT
+
+
+def test_evidence_rule_core_clauses_present():
+    # Behavior contract: the rule must forbid inference from indirect signals
+    # and one-off-to-standing-preference generalization, and require a
+    # supporting user message per entry.
+    for clause in (
+        "explicitly stated",
+        "Do NOT infer",
+        "one-time request into a standing preference",
+        "specific user message",
+    ):
+        assert clause in _MEMORY_EVIDENCE_RULE
+
+
+def test_memory_prompt_still_ends_with_nothing_to_save_escape():
+    # The 'Nothing to save.' escape hatch must survive the prompt edit —
+    # it's what keeps quiet sessions from generating junk writes.
+    assert "Nothing to save." in _MEMORY_REVIEW_PROMPT
+    assert _MEMORY_REVIEW_PROMPT.rstrip().endswith("and stop.")


### PR DESCRIPTION
## Summary
The background memory review now carries an explicit evidence-grounding rule, cutting inferred/fabricated memory writes from 87.5% of saved entries to 30% in an A/B on real session transcripts.

Root cause: `_MEMORY_REVIEW_PROMPT` and the memory section of `_COMBINED_REVIEW_PROMPT` gave no criterion for what counts as a saveable fact, so the review fork saved trait inferences, role assumptions, and one-off requests generalized into standing preferences — none of them stated by the user. This is the over-inference failure mode measured at 35–49% across all 12 models in [The Personalization Mirage (arXiv:2608.04570)](https://arxiv.org/abs/2608.04570); the paper also shows model self-monitoring can't catch it, which is why the fix is a hard prompt rule rather than "double-check yourself".

## Changes
- `agent/background_review.py`: new `_MEMORY_EVIDENCE_RULE` block appended to `_MEMORY_REVIEW_PROMPT` and to the memory section of `_COMBINED_REVIEW_PROMPT` (skill-only prompt untouched). Rule: every entry must trace to a specific user message; no inference from indirect signals; no one-off → standing-preference generalization; uncertain → leave it out.
- `tests/run_agent/test_memory_review_grounding.py`: pins the rule into both memory-bearing prompts, asserts the skill prompt stays clean, and keeps the `Nothing to save.` escape hatch intact.

## Validation
A/B on 10 real sessions from the local `state.db` (interactive CLI/Telegram sessions, ≥4 user turns), 2 reps per cell, generator = `llama-3.3-70b-instruct` (weak model per the "strong models mask harness waste" rule), judge = `gemini-3.6-flash` classifying each proposed entry EXPLICIT / INFERRED / FABRICATED against the transcript.

| | Baseline prompt | + evidence rule |
|---|---|---|
| Cells saying "Nothing to save." | 2/20 | 17/20 |
| Entries proposed | 83 | 10 |
| Explicit (correct) | 12.5% | 70.0% |
| Inferred + fabricated | **87.5%** | **30.0%** |

Recall check: the baseline's extra 73 entries bought almost no additional true facts — on 8 of 10 sessions baseline captured 0–1 of the judge's reference explicit facts, same as grounded. The one genuinely durable preference in the corpus (a user's explicit "now and forevermore use notify-on-complete instead of polling") was captured by the grounded arm in both reps.

Caching: prompt strings are used only in the forked review agent's user message — no system-prompt or mid-conversation context change; cache-neutral.

Targeted tests: 19/19 passing (`test_memory_review_grounding.py`, `test_background_review.py`, `test_background_review_cache_parity.py`, `test_review_prompt_class_first.py`); ruff clean.

## Infographic

![Evidence-grounded memory review](https://v3b.fal.media/files/b/0aa5565b/a8qK8ovmBmAS06uXdHI8m_LGxIMAe5.png)
