### PR TITLE
fix(gateway): release owned context engines on cache eviction

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -819,6 +819,9 @@ def init_agent(
     agent._delegate_depth = 0        # 0 = top-level agent, incremented for children
     agent._active_children = []      # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
+    # Context engines are owned per Python agent.  Cleanup may race between a
+    # cache-eviction worker and hard session teardown, so claim shutdown once.
+    agent._context_engine_shutdown_lock = threading.Lock()
     
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6074,6 +6074,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import threading as _threading
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
+        # Explicit cache eviction may race an active turn. Keep one exact
+        # agent reference here until a turn boundary can release it without a
+        # polling thread. The dict de-duplicates repeated eviction requests.
+        self._pending_evicted_agent_releases: Dict[int, Any] = {}
+        self._pending_evicted_agent_releases_lock = _threading.Lock()
 
         # Conversation-scoped per-session state (/model, /model --once,
         # /reasoning, /fast overrides; per-turn sidecar notes; ephemeral
@@ -22833,6 +22838,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if run_generation is not None and not self._is_session_run_current(
             session_key, run_generation
         ):
+            # A newer generation may already have replaced this turn's exact
+            # agent. Drain any older deferred eviction that is no longer live.
+            self._drain_pending_evicted_agent_releases()
             return False
         state = self._peek_session_state(session_key)
         if state is not None:
@@ -22849,6 +22857,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # are deliberately NOT cleared here — _release_turn_lease owns
             # them (#64934).
             state.turn.clear()
+        # Event-driven completion edge for an explicit eviction that removed
+        # the cache entry while this exact agent was still mid-turn.
+        self._drain_pending_evicted_agent_releases()
         # Turn boundary: a running-agent slot was just released.  Persist the
         # new (lower) in-flight count so the dashboard readout stays current
         # between lifecycle transitions.  Preserves gateway_state (see
@@ -23418,15 +23429,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         # Don't tear down an agent that's actively mid-turn — its client,
-        # sandbox and child subagents are in use by the running request.
+        # sandbox and child subagents are in use by the running request.  The
+        # cache entry is already gone (a config/boundary caller needs a fresh
+        # agent next turn), so defer ownership release until this exact Python
+        # agent leaves the running slot rather than dropping it unclosed.
         running_ids = {
             id(a)
             for _, a in self._running_agent_items()
             if a is not None and a is not _AGENT_PENDING_SENTINEL
         }
         if id(agent) in running_ids:
+            self._defer_evicted_agent_release(agent)
             return
 
+        self._schedule_evicted_agent_soft_release(agent, session_key)
+
+    def _schedule_evicted_agent_soft_release(
+        self, agent: Any, session_key: str = ""
+    ) -> None:
+        """Release one inactive evicted agent without blocking the caller."""
         try:
             threading.Thread(
                 target=self._release_evicted_agent_soft,
@@ -23441,6 +23462,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_evicted_agent_soft(agent)
             except Exception:
                 pass
+
+    def _pending_evicted_release_state(self) -> tuple[dict, Any]:
+        """Return the lazy deferred-release registry and its lock."""
+        registry = self.__dict__.get("_pending_evicted_agent_releases")
+        lock = self.__dict__.get("_pending_evicted_agent_releases_lock")
+        if registry is None or lock is None:
+            self.__dict__.setdefault("_pending_evicted_agent_releases", {})
+            self.__dict__.setdefault(
+                "_pending_evicted_agent_releases_lock", threading.Lock()
+            )
+            registry = self.__dict__["_pending_evicted_agent_releases"]
+            lock = self.__dict__["_pending_evicted_agent_releases_lock"]
+        return registry, lock
+
+    def _defer_evicted_agent_release(self, agent: Any) -> None:
+        """Remember an active evicted agent for event-driven turn cleanup."""
+        registry, lock = self._pending_evicted_release_state()
+        with lock:
+            registry[id(agent)] = agent
+
+    def _drain_pending_evicted_agent_releases(self) -> None:
+        """Schedule deferred agents that no longer own a running turn."""
+        registry, lock = self._pending_evicted_release_state()
+        running_ids = {
+            id(agent)
+            for _, agent in self._running_agent_items()
+            if agent is not None and agent is not _AGENT_PENDING_SENTINEL
+        }
+        ready: list[Any] = []
+        with lock:
+            for agent_id, agent in list(registry.items()):
+                if agent_id not in running_ids:
+                    ready.append(registry.pop(agent_id))
+        for agent in ready:
+            self._schedule_evicted_agent_soft_release(agent)
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -23479,10 +23535,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``_session_expiry_watcher`` when the session finally expires.
 
         But the watcher tears down whatever agent it finds in ``_agent_cache``
-        at expiry time.  If cache pressure (the LRU cap) soft-evicts a
+        at expiry time.  If cache pressure or the idle TTL soft-evicts a
         finalizable session's agent BEFORE it expires, the watcher later finds
         no cached agent and ``on_session_end`` is silently skipped — memory
-        providers never see the transcript (#11205, LRU-cap variant).
+        providers never see the transcript (#11205).
 
         We hold the live, fully-scoped agent right now, so commit its
         end-of-session memory extraction here using the agent's own memory
@@ -23520,7 +23576,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.commit_memory_session(messages if isinstance(messages, list) else None)
             logger.debug(
                 "Committed on_session_end extraction before soft-evicting "
-                "finalizable session=%s (cache pressure, pre-expiry)", key,
+                "finalizable session=%s (soft eviction, pre-expiry)", key,
             )
         except Exception as _e:
             logger.debug("Pre-evict memory commit failed for %s: %s", key, _e)
@@ -23680,45 +23736,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if last_activity is None:
                     continue
                 if (now - last_activity) > _AGENT_CACHE_IDLE_TTL_SECS:
-                    # Check whether the session has actually expired in the
-                    # session store.  If it hasn't (e.g. daily-reset mode
-                    # where the reset fires hours after the user's last
-                    # message), keep the agent in cache so the session-store
-                    # expiry watcher can still find it and call
-                    # on_session_end() with the live transcript.  Skipping
-                    # eviction here means the agent stays alive until the
-                    # session genuinely expires, at which point the watcher
-                    # (gateway/run.py _session_expiry_watcher) tears it down
-                    # properly.  (#11205 follow-up)
-                    #
-                    # BUT only defer when the watcher will EVER finalize this
-                    # session.  For a mode == "none" session the watcher never
-                    # fires (is_session_finalizable() is False), so deferring
-                    # would pin the agent in cache for the gateway's entire
-                    # lifetime — the exact leak this idle sweep exists to
-                    # relieve.  Those sessions fall through to soft eviction
-                    # WITHOUT on_session_end, and that is correct: a mode=="none"
-                    # session never reaches a session-end boundary, so there is
-                    # no missed on_session_end to compensate for.  (The finite
-                    # case — a session evicted under LRU-cap pressure before it
-                    # expires — is instead covered by _commit_memory_before_soft_
-                    # evict on the cap path, which fires on_session_end via the
-                    # live agent's memory manager before releasing it.)
-                    session_entry = None
-                    _store = getattr(self, "session_store", None)
-                    try:
-                        if _store is not None:
-                            _store._ensure_loaded()
-                            session_entry = _store._entries.get(key)
-                    except Exception:
-                        session_entry = None
-                    if (
-                        session_entry is not None
-                        and _store is not None
-                        and _store.is_session_finalizable(session_entry)
-                        and not _store._is_session_expired(session_entry)
-                    ):
-                        continue  # keep agent — finite session hasn't expired
+                    # The idle TTL is an independent bound on Python-agent and
+                    # context-engine ownership.  A finite session can remain
+                    # valid for hours after the one-hour cache TTL, so retaining
+                    # its agent until expiry would pin cloned engine resources.
+                    # The daemon release path commits memory first for finite,
+                    # not-yet-expired sessions; mode="none" remains a soft
+                    # eviction without a synthetic session-end commit.
                     to_evict.append((key, agent))
             for key, _ in to_evict:
                 _cache.pop(key, None)
@@ -23728,8 +23752,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 key, now - getattr(agent, "_last_activity_ts", now),
             )
             threading.Thread(
-                target=self._release_evicted_agent_soft,
-                args=(agent,),
+                target=self._commit_then_release_soft,
+                args=(agent, key),
                 daemon=True,
                 name=f"agent-cache-idle-{key[:24]}",
             ).start()

--- a/run_agent.py
+++ b/run_agent.py
@@ -4146,6 +4146,42 @@ class AIAgent:
         except Exception:
             pass
 
+    def _shutdown_owned_context_engine(self) -> None:
+        """Claim and shut down this agent's context engine at most once.
+
+        ``context_compressor`` is the compatibility name for every context
+        engine, including LCM clones.  Claiming it under a dedicated lock
+        before calling third-party shutdown code makes repeated and concurrent
+        cleanup paths idempotent.  Built-in/legacy engines without a shutdown
+        hook are simply detached.
+        """
+        lock = getattr(self, "_context_engine_shutdown_lock", None)
+        if lock is None:
+            # Partially constructed legacy/test agents normally retain this
+            # lock, so use it rather than racing a lazily-created lock.
+            lock = getattr(self, "_active_children_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._context_engine_shutdown_lock = lock
+
+        with lock:
+            engine = getattr(self, "context_compressor", None)
+            if engine is None:
+                return
+            self.context_compressor = None
+
+        shutdown = getattr(engine, "shutdown", None)
+        if not callable(shutdown):
+            return
+        try:
+            shutdown()
+        except Exception as exc:
+            logger.warning(
+                "Failed to shut down owned context engine %s: %s",
+                type(engine).__name__,
+                exc,
+            )
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 
@@ -4160,6 +4196,8 @@ class AIAgent:
           - memory provider (has its own lifecycle; keeps running)
 
         We DO close:
+          - The context engine owned by this Python agent (plugin engines may
+            hold SQLite helpers; a rebuilt agent receives a fresh clone)
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
           - Active child subagents (per-turn artefacts; safe to drop)
@@ -4168,6 +4206,8 @@ class AIAgent:
         hard teardown for actual session boundaries (/new, /reset, session
         expiry).
         """
+        self._shutdown_owned_context_engine()
+
         # Close active child agents (per-turn; no cross-turn persistence).
         try:
             with self._active_children_lock:
@@ -4265,6 +4305,11 @@ class AIAgent:
                     pass
         except Exception:
             pass
+
+        # 5b. Release the context engine owned by this Python agent.  This is
+        # distinct from shared SessionDB ownership; plugin engines such as LCM
+        # close only their own cloned stores/helpers here.
+        self._shutdown_owned_context_engine()
 
         # 6. Close the OpenAI/httpx client
         try:

--- a/tests/agent/test_context_engine_lifecycle.py
+++ b/tests/agent/test_context_engine_lifecycle.py
@@ -1,0 +1,118 @@
+"""Lifecycle contract for agent-owned context engines.
+
+An AIAgent owns the context engine clone created for that Python agent
+instance. Cache eviction may preserve external session tool state, but it must
+release that clone so plugin SQLite handles do not survive after the agent is
+removed from the cache.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+
+def _partial_agent():
+    """Build the smallest AIAgent fixture accepted by both cleanup paths."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "context-engine-lifecycle-test"
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = None
+    return agent
+
+
+def test_soft_release_shuts_down_owned_context_engine_exactly_once():
+    agent = _partial_agent()
+    engine = MagicMock()
+    agent.context_compressor = engine
+
+    agent.release_clients()
+    agent.release_clients()
+
+    engine.shutdown.assert_called_once_with()
+
+
+def test_concurrent_soft_release_shuts_down_owned_context_engine_once():
+    agent = _partial_agent()
+    shutdown_started = threading.Event()
+    allow_shutdown = threading.Event()
+    calls = []
+
+    class Engine:
+        def shutdown(self):
+            calls.append("shutdown")
+            shutdown_started.set()
+            allow_shutdown.wait(timeout=2)
+
+    agent.context_compressor = Engine()
+    first = threading.Thread(target=agent.release_clients)
+    second = threading.Thread(target=agent.release_clients)
+
+    first.start()
+    assert shutdown_started.wait(timeout=2)
+    second.start()
+    time.sleep(0.05)
+    allow_shutdown.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert calls == ["shutdown"]
+
+
+def test_hard_close_after_soft_release_does_not_double_shutdown_engine():
+    agent = _partial_agent()
+    engine = MagicMock()
+    agent.context_compressor = engine
+    agent._session_db = MagicMock()
+    agent._end_session_on_close = False
+
+    agent.release_clients()
+    with patch("tools.process_registry.process_registry.kill_all"), patch(
+        "run_agent.cleanup_vm"
+    ), patch("run_agent.cleanup_browser"), patch(
+        "tools.computer_use.release_computer_use_session"
+    ):
+        agent.close()
+
+    engine.shutdown.assert_called_once_with()
+    agent._session_db.close.assert_not_called()
+
+
+def test_context_engine_shutdown_failure_does_not_block_client_release():
+    agent = _partial_agent()
+    engine = MagicMock()
+    engine.shutdown.side_effect = RuntimeError("synthetic shutdown failure")
+    agent.context_compressor = engine
+    client = MagicMock()
+    agent.client = client
+    agent._retire_shared_openai_client = MagicMock()
+    agent._close_cached_request_openai_client = MagicMock()
+
+    agent.release_clients()
+
+    engine.shutdown.assert_called_once_with()
+    agent._retire_shared_openai_client.assert_called_once_with(
+        client, reason="cache_evict"
+    )
+    assert agent.client is None
+
+
+def test_soft_release_preserves_external_session_tool_state():
+    agent = _partial_agent()
+    agent.context_compressor = MagicMock()
+
+    with patch("tools.process_registry.process_registry.kill_all") as kill_all, patch(
+        "run_agent.cleanup_vm"
+    ) as cleanup_vm, patch("run_agent.cleanup_browser") as cleanup_browser, patch(
+        "tools.computer_use.release_computer_use_session"
+    ) as cleanup_computer_use:
+        agent.release_clients()
+
+    kill_all.assert_not_called()
+    cleanup_vm.assert_not_called()
+    cleanup_browser.assert_not_called()
+    cleanup_computer_use.assert_not_called()

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -25,6 +25,31 @@ def _make_runner():
     return runner
 
 
+def _context_engine_agent(last_activity: float | None = None):
+    """Minimal real AIAgent carrying an owned context engine mock."""
+    import time
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "cache-context-engine-test"
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent._context_engine_shutdown_lock = threading.Lock()
+    agent.client = None
+    agent._last_activity_ts = last_activity if last_activity is not None else time.time()
+    engine = MagicMock()
+    agent.context_compressor = engine
+    return agent, engine
+
+
+def _wait_for_call(mock, timeout: float = 2.0) -> None:
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline and mock.call_count == 0:
+        time.sleep(0.02)
+
+
 class TestAgentConfigSignature:
     """Config signature produces stable, distinct keys."""
 
@@ -228,6 +253,100 @@ class TestAgentCacheLifecycle:
             assert session_key not in runner._agent_cache
 
 
+class TestOwnedContextEngineEviction:
+    """Every cache-removal path releases its Python agent's engine clone."""
+
+    def _bounded_runner(self):
+        from collections import OrderedDict
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._agent_cache = OrderedDict()
+        runner._agent_cache_lock = threading.Lock()
+        runner._running_agents = {}
+        return runner
+
+    def test_explicit_eviction_shuts_down_engine_once(self):
+        runner = _make_runner()
+        agent, engine = _context_engine_agent()
+        runner._agent_cache["session"] = (agent, "sig")
+
+        runner._evict_cached_agent("session")
+        _wait_for_call(engine.shutdown)
+        runner._evict_cached_agent("session")
+
+        engine.shutdown.assert_called_once_with()
+
+    def test_cache_cap_eviction_shuts_down_each_evicted_engine_once(self, monkeypatch):
+        from gateway import run as gw_run
+
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_MAX_SIZE", 1)
+        runner = self._bounded_runner()
+        old_agent, old_engine = _context_engine_agent()
+        new_agent, new_engine = _context_engine_agent()
+        runner._agent_cache["old"] = (old_agent, "old-sig")
+        runner._agent_cache["new"] = (new_agent, "new-sig")
+
+        with runner._agent_cache_lock:
+            runner._enforce_agent_cache_cap()
+        _wait_for_call(old_engine.shutdown)
+
+        old_engine.shutdown.assert_called_once_with()
+        new_engine.shutdown.assert_not_called()
+
+    def test_idle_eviction_shuts_down_finite_session_engine_once(self, monkeypatch):
+        import time
+        from gateway import run as gw_run
+
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
+        runner = self._bounded_runner()
+        agent, engine = _context_engine_agent(last_activity=time.time() - 10)
+        agent._memory_manager = None
+        runner.session_store = MagicMock()
+        runner.session_store._entries = {"session": MagicMock()}
+        runner.session_store.is_session_finalizable.return_value = True
+        runner.session_store._is_session_expired.return_value = False
+        runner._agent_cache["session"] = (agent, "sig")
+
+        assert runner._sweep_idle_cached_agents() == 1
+        _wait_for_call(engine.shutdown)
+
+        engine.shutdown.assert_called_once_with()
+
+    def test_explicit_eviction_defers_engine_shutdown_until_turn_boundary_without_poller(
+        self, monkeypatch
+    ):
+        import time
+        from gateway import run as gw_run
+
+        runner = self._bounded_runner()
+        agent, engine = _context_engine_agent()
+        runner._agent_cache["session"] = (agent, "sig")
+        runner._running_agents["session"] = agent
+
+        original_thread = gw_run.threading.Thread
+        started_threads: list[object] = []
+
+        class _UnexpectedThread:
+            def __init__(self, *args, **kwargs):
+                started_threads.append((args, kwargs))
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr(gw_run.threading, "Thread", _UnexpectedThread)
+        runner._evict_cached_agent("session")
+        time.sleep(0.1)
+
+        engine.shutdown.assert_not_called()
+        assert started_threads == [], "active eviction must not create an unbounded poller"
+
+        monkeypatch.setattr(gw_run.threading, "Thread", original_thread)
+        assert runner._release_running_agent_state("session") is True
+        _wait_for_call(engine.shutdown)
+        engine.shutdown.assert_called_once_with()
+
+
 class TestAgentCacheBoundedGrowth:
     """LRU cap and idle-TTL eviction prevent unbounded cache growth."""
 
@@ -336,37 +455,77 @@ class TestAgentCacheBoundedGrowth:
         assert old_agent in release_calls  # still released
 
 
-    def test_idle_sweep_keeps_agent_when_session_not_expired(self, monkeypatch):
-        """Agents past idle TTL are kept if the session hasn't expired yet.
+    def test_idle_sweep_commits_then_evicts_finite_session(self, monkeypatch):
+        """The idle TTL bounds finite-policy agents without losing extraction.
 
-        In daily-reset mode the reset can fire hours after the last
-        user message — evicting the agent early means the
-        session-expiry watcher has nothing to call on_session_end()
-        with, and memory providers miss the live transcript.
+        A finalizable session can remain valid for hours after its agent has
+        been idle for one hour.  Retaining that agent defeats the cache TTL and
+        pins its context-engine resources.  Commit the live transcript before
+        eviction, exactly as the existing LRU-cap path does.
         """
         from gateway import run as gw_run
 
         monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
         runner = self._bounded_runner()
-        runner._cleanup_agent_resources = MagicMock()
+        commit_calls: list = []
+        release_calls: list = []
+        runner._release_evicted_agent_soft = lambda agent: release_calls.append(agent)
 
         import time as _t
         stale = self._fake_agent(last_activity=_t.time() - 10.0)
+        stale._memory_manager = MagicMock()
+        stale._session_messages = [{"role": "user", "content": "hi"}]
+        stale.commit_memory_session = lambda msgs=None: commit_calls.append(msgs)
 
-        # Session store says the session is still alive AND is finalizable
-        # (finite reset policy) — so deferring eviction is correct: the expiry
-        # watcher will find this agent later and fire on_session_end().
         session_entry = MagicMock()
         runner.session_store = MagicMock()
         runner.session_store._entries = {"stale-session": session_entry}
         runner.session_store.is_session_finalizable.return_value = True
         runner.session_store._is_session_expired.return_value = False
-
         runner._agent_cache["stale-session"] = (stale, "sig")
 
         evicted = runner._sweep_idle_cached_agents()
-        assert evicted == 0
-        assert "stale-session" in runner._agent_cache
+        deadline = _t.time() + 2.0
+        while _t.time() < deadline and not release_calls:
+            _t.sleep(0.02)
+
+        assert evicted == 1
+        assert "stale-session" not in runner._agent_cache
+        assert commit_calls == [[{"role": "user", "content": "hi"}]]
+        assert release_calls == [stale]
+
+    def test_idle_sweep_evicts_non_finalizable_without_commit(self, monkeypatch):
+        """Mode=none is TTL-bounded but has no synthetic session-end commit."""
+        from gateway import run as gw_run
+
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
+        runner = self._bounded_runner()
+        commit_calls: list = []
+        release_calls: list = []
+        runner._release_evicted_agent_soft = lambda agent: release_calls.append(agent)
+
+        import time as _t
+        stale = self._fake_agent(last_activity=_t.time() - 10.0)
+        stale._memory_manager = MagicMock()
+        stale._session_messages = [{"role": "user", "content": "hi"}]
+        stale.commit_memory_session = lambda msgs=None: commit_calls.append(msgs)
+
+        session_entry = MagicMock()
+        runner.session_store = MagicMock()
+        runner.session_store._entries = {"stale-session": session_entry}
+        runner.session_store.is_session_finalizable.return_value = False
+        runner.session_store._is_session_expired.return_value = False
+        runner._agent_cache["stale-session"] = (stale, "sig")
+
+        evicted = runner._sweep_idle_cached_agents()
+        deadline = _t.time() + 2.0
+        while _t.time() < deadline and not release_calls:
+            _t.sleep(0.02)
+
+        assert evicted == 1
+        assert "stale-session" not in runner._agent_cache
+        assert commit_calls == []
+        assert release_calls == [stale]
 
 
     def test_is_session_finalizable_real_predicate(self, tmp_path):


### PR DESCRIPTION
## Summary

- give each cached `AIAgent` explicit ownership of its cloned context engine and shut it down at most once
- release owned engines on explicit, idle-TTL, and cache-cap eviction while deferring active-agent cleanup to the existing turn-boundary path
- preserve long-lived tool/process/browser/computer-use, memory-provider, and shared `SessionDB` resources during soft eviction
- commit finite-session memory before the one-hour idle eviction path

## Problem

Gateway agent-cache eviction released request clients but left the agent-owned context-engine clone alive. For LCM-backed engines this could retain per-agent worker/thread state after the cached agent was gone. Finite sessions could also remain cached beyond the intended idle bound.

## Implementation

- add an idempotent, lock-protected context-engine ownership seam to `AIAgent`
- make soft release and hard close share that seam
- route explicit/LRU/idle eviction through soft release
- protect the exact currently running agent and queue deferred release without polling threads
- add focused lifecycle, concurrency, resource-preservation, and finite-session eviction tests

## Verification

Candidate: `2251967f9643d7d3ecbd5d3cb1162324a0abb3f7`
Parent: `3671c9f188e1563fd7acb6021f430e4607e17900`

- protected RED on the exact parent: **9 failed, 34 passed**
- focused GREEN: **43 passed**
- core/cache/shutdown/SessionDB suite: **101 passed**
- LCM lifecycle metrics: **23 passed**
- complete LCM engine suite: **750 passed**
- real `LCMEngine.clone_for_agent()` release integration: **PASS**
- `git diff --check` and `py_compile`: **PASS**

Duplicate searches for `context engine cache eviction lifecycle` and `LCM shutdown agent cache` found no matching issue or PR.

## Scope

This is a draft PR. It does not deploy, restart, activate, or modify a running gateway.
