### PR TITLE
feat(moa): per-slot role framing, host-retrieved evidence, and command-only references

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -263,6 +263,114 @@ _REFERENCE_SYSTEM_PROMPT = (
 )
 
 
+# Wall-clock ceiling for a slot's ``context_command``. Reference fan-out is
+# already the slow leg of a turn; a retrieval helper that cannot answer inside
+# this budget is dropped rather than allowed to stall the council.
+_SLOT_CONTEXT_TIMEOUT = 80
+
+# Sentinel for a context_command that produced nothing usable. Rendered to the
+# advisor as an explicit retrieval FAILURE, never as an empty record — a
+# PRECEDENT-style advisor told "here is the record: <nothing>" will report "the
+# record is silent", which is a false statement about the world when the real
+# cause is a broken retriever.
+_CONTEXT_FAILED = "__CONTEXT_COMMAND_FAILED__"
+
+
+def _slot_context_block(slot: dict[str, Any],
+                        ref_messages: list[dict[str, Any]] | None = None) -> str:
+    """Run a slot's ``context_command`` and return retrieved evidence, or ''.
+
+    References are tool-less by design (see the fan-out note below), so an
+    advisor cannot look anything up for itself. This is the escape hatch: a
+    per-slot command runs on the host at fan-out time and its stdout is appended
+    to that advisor's system prompt. The advisor still calls no tools — it just
+    receives real retrieved material instead of reasoning from recall.
+
+    The latest user message is passed on argv (``$1``) and on stdin, so helpers
+    can retrieve against the actual question.
+
+    Fails OPEN: any error, timeout, or non-zero exit yields '' and a warning.
+    A broken retriever degrades that advisor to recall-only; it never breaks the
+    turn. Output is capped so a runaway helper cannot blow up the prompt.
+    """
+    cmd = slot.get("context_command")
+    if not cmd:
+        return ""
+    question = ""
+    for m in reversed(ref_messages or []):
+        if m.get("role") == "user" and isinstance(m.get("content"), str):
+            question = m["content"]
+            break
+    argv = [*cmd, question] if isinstance(cmd, list) else [cmd, question]
+    try:
+        import subprocess
+        r = subprocess.run(argv, capture_output=True, text=True,
+                           input=question, timeout=_SLOT_CONTEXT_TIMEOUT)
+        if r.returncode != 0:
+            logger.warning("MoA slot context_command failed (%s): rc=%s %s",
+                           _slot_label(slot), r.returncode, (r.stderr or "")[:200])
+            return _CONTEXT_FAILED
+        out = (r.stdout or "").strip()
+        if not out:
+            return _CONTEXT_FAILED
+        return out[:12000]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("MoA slot context_command error (%s): %s",
+                       _slot_label(slot), exc)
+        return _CONTEXT_FAILED
+
+
+def _slot_ref_system(slot: dict[str, Any],
+                     ref_messages: list[dict[str, Any]] | None = None,
+                     context_block: str | None = None) -> str:
+    """Resolve the system prompt for one reference slot.
+
+    Optional per-slot keys, all absent by default (so stock presets are
+    byte-identical to prior behaviour):
+
+    - ``prompt_hint``: appended to the END of the stock advisory prompt. The
+      light-touch form — the standard framing (no tools, never claim to have
+      executed anything) stays intact and a role nudge lands at the tail. Tail
+      placement also keeps the cacheable prefix stable across turns.
+    - ``prompt``: full replacement of the stock advisory prompt. Use sparingly;
+      a replacement silently drops the stock guardrails.
+    - ``context_command``: host command whose stdout is appended last — real
+      retrieved evidence for an advisor that cannot call tools.
+
+    Order is deliberate: stable text first, volatile last, so the cacheable
+    prefix does not move when retrieved content changes between turns.
+
+    ``context_block`` is an optional precomputed command result. When set
+    (including empty), the slot's ``context_command`` is NOT run again — the
+    caller has already executed it and is reusing the result (command_only
+    fall-through, failure path). The command is a subprocess; running it twice
+    per reference doubles retrieval latency and side effects at fan-out.
+    """
+    base = str(slot.get("prompt") or "").strip() or _REFERENCE_SYSTEM_PROMPT
+    parts = [base]
+    hint = str(slot.get("prompt_hint") or "").strip()
+    if hint:
+        parts.append(hint)
+    if context_block is None:
+        context_block = _slot_context_block(slot, ref_messages)
+    block = context_block
+    if block == _CONTEXT_FAILED:
+        parts.append(
+            "RETRIEVAL FAILED this turn. A lookup was attempted on your behalf and "
+            "returned nothing — the tool broke, not the record. Do NOT conclude that "
+            "the record is empty or silent: you simply have no retrieval this turn. "
+            "Say \"retrieval unavailable\" and advise from the conversation alone."
+        )
+    elif block:
+        parts.append(
+            "Retrieved material for this turn, gathered on your behalf because you "
+            "cannot call tools. Treat it as the record. Cite from it specifically. "
+            "If it does not cover the question, say so rather than guessing:\n\n"
+            + block
+        )
+    return "\n\n".join(parts)
+
+
 
 def _slot_label(slot: dict[str, Any]) -> str:
     label = f"{(slot.get('provider') or '').strip()}:{(slot.get('model') or '').strip()}"
