### PR TITLE
Inspired by Factory Droid: process tool accepts unique session-ID prefixes

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2350,3 +2350,66 @@ class TestNotificationRedaction:
         _evt, text = results[0]
         assert "ghp_abc123def456" not in text
         assert "ghp_" not in text or "REDACTED" in text
+
+
+# ── Prefix resolution (Factory Droid-inspired task-ID prefixes) ──────────────
+
+
+class TestGetByPrefix:
+    """ProcessRegistry.get() resolves unique ID prefixes like git short hashes."""
+
+    def test_full_id_still_exact(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4dae56ca81f6") is s
+
+    def test_unique_prefix_resolves(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4dae5") is s
+
+    def test_bare_suffix_resolves(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("4dae56") is s
+
+    def test_finished_sessions_also_resolve(self, registry):
+        s = _make_session(sid="proc_9bee77aa0011", exited=True, exit_code=0)
+        registry._finished[s.id] = s
+        assert registry.get("proc_9bee") is s
+
+    def test_ambiguous_prefix_returns_none(self, registry):
+        a = _make_session(sid="proc_4dae56ca81f6")
+        b = _make_session(sid="proc_4dae99999999")
+        registry._running[a.id] = a
+        registry._running[b.id] = b
+        assert registry.get("proc_4dae") is None
+
+    def test_too_short_prefix_returns_none(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4da") is None
+        assert registry.get("4da") is None
+        assert registry.get("proc_") is None
+        assert registry.get("") is None
+
+    def test_exact_id_wins_over_prefix_scan(self, registry):
+        # A session whose FULL id happens to be a prefix of another's must
+        # resolve to itself, never trigger the ambiguity path.
+        short = _make_session(sid="proc_4dae")
+        long = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[short.id] = short
+        registry._running[long.id] = long
+        assert registry.get("proc_4dae") is short
+
+    def test_no_match_returns_none(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_ffff") is None
+
+    def test_poll_accepts_prefix(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6", output="hello world")
+        registry._running[s.id] = s
+        result = registry.poll("4dae56ca")
+        assert result["session_id"] == "proc_4dae56ca81f6"
+        assert result["status"] == "running"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1534,3 +1534,66 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+
+
+# ── Prefix resolution (Factory Droid-inspired task-ID prefixes) ──────────────
+
+
+class TestGetByPrefix:
+    """ProcessRegistry.get() resolves unique ID prefixes like git short hashes."""
+
+    def test_full_id_still_exact(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4dae56ca81f6") is s
+
+    def test_unique_prefix_resolves(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4dae5") is s
+
+    def test_bare_suffix_resolves(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("4dae56") is s
+
+    def test_finished_sessions_also_resolve(self, registry):
+        s = _make_session(sid="proc_9bee77aa0011", exited=True, exit_code=0)
+        registry._finished[s.id] = s
+        assert registry.get("proc_9bee") is s
+
+    def test_ambiguous_prefix_returns_none(self, registry):
+        a = _make_session(sid="proc_4dae56ca81f6")
+        b = _make_session(sid="proc_4dae99999999")
+        registry._running[a.id] = a
+        registry._running[b.id] = b
+        assert registry.get("proc_4dae") is None
+
+    def test_too_short_prefix_returns_none(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_4da") is None
+        assert registry.get("4da") is None
+        assert registry.get("proc_") is None
+        assert registry.get("") is None
+
+    def test_exact_id_wins_over_prefix_scan(self, registry):
+        # A session whose FULL id happens to be a prefix of another's must
+        # resolve to itself, never trigger the ambiguity path.
+        short = _make_session(sid="proc_4dae")
+        long = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[short.id] = short
+        registry._running[long.id] = long
+        assert registry.get("proc_4dae") is short
+
+    def test_no_match_returns_none(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6")
+        registry._running[s.id] = s
+        assert registry.get("proc_ffff") is None
+
+    def test_poll_accepts_prefix(self, registry):
+        s = _make_session(sid="proc_4dae56ca81f6", output="hello world")
+        registry._running[s.id] = s
+        result = registry.poll("4dae56ca")
+        assert result["session_id"] == "proc_4dae56ca81f6"
+        assert result["status"] == "running"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1733,11 +1733,55 @@ class ProcessRegistry:
             self.completion_queue.put(evt)
         return results
 
+    # Minimum characters of the random suffix required for prefix resolution.
+    # Short prefixes ("p", "pr", "proc_1") are too collision-prone to act on.
+    _MIN_PREFIX_CHARS = 4
+
     def get(self, session_id: str) -> Optional[ProcessSession]:
-        """Get a session by ID (running or finished)."""
+        """Get a session by ID (running or finished).
+
+        Accepts either the full ID or a unique ID prefix (inspired by Factory
+        Droid's task-ID prefixes, and the same UX as ``git``/``docker`` short
+        hashes): ``proc_4dae`` — or just the bare suffix ``4dae`` — resolves
+        to ``proc_4dae56ca81f6`` when exactly one session matches. Ambiguous
+        or too-short prefixes resolve to None (callers already report
+        "No process with ID ..."), never to an arbitrary pick.
+        """
         with self._lock:
             session = self._running.get(session_id) or self._finished.get(session_id)
+        if session is None:
+            session = self._resolve_prefix(session_id)
         return self._refresh_detached_session(session)
+
+    def _resolve_prefix(self, session_id: str) -> Optional[ProcessSession]:
+        """Resolve a unique session-ID prefix to its session, else None.
+
+        Exact lookups happen in :meth:`get` before this runs, so a full ID
+        never pays the scan. Matching is prefix-only (no substring) and
+        requires a unique hit; a bare suffix without the ``proc_`` lead is
+        normalized so users can paste just the hex tail.
+        """
+        if not session_id or not isinstance(session_id, str):
+            return None
+        query = session_id.strip()
+        if not query:
+            return None
+        # Allow the bare suffix form: "4dae56" -> "proc_4dae56".
+        if not query.startswith("proc_"):
+            query = f"proc_{query}"
+        suffix = query[len("proc_"):]
+        if len(suffix) < self._MIN_PREFIX_CHARS:
+            return None
+        with self._lock:
+            matches = [
+                s
+                for store in (self._running, self._finished)
+                for sid, s in store.items()
+                if sid.startswith(query)
+            ]
+        if len(matches) == 1:
+            return matches[0]
+        return None
 
     def _reconcile_local_exit(self, session: "ProcessSession") -> None:
         """Reconcile session.exited against the real child process state.
@@ -2914,7 +2958,7 @@ PROCESS_SCHEMA = {
             },
             "session_id": {
                 "type": "string",
-                "description": "Process session ID (from terminal background output). Required for all actions except 'list'."
+                "description": "Process session ID (from terminal background output). Required for all actions except 'list'. A unique ID prefix works too (e.g. 'proc_4dae' or just '4dae' for proc_4dae56ca81f6)."
             },
             "data": {
                 "type": "string",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1358,11 +1358,55 @@ class ProcessRegistry:
             self.completion_queue.put(evt)
         return results
 
+    # Minimum characters of the random suffix required for prefix resolution.
+    # Short prefixes ("p", "pr", "proc_1") are too collision-prone to act on.
+    _MIN_PREFIX_CHARS = 4
+
     def get(self, session_id: str) -> Optional[ProcessSession]:
-        """Get a session by ID (running or finished)."""
+        """Get a session by ID (running or finished).
+
+        Accepts either the full ID or a unique ID prefix (inspired by Factory
+        Droid's task-ID prefixes, and the same UX as ``git``/``docker`` short
+        hashes): ``proc_4dae`` — or just the bare suffix ``4dae`` — resolves
+        to ``proc_4dae56ca81f6`` when exactly one session matches. Ambiguous
+        or too-short prefixes resolve to None (callers already report
+        "No process with ID ..."), never to an arbitrary pick.
+        """
         with self._lock:
             session = self._running.get(session_id) or self._finished.get(session_id)
+        if session is None:
+            session = self._resolve_prefix(session_id)
         return self._refresh_detached_session(session)
+
+    def _resolve_prefix(self, session_id: str) -> Optional[ProcessSession]:
+        """Resolve a unique session-ID prefix to its session, else None.
+
+        Exact lookups happen in :meth:`get` before this runs, so a full ID
+        never pays the scan. Matching is prefix-only (no substring) and
+        requires a unique hit; a bare suffix without the ``proc_`` lead is
+        normalized so users can paste just the hex tail.
+        """
+        if not session_id or not isinstance(session_id, str):
+            return None
+        query = session_id.strip()
+        if not query:
+            return None
+        # Allow the bare suffix form: "4dae56" -> "proc_4dae56".
+        if not query.startswith("proc_"):
+            query = f"proc_{query}"
+        suffix = query[len("proc_"):]
+        if len(suffix) < self._MIN_PREFIX_CHARS:
+            return None
+        with self._lock:
+            matches = [
+                s
+                for store in (self._running, self._finished)
+                for sid, s in store.items()
+                if sid.startswith(query)
+            ]
+        if len(matches) == 1:
+            return matches[0]
+        return None
 
     def _reconcile_local_exit(self, session: "ProcessSession") -> None:
         """Reconcile session.exited against the real child process state.
@@ -2426,7 +2470,7 @@ PROCESS_SCHEMA = {
             },
             "session_id": {
                 "type": "string",
-                "description": "Process session ID (from terminal background output). Required for all actions except 'list'."
+                "description": "Process session ID (from terminal background output). Required for all actions except 'list'. A unique ID prefix works too (e.g. 'proc_4dae' or just '4dae' for proc_4dae56ca81f6)."
             },
             "data": {
                 "type": "string",


### PR DESCRIPTION
## Summary
The `process` tool now accepts unique session-ID prefixes — `process(action='poll', session_id='4dae')` resolves to `proc_4dae56ca81f6` when exactly one session matches, instead of failing with "No process with ID".

Inspired by Factory Droid v0.175.0 ("Task ID prefixes — `TaskOutput` and `TaskStop` now accept task ID prefixes so you can reference background tasks more easily", [changelog](https://docs.factory.ai/changelog/release-notes)). Same UX as git/docker short hashes.

## Their mechanism vs ours
- **Droid**: task tools accept ID prefixes for background-task lookups.
- **Hermes before**: every `process` action (`poll`/`log`/`wait`/`kill`/`write`/`submit`/`close`) required the exact `proc_<12-hex>` ID.
- **Adaptation**: one fallback in `ProcessRegistry.get()` — the single choke point all actions route through — so the whole tool gains prefix support with no per-action changes.

## Changes
- `tools/process_registry.py`: `get()` falls back to `_resolve_prefix()` on exact-lookup miss. Bare suffix form (`4dae`) is normalized to `proc_4dae`. Guards: minimum 4 suffix chars, unique-match-only (ambiguous → None → existing "No process with ID" error), exact IDs never pay the scan and always win over prefix matches. Tool schema description updated.
- `tests/tools/test_process_registry.py`: 9 new tests (`TestGetByPrefix`) — full-ID exactness, unique prefix, bare suffix, finished-store resolution, ambiguity, short-prefix rejection, exact-beats-prefix, no-match, end-to-end `poll()` with a prefix.

## Validation
| | Result |
|---|---|
| `tests/tools/test_process_registry.py` | 63 passed (54 pre-existing + 9 new) |
| Sabotage run (fallback removed) | 4 of 9 new tests fail — tests exercise the fix |
| ruff | clean |

## Infographic

![Process ID prefix resolution](https://v3b.fal.media/files/b/0aa55692/z6IHedVQaeRx5sU9sM0Qr_QfgKxkSv.png)
