### PR TITLE
fix: skip None chunks in streaming API responses

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3206,6 +3206,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _discard_stale_stream_chunk(stream_attempt_id, chunk)
                 continue
 
+            if chunk is None:
+                # Some upstreams (e.g. agentrouter via New-API) emit bare
+                # `data: null` keep-alive events mid-stream; skip them.
+                continue
+
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model


### PR DESCRIPTION
## Problem

Some OpenAI-compatible upstreams emit bare `data: null` keep-alive events mid-stream (observed during reasoning phases). The openai SDK (2.24.0) parses these into Python `None` and yields them as-is. The streaming loop in `interruptible_streaming_api_call` then crashes with:

```
AttributeError: 'NoneType' object has no attribute 'choices'
```

The request fails entirely after 3 retries, even though the model is healthy — the crash happens before any content is delivered.

## Fix

Guard the streaming loop against `None` chunks:

```python
if chunk is None:
    # Some upstreams emit bare `data: null` keep-alive events mid-stream; skip them.
    continue
```

This is a pure defensive check — normal chunks are unaffected.

## Verification

- Reproduced the crash: stream from a non-conforming upstream contains `data: null` events between reasoning deltas; SDK yields `None`; loop crashes on `chunk.choices`.
- After the fix: the same stream completes, `None` chunks are skipped, full content is delivered.
- Non-streaming path and normal streaming responses unaffected.

## Notes

- Minimal change: 5 lines, no behavior change for spec-compliant upstreams.