### PR TITLE
fix(agent): keep final-call steers in the active turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -218,6 +218,30 @@ def _is_copilot_provider(agent: Any) -> bool:
         }
 
 
+def _append_late_steer_continuation(
+    agent: Any,
+    messages: list,
+    final_msg: dict,
+) -> Optional[str]:
+    """Keep a steer from the final model call inside the active run.
+
+    Returns the drained steer text when the loop must continue, otherwise
+    atomically closes steer intake and returns ``None``.
+    """
+    late_steer = agent._drain_pending_steer_or_close()
+    if not late_steer:
+        return None
+    agent._emit_interim_assistant_message(final_msg)
+    messages.append(final_msg)
+    messages.append({"role": "user", "content": late_steer})
+    agent._session_messages = messages
+    # The would-be final call may have consumed the ordinary iteration budget.
+    # Reserve Hermes' existing one-call grace path so the model is guaranteed
+    # one chance to answer the accepted steer inside this same run.
+    agent._budget_grace_call = True
+    return late_steer
+
+
 def _is_stale_copilot_credential_error(status_code: Optional[int], error_message: str) -> bool:
     """Detect a Copilot 400 that is really a STALE / DEGRADED credential.
 
@@ -1347,6 +1371,14 @@ def run_conversation(
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
+    # Cached gateway agents are reused across turns. Re-open steer intake for
+    # this run; the previous final response closed only its own turn.
+    _steer_lock = getattr(agent, "_pending_steer_lock", None)
+    if _steer_lock is None:
+        agent._accepting_steer = True
+    else:
+        with _steer_lock:
+            agent._accepting_steer = True
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -7203,6 +7235,25 @@ def run_conversation(
                         agent._interim_content_was_streamed(final_response or "")
                     )
                     final_response = None
+                    continue
+
+                # A steer can arrive while the model is composing what would
+                # otherwise be the final assistant response. Keep it in this
+                # run: commit that response as interim context, append the
+                # correction as a real user message, and continue. The atomic
+                # drain/close shares steer()'s lock, eliminating the old
+                # accepted-here/replayed-next-turn teardown race.
+                _late_steer = _append_late_steer_continuation(
+                    agent, messages, final_msg
+                )
+                if _late_steer:
+                    if isinstance(original_user_message, str):
+                        original_user_message = (
+                            f"{original_user_message}\n\n"
+                            f"User steering during the turn: {_late_steer}"
+                        )
+                    final_response = None
+                    logger.info("Late steer continued inside active turn")
                     continue
 
                 messages.append(final_msg)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3256,11 +3256,38 @@ class AIAgent:
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
             return True
         with _lock:
+            # Once the conversation loop has atomically committed its final
+            # assistant response, this agent no longer owns a live turn. Do not
+            # accept text into a slot that can only replay as a later user turn.
+            if getattr(self, "_accepting_steer", True) is False:
+                return False
             if self._pending_steer:
                 self._pending_steer = self._pending_steer + "\n" + cleaned
             else:
                 self._pending_steer = cleaned
         return True
+
+    def _drain_pending_steer_or_close(self) -> Optional[str]:
+        """Drain a final-call steer, or atomically close steer intake.
+
+        The final assistant response and ``steer()`` race on the same lock.
+        If the steer wins, the loop continues the current run. If finalization
+        wins, later steers are rejected rather than accepted and replayed as a
+        new turn.
+        """
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            text = getattr(self, "_pending_steer", None)
+            self._pending_steer = None
+            if not text:
+                self._accepting_steer = False
+            return text
+        with _lock:
+            text = self._pending_steer
+            self._pending_steer = None
+            if not text:
+                self._accepting_steer = False
+        return text
 
     def redirect(self, text: str) -> bool:
         """Redirect the active turn without converting it into a new task.

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -23,6 +23,7 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
+    agent._accepting_steer = True
     agent._pending_redirect = None
     agent._pending_redirect_lock = threading.Lock()
     agent._model_request_active = threading.Event()
@@ -48,6 +49,48 @@ class TestSteerAcceptance:
         agent = _bare_agent()
         assert agent.steer("go ahead and check the logs") is True
         assert agent._pending_steer == "go ahead and check the logs"
+
+    def test_final_response_atomically_closes_steer_intake(self):
+        agent = _bare_agent()
+
+        assert agent._drain_pending_steer_or_close() is None
+        assert agent.steer("too late") is False
+        assert agent._pending_steer is None
+
+    def test_final_call_steer_is_drained_without_closing_intake(self):
+        agent = _bare_agent()
+        assert agent.steer("check the migration too") is True
+
+        assert agent._drain_pending_steer_or_close() == "check the migration too"
+        assert agent.steer("and the rollback") is True
+        assert agent._pending_steer == "and the rollback"
+
+    def test_final_call_steer_continues_with_valid_role_alternation(self):
+        from agent.conversation_loop import _append_late_steer_continuation
+
+        agent = _bare_agent()
+        emitted = []
+
+        def emit_interim(assistant_msg):
+            emitted.append(assistant_msg)
+
+        agent._emit_interim_assistant_message = emit_interim  # type: ignore[method-assign]
+        messages = [{"role": "user", "content": "fix it"}]
+        final_msg = {"role": "assistant", "content": "Done."}
+        assert agent.steer("also verify the live path") is True
+
+        drained = _append_late_steer_continuation(agent, messages, final_msg)
+
+        assert drained == "also verify the live path"
+        assert emitted == [final_msg]
+        assert [message["role"] for message in messages] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+        assert messages[-1]["content"] == "also verify the live path"
+        assert agent._session_messages is messages
+        assert getattr(agent, "_budget_grace_call", False) is True
 
 
 


### PR DESCRIPTION
## Summary

`busy_input_mode: steer` can accept a message while the model is producing its final response, then surface that same message as a separate next turn after the task has completed.

The race is caused by the finalizer draining an undelivered steer into `result["pending_steer"]`; gateway, CLI, and TUI consumers then replay it as a new user prompt. That is surprising and potentially destructive for long-running tasks because a correction intended for the active run can reopen already-finished work.

This change fixes the successful final-response path by:

- coordinating `steer()` and final-response commitment under the existing steer lock;
- continuing a steer received during the final model call inside the same run as a valid `assistant -> user` suffix;
- rejecting steer intake once the final response has atomically committed, rather than accepting text into a replay-only slot;
- reserving the existing one-call grace budget so a steer accepted on the last ordinary iteration is still guaranteed one model response.

Empty/error terminal paths retain their existing behavior and are intentionally outside this PR's successful-completion scope.

## Regression coverage

- final response atomically closes steer intake;
- a steer received during the final call is drained without prematurely closing intake;
- the continuation preserves valid `user -> assistant -> user` role alternation;
- the continuation reserves a grace API call at the iteration limit;
- existing gateway busy-steer and turn-finalizer behavior remains green.

## Test plan

```text
pytest -q -o addopts='' \
  tests/run_agent/test_steer.py \
  tests/gateway/test_busy_session_ack.py \
  tests/agent/test_turn_finalizer_interrupt_alternation.py \
  tests/agent/test_turn_finalizer_final_response_persistence.py

46 passed

ruff check run_agent.py agent/conversation_loop.py tests/run_agent/test_steer.py
python -m py_compile run_agent.py agent/conversation_loop.py tests/run_agent/test_steer.py
git diff --check
```

All checks passed.