### PR TITLE
fix(mcp): classify the /reload-mcp diff against config, not live sockets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11984,7 +11984,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         sees the updated tools on the next turn.
         """
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import (
+                shutdown_mcp_servers, discover_mcp_tools, classify_reload_diff,
+                _servers, _lock,
+            )
 
             # Capture old server names
             with _lock:
@@ -12003,9 +12006,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             with _lock:
                 connected_servers = set(_servers.keys())
 
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            # "Removed" must mean "gone from config", not "not connected right
+            # now" — a server still reconnecting at this instant is neither.
+            _diff = classify_reload_diff(old_servers, connected_servers)
+            added = _diff["added"]
+            removed = _diff["removed"]
+            reconnected = _diff["reconnected"]
+            not_connected = _diff["not_connected"]
 
             if reconnected:
                 print(f"  ♻️  Reconnected: {', '.join(sorted(reconnected))}")
@@ -12013,6 +12020,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 print(f"  ➕ Added: {', '.join(sorted(added))}")
             if removed:
                 print(f"  ➖ Removed: {', '.join(sorted(removed))}")
+            if not_connected:
+                print(f"  ⏳ Still configured, not connected: {', '.join(sorted(not_connected))}")
             if not connected_servers:
                 print("  No MCP servers connected.")
             else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20888,7 +20888,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         loop = asyncio.get_running_loop()
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import (
+                shutdown_mcp_servers, discover_mcp_tools, classify_reload_diff,
+                _servers, _lock,
+            )
 
             # Capture old server names before shutdown
             with _lock:
@@ -20905,9 +20908,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             with _lock:
                 connected_servers = set(_servers.keys())
 
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            # "Removed" must mean "gone from config", not "not connected right
+            # now". A server still reconnecting when the diff runs is neither,
+            # and this set is also injected into every cached session's history
+            # — telling the model its tools were deleted when they arrive
+            # seconds later via the late-binding refresh.
+            _diff = classify_reload_diff(old_servers, connected_servers)
+            added = _diff["added"]
+            removed = _diff["removed"]
+            reconnected = _diff["reconnected"]
 
             lines = [t("gateway.reload_mcp.header")]
             if reconnected:

--- a/tests/tools/test_mcp_reload_diff.py
+++ b/tests/tools/test_mcp_reload_diff.py
@@ -1,0 +1,75 @@
+"""`/reload-mcp` must classify its diff against config, not live sockets (#80771).
+
+The reload diff was built purely from ``tools.mcp_tool._servers`` on either
+side of the reconnect, so "removed" answered "was connected, isn't now". A
+server whose connect is still in flight when the diff runs — the normal case
+past ``mcp_discovery_timeout`` — is still in ``config.yaml`` and connects
+moments later, but was reported as ``➖ Removed`` on both the CLI and the
+gateway, and the same wrong set was injected into the model's history.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tools.mcp_tool import classify_reload_diff
+
+
+CONFIG = {"docs": {}, "search": {}, "calendar": {}, "maps": {}}
+
+
+def _diff(before, after, config=CONFIG):
+    with patch("tools.mcp_tool._load_mcp_config", return_value=config):
+        return classify_reload_diff(set(before), set(after))
+
+
+class TestReloadDiffClassification:
+    def test_still_configured_but_slow_is_not_removed(self):
+        """The reported shape: two servers still connecting at diff time."""
+        d = _diff(
+            before=["docs", "search", "calendar", "maps"],
+            after=["docs", "search"],
+        )
+        assert d["removed"] == set()
+        assert d["not_connected"] == {"calendar", "maps"}
+        assert d["reconnected"] == {"docs", "search"}
+
+    def test_genuinely_deleted_server_is_removed(self):
+        """Dropping a server from config is what the label is for."""
+        d = _diff(
+            before=["docs", "gone"],
+            after=["docs"],
+            config={"docs": {}},
+        )
+        assert d["removed"] == {"gone"}
+        assert d["not_connected"] == set()
+
+    def test_disabled_server_is_not_reported_as_removed(self):
+        """`enabled: false` is still configured — _load_mcp_config keeps it."""
+        d = _diff(before=["docs", "calendar"], after=["docs"])
+        assert d["removed"] == set()
+        assert d["not_connected"] == {"calendar"}
+
+    def test_new_server_is_added(self):
+        d = _diff(before=["docs"], after=["docs", "search"])
+        assert d["added"] == {"search"}
+        assert d["removed"] == set()
+        assert d["reconnected"] == {"docs"}
+
+    def test_sets_are_disjoint_and_cover_the_churn(self):
+        """No name may land in two buckets, and none may be dropped."""
+        before = {"docs", "search", "calendar", "gone"}
+        after = {"docs", "brand_new"}
+        d = _diff(before, after)
+        buckets = [d["added"], d["removed"], d["reconnected"], d["not_connected"]]
+        for i, a in enumerate(buckets):
+            for b in buckets[i + 1:]:
+                assert not (a & b), f"{a} and {b} overlap"
+        assert d["added"] | d["reconnected"] == after
+        assert d["removed"] | d["not_connected"] == before - after
+
+    def test_unreadable_config_falls_back_to_connection_only(self):
+        """A config read failure must not raise through a reload path."""
+        with patch("tools.mcp_tool._load_mcp_config", side_effect=RuntimeError("boom")):
+            d = classify_reload_diff({"docs", "calendar"}, {"docs"})
+        assert d["removed"] == {"calendar"}   # pre-fix behaviour, not an exception
+        assert d["not_connected"] == set()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5037,6 +5037,51 @@ def _load_mcp_config() -> Dict[str, dict]:
 
 
 # ---------------------------------------------------------------------------
+# Reload diff
+# ---------------------------------------------------------------------------
+
+
+def classify_reload_diff(before: Set[str], after: Set[str]) -> Dict[str, Set[str]]:
+    """Classify a reload's server churn against the CONFIG, not just live sockets.
+
+    ``before``/``after`` are the connected-server names on either side of a
+    reload. Deriving "removed" from those alone answers "was connected, isn't
+    now", which is not what the label claims: a server whose reconnect is still
+    in flight when the diff runs is still in ``config.yaml`` and connects
+    moments later, but gets reported — and injected into the model's history —
+    as ``Removed``.
+
+    ``removed`` therefore means "no longer configured", and a configured server
+    that simply isn't connected yet comes back under ``not_connected`` so
+    callers can say so instead of claiming it was deleted.
+    ``_load_mcp_config`` deliberately does not apply the ``enabled`` filter, so
+    a server switched off in config stays out of ``removed`` too.
+
+    Falls back to the connection-only answer if the config cannot be read —
+    the pre-existing behaviour, never an exception through a reload path.
+    """
+    added = set(after) - set(before)
+    reconnected = set(after) & set(before)
+    dropped = set(before) - set(after)
+    try:
+        configured = set(_load_mcp_config())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("reload diff could not read MCP config: %s", exc)
+        return {
+            "added": added,
+            "reconnected": reconnected,
+            "removed": dropped,
+            "not_connected": set(),
+        }
+    return {
+        "added": added,
+        "reconnected": reconnected,
+        "removed": dropped - configured,
+        "not_connected": dropped & configured,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Server connection helper
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

`/reload-mcp` built its diff purely from the live connection registry on either side of the reconnect:

```python
added = connected_servers - old_servers
removed = old_servers - connected_servers
reconnected = connected_servers & old_servers
```

So `removed` answers *"was connected, isn't now"* — which is not what the label claims. Any server still in `config.yaml` but not connected at the instant the diff runs is reported as `➖ Removed`: a connect still in flight past `mcp_discovery_timeout` (1.5s by default), a server set `enabled: false`, or one that failed this round.

On the reported shape:

```
♻️ Reconnected: docs, search
➖ Removed: calendar, maps      ← both still configured, both connect
                                 seconds later via the late-binding refresh
```

The label is not the only casualty. The same set is injected into conversation history as `Removed servers: calendar, maps`, so the model is told its tools were deleted while they are on their way in.

### The fix

`classify_reload_diff()` in `tools/mcp_tool.py` owns the classification for both surfaces:

- `removed` now means **no longer in the config**.
- A configured server that simply is not connected yet comes back separately as `not_connected`.
- `_load_mcp_config` deliberately does not apply the `enabled` filter, so a server switched off in config stays out of `removed` too — matching what the label promises.
- A config read that fails degrades to the old connection-only answer rather than raising through a reload path.

Old vs new on the reported inputs (`before={docs,search,calendar,maps}`, `after={docs,search}`, all four configured):

```
OLD  removed : ['calendar', 'maps']
NEW  removed : []
NEW  not_connected: ['calendar', 'maps']

injected into history:
  OLD -> "Removed servers: calendar, maps"
  NEW -> (removed is empty — the sentence is not produced)
```

## Related Issue

Refs #80771 (P2, `comp/cli`, `tool/mcp`, `area/config`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "80771"                  --limit 10
gh search prs --repo NousResearch/hermes-agent "reload-mcp in:title"    --limit 20
```

**Update:** #80855 (open) also fixes #80771 and is the broader of the two. It adds `summarize_mcp_reload()` in `tools/mcp_tool.py`, wires it into `cli.py` and `gateway/run.py`, and adds the `gateway.reload_mcp.pending` key across all 17 locale catalogs, which is exactly the gateway i18n this PR's reviewer note leaves out by design. A reviewer should see both before picking one; if #80855 is preferred, this PR can be closed in its favour.

Nothing else addresses the diff's source of truth. The other open `/reload-mcp` PRs are about different things: #77074 / #77643 point `mcp add` success messages at the command, #72864 reloads args on config changes, #46520 restarts the MCP loop. The issue also distinguishes itself from #78426, where the servers genuinely failed and `Removed` was the correct label.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `tools/mcp_tool.py` — new `classify_reload_diff(before, after)` returning `added` / `removed` / `reconnected` / `not_connected`, with the config read as the source of truth for "removed" and a documented fallback.
- `cli.py` — `_reload_mcp` classifies through the helper; gains an explicit `⏳ Still configured, not connected:` line. The history injection a few lines below reads the same corrected `removed`, so it is fixed by the same change.
- `gateway/run.py` — the `/reload-mcp` handler had the identical expression; moved onto the helper.
- `tests/tools/test_mcp_reload_diff.py` — new, 6 tests.

## How to Test

```
pytest tests/tools/test_mcp_reload_diff.py -q
```

6 passed: the reported shape, a genuinely deleted server, a disabled-but-configured server, a fresh add, bucket disjointness/coverage, and the config-unreadable fallback.

```
pytest tests/tools/ -q -k mcp
```

450 passed — the existing MCP suite is unaffected.

Because the classifier is new code rather than an edited branch, the before/after proof is the direct comparison above: the pre-fix expression (copied verbatim from `cli.py` and `gateway/run.py`) against the shipped helper on the issue's own inputs.

Regression checks across all three touched surfaces:

```
tests/gateway/ + tests/hermes_cli/  -k "reload or mcp"   149 passed, 1 skipped
```

Full `tests/tools/` suite, this branch vs `main`, same environment, run serially:

```
main:   71 failed, 5473 passed, 25 skipped, 7 deselected
branch: 71 failed, 5479 passed, 25 skipped, 7 deselected
```

Comparing the failing sets rather than the counts: **zero regressions** — the two sets are identical, nothing added and nothing removed. The +6 is this PR's new tests. Those 71 are pre-existing in a non-hermetic single-process run (that suite carries browser/docker/network-dependent cases); CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mcp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the helper's docstring records what each bucket means and why the config, not the socket, decides `removed`
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, set arithmetic
- [x] Tool descriptions/schemas — N/A

## Notes for the reviewer

One deliberate asymmetry: the CLI prints raw strings, so it gained the `Still configured, not connected` line directly. The gateway renders through `t()`, so surfacing that set there needs a new i18n key across locales — I left it out rather than add translations as a side effect of a bug fix. The gateway's false `Removed` claim is fixed either way, in both its output and its injected history; if you want the extra line there too, say so and I will add the key.

