### PR TITLE
fix(cron): gateway-loop delivery, per-run prompt context, Matrix standalone send — run-action sweep salvage

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2484,7 +2484,11 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
-def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
+def _build_job_prompt(
+    job: dict,
+    prerun_script: Optional[tuple] = None,
+    extra_prompt: Optional[str] = None,
+) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
     Args:
@@ -2494,8 +2498,14 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             When provided, the script is not re-executed and the cached
             result is used for prompt injection. When omitted, the script
             (if any) runs inline as before.
+        extra_prompt: Optional per-run context (from ``cronjob(action='run')``,
+            #57331 — salvaged from #57342 by @liuhao1024). Appended to the
+            stored prompt under a ``## Run Context`` header for this single
+            fire only — never persisted to the job definition.
     """
     user_prompt = str(job.get("prompt") or "")
+    if extra_prompt:
+        user_prompt = f"{user_prompt}\n\n## Run Context\n{extra_prompt}"
     prompt = user_prompt
     skills = job.get("skills")
     # True when runtime-collected DATA (script stdout, upstream-job output)
@@ -2806,7 +2816,8 @@ def _guard_job_credential_exfil(job: dict) -> None:
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None
+    job: dict, *, defer_agent_teardown: Optional[list] = None,
+    extra_prompt: Optional[str] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2820,6 +2831,10 @@ def run_job(
     torn-down async client (defense-in-depth alongside the interpreter-shutdown
     guard). When ``None`` (the default) teardown happens inline as before, so
     every existing caller is unchanged.
+
+    ``extra_prompt``: optional per-run context from ``cronjob(action='run',
+    prompt=...)`` (#57331). Appended to the stored prompt for this fire only —
+    never persisted to the job definition.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -3029,7 +3044,9 @@ def run_job(
             return True, silent_doc, SILENT_MARKER, None
 
     try:
-        prompt = _build_job_prompt(job, prerun_script=prerun_script)
+        prompt = _build_job_prompt(
+            job, prerun_script=prerun_script, extra_prompt=extra_prompt
+        )
     except CronPromptInjectionBlocked as block_exc:
         # Assembled prompt (user prompt + loaded skill content) tripped the
         # injection scanner. Refuse to run the agent this tick and surface
@@ -3956,7 +3973,10 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+def run_one_job(
+    job: dict, *, adapters=None, loop=None, verbose: bool = False,
+    extra_prompt: Optional[str] = None,
+) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
@@ -4024,7 +4044,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         _deferred_agents: list = []
         try:
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
+                job, defer_agent_teardown=_deferred_agents,
+                extra_prompt=extra_prompt,
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -5079,13 +5079,21 @@ async def _standalone_send(
         except ImportError:
             pass
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
-            async with session.put(url, headers=headers, json=payload) as resp:
-                if resp.status not in {200, 201}:
-                    body = await resp.text()
-                    return {"error": f"Matrix API error ({resp.status}): {body}"}
-                data = await resp.json()
-        return {"success": True, "platform": "matrix", "chat_id": chat_id, "message_id": data.get("event_id")}
+        # Use asyncio.wait_for() instead of aiohttp.ClientTimeout to avoid
+        # "Timeout context manager should be used inside a task" errors when
+        # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
+        async with aiohttp.ClientSession() as session:
+            async def _do_send():
+                async with session.put(url, headers=headers, json=payload) as resp:
+                    if resp.status not in {200, 201}:
+                        body = await resp.text()
+                        return {"error": f"Matrix API error ({resp.status}): {body}"}
+                    data = await resp.json()
+                    return {"success": True, "platform": "matrix", "chat_id": chat_id, "message_id": data.get("event_id")}
+            try:
+                return await asyncio.wait_for(_do_send(), timeout=30)
+            except asyncio.TimeoutError:
+                return {"error": "Matrix API timeout (30s)"}
     except Exception as e:
         return {"error": f"Matrix send failed: {e}"}
 

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -252,7 +252,7 @@ class TestRunJobKanbanIsolation:
             },
         )
         monkeypatch.setattr(
-            sched, "_build_job_prompt", lambda job, prerun_script=None: "hi"
+            sched, "_build_job_prompt", lambda job, prerun_script=None, **kw: "hi"
         )
         monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -199,7 +199,7 @@ class TestRunJobTerminalCwd:
         )
 
         # Stub scheduler helpers that would otherwise hit the filesystem / config.
-        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None, **kw: "hi")
         monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -215,7 +215,7 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(
         scheduler,
         "run_job",
-        lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
+        lambda job, *, defer_agent_teardown=None, **_kw: (True, "output", "response", None),
     )
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -146,7 +146,7 @@ class TestSequentialPool:
 
         barrier = threading.Barrier(2, timeout=5)
 
-        def slow_run(j, *, defer_agent_teardown=None):
+        def slow_run(j, *, defer_agent_teardown=None, **_kw):
             barrier.wait()
             return True, "out", "resp", None
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -18,7 +18,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     """Patch the job pipeline primitives and record the call order."""
     calls = []
 
-    def fake_run_job(job, *, defer_agent_teardown=None):
+    def fake_run_job(job, *, defer_agent_teardown=None, **kw):
         calls.append(("run_job", job["id"]))
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
@@ -83,7 +83,7 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
 
     scope_during_run = {}
 
-    def fake_run_job(job, *, defer_agent_teardown=None):
+    def fake_run_job(job, *, defer_agent_teardown=None, **kw):
         # This is where resolve_runtime_provider() would read a secret. Prove a
         # scope is installed and the profile's secret resolves without raising.
         scope_during_run["scope"] = ss.current_secret_scope()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1268,7 +1268,7 @@ class TestParallelTick:
         barrier = threading.Barrier(2, timeout=5)
         call_order = []
 
-        def mock_run_job(job, *, defer_agent_teardown=None):
+        def mock_run_job(job, *, defer_agent_teardown=None, **kw):
             """Each job hits a barrier — both must be active simultaneously."""
             call_order.append(("start", job["id"]))
             barrier.wait()  # blocks until both threads reach here
@@ -1302,7 +1302,7 @@ class TestParallelTick:
         from gateway.session_context import get_session_env
         seen = {}
 
-        def mock_run_job(job, *, defer_agent_teardown=None):
+        def mock_run_job(job, *, defer_agent_teardown=None, **kw):
             origin = job.get("origin", {})
             # run_job sets ContextVars — verify each job sees its own
             from gateway.session_context import set_session_vars, clear_session_vars

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1936,6 +1936,30 @@ class TestMultiTargetDeliveryContinuesOnFailure:
         assert "b@example.com" in result
         assert mock_pool.submit.call_count == 2
 
+class TestBuildJobPromptExtraPrompt:
+    """Regression: _build_job_prompt merges extra_prompt into the assembled prompt."""
+
+    def test_extra_prompt_appended_with_header(self):
+        """extra_prompt appears under a '## Run Context' header."""
+        job = {"prompt": "stored prompt"}
+        result = _build_job_prompt(job, extra_prompt="CONTEXT: client=Foo")
+        assert "stored prompt" in result
+        assert "## Run Context" in result
+        assert "CONTEXT: client=Foo" in result
+
+    def test_extra_prompt_does_not_mutate_job(self):
+        """The job dict's 'prompt' field must remain unchanged."""
+        job = {"prompt": "original"}
+        _build_job_prompt(job, extra_prompt="transient context")
+        assert job["prompt"] == "original"
+
+    def test_no_extra_prompt_omits_header(self):
+        """Without extra_prompt, no '## Run Context' header is injected."""
+        job = {"prompt": "just the stored prompt"}
+        result = _build_job_prompt(job)
+        assert "## Run Context" not in result
+        assert "just the stored prompt" in result
+
 
 class TestSetCronSessionTitle:
     """Robust cron session titling: #50535/#50536/#50537."""

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -61,7 +61,7 @@ class TestBackgroundDispatch:
         run_started = threading.Event()
         run_release = threading.Event()
 
-        def slow_run_one_job(job):
+        def slow_run_one_job(job, **kw):
             run_started.set()
             assert run_release.wait(timeout=5.0)
             return True
@@ -224,7 +224,7 @@ class TestInFlightDedupe:
 
         seen_during_run = {}
 
-        def probe_run(job):
+        def probe_run(job, **kw):
             seen_during_run["registered"] = "job-bg-09" in sched.get_running_job_ids()
             return True
 

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -69,6 +69,7 @@ class TestCronjobRunExecutesImmediately:
             _JOB,
             adapters=adapters,
             loop=gateway_loop,
+            extra_prompt=None,
         )
 
     def test_execute_job_now_remains_standalone_without_gateway(self):
