### PR TITLE
fix(acp): report unloadable sessions as JSON-RPC errors on load/resume/prompt

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -16,6 +16,7 @@ from typing import Any, Deque, Optional
 from urllib.parse import unquote, urlparse
 
 import acp
+from acp.exceptions import RequestError
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -561,6 +562,23 @@ def _content_blocks_to_openai_user_content(
         return "\n".join(text_parts)
 
     return parts
+
+
+def _session_not_found_error(session_id: str) -> RequestError:
+    """ACP error for a session that does not exist or cannot be rebuilt.
+
+    Code -32002 is the predefined ACP ``ErrorCode.ResourceNotFound``
+    ("a given resource, such as a file, was not found"). Returning a success
+    frame for an unloadable session — as load/resume/prompt did historically —
+    is indistinguishable from a restored session for spec-conformant clients,
+    which then reuse a dead session id indefinitely (#74678).
+    """
+
+    return RequestError(
+        code=-32002,
+        message=f"Session not found: {session_id}",
+        data={"sessionId": session_id},
+    )
 
 
 class HermesACPAgent(acp.Agent):
@@ -1459,11 +1477,20 @@ class HermesACPAgent(acp.Agent):
         session_id: str,
         mcp_servers: list | None = None,
         **kwargs: Any,
-    ) -> LoadSessionResponse | None:
+    ) -> LoadSessionResponse:
+        """Load an existing session, streaming its history back to the client.
+
+        Raises ``RequestError`` (-32002 "Session not found") when the session
+        id is unknown or the persisted session cannot be rebuilt (e.g. its
+        provider is no longer configured) — it never returns None, so a client
+        can always distinguish "restored" from "gone" (#74678).
+        """
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
-            return None
+            # Unknown/unrestorable session must surface as a JSON-RPC error,
+            # not an empty success result (#74678).
+            raise _session_not_found_error(session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Loaded session %s", session_id)
@@ -1510,8 +1537,13 @@ class HermesACPAgent(acp.Agent):
     ) -> ResumeSessionResponse:
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
-            logger.warning("resume_session: session %s not found, creating new", session_id)
-            state = self.session_manager.create_session(cwd=cwd)
+            logger.warning("resume_session: session %s not found", session_id)
+            # No implicit fresh-session fallback: ACP responses carry no
+            # sessionId field, so the replacement would be unreachable by a
+            # spec-conformant client — it would keep prompting a dead id
+            # (#74678). Error instead and let the client call session/new
+            # deliberately.
+            raise _session_not_found_error(session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Resumed session %s", state.session_id)
@@ -1641,7 +1673,10 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.error("prompt: session %s not found", session_id)
-            return PromptResponse(stop_reason="refusal")
+            # stopReason="refusal" is a model-level outcome for a turn that
+            # ran; answering it for a session the adapter does not have makes
+            # a client record an empty successful turn (#74678).
+            raise _session_not_found_error(session_id)
 
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -9,6 +9,7 @@ import pytest
 
 import acp
 from acp.agent.router import build_agent_router
+from acp.exceptions import RequestError
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -282,9 +283,13 @@ class TestSessionOps:
 
 
     @pytest.mark.asyncio
-    async def test_load_session_not_found_returns_none(self, agent):
-        resp = await agent.load_session(cwd="/tmp", session_id="bogus")
-        assert resp is None
+    async def test_load_session_not_found_raises_resource_not_found(self, agent):
+        # #74678: an unknown session must surface as ACP -32002 "Resource not
+        # found", not as an empty success result.
+        with pytest.raises(RequestError) as exc_info:
+            await agent.load_session(cwd="/tmp", session_id="bogus")
+
+        assert exc_info.value.code == -32002
 
 
 
@@ -403,11 +408,14 @@ class TestSessionConfiguration:
 
 class TestPrompt:
     @pytest.mark.asyncio
-    async def test_prompt_returns_refusal_for_unknown_session(self, agent):
+    async def test_prompt_unknown_session_raises_resource_not_found(self, agent):
+        # #74678: a session the adapter does not have must surface as ACP
+        # -32002, not as stopReason="refusal" (which is a model-level outcome).
         prompt = [TextContentBlock(type="text", text="hello")]
-        resp = await agent.prompt(prompt=prompt, session_id="nonexistent")
-        assert isinstance(resp, PromptResponse)
-        assert resp.stop_reason == "refusal"
+        with pytest.raises(RequestError) as exc_info:
+            await agent.prompt(prompt=prompt, session_id="nonexistent")
+
+        assert exc_info.value.code == -32002
 
     @pytest.mark.asyncio
     async def test_prompt_binds_session_id_into_subprocess_env(self, agent, mock_manager):

--- a/tests/acp_adapter/test_acp_unloadable_session.py
+++ b/tests/acp_adapter/test_acp_unloadable_session.py
@@ -1,0 +1,175 @@
+"""ACP must report unloadable sessions as JSON-RPC errors, not silent success.
+
+Regression coverage for #74678: session/load, session/resume and session/prompt
+used to report success for an unknown/unrestorable session id — load returned
+None (empty result), resume silently created a replacement session under a new
+id a spec-conformant client cannot discover, and prompt answered
+stopReason="refusal" for a turn that never ran. ACP defines the -32002
+"Resource not found" error for exactly this condition; clients use it to fall
+back to session/new deliberately.
+"""
+
+import pytest
+from acp.exceptions import RequestError
+from acp.schema import TextContentBlock
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+UNKNOWN_SESSION_ID = "00000000-0000-0000-0000-0000000000ff"
+
+
+class DummyAgent:
+    """Minimal AIAgent stand-in: accepts callback attrs, records runs."""
+
+    def __init__(self):
+        self.model = "dummy-model"
+        self.provider = "dummy-provider"
+        self.conversation_history = []
+        self.runs = []
+        self._supports_active_turn_redirect = True
+
+    def run_conversation(self, *, user_message, conversation_history, **_kwargs):
+        self.runs.append(user_message)
+        messages = list(conversation_history or [])
+        messages.append({"role": "user", "content": user_message})
+        messages.append({"role": "assistant", "content": "done"})
+        return {"final_response": "done", "messages": messages}
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+class UnrestorableDb:
+    """DB has the session row, but rebuilding its agent fails.
+
+    Mirrors the named-custom-provider loss scenario (#63681/#74628): the
+    session exists in state.db but can no longer be recreated, so
+    ``_restore`` returns None and the caller must surface -32002.
+    """
+
+    def get_session(self, session_id, **_kwargs):
+        return {
+            "id": session_id,
+            "source": "acp",
+            "model": "lost-model",
+            "billing_provider": None,
+            "billing_base_url": None,
+            "model_config": "{}",
+        }
+
+    def get_messages_as_conversation(self, *_args, **_kwargs):
+        return []
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+class ExplodingAgentFactory:
+    def __call__(self):
+        raise RuntimeError("No LLM provider configured")
+
+
+def make_agent() -> tuple[HermesACPAgent, SessionManager]:
+    manager = SessionManager(agent_factory=DummyAgent, db=NoopDb())
+    return HermesACPAgent(session_manager=manager), manager
+
+
+@pytest.mark.asyncio
+async def test_load_session_unknown_id_raises_resource_not_found():
+    agent, _ = make_agent()
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.load_session(cwd=".", session_id=UNKNOWN_SESSION_ID)
+
+    assert exc_info.value.code == -32002
+    assert UNKNOWN_SESSION_ID in str(exc_info.value)
+    assert exc_info.value.data == {"sessionId": UNKNOWN_SESSION_ID}
+
+
+@pytest.mark.asyncio
+async def test_resume_session_unknown_id_raises_and_creates_no_replacement():
+    agent, manager = make_agent()
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.resume_session(cwd=".", session_id=UNKNOWN_SESSION_ID)
+
+    assert exc_info.value.code == -32002
+    # No silent replacement session may be created under any id.
+    assert manager.get_session(UNKNOWN_SESSION_ID) is None
+    assert len(manager._sessions) == 0
+
+
+@pytest.mark.asyncio
+async def test_prompt_unknown_id_raises_resource_not_found():
+    agent, _ = make_agent()
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.prompt(
+            session_id=UNKNOWN_SESSION_ID,
+            prompt=[TextContentBlock(type="text", text="hello")],
+        )
+
+    assert exc_info.value.code == -32002
+
+
+@pytest.mark.asyncio
+async def test_load_session_unrestorable_db_row_raises_resource_not_found():
+    # A session that exists in state.db but cannot be rebuilt (provider lost,
+    # #63681/#74628) must produce the same -32002 as a never-created id —
+    # not an empty success result.
+    manager = SessionManager(agent_factory=ExplodingAgentFactory(), db=UnrestorableDb())
+    agent = HermesACPAgent(session_manager=manager)
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent.load_session(cwd=".", session_id=UNKNOWN_SESSION_ID)
+
+    assert exc_info.value.code == -32002
+
+
+@pytest.mark.asyncio
+async def test_load_session_known_id_still_succeeds():
+    agent, manager = make_agent()
+    state = manager.create_session(cwd=".")
+
+    response = await agent.load_session(cwd=".", session_id=state.session_id)
+
+    assert response is not None
+    assert response.modes is not None
+    assert response.models is not None
+
+
+@pytest.mark.asyncio
+async def test_resume_session_known_id_still_succeeds():
+    agent, manager = make_agent()
+    state = manager.create_session(cwd=".")
+
+    response = await agent.resume_session(cwd=".", session_id=state.session_id)
+
+    assert response is not None
+    assert manager.get_session(state.session_id) is state
+
+
+@pytest.mark.asyncio
+async def test_prompt_known_id_still_runs():
+    agent, manager = make_agent()
+    state = manager.create_session(cwd=".")
+
+    response = await agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="continue the task")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.agent.runs == ["continue the task"]


