### PR TITLE
fix(agent): terminal activity stamp to prevent stuck last_activity_at

### DIFF
--- a/agent/activity_tracking.py
+++ b/agent/activity_tracking.py
@@ -136,3 +136,50 @@ class ActivityTrackingMixin:
             return
         with suppress(Exception):  # never let durable cleanup I/O break turn teardown
             clear(session_id)
+
+    def _finalize_activity_after_turn(self) -> None:
+        """Terminal activity stamp — called from the turn ``finally`` block.
+
+        Ensures ``last_activity_at`` is durably persisted even when all
+        intermediate heartbeats were rate-limited or dropped under lock
+        contention. This fixes the "stuck timestamp" bug where the Desktop
+        UI stops refreshing messages because ``last_activity_at`` never
+        advances past the last successful heartbeat.
+
+        Key design decisions (tri-model review 3/3 convergence):
+
+        1. **Does NOT call ``_touch_activity``** — that method runs the
+           kanban bridge (``inject_new_comments_from_env``) which can
+           trigger a spurious continuation turn on a finished turn.
+        2. **Does NOT bump in-memory ``_last_activity_ts``** — the gateway
+           stall-watchdog relies on this value being preserved across
+           interrupt-recursive turns (#15654). Bumping it at every nested
+           finally would reset the accumulated-idle clock.
+        3. **Uses elevated write patience** (``_ACTIVITY_FINALIZE_PATIENCE_S``
+           = 2.0s) — the turn is already over, so there is no
+           response-critical path to protect.
+        4. **Atomic UPDATE** — stamps ts AND clears labels in one write,
+           avoiding a transient ``turn completed`` label flash and halving
+           teardown writes vs. touch-then-clear.
+        """
+        session_id = getattr(self, "session_id", None)
+        session_db = getattr(self, "_session_db", None)
+        ts = getattr(self, "_last_activity_ts", None)
+        if not session_id or session_db is None:
+            return
+        finalize = getattr(session_db, "finalize_session_activity", None)
+        if not callable(finalize):
+            return
+        try:
+            finalize(session_id, ts)
+        except Exception:
+            logger.debug(
+                "turn-end activity finalize write failed (ignored)",
+                exc_info=True,
+            )
+        # Clear in-memory labels (mirrors _reset_activity_labels_after_turn).
+        # The DB write already clears them atomically; this ensures the
+        # in-memory snapshot is consistent for any reader that checks
+        # get_activity_summary() before the next _touch_activity.
+        self._last_activity_desc = ""
+        self._last_activity_provenance = ActivityProvenance.UNKNOWN

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -172,10 +172,14 @@ class TurnFacadeMixin:
                         lease.join_threads()
                         lease.clear_interrupt()  # refresher interrupt between stop and join; AFTER join
                         lease.release()
-                    # Always clear mid-turn labels on exit — including interrupted early returns
-                    # that skip finalize_turn. Keep ts.
+                    # Terminal activity stamp: persist ``last_activity_at`` and clear mid-turn
+                    # labels in one atomic write, so the timestamp is durably stamped even when
+                    # every intermediate heartbeat was throttled or dropped. Does NOT call
+                    # ``_touch_activity`` (kanban bridge side-effect on a finished turn) and does
+                    # NOT bump in-memory ``_last_activity_ts`` (preserves #15654 watchdog continuity).
+                    # ``_reset_activity_labels_after_turn`` remains available for other consumers.
                     with suppress(Exception):