@@ -82,7 +83,7 @@ class TestCronjobRunExecutesImmediately:
             res = _execute_job_now(dict(_JOB))
 
         assert res["success"] is True
-        m_run.assert_called_once_with(_JOB, adapters=None, loop=None)
+        m_run.assert_called_once_with(_JOB, adapters=None, loop=None, extra_prompt=None)
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -11,8 +11,10 @@ into the calling agent's activity tracker — otherwise the gateway inactivity
 watchdog kills the parent turn at ~1800s.
 """
 import json
+import sys
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tools.cronjob_tools import cronjob, _execute_job_now
@@ -49,6 +51,39 @@ class TestCronjobRunExecutesImmediately:
         assert res["success"] is False
         m_run.assert_not_called()
 
+    def test_execute_job_now_passes_live_gateway_context_to_delivery(self):
+        """Manual runs must deliver on the live gateway adapter's owning loop."""
+        adapters = {"matrix": object()}
+        gateway_loop = object()
+        runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(
+            _JOB,
+            adapters=adapters,
+            loop=gateway_loop,
+        )
+
+    def test_execute_job_now_remains_standalone_without_gateway(self):
+        """CLI-only runs retain the standalone delivery path."""
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch.dict(sys.modules, {"gateway.run": None}), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(_JOB, adapters=None, loop=None)
+
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
         with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