### PR DESCRIPTION
## What does this PR do?

Fixes #74678 — the ACP adapter reported **success** on `session/load`, `session/resume` and `session/prompt` for an unknown or unrestorable session id, so a client could not tell "session restored" from "session is gone". A resumed turn silently did nothing and looked like it completed, and the dead session id was handed back and reused on the next turn, repeating the condition indefinitely.

All three entry points now raise the ACP-predefined `-32002 Resource not found` JSON-RPC error (message `Session not found: <id>`, `data.sessionId` set), which the SDK transport serialises as a proper JSON-RPC error frame:

- **`session/load`** — previously returned `None` (serialised as `result={}`). Now raises `-32002`.
- **`session/resume`** — previously fell back to `create_session()`, creating a replacement session whose id is undiscoverable by spec-conformant clients (ACP responses have no `sessionId` field, and `_meta` keys are explicitly off-limits). The implicit fallback is removed; the client now receives `-32002` and can call `session/new` deliberately.
- **`session/prompt`** — previously answered `stopReason="refusal"` for a session the adapter did not have (the only `refusal` source in the adapter — effectively a private signal for this condition). Now raises `-32002`; `refusal` remains reserved for a turn that actually ran and was refused.

The same error covers the *unrestorable* case: a session that exists in `state.db` but can no longer be rebuilt (e.g. named custom provider lost — #63681 / #74628) flows through the same `state is None` path.

## Related Issue

Fixes #74678

Relates to #21934

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`
  - New `_session_not_found_error(session_id)` helper — single source for code `-32002`, message `Session not found: <id>`, `data={"sessionId": <id>}`.
  - `load_session` raises instead of returning `None`; return annotation tightened from `LoadSessionResponse | None` to `LoadSessionResponse` (contract documented in a new docstring).
  - `resume_session` raises instead of silently creating a replacement session.
  - `prompt` raises instead of returning `PromptResponse(stop_reason="refusal")`.
- `tests/acp_adapter/test_acp_unloadable_session.py` (new) — 7 regression tests: unknown id → `-32002` on all three methods (plus: resume creates no replacement session), DB-row-present-but-unrestorable → `-32002`, and positive controls that known sessions still load / resume / prompt.

## How to Test

1. `pytest tests/acp_adapter/ -q -o addopts=''` — 21 passed (14 pre-existing + 7 new). Broader sweep `tests/acp_adapter/ tests/run_agent/`: 1427 passed, 6 skipped, 7 failed — the 7 failures reproduce identically on clean `main` (pre-existing, unrelated to this change; verified in a second checkout).
2. Wire-level probe against `hermes acp` with a fresh `HERMES_HOME`: `session/load`, `session/resume`, `session/prompt` with a never-created id each return `{"code": -32002, "message": "Session not found: 00000000-0000-0000-0000-0000000000ff", "data": {"sessionId": "00000000-0000-0000-0000-0000000000ff"}}`. Before the fix the same probe returned `result={}`, `-32603 Internal error`, and `{"stopReason": "refusal"}` respectively.
3. `ruff check acp_adapter/server.py tests/acp_adapter/test_acp_unloadable_session.py` — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (see How to Test for the verified pre-existing-failure caveat)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

- **Open question:** error message shape. The code is `-32002` (ACP's predefined `ErrorCode.ResourceNotFound`) either way; I used a specific `Session not found: <id>` message rather than the SDK's stock `Resource not found` so clients can surface the failing id. Happy to switch to the stock message if maintainers prefer.
- **Open question:** this removes the implicit fresh-session fallback in `resume_session` (the issue's option 1). That matches the direction in the maintainer discussion on #21934 ("the strict behavior... may be the preferred, more spec-aligned one"). If permissive resume-on-miss semantics are preferred instead, #21934 (preserving the requested id) is the complementary approach — but it leaves `session/load`'s empty-success `None` and direct `session/prompt` on an unknown id unfixed.
- Independent of #63681 / #74628 / #74648 / #30182: those fix *causes* of unrestorable sessions (provider identity lost on restore). This PR makes the failure *visible* when restore fails, so it composes with whichever of those lands.