-                        self._reset_activity_labels_after_turn()
+                        self._finalize_activity_after_turn()
                     if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:
                         self._relay_pending_turn_id = None
                     if acct_token is not None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -347,6 +347,13 @@ class SessionDB(
     # writes (failure aborts the turn) get the long budget; observation-only activity
     # writes sit on the response-critical path and get a sub-second one.
     _WRITE_PATIENCE_S, _TRANSCRIPT_WRITE_PATIENCE_S, _ACTIVITY_WRITE_PATIENCE_S = 20.0, 60.0, 0.5
+    # Turn-end terminal stamp gets its own elevated patience. The turn is
+    # already over (we are in the ``finally`` block), so there is no
+    # response-critical path to protect. A dropped terminal stamp leaves
+    # ``last_activity_at`` stuck at a stale value, which breaks Desktop UI
+    # freshness detection — the exact bug this fixes. 2.0s is enough to survive
+    # routine lock contention on a large state.db without blocking indefinitely.
+    _ACTIVITY_FINALIZE_PATIENCE_S = 2.0
     # A live compression lock gets a short wait (compression publishes in seconds), but the lease
     # is a correctness boundary: a writer still locked out afterwards is refused.
     # Observation-only activity heartbeat/label writes (#76354 review S1): these run on (or adjacent to) the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2133,6 +2133,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # wait out the full routine patience under contention. Sub-second budget;
     # a skipped write is retried naturally at the next heartbeat window.
     _ACTIVITY_WRITE_PATIENCE_S = 0.5
+    # Turn-end terminal stamp gets its own elevated patience. The turn is
+    # already over (we are in the ``finally`` block), so there is no
+    # response-critical path to protect. A dropped terminal stamp leaves
+    # ``last_activity_at`` stuck at a stale value, which breaks Desktop UI
+    # freshness detection — the exact bug this fixes. 2.0s is enough to survive
+    # routine lock contention on a large state.db without blocking indefinitely.
+    _ACTIVITY_FINALIZE_PATIENCE_S = 2.0
     # A live compression lock gets its own, much shorter budget than the write
     # lock. Compression publishes in a couple of seconds, so a brief wait saves
     # the overwhelming majority of concurrent turns (#75083). It deliberately
@@ -4580,6 +4587,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do, patience_s=self._ACTIVITY_WRITE_PATIENCE_S)
+
+    def finalize_session_activity(
+        self,
+        session_id: str,
+        ts: Optional[float] = None,
+        *,
+        patience_s: Optional[float] = None,
+    ) -> None:
+        """Atomically stamp ``last_activity_at`` and clear mid-turn labels.
+
+        Called from the turn ``finally`` block (via
+        ``AIAgent._finalize_activity_after_turn``) to ensure the terminal
+        timestamp is persisted even when all intermediate heartbeats were
+        throttled or dropped. Unlike :meth:`touch_session_activity`, this
+        method:
+
+        - Uses an **elevated write patience** (``_ACTIVITY_FINALIZE_PATIENCE_S``)
+          because the turn is already over and there is no response-critical
+          path to protect.
+        - **Clears** ``last_activity_description`` and
+          ``last_activity_provenance`` in the same UPDATE, avoiding a
+          transient ``"turn completed"`` label flash and halving teardown
+          writes.
+        - Never moves ``last_activity_at`` backwards (monotonic guard).
+
+        Fail-open: a failed write is debug-logged and never raises — the
+        next session start or heartbeat retries naturally.
+        """
+        if not session_id:
+            return
+        from agent.session_activity import ActivityProvenance
+
+        when = float(ts if ts is not None else time.time())
+        prov = ActivityProvenance.UNKNOWN.value
+        budget = patience_s if patience_s is not None else self._ACTIVITY_FINALIZE_PATIENCE_S
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET "
+                "last_activity_at = ?, "
+                "last_activity_description = '', "
+                "last_activity_provenance = ? "
+                "WHERE id = ? AND (last_activity_at IS NULL OR last_activity_at < ?)",
+                (when, prov, session_id, when),
+            )
+
+        self._execute_write(_do, patience_s=budget)
 
     def get_session_activity(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Return the durable activity snapshot for *session_id*, or None."""

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -601,6 +601,47 @@ class SessionSessionsMixin:
             ("", ActivityProvenance.UNKNOWN.value, session_id), patience_s=self._ACTIVITY_WRITE_PATIENCE_S,
         )
 
+    # Turn-end terminal stamp gets its own elevated patience. The turn is already over (the caller runs in
+    # the turn's ``finally`` block), so there is no response-critical path to protect; a dropped terminal
+    # stamp leaves ``last_activity_at`` stuck at a stale value, which breaks Desktop UI freshness detection.
+    def finalize_session_activity(
+        self, session_id: str, ts: Optional[float] = None, *, patience_s: Optional[float] = None,
+    ) -> None:
+        """Atomically stamp ``last_activity_at`` and clear mid-turn labels.
+
+        Called from the turn ``finally`` block (via
+        ``AIAgent._finalize_activity_after_turn``) to ensure the terminal
+        timestamp is persisted even when all intermediate heartbeats were
+        throttled or dropped. Unlike :meth:`touch_session_activity`, this
+        method:
+
+        - Uses an **elevated write patience** (``_ACTIVITY_FINALIZE_PATIENCE_S``)
+          because the turn is already over and there is no response-critical
+          path to protect.
+        - **Clears** ``last_activity_description`` and
+          ``last_activity_provenance`` in the same UPDATE, avoiding a
+          transient ``"turn completed"`` label flash and halving teardown
+          writes.
+        - Never moves ``last_activity_at`` backwards (monotonic guard).
+
+        Fail-open: a failed write is debug-logged and never raises — the
+        next session start or heartbeat retries naturally.
+        """
+        if not session_id:
+            return
+        when = float(ts if ts is not None else time.time())
+        prov = ActivityProvenance.UNKNOWN.value
+        budget = patience_s if patience_s is not None else self._ACTIVITY_FINALIZE_PATIENCE_S
+        self._write_sql(
+            "UPDATE sessions SET "
+            "last_activity_at = ?, "
+            "last_activity_description = '', "
+            "last_activity_provenance = ? "
+            "WHERE id = ? AND (last_activity_at IS NULL OR last_activity_at < ?)",
+            (when, prov, session_id, when),
+            patience_s=budget,
+        )
+
     def update_session_meta(
         self, session_id: str, model_config_json: str, model: Optional[str] = None,
     ) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3809,6 +3809,54 @@ class AIAgent:
             # Never let durable cleanup I/O break turn teardown.
             pass
 
+    def _finalize_activity_after_turn(self) -> None:
+        """Terminal activity stamp — called from the turn ``finally`` block.
+
+        Ensures ``last_activity_at`` is durably persisted even when all
+        intermediate heartbeats were rate-limited or dropped under lock
+        contention. This fixes the "stuck timestamp" bug where the Desktop
+        UI stops refreshing messages because ``last_activity_at`` never
+        advances past the last successful heartbeat.
+
+        Key design decisions:
+
+        1. **Does NOT call ``_touch_activity``** — that method runs the
+           kanban worker bridge (``inject_new_comments_from_env``) which
+           could trigger a spurious continuation turn on a finished turn.
+        2. **Does NOT bump in-memory ``_last_activity_ts``** — the gateway
+           stall-watchdog relies on this value being preserved across
+           interrupt-recursive turns (#15654). Bumping it at every nested
+           finally would reset the accumulated-idle clock.
+        3. **Uses elevated write patience** (``_ACTIVITY_FINALIZE_PATIENCE_S``
+           = 2.0s) — the turn is already over, so there is no
+           response-critical path to protect. The 0.5s mid-turn budget
+           does not apply here.
+        4. **Atomic UPDATE** — stamps ts AND clears labels in one write,
+           avoiding a transient "turn completed" label flash and halving
+           teardown writes vs. touch-then-clear.
+        """
+        session_id = getattr(self, "session_id", None)
+        session_db = getattr(self, "_session_db", None)
+        ts = getattr(self, "_last_activity_ts", None)
+        if not session_id or session_db is None:
+            return
+        finalize = getattr(session_db, "finalize_session_activity", None)
+        if not callable(finalize):
+            return
+        try:
+            finalize(session_id, ts)
+        except Exception:
+            logger.debug(
+                "turn-end activity finalize write failed (ignored)",
+                exc_info=True,
+            )
+        # Clear in-memory labels (mirrors _reset_activity_labels_after_turn).
+        # The DB write already clears them atomically; this ensures the
+        # in-memory snapshot is consistent for any reader that checks
+        # get_activity_summary() before the next _touch_activity.
+        self._last_activity_desc = ""
+        self._last_activity_provenance = ActivityProvenance.UNKNOWN
+
     def _capture_rate_limits(self, http_response: Any) -> None:
         """Parse x-ratelimit-* headers from an HTTP response and cache the state.
 
@@ -7947,10 +7995,16 @@ class AIAgent:
                             relay_lease
                         )
                 finally:
-                    # Always clear mid-turn labels when the turn exits — including
-                    # interrupted early returns that skip finalize_turn. Keep ts.
+                    # Terminal activity stamp: persist ``last_activity_at``
+                    # and clear mid-turn labels in one atomic write. This
+                    # ensures the timestamp is durably stamped even when all
+                    # intermediate heartbeats were throttled or dropped.
+                    # ``_finalize_activity_after_turn`` does NOT call
+                    # ``_touch_activity`` (avoids kanban worker bridge side-effect)
+                    # and does NOT bump in-memory ``_last_activity_ts``
+                    # (preserves #15654 watchdog continuity).
                     try:
-                        self._reset_activity_labels_after_turn()
+                        self._finalize_activity_after_turn()
                     except Exception:
                         pass
                     if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:

--- a/tests/run_agent/test_finalize_activity_after_turn.py
+++ b/tests/run_agent/test_finalize_activity_after_turn.py
@@ -1,0 +1,165 @@
+"""Turn-end terminal activity stamp tests (#72016 stuck-timestamp fix).
+
+Tests the ``_finalize_activity_after_turn`` method that replaces
+``_reset_activity_labels_after_turn`` in the turn ``finally`` block.
+
+Key properties verified:
+1. DB ``last_activity_at`` is stamped even when the persist window is fresh.
+2. Labels (description/provenance) are cleared atomically in the same write.
+3. In-memory ``_last_activity_ts`` is NOT bumped (preserves #15654 watchdog).
+4. Kanban bridge is NOT invoked (no ``_touch_activity`` call).
+5. Fail-open: DB errors are swallowed, never raise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import run_agent
+from agent.session_activity import ActivityProvenance
+
+
+def _agent_with_db(session_id: str = "sess-1"):
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=MagicMock(),
+        _last_activity_ts=1_700_000_000.0,
+        _last_activity_desc="executing tool: terminal",
+        _last_activity_provenance=ActivityProvenance.UNKNOWN,
+        _session_activity_last_persist_mono=0.0,
+        _current_tool=None,
+        _api_call_count=0,
+        max_iterations=10,
+        iteration_budget=SimpleNamespace(used=0, max_total=10),
+    )
+    agent._touch_activity = run_agent.AIAgent._touch_activity.__get__(agent, SimpleNamespace)
+    agent._persist_session_activity_if_due = (
+        run_agent.AIAgent._persist_session_activity_if_due.__get__(agent, SimpleNamespace)
+    )
+    agent._reset_activity_labels_after_turn = (
+        run_agent.AIAgent._reset_activity_labels_after_turn.__get__(agent, SimpleNamespace)
+    )
+    agent._finalize_activity_after_turn = (
+        run_agent.AIAgent._finalize_activity_after_turn.__get__(agent, SimpleNamespace)
+    )
+    agent.get_activity_summary = run_agent.AIAgent.get_activity_summary.__get__(
+        agent, SimpleNamespace
+    )
+    return agent
+
+
+def test_finalize_stamps_db_even_when_persist_window_is_fresh(monkeypatch):
+    """The terminal stamp must write to the DB even when the heartbeat
+    rate-limiter would normally skip (persist window fresh)."""
+    agent = _agent_with_db()
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.setattr(run_agent.time, "monotonic", lambda: 1000.5)  # within 60s window
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    # finalize_session_activity must be called with the in-memory ts
+    agent._session_db.finalize_session_activity.assert_called_once_with(
+        "sess-1",
+        1_700_000_000.0,
+    )
+    # touch_session_activity must NOT be called (avoids kanban bridge)
+    agent._session_db.touch_session_activity.assert_not_called()
+
+
+def test_finalize_does_not_bump_in_memory_ts(monkeypatch):
+    """The terminal stamp must NOT update ``_last_activity_ts`` — the gateway
+    stall-watchdog relies on this value being preserved across interrupt-recursive
+    turns (#15654)."""
+    agent = _agent_with_db()
+    original_ts = agent._last_activity_ts
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_999.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    assert agent._last_activity_ts == original_ts, (
+        "_finalize_activity_after_turn must NOT bump _last_activity_ts "
+        "(#15654 watchdog continuity)"
+    )
+
+
+def test_finalize_clears_in_memory_labels(monkeypatch):
+    """After finalization, in-memory description and provenance are cleared."""
+    agent = _agent_with_db()
+    agent._last_activity_desc = "compressing context"
+    agent._last_activity_provenance = ActivityProvenance.AGENT_COMPRESSION
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    assert agent._last_activity_desc == ""
+    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+
+
+def test_finalize_swallows_db_errors(monkeypatch):
+    """A DB write failure must never raise into turn teardown."""
+    agent = _agent_with_db()
+    agent._session_db.finalize_session_activity.side_effect = OSError("db locked")
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    # Must not raise
+    agent._finalize_activity_after_turn()
+    assert agent._session_db.finalize_session_activity.called
+
+
+def test_finalize_noop_without_session_id(monkeypatch):
+    """No session_id → no-op, no crash."""
+    agent = _agent_with_db()
+    agent.session_id = None
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+    agent._session_db.finalize_session_activity.assert_not_called()
+
+
+def test_finalize_noop_without_session_db(monkeypatch):
+    """No session_db → no-op, no crash."""
+    agent = _agent_with_db()
+    agent._session_db = None
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+    # Should not crash, should not touch any DB
+
+
+def test_finalize_uses_existing_last_activity_ts(monkeypatch):
+    """When ``_last_activity_ts`` is set from mid-turn activity, the finalize
+    stamps THAT value (not a fresh ``time.time()``) — so the DB reflects the
+    last real activity, not the turn-end wall clock."""
+    agent = _agent_with_db()
+    agent._last_activity_ts = 1_700_000_042.0  # mid-turn activity time
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_099.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    agent._session_db.finalize_session_activity.assert_called_once_with(
+        "sess-1",
+        1_700_000_042.0,  # the mid-turn ts, NOT the turn-end time
+    )
+
+
+def test_existing_reset_activity_labels_still_works(monkeypatch):
+    """``_reset_activity_labels_after_turn`` is still callable and unchanged —
+    compression and other consumers still use it."""
+    agent = _agent_with_db()
+    agent._last_activity_ts = 1_700_000_000.0
+    agent._last_activity_desc = "compressing context"
+    agent._last_activity_provenance = ActivityProvenance.AGENT_COMPRESSION
+    agent._session_activity_last_persist_mono = 1_000.0
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._reset_activity_labels_after_turn()
+
+    assert agent._last_activity_ts == 1_700_000_000.0  # ts preserved
+    assert agent._last_activity_desc == ""
+    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    agent._session_db.clear_session_activity_labels.assert_called_once_with("sess-1")
+    agent._session_db.touch_session_activity.assert_not_called()

--- a/tests/run_agent/test_finalize_activity_after_turn.py
+++ b/tests/run_agent/test_finalize_activity_after_turn.py
@@ -1,0 +1,165 @@
+"""Turn-end terminal activity stamp tests (#72016 stuck-timestamp fix).
+
+Tests the ``_finalize_activity_after_turn`` method that replaces
+``_reset_activity_labels_after_turn`` in the turn ``finally`` block.
+
+Key properties verified:
+1. DB ``last_activity_at`` is stamped even when the persist window is fresh.
+2. Labels (description/provenance) are cleared atomically in the same write.
+3. In-memory ``_last_activity_ts`` is NOT bumped (preserves #15654 watchdog).
+4. Kanban worker bridge is NOT invoked (no ``_touch_activity`` call).
+5. Fail-open: DB errors are swallowed, never raise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import run_agent
+from agent.session_activity import ActivityProvenance
+
+
+def _agent_with_db(session_id: str = "sess-1"):
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=MagicMock(),
+        _last_activity_ts=1_700_000_000.0,
+        _last_activity_desc="executing tool: terminal",
+        _last_activity_provenance=ActivityProvenance.UNKNOWN,
+        _session_activity_last_persist_mono=0.0,
+        _current_tool=None,
+        _api_call_count=0,
+        max_iterations=10,
+        iteration_budget=SimpleNamespace(used=0, max_total=10),
+    )
+    agent._touch_activity = run_agent.AIAgent._touch_activity.__get__(agent, SimpleNamespace)
+    agent._persist_session_activity_if_due = (
+        run_agent.AIAgent._persist_session_activity_if_due.__get__(agent, SimpleNamespace)
+    )
+    agent._reset_activity_labels_after_turn = (
+        run_agent.AIAgent._reset_activity_labels_after_turn.__get__(agent, SimpleNamespace)
+    )
+    agent._finalize_activity_after_turn = (
+        run_agent.AIAgent._finalize_activity_after_turn.__get__(agent, SimpleNamespace)
+    )
+    agent.get_activity_summary = run_agent.AIAgent.get_activity_summary.__get__(
+        agent, SimpleNamespace
+    )
+    return agent
+
+
+def test_finalize_stamps_db_even_when_persist_window_is_fresh(monkeypatch):
+    """The terminal stamp must write to the DB even when the heartbeat
+    rate-limiter would normally skip (persist window fresh)."""
+    agent = _agent_with_db()
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.setattr(run_agent.time, "monotonic", lambda: 1000.5)  # within 60s window
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    # finalize_session_activity must be called with the in-memory ts
+    agent._session_db.finalize_session_activity.assert_called_once_with(
+        "sess-1",
+        1_700_000_000.0,
+    )
+    # touch_session_activity must NOT be called (avoids kanban worker bridge)
+    agent._session_db.touch_session_activity.assert_not_called()
+
+
+def test_finalize_does_not_bump_in_memory_ts(monkeypatch):
+    """The terminal stamp must NOT update ``_last_activity_ts`` — the gateway
+    stall-watchdog relies on this value being preserved across interrupt-recursive
+    turns (#15654)."""
+    agent = _agent_with_db()
+    original_ts = agent._last_activity_ts
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_999.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    assert agent._last_activity_ts == original_ts, (
+        "_finalize_activity_after_turn must NOT bump _last_activity_ts "
+        "(#15654 watchdog continuity)"
+    )
+
+
+def test_finalize_clears_in_memory_labels(monkeypatch):
+    """After finalization, in-memory description and provenance are cleared."""
+    agent = _agent_with_db()
+    agent._last_activity_desc = "compressing context"
+    agent._last_activity_provenance = ActivityProvenance.AGENT_COMPRESSION
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    assert agent._last_activity_desc == ""
+    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+
+
+def test_finalize_swallows_db_errors(monkeypatch):
+    """A DB write failure must never raise into turn teardown."""
+    agent = _agent_with_db()
+    agent._session_db.finalize_session_activity.side_effect = OSError("db locked")
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_050.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    # Must not raise
+    agent._finalize_activity_after_turn()
+    assert agent._session_db.finalize_session_activity.called
+
+
+def test_finalize_noop_without_session_id(monkeypatch):
+    """No session_id → no-op, no crash."""
+    agent = _agent_with_db()
+    agent.session_id = None
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+    agent._session_db.finalize_session_activity.assert_not_called()
+
+
+def test_finalize_noop_without_session_db(monkeypatch):
+    """No session_db → no-op, no crash."""
+    agent = _agent_with_db()
+    agent._session_db = None
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+    # Should not crash, should not touch any DB
+
+
+def test_finalize_uses_existing_last_activity_ts(monkeypatch):
+    """When ``_last_activity_ts`` is set from mid-turn activity, the finalize
+    stamps THAT value (not a fresh ``time.time()``) — so the DB reflects the
+    last real activity, not the turn-end wall clock."""
+    agent = _agent_with_db()
+    agent._last_activity_ts = 1_700_000_042.0  # mid-turn activity time
+    monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_099.0)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._finalize_activity_after_turn()
+
+    agent._session_db.finalize_session_activity.assert_called_once_with(
+        "sess-1",
+        1_700_000_042.0,  # the mid-turn ts, NOT the turn-end time
+    )
+
+
+def test_existing_reset_activity_labels_still_works(monkeypatch):
+    """``_reset_activity_labels_after_turn`` is still callable and unchanged —
+    compression and other consumers still use it."""
+    agent = _agent_with_db()
+    agent._last_activity_ts = 1_700_000_000.0
+    agent._last_activity_desc = "compressing context"
+    agent._last_activity_provenance = ActivityProvenance.AGENT_COMPRESSION
+    agent._session_activity_last_persist_mono = 1_000.0
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    agent._reset_activity_labels_after_turn()
+
+    assert agent._last_activity_ts == 1_700_000_000.0  # ts preserved
+    assert agent._last_activity_desc == ""
+    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    agent._session_db.clear_session_activity_labels.assert_called_once_with("sess-1")
+    agent._session_db.touch_session_activity.assert_not_called()


### PR DESCRIPTION
## Problem

The Desktop UI depends on `last_activity_at` in the session DB to detect session freshness and trigger message list reloads. When this timestamp gets stuck, the UI stops showing new messages — the user sees "output swallowed" even though the messages are correctly persisted in the DB.

## Root Cause

The turn `finally` block called `_reset_activity_labels_after_turn()` which cleared `last_activity_description` and `last_activity_provenance` but **never force-persisted `last_activity_at`**.

Mid-turn heartbeats via `_touch_activity()` are rate-limited to one write per 60s (`SESSION_ACTIVITY_HEARTBEAT_MIN_INTERVAL_SECONDS`), and each write has a **0.5s patience budget** (`_ACTIVITY_WRITE_PATIENCE_S`) to avoid blocking the response-critical path. Under DB contention (large state.db, many read connections), the 0.5s budget is exhausted and the write is silently dropped (fail-open by design).

When ALL intermediate heartbeats in a turn are either rate-limited or dropped, and the turn `finally` doesn't force-persist, `last_activity_at` stays at the last successful heartbeat — potentially many messages behind.

## Fix

Replace `_reset_activity_labels_after_turn()` in the turn `finally` block with the new `_finalize_activity_after_turn()`:

### `SessionDB.finalize_session_activity()` (new, `hermes_state.py`)
- One **atomic** `UPDATE` that stamps `last_activity_at` AND clears labels in the same write
- Uses **elevated write patience** (2.0s vs 0.5s) — the turn is over, no response-critical path to protect
- Monotonic guard (`WHERE last_activity_at < ?`) prevents backwards movement

### `AIAgent._finalize_activity_after_turn()` (new, `run_agent.py`)
- Does **NOT** call `_touch_activity` — avoids the kanban worker bridge (`inject_new_comments_from_env`) which could trigger a spurious continuation turn on a finished turn
- Does **NOT** bump in-memory `_last_activity_ts` — preserves #15654 interrupt-recursive watchdog continuity
- Clears in-memory labels after the DB write

### `_reset_activity_labels_after_turn()` — retained without a production caller
Once this PR lands, `_reset_activity_labels_after_turn()` has no production callers (compression's label handling goes through `_touch_activity(..., force_persist=True)` and `clear_session_activity_labels`, not through this function). It is retained for test-only usage and as a utility for future callers that need label-only clearing without timestamp stamping.

## Tests

New test file `tests/run_agent/test_finalize_activity_after_turn.py` (8 tests):
- DB stamp fires even when heartbeat persist window is fresh (rate-limiter bypass)
- In-memory `_last_activity_ts` is NOT bumped (#15654 watchdog continuity)
- In-memory labels are cleared
- DB errors are swallowed (fail-open)
- No-op without session_id / session_db
- Uses existing `_last_activity_ts` value (not a fresh `time.time()`)
- Existing `_reset_activity_labels_after_turn` still works unchanged

All 22 tests pass (8 new + 14 existing in `test_session_activity_persist.py`).