@@ -74,7 +109,7 @@ class TestCronjobRunExecutesImmediately:
 
         set_activity_callback(record)
         try:
-            def slow_run(job):
+            def slow_run(job, **kw):
                 # Deterministic: block until at least one heartbeat has fired
                 # (bounded so a broken heartbeat can't hang the test).
                 assert heartbeat_seen.wait(timeout=5.0), "no heartbeat within 5s"
@@ -123,7 +158,7 @@ class TestCronjobRunExecutesImmediately:
 
         set_activity_callback(record)
         try:
-            def slow_run(job):
+            def slow_run(job, **kw):
                 # Ceiling=0 → the very first wake stops the loop without
                 # touching. Give it a couple of cycles to prove silence.
                 time.sleep(0.2)
@@ -156,7 +191,7 @@ class TestCronjobRunExecutesImmediately:
 
         set_activity_callback(flaky)
         try:
-            def slow_run(job):
+            def slow_run(job, **kw):
                 # Block until a heartbeat AFTER the raising one has fired.
                 assert second_beat.wait(timeout=5.0), \
                     "heartbeat stopped after one callback exception"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -589,7 +589,9 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
+def _execute_job_now(
+    job: Dict[str, Any], extra_prompt: Optional[str] = None
+) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
     Atomically claims the job first via ``claim_job_for_fire`` — the same
@@ -629,10 +631,12 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             pass
         return {"claimed": True, "success": False, "error": str(e)}
 
