### PR TITLE
fix(agent): drop tool_calls key when dedup empties the array

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3439,7 +3439,16 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # Dedup removed every tool call. An empty array is
+                    # semantically "no tool calls", but strict providers
+                    # (DeepSeek) reject `tool_calls: []` with HTTP 400
+                    # "Invalid 'messages[N].tool_calls': empty array".
+                    # Drop the key entirely — same semantics as the
+                    # empty-array pass above (#58755).
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/tests/run_agent/test_sanitize_dedup_empty_tool_calls.py
+++ b/tests/run_agent/test_sanitize_dedup_empty_tool_calls.py
@@ -1,0 +1,94 @@
+"""Regression test: the tool_call_id dedup pass must not re-create empty
+tool_calls arrays.
+
+When the pre-API sanitizer's dedup pass collapses an assistant message whose
+calls are ALL duplicates of ids already seen earlier in the transcript, it
+previously wrote ``tool_calls: []`` back onto the message. Strict
+OpenAI-compatible providers (DeepSeek) reject an empty array outright with
+HTTP 400 "Invalid 'messages[N].tool_calls': empty array. Expected an array
+with minimum length 1, but got an empty array instead." — the same provider
+class that motivated #58755. Duplicated tool-call blocks reach the sanitizer
+from crash/resume glitches or a compression window that re-emits a tool
+result. The dedup pass must drop the key entirely (semantics identical to
+"no tool calls"), never emit an empty array.
+"""
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+def _assistant_with_calls(call_ids, content="x"):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": cid,
+                "type": "function",
+                "function": {"name": "test_tool", "arguments": "{}"},
+            }
+            for cid in call_ids
+        ],
+    }
+
+
+def _tool_result(call_id):
+    return {"role": "tool", "tool_call_id": call_id, "content": "ok"}
+
+
+def test_dedup_all_duplicates_drops_key_not_empty_array():
+    """A replayed duplicate assistant tool-call block must not yield
+    ``tool_calls: []`` — the exact empty array DeepSeek 400s on."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        _assistant_with_calls(["call_a", "call_b"]),
+        _tool_result("call_a"),
+        _tool_result("call_b"),
+        _assistant_with_calls(["call_a", "call_b"]),  # duplicate re-emission
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    # No message may carry an empty tool_calls array.
+    assert all(m.get("tool_calls") != [] for m in out)
+    # The duplicate assistant block survives as a plain message (no key).
+    dupe_block = [
+        m for m in out if m["role"] == "assistant" and "tool_calls" not in m
+    ]
+    assert len(dupe_block) == 1
+    assert dupe_block[0]["content"] == "x"
+
+
+def test_dedup_unique_ids_preserved():
+    """A healthy transcript is untouched."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        _assistant_with_calls(["call_1", "call_2"]),
+        _tool_result("call_1"),
+        _tool_result("call_2"),
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assistant = next(m for m in out if m["role"] == "assistant")
+    assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_1", "call_2"]
+
+
+def test_partial_duplicates_keep_first_occurrence():
+    """When only SOME calls are duplicates, the surviving calls stay — the
+    result is a non-empty array, never an empty one."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        _assistant_with_calls(["call_a", "call_b"]),
+        _tool_result("call_a"),
+        _tool_result("call_b"),
+        _assistant_with_calls(["call_a", "call_c"]),
+        _tool_result("call_c"),
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assistant_blocks = [
+        m for m in out if m["role"] == "assistant" and m.get("tool_calls")
+    ]
+    assert len(assistant_blocks) == 2
+    assert [tc["id"] for tc in assistant_blocks[1]["tool_calls"]] == ["call_c"]


### PR DESCRIPTION
## Why

Long-lived Hermes sessions intermittently 400 on strict providers (DeepSeek):

```
HTTP 400: Invalid 'messages[N].tool_calls': empty array. Expected an array
with minimum length 1, but got an empty array instead.
```

The pre-API sanitizer (`sanitize_api_messages`) drops `tool_calls: []` on
assistant messages (#58755), but its own tool_call_id dedup pass can
re-create it: when an assistant message's calls are ALL duplicates of ids
already seen earlier in the transcript (crash/resume glitch, retry, or a
compression window re-emitting a tool result), `kept_tcs` ends up empty and
the pass writes `msg["tool_calls"] = []` back onto the message — after the
empty-array pass already ran.

DeepSeek rejects the empty array outright, the request fails, and because
the fallback chain's first leg resolves to the same backend, the failure
falls through to the next provider. The poisoned session 400s the same way
every subsequent turn.

## Fix

When dedup empties the array, drop the `tool_calls` key entirely — the same
semantics the empty-array pass already applies (empty array ≡ no tool
calls):

```python
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    if kept_tcs:
        msg = {**msg, "tool_calls": kept_tcs}
    else:
        msg = {k: v for k, v in msg.items() if k != "tool_calls"}
```

The pre-existing empty-array case still cleans up as before; healthy
transcripts are untouched; partial dedup keeps the surviving (first)
calls.

## Test

`tests/run_agent/test_sanitize_dedup_empty_tool_calls.py` — 3 tests:

- all-duplicates block yields a plain assistant message, never `[]`
  (this one fails on the old code)
- unique-id transcript preserved
- partial duplicates keep the first occurrence

Verified: `scripts/run_tests.sh tests/run_agent/test_sanitize_dedup_empty_tool_calls.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_thinking_only_sanitizer.py -q` — all pass.
