### PR TITLE
fix(web): restore ddgs after environment rebuilds

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1859,24 +1859,16 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
+        _print_info("    Installing ddgs (DuckDuckGo search package)...")
         try:
-            __import__("ddgs")
-            _print_success("    ddgs is already installed")
-        except ImportError:
-            _print_info("    Installing ddgs (DuckDuckGo search package)...")
-            try:
-                result = _pip_install(["-U", "ddgs", "--quiet"], timeout=300)
-                if result.returncode == 0:
-                    _print_success("    ddgs installed")
-                else:
-                    _print_warning("    ddgs install failed:")
-                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U ddgs")
-                    return
-            except subprocess.TimeoutExpired:
-                _print_warning("    ddgs install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U ddgs")
-                return
+            from tools.lazy_deps import ensure as _lazy_ensure
+
+            _lazy_ensure("search.ddgs", prompt=False)
+            _print_success("    ddgs installed and current")
+        except Exception as exc:  # noqa: BLE001 — render lazy installer guidance
+            _print_warning(f"    ddgs install failed: {exc}")
+            _print_info("    Retry with: hermes tools post-setup ddgs")
+            return
         _print_info("    No API key required. DuckDuckGo enforces server-side rate limits.")
         _print_info("    Pair with an extract provider if you also need web_extract.")
 

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -308,12 +308,18 @@ class DDGSWebSearchProvider(WebSearchProvider):
         ``primp`` call cannot freeze the Hermes process (#36776, #68096).
         """
         try:
-            import ddgs  # type: ignore  # noqa: F401 — availability probe
+            import ddgs  # type: ignore  # noqa: F401 — fast availability probe
         except ImportError:
-            return {
-                "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
-            }
+            try:
+                from tools.lazy_deps import ensure as _lazy_ensure
+
+                _lazy_ensure("search.ddgs", prompt=False)
+                import ddgs  # type: ignore  # noqa: F401 — verify lazy install
+            except Exception as exc:  # noqa: BLE001 — surface the supported setup hint
+                return {
+                    "success": False,
+                    "error": f"ddgs package is unavailable: {exc}",
+                }
 
         # DDGS().text yields at most `max_results` items; we cap defensively
         # in case the package ignores the hint.

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -75,6 +75,9 @@ class TestSpecSafety:
 
 
 class TestAllowlist:
+    def test_ddgs_is_managed_as_a_pinned_lazy_dependency(self):
+        assert ld.LAZY_DEPS["search.ddgs"] == ("ddgs==9.14.4",)
+
     def test_unknown_feature_raises(self, monkeypatch):
         monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
         with pytest.raises(ld.FeatureUnavailable, match="not in LAZY_DEPS"):

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -90,6 +90,34 @@ class TestDDGSProviderIsConfigured:
 
 
 class TestDDGSProviderSearch:
+    def test_missing_package_is_restored_through_lazy_deps(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "ddgs", None)
+
+        ensure_calls = []
+
+        def fake_ensure(feature, *, prompt):
+            ensure_calls.append((feature, prompt))
+            _install_fake_ddgs(
+                monkeypatch,
+                text_results=[
+                    {
+                        "title": "Restored",
+                        "href": "https://restored.example.com",
+                        "body": "ok",
+                    }
+                ],
+            )
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+        import plugins.web.ddgs.provider as prov
+        _force_inprocess_search(monkeypatch, prov)
+
+        result = prov.DDGSWebSearchProvider().search("q", limit=1)
+
+        assert ensure_calls == [("search.ddgs", False)]
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Restored"
+
     def test_happy_path_normalizes_results(self, monkeypatch):
         _install_fake_ddgs(monkeypatch, text_results=[
             {"title": "A", "href": "https://a.example.com", "body": "desc A"},

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -115,6 +115,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "provider.azure_identity": ("azure-identity==1.25.3",),
 
     # ─── Web search backends ───────────────────────────────────────────────
+    "search.ddgs": ("ddgs==9.14.4",),
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
     "search.parallel": ("parallel-web==0.4.2",),


### PR DESCRIPTION
## Summary

- register the DDGS backend with Hermes' managed lazy-dependency allowlist
- restore the optional `ddgs` package automatically on first search after an environment rebuild
- route `hermes tools post-setup ddgs` through the same version-aware installer
- add regression coverage for the missing-package recovery path

## Problem

Selecting DuckDuckGo through `hermes tools` persists `web.backend: ddgs`, but the optional Python package can disappear when the Hermes virtual environment is rebuilt. The configuration still selects DDGS, so subsequent `web_search` calls fail with a package-not-installed error.

DDGS was not registered in `LAZY_DEPS`, and unlike the Exa and Firecrawl providers, its first-use path did not call `tools.lazy_deps.ensure()`.

## Fix

- add `search.ddgs` with the verified `ddgs==9.14.4` package specification
- keep the cheap import probe for already-installed environments
- on `ImportError`, use the existing allowlisted, venv-scoped lazy installer and verify the import before searching
- make the explicit post-setup command use the same managed path instead of an unbounded `pip install -U ddgs`

This preserves `security.allow_lazy_installs` behavior and gives rebuilt environments the same recovery path as other optional web backends.

## Verification

- `uv run --with pytest python -m pytest -q tests/tools/test_lazy_deps.py tests/tools/test_web_providers_ddgs.py` — 72 passed
- `uv run --with pytest python -m pytest -q tests/hermes_cli/test_post_setup_gating.py tests/hermes_cli/test_lazy_refresh_venv_repair.py` — 5 passed
- `uv run --with ruff ruff check tools/lazy_deps.py plugins/web/ddgs/provider.py hermes_cli/tools_config.py tests/tools/test_web_providers_ddgs.py tests/tools/test_lazy_deps.py` — passed
- clean virtual environment end-to-end check: DDGS absent before the first search, search returned results, and `ddgs 9.14.4` was present afterward
