### PR TITLE
fix(desktop): show and manually switch Copilot credential-pool status

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -757,6 +757,27 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
+    def activate(self, entry_id: str) -> Optional[PooledCredential]:
+        """Force the given entry to be the next one `select()` returns.
+
+        Gives it priority -1 (lower than any existing entry, ties broken by
+        list order) and clears the sticky cursor so selection re-runs. Manual
+        "use this account" action from the Desktop/dashboard UI — everything
+        else about the pool (rotation, exhaustion, refresh) is unchanged.
+        """
+        with self._lock:
+            target = next((e for e in self._entries if e.id == entry_id), None)
+            if target is None:
+                return None
+            self._entries = [
+                replace(e, priority=-1) if e.id == entry_id else e
+                for e in self._entries
+            ]
+            self._entries.sort(key=lambda e: e.priority)
+            self._persist()
+            self._current_id = entry_id
+            return self._current_unlocked()
+
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -760,17 +760,19 @@ class CredentialPool:
     def activate(self, entry_id: str) -> Optional[PooledCredential]:
         """Force the given entry to be the next one `select()` returns.
 
-        Gives it priority -1 (lower than any existing entry, ties broken by
-        list order) and clears the sticky cursor so selection re-runs. Manual
-        "use this account" action from the Desktop/dashboard UI — everything
-        else about the pool (rotation, exhaustion, refresh) is unchanged.
+        Gives it a priority one below the current lowest (so it wins ties
+        against any prior manual pick, not just default-priority entries)
+        and clears the sticky cursor so selection re-runs. Manual "use this
+        account" action from the Desktop/dashboard UI — everything else
+        about the pool (rotation, exhaustion, refresh) is unchanged.
         """
         with self._lock:
             target = next((e for e in self._entries if e.id == entry_id), None)
             if target is None:
                 return None
+            new_priority = min((e.priority for e in self._entries), default=0) - 1
             self._entries = [
-                replace(e, priority=-1) if e.id == entry_id else e
+                replace(e, priority=new_priority) if e.id == entry_id else e
                 for e in self._entries
             ]
             self._entries.sort(key=lambda e: e.priority)

--- a/apps/desktop/src/app/settings/credential-key-ui.tsx
+++ b/apps/desktop/src/app/settings/credential-key-ui.tsx
@@ -16,14 +16,27 @@ export type KeyRowProps = Omit<EnvRowProps, 'info' | 'varKey'>
 
 // Redacted rotation-pool readout: label + active/exhausted status per stored
 // credential, so a user juggling e.g. a personal + a shared Copilot account
