### PR TITLE
fix(execute-code): expose proxied tool results (#80805)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -248,6 +248,10 @@ print(result.get("output", ""))
         self.assertEqual(result["status"], "success")
         self.assertIn("mock output for: echo hello", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
+        # Tool results must remain visible even when the script only prints
+        # progress headings instead of explicitly printing the return value.
+        self.assertEqual(result["tool_results"][0]["tool"], "terminal")
+        self.assertIn("mock output for: echo hello", result["tool_results"][0]["result"])
 
 
     def test_concurrent_tool_calls_match_responses(self):
@@ -737,6 +741,7 @@ class TestRpcTokenAuthorization(unittest.TestCase):
         listener = _OneShotListener(srv)
         stop_event = threading.Event()
         tool_call_log = []
+        tool_call_results = []
         tool_call_counter = [0]
 
         def _run():
@@ -748,6 +753,7 @@ class TestRpcTokenAuthorization(unittest.TestCase):
                     listener,
                     "test-task",
                     tool_call_log,
+                    tool_call_results,
                     tool_call_counter,
                     max_tool_calls=10,
                     allowed_tools=frozenset({"terminal"}),

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -651,6 +651,7 @@ def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
     tool_call_log: list,
+    tool_call_results: list,
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
     allowed_tools: frozenset,
@@ -760,6 +761,9 @@ def _rpc_server_loop(
                     "args_preview": args_preview,
                     "duration": round(call_duration, 2),
                 })
+                # A script may print only progress headings, so preserve the
+                # dispatched result for the model as well as script stdout.
+                tool_call_results.append({"tool": tool_name, "result": result})
 
                 conn.sendall((result + "\n").encode())
 
@@ -921,6 +925,7 @@ def _rpc_poll_loop(
     rpc_dir: str,
     task_id: str,
     tool_call_log: list,
+    tool_call_results: list,
     tool_call_counter: list,
     max_tool_calls: int,
     allowed_tools: frozenset,
@@ -1033,6 +1038,7 @@ def _rpc_poll_loop(
                         "args_preview": str(tool_args)[:80],
                         "duration": round(call_duration, 2),
                     })
+                    tool_call_results.append({"tool": tool_name, "result": tool_result})
 
                 # Write response atomically (tmp + rename).
                 # Use echo piping (not stdin_data) because Modal doesn't
@@ -1089,6 +1095,7 @@ def _execute_remote(
     quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
 
     tool_call_log: list = []
+    tool_call_results: list = []
     tool_call_counter = [0]
     exec_start = time.monotonic()
     stop_event = threading.Event()
@@ -1133,7 +1140,7 @@ def _execute_remote(
             target=propagate_context_to_thread(_rpc_poll_loop),
             args=(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
-                tool_call_log, tool_call_counter, max_tool_calls,
+                tool_call_log, tool_call_results, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event, rpc_token,
             ),
             daemon=True,
@@ -1179,6 +1186,7 @@ def _execute_remote(
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
+            "tool_results": tool_call_results,
             "duration_seconds": duration,
         }, ensure_ascii=False)
 
@@ -1218,6 +1226,7 @@ def _execute_remote(
         "output": stdout_text,
         "exit_code": exit_code,
         "tool_calls_made": tool_call_counter[0],
+        "tool_results": tool_call_results,
         "duration_seconds": duration,
     }
     result.update(stdout_metadata)
@@ -1357,6 +1366,7 @@ def execute_code(
         rpc_endpoint = sock_path
 
     tool_call_log: list = []
+    tool_call_results: list = []
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
     server_sock = None
@@ -1408,7 +1418,7 @@ def execute_code(
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(
-                server_sock, task_id, tool_call_log,
+                server_sock, task_id, tool_call_log, tool_call_results,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
             ),
             daemon=True,
@@ -1642,6 +1652,7 @@ def execute_code(
             "output": stdout_text,
             "exit_code": exit_code,
             "tool_calls_made": tool_call_counter[0],
+            "tool_results": tool_call_results,
             "duration_seconds": duration,
         }
         result.update(stdout_metadata)


### PR DESCRIPTION
## Summary
- Preserve every tool result dispatched through `execute_code`'s local and remote RPC transports.
- Return those results in the execute response so scripts that only print progress headings do not hide command output from the model.

Closes #80805

## Test plan
- `pytest -q tests/tools/test_code_execution.py --disable-warnings --maxfail=1`