@@ -474,12 +582,45 @@ def _run_reference(
 
     label = _slot_label(slot)
     runtime = _slot_runtime(slot)
+    # Slot system prompt, resolved inside the try and reused by the failure
+    # path. _slot_ref_system may run the slot's context_command (a subprocess),
+    # so it must never be resolved twice for one reference.
+    ref_system = None
     try:
+        _cmd_out = None
+        # ``command_only``: the slot's ``context_command`` output IS this
+        # advisor's answer — return it and skip the model call entirely.
+        #
+        # For a retriever that already produces a finished advisory (xAI's
+        # /v1/responses x_search returns a cited practitioner summary), running
+        # the slot model over that output is a second generation that adds
+        # latency and tokens without adding evidence. Measured: ~47s search plus
+        # ~56s relay vs ~47s total. Costs nothing when unset.
+        if slot.get("command_only"):
+            _cmd_out = _slot_context_block(slot, ref_messages)
+            if _cmd_out and _cmd_out != _CONTEXT_FAILED:
+                return label, _cmd_out, _RefAccounting(
+                    CanonicalUsage(),
+                    messages=[{"role": "system", "content": "[command_only slot]"},
+                              *ref_messages],
+                    output=_cmd_out,
+                    model=slot.get("model"),
+                    provider=runtime.get("provider") or slot.get("provider"),
+                    temperature=temperature,
+                )
+            logger.warning("MoA command_only slot %s produced nothing; "
+                           "falling through to the model", label)
         # Prepend the advisory-role system prompt so the reference understands
         # it is analyzing state for an aggregator, not acting on the task. The
         # trimmed view (_reference_messages) already strips the agent's own
         # system prompt, so this is the only system message the reference sees.
-        messages = [{"role": "system", "content": _REFERENCE_SYSTEM_PROMPT}, *ref_messages]
+        # Optional per-slot ``prompt_hint`` (appended) / ``prompt`` (replaces) —
+        # see _slot_ref_system. Absent by default, so stock is unchanged.
+        # Resolved ONCE, with the command_only attempt reused when present:
+        # resolving again would re-run the slot's context_command subprocess.
+        ref_system = _slot_ref_system(slot, ref_messages, context_block=_cmd_out)
+        messages = [{"role": "system", "content": ref_system},
+                    *ref_messages]
         # Trim to fit THIS reference model's context window. Reference models
         # may have a smaller window than the aggregator (e.g. kimi-k2.7-code
         # @ 262K advising a glm-5.2 @ 1M conversation); without this trim the
@@ -594,7 +735,13 @@ def _run_reference(
         logger.warning("MoA reference model %s failed: %s", label, exc)
         return label, f"[failed: {exc}]", _RefAccounting(
             CanonicalUsage(),
-            messages=[{"role": "system", "content": _REFERENCE_SYSTEM_PROMPT}, *ref_messages],
+            # Reuse the slot system prompt resolved in the try block — never
+            # re-run the slot's context_command from here (subprocess with
+            # side effects). Stock prompt only when the failure fired before
+            # the resolve (defensive: _run_reference never raises).
+            messages=[{"role": "system",
+                       "content": ref_system if ref_system is not None
+                       else _REFERENCE_SYSTEM_PROMPT}, *ref_messages],
             output=f"[failed: {exc}]",
             model=slot.get("model"),
             provider=runtime.get("provider") or slot.get("provider"),
@@ -1674,7 +1821,27 @@ class MoAChatCompletions:
         history.
         """
         guidance = prepared.get("guidance")
-        agg_messages = [dict(message) for message in messages]
+        # Strip internal bookkeeping fields before the aggregator call.
+        # The normal agent loop (chat_completion_helpers) strips these via
+        # its sanitizer; the MoA aggregator path copies messages here and
+        # must do the same. Fields to remove:
+        #   - _db_persisted: stamped by run_agent during persistence
+        #   - tool_name: SQLite FTS bookkeeping on tool-role messages
+        #   - codex_reasoning_items / codex_message_items: reasoning carriers
+        #   - timestamp: gateway replay bookkeeping
+        #   - All underscore-prefixed keys: Hermes-internal scaffolding
+        # Strict providers (Anthropic, Fireworks) reject unknown fields
+        # with HTTP 400 "Extra inputs are not permitted".
+        _MOA_INTERNAL_FIELDS = {"_db_persisted", "tool_name", "codex_reasoning_items",
+                                "codex_message_items", "timestamp"}
+        agg_messages = []
+        for message in messages:
+            clean = dict(message)
+            for field in _MOA_INTERNAL_FIELDS:
+                clean.pop(field, None)
+            for key in [k for k in clean if isinstance(k, str) and k.startswith("_")]:
+                clean.pop(key, None)
+            agg_messages.append(clean)
         if guidance:
             _attach_reference_guidance(agg_messages, str(guidance))
         return {**prepared, "messages": agg_messages}
@@ -2130,7 +2297,19 @@ class MoAChatCompletions:
                 )
 
         guidance: str | None = None
-        agg_messages = [dict(m) for m in messages]
+        # Strip internal bookkeeping fields before the aggregator call (same
+        # fix as the prepared-request path above — strict providers reject
+        # unknown fields with HTTP 400 "Extra inputs are not permitted").
+        _MOA_INTERNAL_FIELDS = {"_db_persisted", "tool_name", "codex_reasoning_items",
+                                "codex_message_items", "timestamp"}
+        agg_messages = []
+        for m in messages:
+            clean = dict(m)
+            for field in _MOA_INTERNAL_FIELDS:
+                clean.pop(field, None)
+            for key in [k for k in clean if isinstance(k, str) and k.startswith("_")]:
+                clean.pop(key, None)
+            agg_messages.append(clean)
         successful_outputs = _successful_references(reference_outputs)
         failed_labels = _failed_reference_labels(reference_outputs)
         joined = ""

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -217,6 +217,34 @@ def _clean_slot(slot: Any, *, include_enabled: bool = False) -> dict[str, Any] |
     slot_mt = _coerce_int_or_none(slot.get("max_tokens"))
     if slot_mt is not None:
         clean["max_tokens"] = slot_mt
+    # Optional per-slot advisory framing. Both absent by default, so existing
+    # presets normalize byte-identically.
+    #
+    #   ``prompt_hint`` — appended to the END of the stock advisory prompt. The
+    #     light-touch form: standard framing stays intact (no tools, never claim
+    #     to have executed anything) and a role nudge lands at the tail, which
+    #     also keeps the cacheable prefix stable across turns.
+    #   ``prompt`` — full replacement. Use sparingly: it silently drops the
+    #     stock guardrails.
+    #
+    # Purpose is response diversity. Stock MoA sends every reference the same
+    # framing, so N models return N correlated restatements (PRISM,
+    # arXiv:2602.08586: error correlation breaks on role diversity, not count).
+    # ``context_command``: host command run at fan-out whose stdout is appended
+    # last — real retrieved evidence for an advisor that cannot call tools.
+    _cc = slot.get("context_command")
+    if isinstance(_cc, str) and _cc.strip():
+        clean["context_command"] = _cc.strip()
+    elif isinstance(_cc, list) and _cc and all(isinstance(x, str) for x in _cc):
+        clean["context_command"] = [x for x in _cc]
+    # ``command_only``: the context_command output IS this advisor's answer;
+    # skip the model call. Only meaningful with context_command set.
+    if _coerce_bool(slot.get("command_only"), False):
+        clean["command_only"] = True
+    for _key in ("prompt", "prompt_hint"):
+        _val = slot.get(_key)
+        if isinstance(_val, str) and _val.strip():
+            clean[_key] = _val.strip()
     if include_enabled:
         clean["enabled"] = _coerce_bool(slot.get("enabled"), True)
     return clean

--- a/tests/agent/test_moa_reference_system_prompt.py
+++ b/tests/agent/test_moa_reference_system_prompt.py
@@ -71,3 +71,68 @@ def test_reference_system_prompt_structure():
     # Should contain the word "advisor" (defines role)
     assert "advisor" in _REFERENCE_SYSTEM_PROMPT.lower(), \
         "Prompt should clearly define the advisor role"
+
+
+def test_slot_ref_system_stock_then_hint_then_evidence_order():
+    """Composition order: stock framing, prompt_hint, then retrieved evidence."""
+    from agent.moa_loop import _slot_ref_system
+
+    slot = {
+        "prompt_hint": "act as the steelman",
+        "context_command": ["echo", "EVIDENCE_BLOCK"],
+    }
+    prompt = _slot_ref_system(slot, [{"role": "user", "content": "q"}])
+    assert prompt.startswith(_REFERENCE_SYSTEM_PROMPT)
+    assert prompt.index("act as the steelman") < prompt.index("EVIDENCE_BLOCK")
+    assert "Retrieved material for this turn" in prompt
+
+
+def test_slot_ref_system_failed_command_renders_sentinel_not_silence():
+    """A broken retriever renders as retrieval failure, never an empty record."""
+    from agent.moa_loop import _slot_ref_system
+
+    prompt = _slot_ref_system(
+        {"context_command": ["sh", "-c", "exit 3"]},
+        [{"role": "user", "content": "q"}],
+    )
+    assert "RETRIEVAL FAILED this turn" in prompt
+    assert "the tool broke, not the record" in prompt
+
+
+def test_slot_ref_system_prompt_replaces_stock_and_keeps_evidence():
+    """prompt replaces the stock framing; evidence is still appended last."""
+    from agent.moa_loop import _slot_ref_system
+
+    prompt = _slot_ref_system(
+        {"prompt": "FULL_REPLACEMENT", "context_command": ["echo", "EVIDENCE_BLOCK"]},
+        [{"role": "user", "content": "q"}],
+    )
+    assert prompt.startswith("FULL_REPLACEMENT")
+    assert "EVIDENCE_BLOCK" in prompt
+    assert _REFERENCE_SYSTEM_PROMPT not in prompt
+
+
+def test_slot_ref_system_reuses_precomputed_context_block(monkeypatch):
+    """A precomputed context_block must not re-run the slot command.
+
+    The context_command is a subprocess; resolving the same slot twice per
+    reference would double retrieval latency and side effects at fan-out.
+    """
+    from agent import moa_loop
+
+    calls = []
+    original = moa_loop._slot_context_block
+
+    def counting(slot, ref_messages=None):
+        calls.append(1)
+        return original(slot, ref_messages)
+
+    monkeypatch.setattr(moa_loop, "_slot_context_block", counting)
+
+    prompt = moa_loop._slot_ref_system(
+        {"context_command": ["echo", "EVIDENCE_BLOCK"]},
+        [{"role": "user", "content": "q"}],
+        context_block="PRECOMPUTED",
+    )
+    assert "PRECOMPUTED" in prompt
+    assert calls == []

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -205,3 +205,122 @@ class TestCallLlmApiMode:
         sig = inspect.signature(call_llm)
         assert "api_mode" in sig.parameters
         assert sig.parameters["api_mode"].default is None
+
+
+def test_run_reference_command_only_skips_model_call(monkeypatch):
+    """command_only: the command output IS the answer; no model call happens."""
+    from agent import moa_loop
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("should not be called")
+
+    monkeypatch.setattr(
+        moa_loop, "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": slot["model"],
+            "base_url": "https://api.example/v1",
+            "api_key": "test-key",
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop, "_slot_context_block",
+        lambda slot, ref_messages=None: "FINISHED_ADVISORY",
+    )
+
+    label, text, acct = moa_loop._run_reference(
+        {"provider": "custom", "model": "fake-model", "command_only": True},
+        [{"role": "user", "content": "q"}],
+    )
+    assert label == "custom:fake-model"
+    assert text == "FINISHED_ADVISORY"
+    assert calls == []
+    assert acct.usage is not None
+
+
+def test_run_reference_command_only_falls_through_and_runs_command_once(monkeypatch):
+    """Empty/failed command output falls back to the model — and the command
+    is executed exactly once for the whole reference."""
+    from agent import moa_loop
+
+    cmd_calls = []
+
+    def counting_block(slot, ref_messages=None):
+        cmd_calls.append(1)
+        return moa_loop._CONTEXT_FAILED
+
+    monkeypatch.setattr(moa_loop, "_slot_context_block", counting_block)
+    monkeypatch.setattr(
+        moa_loop, "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": slot["model"],
+            "base_url": "https://api.example/v1",
+            "api_key": "test-key",
+        },
+    )
+    monkeypatch.setattr(
+        moa_loop, "call_llm", lambda **kwargs: _response("model answer")
+    )
+    monkeypatch.setattr(
+        moa_loop, "_maybe_apply_moa_cache_control",
+        lambda messages, runtime: messages,
+    )
+
+    label, text, acct = moa_loop._run_reference(
+        {
+            "provider": "custom",
+            "model": "fake-model",
+            "command_only": True,
+            "context_command": ["echo"],
+            "prompt_hint": "act as the red team",
+        },
+        [{"role": "user", "content": "q"}],
+    )
+    assert text == "model answer"
+    # Single execution: the fall-through path reuses the failed result rather
+    # than re-running the subprocess (regression for double-run at fan-out).
+    assert cmd_calls == [1]
+
+
+def test_run_reference_failure_path_does_not_rerun_context_command(monkeypatch):
+    """The failure path reuses the resolved system prompt — no second run."""
+    from agent import moa_loop
+
+    cmd_calls = []
+
+    def counting_block(slot, ref_messages=None):
+        cmd_calls.append(1)
+        return "EVIDENCE"
+
+    monkeypatch.setattr(moa_loop, "_slot_context_block", counting_block)
+    monkeypatch.setattr(
+        moa_loop, "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": slot["model"],
+            "base_url": "https://api.example/v1",
+            "api_key": "test-key",
+        },
+    )
+
+    def boom(**kwargs):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(moa_loop, "call_llm", boom)
+    monkeypatch.setattr(
+        moa_loop, "_maybe_apply_moa_cache_control",
+        lambda messages, runtime: messages,
+    )
+
+    label, text, acct = moa_loop._run_reference(
+        {"provider": "custom", "model": "fake-model", "context_command": ["echo"]},
+        [{"role": "user", "content": "q"}],
+    )
+    assert text.startswith("[failed:")
+    assert cmd_calls == [1]
+    assert "EVIDENCE" in " ".join(m.get("content", "") for m in acct.messages)

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -181,3 +181,101 @@ def test_validate_moa_payload_agrees_with_clean_slot():
 
 
 
+
+
+def test_normalize_preserves_per_slot_reference_knobs():
+    """prompt_hint / prompt / context_command / command_only survive normalization.
+
+    Absent keys stay absent: existing presets must normalize byte-identically.
+    """
+    cfg = normalize_moa_config({
+        "default_preset": "p",
+        "presets": {
+            "p": {
+                "reference_models": [
+                    {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                        "prompt_hint": "act as the steelman",
+                        "context_command": ["/bin/echo", "evidence"],
+                        "command_only": True,
+                    },
+                    {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                        "prompt": "replacement framing",
+                    },
+                    {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                    },
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            }
+        },
+    })
+    slots = cfg["presets"]["p"]["reference_models"]
+    assert slots[0]["prompt_hint"] == "act as the steelman"
+    assert slots[0]["context_command"] == ["/bin/echo", "evidence"]
+    assert slots[0]["command_only"] is True
+    assert slots[1]["prompt"] == "replacement framing"
+    assert "prompt_hint" not in slots[2]
+    assert "context_command" not in slots[2]
+    assert "command_only" not in slots[2]
+
+
+def test_normalize_coerces_command_only_from_string():
+    """command_only accepts the same boolean strings as other slot flags."""
+    cfg = normalize_moa_config({
+        "default_preset": "p",
+        "presets": {
+            "p": {
+                "reference_models": [
+                    {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                        "context_command": "/bin/echo",
+                        "command_only": "yes",
+                    },
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            }
+        },
+    })
+    slot = cfg["presets"]["p"]["reference_models"][0]
+    assert slot["context_command"] == "/bin/echo"
+    assert slot["command_only"] is True
+
+
+def test_normalize_preserves_command_only_without_context_command():
+    """command_only survives even without a command; runtime treats it as inert.
+
+    Without a context_command, _slot_context_block returns nothing usable and
+    the slot falls through to the model call — the flag alone changes nothing.
+    """
+    cfg = normalize_moa_config({
+        "default_preset": "p",
+        "presets": {
+            "p": {
+                "reference_models": [
+                    {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                        "command_only": True,
+                    },
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            }
+        },
+    })
+    slot = cfg["presets"]["p"]["reference_models"][0]
+    assert slot["command_only"] is True


### PR DESCRIPTION
## What does this PR do?

Reference advisors are tool-less by design — no `tools` argument, no execution, plain text only. Stock Hermes gives every reference identical framing and nothing beyond the conversation. This PR adds three optional per-slot knobs (four keys) to MoA presets — `prompt` / `prompt_hint`, `context_command`, `command_only` — all absent by default so existing presets normalize byte-identically:

- **`prompt_hint` / `prompt`** — per-slot framing, appended to (or replacing) the stock advisory prompt.
- **`context_command`** — a host command run once at fan-out; stdout appended as evidence at the tail of that reference's prompt (latest user message passed on argv and stdin; 80 s ceiling; 12 KB output cap).
- **`command_only`** — the `context_command` output *is* the reference's answer; the model call is skipped. Only for sources whose output is already a finished, cited advisory.

Plus two correctness changes: the reference system prompt is resolved once per reference (the command is a subprocess — the failure path must not re-run it), and the aggregator copies of internal bookkeeping fields are sanitized before the provider request.

**Why now — evidence per change:**

- *Framing:* similar models under identical instructions return correlated restatements, so N identical advisors are one advisor at N× cost; role-differentiated framing is what makes selection between them meaningful (MoA, arXiv:2406.04692).
- *Evidence:* an advisor that cannot look anything up will confidently invent the record when asked about it — this gap produced "the record is silent" false statements in practice. A failed retrieval now renders an explicit `RETRIEVAL FAILED` sentinel, never an empty record, so the advisor cannot mistake a broken reader for an empty history.
- *Command-only:* xAI retired `live_search` on `/v1/chat/completions` (HTTP 410); built-in tools moved to `/v1/responses`. One `/v1/responses` call with `model=grok-4.5` and `tools=[{type:x_search}]` returns a complete, cited answer; relaying it through a second reference-model generation measured **+56 s for zero added evidence**.
- *Single resolution:* before, a failed reference resolved the slot system prompt again in the exception path — re-running the subprocess (double latency and side effects at fan-out, where every reference is already on the critical path).
- *Sanitization:* the aggregator copies carried internal bookkeeping fields (`_db_persisted`, `tool_name`, `codex_*`, `timestamp`, plus any underscore-prefixed key) that strict providers reject with HTTP 400 `Extra inputs are not permitted`; the main loop already strips these, the MoA copies did not.

## Related Issue

None — new feature. Searched open and closed PRs and issues for the feature terms; no duplicates.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/moa_loop.py` — `_slot_ref_system`: per-slot `prompt_hint` / `prompt` / `context_command` composition, precomputed-block reuse; `_slot_context_block`: host command execution (`_SLOT_CONTEXT_TIMEOUT = 80`, 12 KB cap, `_CONTEXT_FAILED` sentinel); `_run_reference`: `command_only` short-circuit, single system-prompt resolution per reference; `MoAChatCompletions`: aggregator sanitization of internal bookkeeping fields.
- `hermes_cli/moa_config.py` — normalization of the new slot keys.
- `tests/hermes_cli/test_moa_config.py`, `tests/agent/test_moa_reference_system_prompt.py`, `tests/agent/test_moa_slot_api_mode.py` — 10 new tests: normalization round-trips (list/string command, boolean coercion, absent defaults), composition order and sentinel rendering, `command_only` skip, fall-through single-execution, failure path no-rerun.

## How to Test

1. Configure a preset with the three knob shapes (example below) and run a MoA turn with it as the model.
2. Reference blocks render per slot: the framing hint applied, evidence appended last, and a `command_only` slot showing the command output verbatim with no model call for that seat.
3. Make the command exit non-zero: the advisor renders `RETRIEVAL FAILED…` and the turn continues under the preset's degraded policy.
4. `pytest` the MoA files — 67 passed across the 16 collectible MoA test files, including the 10 new tests. Four MoA test files fail collection in this environment on a pre-existing missing `fastapi`/`uvicorn` dependency, unrelated to this change.

```yaml
moa:
  presets:
    example:
      aggregator: {provider: anthropic, model: claude-opus-5}
      reference_models:
        - {provider: gemini, model: gemini-3.1-pro-preview, prompt_hint: "act as the steelman"}
        - {provider: openai, model: gpt-5.6-sol, context_command: ["precedent-search"], prompt_hint: "reason from the record"}
        - {provider: xai, model: grok-4.5, context_command: ["x-search"], command_only: true}
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits — PR title is the squash target: `feat(moa): …`; a follow-up commit is `fix(moa): …`
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (an unrelated local `models.py` tweak was excluded)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the complete MoA suite instead: 67/67 on the 16 collectible files; full-tree collection fails in this environment on a pre-existing missing `fastapi`/`uvicorn`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings for the new slot keys and runtime behaviour
- [ ] I've updated `cli-config.yaml.example` — N/A: MoA presets are user config, not CLI config
- [x] I've considered cross-platform impact — commands run as argv lists (no shell); the harness change is portable
- [x] Tool descriptions/schemas — N/A (no tool behavior changed)

## Screenshots / Logs

MoA trace excerpt (the `xai:grok-4.5` reference block, verbatim retriever output as the advisor's answer):

```
Reference 4 — xai:grok-4.5[reasoning=high] (4084 chars):
CACHED RETRIEVAL — gathered 257m ago (STALE by 227m). A refresh is running now.
NOTE: this was gathered for a DIFFERENT question: "close it". Judge whether it
bears on the current one, and say plainly...
```

| What | Before | After |
|---|---|---|
| xAI x_search result → advisor | 2nd model generation, **+56 s**, zero added evidence | direct passthrough (`command_only`) |
| N advisors, identical framing | correlated restatements | role-differentiated positions |
| Broken/empty retrieval | advisor guesses or claims "record is silent" | explicit `RETRIEVAL FAILED` sentinel |
| Aggregator copy to strict provider | HTTP 400 `Extra inputs are not permitted` | sanitized request |