-// can see which one requests are actually using without touching the CLI.
-export function CredentialPoolStatus({ entries }: { entries: CredentialPoolEntry[] }) {
+// can see — and manually switch — which one requests are actually using,
+// without touching the CLI.
+export function CredentialPoolStatus({
+  activating,
+  entries,
+  onActivate
+}: {
+  activating?: number
+  entries: CredentialPoolEntry[]
+  onActivate?: (index: number) => void
+}) {
+  const { t } = useI18n()
   const sorted = [...entries].sort((a, b) => a.priority - b.priority)
+  const current = sorted[0]?.index
 
   return (
     <ul className="mb-1 ml-3 grid gap-0.5 border-l border-(--ui-border) pl-3">
       {sorted.map(entry => {
         const active = entry.last_status !== 'exhausted' && entry.last_status !== 'error'
+        const isCurrent = entry.index === current
+        const busy = activating === entry.index
 
         return (
           <li className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground" key={entry.index}>
@@ -32,12 +45,28 @@ export function CredentialPoolStatus({ entries }: { entries: CredentialPoolEntry
             />
             <span className="truncate">{entry.label || entry.token_preview}</span>
             <span className="text-muted-foreground/60">{entry.last_status ?? (active ? 'active' : 'idle')}</span>
+            {onActivate && !isCurrent && (
+              <Button
+                className="ml-auto h-6 px-1.5 text-[11px]"
+                disabled={busy}
+                onClick={e => {
+                  e.stopPropagation()
+                  onActivate(entry.index)
+                }}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                {busy ? <Loader2 className="size-3 animate-spin" /> : t.settings.credentials.useThisAccount}
+              </Button>
+            )}
           </li>
         )
       })}
     </ul>
   )
 }
+
 
 /** Matches Advanced / config field controls (ListRow + Input). */
 export const CREDENTIAL_CONTROL_CLASS = cn('h-8', CONTROL_TEXT)
@@ -278,7 +307,16 @@ export function CredentialKeyCard({
 }
 
 /** Provider API key group — collapsible card; description, docs link, and advanced fields expand on click. */
-export function ProviderKeyRows({ expanded, group, onExpand, onToggle, poolEntries, rowProps }: ProviderKeyRowsProps) {
+export function ProviderKeyRows({
+  activatingIndex,
+  expanded,
+  group,
+  onActivate,
+  onExpand,
+  onToggle,
+  poolEntries,
+  rowProps
+}: ProviderKeyRowsProps) {
   const { t } = useI18n()
   const docsUrl = group.docsUrl?.trim()
   const description = group.description?.trim()
@@ -361,7 +399,7 @@ export function ProviderKeyRows({ expanded, group, onExpand, onToggle, poolEntri
             no "which one is active" affordance. */}
         {poolEntries && poolEntries.length > 1 && (
           <div className="@2xl:col-span-2">
-            <CredentialPoolStatus entries={poolEntries} />
+            <CredentialPoolStatus activating={activatingIndex} entries={poolEntries} onActivate={onActivate} />
           </div>
         )}
 
@@ -423,8 +461,10 @@ interface CredentialKeyCardProps {
 }
 
 interface ProviderKeyRowsProps {
+  activatingIndex?: number
   expanded: boolean
   group: ProviderKeyRowGroup
+  onActivate?: (index: number) => void
   onExpand: () => void
   onToggle: () => void
   poolEntries?: CredentialPoolEntry[]

--- a/apps/desktop/src/app/settings/credential-key-ui.tsx
+++ b/apps/desktop/src/app/settings/credential-key-ui.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input'
 import { translateNow, useI18n } from '@/i18n'
 import { ChevronDown, ExternalLink, Loader2, Save, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import type { EnvVarInfo } from '@/types/hermes'
+import type { CredentialPoolEntry, EnvVarInfo } from '@/types/hermes'
 
 import { CONTROL_TEXT } from './constants'
 import { prettyName, withoutKey } from './helpers'
@@ -13,6 +13,31 @@ import { ListRow } from './primitives'
 import type { EnvRowProps } from './types'
 
 export type KeyRowProps = Omit<EnvRowProps, 'info' | 'varKey'>
+
+// Redacted rotation-pool readout: label + active/exhausted status per stored
+// credential, so a user juggling e.g. a personal + a shared Copilot account
+// can see which one requests are actually using without touching the CLI.
+export function CredentialPoolStatus({ entries }: { entries: CredentialPoolEntry[] }) {
+  const sorted = [...entries].sort((a, b) => a.priority - b.priority)
+
+  return (
+    <ul className="mb-1 ml-3 grid gap-0.5 border-l border-(--ui-border) pl-3">
+      {sorted.map(entry => {
+        const active = entry.last_status !== 'exhausted' && entry.last_status !== 'error'
+
+        return (
+          <li className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground" key={entry.index}>
+            <span
+              className={cn('inline-block size-1.5 rounded-full', active ? 'bg-primary' : 'bg-muted-foreground/40')}
+            />
+            <span className="truncate">{entry.label || entry.token_preview}</span>
+            <span className="text-muted-foreground/60">{entry.last_status ?? (active ? 'active' : 'idle')}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
 
 /** Matches Advanced / config field controls (ListRow + Input). */
 export const CREDENTIAL_CONTROL_CLASS = cn('h-8', CONTROL_TEXT)
@@ -253,7 +278,7 @@ export function CredentialKeyCard({
 }
 
 /** Provider API key group — collapsible card; description, docs link, and advanced fields expand on click. */
-export function ProviderKeyRows({ expanded, group, onExpand, onToggle, rowProps }: ProviderKeyRowsProps) {
+export function ProviderKeyRows({ expanded, group, onExpand, onToggle, poolEntries, rowProps }: ProviderKeyRowsProps) {
   const { t } = useI18n()
   const docsUrl = group.docsUrl?.trim()
   const description = group.description?.trim()
@@ -331,6 +356,15 @@ export function ProviderKeyRows({ expanded, group, onExpand, onToggle, rowProps 
           />
         </div>
 
+        {/* Only shown when the provider has >1 pooled credential (e.g. a
+            personal + a shared Copilot account) — a single credential needs
+            no "which one is active" affordance. */}
+        {poolEntries && poolEntries.length > 1 && (
+          <div className="@2xl:col-span-2">
+            <CredentialPoolStatus entries={poolEntries} />
+          </div>
+        )}
+
         {expandable && expanded && (
           <div className="grid gap-3 @2xl:col-span-2" onClick={e => e.stopPropagation()}>
             {description && (
@@ -393,6 +427,7 @@ interface ProviderKeyRowsProps {
   group: ProviderKeyRowGroup
   onExpand: () => void
   onToggle: () => void
+  poolEntries?: CredentialPoolEntry[]
   rowProps: KeyRowProps
 }
 
@@ -402,5 +437,6 @@ export interface ProviderKeyRowGroup {
   docsUrl?: string
   hasAnySet: boolean
   name: string
+  poolProvider?: string
   primary: [string, EnvVarInfo]
 }

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -7,12 +7,14 @@ import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 const listOAuthProviders = vi.fn()
 const disconnectOAuthProvider = vi.fn()
 const getEnvVars = vi.fn()
+const getCredentialPool = vi.fn()
 const startManualProviderOAuth = vi.fn()
 const startManualLocalEndpoint = vi.fn()
 const onboarding = atom({ manual: false })
 
 vi.mock('@/hermes', () => ({
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
+  getCredentialPool: () => getCredentialPool(),
   getEnvVars: () => getEnvVars(),
   listOAuthProviders: () => listOAuthProviders()
 }))
@@ -60,6 +62,7 @@ function keyVar(patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
 beforeEach(() => {
   onboarding.set({ manual: false })
   getEnvVars.mockResolvedValue({})
+  getCredentialPool.mockResolvedValue({ providers: [] })
   disconnectOAuthProvider.mockResolvedValue({ ok: true, provider: 'nous' })
   listOAuthProviders.mockResolvedValue({
     providers: [provider('nous', true), provider('minimax-oauth', false)]
@@ -202,5 +205,30 @@ describe('ProvidersSettings', () => {
     fireEvent.click(row)
 
     await waitFor(() => expect(startManualLocalEndpoint).toHaveBeenCalledWith(null))
+  })
+
+  it('shows a per-credential pool status only for a provider with >1 stored credential', async () => {
+    // Regression: multi-credential providers (e.g. a personal + a shared
+    // Copilot key) had no Desktop UI to see which stored credential is
+    // actually active. See issue #80828.
+    getCredentialPool.mockResolvedValue({
+      providers: [
+        {
+          provider: 'nous',
+          entries: [
+            { index: 1, label: 'wadefengx', priority: 0, request_count: 12, token_preview: 'sk-…abcd', has_refresh: false, last_status: 'ok' },
+            { index: 2, label: 'shared-fallback', priority: 1, request_count: 0, token_preview: 'sk-…wxyz', has_refresh: false, last_status: 'exhausted' }
+          ]
+        }
+      ]
+    })
+
+    await renderProvidersSettings()
+
+    expect(await screen.findByText('wadefengx')).toBeTruthy()
+    expect(screen.getByText('shared-fallback')).toBeTruthy()
+    expect(screen.getByText('exhausted')).toBeTruthy()
+    // minimax-oauth has no pool entries in this test → no status list rendered for it.
+    expect(screen.queryByText('sk-…wxyz')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -210,11 +210,17 @@ describe('ProvidersSettings', () => {
   it('shows a per-credential pool status only for a provider with >1 stored credential', async () => {
     // Regression: multi-credential providers (e.g. a personal + a shared
     // Copilot key) had no Desktop UI to see which stored credential is
-    // actually active. See issue #80828.
+    // actually active. Copilot's key lives in the API-keys view, keyed by the
+    // backend's raw provider id ("copilot"), which is what /api/credentials/pool
+    // groups by too — see issue #80828.
+    getEnvVars.mockResolvedValue({
+      COPILOT_GITHUB_TOKEN: keyVar({ provider: 'copilot', provider_label: 'GitHub Copilot', is_set: true }),
+      ACME_API_KEY: keyVar({ provider: 'acme', provider_label: 'Acme', is_set: true })
+    })
     getCredentialPool.mockResolvedValue({
       providers: [
         {
-          provider: 'nous',
+          provider: 'copilot',
           entries: [
             { index: 1, label: 'wadefengx', priority: 0, request_count: 12, token_preview: 'sk-…abcd', has_refresh: false, last_status: 'ok' },
             { index: 2, label: 'shared-fallback', priority: 1, request_count: 0, token_preview: 'sk-…wxyz', has_refresh: false, last_status: 'exhausted' }
@@ -222,13 +228,15 @@ describe('ProvidersSettings', () => {
         }
       ]
     })
+    listOAuthProviders.mockResolvedValue({ providers: [] })
 
-    await renderProvidersSettings()
+    const { ProvidersSettings } = await import('./providers-settings')
+    render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
 
     expect(await screen.findByText('wadefengx')).toBeTruthy()
     expect(screen.getByText('shared-fallback')).toBeTruthy()
     expect(screen.getByText('exhausted')).toBeTruthy()
-    // minimax-oauth has no pool entries in this test → no status list rendered for it.
+    // Acme has no pool entries in this test → no status list rendered for it.
     expect(screen.queryByText('sk-…wxyz')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -6,6 +6,7 @@ import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 const listOAuthProviders = vi.fn()
 const disconnectOAuthProvider = vi.fn()
+const activateCredentialPoolEntry = vi.fn()
 const getEnvVars = vi.fn()
 const getCredentialPool = vi.fn()
 const startManualProviderOAuth = vi.fn()
@@ -13,6 +14,7 @@ const startManualLocalEndpoint = vi.fn()
 const onboarding = atom({ manual: false })
 
 vi.mock('@/hermes', () => ({
+  activateCredentialPoolEntry: (provider: string, index: number) => activateCredentialPoolEntry(provider, index),
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
   getCredentialPool: () => getCredentialPool(),
   getEnvVars: () => getEnvVars(),
@@ -64,6 +66,7 @@ beforeEach(() => {
   getEnvVars.mockResolvedValue({})
   getCredentialPool.mockResolvedValue({ providers: [] })
   disconnectOAuthProvider.mockResolvedValue({ ok: true, provider: 'nous' })
+  activateCredentialPoolEntry.mockResolvedValue({ ok: true, provider: 'copilot' })
   listOAuthProviders.mockResolvedValue({
     providers: [provider('nous', true), provider('minimax-oauth', false)]
   })
@@ -238,5 +241,38 @@ describe('ProvidersSettings', () => {
     expect(screen.getByText('exhausted')).toBeTruthy()
     // Acme has no pool entries in this test → no status list rendered for it.
     expect(screen.queryByText('sk-…wxyz')).toBeNull()
+  })
+
+  it('lets the user click "Use this" to switch which stored credential is active', async () => {
+    // The Desktop-only path for a user who won't touch the CLI (issue #80828
+    // follow-up): clicking the button on the non-current entry calls the new
+    // activate endpoint and re-fetches the pool so the status list updates.
+    getEnvVars.mockResolvedValue({
+      COPILOT_GITHUB_TOKEN: keyVar({ provider: 'copilot', provider_label: 'GitHub Copilot', is_set: true })
+    })
+    getCredentialPool.mockResolvedValue({
+      providers: [
+        {
+          provider: 'copilot',
+          entries: [
+            { index: 1, label: 'wadefengx', priority: 0, request_count: 12, token_preview: 'sk-…abcd', has_refresh: false, last_status: 'ok' },
+            { index: 2, label: 'shared-fallback', priority: 1, request_count: 0, token_preview: 'sk-…wxyz', has_refresh: false, last_status: 'ok' }
+          ]
+        }
+      ]
+    })
+    listOAuthProviders.mockResolvedValue({ providers: [] })
+
+    const { ProvidersSettings } = await import('./providers-settings')
+    render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+
+    await screen.findByText('shared-fallback')
+    // Only the non-current entry (index 2) gets a switch button.
+    expect(screen.queryAllByRole('button', { name: 'Use this' })).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use this' }))
+
+    await waitFor(() => expect(activateCredentialPoolEntry).toHaveBeenCalledWith('copilot', 2))
+    expect(getCredentialPool).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -15,14 +15,14 @@ import {
 import { Button } from '@/components/ui/button'
 import { RowButton } from '@/components/ui/row-button'
 import { SearchField } from '@/components/ui/search-field'
-import { disconnectOAuthProvider, listOAuthProviders } from '@/hermes'
+import { disconnectOAuthProvider, getCredentialPool, listOAuthProviders } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
-import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
+import type { CredentialPoolEntry, EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
 import { CustomEndpointsSettings } from './custom-endpoints-settings'
@@ -128,12 +128,14 @@ function OAuthPicker({
   onDisconnect,
   onTerminalDisconnect,
   onWantApiKey,
+  poolByProvider,
   providers
 }: {
   disconnecting: null | string
   onDisconnect: (provider: OAuthProvider) => void
   onTerminalDisconnect: (provider: OAuthProvider) => void
   onWantApiKey: () => void
+  poolByProvider: Record<string, CredentialPoolEntry[]>
   providers: OAuthProvider[]
 }) {
   const { t } = useI18n()
@@ -187,6 +189,7 @@ function OAuthPicker({
               onDisconnect={onDisconnect}
               onSelect={select}
               onTerminalDisconnect={onTerminalDisconnect}
+              poolEntries={poolByProvider[p.id]}
               provider={p}
             />
           ))}
@@ -222,12 +225,14 @@ function ConnectedProviderRow({
   onDisconnect,
   onSelect,
   onTerminalDisconnect,
+  poolEntries,
   provider
 }: {
   disconnecting: boolean
   onDisconnect: (provider: OAuthProvider) => void
   onSelect: (provider: OAuthProvider) => void
   onTerminalDisconnect: (provider: OAuthProvider) => void
+  poolEntries?: CredentialPoolEntry[]
   provider: OAuthProvider
 }) {
   const { t } = useI18n()
@@ -243,51 +248,86 @@ function ConnectedProviderRow({
   const showHint = !canDisconnect && !terminalDisconnect
 
   return (
-    <div className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[6px] transition-colors hover:bg-(--ui-control-hover-background)">
-      <RowButton className="min-w-0 px-3 py-2.5 text-left" onClick={() => onSelect(provider)}>
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-[length:var(--conversation-text-font-size)] font-semibold">{title}</span>
-          <span className="inline-flex shrink-0 items-center gap-1 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            <Check className="size-3" />
-            {copy.connected}
-          </span>
+    <div className="grid gap-0.5">
+      <div className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[6px] transition-colors hover:bg-(--ui-control-hover-background)">
+        <RowButton className="min-w-0 px-3 py-2.5 text-left" onClick={() => onSelect(provider)}>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[length:var(--conversation-text-font-size)] font-semibold">{title}</span>
+            <span className="inline-flex shrink-0 items-center gap-1 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+              <Check className="size-3" />
+              {copy.connected}
+            </span>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{t.onboarding.flowSubtitles[provider.flow]}</p>
+          {showHint && (
+            <p className="mt-0.5 truncate text-[0.68rem] leading-5 text-muted-foreground/70">
+              {provider.flow === 'external' ? copy.removeExternalGeneric(title) : copy.removeKeyManaged(title)}
+            </p>
+          )}
+        </RowButton>
+        <div className="flex items-center gap-1 pr-2">
+          <Trail className="size-4 text-muted-foreground transition group-hover:text-foreground" />
+          {canDisconnect && (
+            <Button
+              aria-label={`${t.common.remove} ${title}`}
+              disabled={disconnecting}
+              onClick={() => onDisconnect(provider)}
+              size="icon-xs"
+              title={`${t.common.remove} ${title}`}
+              type="button"
+              variant="ghost"
+            >
+              {disconnecting ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
+            </Button>
+          )}
+          {terminalDisconnect && (
+            <Button
+              aria-label={`${copy.disconnect} ${title}`}
+              onClick={() => onTerminalDisconnect(provider)}
+              size="icon-xs"
+              title={copy.disconnectInTerminal}
+              type="button"
+              variant="ghost"
+            >
+              <Trash2 className="size-3" />
+            </Button>
+          )}
         </div>
-        <p className="mt-1 text-xs leading-5 text-muted-foreground">{t.onboarding.flowSubtitles[provider.flow]}</p>
-        {showHint && (
-          <p className="mt-0.5 truncate text-[0.68rem] leading-5 text-muted-foreground/70">
-            {provider.flow === 'external' ? copy.removeExternalGeneric(title) : copy.removeKeyManaged(title)}
-          </p>
-        )}
-      </RowButton>
-      <div className="flex items-center gap-1 pr-2">
-        <Trail className="size-4 text-muted-foreground transition group-hover:text-foreground" />
-        {canDisconnect && (
-          <Button
-            aria-label={`${t.common.remove} ${title}`}
-            disabled={disconnecting}
-            onClick={() => onDisconnect(provider)}
-            size="icon-xs"
-            title={`${t.common.remove} ${title}`}
-            type="button"
-            variant="ghost"
-          >
-            {disconnecting ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
-          </Button>
-        )}
-        {terminalDisconnect && (
-          <Button
-            aria-label={`${copy.disconnect} ${title}`}
-            onClick={() => onTerminalDisconnect(provider)}
-            size="icon-xs"
-            title={copy.disconnectInTerminal}
-            type="button"
-            variant="ghost"
-          >
-            <Trash2 className="size-3" />
-          </Button>
-        )}
       </div>
+      {/* Only shown when the provider has >1 pooled credential — a single
+          account needs no "which one is active" affordance. */}
+      {poolEntries && poolEntries.length > 1 && <CredentialPoolStatus entries={poolEntries} />}
     </div>
+  )
+}
+
+// Redacted rotation-pool readout: label + active/exhausted status per stored
+// credential, so a user juggling e.g. a personal + a shared Copilot account
+// can see which one requests are actually using without touching the CLI.
+function CredentialPoolStatus({ entries }: { entries: CredentialPoolEntry[] }) {
+  const sorted = [...entries].sort((a, b) => a.priority - b.priority)
+
+  return (
+    <ul className="mb-1 ml-3 grid gap-0.5 border-l border-(--ui-border) pl-3">
+      {sorted.map(entry => {
+        const active = entry.last_status !== 'exhausted' && entry.last_status !== 'error'
+
+        return (
+          <li className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground" key={entry.index}>
+            <span
+              className={cn(
+                'inline-block size-1.5 rounded-full',
+                active ? 'bg-primary' : 'bg-muted-foreground/40'
+              )}
+            />
+            <span className="truncate">{entry.label || entry.token_preview}</span>
+            <span className="text-muted-foreground/60">
+              {entry.last_status ?? (active ? 'active' : 'idle')}
+            </span>
+          </li>
+        )
+      })}
+    </ul>
   )
 }
 
@@ -341,6 +381,7 @@ export function ProvidersSettings({
   const { t } = useI18n()
   const { rowProps, vars } = useEnvCredentials()
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
+  const [poolByProvider, setPoolByProvider] = useState<Record<string, CredentialPoolEntry[]>>({})
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)
   // Free-text filter for the API-keys view (provider name / env-var key / desc).
@@ -377,6 +418,28 @@ export function ProvidersSettings({
 
     return () => void (cancelled = true)
   }, [onboardingActive])
+
+  // Rotation-pool status is a lightweight, best-effort readout (redacted, no
+  // secrets) — used only to annotate connected provider rows that have more
+  // than one stored credential. Loads once; skipped entirely if it fails.
+  useEffect(() => {
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const { providers } = await getCredentialPool()
+
+        if (!cancelled) {
+          setPoolByProvider(Object.fromEntries(providers.map(p => [p.provider, p.entries])))
+        }
+      } catch {
+        // Ignore — falls back to the plain connected row with no pool detail.
+      }
+    })()
+
+    return () => void (cancelled = true)
+  }, [])
+
 
   // External (CLI-managed) providers can't be cleared via the API by design —
   // Hermes never deletes creds another tool owns behind a silent API call.
@@ -501,6 +564,7 @@ export function ProvidersSettings({
         onDisconnect={provider => void handleDisconnect(provider)}
         onTerminalDisconnect={handleTerminalDisconnect}
         onWantApiKey={() => onViewChange('keys')}
+        poolByProvider={poolByProvider}
         providers={oauthProviders}
       />
     </SettingsContent>

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -24,7 +24,7 @@ import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
 import type { CredentialPoolEntry, EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
-import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
+import { CredentialPoolStatus, isKeyVar, ProviderKeyRows } from './credential-key-ui'
 import { CustomEndpointsSettings } from './custom-endpoints-settings'
 import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
 import { providerGroup, providerMeta, providerPriority } from './helpers'
@@ -106,6 +106,11 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
       docsUrl: meta?.docsUrl ?? primary[1].url ?? undefined,
       hasAnySet: entries.some(([, i]) => i.is_set),
       name,
+      // The credential-pool endpoint keys by the backend's raw provider id
+      // (`copilot`, `deepseek`, ...), which can differ from the display name
+      // used to bucket this group — carry it through so the row can look up
+      // its pool entries without re-deriving the id.
+      poolProvider: primary[1].provider?.trim(),
       primary,
       priority: providerPriority(name)
     })
@@ -298,36 +303,6 @@ function ConnectedProviderRow({
           account needs no "which one is active" affordance. */}
       {poolEntries && poolEntries.length > 1 && <CredentialPoolStatus entries={poolEntries} />}
     </div>
-  )
-}
-
-// Redacted rotation-pool readout: label + active/exhausted status per stored
-// credential, so a user juggling e.g. a personal + a shared Copilot account
-// can see which one requests are actually using without touching the CLI.
-function CredentialPoolStatus({ entries }: { entries: CredentialPoolEntry[] }) {
-  const sorted = [...entries].sort((a, b) => a.priority - b.priority)
-
-  return (
-    <ul className="mb-1 ml-3 grid gap-0.5 border-l border-(--ui-border) pl-3">
-      {sorted.map(entry => {
-        const active = entry.last_status !== 'exhausted' && entry.last_status !== 'error'
-
-        return (
-          <li className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground" key={entry.index}>
-            <span
-              className={cn(
-                'inline-block size-1.5 rounded-full',
-                active ? 'bg-primary' : 'bg-muted-foreground/40'
-              )}
-            />
-            <span className="truncate">{entry.label || entry.token_preview}</span>
-            <span className="text-muted-foreground/60">
-              {entry.last_status ?? (active ? 'active' : 'idle')}
-            </span>
-          </li>
-        )
-      })}
-    </ul>
   )
 }
 
@@ -536,6 +511,7 @@ export function ProvidersSettings({
                     key={group.name}
                     onExpand={() => setOpenProvider(group.name)}
                     onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
+                    poolEntries={group.poolProvider ? poolByProvider[group.poolProvider] : undefined}
                     rowProps={rowProps}
                   />
                 ))}
@@ -577,6 +553,7 @@ interface ProviderKeyGroup {
   docsUrl?: string
   hasAnySet: boolean
   name: string
+  poolProvider?: string
   primary: [string, EnvVarInfo]
   priority: number
 }

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -15,7 +15,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { RowButton } from '@/components/ui/row-button'
 import { SearchField } from '@/components/ui/search-field'
-import { disconnectOAuthProvider, getCredentialPool, listOAuthProviders } from '@/hermes'
+import { activateCredentialPoolEntry, disconnectOAuthProvider, getCredentialPool, listOAuthProviders } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
@@ -357,6 +357,7 @@ export function ProvidersSettings({
   const { rowProps, vars } = useEnvCredentials()
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
   const [poolByProvider, setPoolByProvider] = useState<Record<string, CredentialPoolEntry[]>>({})
+  const [activating, setActivating] = useState<null | { index: number; provider: string }>(null)
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)
   // Free-text filter for the API-keys view (provider name / env-var key / desc).
@@ -397,23 +398,40 @@ export function ProvidersSettings({
   // Rotation-pool status is a lightweight, best-effort readout (redacted, no
   // secrets) — used only to annotate connected provider rows that have more
   // than one stored credential. Loads once; skipped entirely if it fails.
-  useEffect(() => {
-    let cancelled = false
-
-    void (async () => {
-      try {
-        const { providers } = await getCredentialPool()
-
-        if (!cancelled) {
-          setPoolByProvider(Object.fromEntries(providers.map(p => [p.provider, p.entries])))
-        }
-      } catch {
-        // Ignore — falls back to the plain connected row with no pool detail.
-      }
-    })()
-
-    return () => void (cancelled = true)
+  const refreshPool = useCallback(async () => {
+    try {
+      const { providers } = await getCredentialPool()
+      setPoolByProvider(Object.fromEntries(providers.map(p => [p.provider, p.entries])))
+    } catch {
+      // Ignore — falls back to the plain connected row with no pool detail.
+    }
   }, [])
+
+  useEffect(() => {
+    void refreshPool()
+  }, [refreshPool])
+
+  // Manual "use this account" — the user's alternative to switching Copilot
+  // (or any pooled provider) via the CLI. Re-fetches afterwards so the status
+  // list reflects the new active entry.
+  const handleActivate = useCallback(
+    async (provider: string, index: number) => {
+      setActivating({ index, provider })
+      try {
+        await activateCredentialPoolEntry(provider, index)
+        await refreshPool()
+      } catch (err) {
+        notify({
+          kind: 'error',
+          title: t.settings.providers.removedTitle,
+          message: err instanceof Error ? err.message : String(err)
+        })
+      } finally {
+        setActivating(null)
+      }
+    },
+    [refreshPool, t]
+  )
 
 
   // External (CLI-managed) providers can't be cleared via the API by design —
@@ -506,9 +524,13 @@ export function ProvidersSettings({
               <div className="grid gap-2">
                 {visibleGroups.map(group => (
                   <ProviderKeyRows
+                    activatingIndex={
+                      activating && activating.provider === group.poolProvider ? activating.index : undefined
+                    }
                     expanded={openProvider === group.name}
                     group={group}
                     key={group.name}
+                    onActivate={group.poolProvider ? index => void handleActivate(group.poolProvider!, index) : undefined}
                     onExpand={() => setOpenProvider(group.name)}
                     onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
                     poolEntries={group.poolProvider ? poolByProvider[group.poolProvider] : undefined}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -894,6 +894,16 @@ export function getCredentialPool(): Promise<CredentialPoolResponse> {
   })
 }
 
+// Manual "use this account" — forces `index` (1-based, per getCredentialPool)
+// to be the next credential the pool selects for `provider`.
+export function activateCredentialPoolEntry(provider: string, index: number): Promise<{ ok: boolean; provider: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; provider: string }>({
+    ...profileScoped(),
+    path: `/api/credentials/pool/${encodeURIComponent(provider)}/${index}/activate`,
+    method: 'POST'
+  })
+}
+
 export function disconnectOAuthProvider(providerId: string): Promise<{ ok: boolean; provider: string }> {
   return window.hermesDesktop.api<{ ok: boolean; provider: string }>({
     ...profileScoped(),

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -12,6 +12,7 @@ import type {
   BackendUpdateCheckResponse,
   ComputerUseStatus,
   ConfigSchemaResponse,
+  CredentialPoolResponse,
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,
@@ -880,6 +881,16 @@ export function listOAuthProviders(): Promise<OAuthProvidersResponse> {
   return window.hermesDesktop.api<OAuthProvidersResponse>({
     ...profileScoped(),
     path: '/api/providers/oauth'
+  })
+}
+
+// Redacted rotation-pool status per provider — lets Settings show which
+// stored credential (label) is actually active when a provider has more than
+// one (e.g. a personal + a shared Copilot account).
+export function getCredentialPool(): Promise<CredentialPoolResponse> {
+  return window.hermesDesktop.api<CredentialPoolResponse>({
+    ...profileScoped(),
+    path: '/api/credentials/pool'
   })
 }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -645,7 +645,8 @@ export const ar = defineLocale({
       couldNotSave: 'تعذّر حفظ بيانات الاعتماد.',
       remove: 'إزالة',
       getKey: 'احصل على مفتاح',
-      saving: 'جار الحفظ'
+      saving: 'جار الحفظ',
+      useThisAccount: 'استخدام هذا الحساب'
     },
     envActions: {
       actions: 'إجراءات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -591,7 +591,8 @@ export const en: Translations = {
       couldNotSave: 'Could not save credential.',
       remove: 'Remove',
       getKey: 'Get a key',
-      saving: 'Saving'
+      saving: 'Saving',
+      useThisAccount: 'Use this'
     },
     envActions: {
       actions: 'Actions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -685,7 +685,8 @@ export const ja = defineLocale({
       couldNotSave: '認証情報を保存できませんでした。',
       remove: '削除',
       getKey: 'キーを取得',
-      saving: '保存中'
+      saving: '保存中',
+      useThisAccount: 'このアカウントを使用'
     },
     envActions: {
       actions: 'アクション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -489,6 +489,7 @@ export interface Translations {
       remove: string
       getKey: string
       saving: string
+      useThisAccount: string
     }
     envActions: {
       actions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -671,7 +671,8 @@ export const zhHant = defineLocale({
       couldNotSave: '無法儲存憑證。',
       remove: '移除',
       getKey: '取得金鑰',
-      saving: '儲存中'
+      saving: '儲存中',
+      useThisAccount: '使用此帳號'
     },
     envActions: {
       actions: '動作',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -800,7 +800,8 @@ export const zh: Translations = {
       couldNotSave: '无法保存凭据。',
       remove: '移除',
       getKey: '获取密钥',
-      saving: '保存中'
+      saving: '保存中',
+      useThisAccount: '使用此账号'
     },
     envActions: {
       actions: '操作',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -69,6 +69,31 @@ export interface OAuthProvidersResponse {
   providers: OAuthProvider[]
 }
 
+// Redacted view of one rotating credential-pool entry (agent/credential_pool.py
+// PooledCredential) — enough to show which account is active without ever
+// exposing the raw token.
+export interface CredentialPoolEntry {
+  auth_type?: null | string
+  has_refresh: boolean
+  id?: null | string
+  index: number
+  label?: null | string
+  last_status?: null | string
+  priority: number
+  request_count: number
+  source?: null | string
+  token_preview: string
+}
+
+export interface CredentialPoolProvider {
+  entries: CredentialPoolEntry[]
+  provider: string
+}
+
+export interface CredentialPoolResponse {
+  providers: CredentialPoolProvider[]
+}
+
 export type OAuthStartResponse =
   | {
       auth_url: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12785,6 +12785,32 @@ async def remove_credential_pool_entry(provider: str, index: int):
     }
 
 
+@app.post("/api/credentials/pool/{provider}/{index}/activate")
+async def activate_credential_pool_entry(provider: str, index: int):
+    """Force the pool to use this entry next.  ``index`` is 1-based.
+
+    Manual "switch account" action — lets a user without CLI access pick
+    which stored credential is active from the Desktop/dashboard UI.
+    """
+    from agent.credential_pool import load_pool
+
+    provider = (provider or "").strip().lower()
+    try:
+        pool = load_pool(provider)
+        entries = pool.entries()
+        if not (1 <= index <= len(entries)):
+            raise HTTPException(status_code=404, detail="No pool entry at that index")
+        activated = pool.activate(entries[index - 1].id)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _log.exception("POST /api/credentials/pool/activate failed")
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if activated is None:
+        raise HTTPException(status_code=404, detail="No pool entry at that index")
+    return {"ok": True, "provider": provider, "id": activated.id}
+
+
 # ---------------------------------------------------------------------------
 # Memory provider endpoints — status / list providers / select / disable / reset.
 #


### PR DESCRIPTION
Fixes #80828.

**Problem**

Providers settings had no way to see, let alone change, which stored credential is active when a provider (e.g. GitHub Copilot) has more than one pooled key. `hermes auth list` shows this in the CLI, but Desktop-only users had no equivalent and no way to switch without a terminal.

**Fix**

- `apps/desktop/src/types/hermes.ts`: `CredentialPoolEntry`/`CredentialPoolProvider`/`CredentialPoolResponse` types matching the existing `GET /api/credentials/pool` response.
- `apps/desktop/src/hermes.ts`: `getCredentialPool()` fetcher + `activateCredentialPoolEntry()` for the new activate action.
- `apps/desktop/src/app/settings/providers-settings.tsx` / `credential-key-ui.tsx`: renders a compact label + status per entry under a connected provider row (only when >1 stored credential), with a "Use this account" button on the non-current row that calls activate and refetches the pool.
- Backend: `pool.activate(entry_id)` (agent/credential_pool.py) promotes an entry to top priority and clears the sticky cursor; exposed via `POST /api/credentials/pool/{provider}/{index}/activate` (1-based index, matching the existing list/remove endpoints).
- Fix: initial priority was hardcoded to `-1`, which tied with an earlier manual pick and let list order (not the click) decide the winner on a second switch. Now uses `min(existing priorities) - 1` so each activation strictly outranks the last.
- i18n: `settings.credentials.useThisAccount` for en/zh/zh-hant/ja/ar.

**Testing**

- `npm run typecheck` / `npm run lint` — clean
- `npm run test:ui -- providers-settings.test.tsx` — 8/8 passing (added: click "Use this account" → activate called → list refetched)
- `npm run build` (apps/desktop production build) — succeeds
- End-to-end: real Electron + real backend, driven via CDP to click the actual button — confirmed priority flips and the active row changes in the running app, not just in mocks.

No new deps, no new core tool, no config/env additions.