### PR TITLE
fix(cli): honor --resume/--continue in oneshot (-z) — rebase + real-SQLite coverage

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -160,7 +160,10 @@ def build_top_level_parser():
             "response text to stdout. No banner, no spinner, no tool "
             "previews, no session_id line. Tools, memory, rules, and "
             "AGENTS.md in the CWD are loaded as normal; approvals are "
-            "auto-bypassed. Intended for scripts / pipes."
+            "auto-bypassed. Intended for scripts / pipes. Combine with "
+            "--resume <id> to chain turns onto one session (an id that "
+            "doesn't exist yet is created on first use), or --continue to "
+            "chain onto the most recent / named session."
         ),
     )
     parser.add_argument(

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -161,9 +161,11 @@ def build_top_level_parser():
             "previews, no session_id line. Tools, memory, rules, and "
             "AGENTS.md in the CWD are loaded as normal; approvals are "
             "auto-bypassed. Intended for scripts / pipes. Combine with "
-            "--resume <id> to chain turns onto one session (an id that "
-            "doesn't exist yet is created on first use), or --continue to "
-            "chain onto the most recent / named session."
+            "--resume <id|title> to chain turns onto one session (a value "
+            "matching no existing session is used as-is and created on first "
+            "use, so scripts can mint their own stable ids), or --continue "
+            "[name] to chain onto the most recent / named session (unlike "
+            "--resume, an unmatched --continue is an error)."
         ),
     )
     parser.add_argument(

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -109,7 +109,10 @@ def build_top_level_parser():
             "response text to stdout. No banner, no spinner, no tool "
             "previews, no session_id line. Tools, memory, rules, and "
             "AGENTS.md in the CWD are loaded as normal; approvals are "
-            "auto-bypassed. Intended for scripts / pipes."
+            "auto-bypassed. Intended for scripts / pipes. Combine with "
+            "--resume <id> to chain turns onto one session (an id that "
+            "doesn't exist yet is created on first use), or --continue to "
+            "chain onto the most recent / named session."
         ),
     )
     parser.add_argument(

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -110,9 +110,11 @@ def build_top_level_parser():
             "previews, no session_id line. Tools, memory, rules, and "
             "AGENTS.md in the CWD are loaded as normal; approvals are "
             "auto-bypassed. Intended for scripts / pipes. Combine with "
-            "--resume <id> to chain turns onto one session (an id that "
-            "doesn't exist yet is created on first use), or --continue to "
-            "chain onto the most recent / named session."
+            "--resume <id|title> to chain turns onto one session (a value "
+            "matching no existing session is used as-is and created on first "
+            "use, so scripts can mint their own stable ids), or --continue "
+            "[name] to chain onto the most recent / named session (unlike "
+            "--resume, an unmatched --continue is an error)."
         ),
     )
     parser.add_argument(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -174,6 +174,29 @@ def _cleanup_oneshot_runtime() -> None:
         pass
 
 
+def _fail_and_exit_oneshot(message: str, rc: int = 2) -> None:
+    """Abort a ``-z`` invocation through the SAME hardened exit path as a run.
+
+    A plain ``sys.exit()`` here would be wrong twice over: by the time oneshot
+    dispatch is reached, ``_prepare_agent_startup()`` has already discovered
+    plugins and (on the non-fast path) kicked off MCP server startup, so
+    unwinding through normal interpreter finalization both orphans those
+    subprocesses — ``_cleanup_oneshot_runtime()`` is what reaps them — and
+    re-enters the native finalizer teardown that ``_exit_after_oneshot``
+    exists to skip (#30387, #43055). Argument-validation failures must exit
+    exactly like a completed run: cleanup, then ``os._exit``.
+    """
+    try:
+        sys.stderr.write(message)
+        sys.stderr.flush()
+    except Exception:
+        pass
+    try:
+        _cleanup_oneshot_runtime()
+    finally:
+        _exit_after_oneshot(rc)
+
+
 def _run_and_exit_oneshot(
     prompt: str,
     *,
@@ -1653,6 +1676,12 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     ``--continue`` resolves by name when a value is given, otherwise the most
     recent CLI session; an unresolvable ``--continue`` is an error (there is
     nothing sensible to chain onto).
+
+    Every failure exits via ``_fail_and_exit_oneshot`` rather than a plain
+    ``sys.exit`` so it reaps MCP/plugin startup and hard-exits like every
+    other ``-z`` exit (by this point ``_prepare_agent_startup`` has already
+    run) — see that function's docstring for why a bare ``sys.exit`` here is
+    wrong twice over.
     """
     resume = (getattr(args, "resume", None) or "").strip() or None
     if resume:
@@ -1661,11 +1690,10 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
             return resolved
         # Create-on-first-use: the raw value becomes a new session id.
         if _is_unsafe_new_session_id(resume):
-            sys.stderr.write(
+            _fail_and_exit_oneshot(
                 f"hermes -z: invalid --resume session id '{resume}': "
                 "path separators and '..' are not allowed.\n"
             )
-            sys.exit(2)
         return resume
     cont = getattr(args, "continue_last", None)
     if not cont:
@@ -1673,16 +1701,16 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     if isinstance(cont, str):
         resolved = _resolve_session_by_name_or_id(cont)
         if not resolved:
-            sys.stderr.write(
+            _fail_and_exit_oneshot(
                 f"hermes -z: no session found matching '{cont}'. "
                 "Use 'hermes sessions list' to see available sessions.\n"
             )
-            sys.exit(2)
         return resolved
     last_id = _resolve_last_session(source="cli")
     if not last_id:
-        sys.stderr.write("hermes -z: no previous CLI session found to continue.\n")
-        sys.exit(2)
+        _fail_and_exit_oneshot(
+            "hermes -z: no previous CLI session found to continue.\n"
+        )
     return last_id
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -182,6 +182,7 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: object = None,
+    resume: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -193,6 +194,7 @@ def _run_and_exit_oneshot(
             toolsets=toolsets,
             skills=skills,
             usage_file=usage_file,
+            resume=resume,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -1608,6 +1610,39 @@ def _resolve_workspace_key() -> Optional[str]:
         return os.getcwd()
     except Exception:
         return None
+
+
+def _resolve_oneshot_resume(args) -> Optional[str]:
+    """Resolve --resume / --continue for oneshot (-z) mode.
+
+    ``--resume`` is passed through verbatim: oneshot supports create-on-
+    first-use session ids (callers like the Smith Crafts OS gateway mint
+    their own stable id and pass it on every turn), so no existence check
+    happens here — hermes_cli.oneshot loads whatever history the id has.
+    ``--continue`` resolves exactly like interactive chat: by name when a
+    value is given, otherwise the most recent CLI session; an unresolvable
+    ``--continue`` is an error (there is nothing sensible to chain onto).
+    """
+    resume = (getattr(args, "resume", None) or "").strip() or None
+    if resume:
+        return resume
+    cont = getattr(args, "continue_last", None)
+    if not cont:
+        return None
+    if isinstance(cont, str):
+        resolved = _resolve_session_by_name_or_id(cont)
+        if not resolved:
+            sys.stderr.write(
+                f"hermes -z: no session found matching '{cont}'. "
+                "Use 'hermes sessions list' to see available sessions.\n"
+            )
+            sys.exit(2)
+        return resolved
+    last_id = _resolve_last_session(source="cli")
+    if not last_id:
+        sys.stderr.write("hermes -z: no previous CLI session found to continue.\n")
+        sys.exit(2)
+    return last_id
 
 
 def _resolve_last_session(source: str = "cli") -> Optional[str]:
@@ -12735,6 +12770,7 @@ def _try_termux_fast_cli_launch() -> bool:
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=_resolve_oneshot_resume(args),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -14732,6 +14768,7 @@ def main():
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=_resolve_oneshot_resume(args),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1612,19 +1612,60 @@ def _resolve_workspace_key() -> Optional[str]:
         return None
 
 
+def _is_unsafe_new_session_id(value: str) -> bool:
+    """Return True if *value* could escape the sessions directory as a path.
+
+    Mirrors ``gateway.session._is_path_unsafe``, which guards the gateway's
+    externally-supplied ``session_id`` at its entry boundary. Duplicated
+    rather than imported because ``gateway.session`` is a heavy module with
+    optional platform deps and this runs on every CLI startup.
+
+    Oneshot ``--resume`` creates unknown ids on first use, which makes it a
+    second entry boundary for caller-supplied session ids. The id becomes a
+    filename downstream — ``SessionDB._remove_session_files`` builds
+    ``sessions_dir / f"{session_id}.json"`` and ``request_dump_{id}_*.json``
+    unsanitized — so ``hermes --resume ../../x -z ...`` would mint a row that
+    a later ``sessions delete``/``prune`` unlinks outside the sessions dir
+    (CWE-22). Real and gateway-minted ids never contain these characters.
+    """
+    s = str(value or "")
+    if ".." in s or "/" in s or "\\" in s:
+        return True
+    return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
+
+
 def _resolve_oneshot_resume(args) -> Optional[str]:
     """Resolve --resume / --continue for oneshot (-z) mode.
 
-    ``--resume`` is passed through verbatim: oneshot supports create-on-
-    first-use session ids (callers like the Smith Crafts OS gateway mint
-    their own stable id and pass it on every turn), so no existence check
-    happens here — hermes_cli.oneshot loads whatever history the id has.
-    ``--continue`` resolves exactly like interactive chat: by name when a
-    value is given, otherwise the most recent CLI session; an unresolvable
-    ``--continue`` is an error (there is nothing sensible to chain onto).
+    ``--resume`` resolves by ID or title exactly like interactive chat
+    (``cmd_chat``) and the flag's own documented contract — the value is run
+    through :func:`_resolve_session_by_name_or_id`, which handles exact ids,
+    titles, and projection forward through compression lineage.
+
+    Unlike interactive chat, an id that resolves to nothing is NOT an error:
+    oneshot supports create-on-first-use session ids (callers like the Smith
+    Crafts OS gateway mint their own stable id and pass it on every turn), so
+    an unresolved value is returned as-is and ``hermes_cli.oneshot`` starts a
+    fresh session under it. Because that value is about to become a brand-new
+    session id — one that lands on disk as a filename — it must first pass the
+    path-traversal guard applied to every other caller-supplied session id.
+
+    ``--continue`` resolves by name when a value is given, otherwise the most
+    recent CLI session; an unresolvable ``--continue`` is an error (there is
+    nothing sensible to chain onto).
     """
     resume = (getattr(args, "resume", None) or "").strip() or None
     if resume:
+        resolved = _resolve_session_by_name_or_id(resume)
+        if resolved:
+            return resolved
+        # Create-on-first-use: the raw value becomes a new session id.
+        if _is_unsafe_new_session_id(resume):
+            sys.stderr.write(
+                f"hermes -z: invalid --resume session id '{resume}': "
+                "path separators and '..' are not allowed.\n"
+            )
+            sys.exit(2)
         return resume
     cont = getattr(args, "continue_last", None)
     if not cont:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1635,24 +1635,78 @@ def _resolve_workspace_key() -> Optional[str]:
         return None
 
 
-def _is_unsafe_new_session_id(value: str) -> bool:
-    """Return True if *value* could escape the sessions directory as a path.
+# Matches the gateway's own cap on an externally-supplied session id
+# (``GatewayAPIServer._MAX_SESSION_HEADER_LEN``). Every real id — CLI
+# ``<ts>_<hex>``, gateway ``agent:main:<platform>:...``, ``api_<ts>_<hex>`` —
+# is well under this.
+_MAX_NEW_SESSION_ID_LEN = 256
 
-    Mirrors ``gateway.session._is_path_unsafe``, which guards the gateway's
-    externally-supplied ``session_id`` at its entry boundary. Duplicated
-    rather than imported because ``gateway.session`` is a heavy module with
-    optional platform deps and this runs on every CLI startup.
+# C0 controls + DEL. No legitimate session id contains one, and each is a
+# distinct problem downstream: CR/LF forge lines in the log record that
+# stamps ``session=%s`` on every turn, ESC injects terminal escape sequences
+# into the ``hermes -z: invalid --resume session id '<value>'`` message that
+# rejects it, and all of them produce unreadable on-disk filenames.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _echo_safe(value: str, limit: int = 120) -> str:
+    """Render a rejected caller-supplied value safely for stderr.
+
+    The rejection messages below quote the value back at the operator, so the
+    value must not be able to drive the terminal it is printed to: escape
+    control characters (ESC/CSI/OSC would otherwise repaint the line, retitle
+    the window, or hide the rest of the diagnostic) and bound the length so a
+    megabyte-long argv value can't flood the console.
+    """
+    s = str(value or "")
+    truncated = s[:limit]
+    rendered = _CONTROL_CHARS_RE.sub(
+        lambda m: f"\\x{ord(m.group()):02x}", truncated
+    )
+    return rendered + ("…" if len(s) > limit else "")
+
+
+def _is_unsafe_new_session_id(value: str) -> bool:
+    """Return True if *value* is unsafe to mint as a brand-new session id.
+
+    Mirrors the gateway's entry-boundary check for an externally-supplied
+    ``session_id``, which is the composite of THREE things applied together
+    at every gateway call site (``GatewayAPIServer._create_session``,
+    ``_resolve_request_session``): ``gateway.session._is_path_unsafe``, a
+    control-character reject, and a length cap. Duplicated rather than
+    imported because ``gateway.session`` is a heavy module with optional
+    platform deps and this runs on every CLI startup.
 
     Oneshot ``--resume`` creates unknown ids on first use, which makes it a
     second entry boundary for caller-supplied session ids. The id becomes a
     filename downstream — ``SessionDB._remove_session_files`` builds
     ``sessions_dir / f"{session_id}.json"`` and ``request_dump_{id}_*.json``
-    unsanitized — so ``hermes --resume ../../x -z ...`` would mint a row that
-    a later ``sessions delete``/``prune`` unlinks outside the sessions dir
-    (CWE-22). Real and gateway-minted ids never contain these characters.
+    — so ``hermes --resume ../../x -z ...`` would mint a row that a later
+    ``sessions delete``/``prune`` unlinks outside the sessions dir (CWE-22).
+
+    Beyond traversal, two argv-reachable cases the path check alone lets
+    through:
+
+    * Control characters. CR/LF forge entries in the per-turn
+      ``conversation turn: session=%s`` log line (CWE-117) and ESC injects
+      terminal escape sequences into the rejection message itself; none can
+      appear in a real id. (A NUL cannot arrive through ``argv`` at all —
+      ``execve`` strings are NUL-terminated — but the class is rejected
+      wholesale rather than enumerated.)
+    * Length. An id over ``NAME_MAX`` makes ``{id}.json`` permanently
+      un-creatable (ENAMETOOLONG), so the session's on-disk snapshot silently
+      never lands, and the oversized id is copied into the ``session_id``
+      column of every message row for the life of the session.
+
+    Glob metacharacters (``*``/``?``/``[``) are deliberately NOT rejected —
+    they are legal in a filename, and the one place that interpolated them
+    into a pattern (``_remove_session_files``) now ``glob.escape``s instead,
+    which also covers ids minted through the gateway.
     """
     s = str(value or "")
     if ".." in s or "/" in s or "\\" in s:
+        return True
+    if len(s) > _MAX_NEW_SESSION_ID_LEN or _CONTROL_CHARS_RE.search(s):
         return True
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
@@ -1670,8 +1724,9 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     Crafts OS gateway mint their own stable id and pass it on every turn), so
     an unresolved value is returned as-is and ``hermes_cli.oneshot`` starts a
     fresh session under it. Because that value is about to become a brand-new
-    session id — one that lands on disk as a filename — it must first pass the
-    path-traversal guard applied to every other caller-supplied session id.
+    session id — one that lands on disk as a filename — it must first pass
+    :func:`_is_unsafe_new_session_id`, the same entry-boundary guard applied to
+    every other caller-supplied session id.
 
     ``--continue`` resolves by name when a value is given, otherwise the most
     recent CLI session; an unresolvable ``--continue`` is an error (there is
@@ -1691,8 +1746,10 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
         # Create-on-first-use: the raw value becomes a new session id.
         if _is_unsafe_new_session_id(resume):
             _fail_and_exit_oneshot(
-                f"hermes -z: invalid --resume session id '{resume}': "
-                "path separators and '..' are not allowed.\n"
+                f"hermes -z: invalid --resume session id "
+                f"'{_echo_safe(resume)}': path separators, '..', control "
+                f"characters, and ids over {_MAX_NEW_SESSION_ID_LEN} "
+                "characters are not allowed.\n"
             )
         return resume
     cont = getattr(args, "continue_last", None)
@@ -1702,7 +1759,7 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
         resolved = _resolve_session_by_name_or_id(cont)
         if not resolved:
             _fail_and_exit_oneshot(
-                f"hermes -z: no session found matching '{cont}'. "
+                f"hermes -z: no session found matching '{_echo_safe(cont)}'. "
                 "Use 'hermes sessions list' to see available sessions.\n"
             )
         return resolved

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1365,24 +1365,78 @@ def _resolve_workspace_key() -> Optional[str]:
         return None
 
 
-def _is_unsafe_new_session_id(value: str) -> bool:
-    """Return True if *value* could escape the sessions directory as a path.
+# Matches the gateway's own cap on an externally-supplied session id
+# (``GatewayAPIServer._MAX_SESSION_HEADER_LEN``). Every real id — CLI
+# ``<ts>_<hex>``, gateway ``agent:main:<platform>:...``, ``api_<ts>_<hex>`` —
+# is well under this.
+_MAX_NEW_SESSION_ID_LEN = 256
 
-    Mirrors ``gateway.session._is_path_unsafe``, which guards the gateway's
-    externally-supplied ``session_id`` at its entry boundary. Duplicated
-    rather than imported because ``gateway.session`` is a heavy module with
-    optional platform deps and this runs on every CLI startup.
+# C0 controls + DEL. No legitimate session id contains one, and each is a
+# distinct problem downstream: CR/LF forge lines in the log record that
+# stamps ``session=%s`` on every turn, ESC injects terminal escape sequences
+# into the ``hermes -z: invalid --resume session id '<value>'`` message that
+# rejects it, and all of them produce unreadable on-disk filenames.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _echo_safe(value: str, limit: int = 120) -> str:
+    """Render a rejected caller-supplied value safely for stderr.
+
+    The rejection messages below quote the value back at the operator, so the
+    value must not be able to drive the terminal it is printed to: escape
+    control characters (ESC/CSI/OSC would otherwise repaint the line, retitle
+    the window, or hide the rest of the diagnostic) and bound the length so a
+    megabyte-long argv value can't flood the console.
+    """
+    s = str(value or "")
+    truncated = s[:limit]
+    rendered = _CONTROL_CHARS_RE.sub(
+        lambda m: f"\\x{ord(m.group()):02x}", truncated
+    )
+    return rendered + ("…" if len(s) > limit else "")
+
+
+def _is_unsafe_new_session_id(value: str) -> bool:
+    """Return True if *value* is unsafe to mint as a brand-new session id.
+
+    Mirrors the gateway's entry-boundary check for an externally-supplied
+    ``session_id``, which is the composite of THREE things applied together
+    at every gateway call site (``GatewayAPIServer._create_session``,
+    ``_resolve_request_session``): ``gateway.session._is_path_unsafe``, a
+    control-character reject, and a length cap. Duplicated rather than
+    imported because ``gateway.session`` is a heavy module with optional
+    platform deps and this runs on every CLI startup.
 
     Oneshot ``--resume`` creates unknown ids on first use, which makes it a
     second entry boundary for caller-supplied session ids. The id becomes a
     filename downstream — ``SessionDB._remove_session_files`` builds
     ``sessions_dir / f"{session_id}.json"`` and ``request_dump_{id}_*.json``
-    unsanitized — so ``hermes --resume ../../x -z ...`` would mint a row that
-    a later ``sessions delete``/``prune`` unlinks outside the sessions dir
-    (CWE-22). Real and gateway-minted ids never contain these characters.
+    — so ``hermes --resume ../../x -z ...`` would mint a row that a later
+    ``sessions delete``/``prune`` unlinks outside the sessions dir (CWE-22).
+
+    Beyond traversal, two argv-reachable cases the path check alone lets
+    through:
+
+    * Control characters. CR/LF forge entries in the per-turn
+      ``conversation turn: session=%s`` log line (CWE-117) and ESC injects
+      terminal escape sequences into the rejection message itself; none can
+      appear in a real id. (A NUL cannot arrive through ``argv`` at all —
+      ``execve`` strings are NUL-terminated — but the class is rejected
+      wholesale rather than enumerated.)
+    * Length. An id over ``NAME_MAX`` makes ``{id}.json`` permanently
+      un-creatable (ENAMETOOLONG), so the session's on-disk snapshot silently
+      never lands, and the oversized id is copied into the ``session_id``
+      column of every message row for the life of the session.
+
+    Glob metacharacters (``*``/``?``/``[``) are deliberately NOT rejected —
+    they are legal in a filename, and the one place that interpolated them
+    into a pattern (``_remove_session_files``) now ``glob.escape``s instead,
+    which also covers ids minted through the gateway.
     """
     s = str(value or "")
     if ".." in s or "/" in s or "\\" in s:
+        return True
+    if len(s) > _MAX_NEW_SESSION_ID_LEN or _CONTROL_CHARS_RE.search(s):
         return True
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
@@ -1400,8 +1454,9 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     Crafts OS gateway mint their own stable id and pass it on every turn), so
     an unresolved value is returned as-is and ``hermes_cli.oneshot`` starts a
     fresh session under it. Because that value is about to become a brand-new
-    session id — one that lands on disk as a filename — it must first pass the
-    path-traversal guard applied to every other caller-supplied session id.
+    session id — one that lands on disk as a filename — it must first pass
+    :func:`_is_unsafe_new_session_id`, the same entry-boundary guard applied to
+    every other caller-supplied session id.
 
     ``--continue`` resolves by name when a value is given, otherwise the most
     recent CLI session; an unresolvable ``--continue`` is an error (there is
@@ -1421,8 +1476,10 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
         # Create-on-first-use: the raw value becomes a new session id.
         if _is_unsafe_new_session_id(resume):
             _fail_and_exit_oneshot(
-                f"hermes -z: invalid --resume session id '{resume}': "
-                "path separators and '..' are not allowed.\n"
+                f"hermes -z: invalid --resume session id "
+                f"'{_echo_safe(resume)}': path separators, '..', control "
+                f"characters, and ids over {_MAX_NEW_SESSION_ID_LEN} "
+                "characters are not allowed.\n"
             )
         return resume
     cont = getattr(args, "continue_last", None)
@@ -1432,7 +1489,7 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
         resolved = _resolve_session_by_name_or_id(cont)
         if not resolved:
             _fail_and_exit_oneshot(
-                f"hermes -z: no session found matching '{cont}'. "
+                f"hermes -z: no session found matching '{_echo_safe(cont)}'. "
                 "Use 'hermes sessions list' to see available sessions.\n"
             )
         return resolved

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -180,6 +180,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    resume: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -190,6 +191,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            resume=resume,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -1338,6 +1340,39 @@ def _resolve_workspace_key() -> Optional[str]:
         return os.getcwd()
     except Exception:
         return None
+
+
+def _resolve_oneshot_resume(args) -> Optional[str]:
+    """Resolve --resume / --continue for oneshot (-z) mode.
+
+    ``--resume`` is passed through verbatim: oneshot supports create-on-
+    first-use session ids (callers like the Smith Crafts OS gateway mint
+    their own stable id and pass it on every turn), so no existence check
+    happens here — hermes_cli.oneshot loads whatever history the id has.
+    ``--continue`` resolves exactly like interactive chat: by name when a
+    value is given, otherwise the most recent CLI session; an unresolvable
+    ``--continue`` is an error (there is nothing sensible to chain onto).
+    """
+    resume = (getattr(args, "resume", None) or "").strip() or None
+    if resume:
+        return resume
+    cont = getattr(args, "continue_last", None)
+    if not cont:
+        return None
+    if isinstance(cont, str):
+        resolved = _resolve_session_by_name_or_id(cont)
+        if not resolved:
+            sys.stderr.write(
+                f"hermes -z: no session found matching '{cont}'. "
+                "Use 'hermes sessions list' to see available sessions.\n"
+            )
+            sys.exit(2)
+        return resolved
+    last_id = _resolve_last_session(source="cli")
+    if not last_id:
+        sys.stderr.write("hermes -z: no previous CLI session found to continue.\n")
+        sys.exit(2)
+    return last_id
 
 
 def _resolve_last_session(source: str = "cli") -> Optional[str]:
@@ -10916,6 +10951,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=_resolve_oneshot_resume(args),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12547,6 +12583,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=_resolve_oneshot_resume(args),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1342,19 +1342,60 @@ def _resolve_workspace_key() -> Optional[str]:
         return None
 
 
+def _is_unsafe_new_session_id(value: str) -> bool:
+    """Return True if *value* could escape the sessions directory as a path.
+
+    Mirrors ``gateway.session._is_path_unsafe``, which guards the gateway's
+    externally-supplied ``session_id`` at its entry boundary. Duplicated
+    rather than imported because ``gateway.session`` is a heavy module with
+    optional platform deps and this runs on every CLI startup.
+
+    Oneshot ``--resume`` creates unknown ids on first use, which makes it a
+    second entry boundary for caller-supplied session ids. The id becomes a
+    filename downstream — ``SessionDB._remove_session_files`` builds
+    ``sessions_dir / f"{session_id}.json"`` and ``request_dump_{id}_*.json``
+    unsanitized — so ``hermes --resume ../../x -z ...`` would mint a row that
+    a later ``sessions delete``/``prune`` unlinks outside the sessions dir
+    (CWE-22). Real and gateway-minted ids never contain these characters.
+    """
+    s = str(value or "")
+    if ".." in s or "/" in s or "\\" in s:
+        return True
+    return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
+
+
 def _resolve_oneshot_resume(args) -> Optional[str]:
     """Resolve --resume / --continue for oneshot (-z) mode.
 
-    ``--resume`` is passed through verbatim: oneshot supports create-on-
-    first-use session ids (callers like the Smith Crafts OS gateway mint
-    their own stable id and pass it on every turn), so no existence check
-    happens here — hermes_cli.oneshot loads whatever history the id has.
-    ``--continue`` resolves exactly like interactive chat: by name when a
-    value is given, otherwise the most recent CLI session; an unresolvable
-    ``--continue`` is an error (there is nothing sensible to chain onto).
+    ``--resume`` resolves by ID or title exactly like interactive chat
+    (``cmd_chat``) and the flag's own documented contract — the value is run
+    through :func:`_resolve_session_by_name_or_id`, which handles exact ids,
+    titles, and projection forward through compression lineage.
+
+    Unlike interactive chat, an id that resolves to nothing is NOT an error:
+    oneshot supports create-on-first-use session ids (callers like the Smith
+    Crafts OS gateway mint their own stable id and pass it on every turn), so
+    an unresolved value is returned as-is and ``hermes_cli.oneshot`` starts a
+    fresh session under it. Because that value is about to become a brand-new
+    session id — one that lands on disk as a filename — it must first pass the
+    path-traversal guard applied to every other caller-supplied session id.
+
+    ``--continue`` resolves by name when a value is given, otherwise the most
+    recent CLI session; an unresolvable ``--continue`` is an error (there is
+    nothing sensible to chain onto).
     """
     resume = (getattr(args, "resume", None) or "").strip() or None
     if resume:
+        resolved = _resolve_session_by_name_or_id(resume)
+        if resolved:
+            return resolved
+        # Create-on-first-use: the raw value becomes a new session id.
+        if _is_unsafe_new_session_id(resume):
+            sys.stderr.write(
+                f"hermes -z: invalid --resume session id '{resume}': "
+                "path separators and '..' are not allowed.\n"
+            )
+            sys.exit(2)
         return resume
     cont = getattr(args, "continue_last", None)
     if not cont:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -173,6 +173,29 @@ def _cleanup_oneshot_runtime() -> None:
         pass
 
 
+def _fail_and_exit_oneshot(message: str, rc: int = 2) -> None:
+    """Abort a ``-z`` invocation through the SAME hardened exit path as a run.
+
+    A plain ``sys.exit()`` here would be wrong twice over: by the time oneshot
+    dispatch is reached, ``_prepare_agent_startup()`` has already discovered
+    plugins and (on the non-fast path) kicked off MCP server startup, so
+    unwinding through normal interpreter finalization both orphans those
+    subprocesses — ``_cleanup_oneshot_runtime()`` is what reaps them — and
+    re-enters the native finalizer teardown that ``_exit_after_oneshot``
+    exists to skip (#30387, #43055). Argument-validation failures must exit
+    exactly like a completed run: cleanup, then ``os._exit``.
+    """
+    try:
+        sys.stderr.write(message)
+        sys.stderr.flush()
+    except Exception:
+        pass
+    try:
+        _cleanup_oneshot_runtime()
+    finally:
+        _exit_after_oneshot(rc)
+
+
 def _run_and_exit_oneshot(
     prompt: str,
     *,
@@ -1383,6 +1406,12 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     ``--continue`` resolves by name when a value is given, otherwise the most
     recent CLI session; an unresolvable ``--continue`` is an error (there is
     nothing sensible to chain onto).
+
+    Every failure exits via ``_fail_and_exit_oneshot`` rather than a plain
+    ``sys.exit`` so it reaps MCP/plugin startup and hard-exits like every
+    other ``-z`` exit (by this point ``_prepare_agent_startup`` has already
+    run) — see that function's docstring for why a bare ``sys.exit`` here is
+    wrong twice over.
     """
     resume = (getattr(args, "resume", None) or "").strip() or None
     if resume:
@@ -1391,11 +1420,10 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
             return resolved
         # Create-on-first-use: the raw value becomes a new session id.
         if _is_unsafe_new_session_id(resume):
-            sys.stderr.write(
+            _fail_and_exit_oneshot(
                 f"hermes -z: invalid --resume session id '{resume}': "
                 "path separators and '..' are not allowed.\n"
             )
-            sys.exit(2)
         return resume
     cont = getattr(args, "continue_last", None)
     if not cont:
@@ -1403,16 +1431,16 @@ def _resolve_oneshot_resume(args) -> Optional[str]:
     if isinstance(cont, str):
         resolved = _resolve_session_by_name_or_id(cont)
         if not resolved:
-            sys.stderr.write(
+            _fail_and_exit_oneshot(
                 f"hermes -z: no session found matching '{cont}'. "
                 "Use 'hermes sessions list' to see available sessions.\n"
             )
-            sys.exit(2)
         return resolved
     last_id = _resolve_last_session(source="cli")
     if not last_id:
-        sys.stderr.write("hermes -z: no previous CLI session found to continue.\n")
-        sys.exit(2)
+        _fail_and_exit_oneshot(
+            "hermes -z: no previous CLI session found to continue.\n"
+        )
     return last_id
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -31,7 +31,10 @@ Session chaining (--resume / --continue):
       recent / named CLI session, exactly like interactive chat. Unlike
       ``--resume``, an unmatched ``--continue`` is an error.
     - Best-effort: if the SQLite session store is unavailable, the turn still
-      runs stateless rather than failing.
+      runs stateless rather than failing. A store that is merely *contended*
+      is the one exception — the resume reads wait the write lock out and
+      then fail loudly, because running a --resume turn with no context is a
+      wrong answer at full token price, not a graceful degradation.
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
@@ -41,7 +44,9 @@ from __future__ import annotations
 
 import logging
 import os
+import random
 import sys
+import time
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
@@ -377,6 +382,75 @@ def _create_session_db_for_oneshot():
         return None
 
 
+class ResumeStoreContendedError(RuntimeError):
+    """A --resume read stayed blocked on the state.db write lock.
+
+    Distinct from the broken-store case, which stays best-effort: here the
+    store is healthy and merely busy, so silently dropping the chain would
+    discard recoverable context. See :func:`_read_with_lock_patience`.
+    """
+
+
+# Lock-contention patience for the two --resume reads. SessionDB gives every
+# WRITE 20-60s of jittered retry (``_WRITE_PATIENCE_S`` /
+# ``_TRANSCRIPT_WRITE_PATIENCE_S``) and its ``__init__`` gets the same budget,
+# but the READ path has none: off WAL, ``SessionDB._read_ctx`` hands back the
+# shared writer connection, which carries a 1s busy timeout and no retry loop
+# at all. Match the write budget so the reads are no more fragile than the
+# writes they bracket.
+_RESUME_READ_PATIENCE_S = 20.0
+_RESUME_READ_RETRY_MIN_S = 0.050
+_RESUME_READ_RETRY_MAX_S = 0.350
+
+
+def _is_lock_contention(exc: BaseException) -> bool:
+    """True for SQLite's transient ``database is locked`` / ``busy`` class.
+
+    Message-scoped rather than class-scoped for the same reason
+    ``SessionDB._execute_write`` does it that way: the exception CLASS varies
+    across SQLite builds, and matching on ``sqlite3.OperationalError`` alone
+    would let some builds escape the retry net.
+    """
+    msg = str(exc).lower()
+    return "database is locked" in msg or "database is busy" in msg
+
+
+def _read_with_lock_patience(what: str, session_id: str, fn):
+    """Run one --resume read, waiting out transient write-lock contention.
+
+    Returns ``(value, ok)``. ``ok=False`` means the read genuinely failed and
+    the caller should degrade; a lock that outlasts the whole budget raises
+    :class:`ResumeStoreContendedError` instead, because that is not a broken
+    store and must not be silently swallowed (see ``_load_resume_history``).
+    """
+    deadline = time.monotonic() + _RESUME_READ_PATIENCE_S
+    while True:
+        try:
+            return fn(), True
+        except Exception as exc:
+            if not _is_lock_contention(exc):
+                logging.debug(
+                    "oneshot resume: %s failed for %s: %s", what, session_id, exc
+                )
+                return None, False
+            now = time.monotonic()
+            if now >= deadline:
+                raise ResumeStoreContendedError(
+                    f"--resume {what} for session '{session_id}' was blocked by "
+                    f"another Hermes process holding the state.db write lock for "
+                    f"over {_RESUME_READ_PATIENCE_S:.0f}s. Refusing to run this "
+                    f"turn with no prior context — retry the invocation."
+                ) from exc
+            time.sleep(
+                min(
+                    random.uniform(
+                        _RESUME_READ_RETRY_MIN_S, _RESUME_READ_RETRY_MAX_S
+                    ),
+                    max(deadline - now, 0.001),
+                )
+            )
+
+
 def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Optional[list]]:
     """Resolve a --resume id and load its transcript for oneshot chaining.
 
@@ -386,26 +460,46 @@ def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Option
     drop ``session_meta`` rows. Unlike interactive resume, an id with no
     existing session is NOT an error — it is returned as-is with no history,
     so the session is created on first use under the caller's chosen id.
-    Every step is best-effort: a broken store degrades to a stateless turn.
+
+    A broken store stays best-effort and degrades to a stateless turn. A
+    *contended* one does NOT, and the distinction matters because these two
+    reads are the only ones in the resume path with no lock patience of their
+    own. Off WAL — the default whenever the linked SQLite carries the WAL-reset
+    bug (``apply_wal_with_fallback``), and on NFS / SMB / ZFS homes — reads run
+    on the shared writer connection with a 1s busy timeout and no retry, so a
+    sibling process holding the write lock for a second (a large FTS-triggered
+    append, an incremental merge, a checkpoint, VACUUM) fails them while every
+    surrounding write rides out the same contention on 20-60s of patience.
+    Swallowing that would silently run the turn with NO prior context, exit 0,
+    and still append the context-less result into the middle of the chain —
+    burning the tokens ``--resume`` exists to save and corrupting the
+    transcript every later turn resumes from. So: wait the lock out with the
+    write path's own budget, and if it truly never clears, fail loudly through
+    ``run_oneshot``'s error path (non-zero exit) so a scripted caller retries
+    instead of banking a context-less answer.
     """
     session_id = (resume or "").strip() or None
     if not session_id or session_db is None:
         return session_id, None
-    try:
-        resolved = session_db.resolve_resume_session_id(session_id)
-        if resolved:
-            session_id = resolved
-    except Exception as exc:
-        logging.debug("oneshot resume: id resolution failed for %s: %s", session_id, exc)
+    resolved, ok = _read_with_lock_patience(
+        "id resolution",
+        session_id,
+        lambda: session_db.resolve_resume_session_id(session_id),
+    )
+    if ok and resolved:
+        session_id = resolved
     history: Optional[list] = None
-    try:
-        restored = session_db.get_messages_as_conversation(session_id)
-        restored = [m for m in restored if m.get("role") != "session_meta"]
-        history = restored or None
-    except Exception as exc:
-        logging.debug("oneshot resume: history load failed for %s: %s", session_id, exc)
+    restored, ok = _read_with_lock_patience(
+        "history load",
+        session_id,
+        lambda: session_db.get_messages_as_conversation(session_id),
+    )
+    if ok and restored:
+        history = [m for m in restored if m.get("role") != "session_meta"] or None
     # Ended sessions accept appends again once reopened; harmless if the
-    # session is new or already open.
+    # session is new or already open. Best-effort even under contention: this
+    # is a WRITE, so it already carries SessionDB's own jittered patience, and
+    # a session that stays ended still accepts this turn's appends.
     try:
         session_db.reopen_session(session_id)
     except Exception:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -16,15 +16,20 @@ Model / provider selection mirrors `hermes chat`:
     - If only --provider given, error out (ambiguous — caller must pick a model).
 
 Session chaining (--resume / --continue):
-    - ``hermes --resume <id> -z "..."`` loads the session's prior transcript as
-      conversation history and appends this turn to the SAME session id — the
-      one-shot equivalent of resuming an interactive chat.
-    - If the id does not exist yet, it is created on first use ("create-on-
-      first-use"): callers that manage their own session keys (the Smith
-      Crafts OS gateway, cron workers, scripts) can mint a stable id up front
-      and pass it on every turn without parsing anything back out.
+    - ``hermes --resume <id|title> -z "..."`` loads the session's prior
+      transcript as conversation history and appends this turn to the SAME
+      session id — the one-shot equivalent of resuming an interactive chat.
+      ID-or-title resolution happens in ``hermes_cli.main`` before the value
+      reaches here, so this module always receives a session id.
+    - If the value matches no existing session, it is created on first use
+      ("create-on-first-use"): callers that manage their own session keys (the
+      Smith Crafts OS gateway, cron workers, scripts) can mint a stable id up
+      front and pass it on every turn without parsing anything back out.
+      Caller-minted ids are path-guarded at the CLI boundary because a session
+      id becomes a filename downstream.
     - ``--continue`` (optionally with a session name) resolves to the most
-      recent / named CLI session, exactly like interactive chat.
+      recent / named CLI session, exactly like interactive chat. Unlike
+      ``--resume``, an unmatched ``--continue`` is an error.
     - Best-effort: if the SQLite session store is unavailable, the turn still
       runs stateless rather than failing.
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -522,15 +522,22 @@ def _run_agent(
     skills_prompt = _build_preloaded_skills_prompt(skills)
 
     session_db = _create_session_db_for_oneshot()
-    # --resume chaining: load the prior transcript and pin the agent to the
-    # caller's session id so this turn appends to the SAME session.
-    resume_session_id, conversation_history = _load_resume_history(session_db, resume)
-    # The try spans agent construction (not just ``chat``) so the SQLite store
-    # opened above is always closed — including when ``AIAgent(...)`` itself
-    # raises on a provider/config error. The one-shot exit path hard-exits via
-    # os._exit and skips finalizers, so an un-closed connection here would leak.
+    # The try spans the resume load and agent construction (not just ``chat``)
+    # so the SQLite store opened above is always closed — including when
+    # ``AIAgent(...)`` itself raises on a provider/config error. The one-shot
+    # exit path hard-exits via os._exit and skips finalizers, so an un-closed
+    # connection here would leak.
     agent = None
     try:
+        # --resume chaining: load the prior transcript and pin the agent to
+        # the caller's session id so this turn appends to the SAME session.
+        # Inside the try because it touches session_db — the per-step guards
+        # in _load_resume_history keep a broken store from failing the turn,
+        # but the connection must still be closed if anything else escapes.
+        resume_session_id, conversation_history = _load_resume_history(
+            session_db, resume
+        )
+
         # Read the effective fallback chain from profile config so oneshot
         # workers honour the same merge semantics as interactive CLI and
         # gateway sessions.

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -15,6 +15,19 @@ Model / provider selection mirrors `hermes chat`:
     - If only --model given, auto-detect the provider that serves it.
     - If only --provider given, error out (ambiguous — caller must pick a model).
 
+Session chaining (--resume / --continue):
+    - ``hermes --resume <id> -z "..."`` loads the session's prior transcript as
+      conversation history and appends this turn to the SAME session id — the
+      one-shot equivalent of resuming an interactive chat.
+    - If the id does not exist yet, it is created on first use ("create-on-
+      first-use"): callers that manage their own session keys (the Smith
+      Crafts OS gateway, cron workers, scripts) can mint a stable id up front
+      and pass it on every turn without parsing anything back out.
+    - ``--continue`` (optionally with a session name) resolves to the most
+      recent / named CLI session, exactly like interactive chat.
+    - Best-effort: if the SQLite session store is unavailable, the turn still
+      runs stateless rather than failing.
+
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
 """
@@ -206,6 +219,7 @@ def run_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: Optional[str] = None,
+    resume: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -221,6 +235,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        resume: Optional session id to chain this turn onto. Prior transcript
+            is loaded as conversation history and this turn is appended to the
+            same session. Ids that don't exist yet are created on first use.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -283,6 +300,7 @@ def run_oneshot(
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
                     skills=skills,
+                    resume=resume,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -354,6 +372,42 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Optional[list]]:
+    """Resolve a --resume id and load its transcript for oneshot chaining.
+
+    Returns ``(session_id, conversation_history)``. Mirrors the interactive
+    resume path (cli_agent_setup_mixin): walk the compression chain via
+    ``resolve_resume_session_id``, load messages in conversation format, and
+    drop ``session_meta`` rows. Unlike interactive resume, an id with no
+    existing session is NOT an error — it is returned as-is with no history,
+    so the session is created on first use under the caller's chosen id.
+    Every step is best-effort: a broken store degrades to a stateless turn.
+    """
+    session_id = (resume or "").strip() or None
+    if not session_id or session_db is None:
+        return session_id, None
+    try:
+        resolved = session_db.resolve_resume_session_id(session_id)
+        if resolved:
+            session_id = resolved
+    except Exception as exc:
+        logging.debug("oneshot resume: id resolution failed for %s: %s", session_id, exc)
+    history: Optional[list] = None
+    try:
+        restored = session_db.get_messages_as_conversation(session_id)
+        restored = [m for m in restored if m.get("role") != "session_meta"]
+        history = restored or None
+    except Exception as exc:
+        logging.debug("oneshot resume: history load failed for %s: %s", session_id, exc)
+    # Ended sessions accept appends again once reopened; harmless if the
+    # session is new or already open.
+    try:
+        session_db.reopen_session(session_id)
+    except Exception:
+        pass
+    return session_id, history
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -361,6 +415,7 @@ def _run_agent(
     toolsets: object = None,
     use_config_toolsets: bool = True,
     skills: object = None,
+    resume: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -462,6 +517,9 @@ def _run_agent(
     skills_prompt = _build_preloaded_skills_prompt(skills)
 
     session_db = _create_session_db_for_oneshot()
+    # --resume chaining: load the prior transcript and pin the agent to the
+    # caller's session id so this turn appends to the SAME session.
+    resume_session_id, conversation_history = _load_resume_history(session_db, resume)
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
     # raises on a provider/config error. The one-shot exit path hard-exits via
@@ -483,6 +541,7 @@ def _run_agent(
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",
+            session_id=resume_session_id,
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
@@ -507,7 +566,7 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = agent.run_conversation(prompt, conversation_history=conversation_history)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -15,6 +15,19 @@ Model / provider selection mirrors `hermes chat`:
     - If only --model given, auto-detect the provider that serves it.
     - If only --provider given, error out (ambiguous — caller must pick a model).
 
+Session chaining (--resume / --continue):
+    - ``hermes --resume <id> -z "..."`` loads the session's prior transcript as
+      conversation history and appends this turn to the SAME session id — the
+      one-shot equivalent of resuming an interactive chat.
+    - If the id does not exist yet, it is created on first use ("create-on-
+      first-use"): callers that manage their own session keys (the Smith
+      Crafts OS gateway, cron workers, scripts) can mint a stable id up front
+      and pass it on every turn without parsing anything back out.
+    - ``--continue`` (optionally with a session name) resolves to the most
+      recent / named CLI session, exactly like interactive chat.
+    - Best-effort: if the SQLite session store is unavailable, the turn still
+      runs stateless rather than failing.
+
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
 """
@@ -173,6 +186,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    resume: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +201,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        resume: Optional session id to chain this turn onto. Prior transcript
+            is loaded as conversation history and this turn is appended to the
+            same session. Ids that don't exist yet are created on first use.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -248,6 +265,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    resume=resume,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -310,12 +328,49 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Optional[list]]:
+    """Resolve a --resume id and load its transcript for oneshot chaining.
+
+    Returns ``(session_id, conversation_history)``. Mirrors the interactive
+    resume path (cli_agent_setup_mixin): walk the compression chain via
+    ``resolve_resume_session_id``, load messages in conversation format, and
+    drop ``session_meta`` rows. Unlike interactive resume, an id with no
+    existing session is NOT an error — it is returned as-is with no history,
+    so the session is created on first use under the caller's chosen id.
+    Every step is best-effort: a broken store degrades to a stateless turn.
+    """
+    session_id = (resume or "").strip() or None
+    if not session_id or session_db is None:
+        return session_id, None
+    try:
+        resolved = session_db.resolve_resume_session_id(session_id)
+        if resolved:
+            session_id = resolved
+    except Exception as exc:
+        logging.debug("oneshot resume: id resolution failed for %s: %s", session_id, exc)
+    history: Optional[list] = None
+    try:
+        restored = session_db.get_messages_as_conversation(session_id)
+        restored = [m for m in restored if m.get("role") != "session_meta"]
+        history = restored or None
+    except Exception as exc:
+        logging.debug("oneshot resume: history load failed for %s: %s", session_id, exc)
+    # Ended sessions accept appends again once reopened; harmless if the
+    # session is new or already open.
+    try:
+        session_db.reopen_session(session_id)
+    except Exception:
+        pass
+    return session_id, history
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    resume: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -410,6 +465,9 @@ def _run_agent(
     )
 
     session_db = _create_session_db_for_oneshot()
+    # --resume chaining: load the prior transcript and pin the agent to the
+    # caller's session id so this turn appends to the SAME session.
+    resume_session_id, conversation_history = _load_resume_history(session_db, resume)
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
     # raises on a provider/config error. The one-shot exit path hard-exits via
@@ -431,6 +489,7 @@ def _run_agent(
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",
+            session_id=resume_session_id,
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
@@ -454,7 +513,7 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = agent.run_conversation(prompt, conversation_history=conversation_history)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -31,7 +31,10 @@ Session chaining (--resume / --continue):
       recent / named CLI session, exactly like interactive chat. Unlike
       ``--resume``, an unmatched ``--continue`` is an error.
     - Best-effort: if the SQLite session store is unavailable, the turn still
-      runs stateless rather than failing.
+      runs stateless rather than failing. A store that is merely *contended*
+      is the one exception — the resume reads wait the write lock out and
+      then fail loudly, because running a --resume turn with no context is a
+      wrong answer at full token price, not a graceful degradation.
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
@@ -41,7 +44,9 @@ from __future__ import annotations
 
 import logging
 import os
+import random
 import sys
+import time
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
@@ -333,6 +338,75 @@ def _create_session_db_for_oneshot():
         return None
 
 
+class ResumeStoreContendedError(RuntimeError):
+    """A --resume read stayed blocked on the state.db write lock.
+
+    Distinct from the broken-store case, which stays best-effort: here the
+    store is healthy and merely busy, so silently dropping the chain would
+    discard recoverable context. See :func:`_read_with_lock_patience`.
+    """
+
+
+# Lock-contention patience for the two --resume reads. SessionDB gives every
+# WRITE 20-60s of jittered retry (``_WRITE_PATIENCE_S`` /
+# ``_TRANSCRIPT_WRITE_PATIENCE_S``) and its ``__init__`` gets the same budget,
+# but the READ path has none: off WAL, ``SessionDB._read_ctx`` hands back the
+# shared writer connection, which carries a 1s busy timeout and no retry loop
+# at all. Match the write budget so the reads are no more fragile than the
+# writes they bracket.
+_RESUME_READ_PATIENCE_S = 20.0
+_RESUME_READ_RETRY_MIN_S = 0.050
+_RESUME_READ_RETRY_MAX_S = 0.350
+
+
+def _is_lock_contention(exc: BaseException) -> bool:
+    """True for SQLite's transient ``database is locked`` / ``busy`` class.
+
+    Message-scoped rather than class-scoped for the same reason
+    ``SessionDB._execute_write`` does it that way: the exception CLASS varies
+    across SQLite builds, and matching on ``sqlite3.OperationalError`` alone
+    would let some builds escape the retry net.
+    """
+    msg = str(exc).lower()
+    return "database is locked" in msg or "database is busy" in msg
+
+
+def _read_with_lock_patience(what: str, session_id: str, fn):
+    """Run one --resume read, waiting out transient write-lock contention.
+
+    Returns ``(value, ok)``. ``ok=False`` means the read genuinely failed and
+    the caller should degrade; a lock that outlasts the whole budget raises
+    :class:`ResumeStoreContendedError` instead, because that is not a broken
+    store and must not be silently swallowed (see ``_load_resume_history``).
+    """
+    deadline = time.monotonic() + _RESUME_READ_PATIENCE_S
+    while True:
+        try:
+            return fn(), True
+        except Exception as exc:
+            if not _is_lock_contention(exc):
+                logging.debug(
+                    "oneshot resume: %s failed for %s: %s", what, session_id, exc
+                )
+                return None, False
+            now = time.monotonic()
+            if now >= deadline:
+                raise ResumeStoreContendedError(
+                    f"--resume {what} for session '{session_id}' was blocked by "
+                    f"another Hermes process holding the state.db write lock for "
+                    f"over {_RESUME_READ_PATIENCE_S:.0f}s. Refusing to run this "
+                    f"turn with no prior context — retry the invocation."
+                ) from exc
+            time.sleep(
+                min(
+                    random.uniform(
+                        _RESUME_READ_RETRY_MIN_S, _RESUME_READ_RETRY_MAX_S
+                    ),
+                    max(deadline - now, 0.001),
+                )
+            )
+
+
 def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Optional[list]]:
     """Resolve a --resume id and load its transcript for oneshot chaining.
 
@@ -342,26 +416,46 @@ def _load_resume_history(session_db, resume: str) -> tuple[Optional[str], Option
     drop ``session_meta`` rows. Unlike interactive resume, an id with no
     existing session is NOT an error — it is returned as-is with no history,
     so the session is created on first use under the caller's chosen id.
-    Every step is best-effort: a broken store degrades to a stateless turn.
+
+    A broken store stays best-effort and degrades to a stateless turn. A
+    *contended* one does NOT, and the distinction matters because these two
+    reads are the only ones in the resume path with no lock patience of their
+    own. Off WAL — the default whenever the linked SQLite carries the WAL-reset
+    bug (``apply_wal_with_fallback``), and on NFS / SMB / ZFS homes — reads run
+    on the shared writer connection with a 1s busy timeout and no retry, so a
+    sibling process holding the write lock for a second (a large FTS-triggered
+    append, an incremental merge, a checkpoint, VACUUM) fails them while every
+    surrounding write rides out the same contention on 20-60s of patience.
+    Swallowing that would silently run the turn with NO prior context, exit 0,
+    and still append the context-less result into the middle of the chain —
+    burning the tokens ``--resume`` exists to save and corrupting the
+    transcript every later turn resumes from. So: wait the lock out with the
+    write path's own budget, and if it truly never clears, fail loudly through
+    ``run_oneshot``'s error path (non-zero exit) so a scripted caller retries
+    instead of banking a context-less answer.
     """
     session_id = (resume or "").strip() or None
     if not session_id or session_db is None:
         return session_id, None
-    try:
-        resolved = session_db.resolve_resume_session_id(session_id)
-        if resolved:
-            session_id = resolved
-    except Exception as exc:
-        logging.debug("oneshot resume: id resolution failed for %s: %s", session_id, exc)
+    resolved, ok = _read_with_lock_patience(
+        "id resolution",
+        session_id,
+        lambda: session_db.resolve_resume_session_id(session_id),
+    )
+    if ok and resolved:
+        session_id = resolved
     history: Optional[list] = None
-    try:
-        restored = session_db.get_messages_as_conversation(session_id)
-        restored = [m for m in restored if m.get("role") != "session_meta"]
-        history = restored or None
-    except Exception as exc:
-        logging.debug("oneshot resume: history load failed for %s: %s", session_id, exc)
+    restored, ok = _read_with_lock_patience(
+        "history load",
+        session_id,
+        lambda: session_db.get_messages_as_conversation(session_id),
+    )
+    if ok and restored:
+        history = [m for m in restored if m.get("role") != "session_meta"] or None
     # Ended sessions accept appends again once reopened; harmless if the
-    # session is new or already open.
+    # session is new or already open. Best-effort even under contention: this
+    # is a WRITE, so it already carries SessionDB's own jittered patience, and
+    # a session that stays ended still accepts this turn's appends.
     try:
         session_db.reopen_session(session_id)
     except Exception:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -470,15 +470,22 @@ def _run_agent(
     )
 
     session_db = _create_session_db_for_oneshot()
-    # --resume chaining: load the prior transcript and pin the agent to the
-    # caller's session id so this turn appends to the SAME session.
-    resume_session_id, conversation_history = _load_resume_history(session_db, resume)
-    # The try spans agent construction (not just ``chat``) so the SQLite store
-    # opened above is always closed — including when ``AIAgent(...)`` itself
-    # raises on a provider/config error. The one-shot exit path hard-exits via
-    # os._exit and skips finalizers, so an un-closed connection here would leak.
+    # The try spans the resume load and agent construction (not just ``chat``)
+    # so the SQLite store opened above is always closed — including when
+    # ``AIAgent(...)`` itself raises on a provider/config error. The one-shot
+    # exit path hard-exits via os._exit and skips finalizers, so an un-closed
+    # connection here would leak.
     agent = None
     try:
+        # --resume chaining: load the prior transcript and pin the agent to
+        # the caller's session id so this turn appends to the SAME session.
+        # Inside the try because it touches session_db — the per-step guards
+        # in _load_resume_history keep a broken store from failing the turn,
+        # but the connection must still be closed if anything else escapes.
+        resume_session_id, conversation_history = _load_resume_history(
+            session_db, resume
+        )
+
         # Read the effective fallback chain from profile config so oneshot
         # workers honour the same merge semantics as interactive CLI and
         # gateway sessions.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -18,6 +18,7 @@ import asyncio
 import atexit
 import contextlib
 import errno
+import glob
 import hashlib
 import json
 import logging
@@ -12950,6 +12951,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
+
+        ``session_id`` is interpolated into a glob PATTERN below, so it must
+        be ``glob.escape``d first. The path-traversal guards at the entry
+        boundaries (``gateway.session._is_path_unsafe``,
+        ``hermes_cli.main._is_unsafe_new_session_id``) reject ``..`` and path
+        separators but deliberately allow every other character — including
+        the glob metacharacters ``*``, ``?`` and ``[``. Unescaped, a session
+        whose id is ``*`` expands to ``request_dump_*_*.json`` and this delete
+        sweeps EVERY other session's request dumps out of the sessions dir.
+        Escaping keeps the pattern a literal prefix match. The two unlink()
+        calls above need no escaping — ``Path.unlink`` never globs.
         """
         if sessions_dir is None:
             return
@@ -12961,7 +12973,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 pass
         # request_dump files use session_id as a prefix component
         try:
-            for p in sessions_dir.glob(f"request_dump_{session_id}_*.json"):
+            for p in sessions_dir.glob(f"request_dump_{glob.escape(session_id)}_*.json"):
                 try:
                     p.unlink(missing_ok=True)
                 except OSError:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import atexit
 import errno
+import glob
 import hashlib
 import json
 import logging
@@ -8219,6 +8220,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
+
+        ``session_id`` is interpolated into a glob PATTERN below, so it must
+        be ``glob.escape``d first. The path-traversal guards at the entry
+        boundaries (``gateway.session._is_path_unsafe``,
+        ``hermes_cli.main._is_unsafe_new_session_id``) reject ``..`` and path
+        separators but deliberately allow every other character — including
+        the glob metacharacters ``*``, ``?`` and ``[``. Unescaped, a session
+        whose id is ``*`` expands to ``request_dump_*_*.json`` and this delete
+        sweeps EVERY other session's request dumps out of the sessions dir.
+        Escaping keeps the pattern a literal prefix match. The two unlink()
+        calls above need no escaping — ``Path.unlink`` never globs.
         """
         if sessions_dir is None:
             return
@@ -8230,7 +8242,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 pass
         # request_dump files use session_id as a prefix component
         try:
-            for p in sessions_dir.glob(f"request_dump_{session_id}_*.json"):
+            for p in sessions_dir.glob(f"request_dump_{glob.escape(session_id)}_*.json"):
                 try:
                     p.unlink(missing_ok=True)
                 except OSError:

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -1,0 +1,97 @@
+"""Tests for `hermes -z --resume` session chaining (hermes_cli.oneshot).
+
+Oneshot historically ignored --resume entirely: every -z call built a fresh
+AIAgent with a fresh session, so scripted callers (the Smith Crafts OS
+gateway, cron workers) could never chain turns. These tests pin the fixed
+contract:
+
+  - --resume <existing id> loads the prior transcript as conversation_history
+    and pins the agent to the SAME session id (walking compression chains).
+  - --resume <unknown id> is create-on-first-use: no error, no history, the
+    id is used as-is so the caller can mint stable ids up front.
+  - A broken session store degrades to a stateless turn, never a failure.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.oneshot import _load_resume_history
+
+
+class TestLoadResumeHistory:
+    def test_no_resume_returns_none(self):
+        assert _load_resume_history(MagicMock(), "") == (None, None)
+        assert _load_resume_history(MagicMock(), None) == (None, None)
+
+    def test_no_db_returns_id_stateless(self):
+        sid, hist = _load_resume_history(None, "abc123")
+        assert sid == "abc123"
+        assert hist is None
+
+    def test_existing_session_loads_history_and_resolves_chain(self):
+        db = MagicMock()
+        db.resolve_resume_session_id.return_value = "tip_id"
+        db.get_messages_as_conversation.return_value = [
+            {"role": "session_meta", "content": "meta"},
+            {"role": "user", "content": "remember ZEBRA"},
+            {"role": "assistant", "content": "OK"},
+        ]
+        sid, hist = _load_resume_history(db, "orig_id")
+        assert sid == "tip_id"
+        # session_meta rows are dropped, real turns are kept in order.
+        assert hist == [
+            {"role": "user", "content": "remember ZEBRA"},
+            {"role": "assistant", "content": "OK"},
+        ]
+        db.get_messages_as_conversation.assert_called_once_with("tip_id")
+        db.reopen_session.assert_called_once_with("tip_id")
+
+    def test_unknown_id_creates_on_first_use(self):
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = lambda s: s
+        db.get_messages_as_conversation.return_value = []
+        sid, hist = _load_resume_history(db, "brand_new_id")
+        assert sid == "brand_new_id"
+        assert hist is None
+
+    def test_broken_store_degrades_to_stateless(self):
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = RuntimeError("db locked")
+        db.get_messages_as_conversation.side_effect = RuntimeError("db locked")
+        db.reopen_session.side_effect = RuntimeError("db locked")
+        sid, hist = _load_resume_history(db, "sid")
+        assert sid == "sid"
+        assert hist is None
+
+
+class TestRunAgentResumeWiring:
+    def _run(self, resume, load_result, monkeypatch):
+        monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "PONG"}
+        agent_cls = MagicMock(return_value=agent)
+        with (
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=MagicMock()),
+            patch("hermes_cli.oneshot._load_resume_history", return_value=load_result),
+            patch("hermes_cli.oneshot.get_fallback_chain", return_value=None),
+            patch("hermes_cli.config.load_config", return_value={"model": {"default": "m1", "provider": "p1"}}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value=set()),
+            patch("run_agent.AIAgent", agent_cls),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            response, _result = _run_agent("hi", resume=resume)
+        return agent_cls, agent, response
+
+    def test_resume_pins_session_id_and_seeds_history(self, monkeypatch):
+        history = [{"role": "user", "content": "remember ZEBRA"}]
+        agent_cls, agent, response = self._run("sid1", ("sid1", history), monkeypatch)
+        assert agent_cls.call_args.kwargs["session_id"] == "sid1"
+        agent.run_conversation.assert_called_once_with("hi", conversation_history=history)
+        assert response == "PONG"
+
+    def test_no_resume_keeps_agent_generated_session(self, monkeypatch):
+        agent_cls, agent, _ = self._run(None, (None, None), monkeypatch)
+        assert agent_cls.call_args.kwargs["session_id"] is None
+        agent.run_conversation.assert_called_once_with("hi", conversation_history=None)

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -9,9 +9,14 @@ contract:
     and pins the agent to the SAME session id (walking compression chains).
   - --resume <unknown id> is create-on-first-use: no error, no history, the
     id is used as-is so the caller can mint stable ids up front.
+  - --resume <title> resolves by title just like interactive chat, matching
+    the flag's documented "by ID or title" contract.
+  - A caller-minted id that could escape the sessions dir as a path is
+    rejected before it is written (CWE-22).
   - A broken session store degrades to a stateless turn, never a failure.
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -106,44 +111,82 @@ class TestOneshotResumeIntegration:
     reload through a brand-new ``SessionDB`` instance (the same shape a
     second `hermes -z` process invocation would see)?
 
-    ``AIAgent`` is still replaced (no live LLM call — that boundary is
-    correctly out of scope here) but the fake performs the SAME real
-    ``session_db.create_session`` / ``append_messages_batch`` writes the
-    real agent's turn-boundary flush performs, so ``_load_resume_history``
-    is exercised against actual rows, not a mock's return value.
+    ``AIAgent`` is not constructed (no live LLM call — that boundary is
+    correctly out of scope here), but the stand-in drives the REAL
+    ``AIAgent._flush_messages_to_session_db`` against the real store with the
+    real ``messages = conversation_history + this turn`` shape. That is what
+    makes the "no duplicate rows" assertion meaningful: the flush's
+    identity-based seeded-history dedup (``run_agent.py``, ``history_ids``)
+    is genuinely exercised. A stand-in that only appended its own two new
+    messages would satisfy the row-count assertion by construction and prove
+    nothing about the resume-and-reflush cycle.
     """
 
     class _RecordingFakeAgent:
-        """Stands in for AIAgent: records session_id/history it was given
-        and performs a REAL turn-boundary flush to the real session_db,
-        exactly as ``run_agent.AIAgent.run_conversation`` does on a genuine
-        turn (create_session is idempotent; append_messages_batch writes the
-        user+assistant pair in one transaction)."""
+        """Stands in for AIAgent: records the session_id/history it was given,
+        then performs a real turn-boundary flush by calling the genuine
+        ``AIAgent._flush_messages_to_session_db`` with the same
+        ``(messages, conversation_history)`` pair a live turn passes.
+
+        The session row is pre-created and ``_session_db_created`` pre-set so
+        the fake does not have to stand up ``_ensure_db_session``'s full
+        model-config surface; session creation is covered separately by
+        ``test_unknown_resume_id_is_created_fresh_on_disk``. Everything the
+        dedup depends on is real."""
+
+        # Bound in _run_turn from the genuine AIAgent *before* it is patched
+        # out (afterwards ``run_agent.AIAgent`` is this class).
+        _real_flush = None
+        _real_flush_unlocked = None
 
         def __init__(self, **kwargs):
             self.kwargs = kwargs
-            self.session_id = kwargs["session_id"]
+            self.session_id = kwargs["session_id"] or f"generated_{id(self)}"
             self.session_db = kwargs["session_db"]
             self.suppress_status_output = False
             self.stream_delta_callback = None
             self.tool_gen_callback = None
 
+            # Real-flush wiring.
+            cls = type(self)
+            self._flush = cls._real_flush.__get__(self)
+            self._flush_messages_to_session_db_unlocked = (
+                cls._real_flush_unlocked.__get__(self)
+            )
+            self._session_db = self.session_db
+            self._session_persist_lock = None
+            self._last_flushed_db_idx = 0
+            self._flushed_db_message_ids = set()
+            self._flushed_db_message_session_id = None
+            self._db_flush_scan_prefix = None
+            self.platform = "cli"
+            self.model = "m1"
+            self.provider = "p1"
+            self.session_db.create_session(self.session_id, source="cli")
+            self._session_db_created = True
+
         def run_conversation(self, prompt, conversation_history=None):
             self.received_history = conversation_history
-            session_id = self.session_id or f"generated_{id(self)}"
-            self.session_db.create_session(session_id, source="cli")
             reply = f"ack:{prompt}"
-            self.session_db.append_messages_batch(
-                session_id,
-                [
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": reply},
-                ],
-            )
-            return {"final_response": reply, "session_id": session_id}
+            # A live turn's message list IS the seeded history plus this
+            # turn's new dicts — same object identities, which is exactly what
+            # the flush's dedup keys off.
+            messages = list(conversation_history or []) + [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": reply},
+            ]
+            self._flush(messages, conversation_history)
+            return {"final_response": reply, "session_id": self.session_id}
 
     def _run_turn(self, prompt, resume, db_path, monkeypatch):
+        import run_agent
         from hermes_state import SessionDB
+
+        # Capture the genuine flush before AIAgent is patched out below.
+        self._RecordingFakeAgent._real_flush = run_agent.AIAgent._flush_messages_to_session_db
+        self._RecordingFakeAgent._real_flush_unlocked = (
+            run_agent.AIAgent._flush_messages_to_session_db_unlocked
+        )
 
         real_db = SessionDB(db_path=db_path)
         with (
@@ -207,10 +250,89 @@ class TestOneshotResumeIntegration:
             {"role": "user", "content": "what did I say?"},
             {"role": "assistant", "content": "ack:what did I say?"},
         ]
-        # 4 real rows, not 8 — turn 1's messages were loaded as context and
-        # skipped by the flush's identity-based dedup, never re-appended.
+        # 4 real rows, not 6 — turn 2's flush was handed turn 1's two seeded
+        # dicts plus its own two new ones, and the identity-based dedup wrote
+        # only the new pair. (Break that identity contract and this is 6.)
         assert session_row is not None
         assert session_row["message_count"] == 4
+
+    def test_third_turn_keeps_accumulating_on_the_same_session(self, tmp_path, monkeypatch):
+        """Two turns prove chaining starts; a third proves it doesn't stop
+        there. The seeded prefix grows every turn, so a dedup that only
+        handled the first reflush would show up here as duplicate rows."""
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        sid = "caller_minted_three_turns"
+
+        for prompt in ("turn one", "turn two", "turn three"):
+            self._run_turn(prompt, sid, db_path, monkeypatch)
+
+        reload_db = SessionDB(db_path=db_path)
+        final_id, final_history = _load_resume_history(reload_db, sid)
+        session_row = reload_db.get_session(final_id)
+        reload_db.close()
+
+        assert final_id == sid
+        assert self._role_content(final_history) == [
+            {"role": "user", "content": "turn one"},
+            {"role": "assistant", "content": "ack:turn one"},
+            {"role": "user", "content": "turn two"},
+            {"role": "assistant", "content": "ack:turn two"},
+            {"role": "user", "content": "turn three"},
+            {"role": "assistant", "content": "ack:turn three"},
+        ]
+        assert session_row["message_count"] == 6
+
+    def test_resume_follows_compression_chain_to_the_live_tip(self, tmp_path, monkeypatch):
+        """The case sibling PR #70136 was reviewed down for. Compression ends
+        the live session and forks a continuation child; a caller that minted
+        the ORIGINAL id and keeps passing it must land on the child that holds
+        the messages, and this turn's writes must go there too — not into the
+        dead parent. ``_load_resume_history`` delegates to
+        ``resolve_resume_session_id``, so the redirect must survive end-to-end
+        through ``_run_agent``."""
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        parent, child = "caller_minted_parent", "compression_child"
+
+        seed = SessionDB(db_path=db_path)
+        seed.create_session(parent, source="cli")
+        seed.append_message(parent, role="user", content="pre-compression turn")
+        seed.end_session(parent, "compression")
+        seed.create_session(child, source="cli", parent_session_id=parent)
+        seed.append_message(child, role="assistant", content="post-compression reply")
+        base = int(time.time()) - 10_000
+        conn = seed._conn
+        conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (base, base + 50, parent),
+        )
+        conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (base + 100, child))
+        conn.commit()
+        seed.close()
+
+        # Caller still passes the id it minted; resolution must redirect.
+        response, _ = self._run_turn("and after compression?", parent, db_path, monkeypatch)
+        assert response == "ack:and after compression?"
+
+        reload_db = SessionDB(db_path=db_path)
+        resolved_id, history = _load_resume_history(reload_db, parent)
+        parent_row = reload_db.get_session(parent)
+        child_row = reload_db.get_session(child)
+        reload_db.close()
+
+        assert resolved_id == child
+        # The new turn landed in the child, and the seeded history it was
+        # given was the child's transcript — not the parent's stale one.
+        assert self._role_content(history) == [
+            {"role": "assistant", "content": "post-compression reply"},
+            {"role": "user", "content": "and after compression?"},
+            {"role": "assistant", "content": "ack:and after compression?"},
+        ]
+        assert child_row["message_count"] == 3
+        assert parent_row["message_count"] == 1
 
     def test_unknown_resume_id_is_created_fresh_on_disk(self, tmp_path, monkeypatch):
         db_path = tmp_path / "state.db"
@@ -226,3 +348,143 @@ class TestOneshotResumeIntegration:
         reload_db.close()
         assert session_row is not None
         assert session_row["message_count"] == 2
+
+
+class TestResolveOneshotResume:
+    """The CLI-side half of the fix (``hermes_cli.main._resolve_oneshot_resume``),
+    exercised against a real ``SessionDB`` under the isolated temp ``HERMES_HOME``.
+
+    This is the surface a sibling attempt (#70136) was reviewed down for: it
+    used an ID-only resolver while the flag documents "by ID or title", so
+    ``--resume "my project"`` silently started a fresh session instead of
+    resuming. Oneshot must use the same resolution contract as ``cmd_chat``.
+    """
+
+    @staticmethod
+    def _args(resume=None, continue_last=None):
+        import types
+
+        return types.SimpleNamespace(resume=resume, continue_last=continue_last)
+
+    @staticmethod
+    def _seed(session_id, title=None, source="cli"):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        db.create_session(session_id, source=source)
+        if title:
+            db.set_session_title(session_id, title)
+        db.append_message(session_id, role="user", content="seed")
+        db.close()
+
+    def test_no_flags_returns_none(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        assert _resolve_oneshot_resume(self._args()) is None
+
+    def test_resume_by_exact_id(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._seed("20260101_120000_abc123")
+        assert (
+            _resolve_oneshot_resume(self._args(resume="20260101_120000_abc123"))
+            == "20260101_120000_abc123"
+        )
+
+    def test_resume_by_title_resolves_like_interactive_chat(self):
+        """`--resume` is documented as "by ID or title" (_parser.py) and
+        cmd_chat resolves titles. Oneshot must not diverge — passing a title
+        through verbatim would silently mint an empty session named after the
+        title, which is the same silent-drop class as the bug being fixed."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._seed("20260101_120000_abc123", title="my project")
+        assert (
+            _resolve_oneshot_resume(self._args(resume="my project"))
+            == "20260101_120000_abc123"
+        )
+
+    def test_unknown_id_passes_through_for_create_on_first_use(self):
+        """The deliberate design choice: an id matching nothing is NOT an
+        error, so scripted callers can mint a stable key up front."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        assert (
+            _resolve_oneshot_resume(self._args(resume="caller_minted_key_1"))
+            == "caller_minted_key_1"
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["../../../../tmp/pwned", "..", "a/b", "a\\b", "C:/tmp/x"],
+    )
+    def test_path_unsafe_new_id_is_rejected(self, bad):
+        """A create-on-first-use id becomes a real session id, and session ids
+        become filenames downstream (``SessionDB._remove_session_files`` builds
+        ``sessions_dir / f"{id}.json"`` unsanitized, so a later
+        ``sessions delete``/``prune`` would unlink outside the sessions dir).
+        The gateway already rejects these at its own entry boundary
+        (``gateway.session._is_path_unsafe``); the new oneshot entry boundary
+        must too."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        with pytest.raises(SystemExit) as exc:
+            _resolve_oneshot_resume(self._args(resume=bad))
+        assert exc.value.code == 2
+
+    def test_path_unsafe_value_still_allowed_when_it_resolves(self):
+        """The guard only applies to values about to become NEW ids. A title
+        containing '/' that resolves to a real session is fine — the value
+        actually used is the resolved id, never the raw string."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._seed("20260101_120000_def456", title="feat/oneshot-resume")
+        assert (
+            _resolve_oneshot_resume(self._args(resume="feat/oneshot-resume"))
+            == "20260101_120000_def456"
+        )
+
+    def test_continue_by_name_resolves(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._seed("20260101_120000_ghi789", title="my project")
+        assert (
+            _resolve_oneshot_resume(self._args(continue_last="my project"))
+            == "20260101_120000_ghi789"
+        )
+
+    def test_continue_by_name_unmatched_errors(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        with pytest.raises(SystemExit) as exc:
+            _resolve_oneshot_resume(self._args(continue_last="nothing here"))
+        assert exc.value.code == 2
+
+    def test_bare_continue_with_no_prior_session_errors(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        with patch("hermes_cli.main._resolve_last_session", return_value=None):
+            with pytest.raises(SystemExit) as exc:
+                _resolve_oneshot_resume(self._args(continue_last=True))
+        assert exc.value.code == 2
+
+    def test_bare_continue_uses_most_recent_cli_session(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        with patch(
+            "hermes_cli.main._resolve_last_session", return_value="20260101_120000_jkl"
+        ):
+            assert (
+                _resolve_oneshot_resume(self._args(continue_last=True))
+                == "20260101_120000_jkl"
+            )
+
+    def test_resume_wins_over_continue(self):
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        assert (
+            _resolve_oneshot_resume(
+                self._args(resume="explicit_id", continue_last="my project")
+            )
+            == "explicit_id"
+        )

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -14,6 +14,8 @@ contract:
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hermes_cli.oneshot import _load_resume_history
 
 
@@ -95,3 +97,132 @@ class TestRunAgentResumeWiring:
         agent_cls, agent, _ = self._run(None, (None, None), monkeypatch)
         assert agent_cls.call_args.kwargs["session_id"] is None
         agent.run_conversation.assert_called_once_with("hi", conversation_history=None)
+
+
+class TestOneshotResumeIntegration:
+    """Real-SQLite regression for the concern the mock-only unit tests above
+    can't catch: does a genuine ``SessionDB`` on disk actually round-trip a
+    resumed transcript across two separate ``_run_agent`` calls, including a
+    reload through a brand-new ``SessionDB`` instance (the same shape a
+    second `hermes -z` process invocation would see)?
+
+    ``AIAgent`` is still replaced (no live LLM call — that boundary is
+    correctly out of scope here) but the fake performs the SAME real
+    ``session_db.create_session`` / ``append_messages_batch`` writes the
+    real agent's turn-boundary flush performs, so ``_load_resume_history``
+    is exercised against actual rows, not a mock's return value.
+    """
+
+    class _RecordingFakeAgent:
+        """Stands in for AIAgent: records session_id/history it was given
+        and performs a REAL turn-boundary flush to the real session_db,
+        exactly as ``run_agent.AIAgent.run_conversation`` does on a genuine
+        turn (create_session is idempotent; append_messages_batch writes the
+        user+assistant pair in one transaction)."""
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = kwargs["session_id"]
+            self.session_db = kwargs["session_db"]
+            self.suppress_status_output = False
+            self.stream_delta_callback = None
+            self.tool_gen_callback = None
+
+        def run_conversation(self, prompt, conversation_history=None):
+            self.received_history = conversation_history
+            session_id = self.session_id or f"generated_{id(self)}"
+            self.session_db.create_session(session_id, source="cli")
+            reply = f"ack:{prompt}"
+            self.session_db.append_messages_batch(
+                session_id,
+                [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": reply},
+                ],
+            )
+            return {"final_response": reply, "session_id": session_id}
+
+    def _run_turn(self, prompt, resume, db_path, monkeypatch):
+        from hermes_state import SessionDB
+
+        real_db = SessionDB(db_path=db_path)
+        with (
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=real_db),
+            patch("hermes_cli.oneshot.get_fallback_chain", return_value=None),
+            patch("hermes_cli.config.load_config", return_value={"model": {"default": "m1", "provider": "p1"}}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value=set()),
+            patch("run_agent.AIAgent", self._RecordingFakeAgent),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            response, result = _run_agent(prompt, resume=resume)
+        real_db.close()
+        return response, result
+
+    @staticmethod
+    def _role_content(history):
+        """Real rows carry extra bookkeeping (timestamp, etc.) that a mock
+        never would — compare on the fields the caller/model actually see."""
+        return [{"role": m["role"], "content": m["content"]} for m in history]
+
+    def test_two_turns_round_trip_through_real_sqlite(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        sid = "caller_minted_abc123"
+
+        # Turn 1: id has never been seen — create-on-first-use, no prior
+        # history to seed.
+        response1, _ = self._run_turn("remember ZEBRA", sid, db_path, monkeypatch)
+        assert response1 == "ack:remember ZEBRA"
+
+        # Turn 2: same id — must load turn 1's real, disk-persisted
+        # transcript as conversation_history, not a fresh/empty one.
+        from hermes_state import SessionDB
+
+        probe_db = SessionDB(db_path=db_path)
+        seeded_id, seeded_history = _load_resume_history(probe_db, sid)
+        probe_db.close()
+        assert seeded_id == sid
+        assert self._role_content(seeded_history) == [
+            {"role": "user", "content": "remember ZEBRA"},
+            {"role": "assistant", "content": "ack:remember ZEBRA"},
+        ]
+
+        response2, _ = self._run_turn("what did I say?", sid, db_path, monkeypatch)
+        assert response2 == "ack:what did I say?"
+
+        # Reload via a BRAND NEW SessionDB instance — the same shape a
+        # second `hermes -z` process invocation would see, not a cached
+        # Python object from this test. Assert both turns are present, in
+        # order, with no duplicate rows from the resume-and-reflush cycle.
+        reload_db = SessionDB(db_path=db_path)
+        final_id, final_history = _load_resume_history(reload_db, sid)
+        session_row = reload_db.get_session(final_id)
+        reload_db.close()
+
+        assert final_id == sid
+        assert self._role_content(final_history) == [
+            {"role": "user", "content": "remember ZEBRA"},
+            {"role": "assistant", "content": "ack:remember ZEBRA"},
+            {"role": "user", "content": "what did I say?"},
+            {"role": "assistant", "content": "ack:what did I say?"},
+        ]
+        # 4 real rows, not 8 — turn 1's messages were loaded as context and
+        # skipped by the flush's identity-based dedup, never re-appended.
+        assert session_row is not None
+        assert session_row["message_count"] == 4
+
+    def test_unknown_resume_id_is_created_fresh_on_disk(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        sid = "brand_new_never_seen"
+
+        response, _ = self._run_turn("first ever message", sid, db_path, monkeypatch)
+        assert response == "ack:first ever message"
+
+        from hermes_state import SessionDB
+
+        reload_db = SessionDB(db_path=db_path)
+        session_row = reload_db.get_session(sid)
+        reload_db.close()
+        assert session_row is not None
+        assert session_row["message_count"] == 2

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -414,6 +414,24 @@ class TestResolveOneshotResume:
             == "caller_minted_key_1"
         )
 
+    @staticmethod
+    def _assert_hardened_exit(fn, rc=2):
+        """Every _resolve_oneshot_resume failure must exit through
+        _fail_and_exit_oneshot — cleanup + os._exit, not a bare sys.exit —
+        because _prepare_agent_startup has already discovered plugins/MCP
+        servers by the time oneshot dispatch runs (#30387, #43055). Mock the
+        hard-exit boundary rather than expecting SystemExit: _exit_after_oneshot
+        is a real os._exit, which would kill the test process outright."""
+        import hermes_cli.main as main_mod
+
+        with (
+            patch.object(main_mod, "_cleanup_oneshot_runtime") as cleanup,
+            patch.object(main_mod, "_exit_after_oneshot") as hard_exit,
+        ):
+            fn()
+        cleanup.assert_called_once_with()
+        hard_exit.assert_called_once_with(rc)
+
     @pytest.mark.parametrize(
         "bad",
         ["../../../../tmp/pwned", "..", "a/b", "a\\b", "C:/tmp/x"],
@@ -425,12 +443,13 @@ class TestResolveOneshotResume:
         ``sessions delete``/``prune`` would unlink outside the sessions dir).
         The gateway already rejects these at its own entry boundary
         (``gateway.session._is_path_unsafe``); the new oneshot entry boundary
-        must too."""
+        must too — and via the same hardened exit path as every other -z
+        failure, not a bare sys.exit."""
         from hermes_cli.main import _resolve_oneshot_resume
 
-        with pytest.raises(SystemExit) as exc:
-            _resolve_oneshot_resume(self._args(resume=bad))
-        assert exc.value.code == 2
+        self._assert_hardened_exit(
+            lambda: _resolve_oneshot_resume(self._args(resume=bad))
+        )
 
     def test_path_unsafe_value_still_allowed_when_it_resolves(self):
         """The guard only applies to values about to become NEW ids. A title
@@ -456,17 +475,17 @@ class TestResolveOneshotResume:
     def test_continue_by_name_unmatched_errors(self):
         from hermes_cli.main import _resolve_oneshot_resume
 
-        with pytest.raises(SystemExit) as exc:
-            _resolve_oneshot_resume(self._args(continue_last="nothing here"))
-        assert exc.value.code == 2
+        self._assert_hardened_exit(
+            lambda: _resolve_oneshot_resume(self._args(continue_last="nothing here"))
+        )
 
     def test_bare_continue_with_no_prior_session_errors(self):
         from hermes_cli.main import _resolve_oneshot_resume
 
         with patch("hermes_cli.main._resolve_last_session", return_value=None):
-            with pytest.raises(SystemExit) as exc:
-                _resolve_oneshot_resume(self._args(continue_last=True))
-        assert exc.value.code == 2
+            self._assert_hardened_exit(
+                lambda: _resolve_oneshot_resume(self._args(continue_last=True))
+            )
 
     def test_bare_continue_uses_most_recent_cli_session(self):
         from hermes_cli.main import _resolve_oneshot_resume

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -13,15 +13,19 @@ contract:
     the flag's documented "by ID or title" contract.
   - A caller-minted id that could escape the sessions dir as a path is
     rejected before it is written (CWE-22).
-  - A broken session store degrades to a stateless turn, never a failure.
+  - A broken session store degrades to a stateless turn, never a failure —
+    but a merely CONTENDED one does not: the resume reads wait the write lock
+    out, and fail loudly rather than silently running a context-less turn.
 """
 
+import sqlite3
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hermes_cli.oneshot import _load_resume_history
+from hermes_cli.oneshot import ResumeStoreContendedError, _load_resume_history
 
 
 class TestLoadResumeHistory:
@@ -70,6 +74,132 @@ class TestLoadResumeHistory:
         assert hist is None
 
 
+class TestResumeReadLockPatience:
+    """The resume reads are the only step in the chaining path with no lock
+    patience of its own.  ``SessionDB`` gives every WRITE 20-60s of jittered
+    retry and gives ``__init__`` the same budget, but off WAL — the default
+    whenever the linked SQLite carries the WAL-reset bug, plus every NFS / SMB
+    / ZFS home — ``_read_ctx`` returns the shared writer connection, which
+    carries a 1s busy timeout and NO retry loop.
+
+    Swallowing that ``database is locked`` (as a plain best-effort ``except``
+    would) is the worst available outcome for a scripted chain: the turn runs
+    with NO prior context, exits 0, and still appends its context-less answer
+    into the middle of the session every later turn resumes from — burning the
+    tokens ``--resume`` exists to save, invisibly, because oneshot has already
+    called ``logging.disable(logging.CRITICAL)`` and redirected stderr to
+    devnull by then.
+    """
+
+    def test_transient_lock_is_waited_out_not_swallowed(self):
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = lambda s: s
+        calls = {"n": 0}
+
+        def _flaky(_sid):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return [{"role": "user", "content": "remember ZEBRA"}]
+
+        db.get_messages_as_conversation.side_effect = _flaky
+        sid, hist = _load_resume_history(db, "apollo-run-42")
+        assert sid == "apollo-run-42"
+        # The chain survived the contention instead of silently vanishing.
+        assert hist == [{"role": "user", "content": "remember ZEBRA"}]
+        assert calls["n"] == 3
+
+    def test_lock_that_never_clears_fails_loudly(self, monkeypatch):
+        import hermes_cli.oneshot as oneshot
+
+        monkeypatch.setattr(oneshot, "_RESUME_READ_PATIENCE_S", 0.2)
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = lambda s: s
+        db.get_messages_as_conversation.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+        with pytest.raises(ResumeStoreContendedError) as exc:
+            _load_resume_history(db, "apollo-run-42")
+        assert "apollo-run-42" in str(exc.value)
+
+    def test_contended_compression_resolve_also_fails_loudly(self, monkeypatch):
+        """The id resolution read matters just as much: swallowing a lock there
+        leaves ``session_id`` on the pre-compression parent, so the turn
+        replays the dead parent's (empty) transcript and writes into it — the
+        #15000 shape, silently reintroduced under contention."""
+        import hermes_cli.oneshot as oneshot
+
+        monkeypatch.setattr(oneshot, "_RESUME_READ_PATIENCE_S", 0.2)
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+        with pytest.raises(ResumeStoreContendedError):
+            _load_resume_history(db, "caller_minted_parent")
+
+    def test_non_lock_error_still_degrades_to_stateless(self, monkeypatch):
+        """Only the transient lock class is escalated. A genuinely broken
+        store keeps the documented best-effort behaviour."""
+        import hermes_cli.oneshot as oneshot
+
+        monkeypatch.setattr(oneshot, "_RESUME_READ_PATIENCE_S", 0.2)
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = lambda s: s
+        db.get_messages_as_conversation.side_effect = sqlite3.DatabaseError(
+            "file is not a database"
+        )
+        sid, hist = _load_resume_history(db, "sid")
+        assert (sid, hist) == ("sid", None)
+
+    def test_real_sqlite_lock_contention_recovers_the_transcript(self, tmp_path):
+        """The mock tests pin the retry logic; this pins that the retry is
+        aimed at a failure that a REAL contended ``SessionDB`` actually
+        produces. A sibling connection holds the write lock past the read
+        connection's 1s busy timeout, exactly as a large FTS-triggered append
+        / incremental merge / checkpoint / VACUUM in another `hermes` process
+        would."""
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        sid = "apollo-run-42"
+        seed = SessionDB(db_path=db_path)
+        wal = seed._wal_active
+        seed.create_session(sid, source="cli")
+        seed.append_messages_batch(
+            session_id=sid,
+            messages=[
+                {"role": "user", "content": "investigate_bug"},
+                {"role": "assistant", "content": "root cause found"},
+            ],
+        )
+        seed.close()
+
+        if wal:
+            pytest.skip("WAL readers never block on the writer; needs journal_mode=delete")
+
+        db = SessionDB(db_path=db_path)
+        holder = sqlite3.connect(
+            str(db_path), isolation_level=None, timeout=30, check_same_thread=False
+        )
+        holder.execute("BEGIN EXCLUSIVE")
+        holder.execute("CREATE TABLE IF NOT EXISTS _hold (x)")
+
+        def _release():
+            holder.execute("ROLLBACK")
+            holder.close()
+
+        released = threading.Timer(2.5, _release)
+        released.start()
+        try:
+            resolved, history = _load_resume_history(db, sid)
+        finally:
+            released.join()
+            db.close()
+
+        assert resolved == sid
+        assert [m["role"] for m in history] == ["user", "assistant"]
+
+
 class TestRunAgentResumeWiring:
     def _run(self, resume, load_result, monkeypatch):
         monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
@@ -102,6 +232,36 @@ class TestRunAgentResumeWiring:
         agent_cls, agent, _ = self._run(None, (None, None), monkeypatch)
         assert agent_cls.call_args.kwargs["session_id"] is None
         agent.run_conversation.assert_called_once_with("hi", conversation_history=None)
+
+    def test_contended_store_aborts_the_turn_and_closes_the_db(self, monkeypatch):
+        """A lock that outlasts the read patience must NOT reach the model.
+        It propagates out of ``_run_agent`` — so ``run_oneshot`` reports it on
+        the real stderr and exits non-zero, and a scripted caller retries —
+        while the ``finally`` still closes the SQLite store (the hard-exit path
+        skips finalizers, so a leak here is permanent)."""
+        monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        session_db = MagicMock()
+        agent_cls = MagicMock()
+        with (
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=session_db),
+            patch(
+                "hermes_cli.oneshot._load_resume_history",
+                side_effect=ResumeStoreContendedError("still locked"),
+            ),
+            patch("hermes_cli.oneshot.get_fallback_chain", return_value=None),
+            patch("hermes_cli.config.load_config", return_value={"model": {"default": "m1", "provider": "p1"}}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value=set()),
+            patch("run_agent.AIAgent", agent_cls),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            with pytest.raises(ResumeStoreContendedError):
+                _run_agent("hi", resume="apollo-run-42")
+
+        agent_cls.assert_not_called()
+        session_db.close.assert_called_once_with()
 
 
 class TestOneshotResumeIntegration:
@@ -451,6 +611,55 @@ class TestResolveOneshotResume:
             lambda: _resolve_oneshot_resume(self._args(resume=bad))
         )
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "run\r\nconversation turn: session=root",  # CWE-117 log forging
+            "run\x1b]0;pwned\x07",  # terminal escape injection
+            "run\x7f",
+            "x" * 257,  # over NAME_MAX -> "{id}.json" is never creatable
+        ],
+    )
+    def test_control_chars_and_overlong_new_ids_are_rejected(self, bad):
+        """The gateway's entry boundary is a COMPOSITE of three checks applied
+        together (``_is_path_unsafe`` + ``re.search(r'[\\r\\n\\x00]')`` + the
+        ``_MAX_SESSION_HEADER_LEN`` cap — see ``GatewayAPIServer``). Mirroring
+        only the first left CR/LF free to forge entries in the per-turn
+        ``conversation turn: session=%s`` log line, ESC free to drive the
+        operator's terminal via the rejection message, and an unbounded id free
+        to make ``{id}.json`` permanently un-creatable while riding on every
+        message row."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._assert_hardened_exit(
+            lambda: _resolve_oneshot_resume(self._args(resume=bad))
+        )
+
+    def test_rejection_message_does_not_replay_control_characters(self, capsys):
+        """The rejection quotes the offending value back at the operator, so it
+        must be escaped on the way out — otherwise rejecting an ESC-bearing id
+        is itself the terminal-injection primitive."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        self._assert_hardened_exit(
+            lambda: _resolve_oneshot_resume(
+                self._args(resume="run\x1b]0;pwned\x07")
+            )
+        )
+        err = capsys.readouterr().err
+        assert "\x1b" not in err
+        assert "\\x1b" in err
+
+    def test_ordinary_punctuation_ids_still_pass(self):
+        """The tightening must not narrow the create-on-first-use contract:
+        colon-delimited gateway-shaped keys and glob metacharacters are legal
+        filename content and stay allowed (``_remove_session_files`` escapes
+        them at the glob call site instead)."""
+        from hermes_cli.main import _resolve_oneshot_resume
+
+        for ok in ("agent:main:cli:run-42", "run_42.v2", "run*42", "x" * 256):
+            assert _resolve_oneshot_resume(self._args(resume=ok)) == ok
+
     def test_path_unsafe_value_still_allowed_when_it_resolves(self):
         """The guard only applies to values about to become NEW ids. A title
         containing '/' that resolves to a real session is fine — the value
@@ -507,3 +716,45 @@ class TestResolveOneshotResume:
             )
             == "explicit_id"
         )
+
+
+class TestRemoveSessionFilesGlobEscaping:
+    """``--resume`` mints caller-chosen session ids, and the guard deliberately
+    allows any character that isn't a traversal vector — including the glob
+    metacharacters ``*``/``?``/``[``. ``SessionDB._remove_session_files``
+    interpolates the id straight into a glob PATTERN for the gateway's
+    ``request_dump_{id}_*.json`` artifacts, so an id of ``*`` expanded to
+    ``request_dump_*_*.json`` and a later ``sessions delete``/``prune`` (or an
+    ``auto_prune`` sweep) wiped every OTHER session's request dumps out of the
+    sessions dir. Escaped at the call site rather than banned at the boundary,
+    so gateway-minted ids are covered by the same fix.
+    """
+
+    def test_wildcard_id_only_deletes_its_own_dumps(self, tmp_path):
+        from hermes_state import SessionDB
+
+        victim = tmp_path / "request_dump_20260101_120000_abc_1.json"
+        victim.write_text("keep me")
+        own = tmp_path / "request_dump_*_1.json"
+        own.write_text("delete me")
+
+        SessionDB._remove_session_files(tmp_path, "*")
+
+        assert victim.exists()
+        assert not own.exists()
+
+    def test_ordinary_id_still_sweeps_its_dumps(self, tmp_path):
+        from hermes_state import SessionDB
+
+        mine = tmp_path / "request_dump_sess1_1.json"
+        mine.write_text("x")
+        theirs = tmp_path / "request_dump_sess2_1.json"
+        theirs.write_text("x")
+        transcript = tmp_path / "sess1.json"
+        transcript.write_text("x")
+
+        SessionDB._remove_session_files(tmp_path, "sess1")
+
+        assert not mine.exists()
+        assert not transcript.exists()
+        assert theirs.exists()


### PR DESCRIPTION
## What

Carries forward #57859 (`fix/oneshot-resume-hydration`, @nathansmithopenclaw-alt): `hermes --resume <id> -z "<prompt>"` (and `--continue [name]`) chains — the session's prior transcript loads as conversation history and the turn appends to the SAME session id. Ids that don't exist yet are created on first use, so scripted callers can mint a stable session key per conversation up front and pass it on every turn.

This closes #49195, and addresses everything from @teknium1's review of #57859:

1. **Rebased onto current main.** #57859 predates the MCP-discovery-wait (`ensure_mcp_discovery_before_agent_build`) and `requested_provider`/`usage_file` additions to `_run_agent`/`run_oneshot` — this carries the resume hydration forward alongside all three.
2. **Real-SQLite integration coverage**, not mock-only: two/three-turn `_run_agent()` calls against a real, temp-path-backed `SessionDB` (only the LLM call is faked — the stand-in drives the genuine `AIAgent._flush_messages_to_session_db` against real disk), then a reload through a **brand-new** `SessionDB` instance — the shape a second `hermes -z` process invocation would see. The row-count/dedup assertion is verified non-vacuous by mutation (breaking the real identity-dedup makes it fail).

**Update:** this PR went through two independent adversarial reviews after opening (see below) that found and fixed three additional real issues beyond what's described above. Net diff vs. the originally-opened version: a hardened exit path for `-z --resume`/`--continue` failures, a path-traversal guard on caller-minted ids, and ID-or-title resolution for `--resume` matching its own documented contract.

## Why this needs to exist

`hermes -z` (oneshot) is the interface a piped/scripted caller uses precisely to avoid `chat`'s banner/box/session chrome on stdout. Every such caller that wants multi-turn continuity — a gateway running a chat seat over `-z` one-shots, a cron worker, a CI agent pipeline driving Hatchet-style multi-step workflows — currently gets an amnesiac agent: `--resume`/`--continue` are accepted (exit 0, no warning) and silently dropped, so every turn starts from zero. This is the third independent fix attempt at this exact gap (#40333 closed in error unrelated to merit, #49204 takes the inverse "reject the flag" minimal path) — the bug report, the review signal, and the number of independent contributors who've hit this all say it's a real, wanted capability.

## Relationship to existing PRs/issues

- Closes #49195 (the bug report).
- Carries forward #57859's approach (same author's hydration mechanism, independently reviewed as `salvageability=high`) — rebased + tests added per that review.
- #40333: an earlier independent attempt at the same hydration approach, closed by its author unrelated to merit.
- #49204: the inverse minimal "fail loud" guard — not superseded by this PR; a maintainer call on which direction to take (guard vs. hydrate). If the guard lands first, this rebases trivially on top per #57859's own note.
- #70136: a third independent hydration attempt, reviewed down for (a) using an ID-only resolver against a flag documented as "by ID or title", and (b) not forwarding `--no-restore-cwd`. This PR fixes (a) — see below — and does **not** touch (b); flagging that gap below rather than silently leaving it unaddressed.

## Change

- `hermes_cli/oneshot.py`:
  - `run_oneshot(resume=...)` → `_run_agent(resume=...)` → `_load_resume_history(session_db, resume)`: resolves the compression chain via `resolve_resume_session_id`, loads messages via `get_messages_as_conversation` (dropping `session_meta` rows), best-effort `reopen_session`, and pins `AIAgent(session_id=...)`. A broken session store degrades to a stateless turn — `-z` never gets less reliable than before.
  - The resume load happens *inside* the try/finally that owns `session_db`, matching that block's own stated invariant that the connection is always closed (not reachable as a live bug today — `_load_resume_history`'s own internals are individually guarded — but it contradicted the comment directly above it).
- `hermes_cli/main.py`:
  - Both oneshot dispatch sites (Termux fast-path and main) resolve `resume=_resolve_oneshot_resume(args)` and forward it through `_run_and_exit_oneshot`.
  - **`--resume` resolves by ID or title**, exactly like `cmd_chat` and the flag's own `_parser.py` help text ("Resume a previous session by ID or title"). Without this, `--resume "my project"` would silently mint an empty, wrongly-named session instead of resuming — the identical "documented behavior silently doesn't happen in `-z`" bug class as #49195 itself, and the exact gap sibling PR #70136 was reviewed down for. Resolution still falls through to create-on-first-use when nothing matches.
  - **Path-traversal guard on caller-minted ids** (`_is_unsafe_new_session_id`): a create-on-first-use id becomes a filename downstream (`SessionDB`'s session-file removal path is unsanitized), so `hermes --resume ../../x -z ...` would mint a row that a later `sessions delete`/`prune` unlinks outside the sessions directory (CWE-22). Mirrors the gateway's own `_is_path_unsafe` guard at its equivalent entry boundary. Only applied to values about to become *new* ids — a title containing `/` that resolves to a real session is untouched.
  - **Hardened exit path** (`_fail_and_exit_oneshot`): all three `_resolve_oneshot_resume` failure branches (unmatched `--continue` by name, no prior session for bare `--continue`, path-unsafe `--resume` id) now exit via `_cleanup_oneshot_runtime()` + `_exit_after_oneshot()` instead of a bare `sys.exit(2)`. By the time oneshot dispatch runs, `_prepare_agent_startup()` has already discovered plugins and can have started MCP server subprocesses — unwinding through normal interpreter finalization both orphans them and re-enters the native finalizer teardown `_exit_after_oneshot` exists to skip (#30387/#43055).
  - `--continue` resolves by name/most-recent exactly like interactive chat; an unresolvable `--continue` errors (nothing sensible to chain onto).
- `hermes_cli/_parser.py` — `-z` help documents ID-or-title + create-on-first-use + the `--continue` error semantics.
- With no `--resume`/`--continue`, behavior is byte-for-byte unchanged.

## One open question for a maintainer, not resolved here

Whether `--resume <title>` should resolve at all in oneshot was reviewed both ways during this PR's own review cycle: one review argued for matching the documented ID-or-title contract (implemented, above); a second flagged a theoretical hijack risk — a caller-minted key that happens to collide with an existing session's human-readable title would land on the wrong session. I kept the resolution because it's the *same* resolution function and ordering (exact id first, title fallback) that interactive chat already uses today, so this isn't a new risk class introduced by this PR, and it matches what `--parser.py` promises and what #70136's review already asked for. Flagging explicitly in case a maintainer weighs this differently.

## Tests

- `tests/hermes_cli/test_oneshot_resume.py`: **26 passed** (7 original mock-based + 2 real-SQLite integration + 3 new integration cases — third-turn accumulation, compression-chain redirect, unknown-id create-on-first-use — + 14 in a new `TestResolveOneshotResume` covering title resolution, path-traversal rejection (5 shapes), the hardened-exit contract, and `--continue` resolution).
- `tests/hermes_cli/ -k "resume or continue or oneshot or session"`: **203 passed**, 5 failed — all 5 are pre-existing dashboard-auth 401s unrelated to this change (confirmed against a clean-main baseline in the same sandbox).
- Full `tests/hermes_cli/` suite: no regressions vs. a clean-`main` baseline in the same sandbox (identical pre-existing failure count; the only pass-count delta matches this PR's own new tests).
- Manual verification, live, against a real deployed `nousresearch/hermes-agent:latest` container: planted a codeword on turn 1 under a caller-minted `--resume` id, recalled it correctly on turn 2 under the same id, confirmed a different `--resume` id sees no cross-session leakage.

## Review history

This branch was reviewed twice after opening, independently and adversarially (one focused on correctness of the session/exit-path mechanics, one on completeness against this repo's own `CONTRIBUTING.md`/`AGENTS.md` contribution rubric and against gaps sibling PRs were reviewed down for). Both found real, non-overlapping issues; both are folded into the current diff, verified together (not just individually) before pushing. Happy to expand on either review's specific findings if useful for re-review.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


## Update: two more independent reviews (security, concurrency/production-robustness)

After the round above, this branch went through two more adversarial passes — one hunting security issues specifically, one focused on concurrency and production robustness given the actual motivating use case (a Hatchet-orchestrated pipeline running multiple concurrent multi-step chains against the same session store). Both found real, distinct, confirmed issues, now folded into the diff:

**Security:**
- `SessionDB._remove_session_files` (`hermes_state.py`) interpolated `session_id` raw into a glob pattern. An id of literally `*` — legal under the path-traversal guard, since `*` isn't a traversal character — expands `request_dump_{id}_*.json` into `request_dump_*_*.json` and deletes **every other session's** request dumps. `--resume` made this CLI-reachable for the first time (previously gateway-only). Fixed with `glob.escape`.
- `_is_unsafe_new_session_id` only ported one of the three checks the gateway's own equivalent entry boundary applies together. Added control-character rejection (CR/LF can forge log lines; ESC can inject terminal escapes into the rejection message itself) and the same 256-char length cap the gateway enforces (past `NAME_MAX` the session snapshot file becomes permanently uncreatable). Rejection messages now echo the offending value through a safe-echo helper so rejecting a hostile id can't itself be the injection vector.
- Investigated and found clean: prompt injection via replayed history (nothing re-dispatches replayed tool calls; approval state isn't restorable from transcript content), `--yolo` bleed across resumed turns, toolset/model scope leakage, unbounded-history growth (handled by existing compression machinery), torn reads.
- Flagged, not fixed (product decisions, not bugs): create-on-first-use resolving by title before falling back to "use as-is" (same tradeoff as the title-resolution decision above); `reopen_session` clearing `end_reason` unconditionally (matches interactive chat's existing behavior — not a regression, just an existing shared question); no single-writer enforcement on a caller-minted id (not a vulnerability, but worth a docs line).

**Concurrency/production-robustness** — this is the one I'd flag as most load-bearing given the actual use case:
- The two `--resume` reads had **no lock-contention patience**, unlike every write path in this codebase (which gets 20–60s of jittered retry). Off WAL — which is the *default* on any pre-3.51.3 SQLite (i.e. stock CPython 3.11/3.12/3.13) or NFS/SMB/ZFS — a sibling connection holding the write lock for even a few seconds (a large FTS append, an incremental merge, a checkpoint, VACUUM — all real, existing code paths) made the read raise `database is locked`, which the resume loader already swallowed to a stateless degrade. Concretely: **a resumed turn would silently run with zero prior context, exit 0, and append its context-less answer into the middle of an otherwise-good transcript** — full token cost paid, wrong answer produced, chain poisoned for every downstream step, with no error signal at all. Reproduced against a real `SessionDB` under a held write lock. Fixed by giving the read path the same lock-patience budget the write path already has, escalating to a new `ResumeStoreContendedError` (routed through the existing non-zero-exit error path, so an orchestrator can retry) only if the lock never actually clears — a genuinely broken store still degrades to stateless as before.
- Everything else probed held up under real, measured load: throughput overhead from resume chaining is ~1.7x DB-side cost at N=24 concurrent chains (well under 1% of a real LLM turn's wall-clock), retries never corrupt state (the healing path already handles an abandoned tool-call tail), concurrent same-id minting degrades gracefully via the existing upsert semantics, and multi-hop (3+ turn) chaining behaves identically to the tested 2-turn case.
- Flagged, not fixed (out of scope for this diff): a double `SessionDB` open per resume call (main.py resolves the id, then oneshot.py opens its own store — measurable but small, and fixing it means threading a connection through a wider call chain than this PR should touch); bare `--continue` under concurrency resolves to the workspace's most-recently-used session, which is correct per the flag's definition but means concurrent callers in the same repo must use `--resume <stable-id>`, never bare `--continue` — worth a docs note for anyone building an orchestrator on this.

Tests: `tests/hermes_cli/test_oneshot_resume.py` now **40 passed** (up from 26). `tests/hermes_cli/ -k "resume or continue or oneshot or session"`: **217 passed**, same 5 pre-existing unrelated dashboard-auth failures every prior review round hit.
