### PR TITLE
docs(cron): document async manual runs and per-run prompt context

### DIFF
--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -637,6 +637,30 @@ cronjob(action="remove", job_id="...")
 
 For `update`, pass `skills=[]` to remove all attached skills.
 
+### Manual runs are asynchronous
+
+`cronjob(action="run")` fires the job immediately **in the background** (like
+`delegate_task`): the tool call returns at once with a handle, and the job's
+outcome — success/failure, delivery target, next scheduled run, and an output
+excerpt — re-enters the conversation as a new message when the run finishes.
+The agent (and you) can keep working in the meantime, and a job that is
+already mid-run is refused with "already running" instead of double-firing.
+
+You can also pass `prompt` with `action="run"` to inject transient per-run
+context:
+
+```python
+cronjob(action="run", job_id="...", prompt="CONTEXT: focus on the EU region today")
+```
+
+The context is appended to the job's stored prompt under a `## Run Context`
+header for that single fire only — it is never persisted to the job
+definition, and it passes the same prompt-injection scan as stored prompts.
+
+Runtimes that can't receive detached results (one-shot `hermes -z`, `hermes
+cron run` from the CLI, cron child sessions, Kanban workers) fall back to
+synchronous execution automatically.
+
 ## Toolsets available to cron jobs
 
 Cron runs each job in a fresh agent session with no chat platform attached. By default the cron agent gets **the toolset you configured for the `cron` platform in `hermes tools`** — not the CLI default, not everything under the sun.


### PR DESCRIPTION
## Summary
Documents the new `cronjob(action="run")` semantics shipped in #80807 and #80838: manual runs are asynchronous (return a handle, outcome re-enters the chat as a completion), refuse to double-fire mid-run jobs, accept transient `prompt` context under a `## Run Context` header, and fall back to sync on runtimes without detached delivery.

## Changes
- `website/docs/user-guide/features/cron.md`: new "Manual runs are asynchronous" subsection under "Managing jobs programmatically".

## Validation
Docs-only markdown change; page renders from existing structure. CI build validates.

## Infographic

![docs cron run async](https://v3b.fal.media/files/b/0aa55715/z_DQU_Cri78sqqnsoCMXS_spn11EZR.png)
