### PR TITLE
feat(discord-tool): add add_reaction / remove_reaction actions

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -13,6 +13,7 @@ from tools.discord_tool import (
     _ADMIN_ACTIONS,
     _CORE_ACTIONS,
     _available_actions,
+    _build_schema,
     _channel_type_name,
     _detect_capabilities,
     _discord_request,
@@ -220,6 +221,57 @@ class TestFetchMessages:
 # ---------------------------------------------------------------------------
 # Action: create_thread
 # ---------------------------------------------------------------------------
+
+class TestReactions:
+    @patch("tools.discord_tool._discord_request")
+    def test_add_reaction(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = None
+        result = json.loads(discord_core(
+            action="add_reaction", channel_id="11", message_id="1001", emoji="🟢",
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "PUT", "/channels/11/messages/1001/reactions/%F0%9F%9F%A2/@me", "test-token",
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_add_reaction_keeps_custom_emoji_name_id_form(self, mock_req, monkeypatch):
+        """Custom emoji address as name:id — the colon must survive encoding."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = None
+        discord_core(action="add_reaction", channel_id="11", message_id="1001", emoji="party:12345")
+        assert mock_req.call_args[0][1] == "/channels/11/messages/1001/reactions/party:12345/@me"
+
+    @patch("tools.discord_tool._discord_request")
+    def test_remove_reaction(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = None
+        result = json.loads(discord_core(
+            action="remove_reaction", channel_id="11", message_id="1001", emoji="🟢",
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "DELETE", "/channels/11/messages/1001/reactions/%F0%9F%9F%A2/@me", "test-token",
+        )
+
+    def test_reactions_are_core_not_admin(self):
+        """Reacting is participation, like create_thread — not server management."""
+        assert "add_reaction" in _CORE_ACTIONS
+        assert "remove_reaction" in _CORE_ACTIONS
+        assert "add_reaction" not in _ADMIN_ACTIONS
+
+    def test_add_reaction_is_documented_in_the_schema(self):
+        # _build_schema rather than get_dynamic_schema_core: the dynamic one
+        # needs a live bot token for capability detection and returns None
+        # without one.
+        schema = _build_schema(
+            list(_CORE_ACTIONS.keys()), caps={"detected": False}, tool_name="discord",
+        )
+        assert "add_reaction" in schema["parameters"]["properties"]["action"]["enum"]
+        assert "emoji" in schema["parameters"]["properties"]
+        assert "add_reaction(channel_id, message_id, emoji)" in schema["description"]
+
 
 class TestCreateThread:
     @patch("tools.discord_tool._discord_request")

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -583,6 +583,38 @@ def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any
     return json.dumps({"success": True, "message": f"Message {message_id} deleted."})
 
 
+def _reaction_path(channel_id: str, message_id: str, emoji: str) -> str:
+    """Build the reaction endpoint path for the bot's own reaction.
+
+    Unicode emoji are percent-encoded. Custom emoji address as ``name:id``,
+    so the colon is preserved rather than escaped.
+    """
+    encoded = urllib.parse.quote(emoji, safe=":")
+    return f"/channels/{channel_id}/messages/{message_id}/reactions/{encoded}/@me"
+
+
+def _add_reaction(
+    token: str, channel_id: str, message_id: str, emoji: str, **_kwargs: Any
+) -> str:
+    """React to a message with an emoji."""
+    _discord_request("PUT", _reaction_path(channel_id, message_id, emoji), token)
+    return json.dumps({
+        "success": True,
+        "message": f"Reacted {emoji} to message {message_id}.",
+    })
+
+
+def _remove_reaction(
+    token: str, channel_id: str, message_id: str, emoji: str, **_kwargs: Any
+) -> str:
+    """Retract the bot's own emoji reaction from a message."""
+    _discord_request("DELETE", _reaction_path(channel_id, message_id, emoji), token)
+    return json.dumps({
+        "success": True,
+        "message": f"Removed {emoji} reaction from message {message_id}.",
+    })
+
+
 def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
@@ -643,11 +675,16 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "add_reaction": _add_reaction,
+    "remove_reaction": _remove_reaction,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({
+    "fetch_messages", "search_members", "create_thread",
+    "add_reaction", "remove_reaction",
+})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -665,6 +702,8 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
     ("fetch_messages", "(channel_id)", "recent messages; optional before/after snowflakes"),
+    ("add_reaction", "(channel_id, message_id, emoji)", "react to a message with an emoji"),
+    ("remove_reaction", "(channel_id, message_id, emoji)", "retract your own reaction"),
     ("list_pins", "(channel_id)", "pinned messages in a channel"),
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
@@ -691,6 +730,8 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "add_reaction": ["channel_id", "message_id", "emoji"],
+    "remove_reaction": ["channel_id", "message_id", "emoji"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -852,6 +893,13 @@ def _build_schema(
             "type": "string",
             "description": "New thread name (create_thread).",
         },
+        "emoji": {
+            "type": "string",
+            "description": (
+                "Emoji to react with (add_reaction, remove_reaction). A unicode "
+                "emoji such as '\U0001f7e2', or 'name:id' for a custom emoji."
+            ),
+        },
         "limit": {
             "type": "integer",
             "minimum": 1,
@@ -994,6 +1042,7 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    emoji: str = "",
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -1029,6 +1078,7 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "emoji": emoji,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -1047,6 +1097,7 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            emoji=emoji,
             limit=limit,
             before=before,
             after=after,
@@ -1078,7 +1129,7 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
+    "role_id": "", "message_id": "", "query": "", "name": "", "emoji": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 


### PR DESCRIPTION
## What does this PR do?

The `discord` tool can pin, unpin, delete and thread a message, but not react to one. Adds the missing pair to the core (participate) action set, next to `create_thread`:

```
add_reaction(channel_id, message_id, emoji)
remove_reaction(channel_id, message_id, emoji)
```

Both target `/channels/{cid}/messages/{mid}/reactions/{emoji}/@me`, following the existing `pin_message`/`unpin_message` shape. Because they are scoped to `@me`, an agent can retract only what it placed and can never strip another user's reaction — including the adapter's own 👀/✅ lifecycle marks. The emoji is percent-encoded with `:` preserved, so both unicode emoji and the custom-emoji `name:id` form address correctly.

## Why

An agent asked to react has nowhere to go today, and the failure is silent rather than loud:

- The Discord adapter's reaction machinery (`_add_reaction`/`_remove_reaction`) is private and reachable only from the lifecycle hooks.
- `send_message(action="react")` is deliberately **not** agent-callable — `toolsets.py` is explicit that outbound platform messaging is handled outside the agent loop, and `send_message_tool.py` says the same. (I opened #79074 to give the Discord adapter the public `add_reaction`/`remove_reaction` pair for photon parity, which is worth having on its own — but it does not put reactions in reach of a model, because nothing in an agent's toolset dispatches to it.)
- So the only Discord tools a model can actually call are `discord` and `discord_admin`, and neither could react.

Observed failure mode, from a real transcript: asked to reply with a verdict *and* react with it, the model searched its tools (`"Discord reply to message and add reaction"`), got back `discord` and `discord_admin`, found pin/delete/thread but nothing for reactions, and silently gave up — typing the emoji into its reply text instead, where it is prose rather than a reaction. Nothing errored; the capability just wasn't there.

With this change the same prompt works unmodified: the model finds `add_reaction`, calls it, and the reaction lands alongside the lifecycle ✅.

## Related Issue

Partially addresses #29026, which asks for both directions. This is the outbound half (the agent *placing* reactions); inbound Discord reaction events remain #46855.

## Changes Made

- `tools/discord_tool.py` — `_add_reaction`/`_remove_reaction` action handlers, a shared `_reaction_path()` encoder, both registered in `_ACTIONS` and `_CORE_ACTION_NAMES`, entries in `_ACTION_MANIFEST` and `_REQUIRED_PARAMS`, and an `emoji` parameter threaded through `_run_discord_action` + `_HANDLER_DEFAULTS` + the schema properties.
- `tests/tools/test_discord_tool.py` — 5 tests: add, remove, custom-emoji `name:id` encoding, core-vs-admin placement, and schema exposure.

## How to Test

1. `pytest tests/tools/test_discord_tool.py -q` → 46 passed.
2. Against a live guild, with `DISCORD_BOT_TOKEN` set:
   ```python
   discord_core(action="add_reaction", channel_id="<cid>", message_id="<mid>", emoji="🟢")
   discord_core(action="remove_reaction", channel_id="<cid>", message_id="<mid>", emoji="🟢")
   ```
   Both return `{"success": true, ...}` and the reaction appears/disappears. I verified this on a real message, then end-to-end: an agent asked for a verdict reaction placed 🔴 itself via the new action, leaving the lifecycle ✅ untouched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (nothing covers reactions on the `discord` REST tool; #77994/#79074 add the *adapter*-side pair for Matrix/Discord, which is a different, non-agent-callable path)
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: `tests/tools/test_discord_tool.py` is fully green (46 passed). The full run in my environment has pre-existing failures from optional deps I don't have installed; the file I touch has an identical pass/fail set before and after.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), against a live Discord guild

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the tool's own action manifest and schema, which is what the model reads
- [x] N/A — no config keys added (the actions respect the existing `discord.server_actions` allowlist)
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python + stdlib urllib
- [x] I've updated tool descriptions/schemas