-    return _run_claimed_job(job)
+    return _run_claimed_job(job, extra_prompt=extra_prompt)
 
 
-def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _run_claimed_job(
+    job: Dict[str, Any], extra_prompt: Optional[str] = None
+) -> Dict[str, Any]:
     """Fire an already-claimed job through the shared ``run_one_job`` body.
 
     Split out of ``_execute_job_now`` so the background dispatch path
@@ -745,7 +749,10 @@ def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
         try:
             try:
-                processed = run_one_job(job, adapters=adapters, loop=gateway_loop)
+                processed = run_one_job(
+                    job, adapters=adapters, loop=gateway_loop,
+                    extra_prompt=extra_prompt,
+                )
             finally:
                 _heartbeat_stop.set()
                 if _heartbeat_thread is not None:
@@ -806,7 +813,8 @@ def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[s
 
 
 def _try_dispatch_background_run(
-    job: Dict[str, Any], session_id: Optional[str] = None
+    job: Dict[str, Any], session_id: Optional[str] = None,
+    extra_prompt: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Claim ``job`` now, then fire it on the async-delegation daemon executor.
 
@@ -935,7 +943,7 @@ def _try_dispatch_background_run(
             "cronjob run: async delegation registry unavailable (%s); "
             "running job '%s' inline.", e, job_name,
         )
-        result = _run_claimed_job(job)
+        result = _run_claimed_job(job, extra_prompt=extra_prompt)
         result["dispatched"] = False
         return result
 
@@ -950,7 +958,7 @@ def _try_dispatch_background_run(
     deliver = job.get("deliver", "local")
 
     def _runner() -> Dict[str, Any]:
-        res = _run_claimed_job(job)
+        res = _run_claimed_job(job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
         lines = [
@@ -1008,7 +1016,7 @@ def _try_dispatch_background_run(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(job)
+    result = _run_claimed_job(job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 
@@ -1194,6 +1202,16 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
+            # Per-run context (#57331, salvaged from #57342/@liuhao1024 and
+            # #57360/@ghedeselmabot): `prompt` on the run action is transient
+            # context appended to the stored prompt for THIS fire only, never
+            # persisted. It goes through the same strict injection scan as
+            # stored prompts before firing.
+            extra_prompt = prompt or None
+            if extra_prompt:
+                scan_error = _scan_cron_prompt(extra_prompt)
+                if scan_error:
+                    return tool_error(scan_error, success=False)
             # Execute the job immediately rather than only scheduling it for the
             # next scheduler tick — a manual `run` should actually run, even when
             # no gateway/ticker is active (the #41037 case). The claim (taken
@@ -1208,7 +1226,9 @@ def cronjob(
             # batches of manual runs (#80xxx — the "stuck Telegram session"
             # incident). Falls back to inline execution when the session
             # runtime can't receive detached completions.
-            bg = _try_dispatch_background_run(job, session_id=session_id)
+            bg = _try_dispatch_background_run(
+                job, session_id=session_id, extra_prompt=extra_prompt
+            )
             if bg is not None and bg.get("dispatched"):
                 _notify_provider_jobs_changed_safe()
                 result = _format_job(get_job(job_id) or {"id": job_id})
@@ -1231,7 +1251,10 @@ def cronjob(
             # bg carries a terminal result (claim lost, or inline fallback
             # after pool rejection); None means background delivery is
             # unsupported here — run synchronously as before.
-            exec_result = bg if bg is not None else _execute_job_now(job)
+            exec_result = (
+                bg if bg is not None
+                else _execute_job_now(job, extra_prompt=extra_prompt)
+            )
             # A claimed direct run advances next_run_at and may race the
             # external one-shot for the same occurrence. If Chronos loses that
             # claim, its consumed fire cannot re-arm itself; reconcile from the
@@ -1371,7 +1394,7 @@ Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
-action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue.
+action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue. Optionally pass 'prompt' with action='run' to inject transient per-run context (appended to the job's stored prompt for that single fire only, never persisted).
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
@@ -1397,7 +1420,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "prompt": {
                 "type": "string",
-                "description": "For create: the full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills."
+                "description": "For create: the full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills. For run: optional transient context appended to the stored prompt for that single fire only (never persisted)."
             },
             "schedule": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -729,9 +729,23 @@ def _run_claimed_job(job: Dict[str, Any]) -> Dict[str, Any]:
             )
             _heartbeat_thread.start()
 
+        # Manual runs invoked from a gateway agent execute outside the scheduler
+        # ticker, but they still share the process with the live platform
+        # adapters. Pass the gateway-owned adapter map and event loop through
+        # to run_one_job so delivery is scheduled on the loop that owns clients
+        # such as Matrix/aiohttp. Calling those clients from run_one_job's
+        # standalone asyncio.run() loop raises errors like "Timeout context
+        # manager should be used inside a task" and can break encrypted Matrix
+        # delivery (#61495 — salvaged from #63586 by @Fly-onlyone).
+        gateway_module = sys.modules.get("gateway.run")
+        runner_ref = getattr(gateway_module, "_gateway_runner_ref", None)
+        runner = runner_ref() if callable(runner_ref) else None
+        adapters = getattr(runner, "adapters", None) if runner is not None else None
+        gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
+
         try:
             try:
-                processed = run_one_job(job)
+                processed = run_one_job(job, adapters=adapters, loop=gateway_loop)
             finally:
                 _heartbeat_stop.set()
                 if _heartbeat_thread is not None:


### PR DESCRIPTION
## Summary
Cluster salvage of the three surviving fixes from the `cronjob(action='run')` sweep (follow-up to #80807): manual runs now deliver on the live gateway loop (fixes Matrix delivery, #61495), accept transient per-run prompt context (#57331), and Matrix standalone send no longer crashes on aiohttp's task-context check.

## Changes
- **Gateway loop delivery** (salvaged from #63586 by @Fly-onlyone, fixes #61495): `_run_claimed_job` resolves the live `GatewayRunner`'s adapter map + owning event loop via the existing `_gateway_runner_ref` weakref and passes them to `run_one_job`, matching what scheduled ticks already do. Matrix (mautrix/aiohttp) delivery from a manual run previously failed with "Timeout context manager should be used inside a task" because it ran on a fresh `asyncio.run()` loop. CLI-only runs keep the standalone path (`adapters=None, loop=None`).
- **Per-run prompt context** (salvaged from #57342 by @liuhao1024 + the injection-scan half of #57360, fixes #57331): `cronjob(action='run', prompt=...)` previously discarded the prompt silently. It now threads as `extra_prompt` through the full chain (run action → background/sync paths → `run_one_job` → `run_job` → `_build_job_prompt`), appended under a `## Run Context` header for that single fire only — never persisted. Passes the same strict `_scan_cron_prompt` injection scan as stored prompts. Works identically on background and sync-fallback paths.
- **Matrix standalone send** (cherry-picked from #61502 by @liuhao1024, fixes #61495's second half): `_standalone_send()` replaces `aiohttp.ClientTimeout` in the session constructor with `asyncio.wait_for(..., 30)`, the same pattern Weixin uses — `ClientTimeout` requires a proper task context that the standalone path doesn't always have.
- Test fakes across `tests/cron/` updated for the new kwargs (sibling-test blast radius from the `run_job`/`run_one_job`/`_build_job_prompt` signature changes).

## Validation
| | Before | After |
|---|---|---|
| Manual run → Matrix delivery | "Timeout context manager..." error | delivered on gateway loop |
| `cronjob(run, prompt=...)` | prompt silently discarded | `## Run Context` in assembled prompt |
| Injection attempt in run prompt | n/a (discarded) | blocked by `_scan_cron_prompt` |
| Job definition after context run | unchanged | unchanged (verified) |
| Targeted suites | — | 506/506 cron+tool, 155/155 Matrix |

E2E (real job store, temp `HERMES_HOME`): background run with `prompt="CONTEXT: client=Acme"` → assembled prompt contains stored prompt + `## Run Context` + context; stored job untouched; injection-shaped context refused with the scanner error before any fire.

Attribution: commits cherry-picked/salvaged preserve @Fly-onlyone and @liuhao1024 authorship (audit green).

## Infographic

![cron sweep salvage](https://v3b.fal.media/files/b/0aa558a0/_cvory87Sl12GYeePu6bU_eg7ot3CJ.png)
