### PR TITLE
fix(gateway): make a history-dropping prompt.submit prove it meant to (#80763)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2248,6 +2248,7 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
+        confirm_truncate: true,
         truncate_before_user_ordinal: 0,
         confirm_empty_truncate: true
       },
@@ -2316,6 +2317,7 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
+        confirm_truncate: true,
         truncate_before_user_ordinal: 0,
         confirm_empty_truncate: true
       },
@@ -2362,6 +2364,7 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
+        confirm_truncate: true,
         truncate_before_user_ordinal: 0,
         confirm_empty_truncate: true
       },

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -7,13 +7,27 @@ describe('truncateSubmitParams', () => {
     expect(truncateSubmitParams(undefined)).toEqual({})
   })
 
-  it('requires confirm_empty_truncate only for ordinal 0', () => {
+  it('confirms intent for every ordinal, and the empty edge only for ordinal 0', () => {
     expect(truncateSubmitParams(0)).toEqual({
+      confirm_truncate: true,
       truncate_before_user_ordinal: 0,
       confirm_empty_truncate: true
     })
     expect(truncateSubmitParams(1)).toEqual({
+      confirm_truncate: true,
       truncate_before_user_ordinal: 1
     })
+  })
+
+  it('never sends an ordinal without the intent flag the gateway requires', () => {
+    // The gateway drops history only for a submit that declares itself a
+    // rewind. An ordinal built here without confirm_truncate would be refused
+    // (and, on an older gateway, would truncate silently).
+    for (const ordinal of [0, 1, 2, 7]) {
+      const params = truncateSubmitParams(ordinal)
+
+      expect(params.truncate_before_user_ordinal).toBe(ordinal)
+      expect(params.confirm_truncate).toBe(true)
+    }
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -26,10 +26,12 @@ import {
 type RequestGateway = <T = unknown>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
 
 /**
- * Build `prompt.submit` truncation params. Ordinal 0 truncates to an empty
- * transcript (restore/regenerate the first user turn) — the gateway refuses
- * that edge unless `confirm_empty_truncate` is set, so stale clients cannot
- * silently wipe a session via a leftover ordinal.
+ * Build `prompt.submit` truncation params. `confirm_truncate` states that this
+ * submit really is a rewind/edit/regenerate: the gateway drops history only for
+ * a submit that says so, so a leftover ordinal riding along on an ordinary send
+ * cannot delete the transcript. Ordinal 0 additionally truncates to an empty
+ * transcript (restore/regenerate the first user turn), which the gateway gates
+ * behind `confirm_empty_truncate` on top of that.
  */
 export function truncateSubmitParams(truncateOrdinal: number | undefined): Record<string, unknown> {
   if (truncateOrdinal === undefined) {
@@ -37,6 +39,7 @@ export function truncateSubmitParams(truncateOrdinal: number | undefined): Recor
   }
 
   return {
+    confirm_truncate: true,
     truncate_before_user_ordinal: truncateOrdinal,
     ...(truncateOrdinal === 0 ? { confirm_empty_truncate: true } : {})
   }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4276,6 +4276,7 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
                     "session_id": "trunc-sid",
                     "text": "next",
                     "truncate_before_user_ordinal": -1,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -4288,12 +4289,77 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
         server._sessions.pop("trunc-sid", None)
 
 
-def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
-    """Stale truncate_before_user_ordinal=0 must not wipe a non-empty transcript.
+def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
+    """An ordinal without confirm_truncate must not drop the session tail.
 
-    Desktop desync can attach ordinal 0 to an ordinary fresh submit. That cuts
-    at the first user message (history[:0] == []) and replace_messages() would
-    DELETE every durable row. Refuse unless confirm_empty_truncate is set.
+    #80763: a desktop client carried a leftover truncate_before_user_ordinal
+    into an ORDINARY submit. The request was indistinguishable from a real
+    rewind — in-range ordinal, non-empty result — so the empty-truncation guard
+    never fired and replace_messages() DELETEd 244 durable rows (296 -> 52).
+    Intent has to be stated: refuse on 4029 and leave memory and DB untouched.
+    """
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "sure"},
+    ]
+    server._sessions["unconfirmed-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    def _submit(**extra):
+        return server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "unconfirmed-trunc-sid",
+                    "text": "an ordinary typed message",
+                    "truncate_before_user_ordinal": 2,
+                    **extra,
+                },
+            }
+        )
+
+    try:
+        resp = _submit()
+        assert resp["error"]["code"] == 4029
+        assert "confirm_truncate" in resp["error"]["message"]
+        # Explicit falsey values must not satisfy the opt-in either.
+        for falsey in (False, 0, "", "false", "no"):
+            assert _submit(confirm_truncate=falsey)["error"]["code"] == 4029, falsey
+        # confirm_empty_truncate is a different gate — it must not stand in for
+        # rewind intent on a cut that leaves the transcript non-empty.
+        assert _submit(confirm_empty_truncate=True)["error"]["code"] == 4029
+        session = server._sessions["unconfirmed-trunc-sid"]
+        assert session["history"] == history
+        assert session["history_version"] == 0
+        assert session["running"] is False
+        assert replaced == []
+    finally:
+        server._sessions.pop("unconfirmed-trunc-sid", None)
+
+
+def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
+    """A confirmed rewind still must not wipe a non-empty transcript by accident.
+
+    Ordinal 0 cuts at the first user message (history[:0] == []) and
+    replace_messages() would DELETE every durable row. Even a submit that
+    declares rewind intent needs the second opt-in for that edge.
     """
     replaced = []
 
@@ -4326,6 +4392,7 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                     "session_id": "empty-trunc-sid",
                     "text": "fresh typed message",
                     "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -4341,6 +4408,7 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                         "session_id": "empty-trunc-sid",
                         "text": "fresh typed message",
                         "truncate_before_user_ordinal": 0,
+                        "confirm_truncate": True,
                         "confirm_empty_truncate": falsey,
                     },
                 }
@@ -4411,6 +4479,7 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
                     "session_id": "confirm-empty-sid",
                     "text": "first",
                     "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
                     "confirm_empty_truncate": True,
                 },
             }
@@ -9295,6 +9364,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
                     "session_id": "sid",
                     "text": "edited second",
                     "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -9351,6 +9421,7 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
                     "session_id": "trunc-fail-sid",
                     "text": "edited second",
                     "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -9444,6 +9515,7 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
                     "session_id": "sid",
                     "text": "edited first",
                     "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
                 },
             }
         )

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -163,6 +163,31 @@ def _(rid, params: dict) -> dict:
             except (TypeError, ValueError):
                 return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
             history = session.get("history", [])
+            # An ordinal alone is not consent. A client that carries a leftover
+            # ordinal into an ORDINARY submit sends a request that is
+            # indistinguishable, field by field, from a real rewind — same
+            # method, same shape, an in-range target — and the cut it asks for
+            # is a destructive replace_messages() the user never requested
+            # (#80763: 296 -> 52 messages, 244 durable rows gone). Only the
+            # client knows whether this submit is a rewind/edit/regenerate, so
+            # it has to say so; refuse the cut when it doesn't.
+            if not is_truthy_value(params.get("confirm_truncate")):
+                logger.warning(
+                    "prompt.submit: REFUSED unconfirmed truncation of session %s "
+                    "(%d messages held; ordinal=%d). The client attached "
+                    "truncate_before_user_ordinal without confirm_truncate — "
+                    "likely a stale ordinal on an ordinary submit.",
+                    sid,
+                    len(history),
+                    ordinal,
+                )
+                return _err(
+                    rid,
+                    4029,
+                    "truncate_before_user_ordinal requires confirm_truncate=true; "
+                    "an ordinary prompt.submit must not drop session history "
+                    "(update your Hermes client if a rewind was intended)",
+                )
             user_indices = [
                 i for i, m in enumerate(history)
                 if m.get("role") == "user" and not m.get("display_kind")
@@ -175,12 +200,11 @@ def _(rid, params: dict) -> dict:
             if ordinal < 0 or ordinal >= len(user_indices):
                 return _err(rid, 4018, "target user message is no longer in session history")
             truncated = history[: user_indices[ordinal]]
-            # Stale clients can attach truncate_before_user_ordinal=0 to an
-            # ordinary submit. That resolves to history[:0] == [] and
-            # replace_messages() DELETEs every durable row — silent total
-            # transcript loss. Refuse the empty-truncation edge unless the
-            # client explicitly opts in (legitimate restore/regenerate of the
-            # first user turn).
+            # Second gate, on top of confirm_truncate: ordinal 0 resolves to
+            # history[:0] == [] and replace_messages() DELETEs every durable
+            # row. A confirmed rewind that happens to erase the whole
+            # transcript still needs its own opt-in (legitimate restore/
+            # regenerate of the first user turn).
             if (
                 not truncated
                 and history

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -57,6 +57,18 @@ terminal.resize         clipboard.paste         image.attach
 
 `session.active_list`, `session.activate`, and `session.close` are the process-local live-session controls used by the TUI session switcher. Use `session.list` / `/resume` for saved transcript discovery; use the active-session methods only for sessions that are currently open in the TUI gateway process.
 
+### Rewinding history on `prompt.submit`
+
+A rewind / edit / regenerate is a `prompt.submit` that drops part of the stored transcript before running the new turn. Because that write is a destructive rewrite of the session's durable rows, the gateway honors it only when the client states its intent:
+
+| Parameter | Meaning |
+|-----------|---------|
+| `truncate_before_user_ordinal` | Zero-based index of the user turn to cut at. Everything from that turn onward is dropped. Display-only timeline rows (`display_kind`) are not counted. |
+| `confirm_truncate` | Required whenever an ordinal is sent. Declares that this submit really is a rewind, not an ordinary send that happens to carry a leftover ordinal. |
+| `confirm_empty_truncate` | Additionally required when the cut would leave the transcript empty (ordinal `0`). |
+
+An ordinal without `confirm_truncate` is refused with code `4029` and nothing is written. Hosts that implement rewind must set the flag at the moment the user asks for it, and must never keep the ordinal in state across ordinary submits.
+
 ### Events streamed back
 
 `message.delta`, `message.complete`, `tool.start`, `tool.progress`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.


### PR DESCRIPTION
Fixes #80763.

## Summary

`prompt.submit` honored `truncate_before_user_ordinal` on every request. A client that carried a leftover ordinal into an **ordinary** send issued something the gateway could not tell apart from a real rewind — same method, same field shape, an in-range target — and the cut was applied with `replace_messages()`, which DELETEs the durable rows and drops them from FTS. The reporter lost 244 messages (296 → 52) across two days of work, with no confirmation and nothing to restore from.

The existing guard only covered the ordinal-0 edge, where the cut empties the transcript. A mid-session ordinal produced a non-empty result and sailed straight past it — which is exactly the shape both logged incidents had (`ordinal=2`, 296 → 52 and 53 → 52).

Nothing server-side can distinguish a stale ordinal from a deliberate rewind, because the two requests are identical. Only the client knows whether the user asked for a rewind, an edit, or a regenerate — so it now has to say so:

- **Gateway** (`tui_gateway/methods_prompt.py`): an ordinal without `confirm_truncate` is refused with code `4029`. The refusal is logged with the session and the size of the history it protected, and neither `session["history"]` nor the DB is touched. The `confirm_empty_truncate` gate stays on top of it for the whole-transcript edge.
- **Desktop** (`use-prompt-actions/rewind.ts`): `truncateSubmitParams` — the one place every rewind, edit, regenerate, and restore-checkpoint path builds these params — always sets the flag, so all four paths are covered by construction.

The guard fails closed on purpose. A desktop build older than this change loses rewind against a newer gateway and gets an actionable error, instead of silently deleting a conversation; for a destructive, unrecoverable write that is the right side to fail on.

Making the truncation itself reversible (the issue's suggestion 2 — soft-archive the dropped rows the way `archive_and_compact` does instead of DELETEing them) is worth doing and is deliberately not in this PR: it is a storage-layer change with its own retention and restore-UX questions, and it does not need to block closing the vector that caused the loss.

## Test plan

- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 519 passed.
  - New `test_prompt_submit_refuses_unconfirmed_nonempty_truncation` reproduces the report: a 6-message history, `ordinal=2` on an ordinary submit, no confirm flag. Asserts `4029`, that history / `history_version` / `running` are untouched, that `replace_messages` was never called, that falsey confirm values do not satisfy the opt-in, and that `confirm_empty_truncate` cannot stand in for rewind intent on a non-empty cut.
  - Existing truncation tests now send `confirm_truncate` and still pass, so edit / regenerate / display_kind-skipping / persist-failure behavior is unchanged for a confirmed rewind.
- `npx vitest run src/app/session` in `apps/desktop` — 443 passed. `rewind.test.ts` asserts no ordinal is ever built without the flag; the three `index.test.tsx` restore-checkpoint assertions cover the full wire params.
- `npm run typecheck` in `apps/desktop` — clean.