### PR TITLE
fix: track truncated Telegram stream previews

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1078,17 +1078,21 @@ class GatewayStreamConsumer:
                                 not self._adapter_requires_finalize
                                 or self._last_edit_overflowed
                             )
+                            and (
+                                self._last_edit_overflowed
+                                or self.has_delivered_text(self._accumulated)
+                            )
                         ):
                             # Mid-stream edit above already delivered the
                             # final accumulated content.  Skip the redundant
-                            # final edit for adapters that don't need an
-                            # explicit finalize signal, and for any adapter
-                            # when that edit split-and-delivered across
-                            # continuations: the split edit carried
-                            # finalize=True itself, and re-finalizing with
-                            # the full text would overflow-split again into
-                            # the adopted continuation, duplicating chunks
-                            # on screen.
+                            # final edit only when we can prove the visible
+                            # payload equals the accumulated final text, or
+                            # when the adapter reported an overflow split that
+                            # delivered continuations.  Telegram's mid-stream
+                            # overflow preview can return success after showing
+                            # only a truncated prefix; treating that success as
+                            # final delivery records unsent text and makes the
+                            # gateway suppress the real final send.
                             self._final_response_sent = True
                             self._final_content_delivered = True
                             self._record_turn_final_payload(self._accumulated)
@@ -2239,7 +2243,13 @@ class GatewayStreamConsumer:
                             self._last_sent_text = ""
                             self._notify_new_message()
                         else:
-                            self._last_sent_text = text
+                            raw_response = getattr(result, "raw_response", None)
+                            delivered_text = None
+                            if isinstance(raw_response, dict):
+                                delivered_text = raw_response.get("delivered_text")
+                            self._last_sent_text = (
+                                delivered_text if isinstance(delivered_text, str) else text
+                            )
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4856,7 +4856,14 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={
+                        "truncated_preview": True,
+                        "delivered_text": content,
+                    },
+                )
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -4872,7 +4879,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={
+                        "truncated_preview": True,
+                        "delivered_text": content,
+                    },
+                )
 
             formatted = self.format_message(content)
             try:

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -569,6 +569,99 @@ async def test_failed_final_edit_after_split_records_visible_payload():
     assert consumer.delivered_final_matches(full) is True
 
 
+class _TruncatingOverflowPreviewAdapter(_SplittingAdapter):
+    """Telegram-like adapter: mid-stream oversized edits show only chunk 1.
+
+    The real Telegram adapter deliberately truncates saturated previews instead
+    of sending continuation messages mid-stream; only finalize=True is allowed
+    to split and deliver the complete reply.
+    """
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        if self.fail_edits:
+            return SendResult(
+                success=False, error="Flood control exceeded. Retry in 12 seconds"
+            )
+        if len(content) > self.MAX_MESSAGE_LENGTH and not finalize:
+            preview = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)[0]
+            self.edits.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": preview,
+                    "finalize": finalize,
+                }
+            )
+            return SendResult(
+                success=True,
+                message_id=message_id,
+                raw_response={
+                    "truncated_preview": True,
+                    "delivered_text": preview,
+                },
+            )
+        if len(content) > self.MAX_MESSAGE_LENGTH and finalize:
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+            self.edits.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": chunks[0],
+                    "finalize": finalize,
+                }
+            )
+            continuation_ids = []
+            for chunk in chunks[1:]:
+                msg_id = self._mint_id()
+                self.sent.append(
+                    {"chat_id": chat_id, "content": chunk, "metadata": metadata}
+                )
+                continuation_ids.append(msg_id)
+            return SendResult(
+                success=True,
+                message_id=continuation_ids[-1] if continuation_ids else message_id,
+                continuation_message_ids=tuple(continuation_ids),
+            )
+        return await super().edit_message(
+            chat_id, message_id, content, finalize=finalize, metadata=metadata
+        )
+
+
+@pytest.mark.asyncio
+async def test_truncated_overflow_preview_does_not_claim_final_delivery():
+    """A successful saturated preview edit is not final delivery.
+
+    Telegram mid-stream overflow previews return success after showing only the
+    first chunk.  On got_done the consumer must still issue a finalize=True edit
+    that splits/delivers the complete answer, instead of recording the unsent
+    accumulated text and suppressing gateway delivery.
+    """
+    adapter = _TruncatingOverflowPreviewAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-split",
+        StreamConsumerConfig(
+            edit_interval=0.0, buffer_threshold=1, cursor="",
+            fresh_final_after_seconds=999.0,
+        ),
+    )
+    full = ""
+    task = asyncio.create_task(consumer.run())
+    for i in range(12):
+        delta = f"line {i} " + "x" * 60 + "\n"
+        full += delta
+        consumer.on_delta(delta)
+        await asyncio.sleep(0.005)
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=10)
+
+    assert any(edit["finalize"] for edit in adapter.edits)
+    assert adapter.sent, "final overflow continuations were never delivered"
+    assert consumer.delivered_final_matches(full) is True
+
+
 @pytest.mark.asyncio
 async def test_empty_fallback_final_after_split_records_only_what_survives():
     """A recovery that DELETES the sealed heads must not claim them as delivered.


### PR DESCRIPTION
## Summary
- report Telegram saturated stream-preview edits as truncated deliveries with the actual visible text
- make `GatewayStreamConsumer` record adapter-reported delivered text instead of the requested edit payload
- require proof that the visible stream payload matches the final accumulated answer before suppressing the final send
- add regression coverage for Telegram-like mid-stream overflow previews that only show chunk 1 until finalization

## Root cause
Telegram intentionally truncates oversized mid-stream edits to the first chunk to avoid continuation-message duplication loops. The adapter returned `SendResult(success=True)` without indicating that only a preview prefix was visible. The stream consumer then stored the requested full payload as `_last_sent_text`, treated the accumulated response as already delivered on `got_done`, and allowed gateway final-delivery suppression/reconciliation to operate on false visible-state data.

## Test plan
```bash
uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/gateway/test_stale_finalize_suppression.py \
  tests/gateway/test_telegram_final_delivery.py -q
```

Result: `22 passed in 1.00s`.
