### PR TITLE
fix(disk-cleanup): protect Git worktrees and durable roots

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -148,6 +148,7 @@ _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     "logs", "memories", "sessions", "cron", "cronjobs",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
     "hermes-agent", "backups", "profiles", ".worktrees",
+    "scripts", "kanban", "workspace", "worktrees",
     # User-authored project trees — never sweep empty directories
     # inside these (#75403).
     "patches", "projects", "skins", "themes", "contributors",
@@ -564,6 +565,27 @@ _TEST_PATTERNS = ("test_", "tmp_")
 _TEST_SUFFIXES = (".test.py", ".test.js", ".test.ts", ".test.md")
 
 
+def _is_git_worktree_path(path: Path) -> bool:
+    """Return whether *path* is inside a Git checkout or linked worktree."""
+    resolved = path.resolve()
+    hermes_home = get_hermes_home()
+    try:
+        resolved.relative_to(hermes_home)
+        scope_root = hermes_home
+    except ValueError:
+        parts = resolved.parts
+        if len(parts) < 3 or parts[1] != "tmp" or not parts[2].startswith("hermes-"):
+            return False
+        scope_root = Path(*parts[:3])
+
+    current = resolved if resolved.is_dir() else resolved.parent
+    while current != scope_root.parent:
+        if (current / ".git").exists():
+            return True
+        current = current.parent
+    return False
+
+
 def guess_category(path: Path) -> Optional[str]:
     """Return a category label for *path*, or None if we shouldn't track it.
 
@@ -581,6 +603,7 @@ def guess_category(path: Path) -> Optional[str]:
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
             "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
             "auth.json", "hermes-agent",
+            "scripts", "kanban", "workspace", "worktrees",
             # User-authored and project trees — never auto-delete files
             # inside these just because they happen to be named test_* or
             # tmp_* (#75403, also #32164, #37721).
@@ -602,6 +625,9 @@ def guess_category(path: Path) -> Optional[str]:
     except ValueError:
         # Path isn't under HERMES_HOME (e.g. /tmp/hermes-*) — fall through.
         pass
+
+    if _is_git_worktree_path(path):
+        return None
 
     name = path.name
     if name.startswith(_TEST_PATTERNS):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -88,6 +88,40 @@ class TestIsSafePath:
 
 
 class TestGuessCategory:
+    @pytest.mark.parametrize("git_marker_is_dir", [True, False])
+    def test_git_worktree_test_file_not_categorised(
+        self, _isolate_env, git_marker_is_dir
+    ):
+        """Tracked source tests are durable, including linked worktrees."""
+        dg = _load_lib()
+        repo = _isolate_env / "checkout"
+        repo.mkdir()
+        git_marker = repo / ".git"
+        if git_marker_is_dir:
+            git_marker.mkdir()
+        else:
+            git_marker.write_text("gitdir: /tmp/example-worktree-gitdir\n")
+        tests = repo / "tests"
+        tests.mkdir()
+        p = tests / "test_regression.py"
+        p.write_text("def test_regression(): pass\n")
+
+        assert dg.guess_category(p) is None
+
+    @pytest.mark.parametrize(
+        "top", ["scripts", "kanban", "workspace", "worktrees"]
+    )
+    def test_skips_additional_durable_top_level_test_paths(
+        self, _isolate_env, top
+    ):
+        dg = _load_lib()
+        durable_dir = _isolate_env / top
+        durable_dir.mkdir()
+        p = durable_dir / "test_durable.py"
+        p.write_text("def test_durable(): pass\n")
+
+        assert dg.guess_category(p) is None
+
     def test_test_prefix(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "test_foo.py"
@@ -225,6 +259,33 @@ class TestStaleCronEntryMigration:
         assert not run_md.exists()
 
 
+class TestStaleGitWorktreeEntryMigration:
+    def test_quick_preserves_test_file_inside_git_worktree(self, _isolate_env):
+        """Pre-fix tracking state must not delete durable regression source."""
+        dg = _load_lib()
+        repo = _isolate_env / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        tests = repo / "tests"
+        tests.mkdir()
+        regression = tests / "test_regression.py"
+        regression.write_text("def test_regression(): pass\n")
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(regression),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": regression.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert regression.exists()
+        assert json.loads(tracked_file.read_text()) == []
+
+
 class TestTrackForgetQuick:
     def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()
@@ -243,6 +304,20 @@ class TestTrackForgetQuick:
         dg.track(str(p), "temp", silent=True)
         assert dg.forget(str(p)) == 1
         assert p.exists()  # forget does NOT delete the file
+
+    @pytest.mark.parametrize(
+        "top", ["scripts", "kanban", "workspace", "worktrees"]
+    )
+    def test_quick_preserves_additional_durable_top_level_dirs(
+        self, _isolate_env, top
+    ):
+        dg = _load_lib()
+        durable_dir = _isolate_env / top
+        durable_dir.mkdir()
+
+        dg.quick()
+
+        assert durable_dir.exists()
 
 
 class TestStatus:


### PR DESCRIPTION
## Summary

Disk cleanup currently protects several durable top-level trees, but a `test_*` file can still be auto-categorised as disposable when it lives inside a Git checkout or linked worktree under an otherwise allowed cleanup scope.

This narrow residual change:

- detects `.git` directories and linked-worktree `.git` files while walking only within `HERMES_HOME` or the applicable `/tmp/hermes-*` root;
- excludes Git checkout/worktree source from basename-based `test` categorisation;
- adds `scripts`, `kanban`, `workspace`, and `worktrees` to both durable top-level categorisation exclusions and empty-directory sweep protection;
- reuses the existing `quick()` stale-entry revalidation so formerly tracked durable test files are forgotten without deletion;
- preserves cleanup of ordinary scratch `test_*` files.

Related to #75403.

## Exact candidate

- Base and merge base: `bee2bd8bc2a321dec0abfba37e52cffeb3d3cfaa`
- Candidate: `7c4bb4b04b5185af5ac2686dc6ec621df4d32e16`
- Scope: exactly two modified files, 101 insertions, no deletions
  - `plugins/disk-cleanup/disk_cleanup.py`: 26 insertions
  - `tests/plugins/test_disk_cleanup_plugin.py`: 75 insertions
- Cumulative binary-diff SHA-256: `e3d60e47c9121f1e9e2bd91d3219c86211e8ee86e040b951e73000b759f54818`

## Relationship to #75424 / `6f400d2a2`

[#75424](https://github.com/NousResearch/hermes-agent/pull/75424) merged as a two-commit series: `5286fe198` introduced durable project-root categorisation exclusions; follow-up `6f400d2a2076915c36d33783c3a613a308dad7c0` added stale `test` entry revalidation and empty-directory sweep protection. GitHub reports `6f400d2a2076915c36d33783c3a613a308dad7c0` as the PR merge SHA.

This candidate builds on that merged behavior. It does not introduce another stale-state migration path or replace #75424. Its residual additions are bounded Git-checkout/worktree detection and the four additional durable roots listed above.

## Overlap with open #75464

[#75464](https://github.com/NousResearch/hermes-agent/pull/75464) remains open at observed head `ca5395dfd13d774bd841c64c7719fe69b18412ed`. Its current public diff is broader: three files, 514 insertions and 18 deletions. It includes pre-/post-tool pre-existence tracking and `dry_run()` stale-entry handling in addition to durable-file protection.

The overlap is narrow but real: both changes protect durable test-named files and modify `disk_cleanup.py` plus its tests. This PR does **not** claim to supersede or replace #75464. It presents a smaller alternative for the Git-checkout/worktree and four-root residual while preserving the current-main cleanup architecture. Maintainers should decide whether to consolidate the approaches or choose one.

## Test plan

TDD contract:

- RED before production changes: `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py -k 'git_worktree or additional_durable'` → 11 failed, 27 deselected
- GREEN after production changes: same command → 11 passed, 27 deselected

Final verification:

- `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py` → 38 passed
- `scripts/run_tests.sh tests/plugins/` → 98 files, 1,317 tests passed
- `python -m ruff check plugins/disk-cleanup/disk_cleanup.py tests/plugins/test_disk_cleanup_plugin.py` → passed
- `python -m compileall -q plugins/disk-cleanup/disk_cleanup.py tests/plugins/test_disk_cleanup_plugin.py` → passed
- `git diff --check` and `git diff-tree --check HEAD^ HEAD` → passed
- added-line security scan → 101 added lines, zero findings
- isolated real linked-worktree probe → durable source preserved, stale tracking removed, ordinary scratch test deleted

## Limits and rollback

`dry_run()` does not yet revalidate stale `test` entries; that pre-existing preview-parity gap is outside this deletion-safety residual and should be handled separately if desired.

If this PR is merged and needs to be undone, revert the actual resulting GitHub merge/squash commit (or use GitHub's Revert action). No superseded local commit is the rollback target.
