### PR TITLE
fix: dispatch cronjob(action='run') to the background like delegate_task

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -363,6 +363,35 @@ def get_running_job_ids() -> "frozenset[str]":
         return frozenset(_running_job_ids)
 
 
+def try_register_running_job(job_id: str) -> bool:
+    """Atomically add ``job_id`` to the in-flight running set.
+
+    Returns False (without registering) when the job is already mid-run —
+    the caller must skip the fire. This is the single dedupe owner shared by
+    the ticker's ``_submit_with_guard`` and manual runs
+    (``tools/cronjob_tools``): the fire claim alone cannot prevent a
+    double-fire because its TTL (300s) is routinely outlived by real jobs,
+    after which a manual ``cronjob(action='run')`` would claim successfully
+    and run the same job concurrently (idea from #53395 by @izumi0uu).
+
+    Registration also makes the run visible to ``get_running_job_ids`` (the
+    gateway shutdown drain, #60432) and ``mark_running_jobs_interrupted``.
+    Callers MUST pair a successful registration with
+    ``release_running_job`` in a ``finally`` block.
+    """
+    with _running_lock:
+        if job_id in _running_job_ids:
+            return False
+        _running_job_ids.add(job_id)
+        return True
+
+
+def release_running_job(job_id: str) -> None:
+    """Remove ``job_id`` from the in-flight running set (idempotent)."""
+    with _running_lock:
+        _running_job_ids.discard(job_id)
+
+
 def mark_running_jobs_interrupted(reason: str) -> list:
     """Best-effort: mark every currently in-flight cron job interrupted.
 
@@ -4288,11 +4317,9 @@ def tick(
                     job.get("name", job_id),
                 )
                 return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                    return None
-                _running_job_ids.add(job_id)
+            if not try_register_running_job(job_id):
+                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                return None
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
             execution = create_execution(job_id, source="builtin")
@@ -4303,14 +4330,12 @@ def tick(
                 try:
                     return ctx.run(_process_job, j)
                 finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
+                    release_running_job(j["id"])
 
             try:
                 return pool.submit(_run_and_release)
             except Exception as submit_err:
-                with _running_lock:
-                    _running_job_ids.discard(job_id)
+                release_running_job(job_id)
                 finish_execution(
                     execution["id"],
                     success=False,

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -26,6 +26,18 @@ _JOB = {"id": "job-bg-1", "name": "bg run", "prompt": "hi",
         "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
 
 
+def _job(job_id):
+    """Per-test job dict with a UNIQUE id.
+
+    Background workers outlive their test (daemon executor) and hold the id
+    in the scheduler's shared running set until the run finishes; reusing one
+    id across tests makes the in-flight dedupe guard see a phantom
+    'already running' from a previous test's straggler worker.
+    """
+    return {"id": job_id, "name": f"bg run {job_id}", "prompt": "hi",
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
+
+
 def _bound_session_key(key="agent:main:telegram:dm:123"):
     """Context manager binding the approval session key contextvar."""
     import contextlib
@@ -59,7 +71,7 @@ class TestBackgroundDispatch:
                  patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-01'))
 
         try:
             # Returned BEFORE the job finished — that's the whole point.
@@ -67,7 +79,7 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-1")
+            m_claim.assert_called_once_with("job-bg-01")
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -88,7 +100,7 @@ class TestBackgroundDispatch:
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
                                      "next_run_at": "2026-08-07T09:00:00"}):
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-02'))
                 assert res["dispatched"] is True
 
                 found = None
@@ -121,7 +133,7 @@ class TestBackgroundDispatch:
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "error",
                                      "last_error": "provider exploded"}):
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-03'))
                 assert res["dispatched"] is True
 
                 found = None
@@ -148,7 +160,7 @@ class TestBackgroundDispatch:
                  patch("tools.cronjob_tools.get_job",
                        return_value={**_JOB, "enabled": False}), \
                  patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-04'))
         assert res["claimed"] is False
         assert "paused/disabled" in res["error"]
         m_disp.assert_not_called()
@@ -157,7 +169,7 @@ class TestBackgroundDispatch:
 class TestSyncFallbacks:
     def test_no_session_key_falls_back_to_sync(self):
         """Direct Python callers (no agent session) keep the sync path."""
-        res = _try_dispatch_background_run(dict(_JOB))
+        res = _try_dispatch_background_run(_job('job-bg-05'))
         assert res is None
 
     def test_async_delivery_unsupported_falls_back_to_sync(self):
@@ -165,7 +177,7 @@ class TestSyncFallbacks:
         with _bound_session_key():
             with patch("gateway.session_context.async_delivery_supported",
                        return_value=False):
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-06'))
         assert res is None
 
     def test_pool_at_capacity_runs_inline(self):
@@ -177,23 +189,101 @@ class TestSyncFallbacks:
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
-                res = _try_dispatch_background_run(dict(_JOB))
+                res = _try_dispatch_background_run(_job('job-bg-07'))
         assert res["dispatched"] is False
         assert res["success"] is True
         m_run.assert_called_once()   # ran inline on this thread
+
+
+class TestInFlightDedupe:
+    """Manual runs must not double-fire a job that is already mid-run
+    (salvaged from #53395 by @izumi0uu): the fire claim's 300s TTL is
+    routinely outlived by real jobs, so the claim alone can't prevent it."""
+
+    def test_run_claimed_job_skips_when_already_running(self):
+        """The authoritative guard: _run_claimed_job refuses to fire a job
+        whose id is already registered in the scheduler running set."""
+        from cron import scheduler as sched
+        from tools.cronjob_tools import _run_claimed_job
+
+        assert sched.try_register_running_job("job-bg-08")   # simulate ticker mid-run
+        try:
+            with patch("cron.scheduler.run_one_job") as m_run:
+                res = _run_claimed_job(_job('job-bg-08'))
+            assert res["success"] is False
+            assert "already running" in res["error"]
+            m_run.assert_not_called()
+        finally:
+            sched.release_running_job("job-bg-08")
+
+    def test_run_claimed_job_registers_and_releases(self):
+        """A normal run holds the registration for run_one_job's duration and
+        releases it after — visible to get_running_job_ids mid-run."""
+        from cron import scheduler as sched
+        from tools.cronjob_tools import _run_claimed_job
+
+        seen_during_run = {}
+
+        def probe_run(job):
+            seen_during_run["registered"] = "job-bg-09" in sched.get_running_job_ids()
+            return True
+
+        with patch("cron.scheduler.run_one_job", side_effect=probe_run), \
+             patch("tools.cronjob_tools.get_job",
+                   return_value={"last_status": "ok", "last_error": None}):
+            res = _run_claimed_job(_job('job-bg-09'))
+
+        assert res["success"] is True
+        assert seen_during_run["registered"] is True
+        assert "job-bg-09" not in sched.get_running_job_ids()   # released after
+
+    def test_background_dispatch_reports_running_job_immediately(self):
+        """The dispatch path pre-checks the running set so a mid-run job
+        reports in the tool response, not as a delayed completion event."""
+        from cron import scheduler as sched
+
+        assert sched.try_register_running_job("job-bg-10")
+        try:
+            with _bound_session_key():
+                with patch("tools.cronjob_tools.claim_job_for_fire") as m_claim, \
+                     patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
+                    res = _try_dispatch_background_run(_job('job-bg-10'))
+            assert res["claimed"] is False
+            assert "already running" in res["error"]
+            m_claim.assert_not_called()   # no claim consumed for a skipped run
+            m_disp.assert_not_called()
+        finally:
+            sched.release_running_job("job-bg-10")
+
+    def test_ticker_guard_uses_shared_helpers(self):
+        """The ticker's _submit_with_guard and manual runs share ONE dedupe
+        owner: registration through either side blocks the other."""
+        from cron import scheduler as sched
+
+        # Manual-run registration…
+        assert sched.try_register_running_job("job-shared-1")
+        try:
+            # …is exactly what the ticker-side helper consults.
+            assert not sched.try_register_running_job("job-shared-1")
+            assert "job-shared-1" in sched.get_running_job_ids()
+        finally:
+            sched.release_running_job("job-shared-1")
+        assert "job-shared-1" not in sched.get_running_job_ids()
+        # Idempotent release: never raises on a non-member.
+        sched.release_running_job("job-shared-1")
 
 
 class TestCronjobRunToolIntegration:
     def test_run_action_returns_background_note(self):
         """cronjob(action='run') surfaces the handle + do-not-wait note."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+            with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-12')), \
                  patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"id": "job-bg-1", "name": "bg run",
+                       return_value={"id": "job-bg-12", "name": "bg run",
                                      "last_status": "ok", "last_error": None}):
-                out = json.loads(cronjob(action="run", job_id="job-bg-1"))
+                out = json.loads(cronjob(action="run", job_id="job-bg-12"))
 
         assert out["success"] is True
         assert out["job"]["executed"] is True
@@ -205,14 +295,14 @@ class TestCronjobRunToolIntegration:
         """No session context → the legacy synchronous behavior (executed +
         execution_success populated from the completed run)."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-13')), \
              patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
-            out = json.loads(cronjob(action="run", job_id="job-bg-1"))
+            out = json.loads(cronjob(action="run", job_id="job-bg-13"))
 
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-1")
+        m_claim.assert_called_once_with("job-bg-13")
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -1,0 +1,218 @@
+"""Tests for cronjob action='run' background dispatch.
+
+A manual `cronjob(action='run')` used to execute the job synchronously on the
+calling agent's tool thread — a full agent run (minutes to hours) inside ONE
+tool call, uninterruptible and serial. It now dispatches through the async
+delegation registry (same rail as delegate_task background mode): the tool
+returns immediately with a handle and the run's outcome re-enters the
+conversation as a type='async_delegation' completion event.
+
+Sync fallbacks preserved:
+  - no routable session (direct Python callers, `hermes cron run`)
+  - async delivery unsupported (one-shot runners, cron child sessions)
+  - dispatch pool at capacity (claim already taken — must not strand it)
+"""
+import json
+import threading
+from unittest.mock import patch
+
+from tools.cronjob_tools import (
+    _try_dispatch_background_run,
+    cronjob,
+)
+
+
+_JOB = {"id": "job-bg-1", "name": "bg run", "prompt": "hi",
+        "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
+
+
+def _bound_session_key(key="agent:main:telegram:dm:123"):
+    """Context manager binding the approval session key contextvar."""
+    import contextlib
+
+    from tools.approval import _approval_session_key
+
+    @contextlib.contextmanager
+    def _cm():
+        token = _approval_session_key.set(key)
+        try:
+            yield
+        finally:
+            _approval_session_key.reset(token)
+
+    return _cm()
+
+
+class TestBackgroundDispatch:
+    def test_dispatches_and_returns_handle_immediately(self):
+        """With a routable session, run claims sync then dispatches async."""
+        run_started = threading.Event()
+        run_release = threading.Event()
+
+        def slow_run_one_job(job):
+            run_started.set()
+            assert run_release.wait(timeout=5.0)
+            return True
+
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+                 patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _try_dispatch_background_run(dict(_JOB))
+
+        try:
+            # Returned BEFORE the job finished — that's the whole point.
+            assert res is not None
+            assert res["claimed"] is True
+            assert res["dispatched"] is True
+            assert res["delegation_id"]
+            m_claim.assert_called_once_with("job-bg-1")
+            # The job actually starts on the daemon executor.
+            assert run_started.wait(timeout=5.0), "job never started in background"
+        finally:
+            run_release.set()
+
+    def test_completion_event_reaches_shared_queue(self):
+        """The finished run pushes a type='async_delegation' event carrying
+        the job outcome onto process_registry.completion_queue."""
+        import time
+
+        from tools.process_registry import process_registry
+
+        # The runner executes on a daemon thread — the patches must stay
+        # active until the completion event lands, so poll INSIDE the blocks.
+        with _bound_session_key("agent:main:telegram:dm:777"):
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_one_job", return_value=True), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None,
+                                     "next_run_at": "2026-08-07T09:00:00"}):
+                res = _try_dispatch_background_run(dict(_JOB))
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if (evt.get("type") == "async_delegation"
+                            and evt.get("delegation_id") == res["delegation_id"]):
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+        assert found is not None, "completion event never reached the queue"
+        assert found["session_key"] == "agent:main:telegram:dm:777"
+        assert found["status"] == "completed"
+        assert "bg run" in (found.get("summary") or "")
+        assert "Next scheduled run" in found["summary"]
+
+    def test_failed_run_reports_error_status_in_event(self):
+        import time
+
+        from tools.process_registry import process_registry
+
+        with _bound_session_key("agent:main:telegram:dm:778"):
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_one_job", return_value=True), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "error",
+                                     "last_error": "provider exploded"}):
+                res = _try_dispatch_background_run(dict(_JOB))
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+        assert found is not None
+        assert found["status"] == "error"
+        assert "provider exploded" in (found.get("error") or "")
+
+    def test_claim_lost_reports_immediately_without_dispatch(self):
+        """Paused/already-firing jobs report in the tool response, not as a
+        delayed completion event."""
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={**_JOB, "enabled": False}), \
+                 patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
+                res = _try_dispatch_background_run(dict(_JOB))
+        assert res["claimed"] is False
+        assert "paused/disabled" in res["error"]
+        m_disp.assert_not_called()
+
+
+class TestSyncFallbacks:
+    def test_no_session_key_falls_back_to_sync(self):
+        """Direct Python callers (no agent session) keep the sync path."""
+        res = _try_dispatch_background_run(dict(_JOB))
+        assert res is None
+
+    def test_async_delivery_unsupported_falls_back_to_sync(self):
+        """One-shot runtimes (hermes -z, cron child, Kanban) keep sync."""
+        with _bound_session_key():
+            with patch("gateway.session_context.async_delivery_supported",
+                       return_value=False):
+                res = _try_dispatch_background_run(dict(_JOB))
+        assert res is None
+
+    def test_pool_at_capacity_runs_inline(self):
+        """A rejected dispatch must not strand the already-taken claim."""
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.async_delegation.dispatch_async_delegation",
+                       return_value={"status": "rejected", "error": "capacity"}), \
+                 patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _try_dispatch_background_run(dict(_JOB))
+        assert res["dispatched"] is False
+        assert res["success"] is True
+        m_run.assert_called_once()   # ran inline on this thread
+
+
+class TestCronjobRunToolIntegration:
+    def test_run_action_returns_background_note(self):
+        """cronjob(action='run') surfaces the handle + do-not-wait note."""
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+                 patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_one_job", return_value=True), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"id": "job-bg-1", "name": "bg run",
+                                     "last_status": "ok", "last_error": None}):
+                out = json.loads(cronjob(action="run", job_id="job-bg-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_mode"] == "background"
+        assert out["job"]["delegation_id"]
+        assert "background" in out["note"]
+
+    def test_run_action_sync_path_unchanged_without_session(self):
+        """No session context → the legacy synchronous behavior (executed +
+        execution_success populated from the completed run)."""
+        ran = {"job": "after-run", "last_status": "ok", "last_error": None}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=ran):
+            out = json.loads(cronjob(action="run", job_id="job-bg-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is True
+        m_claim.assert_called_once_with("job-bg-1")
+        m_run.assert_called_once()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -607,8 +607,6 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     """
     job_id = job["id"]
     try:
-        from cron.scheduler import run_one_job
-
         # At-most-once claim: bail without running if a tick/other fire owns it.
         if not claim_job_for_fire(job_id):
             # claim_job_for_fire returns False for paused/disabled/missing
@@ -623,6 +621,30 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
             return {"claimed": False, "success": False, "error": reason}
+    except Exception as e:
+        logger.error("Failed to claim cron job %s for immediate run: %s", job_id, e)
+        try:
+            mark_job_run(job_id, False, str(e))
+        except Exception:
+            pass
+        return {"claimed": True, "success": False, "error": str(e)}
+
+    return _run_claimed_job(job)
+
+
+def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Fire an already-claimed job through the shared ``run_one_job`` body.
+
+    Split out of ``_execute_job_now`` so the background dispatch path
+    (``_try_dispatch_background_run``) can take the claim synchronously — so
+    the tool response can report "paused"/"already firing" immediately — and
+    hand the actual run to a daemon worker.
+
+    Returns {"claimed": True, "success": bool, "error": str|None}.
+    """
+    job_id = job["id"]
+    try:
+        from cron.scheduler import run_one_job
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
@@ -707,6 +729,219 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         return {"claimed": True, "success": False, "error": str(e)}
 
 
+def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
+    """Best-effort excerpt of the job's most recent saved output file.
+
+    Included in the background-run completion block so the parent agent sees
+    what the job actually produced without having to dig through
+    ``~/.hermes/cron/output/``. Never raises.
+    """
+    try:
+        from cron.jobs import get_cron_output_dir
+
+        out_dir = get_cron_output_dir() / job_id
+        files = sorted(out_dir.glob("*.md"))
+        if not files:
+            return None
+        text = files[-1].read_text(encoding="utf-8", errors="replace").strip()
+        if not text:
+            return None
+        if len(text) > max_chars:
+            text = text[:max_chars] + f"\n… (truncated; full output: {files[-1]})"
+        return text
+    except Exception:
+        return None
+
+
+def _try_dispatch_background_run(
+    job: Dict[str, Any], session_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Claim ``job`` now, then fire it on the async-delegation daemon executor.
+
+    A manual ``cronjob(action='run')`` used to execute the job synchronously
+    on the calling agent's tool thread. A cron job is a full agent run that
+    routinely takes minutes-to-hours, so the parent turn sat inside ONE tool
+    call the whole time: uninterruptible (the interrupt flag is only checked
+    between loop iterations) and serial (a batch of runs executed one by one).
+
+    This dispatches the run like ``delegate_task``'s background mode: the tool
+    returns immediately with a handle, the run executes on the shared async
+    daemon executor, and a ``type="async_delegation"`` completion event
+    re-enters the conversation as a fresh turn when the job finishes — riding
+    the existing completion-queue rail (CLI drain + gateway watcher), which
+    keeps message-role alternation legal and the prompt cache intact.
+
+    The at-most-once claim is taken SYNCHRONOUSLY before dispatch so
+    unrunnable jobs (paused / missing / already firing) report in the tool
+    response immediately instead of as a delayed completion event.
+
+    Returns
+    -------
+    None
+        Background delivery unavailable on this session runtime (one-shot
+        ``hermes -z``, stateless HTTP, Kanban worker, nested cron run).
+        Caller falls back to the synchronous path unchanged.
+    dict
+        ``{"claimed": False, "success": False, "error": ...}`` — claim lost;
+        same shape as ``_execute_job_now`` so the caller's existing response
+        formatting applies.
+        ``{"claimed": True, "dispatched": True, "delegation_id": ...}`` —
+        run is executing in the background.
+        ``{"claimed": True, "dispatched": False, "success": ..., "error": ...}``
+        — dispatch pool was at capacity; the run executed inline (the claim
+        was already taken and must not be stranded).
+    """
+    # Finite sessions cannot route a detached result back after the turn
+    # ends — mirror delegate_task's gate and fall back to sync execution.
+    try:
+        from gateway.session_context import async_delivery_supported
+
+        if not async_delivery_supported():
+            return None
+    except Exception:
+        pass
+
+    job_id = job["id"]
+    job_name = str(job.get("name") or job_id)
+
+    # ---- routing capture (on THIS thread; contextvars don't cross the pool) ----
+    # Resolved BEFORE the claim: with no routable session there is no durable
+    # consumer for a detached completion, so we must not claim-and-dispatch.
+    try:
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="")
+    except Exception:
+        session_key = ""
+    if not session_key and session_id:
+        # CLI path: the approval contextvar is only bound during gateway/TUI
+        # turns. The CLI drain filters completions by the durable agent
+        # session id (#64240), so stamp it as the key — an empty key would
+        # fail closed and the completion could never be claimed.
+        session_key = str(session_id)
+    if not session_key:
+        # Direct Python callers (`hermes cron run`, tests) have no agent
+        # session to deliver a completion to — the process exits right after
+        # the tool returns. Run synchronously.
+        return None
+
+    # ---- synchronous claim (same semantics as _execute_job_now) ----
+    try:
+        if not claim_job_for_fire(job_id):
+            refreshed = get_job(job_id)
+            if refreshed is None:
+                reason = "Job no longer exists; nothing to run."
+            elif not refreshed.get("enabled", True) or refreshed.get("state") == "paused":
+                reason = "Job is paused/disabled; resume it before running."
+            else:
+                reason = "Job is already being fired by the scheduler; not run again."
+            return {"claimed": False, "success": False, "error": reason}
+    except Exception as e:
+        logger.error("Failed to claim cron job %s for background run: %s", job_id, e)
+        try:
+            mark_job_run(job_id, False, str(e))
+        except Exception:
+            pass
+        return {"claimed": True, "dispatched": False, "success": False, "error": str(e)}
+
+    origin_ui_session_id = ""
+    try:
+        from gateway.session_context import get_session_env
+
+        origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "") or ""
+    except Exception:
+        pass
+
+    try:
+        from tools.async_delegation import (
+            _current_origin_session_id,
+            dispatch_async_delegation,
+        )
+
+        origin_session_id = _current_origin_session_id()
+    except Exception as e:
+        logger.warning(
+            "cronjob run: async delegation registry unavailable (%s); "
+            "running job '%s' inline.", e, job_name,
+        )
+        result = _run_claimed_job(job)
+        result["dispatched"] = False
+        return result
+
+    try:
+        from tools.delegate_tool import _get_max_async_children
+
+        max_async = _get_max_async_children()
+    except Exception:
+        max_async = 3
+
+    started_at = time.time()
+    deliver = job.get("deliver", "local")
+
+    def _runner() -> Dict[str, Any]:
+        res = _run_claimed_job(job)
+        duration = round(time.time() - started_at, 2)
+        refreshed = get_job(job_id) or {}
+        lines = [
+            f"Cron job '{job_name}' ({job_id}) finished its manual run.",
+            f"Result: {'ok' if res.get('success') else 'FAILED'}"
+            + (f" — {res.get('error')}" if res.get("error") else ""),
+            f"Delivery target: {deliver}"
+            + (
+                " (output was delivered there by the job itself)"
+                if deliver != "local"
+                else " (output saved locally only)"
+            ),
+        ]
+        if refreshed.get("next_run_at"):
+            lines.append(f"Next scheduled run: {refreshed['next_run_at']}")
+        excerpt = _latest_job_output_excerpt(job_id)
+        if excerpt:
+            lines.append("--- JOB OUTPUT ---")
+            lines.append(excerpt)
+        return {
+            "status": "completed" if res.get("success") else "error",
+            "summary": "\n".join(lines),
+            "error": res.get("error"),
+            "api_calls": 0,
+            "duration_seconds": duration,
+        }
+
+    dispatch = dispatch_async_delegation(
+        goal=f"Manual run of cron job '{job_name}' ({job_id})",
+        context=(
+            "Triggered via cronjob(action='run'). The job executed in its own "
+            "fresh cron session; this block reports its outcome."
+        ),
+        toolsets=None,
+        role="cron_run",
+        model=job.get("model"),
+        session_key=session_key,
+        parent_session_id=str(session_id) if session_id else None,
+        runner=_runner,
+        origin_ui_session_id=origin_ui_session_id,
+        origin_session_id=origin_session_id,
+        max_async_children=max_async,
+    )
+
+    if dispatch.get("status") == "dispatched":
+        return {
+            "claimed": True,
+            "dispatched": True,
+            "delegation_id": dispatch.get("delegation_id"),
+        }
+
+    # Pool at capacity (or submit failure): the claim is already taken and
+    # must not be stranded — run inline exactly as the legacy path did.
+    logger.info(
+        "cronjob run: background pool unavailable (%s); running job '%s' inline.",
+        dispatch.get("error", "rejected"), job_name,
+    )
+    result = _run_claimed_job(job)
+    result["dispatched"] = False
+    return result
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -729,6 +964,7 @@ def cronjob(
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     task_id: str = None,
+    session_id: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -889,10 +1125,42 @@ def cronjob(
         if normalized in {"run", "run_now", "trigger"}:
             # Execute the job immediately rather than only scheduling it for the
             # next scheduler tick — a manual `run` should actually run, even when
-            # no gateway/ticker is active (the #41037 case). The claim inside
-            # _execute_job_now advances next_run_at and blocks a concurrent tick
-            # from double-firing.
-            exec_result = _execute_job_now(job)
+            # no gateway/ticker is active (the #41037 case). The claim (taken
+            # inside both paths below) advances next_run_at and blocks a
+            # concurrent tick from double-firing.
+            #
+            # Preferred path: dispatch the run to the background like
+            # delegate_task — the tool returns a handle immediately and the
+            # job's outcome re-enters the conversation as a completion event.
+            # A cron job is a full agent run (minutes to hours); executing it
+            # inline made the parent turn uninterruptible and serialized
+            # batches of manual runs (#80xxx — the "stuck Telegram session"
+            # incident). Falls back to inline execution when the session
+            # runtime can't receive detached completions.
+            bg = _try_dispatch_background_run(job, session_id=session_id)
+            if bg is not None and bg.get("dispatched"):
+                _notify_provider_jobs_changed_safe()
+                result = _format_job(get_job(job_id) or {"id": job_id})
+                result["executed"] = True
+                result["execution_mode"] = "background"
+                result["delegation_id"] = bg.get("delegation_id")
+                return json.dumps(
+                    {
+                        "success": True,
+                        "job": result,
+                        "note": (
+                            "The job is running in the background. You and the "
+                            "user can keep working; its outcome re-enters the "
+                            "conversation as a new message when it finishes. "
+                            "Do not wait or poll — just continue."
+                        ),
+                    },
+                    indent=2,
+                )
+            # bg carries a terminal result (claim lost, or inline fallback
+            # after pool rejection); None means background delivery is
+            # unsupported here — run synchronously as before.
+            exec_result = bg if bg is not None else _execute_job_now(job)
             # A claimed direct run advances next_run_at and may race the
             # external one-shot for the same occurrence. If Chronos loses that
             # claim, its consumed fire cannot re-arm itself; reconcile from the
@@ -1031,6 +1299,8 @@ CRONJOB_SCHEMA = {
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
+
+action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
@@ -1185,6 +1455,7 @@ registry.register(
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
         task_id=kw.get("task_id"),
+        session_id=kw.get("session_id"),
     ),
     check_fn=check_cronjob_requirements,
     emoji="⏰",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -643,8 +643,31 @@ def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
     Returns {"claimed": True, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    _registered = False
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import (
+            release_running_job,
+            run_one_job,
+            try_register_running_job,
+        )
+
+        # In-flight dedupe (idea from #53395 by @izumi0uu): the fire claim's
+        # TTL (300s) is routinely outlived by real jobs, so it alone cannot
+        # stop a manual run from double-firing a job the ticker (or another
+        # manual run) is still executing. Register in the scheduler's shared
+        # running set — the same guard _submit_with_guard uses — which also
+        # makes this run visible to the gateway shutdown drain
+        # (get_running_job_ids, #60432) and mark_running_jobs_interrupted.
+        if not try_register_running_job(job_id):
+            return {
+                "claimed": True,
+                "success": False,
+                "error": (
+                    "Job is already running (a scheduler tick or another "
+                    "manual run is executing it); not started again."
+                ),
+            }
+        _registered = True
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
@@ -707,11 +730,15 @@ def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
             _heartbeat_thread.start()
 
         try:
-            processed = run_one_job(job)
+            try:
+                processed = run_one_job(job)
+            finally:
+                _heartbeat_stop.set()
+                if _heartbeat_thread is not None:
+                    _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
         finally:
-            _heartbeat_stop.set()
-            if _heartbeat_thread is not None:
-                _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
+            _registered = False
+            release_running_job(job_id)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {
@@ -722,6 +749,17 @@ def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
+        if _registered:
+            # Registration succeeded but we raised before the run's own
+            # release ran (e.g. heartbeat setup) — don't leave the job
+            # permanently marked in-flight. Only release registrations WE
+            # took: a bare discard here could erase a ticker-owned entry.
+            try:
+                from cron.scheduler import release_running_job as _release
+
+                _release(job_id)
+            except Exception:
+                pass
         try:
             mark_job_run(job_id, False, str(e))
         except Exception:
@@ -827,6 +865,25 @@ def _try_dispatch_background_run(
 
     # ---- synchronous claim (same semantics as _execute_job_now) ----
     try:
+        # Best-effort early dedupe so a mid-run job reports in THIS tool
+        # response instead of as a delayed error completion event. The
+        # authoritative (atomic) check is try_register_running_job inside
+        # _run_claimed_job on the worker.
+        try:
+            from cron.scheduler import get_running_job_ids
+
+            if job_id in get_running_job_ids():
+                return {
+                    "claimed": False,
+                    "success": False,
+                    "error": (
+                        "Job is already running (a scheduler tick or another "
+                        "manual run is executing it); not started again."
+                    ),
+                }
+        except Exception:
+            pass
+
         if not claim_job_for_fire(job_id):
             refreshed = get_job(job_id)
             if refreshed is None:


### PR DESCRIPTION
## Summary
`cronjob(action='run')` now dispatches the job to the background like `delegate_task`: the tool call returns immediately with a handle, and the job's outcome re-enters the conversation as a completion event when it finishes. Manual runs also gain in-flight dedupe shared with the scheduler ticker (salvaged from #53395 by @izumi0uu).

Root cause of the incident this fixes: a manual run executed the full cron job (a complete agent run, minutes to hours) synchronously inside ONE tool call on the calling agent's thread. The parent turn was uninterruptible for the whole window (the interrupt flag is only checked between loop iterations) and a batch of manual runs executed strictly serially — a Telegram session that kicked off dozens of new jobs "right now" was wedged for hours ignoring every interrupt. Reported earlier as #52705 (first fix attempt by @Tranquil-Flow in #52720).

## Changes
- `tools/cronjob_tools.py`:
  - `_execute_job_now()` split into claim + `_run_claimed_job()` halves (behavior unchanged).
  - New `_try_dispatch_background_run()`: takes the at-most-once claim synchronously (paused / missing / already-firing / already-running still report immediately in the tool response), then fires the run through `tools.async_delegation.dispatch_async_delegation` on the shared daemon executor. Completion rides the existing `process_registry.completion_queue` rail (CLI drain + gateway `_async_delegation_watcher`) — role alternation and prompt cache preserved, zero new drain loops.
  - Completion block reports ok/failure, delivery target, next scheduled run, and an excerpt of the job's saved output.
  - Sync fallbacks preserved: no routable session (direct Python callers / `hermes cron run`), `async_delivery_supported()` false (one-shot runners, cron child sessions, Kanban workers, stateless HTTP), and dispatch pool at capacity (claim already taken — runs inline rather than stranding it).
- `cron/scheduler.py` (salvaged from #53395, credited via co-author):
  - Running-set dedupe extracted into shared `try_register_running_job()` / `release_running_job()`; the ticker's `_submit_with_guard` and manual runs now use ONE owner. The fire claim's 300s TTL is routinely outlived by real jobs, so the claim alone couldn't stop a manual run from double-firing a mid-run job.
  - Manual runs become visible to `get_running_job_ids()` (gateway shutdown drain, #60432) and `mark_running_jobs_interrupted()`, which previously couldn't see them.
- `tests/tools/test_cronjob_run_background.py`: 13 tests — immediate return with handle, completion event on the shared queue (ok + failure), claim-lost immediate report, all three sync fallbacks, in-flight dedupe (both directions + release), tool-level integration for both modes.

## Validation
| | Before | After |
|---|---|---|
| Tool call duration (job takes 0.5s) | 0.5s+ (blocks) | 0.04s (returns handle) |
| Parent turn during job | uninterruptible | free; interrupts work |
| Batch of N manual runs | serial | parallel (async pool) |
| Job outcome | inline tool result | completion event, new turn |
| Manual run of a mid-run job | double-fires after claim TTL (300s) | refused: "already running" |
| Shutdown drain sees manual runs | no | yes (shared running set) |
| `hermes cron run` / one-shot runtimes | sync | sync (unchanged) |

E2E: real job store in temp `HERMES_HOME`, real `run_one_job` body (agent-run boundary stubbed with the real 4-tuple signature) — tool returns in 0.04s, completion event lands with correct `session_key`/status/output excerpt, `last_status` persisted; second manual run while the first is mid-flight is refused immediately and the running set is empty after completion. Targeted suites: 501/501 passing (`tests/cron/` + all cronjob tool tests + shutdown-interrupt/execution-ledger).

## Infographic

![cron run background dispatch](https://v3b.fal.media/files/b/0aa55715/z_DQU_Cri78sqqnsoCMXS_spn11EZR.png)
