### PR TITLE
fix(desktop): route message.reaction events by session id, not window id

### DIFF
--- a/tests/tools/test_desktop_ui.py
+++ b/tests/tools/test_desktop_ui.py
@@ -28,3 +28,34 @@ def test_routes_event_to_owning_window(monkeypatch):
     assert desktop_ui.available() is True
     assert desktop_ui.emit("pane.reveal", {"pane": "terminal"}) is True
     assert seen == [("win-7", "pane.reveal", {"pane": "terminal"})]
+
+
+def test_session_scoped_event_uses_session_id(monkeypatch):
+    """message.reaction (and future session-scoped events) route by
+    HERMES_SESSION_ID, not HERMES_UI_SESSION_ID (#80678)."""
+    monkeypatch.setattr(
+        desktop_ui, "get_session_env",
+        lambda name, default="": {
+            "HERMES_UI_SESSION_ID": "win-3",
+            "HERMES_SESSION_ID": "sess-9",
+        }.get(name, default),
+    )
+    seen = []
+    desktop_ui.set_emitter(lambda sid, event, payload: seen.append((sid, event, payload)))
+
+    assert desktop_ui.emit("message.reaction", {"row_id": 42, "reactions": ["❤️"]}) is True
+    assert seen == [("sess-9", "message.reaction", {"row_id": 42, "reactions": ["❤️"]})]
+
+
+def test_session_scoped_falls_back_to_ui_session_id(monkeypatch):
+    """When HERMES_SESSION_ID is empty, fall back to the window id
+    so legacy sessions without a chat-session env var still work."""
+    monkeypatch.setattr(
+        desktop_ui, "get_session_env",
+        lambda name, default="": "win-5" if name == "HERMES_UI_SESSION_ID" else default,
+    )
+    seen = []
+    desktop_ui.set_emitter(lambda sid, event, payload: seen.append((sid, event, payload)))
+
+    assert desktop_ui.emit("message.reaction", {"row_id": 1, "reactions": ["👍"]}) is True
+    assert seen == [("win-5", "message.reaction", {"row_id": 1, "reactions": ["👍"]})]

--- a/tools/desktop_ui.py
+++ b/tools/desktop_ui.py
@@ -4,18 +4,31 @@
 The preview pane, pane focus, and friends live in the desktop renderer, so
 desktop-gated tools reach them through an emitter the desktop ``tui_gateway``
 installs at session start via :func:`set_emitter`. Everywhere else it stays
-``None`` and the tools report "desktop only". Routing keys off
-``HERMES_UI_SESSION_ID`` so the event lands on the window that owns the turn
-(``_emit``/``write_json`` is ``_stdout_lock``-guarded, so emitting from the
-tool's thread is safe).
+``None`` and the tools report "desktop only".
+
+Window-level events (``pane.reveal``, ``preview.open``) route by
+``HERMES_UI_SESSION_ID`` — the window/socket that owns the turn.
+Session-scoped events (``message.reaction``) route by
+``HERMES_SESSION_ID`` so the renderer's gateway-event stream, keyed on
+the chat session, receives the frame on the correct transcript transport.
+
+``_emit``/``write_json`` is ``_stdout_lock``-guarded, so emitting from the
+tool's thread is safe.
 """
 
-from typing import Callable, Optional
+from typing import Callable, FrozenSet, Optional
 
 from gateway.session_context import get_session_env
 
 # (sid, event, payload) sink, installed by the desktop gateway.
 _emit: Optional[Callable[[str, str, dict], None]] = None
+
+# Events that target a specific chat session rather than a window/socket.
+# The renderer's gateway-event stream is keyed on the session id, so
+# routing these through HERMES_UI_SESSION_ID (the window identity) means
+# the frame lands on a stream that doesn't own the transcript and is
+# never painted (#80678).
+_SESSION_SCOPED_EVENTS: FrozenSet[str] = frozenset({"message.reaction"})
 
 
 def set_emitter(fn: Optional[Callable[[str, str, dict], None]]) -> None:
@@ -36,5 +49,11 @@ def emit(event: str, payload: dict) -> bool:
     fn = _emit
     if fn is None:
         return False
-    fn(get_session_env("HERMES_UI_SESSION_ID", ""), event, payload)
+    if event in _SESSION_SCOPED_EVENTS:
+        sid = get_session_env("HERMES_SESSION_ID", "")
+        if not sid:
+            sid = get_session_env("HERMES_UI_SESSION_ID", "")
+    else:
+        sid = get_session_env("HERMES_UI_SESSION_ID", "")
+    fn(sid, event, payload)
     return True


### PR DESCRIPTION
## Problem

Agent reactions (via react_to_message) persist correctly in the DB but never paint live in Desktop. The emoji only appears after reload. Reported in #80678.

## Root Cause

desktop_ui.emit() routes ALL events through HERMES_UI_SESSION_ID — a window/socket identity. But message.reaction is session-scoped: the renderer's gateway-event stream is keyed on HERMES_SESSION_ID, so the frame lands on a stream that doesn't own the transcript.

## Fix

Add SESSION_SCOPED_EVENTS set. Route session-scoped events by HERMES_SESSION_ID with fallback to HERMES_UI_SESSION_ID for legacy sessions. Window-level events unchanged.

## Files

- tools/desktop_ui.py: route session-scoped events by session id
- tests/tools/test_desktop_ui.py: two new tests (session id routing + fallback)

Fixes #80678