### PR TITLE
fix(agent): honor model.streaming: false as a non-streaming escape hatch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1649,6 +1649,34 @@ def init_agent(
     except Exception:
         agent.lmstudio_load_mode = "explicit"
 
+    # API-transport streaming (``model.streaming``, default true).  The
+    # conversation loop prefers ``stream=True`` for every turn — including
+    # subagent turns — to get fine-grained liveness health-checking (#3120),
+    # but self-hosted OpenAI-compatible backends with broken streaming
+    # tool-call paths (e.g. vLLM ``--tool-call-parser qwen3_xml`` + a
+    # reasoning parser can leak tool-call markup into plain text and return
+    # zero ``tool_calls``, #72901) silently no-op instead of executing.
+    # ``model.streaming: false`` seeds ``_disable_streaming`` so the session
+    # uses the non-streaming path, which the loop already falls back to at
+    # runtime when a provider rejects streaming.  The setting is
+    # session-scoped: it persists across mid-session model switches, mirroring
+    # the runtime fallback's semantics.  Orthogonal to ``display.streaming``
+    # (token rendering) — display-only settings are untouched.
+    agent._disable_streaming = False
+    try:
+        _model_section = _agent_cfg.get("model", {})
+        if isinstance(_model_section, dict):
+            _streaming = str(_model_section.get("streaming", "true")).strip().lower()
+            if _streaming in {"false", "0", "no", "off"}:
+                agent._disable_streaming = True
+            elif _streaming not in {"true", "1", "yes", "on"}:
+                logger.warning(
+                    "Invalid model.streaming=%r; expected a boolean. Using streaming (default).",
+                    _model_section.get("streaming"),
+                )
+    except Exception:
+        agent._disable_streaming = False
+
     try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -63,6 +63,17 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # Stream API responses from the provider (default: true). The agent core
+  # prefers streaming for every turn — subagents included — for liveness
+  # health-checking. Set false to force non-streaming requests for the whole
+  # session (persists across mid-session model switches). Escape hatch for
+  # self-hosted OpenAI-compatible servers whose streaming tool-call path is
+  # broken (e.g. vLLM with --tool-call-parser qwen3_xml + a reasoning parser
+  # can leak tool calls into plain text instead of returning tool_calls —
+  # #72901). Orthogonal to display.streaming, which controls token rendering
+  # only.
+  # streaming: true
+
   # Azure Foundry keyless auth example:
   # provider: "azure-foundry"
   # base_url: "https://<resource>.openai.azure.com/openai/v1"

--- a/tests/run_agent/test_model_streaming_config.py
+++ b/tests/run_agent/test_model_streaming_config.py
@@ -1,0 +1,151 @@
+"""``model.streaming`` config seeds the session's streaming decision (#72901).
+
+The conversation loop prefers ``stream=True`` for every turn — subagents
+included — for liveness health-checking (#3120). Self-hosted OpenAI-compatible
+backends with broken streaming tool-call paths (e.g. vLLM
+``--tool-call-parser qwen3_xml`` + reasoning parser) can leak tool-call markup
+into plain text and return zero ``tool_calls``, silently no-oping delegated
+tasks. ``model.streaming: false`` must seed ``_disable_streaming`` at agent
+init so the whole session (parent and subagents) uses the non-streaming path.
+"""
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+_BASE = {
+    "model": {
+        "default": "test/model",
+        "provider": "custom",
+        "base_url": "http://127.0.0.1:9999/v1",
+        "api_key": "x",
+    }
+}
+
+
+def _build_agent(config):
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        return AIAgent(
+            api_key="x",
+            base_url="http://127.0.0.1:9999/v1",
+            model="test/model",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_false_seeds_disable_streaming(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": {**_BASE["model"], "streaming": False}})
+
+    assert agent._disable_streaming is True
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_absent_keeps_streaming_enabled(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent(_BASE)
+
+    assert agent._disable_streaming is False
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_true_keeps_streaming_enabled(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": {**_BASE["model"], "streaming": True}})
+
+    assert agent._disable_streaming is False
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_string_false_seeds_disable_streaming(mock_openai):
+    """String falsy values ('false', '0') must also disable streaming —
+    YAML users commonly quote booleans."""
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": {**_BASE["model"], "streaming": "false"}})
+
+    assert agent._disable_streaming is True
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_zero_seeds_disable_streaming(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": {**_BASE["model"], "streaming": 0}})
+
+    assert agent._disable_streaming is True
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_invalid_value_keeps_streaming_enabled(mock_openai):
+    """Unrecognized values warn and keep the safe default (streaming on),
+    rather than silently disabling or crashing init."""
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": {**_BASE["model"], "streaming": "flase"}})
+
+    assert agent._disable_streaming is False
+
+
+@patch("run_agent.OpenAI")
+def test_missing_model_section_keeps_streaming_enabled(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({})
+
+    assert agent._disable_streaming is False
+
+
+@patch("run_agent.OpenAI")
+def test_legacy_string_model_section_does_not_crash(mock_openai):
+    """The top-level ``model`` key is a legacy string; init must not crash."""
+    mock_openai.return_value = MagicMock()
+    agent = _build_agent({"model": "test/model"})
+
+    assert agent._disable_streaming is False
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_false_applies_to_every_agent_built_from_config(mock_openai):
+    """Delegate children are constructed through the same init, so any agent
+    (parent or subagent) built under this config gets the escape hatch —
+    covering the reported failure surface."""
+    mock_openai.return_value = MagicMock()
+    cfg = {"model": {**_BASE["model"], "streaming": False}}
+
+    first = _build_agent(cfg)
+    second = _build_agent(cfg)
+
+    assert first._disable_streaming is True
+    assert second._disable_streaming is True
+
+
+@patch("run_agent.OpenAI")
+def test_streaming_false_read_from_real_config_file(mock_openai):
+    """End-to-end: a real config.yaml in HERMES_HOME (sandboxed per-test by
+    conftest) with ``model.streaming: false`` must seed the flag through the
+    actual config loader — not just the patched function."""
+    mock_openai.return_value = MagicMock()
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  default: \"test/model\"\n"
+        "  provider: \"custom\"\n"
+        "  base_url: \"http://127.0.0.1:9999/v1\"\n"
+        "  api_key: \"x\"\n"
+        "  streaming: false\n",
+        encoding="utf-8",
+    )
+
+    agent = AIAgent(
+        api_key="x",
+        base_url="http://127.0.0.1:9999/v1",
+        model="test/model",
+        provider="custom",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent._disable_streaming is True


### PR DESCRIPTION
## Summary

Closes #72901. `delegate_task` subagents can silently no-op on self-hosted OpenAI-compatible backends (e.g. vLLM with `--tool-call-parser qwen3_xml` + a reasoning parser): the turn is streamed, the backend drops the structured `tool_calls` (leaking the tool-call markup into plain text), and the loop treats the turn as a completed text reply — no tool ever executes.

This PR adds a real `model.streaming: false` escape hatch. The conversation loop has preferred `stream=True` for every turn (subagents included) since #3120, and `model.streaming` was never a wired config key, so users with broken streaming tool-call paths had no way to opt out. `model.streaming: false` now seeds `agent._disable_streaming` at agent init, routing the whole session (parent and subagents) through the existing non-streaming path — the same path already used when a provider rejects streaming at runtime. Default remains streaming-on, preserving #3120's liveness health-checking behavior for everyone else.

## Root cause

- `agent/conversation_loop.py` sets `_use_streaming = True` unconditionally (since `c511e087e`, #3120, March 2026 — not a v0.19.0 regression; the v0.19.0 live-transcript commit only added a log writer).
- `agent/chat_completion_helpers.py` `_open_stream` hardcodes `"stream": True`.
- `model.streaming` was never read anywhere — the key some users set in `config.yaml` (including the #72901 reporter) was inert.
- Upstream trigger (vllm-project/vllm): with `--tool-call-parser qwen3_xml` / `qwen3_coder` and `--reasoning-parser qwen3`, tool calls emitted inside/after the reasoning block can be dropped in streaming mode (raw XML in `delta.content`, zero `delta.tool_calls`, `finish_reason: "stop"`); MTP speculative decoding makes the boundary worse. Upstream fixes: vllm-project/vllm#35687, #35936, #40787.

## Changes

- `agent/agent_init.py`: seed `agent._disable_streaming = True` when `model.streaming` is falsy (`false`, `"false"`, `0`, `no`, `off`); unrecognized values warn and keep the default; guarded against the legacy string `model:` form. The setting is session-scoped (persists across mid-session model switches), matching the runtime fallback's semantics. The loop already honors `_disable_streaming`.
- `cli-config.yaml.example`: document the key, its scope, and the vLLM caveat. Orthogonal to `display.streaming` (token rendering).
- `tests/run_agent/test_model_streaming_config.py`: 10 tests — boolean/string/int falsy, absent/`true` keep streaming, invalid value keeps default, legacy string `model:` no-crash, multi-agent config propagation, and a real-config.yaml E2E through the sandboxed `HERMES_HOME`.

## Tests

- `pytest tests/run_agent/test_model_streaming_config.py -v` → 10 passed
- `pytest tests/run_agent/test_streaming.py tests/run_agent/test_conversation_fallback_state.py` → 31 passed, 3 failed (pre-existing baseline: optional `anthropic` package not installed in the local test venv — unrelated to this change), 4 skipped
- `pytest tests/run_agent/test_custom_provider_extra_headers_client.py tests/run_agent/test_lmstudio_load_mode.py tests/run_agent/test_empty_terminal_reasoning_surface.py` → 6 passed
- `ruff check agent/agent_init.py tests/run_agent/test_model_streaming_config.py` → clean

## Notes

**Open questions:**

- Whether to also add a self-healing fallback that detects leaked tool-call markup in a streamed turn (e.g. `<tool_call>`, `[name(...)]`) and retries non-streaming. We scoped this PR to the opt-out escape hatch: heuristic detection in the hot loop risks false positives on legitimate text that resembles tool-call syntax and adds a silent extra LLM round-trip for everyone. A follow-up could add it behind the same flag. Server-side, upgrading vLLM to a version containing #35687 / #35936 / #40787 (or switching the tool-call parser / chat template) also resolves the trigger.

- Whether `model.streaming: false` should additionally suppress the subagent live-transcript relay (`delegation_live_log.py`) — currently the transcript simply shows the final reply once instead of streaming deltas, which is the correct non-streaming behavior.
