### PR TITLE
fix(gateway): guard Teams multiplex listener ownership

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -391,6 +391,7 @@ PORT_BINDING_PLATFORM_VALUES = frozenset({
     "sms",
     "whatsapp_cloud",
     "line",
+    "teams",
 })
 
 # Platforms whose port-binding status depends on connection mode. Feishu in

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2825,6 +2825,7 @@ _PORT_BINDING_PLATFORM_PORTS: Dict[str, Tuple[str, int]] = {
     "sms": ("webhook_port", 8080),
     "whatsapp_cloud": ("webhook_port", 8090),
     "line": ("port", 8646),
+    "teams": ("port", 3978),
 }
 
 # Platform states that mean the adapter is NOT serving its port right now.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -467,6 +467,47 @@ class TestSecondaryProfileConfigHandling:
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
 
+    def test_port_binding_set_covers_known_listeners(self):
+        from gateway.run import _PORT_BINDING_PLATFORM_VALUES
+
+        # Every adapter that binds a TCP port must be in the guard set.
+        for platform in (
+            "webhook",
+            "api_server",
+            "msgraph_webhook",
+            "feishu",
+            "wecom_callback",
+            "bluebubbles",
+            "sms",
+            "whatsapp_cloud",
+            "line",
+            "teams",
+        ):
+            assert platform in _PORT_BINDING_PLATFORM_VALUES
+
+    @pytest.mark.asyncio
+    async def test_secondary_teams_uses_degradable_error(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import SecondaryPortBindingConfigError
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform("teams"): PlatformConfig(enabled=True, extra={"port": 3978}),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+
+        with pytest.raises(SecondaryPortBindingConfigError) as exc_info:
+            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert "teams" in str(exc_info.value)
+        assert "reviewer" in str(exc_info.value)
+        assert "reviewer" not in runner._profile_adapters
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""


### PR DESCRIPTION
## Summary

- classify Microsoft Teams as a host-port-binding gateway platform
- expose the Teams default listener port in gateway topology reporting
- reject Teams on secondary multiplex profiles with the existing degradable configuration error

## Why

The Teams adapter always starts an HTTP listener on its configured port (3978 by default), but Teams was missing from the shared port-binding registry. In multiplex mode, secondary profiles could therefore attempt to start additional Teams listeners on the same host port, producing address-in-use failures and unreliable inbound delivery.

The default profile should own the shared listener and route profile-specific traffic through the existing multiplex URL prefixes.

## Impact

Misconfigured secondary Teams profiles are skipped with an actionable warning instead of attempting a conflicting socket bind. Single-profile Teams gateways are unchanged.

## Validation

`scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py --file-timeout 60 -- -q`

Result: 16 passed.
