### PR TITLE
fix(titles): reject answer-shaped auto-title output (port of oh-my-pi#7306)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -63,6 +63,14 @@ MAX_TITLE_INPUT_CHARS = 1000
 # Codex CLI independently landed on the same ~50-char slice.
 MAX_DERIVED_TITLE_CHARS = 48
 
+# Upper bound on accepted title word count. Titling is a 3-7 word task; a
+# small tiny-model sometimes ignores the task and answers the user's message
+# instead — that answer must never become the session title (see the
+# answer-shaped output guard in generate_title; port of
+# can1357/oh-my-pi#7306). 12 leaves headroom for legitimate wordy titles
+# while excluding full-sentence answers.
+_MAX_TITLE_WORDS = 12
+
 _TITLE_PROMPT_TEMPLATE = (
     "You name chat sessions. Given the user's opening message, write a title "
     "that lets them find this conversation again in a list.\n\n"
@@ -404,7 +412,22 @@ def generate_title(
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
         content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
+        title = _clean_title(_extract_title_text(content))
+        # Answer-shaped output guard: titling is a 3-7 word task, so a title
+        # with many words is a model that ignored the task and answered
+        # the user's message instead ("I don't have context on X — that's
+        # not something I recognize..."). Truncating would store half an
+        # assistant blob as the session title, which is still an assistant
+        # blob — reject instead so the caller retries on the next exchange
+        # (maybe_auto_title fires for the first two exchanges).
+        # Port of can1357/oh-my-pi#7306.
+        if title is not None and len(title.split()) > _MAX_TITLE_WORDS:
+            logger.debug(
+                "Rejecting answer-shaped title output (%d words > %d)",
+                len(title.split()), _MAX_TITLE_WORDS,
+            )
+            return None
+        return title
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -25,6 +25,14 @@ TitleCallback = Callable[[str], None]
 # the request would reload a model the runtime already evicted (#19027).
 RuntimeValidator = Callable[[], bool]
 
+# Upper bound on accepted title word count. Titling is a 3-7 word task; a
+# small tiny-model sometimes ignores the task and answers the user's message
+# instead — that answer must never become the session title (see the
+# answer-shaped output guard in generate_title; port of
+# can1357/oh-my-pi#7306). 12 leaves headroom for legitimate wordy titles
+# while excluding full-sentence answers.
+_MAX_TITLE_WORDS = 12
+
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
@@ -169,7 +177,22 @@ def generate_title(
         # otherwise be stored verbatim and truncated mid-command. Keep the first
         # non-empty line — the closest thing to a title in that response.
         title = next((line.strip() for line in title.splitlines() if line.strip()), "")
-        # Enforce reasonable length
+        # Answer-shaped output guard: titling is a 3-7 word task, so a first
+        # line with many words is a model that ignored the task and answered
+        # the user's message instead ("I don't have context on X — that's
+        # not something I recognize..."). Truncating would store half an
+        # assistant blob as the session title, which is still an assistant
+        # blob — reject instead so the caller retries on the next exchange
+        # (maybe_auto_title fires for the first two exchanges).
+        # Port of can1357/oh-my-pi#7306.
+        if len(title.split()) > _MAX_TITLE_WORDS:
+            logger.debug(
+                "Rejecting answer-shaped title output (%d words > %d)",
+                len(title.split()), _MAX_TITLE_WORDS,
+            )
+            return None
+        # Enforce reasonable length for genuine-but-wordy titles that pass
+        # the word bound (e.g. one long identifier/path).
         if len(title) > 80:
             title = title[:77] + "..."
         return title if title else None

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -90,6 +90,43 @@ class TestGenerateTitle:
             assert len(title) == 80
             assert title.endswith("...")
 
+    def test_rejects_answer_shaped_output(self):
+        """A model that ignores the titling task and answers the user's
+        message returns a full sentence; without a word bound the whole
+        reply (truncated mid-sentence) became the session title.
+        Regression for the can1357/oh-my-pi#7306 bug class."""
+        answer = (
+            "I don't have context on a \"registration system\" - that's not "
+            "something I recognize from this conversation, and I don't see "
+            "any prior discussion or code about it here"
+        )
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = answer
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("how does the registration system work?", "...") is None
+
+    def test_rejects_many_short_words(self):
+        """13 short words stays under the 80-char cap but is not a title."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "one two three four five six seven eight nine ten eleven twelve thirteen"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") is None
+
+    def test_accepts_normal_title(self):
+        """A normal 3-7 word title is unaffected by the answer-shape guard."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Investigate the title resolver bug"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") == "Investigate the title resolver bug"
+
 
 
     def test_invokes_failure_callback_on_exception(self):


### PR DESCRIPTION
## Summary

Auto-generated session titles can no longer be a truncated assistant answer: `generate_title` now rejects output longer than 12 words and returns `None`, so titling retries on the next exchange instead of storing an answer blob.

Port of [can1357/oh-my-pi#7306](https://github.com/can1357/oh-my-pi/pull/7306) (their issue #7303): a tiny title model sometimes ignores the 3-7-word titling task and answers the user's first message instead ("I don't have context on a 'registration system' — that's not something I recognize..."). Hermes had the same failure shape — our only guards were first-non-empty-line + an 80-char truncation, so the answer's first sentence became the session title, cut mid-sentence.

## Ours vs theirs

| | oh-my-pi | this port |
|---|---|---|
| Bounds | >80 chars OR >12 words → reject | >12 words → reject; 80-char truncation kept for wordy-but-genuine titles (long identifiers/paths) |
| On reject | defer titling to next user turn | same — `maybe_auto_title` already fires on the first two exchanges |

We keep the char-truncation path because a single 100-char token (existing `test_truncates_long_titles`) is a degenerate title, not an answer — truncating it is fine; rejecting it would leave real sessions untitled.

## Changes
- `agent/title_generator.py`: `_MAX_TITLE_WORDS = 12` + answer-shape reject in `generate_title`
- `tests/agent/test_title_generator.py`: 3 new tests (answer-shaped reject, 13-short-words reject, normal title accepted)

## Validation
| | Before | After |
|---|---|---|
| Full-sentence answer output | stored as title, truncated at 80 chars | rejected, title deferred |
| 13 short words | stored | rejected |
| "Investigate the title resolver bug" | stored | stored |
| tests/agent/test_title_generator.py | 15 passed | 18 passed |

## Infographic

![title-guard](https://v3b.fal.media/files/b/0aa55831/b9fabyMGmwfn8uTc-QHaZ_JM9BLC5n.png)
