### PR TITLE
fix(tools): stop browser_cdp frame_id routing from skipping private-page SSRF guard

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -81,6 +81,14 @@ class _CDPServer:
                                 result = fn(params, session_id)
                                 if isinstance(result, Exception):
                                     raise result
+                                events_before = []
+                                events_after = []
+                                if isinstance(result, dict):
+                                    result = dict(result)
+                                    events_before = result.pop("__events_before__", [])
+                                    events_after = result.pop("__events_after__", [])
+                                for event in events_before:
+                                    await ws.send(json.dumps(event))
                                 reply = {"id": call_id, "result": result}
                             except Exception as exc:
                                 reply = {
@@ -90,6 +98,8 @@ class _CDPServer:
                         if session_id:
                             reply["sessionId"] = session_id
                         await ws.send(json.dumps(reply))
+                        for event in events_after:
+                            await ws.send(json.dumps(event))
                 except websockets.exceptions.ConnectionClosed:
                     pass
 
@@ -186,11 +196,32 @@ def test_websockets_missing_returns_error(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_browser_level_redacts_secret_result(cdp_server):
+def test_browser_level_redacts_secret_result(cdp_server, monkeypatch):
+    import agent.redact
+
+    secret_key_one = "sk-" + "CDPSECRETKEYONE1234567890"
+    secret_key_two = "sk-" + "CDPSECRETKEYTWO1234567890"
     fake_key = "sk-" + "CDPSECRETRESULT1234567890"
+    real_redact = agent.redact.redact_sensitive_text
+
+    def colliding_redact(text, **kwargs):
+        if text in {secret_key_one, secret_key_two}:
+            return "sk-«redacted:test…»"
+        return real_redact(text, **kwargs)
+
+    monkeypatch.setattr(agent.redact, "redact_sensitive_text", colliding_redact)
     cdp_server.on(
         "Runtime.evaluate",
-        lambda params, sid: {"result": {"type": "string", "value": fake_key}},
+        lambda params, sid: {
+            "result": {
+                "type": "object",
+                "value": fake_key,
+                "properties": {
+                    secret_key_one: {"source": "first"},
+                    secret_key_two: {"source": "second"},
+                },
+            }
+        },
     )
 
     result = json.loads(browser_cdp_tool.browser_cdp(method="Runtime.evaluate"))
@@ -198,12 +229,356 @@ def test_browser_level_redacts_secret_result(cdp_server):
     assert result["success"] is True
     serialized = json.dumps(result)
     assert "CDPSECRETRESULT" not in serialized
+    assert "CDPSECRETKEY" not in serialized
     assert result["result"]["result"]["value"].startswith("sk-")
+    properties = result["result"]["result"]["properties"]
+    assert len(properties) == 2
+    assert {entry["source"] for entry in properties.values()} == {"first", "second"}
+
+
+def test_cdp_key_redaction_preserves_large_collision_sets(monkeypatch):
+    import agent.redact
+
+    key_count = 2_000
+    payload = {f"secret-{index}": index for index in range(key_count)}
+    monkeypatch.setattr(
+        agent.redact,
+        "redact_sensitive_text",
+        lambda text, **kwargs: "redacted" if text.startswith("secret-") else text,
+    )
+
+    first = browser_cdp_tool._redact_cdp_output(payload)
+    second = browser_cdp_tool._redact_cdp_output(payload)
+
+    assert first == second
+    assert len(first) == key_count
+    assert set(first.values()) == set(range(key_count))
+    assert list(first)[:3] == ["redacted", "redacted (2)", "redacted (3)"]
+    assert list(first)[-1] == f"redacted ({key_count})"
 
 
 # ---------------------------------------------------------------------------
 # Happy-path: target-attached call
 # ---------------------------------------------------------------------------
+
+
+def test_public_top_level_target_is_resolved_before_attach(cdp_server, monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: True)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "public-page", "type": "page", "url": "https://example.com"}
+            ]
+        },
+    )
+    cdp_server.on(
+        "Target.attachToTarget", lambda params, sid: {"sessionId": "page-session"}
+    )
+    cdp_server.on(
+        "Page.getFrameTree",
+        lambda params, sid: {
+            "frameTree": {"frame": {"url": "https://example.com"}}
+        },
+    )
+    cdp_server.on(
+        "Runtime.evaluate",
+        lambda params, sid: {"result": {"type": "string", "value": "public"}},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.title"},
+            target_id="public-page",
+            task_id="task-1",
+        )
+    )
+
+    assert result["success"] is True
+    assert [call["method"] for call in cdp_server.received()] == [
+        "Target.getTargets",
+        "Target.attachToTarget",
+        "Page.getFrameTree",
+        "Runtime.evaluate",
+    ]
+
+
+def test_private_oopif_target_id_is_blocked_before_attach(cdp_server, monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "private-oopif", "type": "iframe", "url": PRIVATE_URL}
+            ]
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            target_id="private-oopif",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "top-level page target" in result["error"]
+    assert [call["method"] for call in cdp_server.received()] == ["Target.getTargets"]
+
+
+def test_non_page_target_is_rejected_when_ssrf_guard_is_inactive(cdp_server, monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: False)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "child-target", "type": "iframe", "url": "https://child.example"}
+            ]
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            target_id="child-target",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "top-level page target" in result["error"]
+    assert [call["method"] for call in cdp_server.received()] == ["Target.getTargets"]
+
+
+def test_allowlisted_method_still_rejects_non_page_target(cdp_server, monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "private-oopif", "type": "iframe", "url": PRIVATE_URL}
+            ]
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.reload",
+            target_id="private-oopif",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "top-level page target" in result["error"]
+    assert [call["method"] for call in cdp_server.received()] == ["Target.getTargets"]
+
+
+def test_target_navigation_to_private_url_is_blocked_after_attach(cdp_server, monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: url != PRIVATE_URL)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "changing-page", "type": "page", "url": "https://example.com"}
+            ]
+        },
+    )
+    cdp_server.on(
+        "Target.attachToTarget", lambda params, sid: {"sessionId": "page-session"}
+    )
+    cdp_server.on(
+        "Page.getFrameTree",
+        lambda params, sid: {"frameTree": {"frame": {"url": PRIVATE_URL}}},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            target_id="changing-page",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "navigated to a private or internal address" in result["error"]
+    assert [call["method"] for call in cdp_server.received()] == [
+        "Target.getTargets",
+        "Target.attachToTarget",
+        "Page.getFrameTree",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("method", "params", "selected_frame_id", "private_commit_only"),
+    [
+        (
+            "Page.navigate",
+            {"url": "https://public.example/redirect"},
+            "top-frame",
+            False,
+        ),
+        ("Page.reload", {}, "top-frame", False),
+        (
+            "Page.navigate",
+            {"url": "https://public.example/redirect", "frameId": "child-frame"},
+            "child-frame",
+            False,
+        ),
+        (
+            "Page.navigate",
+            {"url": "https://public.example/private-then-public"},
+            "top-frame",
+            True,
+        ),
+    ],
+)
+def test_target_navigation_result_is_revalidated_and_blank_on_private_redirect(
+    cdp_server, monkeypatch, method, params, selected_frame_id, private_commit_only
+):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: url != PRIVATE_URL)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "public-page", "type": "page", "url": "https://public.example"}
+            ]
+        },
+    )
+    cdp_server.on(
+        "Target.attachToTarget", lambda params, sid: {"sessionId": "page-session"}
+    )
+    cdp_server.on("Page.enable", lambda params, sid: {})
+    frame_tree_calls = 0
+
+    def frame_tree(params, sid):
+        nonlocal frame_tree_calls
+        frame_tree_calls += 1
+        selected_url = (
+            "https://public.example"
+            if frame_tree_calls == 1 or private_commit_only
+            else PRIVATE_URL
+        )
+        child_frames = []
+        top_url = selected_url
+        if selected_frame_id == "child-frame":
+            top_url = "https://public.example"
+            child_frames = [
+                {
+                    "frame": {
+                        "id": "child-frame",
+                        "loaderId": "initial-child-loader",
+                        "url": selected_url,
+                    }
+                }
+            ]
+        return {
+            "frameTree": {
+                "frame": {
+                    "id": "top-frame",
+                    "loaderId": "initial-loader",
+                    "url": top_url,
+                },
+                "childFrames": child_frames,
+            }
+        }
+
+    def navigate(params, sid):
+        if params.get("url") == "about:blank":
+            return {
+                "frameId": "top-frame",
+                "loaderId": "blank-loader",
+                "__events_after__": [
+                    {
+                        "method": "Page.frameNavigated",
+                        "params": {
+                            "frame": {
+                                "id": "top-frame",
+                                "loaderId": "blank-loader",
+                                "url": "about:blank",
+                            }
+                        },
+                    }
+                ],
+            }
+        return navigation_result()
+
+    def navigation_result():
+        return {
+            "frameId": selected_frame_id,
+            "loaderId": "private-loader",
+            "__events_after__": [
+                {
+                    "method": "Page.frameNavigated",
+                    "params": {
+                        "frame": {
+                            "id": selected_frame_id,
+                            "loaderId": "private-loader",
+                            "url": PRIVATE_URL,
+                        }
+                    },
+                }
+            ],
+        }
+
+    cdp_server.on(method, lambda params, sid: navigation_result())
+    cdp_server.on(
+        "Page.getFrameTree",
+        frame_tree,
+    )
+    cdp_server.on("Page.navigate", navigate)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method=method,
+            params=params,
+            target_id="public-page",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "landed on a private or internal address" in result["error"]
+    calls = cdp_server.received()
+    assert [call["method"] for call in calls] == [
+        "Target.getTargets",
+        "Target.attachToTarget",
+        "Page.enable",
+        "Page.getFrameTree",
+        method,
+        "Page.getFrameTree",
+        "Page.navigate",
+    ]
+    assert calls[-1]["params"] == {"url": "about:blank"}
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +705,547 @@ def test_frame_id_route_allowed_when_page_is_not_private(monkeypatch):
 
     assert result.get("success") is True
     assert len(supervisor_calls) == 1
+
+
+def test_frame_id_rejects_non_dict_params_before_guard(monkeypatch):
+    """frame_id path must reject non-dict params like the stateless path.
+
+    Without this check, a truthy non-dict (e.g. a string) reaches
+    ``_browser_cdp_private_guard``, raises on ``.get``, and the guard's
+    broad except fail-opens — skipping the private-page boundary and
+    never surfacing the clear params validation error.
+    """
+    supervisor_calls = []
+    guard_calls = []
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: PRIVATE_URL)
+
+    real_guard = browser_cdp_tool._browser_cdp_private_guard
+
+    def tracking_guard(**kwargs):
+        guard_calls.append(kwargs)
+        return real_guard(**kwargs)
+
+    def fake_supervisor_route(**kwargs):
+        supervisor_calls.append(kwargs)
+        return json.dumps({"success": True, "result": {"value": "leaked"}})
+
+    monkeypatch.setattr(browser_cdp_tool, "_browser_cdp_private_guard", tracking_guard)
+    monkeypatch.setattr(
+        browser_cdp_tool, "_browser_cdp_via_supervisor", fake_supervisor_route
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params="not-a-dict",
+            frame_id="frame-1",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "params" in result["error"].lower()
+    assert "object/dict" in result["error"]
+    assert "str" in result["error"]
+    assert guard_calls == []
+    assert supervisor_calls == []
+
+
+class _FakeFrame:
+    def __init__(self, **kwargs):
+        self._data = dict(kwargs)
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeSnapshot:
+    def __init__(self, frame_tree):
+        self.frame_tree = frame_tree
+
+
+class _FakeSupervisor:
+    """Minimal supervisor stub for frame_id private-URL routing tests."""
+
+    def __init__(self, *, frame_tree=None, frames=None):
+        self._frame_tree = frame_tree or {"top": None, "children": []}
+        self._frames = frames or {}
+        self._state_lock = threading.Lock()
+        self._loop = None
+        self.cdp_calls = []
+
+    def snapshot(self):
+        return _FakeSnapshot(self._frame_tree)
+
+
+def test_frame_id_blocks_private_oopif_when_top_page_is_public(monkeypatch):
+    """Public parent + private OOPIF child must still block page-content CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    # Top-level page is public — the regression the review called out.
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+                "session_id": "top-session",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-private",
+                    "url": PRIVATE_URL,
+                    "origin": "http://169.254.169.254",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-private",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert "private or internal address" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_raw_frames_fallback_blocks_private_oopif(monkeypatch):
+    """Raw ``_frames`` fallback (outside capped frame_tree) must apply the same check."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={"top": {"frame_id": "top-1", "url": "https://example.com/"}, "children": []},
+        frames={
+            "oopif-raw": _FakeFrame(
+                frame_id="oopif-raw",
+                url=PRIVATE_URL,
+                origin="http://169.254.169.254",
+                session_id="raw-session",
+            )
+        },
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="DOM.getDocument",
+            params={},
+            frame_id="oopif-raw",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
+    """Navigation/inspection allowlist must still reach supervisor on private frames."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    private_frame = _FakeFrame(
+        frame_id="oopif-private",
+        url=PRIVATE_URL,
+        origin="http://169.254.169.254",
+        session_id="child-session",
+    )
+    import agent.redact
+
+    secret_key_one = "sk-" + "CDPFRAMEKEYONE1234567890"
+    secret_key_two = "sk-" + "CDPFRAMEKEYTWO1234567890"
+    fake_key = "sk-" + "CDPFRAMESECRET1234567890"
+    real_redact = agent.redact.redact_sensitive_text
+
+    def colliding_redact(text, **kwargs):
+        if text in {secret_key_one, secret_key_two}:
+            return "sk-«redacted:test…»"
+        return real_redact(text, **kwargs)
+
+    monkeypatch.setattr(agent.redact, "redact_sensitive_text", colliding_redact)
+
+    class _AllowlistSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [private_frame.to_dict()],
+                },
+                frames={"oopif-private": private_frame},
+            )
+            # Running loop stub so via_supervisor proceeds past the loop check.
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+        async def _cdp(self, method, params=None, *, session_id=None, timeout=10.0):
+            self.cdp_calls.append(
+                {"method": method, "params": params, "session_id": session_id}
+            )
+            return {
+                "result": {
+                    "value": fake_key,
+                    "properties": {
+                        secret_key_one: {"source": "first"},
+                        secret_key_two: {"source": "second"},
+                    },
+                }
+            }
+
+    supervisor = _AllowlistSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        class _Fut:
+            def result(self, timeout=None):
+                return asyncio.run(coro)
+
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.reload",
+            params={},
+            frame_id="oopif-private",
+            task_id="task-1",
+        )
+    )
+
+    assert result.get("success") is True
+    assert result.get("session_id") == "child-session"
+    assert "CDPFRAMESECRET" not in json.dumps(result)
+    assert "CDPFRAMEKEY" not in json.dumps(result)
+    assert result["result"]["value"].startswith("sk-")
+    properties = result["result"]["properties"]
+    assert len(properties) == 2
+    assert {entry["source"] for entry in properties.values()} == {"first", "second"}
+    assert supervisor.cdp_calls == [
+        {"method": "Page.reload", "params": {}, "session_id": "child-session"}
+    ]
+
+
+def test_frame_id_revalidates_live_url_before_dispatch(monkeypatch):
+    """Public snapshot must not win if the live OOPIF navigates private before _cdp."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    # Hermetic runner has no DNS; keep always-blocked IMDS URLs blocked via
+    # _is_always_blocked_url while treating ordinary public hosts as safe.
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: True)
+
+    public_frame = _FakeFrame(
+        frame_id="oopif-race",
+        url="https://example.com/widget",
+        origin="https://example.com",
+        session_id="child-session",
+    )
+    private_frame = _FakeFrame(
+        frame_id="oopif-race",
+        url=PRIVATE_URL,
+        origin="http://169.254.169.254",
+        session_id="child-session",  # same session — mirrors _on_frame_navigated
+    )
+
+    class _RaceSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [public_frame.to_dict()],
+                },
+                frames={"oopif-race": public_frame},
+            )
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+        async def _cdp(self, method, params=None, *, session_id=None, timeout=10.0):
+            self.cdp_calls.append(
+                {
+                    "method": method,
+                    "params": params,
+                    "session_id": session_id,
+                    "live_url": self._frames["oopif-race"].to_dict().get("url"),
+                }
+            )
+            return {"result": {"ok": True}}
+
+    supervisor = _RaceSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        # Simulate Page.frameNavigated after the copied snapshot check and
+        # before the supervisor-loop dispatch body runs.
+        supervisor._frames["oopif-race"] = private_frame
+
+        class _Fut:
+            def result(self, timeout=None):
+                return asyncio.run(coro)
+
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-race",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert "private or internal address" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_blocks_when_live_frame_missing_before_dispatch(monkeypatch):
+    """Fail closed if the selected frame disappears after the snapshot check."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: True)
+
+    public_frame = _FakeFrame(
+        frame_id="oopif-gone",
+        url="https://example.com/widget",
+        origin="https://example.com",
+        session_id="child-session",
+    )
+
+    class _GoneSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [public_frame.to_dict()],
+                },
+                frames={"oopif-gone": public_frame},
+            )
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+        async def _cdp(self, method, params=None, *, session_id=None, timeout=10.0):
+            self.cdp_calls.append({"method": method, "session_id": session_id})
+            return {"result": {"ok": True}}
+
+    supervisor = _GoneSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        supervisor._frames.pop("oopif-gone", None)
+
+        class _Fut:
+            def result(self, timeout=None):
+                return asyncio.run(coro)
+
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "1+1"},
+            frame_id="oopif-gone",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "missing or transitioning" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_blocks_oopif_with_empty_url_and_origin(monkeypatch):
+    """OOPIF session without URL/origin metadata must fail closed for page CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-pending",
+                    "url": "",
+                    "origin": "",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-pending",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "no URL/origin metadata" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_fails_closed_when_selected_frame_probe_raises(monkeypatch):
+    """Active SSRF guard + probe exception must not fail-open into child CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("url safety probe exploded")
+
+    monkeypatch.setattr(
+        browser_cdp_tool, "_private_address_from_candidates", boom
+    )
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-public",
+                    "url": "https://example.com/widget",
+                    "origin": "https://example.com",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-public",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "guard probe failed" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_fails_closed_when_guard_activation_probe_raises(monkeypatch):
+    """Activation-probe exception must not fail-open into child CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    def boom_activation(_task_id):
+        raise RuntimeError("ssrf guard activation probe exploded")
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", boom_activation)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-public",
+                    "url": "https://example.com/widget",
+                    "origin": "https://example.com",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-public",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "activation probe failed" in result["error"]
+    assert supervisor.cdp_calls == []
 
 
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -569,15 +569,24 @@ def test_target_navigation_result_is_revalidated_and_blank_on_private_redirect(
     assert "error" in result
     assert "landed on a private or internal address" in result["error"]
     calls = cdp_server.received()
-    assert [call["method"] for call in calls] == [
+    expected = [
         "Target.getTargets",
         "Target.attachToTarget",
-        "Page.enable",
-        "Page.getFrameTree",
-        method,
-        "Page.getFrameTree",
-        "Page.navigate",
     ]
+    if method == "Page.reload":
+        # Reload is not allowlisted, so the selected-target private-page
+        # revalidation runs immediately after attach.
+        expected.append("Page.getFrameTree")
+    expected.extend(
+        [
+            "Page.enable",
+            "Page.getFrameTree",
+            method,
+            "Page.getFrameTree",
+            "Page.navigate",
+        ]
+    )
+    assert [call["method"] for call in calls] == expected
     assert calls[-1]["params"] == {"url": "about:blank"}
 
 
@@ -862,7 +871,7 @@ def test_frame_id_raw_frames_fallback_blocks_private_oopif(monkeypatch):
 
 
 def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
-    """Navigation/inspection allowlist must still reach supervisor on private frames."""
+    """Non-reload allowlist methods must still reach supervisor on private frames."""
     import tools.browser_tool as bt
     import tools.browser_supervisor as bs
 
@@ -939,7 +948,7 @@ def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
 
     result = json.loads(
         browser_cdp_tool.browser_cdp(
-            method="Page.reload",
+            method="Page.stopLoading",
             params={},
             frame_id="oopif-private",
             task_id="task-1",
@@ -955,8 +964,185 @@ def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
     assert len(properties) == 2
     assert {entry["source"] for entry in properties.values()} == {"first", "second"}
     assert supervisor.cdp_calls == [
-        {"method": "Page.reload", "params": {}, "session_id": "child-session"}
+        {"method": "Page.stopLoading", "params": {}, "session_id": "child-session"}
     ]
+
+
+def test_frame_id_reload_blocked_on_private_oopif(monkeypatch):
+    """Page.reload must not re-fetch an already-private OOPIF child session."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    private_frame = _FakeFrame(
+        frame_id="oopif-private",
+        url=PRIVATE_URL,
+        origin="http://169.254.169.254",
+        session_id="child-session",
+    )
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+            },
+            "children": [private_frame.to_dict()],
+        },
+        frames={"oopif-private": private_frame},
+    )
+    supervisor._loop = type(
+        "Loop",
+        (),
+        {"is_running": staticmethod(lambda: True)},
+    )()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.reload",
+            params={},
+            frame_id="oopif-private",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
+    """frame_id Page.navigate must post-check and blank public-to-private landings."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: url != PRIVATE_URL)
+
+    public_frame = _FakeFrame(
+        frame_id="oopif-public",
+        url="https://public.example/widget",
+        origin="https://public.example",
+        session_id="child-session",
+    )
+
+    class _NavSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [public_frame.to_dict()],
+                },
+                frames={"oopif-public": public_frame},
+            )
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+        async def _cdp(self, method, params=None, *, session_id=None, timeout=10.0):
+            self.cdp_calls.append(
+                {"method": method, "params": params or {}, "session_id": session_id}
+            )
+            if method == "Page.navigate" and (params or {}).get("url") != "about:blank":
+                public_frame._data["url"] = PRIVATE_URL
+                public_frame._data["origin"] = "http://169.254.169.254"
+                return {
+                    "result": {
+                        "frameId": "oopif-public",
+                        "loaderId": "private-loader",
+                    }
+                }
+            if method == "Page.getFrameTree":
+                return {
+                    "result": {
+                        "frameTree": {
+                            "frame": {
+                                "id": "oopif-public",
+                                "url": public_frame._data["url"],
+                            }
+                        }
+                    }
+                }
+            if method == "Page.navigate" and (params or {}).get("url") == "about:blank":
+                public_frame._data["url"] = "about:blank"
+                public_frame._data["origin"] = "null"
+                return {"result": {"frameId": "oopif-public", "loaderId": "blank-loader"}}
+            return {"result": {}}
+
+    supervisor = _NavSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        class _Fut:
+            def result(self, timeout=None):
+                return asyncio.run(coro)
+
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.navigate",
+            params={"url": "https://public.example/redirect"},
+            frame_id="oopif-public",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "landed on a private or internal address" in result["error"]
+    assert "frame reset to about:blank" in result["error"]
+    assert [call["method"] for call in supervisor.cdp_calls] == [
+        "Page.navigate",
+        "Page.getFrameTree",
+        "Page.navigate",
+    ]
+    assert supervisor.cdp_calls[-1]["params"] == {"url": "about:blank"}
+    assert public_frame._data["url"] == "about:blank"
+
+
+def test_target_reload_blocked_when_selected_target_is_private(cdp_server, monkeypatch):
+    """Page.reload must not attach to an already-private page target."""
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: url != PRIVATE_URL)
+    cdp_server.on(
+        "Target.getTargets",
+        lambda params, sid: {
+            "targetInfos": [
+                {"targetId": "private-page", "type": "page", "url": PRIVATE_URL}
+            ]
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.reload",
+            target_id="private-page",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "private or internal address" in result["error"]
+    assert [call["method"] for call in cdp_server.received()] == ["Target.getTargets"]
 
 
 def test_frame_id_revalidates_live_url_before_dispatch(monkeypatch):

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -1029,6 +1029,7 @@ def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
         url="https://public.example/widget",
         origin="https://public.example",
         session_id="child-session",
+        loaderId="public-loader",
     )
 
     class _NavSupervisor(_FakeSupervisor):
@@ -1054,9 +1055,12 @@ def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
             self.cdp_calls.append(
                 {"method": method, "params": params or {}, "session_id": session_id}
             )
+            if method == "Page.enable":
+                return {"result": {}}
             if method == "Page.navigate" and (params or {}).get("url") != "about:blank":
                 public_frame._data["url"] = PRIVATE_URL
                 public_frame._data["origin"] = "http://169.254.169.254"
+                public_frame._data["loaderId"] = "private-loader"
                 return {
                     "result": {
                         "frameId": "oopif-public",
@@ -1070,6 +1074,7 @@ def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
                             "frame": {
                                 "id": "oopif-public",
                                 "url": public_frame._data["url"],
+                                "loaderId": public_frame._data.get("loaderId", ""),
                             }
                         }
                     }
@@ -1077,6 +1082,7 @@ def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
             if method == "Page.navigate" and (params or {}).get("url") == "about:blank":
                 public_frame._data["url"] = "about:blank"
                 public_frame._data["origin"] = "null"
+                public_frame._data["loaderId"] = "blank-loader"
                 return {"result": {"frameId": "oopif-public", "loaderId": "blank-loader"}}
             return {"result": {}}
 
@@ -1107,12 +1113,175 @@ def test_frame_id_navigate_redirect_to_private_is_blanked(monkeypatch):
     assert "landed on a private or internal address" in result["error"]
     assert "frame reset to about:blank" in result["error"]
     assert [call["method"] for call in supervisor.cdp_calls] == [
+        "Page.enable",
+        "Page.getFrameTree",
         "Page.navigate",
         "Page.getFrameTree",
         "Page.navigate",
+        "Page.getFrameTree",
     ]
-    assert supervisor.cdp_calls[-1]["params"] == {"url": "about:blank"}
+    assert supervisor.cdp_calls[2]["params"] == {"url": "https://public.example/redirect"}
+    assert supervisor.cdp_calls[4]["params"] == {"url": "about:blank"}
     assert public_frame._data["url"] == "about:blank"
+
+
+def test_frame_id_navigate_waits_for_delayed_private_commit(monkeypatch):
+    """frame_id navigate must not trust a still-public tree before redirect commit."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "_is_safe_url", lambda url: url != PRIVATE_URL)
+
+    public_frame = _FakeFrame(
+        frame_id="oopif-public",
+        url="https://public.example/widget",
+        origin="https://public.example",
+        session_id="child-session",
+        loaderId="public-loader",
+    )
+    post_nav_tree_reads = {"count": 0}
+    navigated = {"done": False}
+
+    class _DelayedCommitSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [public_frame.to_dict()],
+                },
+                frames={"oopif-public": public_frame},
+            )
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+        async def _cdp(self, method, params=None, *, session_id=None, timeout=10.0):
+            self.cdp_calls.append(
+                {"method": method, "params": params or {}, "session_id": session_id}
+            )
+            if method == "Page.enable":
+                return {"result": {}}
+            if method == "Page.navigate" and (params or {}).get("url") == "about:blank":
+                public_frame._data["url"] = "about:blank"
+                public_frame._data["origin"] = "null"
+                public_frame._data["loaderId"] = "blank-loader"
+                return {"result": {"frameId": "oopif-public", "loaderId": "blank-loader"}}
+            if method == "Page.navigate":
+                # Navigate returns the new loaderId while the frame is still on
+                # the public URL — mirrors CDP returning before redirect commit.
+                navigated["done"] = True
+                return {
+                    "result": {
+                        "frameId": "oopif-public",
+                        "loaderId": "private-loader",
+                    }
+                }
+            if method == "Page.getFrameTree":
+                if public_frame._data.get("loaderId") == "blank-loader":
+                    return {
+                        "result": {
+                            "frameTree": {
+                                "frame": {
+                                    "id": "oopif-public",
+                                    "url": "about:blank",
+                                    "loaderId": "blank-loader",
+                                }
+                            }
+                        }
+                    }
+                if not navigated["done"]:
+                    return {
+                        "result": {
+                            "frameTree": {
+                                "frame": {
+                                    "id": "oopif-public",
+                                    "url": public_frame._data["url"],
+                                    "loaderId": public_frame._data.get(
+                                        "loaderId", "public-loader"
+                                    ),
+                                }
+                            }
+                        }
+                    }
+                post_nav_tree_reads["count"] += 1
+                if post_nav_tree_reads["count"] < 3:
+                    # Still the old public commit — early revalidate would pass.
+                    return {
+                        "result": {
+                            "frameTree": {
+                                "frame": {
+                                    "id": "oopif-public",
+                                    "url": "https://public.example/widget",
+                                    "loaderId": "public-loader",
+                                }
+                            }
+                        }
+                    }
+                public_frame._data["url"] = PRIVATE_URL
+                public_frame._data["origin"] = "http://169.254.169.254"
+                public_frame._data["loaderId"] = "private-loader"
+                return {
+                    "result": {
+                        "frameTree": {
+                            "frame": {
+                                "id": "oopif-public",
+                                "url": PRIVATE_URL,
+                                "loaderId": "private-loader",
+                            }
+                        }
+                    }
+                }
+            return {"result": {}}
+
+    supervisor = _DelayedCommitSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        class _Fut:
+            def result(self, timeout=None):
+                return asyncio.run(coro)
+
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.navigate",
+            params={"url": "https://public.example/redirect"},
+            frame_id="oopif-public",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "landed on a private or internal address" in result["error"]
+    assert "frame reset to about:blank" in result["error"]
+    assert post_nav_tree_reads["count"] >= 3
+    assert public_frame._data["url"] == "about:blank"
+    blank_calls = [
+        call
+        for call in supervisor.cdp_calls
+        if call["method"] == "Page.navigate"
+        and call["params"].get("url") == "about:blank"
+    ]
+    assert len(blank_calls) == 1
+    assert [call["method"] for call in supervisor.cdp_calls[:3]] == [
+        "Page.enable",
+        "Page.getFrameTree",
+        "Page.navigate",
+    ]
 
 
 def test_target_reload_blocked_when_selected_target_is_private(cdp_server, monkeypatch):

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -551,6 +551,47 @@ def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
     assert len(dispatched) == 1
 
 
+def test_frame_id_blocks_oopif_with_empty_url_and_origin(monkeypatch):
+    """OOPIF session without URL/origin metadata must fail closed for page CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-pending",
+                    "url": "",
+                    "origin": "",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-pending",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "no URL/origin metadata" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     calls = []
 

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -380,6 +380,177 @@ def test_frame_id_rejects_non_dict_params_before_guard(monkeypatch):
     assert supervisor_calls == []
 
 
+class _FakeFrame:
+    def __init__(self, **kwargs):
+        self._data = dict(kwargs)
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeSnapshot:
+    def __init__(self, frame_tree):
+        self.frame_tree = frame_tree
+
+
+class _FakeSupervisor:
+    """Minimal supervisor stub for frame_id private-URL routing tests."""
+
+    def __init__(self, *, frame_tree=None, frames=None):
+        self._frame_tree = frame_tree or {"top": None, "children": []}
+        self._frames = frames or {}
+        self._state_lock = threading.Lock()
+        self._loop = None
+        self.cdp_calls = []
+
+    def snapshot(self):
+        return _FakeSnapshot(self._frame_tree)
+
+
+def test_frame_id_blocks_private_oopif_when_top_page_is_public(monkeypatch):
+    """Public parent + private OOPIF child must still block page-content CDP."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    # Top-level page is public — the regression the review called out.
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={
+            "top": {
+                "frame_id": "top-1",
+                "url": "https://example.com/",
+                "origin": "https://example.com",
+                "session_id": "top-session",
+            },
+            "children": [
+                {
+                    "frame_id": "oopif-private",
+                    "url": PRIVATE_URL,
+                    "origin": "http://169.254.169.254",
+                    "session_id": "child-session",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="oopif-private",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert "private or internal address" in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_raw_frames_fallback_blocks_private_oopif(monkeypatch):
+    """Raw ``_frames`` fallback (outside capped frame_tree) must apply the same check."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    supervisor = _FakeSupervisor(
+        frame_tree={"top": {"frame_id": "top-1", "url": "https://example.com/"}, "children": []},
+        frames={
+            "oopif-raw": _FakeFrame(
+                frame_id="oopif-raw",
+                url=PRIVATE_URL,
+                origin="http://169.254.169.254",
+                session_id="raw-session",
+            )
+        },
+    )
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="DOM.getDocument",
+            params={},
+            frame_id="oopif-raw",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert supervisor.cdp_calls == []
+
+
+def test_frame_id_allowlist_survives_private_oopif(monkeypatch):
+    """Navigation/inspection allowlist must still reach supervisor on private frames."""
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bs
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    dispatched = []
+
+    class _AllowlistSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__(
+                frame_tree={
+                    "top": {
+                        "frame_id": "top-1",
+                        "url": "https://example.com/",
+                        "origin": "https://example.com",
+                    },
+                    "children": [
+                        {
+                            "frame_id": "oopif-private",
+                            "url": PRIVATE_URL,
+                            "origin": "http://169.254.169.254",
+                            "session_id": "child-session",
+                        }
+                    ],
+                }
+            )
+            # Running loop stub so via_supervisor proceeds past the loop check.
+            self._loop = type(
+                "Loop",
+                (),
+                {"is_running": staticmethod(lambda: True)},
+            )()
+
+    supervisor = _AllowlistSupervisor()
+    monkeypatch.setattr(bs.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+
+    def fake_schedule(coro, loop):
+        dispatched.append(coro)
+        class _Fut:
+            def result(self, timeout=None):
+                return {"result": {"ok": True}}
+        # Close the coroutine to avoid "never awaited" warnings.
+        coro.close()
+        return _Fut()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Page.reload",
+            params={},
+            frame_id="oopif-private",
+            task_id="task-1",
+        )
+    )
+
+    assert result.get("success") is True
+    assert len(dispatched) == 1
+
+
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     calls = []
 

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -332,6 +332,54 @@ def test_frame_id_route_allowed_when_page_is_not_private(monkeypatch):
     assert len(supervisor_calls) == 1
 
 
+def test_frame_id_rejects_non_dict_params_before_guard(monkeypatch):
+    """frame_id path must reject non-dict params like the stateless path.
+
+    Without this check, a truthy non-dict (e.g. a string) reaches
+    ``_browser_cdp_private_guard``, raises on ``.get``, and the guard's
+    broad except fail-opens — skipping the private-page boundary and
+    never surfacing the clear params validation error.
+    """
+    supervisor_calls = []
+    guard_calls = []
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: PRIVATE_URL)
+
+    real_guard = browser_cdp_tool._browser_cdp_private_guard
+
+    def tracking_guard(**kwargs):
+        guard_calls.append(kwargs)
+        return real_guard(**kwargs)
+
+    def fake_supervisor_route(**kwargs):
+        supervisor_calls.append(kwargs)
+        return json.dumps({"success": True, "result": {"value": "leaked"}})
+
+    monkeypatch.setattr(browser_cdp_tool, "_browser_cdp_private_guard", tracking_guard)
+    monkeypatch.setattr(
+        browser_cdp_tool, "_browser_cdp_via_supervisor", fake_supervisor_route
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params="not-a-dict",
+            frame_id="frame-1",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert "params" in result["error"].lower()
+    assert "object/dict" in result["error"]
+    assert "str" in result["error"]
+    assert guard_calls == []
+    assert supervisor_calls == []
+
+
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     calls = []
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -270,6 +270,213 @@ def _live_selected_frame_info(supervisor: Any, frame_id: str) -> Optional[Dict[s
         return raw.to_dict()
 
 
+def _selected_frame_from_tree(
+    frame_tree: Dict[str, Any], frame_id: str
+) -> Dict[str, Any]:
+    selected = _find_frame_in_tree(frame_tree, frame_id)
+    if selected is None:
+        # OOPIF child sessions often expose only the selected frame as root.
+        selected = frame_tree.get("frame", {})
+    return selected if isinstance(selected, dict) else {}
+
+
+async def _supervisor_selected_frame_tree_entry(
+    *,
+    supervisor: Any,
+    frame_id: str,
+    session_id: str,
+    timeout: float,
+) -> Dict[str, Any]:
+    tree_msg = await supervisor._cdp(  # type: ignore[attr-defined]
+        "Page.getFrameTree",
+        {},
+        session_id=session_id,
+        timeout=timeout,
+    )
+    frame_tree = tree_msg.get("result", {}).get("frameTree", {})
+    if not isinstance(frame_tree, dict):
+        return {}
+    return _selected_frame_from_tree(frame_tree, frame_id)
+
+
+async def _prepare_supervisor_frame_navigation(
+    *,
+    supervisor: Any,
+    frame_id: str,
+    session_id: str,
+    method: str,
+    timeout: float,
+) -> str:
+    """Enable page events and capture the pre-dispatch loaderId for commit waits."""
+    try:
+        await supervisor._cdp(  # type: ignore[attr-defined]
+            "Page.enable",
+            {},
+            session_id=session_id,
+            timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                f"Blocked: Page.enable failed before {method}: {exc}",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        ) from exc
+
+    try:
+        selected = await _supervisor_selected_frame_tree_entry(
+            supervisor=supervisor,
+            frame_id=frame_id,
+            session_id=session_id,
+            timeout=timeout,
+        )
+    except _BrowserCdpFrameGuardBlocked:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                f"Blocked: Page.getFrameTree failed before {method}: {exc}",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        ) from exc
+
+    if not selected:
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                f"Blocked: selected frame is missing before {method}",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        )
+    return str(selected.get("loaderId") or "").strip()
+
+
+def _supervisor_frame_commit_matched(
+    *,
+    frame: Dict[str, Any],
+    expected_frame_id: str,
+    expected_loader_id: str,
+    initial_loader_id: str,
+) -> bool:
+    frame_entry_id = str(frame.get("id") or frame.get("frame_id") or "").strip()
+    if expected_frame_id and frame_entry_id and frame_entry_id != expected_frame_id:
+        return False
+    loader_id = str(frame.get("loaderId") or "").strip()
+    if expected_loader_id:
+        return loader_id == expected_loader_id
+    return bool(loader_id and loader_id != initial_loader_id)
+
+
+async def _wait_supervisor_frame_commit(
+    *,
+    supervisor: Any,
+    frame_id: str,
+    session_id: str,
+    method: str,
+    expected_frame_id: str,
+    expected_loader_id: str,
+    initial_loader_id: str,
+    timeout: float,
+) -> Dict[str, Any]:
+    """Poll ``Page.getFrameTree`` until the navigate/reload loader commits.
+
+    ``Page.navigate`` can return before a redirect lands. Matching the
+    target-scoped path, wait for the new ``loaderId`` (or a changed loader on
+    reload) before treating the landing URL as authoritative.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise _BrowserCdpFrameGuardBlocked(
+                tool_error(
+                    f"Blocked: timed out waiting for frame commit after {method}",
+                    method=method,
+                    cdp_docs=CDP_DOCS_URL,
+                )
+            )
+        try:
+            selected = await _supervisor_selected_frame_tree_entry(
+                supervisor=supervisor,
+                frame_id=frame_id,
+                session_id=session_id,
+                timeout=max(0.05, remaining),
+            )
+        except _BrowserCdpFrameGuardBlocked:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "browser_cdp: Page.getFrameTree while waiting for frame %s commit: %s",
+                method,
+                exc,
+            )
+            await asyncio.sleep(0.05)
+            continue
+
+        if _supervisor_frame_commit_matched(
+            frame=selected,
+            expected_frame_id=expected_frame_id,
+            expected_loader_id=expected_loader_id,
+            initial_loader_id=initial_loader_id,
+        ):
+            return selected
+        await asyncio.sleep(0.05)
+
+
+async def _reset_supervisor_frame_to_blank(
+    *,
+    supervisor: Any,
+    frame_id: str,
+    session_id: str,
+    timeout: float,
+) -> Optional[str]:
+    """Navigate the child session to about:blank and wait for that commit."""
+    try:
+        blank_msg = await supervisor._cdp(  # type: ignore[attr-defined]
+            "Page.navigate",
+            {"url": "about:blank"},
+            session_id=session_id,
+            timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"failed to reset frame to about:blank: {exc}"
+
+    blank_result = blank_msg.get("result", {}) if isinstance(blank_msg, dict) else {}
+    blank_frame_id = str(
+        (blank_result or {}).get("frameId") or frame_id
+    ).strip() or frame_id
+    blank_loader_id = str((blank_result or {}).get("loaderId") or "").strip()
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            return "timed out waiting for about:blank reset to commit"
+        try:
+            selected = await _supervisor_selected_frame_tree_entry(
+                supervisor=supervisor,
+                frame_id=blank_frame_id,
+                session_id=session_id,
+                timeout=max(0.05, remaining),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "browser_cdp: Page.getFrameTree while waiting for about:blank: %s",
+                exc,
+            )
+            await asyncio.sleep(0.05)
+            continue
+
+        url = str(selected.get("url") or "").strip()
+        loader_id = str(selected.get("loaderId") or "").strip()
+        if url == "about:blank" and (
+            not blank_loader_id or loader_id == blank_loader_id
+        ):
+            return None
+        await asyncio.sleep(0.05)
+
+
 async def _revalidate_supervisor_frame_navigation(
     *,
     supervisor: Any,
@@ -278,14 +485,16 @@ async def _revalidate_supervisor_frame_navigation(
     session_id: str,
     method: str,
     timeout: float,
+    nav_result: Optional[Dict[str, Any]] = None,
+    initial_loader_id: str = "",
 ) -> None:
     """Fail closed when frame_id navigate/reload lands on a private address.
 
     ``Page.navigate`` remains allowlisted so a private OOPIF can be left, but
     public-to-private redirects (and reload of a page that becomes private)
     must not keep the child session on an internal URL. Mirror the target-scoped
-    post-check: inspect live frame metadata + ``Page.getFrameTree``, then reset
-    to ``about:blank`` when blocked.
+    post-check: wait for the navigation commit, inspect live frame metadata +
+    ``Page.getFrameTree``, then reset to ``about:blank`` when blocked.
     """
     try:
         from tools import browser_tool as bt  # type: ignore[import-not-found]
@@ -307,36 +516,59 @@ async def _revalidate_supervisor_frame_navigation(
             )
         ) from exc
 
+    nav_payload = nav_result if isinstance(nav_result, dict) else {}
+    expected_frame_id = str(nav_payload.get("frameId") or frame_id).strip() or frame_id
+    expected_loader_id = str(nav_payload.get("loaderId") or "").strip()
+    # Cross-document Page.navigate returns a loaderId. Page.reload has no
+    # result payload, so compare against the pre-dispatch loader. Same-document
+    # Page.navigate has no loaderId and is already committed on return.
+    commit_required = method == "Page.reload" or bool(expected_loader_id)
+
+    commit_url = ""
+    if commit_required:
+        committed = await _wait_supervisor_frame_commit(
+            supervisor=supervisor,
+            frame_id=frame_id,
+            session_id=session_id,
+            method=method,
+            expected_frame_id=expected_frame_id,
+            expected_loader_id=expected_loader_id,
+            initial_loader_id=initial_loader_id,
+            timeout=timeout,
+        )
+        commit_url = str(committed.get("url") or "").strip()
+        if not commit_url:
+            raise _BrowserCdpFrameGuardBlocked(
+                tool_error(
+                    f"Blocked: committed frame has no URL metadata after {method}",
+                    method=method,
+                    cdp_docs=CDP_DOCS_URL,
+                )
+            )
+    else:
+        try:
+            selected = await _supervisor_selected_frame_tree_entry(
+                supervisor=supervisor,
+                frame_id=frame_id,
+                session_id=session_id,
+                timeout=timeout,
+            )
+            commit_url = str(selected.get("url") or "").strip()
+        except _BrowserCdpFrameGuardBlocked:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "browser_cdp: Page.getFrameTree after frame %s failed: %s",
+                method,
+                exc,
+            )
+
     live_info = _live_selected_frame_info(supervisor, frame_id)
     live_url = str((live_info or {}).get("url") or "").strip()
     live_origin = str((live_info or {}).get("origin") or "").strip()
 
-    tree_url = ""
     try:
-        tree_msg = await supervisor._cdp(  # type: ignore[attr-defined]
-            "Page.getFrameTree",
-            {},
-            session_id=session_id,
-            timeout=timeout,
-        )
-        frame_tree = tree_msg.get("result", {}).get("frameTree", {})
-        selected = _find_frame_in_tree(frame_tree, frame_id)
-        if selected is None:
-            # OOPIF child sessions often expose only the selected frame as root.
-            selected = frame_tree.get("frame", {})
-        tree_url = str((selected or {}).get("url") or "").strip()
-    except _BrowserCdpFrameGuardBlocked:
-        raise
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "browser_cdp: Page.getFrameTree after frame %s failed: %s",
-            method,
-            exc,
-        )
-        # Fall through to live supervisor metadata; empty sources fail closed below.
-
-    try:
-        blocked = _private_address_from_candidates(live_url, live_origin, tree_url)
+        blocked = _private_address_from_candidates(live_url, live_origin, commit_url)
     except Exception as exc:  # noqa: BLE001
         raise _BrowserCdpFrameGuardBlocked(
             tool_error(
@@ -348,7 +580,7 @@ async def _revalidate_supervisor_frame_navigation(
             )
         ) from exc
 
-    if not live_url and not live_origin and not tree_url:
+    if not live_url and not live_origin and not commit_url:
         raise _BrowserCdpFrameGuardBlocked(
             tool_error(
                 "Blocked: selected OOPIF frame has no URL/origin metadata after "
@@ -362,17 +594,12 @@ async def _revalidate_supervisor_frame_navigation(
     if not blocked:
         return
 
-    blank_error: Optional[str] = None
-    try:
-        await supervisor._cdp(  # type: ignore[attr-defined]
-            "Page.navigate",
-            {"url": "about:blank"},
-            session_id=session_id,
-            timeout=timeout,
-        )
-    except Exception as exc:  # noqa: BLE001
-        blank_error = f"failed to reset frame to about:blank: {exc}"
-
+    blank_error = await _reset_supervisor_frame_to_blank(
+        supervisor=supervisor,
+        frame_id=expected_frame_id,
+        session_id=session_id,
+        timeout=timeout,
+    )
     reset_status = (
         f"; {blank_error}" if blank_error else "; frame reset to about:blank"
     )
@@ -1033,6 +1260,15 @@ def _browser_cdp_via_supervisor(
                     f"at the top-level page instead."
                 )
             )
+        initial_loader_id = ""
+        if method in _CDP_TARGET_NAVIGATION_METHODS:
+            initial_loader_id = await _prepare_supervisor_frame_navigation(
+                supervisor=supervisor,
+                frame_id=frame_id,
+                session_id=live_sid,
+                method=method,
+                timeout=timeout,
+            )
         result_msg = await supervisor._cdp(  # type: ignore[attr-defined]
             method,
             params or {},
@@ -1047,6 +1283,8 @@ def _browser_cdp_via_supervisor(
                 session_id=live_sid,
                 method=method,
                 timeout=timeout,
+                nav_result=result_msg.get("result", {}),
+                initial_loader_id=initial_loader_id,
             )
         return result_msg, live_sid
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -41,6 +41,21 @@ _CDP_PRIVATE_PAGE_ALLOWED_METHODS = {
     "Page.stopLoading",
 }
 
+_CDP_TARGET_NAVIGATION_METHODS = {"Page.navigate", "Page.reload"}
+
+
+def _find_frame_in_tree(
+    frame_tree: Dict[str, Any], frame_id: str
+) -> Optional[Dict[str, Any]]:
+    frame = frame_tree.get("frame", {})
+    if str(frame.get("id") or "") == frame_id:
+        return frame
+    for child in frame_tree.get("childFrames", []) or []:
+        found = _find_frame_in_tree(child, frame_id)
+        if found is not None:
+            return found
+    return None
+
 
 def _redact_cdp_output(value: Any) -> Any:
     """Redact browser-originated CDP result data before returning it."""
@@ -53,7 +68,22 @@ def _redact_cdp_output(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(_redact_cdp_output(item) for item in value)
     if isinstance(value, dict):
-        return {key: _redact_cdp_output(item) for key, item in value.items()}
+        redacted: Dict[Any, Any] = {}
+        next_duplicate: Dict[Any, int] = {}
+        for key, item in value.items():
+            redacted_key = _redact_cdp_output(key) if isinstance(key, str) else key
+            candidate = redacted_key
+            if candidate in redacted:
+                duplicate = next_duplicate.get(redacted_key, 2)
+                candidate = f"{redacted_key} ({duplicate})"
+                while candidate in redacted:
+                    duplicate += 1
+                    candidate = f"{redacted_key} ({duplicate})"
+                next_duplicate[redacted_key] = duplicate + 1
+            else:
+                next_duplicate.setdefault(redacted_key, 2)
+            redacted[candidate] = _redact_cdp_output(item)
+        return redacted
     return value
 
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP
@@ -124,6 +154,121 @@ def _private_page_guard_error(blocked_url: str, method: str) -> str:
     )
 
 
+def _private_address_from_candidates(*candidates: Any) -> Optional[str]:
+    """Return the first private/always-blocked URL-or-origin among candidates."""
+    from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+    for raw in candidates:
+        candidate = str(raw or "").strip()
+        if not candidate:
+            continue
+        if bt._is_always_blocked_url(candidate) or not bt._is_safe_url(candidate):  # type: ignore[attr-defined]
+            return candidate
+    return None
+
+
+class _BrowserCdpFrameGuardBlocked(Exception):
+    """Carry a ready-to-return tool_error JSON across the supervisor loop."""
+
+    def __init__(self, error_json: str):
+        self.error_json = error_json
+        super().__init__(error_json)
+
+
+def _browser_cdp_selected_frame_private_guard(
+    *,
+    task_id: str,
+    method: str,
+    frame_info: Dict[str, Any],
+) -> Optional[str]:
+    """Block page-content CDP calls against a private selected OOPIF frame.
+
+    Top-level ``_current_page_private_url`` is not enough for ``frame_id``
+    routing: a public parent can embed a private OOPIF, and the supervisor
+    dispatches into that child session independently. Navigation/inspection
+    allowlisted methods still pass so the model can leave or inspect tabs.
+
+    When the selected frame already has a child ``session_id`` but URL/origin
+    metadata is still empty (common briefly after Target.attachedToTarget),
+    fail closed for non-allowlisted methods instead of dispatching blind.
+
+    Guard-activation and URL/origin probe failures also fail closed —
+    returning ``None`` here would re-open the public-top / private-child
+    boundary that this path exists to enforce. Unlike the top-level
+    private-page guard (best-effort for local CDP), selected-frame routing
+    crosses into a model-chosen OOPIF child session and must not dispatch
+    page-content CDP when guard state is unknown.
+    """
+    if method in _CDP_PRIVATE_PAGE_ALLOWED_METHODS:
+        return None
+
+    try:
+        from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+        if not bt._eval_ssrf_guard_active(task_id):  # type: ignore[attr-defined]
+            return None
+    except Exception as exc:  # noqa: BLE001
+        # Cannot tell whether the cloud/private-network guard is active;
+        # do not fail-open into a selected child session.
+        logger.debug(
+            "browser_cdp: selected-frame guard activation probe failed: %s",
+            exc,
+        )
+        return tool_error(
+            "Blocked: selected-frame SSRF guard activation probe failed; "
+            f"raw CDP method {method!r} could expose private page content "
+            "or state.",
+            method=method,
+            cdp_docs=CDP_DOCS_URL,
+        )
+
+    try:
+        frame_url = str(frame_info.get("url") or "").strip()
+        frame_origin = str(frame_info.get("origin") or "").strip()
+        blocked = _private_address_from_candidates(frame_url, frame_origin)
+        if blocked:
+            return _private_page_guard_error(blocked, method)
+        # OOPIF session without address metadata: cannot prove the frame is
+        # public, so do not fail-open into page-content CDP.
+        if frame_info.get("session_id") and not frame_url and not frame_origin:
+            return tool_error(
+                "Blocked: selected OOPIF frame has no URL/origin metadata "
+                f"yet; raw CDP method {method!r} could expose private page "
+                "content or state. Retry after browser_snapshot once the "
+                "frame has navigated.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "browser_cdp: selected-frame private-page guard probe failed: %s",
+            exc,
+        )
+        return tool_error(
+            "Blocked: selected-frame private-page guard probe failed; "
+            f"raw CDP method {method!r} could expose private page content "
+            "or state.",
+            method=method,
+            cdp_docs=CDP_DOCS_URL,
+        )
+    return None
+
+
+def _live_selected_frame_info(supervisor: Any, frame_id: str) -> Optional[Dict[str, Any]]:
+    """Return the live frame dict from supervisor ``_frames`` under the lock.
+
+    ``_on_frame_navigated`` updates URL/origin in place while preserving the
+    child ``cdp_session_id``. Copied snapshot()/to_dict() views can therefore
+    go stale between the pre-schedule check and ``_cdp``; the live map is the
+    dispatch-time source of truth.
+    """
+    with supervisor._state_lock:  # type: ignore[attr-defined]
+        raw = supervisor._frames.get(frame_id)  # type: ignore[attr-defined]
+        if raw is None:
+            return None
+        return raw.to_dict()
+
+
 def _browser_cdp_private_guard(
     *,
     task_id: str,
@@ -191,6 +336,8 @@ async def _cdp_call(
     params: Dict[str, Any],
     target_id: Optional[str],
     timeout: float,
+    guard_selected_target_url: bool = False,
+    guard_navigation_result_url: bool = False,
 ) -> Dict[str, Any]:
     """Make a single CDP call, optionally attaching to a target first.
 
@@ -215,6 +362,59 @@ async def _cdp_call(
 
         # --- Step 1: attach to target if requested ---
         if target_id:
+            targets_id = next_id
+            next_id += 1
+            await ws.send(
+                json.dumps({"id": targets_id, "method": "Target.getTargets", "params": {}})
+            )
+            deadline = asyncio.get_running_loop().time() + timeout
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError(f"Timed out resolving target {target_id} before attach")
+                raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                msg = json.loads(raw)
+                if msg.get("id") != targets_id:
+                    continue
+                if "error" in msg:
+                    raise RuntimeError(
+                        f"Target.getTargets failed before attach: {msg['error']}"
+                    )
+                target_info = next(
+                    (
+                        info
+                        for info in msg.get("result", {}).get("targetInfos", [])
+                        if info.get("targetId") == target_id
+                    ),
+                    None,
+                )
+                if target_info is None:
+                    raise RuntimeError(f"Blocked: selected target {target_id!r} was not found")
+                target_type = str(target_info.get("type") or "").strip()
+                target_url = str(target_info.get("url") or "").strip()
+                if target_type != "page":
+                    raise RuntimeError(
+                        "Blocked: target_id is only valid for a top-level page target; "
+                        f"selected target type was {target_type or 'unknown'!r}"
+                    )
+                if not target_url:
+                    raise RuntimeError(
+                        "Blocked: selected target has no URL metadata; refusing to attach"
+                    )
+                if guard_selected_target_url:
+                    try:
+                        blocked_target = _private_address_from_candidates(target_url)
+                    except Exception as exc:  # noqa: BLE001
+                        raise RuntimeError(
+                            "Blocked: selected-target private-page guard probe failed"
+                        ) from exc
+                    if blocked_target:
+                        raise RuntimeError(
+                            "Blocked: selected target is a private or internal address "
+                            f"({blocked_target})"
+                        )
+                break
+
             attach_id = next_id
             next_id += 1
             await ws.send(
@@ -248,6 +448,137 @@ async def _cdp_call(
                     break
                 # Ignore events (messages without "id") while waiting
 
+            if guard_selected_target_url:
+                frame_tree_id = next_id
+                next_id += 1
+                await ws.send(
+                    json.dumps(
+                        {
+                            "id": frame_tree_id,
+                            "method": "Page.getFrameTree",
+                            "params": {},
+                            "sessionId": session_id,
+                        }
+                    )
+                )
+                deadline = asyncio.get_running_loop().time() + timeout
+                while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Timed out revalidating target {target_id} after attach"
+                        )
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    msg = json.loads(raw)
+                    if msg.get("id") != frame_tree_id:
+                        continue
+                    if "error" in msg:
+                        raise RuntimeError(
+                            "Blocked: Page.getFrameTree failed while revalidating "
+                            f"selected target: {msg['error']}"
+                        )
+                    live_url = str(
+                        msg.get("result", {})
+                        .get("frameTree", {})
+                        .get("frame", {})
+                        .get("url")
+                        or ""
+                    ).strip()
+                    if not live_url:
+                        raise RuntimeError(
+                            "Blocked: attached target has no live URL metadata"
+                        )
+                    try:
+                        blocked_live_target = _private_address_from_candidates(live_url)
+                    except Exception as exc:  # noqa: BLE001
+                        raise RuntimeError(
+                            "Blocked: attached-target private-page guard probe failed"
+                        ) from exc
+                    if blocked_live_target:
+                        raise RuntimeError(
+                            "Blocked: attached target navigated to a private or internal "
+                            f"address ({blocked_live_target})"
+                        )
+                    break
+
+            navigation_frame_id = ""
+            initial_loader_id = ""
+            if guard_navigation_result_url:
+                enable_id = next_id
+                next_id += 1
+                await ws.send(
+                    json.dumps(
+                        {
+                            "id": enable_id,
+                            "method": "Page.enable",
+                            "params": {},
+                            "sessionId": session_id,
+                        }
+                    )
+                )
+                deadline = asyncio.get_running_loop().time() + timeout
+                while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Timed out enabling navigation events for target {target_id}"
+                        )
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    msg = json.loads(raw)
+                    if msg.get("id") != enable_id:
+                        continue
+                    if "error" in msg:
+                        raise RuntimeError(
+                            f"Blocked: Page.enable failed before {method}: {msg['error']}"
+                        )
+                    break
+
+                initial_tree_id = next_id
+                next_id += 1
+                await ws.send(
+                    json.dumps(
+                        {
+                            "id": initial_tree_id,
+                            "method": "Page.getFrameTree",
+                            "params": {},
+                            "sessionId": session_id,
+                        }
+                    )
+                )
+                deadline = asyncio.get_running_loop().time() + timeout
+                while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Timed out resolving target {target_id} before {method}"
+                        )
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    msg = json.loads(raw)
+                    if msg.get("id") != initial_tree_id:
+                        continue
+                    if "error" in msg:
+                        raise RuntimeError(
+                            f"Blocked: Page.getFrameTree failed before {method}: {msg['error']}"
+                        )
+                    initial_tree = msg.get("result", {}).get("frameTree", {})
+                    top_frame_id = str(
+                        initial_tree.get("frame", {}).get("id") or ""
+                    ).strip()
+                    navigation_frame_id = str(
+                        (params or {}).get("frameId") or top_frame_id
+                    ).strip()
+                    initial_frame = _find_frame_in_tree(
+                        initial_tree, navigation_frame_id
+                    )
+                    if initial_frame is None:
+                        raise RuntimeError(
+                            f"Blocked: selected frame is missing before {method}"
+                        )
+                    initial_loader_id = str(
+                        initial_frame.get("loaderId") or ""
+                    ).strip()
+                    break
+
         # --- Step 2: dispatch the real method ---
         call_id = next_id
         next_id += 1
@@ -261,6 +592,7 @@ async def _cdp_call(
         await ws.send(json.dumps(req))
 
         deadline = asyncio.get_running_loop().time() + timeout
+        navigation_events: list[Dict[str, Any]] = []
         while True:
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
@@ -269,11 +601,191 @@ async def _cdp_call(
                 )
             raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
             msg = json.loads(raw)
+            if msg.get("method") == "Page.frameNavigated":
+                navigation_events.append(msg)
             if msg.get("id") == call_id:
                 if "error" in msg:
                     raise RuntimeError(f"CDP error: {msg['error']}")
-                return msg.get("result", {})
+                result = msg.get("result", {})
+                break
             # Ignore events / out-of-order responses
+
+        if guard_navigation_result_url and session_id:
+            expected_frame_id = str(result.get("frameId") or navigation_frame_id).strip()
+            expected_loader_id = str(result.get("loaderId") or "").strip()
+
+            def _matching_commit(event: Dict[str, Any]) -> bool:
+                frame = event.get("params", {}).get("frame", {})
+                if str(frame.get("id") or "") != expected_frame_id:
+                    return False
+                event_loader_id = str(frame.get("loaderId") or "")
+                if expected_loader_id:
+                    return event_loader_id == expected_loader_id
+                return bool(event_loader_id and event_loader_id != initial_loader_id)
+
+            commit_event = next(
+                (event for event in navigation_events if _matching_commit(event)),
+                None,
+            )
+            # Cross-document Page.navigate returns a loaderId. Page.reload has
+            # no result payload, so compare the top frame's new loader against
+            # the one captured before dispatch. Same-document Page.navigate
+            # has no loaderId and is already committed when the command returns.
+            commit_required = method == "Page.reload" or bool(expected_loader_id)
+            if commit_required and commit_event is None:
+                deadline = asyncio.get_running_loop().time() + timeout
+                while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Timed out waiting for target {target_id} to commit after {method}"
+                        )
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    event = json.loads(raw)
+                    if event.get("method") == "Page.frameNavigated" and _matching_commit(
+                        event
+                    ):
+                        commit_event = event
+                        break
+
+            blocked_commit_url: Optional[str] = None
+            if commit_event is not None:
+                commit_url = str(
+                    commit_event.get("params", {}).get("frame", {}).get("url") or ""
+                ).strip()
+                if not commit_url:
+                    raise RuntimeError(
+                        f"Blocked: committed frame has no URL metadata after {method}"
+                    )
+                try:
+                    blocked_commit_url = _private_address_from_candidates(commit_url)
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"Blocked: committed-frame private-page guard probe failed after {method}"
+                    ) from exc
+
+            frame_tree_id = next_id
+            next_id += 1
+            await ws.send(
+                json.dumps(
+                    {
+                        "id": frame_tree_id,
+                        "method": "Page.getFrameTree",
+                        "params": {},
+                        "sessionId": session_id,
+                    }
+                )
+            )
+            deadline = asyncio.get_running_loop().time() + timeout
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out validating target {target_id} after {method}"
+                    )
+                raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                msg = json.loads(raw)
+                if msg.get("id") != frame_tree_id:
+                    continue
+                if "error" in msg:
+                    raise RuntimeError(
+                        f"Blocked: Page.getFrameTree failed after {method}: {msg['error']}"
+                    )
+                final_tree = msg.get("result", {}).get("frameTree", {})
+                final_frame = _find_frame_in_tree(final_tree, expected_frame_id)
+                if final_frame is None:
+                    raise RuntimeError(
+                        f"Blocked: selected frame is missing after {method}"
+                    )
+                final_url = str(final_frame.get("url") or "").strip()
+                if not final_url:
+                    raise RuntimeError(
+                        f"Blocked: target has no live URL metadata after {method}"
+                    )
+                try:
+                    blocked_final_url = _private_address_from_candidates(final_url)
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"Blocked: target private-page guard probe failed after {method}"
+                    ) from exc
+                break
+
+            blocked_navigation_url = blocked_commit_url or blocked_final_url
+            if blocked_navigation_url:
+                blank_id = next_id
+                await ws.send(
+                    json.dumps(
+                        {
+                            "id": blank_id,
+                            "method": "Page.navigate",
+                            "params": {"url": "about:blank"},
+                            "sessionId": session_id,
+                        }
+                    )
+                )
+                deadline = asyncio.get_running_loop().time() + timeout
+                blank_error: Optional[str] = None
+                blank_result: Dict[str, Any] = {}
+                blank_events: list[Dict[str, Any]] = []
+                while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        blank_error = "timed out resetting the target to about:blank"
+                        break
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    msg = json.loads(raw)
+                    if msg.get("method") == "Page.frameNavigated":
+                        blank_events.append(msg)
+                    if msg.get("id") != blank_id:
+                        continue
+                    if "error" in msg:
+                        blank_error = f"failed to reset target to about:blank: {msg['error']}"
+                    else:
+                        blank_result = msg.get("result", {})
+                    break
+                if blank_error is None:
+                    blank_frame_id = str(
+                        blank_result.get("frameId") or expected_frame_id
+                    ).strip()
+                    blank_loader_id = str(blank_result.get("loaderId") or "").strip()
+
+                    def _blank_committed(event: Dict[str, Any]) -> bool:
+                        frame = event.get("params", {}).get("frame", {})
+                        if str(frame.get("id") or "") != blank_frame_id:
+                            return False
+                        if blank_loader_id and str(frame.get("loaderId") or "") != blank_loader_id:
+                            return False
+                        return str(frame.get("url") or "").strip() == "about:blank"
+
+                    blank_commit = next(
+                        (event for event in blank_events if _blank_committed(event)),
+                        None,
+                    )
+                    if blank_commit is None:
+                        deadline = asyncio.get_running_loop().time() + timeout
+                        while True:
+                            remaining = deadline - asyncio.get_running_loop().time()
+                            if remaining <= 0:
+                                blank_error = (
+                                    "timed out waiting for about:blank reset to commit"
+                                )
+                                break
+                            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                            event = json.loads(raw)
+                            if event.get("method") == "Page.frameNavigated" and _blank_committed(
+                                event
+                            ):
+                                blank_commit = event
+                                break
+                reset_status = (
+                    f"; {blank_error}" if blank_error else "; target reset to about:blank"
+                )
+                raise RuntimeError(
+                    "Blocked: target navigation landed on a private or internal address "
+                    f"({blocked_navigation_url}){reset_status}"
+                )
+
+        return result
 
 
 # ---------------------------------------------------------------------------
@@ -337,6 +849,17 @@ def _browser_cdp_via_supervisor(
             f"Call browser_snapshot to see current frame_tree."
         )
 
+    # Validate the selected frame (frame_tree hit or raw _frames fallback)
+    # before any child-session dispatch. A public top-level page can embed a
+    # private OOPIF; top-page probing alone would miss that boundary.
+    blocked_frame = _browser_cdp_selected_frame_private_guard(
+        task_id=task_id,
+        method=method,
+        frame_info=frame_info,
+    )
+    if blocked_frame:
+        return blocked_frame
+
     child_sid = frame_info.get("session_id")
     if not child_sid:
         # Not an OOPIF — fall back to top-level session (evaluating at page
@@ -359,12 +882,47 @@ def _browser_cdp_via_supervisor(
         )
 
     async def _do_cdp():
-        return await supervisor._cdp(  # type: ignore[attr-defined]
+        # Re-resolve on the supervisor loop immediately before _cdp().
+        # Page.frameNavigated can replace URL/origin on the same child
+        # session after the copied snapshot check above; dispatch must see
+        # the live address (or fail closed if the frame is gone / metadata-
+        # less / private).
+        live_info = _live_selected_frame_info(supervisor, frame_id)
+        if live_info is None:
+            raise _BrowserCdpFrameGuardBlocked(
+                tool_error(
+                    "Blocked: selected frame is missing or transitioning; "
+                    f"raw CDP method {method!r} could expose private page "
+                    "content or state. Retry after browser_snapshot.",
+                    method=method,
+                    cdp_docs=CDP_DOCS_URL,
+                )
+            )
+        live_blocked = _browser_cdp_selected_frame_private_guard(
+            task_id=task_id,
+            method=method,
+            frame_info=live_info,
+        )
+        if live_blocked:
+            raise _BrowserCdpFrameGuardBlocked(live_blocked)
+        live_sid = live_info.get("session_id")
+        if not live_sid:
+            raise _BrowserCdpFrameGuardBlocked(
+                tool_error(
+                    f"frame_id {frame_id!r} is not an out-of-process iframe "
+                    f"(no dedicated CDP session). For same-origin iframes, use "
+                    f"`browser_cdp(method='Runtime.evaluate', params={{'expression': "
+                    f"\"document.querySelector('iframe').contentDocument.title\"}})` "
+                    f"at the top-level page instead."
+                )
+            )
+        result_msg = await supervisor._cdp(  # type: ignore[attr-defined]
             method,
             params or {},
-            session_id=child_sid,
+            session_id=live_sid,
             timeout=timeout,
         )
+        return result_msg, live_sid
 
     try:
         from agent.async_utils import safe_schedule_threadsafe
@@ -374,7 +932,9 @@ def _browser_cdp_via_supervisor(
                 "CDP call via supervisor failed: loop unavailable",
                 cdp_docs=CDP_DOCS_URL,
             )
-        result_msg = fut.result(timeout=timeout + 2)
+        result_msg, dispatched_sid = fut.result(timeout=timeout + 2)
+    except _BrowserCdpFrameGuardBlocked as blocked:
+        return blocked.error_json
     except Exception as exc:
         return tool_error(
             f"CDP call via supervisor failed: {type(exc).__name__}: {exc}",
@@ -385,8 +945,8 @@ def _browser_cdp_via_supervisor(
         "success": True,
         "method": method,
         "frame_id": frame_id,
-        "session_id": child_sid,
-        "result": result_msg.get("result", {}),
+        "session_id": dispatched_sid,
+        "result": _redact_cdp_output(result_msg.get("result", {})),
     }
     return json.dumps(payload, ensure_ascii=False)
 
@@ -426,6 +986,18 @@ def browser_cdp(
     """
     effective_task_id = task_id or "default"
 
+    # Validate params before any path (including frame_id early-return).
+    # A non-dict would AttributeError inside _browser_cdp_private_guard's
+    # (params or {}).get(...); that probe's broad except fail-opens, so
+    # rejecting here keeps the SSRF/private-page boundary fail-closed and
+    # matches the clear input-validation error the stateless path already
+    # returned.
+    call_params: Dict[str, Any] = params or {}
+    if not isinstance(call_params, dict):
+        return tool_error(
+            f"'params' must be an object/dict, got {type(call_params).__name__}"
+        )
+
     # --- Route iframe-scoped calls through the supervisor ---------------
     if frame_id:
         # Same private-page/SSRF boundary as the stateless path below —
@@ -433,7 +1005,7 @@ def browser_cdp(
         blocked = _browser_cdp_private_guard(
             task_id=effective_task_id,
             method=method,
-            params=params or {},
+            params=call_params,
         )
         if blocked:
             return blocked
@@ -441,7 +1013,7 @@ def browser_cdp(
             task_id=effective_task_id,
             frame_id=frame_id,
             method=method,
-            params=params,
+            params=call_params,
             timeout=timeout,
         )
 
@@ -475,12 +1047,6 @@ def browser_cdp(
             "browser is actually listening on the debug port."
         )
 
-    call_params: Dict[str, Any] = params or {}
-    if not isinstance(call_params, dict):
-        return tool_error(
-            f"'params' must be an object/dict, got {type(call_params).__name__}"
-        )
-
     blocked = _browser_cdp_private_guard(
         task_id=effective_task_id,
         method=method,
@@ -488,6 +1054,26 @@ def browser_cdp(
     )
     if blocked:
         return blocked
+
+    guard_selected_target_url = False
+    guard_navigation_result_url = False
+    selected_target_guard_needed = method not in _CDP_PRIVATE_PAGE_ALLOWED_METHODS
+    navigation_result_guard_needed = method in _CDP_TARGET_NAVIGATION_METHODS
+    if target_id and (selected_target_guard_needed or navigation_result_guard_needed):
+        try:
+            from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+            guard_active = bool(bt._eval_ssrf_guard_active(effective_task_id))  # type: ignore[attr-defined]
+            guard_selected_target_url = guard_active and selected_target_guard_needed
+            guard_navigation_result_url = guard_active and navigation_result_guard_needed
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("browser_cdp: selected-target guard activation probe failed: %s", exc)
+            return tool_error(
+                "Blocked: selected-target SSRF guard activation probe failed; "
+                f"raw CDP method {method!r} could expose private page content or state.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
 
     try:
         safe_timeout = float(timeout) if timeout else 30.0
@@ -497,7 +1083,15 @@ def browser_cdp(
 
     try:
         result = _run_async(
-            _cdp_call(endpoint, method, call_params, target_id, safe_timeout)
+            _cdp_call(
+                endpoint,
+                method,
+                call_params,
+                target_id,
+                safe_timeout,
+                guard_selected_target_url=guard_selected_target_url,
+                guard_navigation_result_url=guard_navigation_result_url,
+            )
         )
     except asyncio.TimeoutError as exc:
         return tool_error(

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -32,12 +32,13 @@ _CDP_PRIVATE_PAGE_ALLOWED_METHODS = {
     # Browser/target inspection does not read the current page body, cookies,
     # DOM, storage, or screenshots. Keep these working so the model can list
     # tabs or navigate away from a blocked page.
+    # Page.reload is intentionally excluded: reloading an already-private
+    # page re-requests private/internal content. Use Page.navigate to leave.
     "Browser.getVersion",
     "Target.getTargets",
     "Target.attachToTarget",
     "Target.detachFromTarget",
     "Page.navigate",
-    "Page.reload",
     "Page.stopLoading",
 }
 
@@ -267,6 +268,122 @@ def _live_selected_frame_info(supervisor: Any, frame_id: str) -> Optional[Dict[s
         if raw is None:
             return None
         return raw.to_dict()
+
+
+async def _revalidate_supervisor_frame_navigation(
+    *,
+    supervisor: Any,
+    task_id: str,
+    frame_id: str,
+    session_id: str,
+    method: str,
+    timeout: float,
+) -> None:
+    """Fail closed when frame_id navigate/reload lands on a private address.
+
+    ``Page.navigate`` remains allowlisted so a private OOPIF can be left, but
+    public-to-private redirects (and reload of a page that becomes private)
+    must not keep the child session on an internal URL. Mirror the target-scoped
+    post-check: inspect live frame metadata + ``Page.getFrameTree``, then reset
+    to ``about:blank`` when blocked.
+    """
+    try:
+        from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+        if not bt._eval_ssrf_guard_active(task_id):  # type: ignore[attr-defined]
+            return
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "browser_cdp: frame navigation guard activation probe failed: %s",
+            exc,
+        )
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                "Blocked: selected-frame SSRF guard activation probe failed after "
+                f"{method}; raw CDP navigation could expose private page content "
+                "or state.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        ) from exc
+
+    live_info = _live_selected_frame_info(supervisor, frame_id)
+    live_url = str((live_info or {}).get("url") or "").strip()
+    live_origin = str((live_info or {}).get("origin") or "").strip()
+
+    tree_url = ""
+    try:
+        tree_msg = await supervisor._cdp(  # type: ignore[attr-defined]
+            "Page.getFrameTree",
+            {},
+            session_id=session_id,
+            timeout=timeout,
+        )
+        frame_tree = tree_msg.get("result", {}).get("frameTree", {})
+        selected = _find_frame_in_tree(frame_tree, frame_id)
+        if selected is None:
+            # OOPIF child sessions often expose only the selected frame as root.
+            selected = frame_tree.get("frame", {})
+        tree_url = str((selected or {}).get("url") or "").strip()
+    except _BrowserCdpFrameGuardBlocked:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "browser_cdp: Page.getFrameTree after frame %s failed: %s",
+            method,
+            exc,
+        )
+        # Fall through to live supervisor metadata; empty sources fail closed below.
+
+    try:
+        blocked = _private_address_from_candidates(live_url, live_origin, tree_url)
+    except Exception as exc:  # noqa: BLE001
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                "Blocked: selected-frame private-page guard probe failed after "
+                f"{method}; raw CDP navigation could expose private page content "
+                "or state.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        ) from exc
+
+    if not live_url and not live_origin and not tree_url:
+        raise _BrowserCdpFrameGuardBlocked(
+            tool_error(
+                "Blocked: selected OOPIF frame has no URL/origin metadata after "
+                f"{method}; raw CDP navigation could expose private page content "
+                "or state.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
+        )
+
+    if not blocked:
+        return
+
+    blank_error: Optional[str] = None
+    try:
+        await supervisor._cdp(  # type: ignore[attr-defined]
+            "Page.navigate",
+            {"url": "about:blank"},
+            session_id=session_id,
+            timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        blank_error = f"failed to reset frame to about:blank: {exc}"
+
+    reset_status = (
+        f"; {blank_error}" if blank_error else "; frame reset to about:blank"
+    )
+    raise _BrowserCdpFrameGuardBlocked(
+        tool_error(
+            "Blocked: frame navigation landed on a private or internal address "
+            f"({blocked}){reset_status}",
+            method=method,
+            cdp_docs=CDP_DOCS_URL,
+        )
+    )
 
 
 def _browser_cdp_private_guard(
@@ -922,6 +1039,15 @@ def _browser_cdp_via_supervisor(
             session_id=live_sid,
             timeout=timeout,
         )
+        if method in _CDP_TARGET_NAVIGATION_METHODS:
+            await _revalidate_supervisor_frame_navigation(
+                supervisor=supervisor,
+                task_id=task_id,
+                frame_id=frame_id,
+                session_id=live_sid,
+                method=method,
+                timeout=timeout,
+            )
         return result_msg, live_sid
 
     try:

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -149,6 +149,10 @@ def _browser_cdp_selected_frame_private_guard(
     routing: a public parent can embed a private OOPIF, and the supervisor
     dispatches into that child session independently. Navigation/inspection
     allowlisted methods still pass so the model can leave or inspect tabs.
+
+    When the selected frame already has a child ``session_id`` but URL/origin
+    metadata is still empty (common briefly after Target.attachedToTarget),
+    fail closed for non-allowlisted methods instead of dispatching blind.
     """
     try:
         from tools import browser_tool as bt  # type: ignore[import-not-found]
@@ -157,12 +161,22 @@ def _browser_cdp_selected_frame_private_guard(
             return None
         if method in _CDP_PRIVATE_PAGE_ALLOWED_METHODS:
             return None
-        blocked = _private_address_from_candidates(
-            frame_info.get("url"),
-            frame_info.get("origin"),
-        )
+        frame_url = str(frame_info.get("url") or "").strip()
+        frame_origin = str(frame_info.get("origin") or "").strip()
+        blocked = _private_address_from_candidates(frame_url, frame_origin)
         if blocked:
             return _private_page_guard_error(blocked, method)
+        # OOPIF session without address metadata: cannot prove the frame is
+        # public, so do not fail-open into page-content CDP.
+        if frame_info.get("session_id") and not frame_url and not frame_origin:
+            return tool_error(
+                "Blocked: selected OOPIF frame has no URL/origin metadata "
+                f"yet; raw CDP method {method!r} could expose private page "
+                "content or state. Retry after browser_snapshot once the "
+                "frame has navigated.",
+                method=method,
+                cdp_docs=CDP_DOCS_URL,
+            )
     except Exception as exc:  # noqa: BLE001
         logger.debug(
             "browser_cdp: selected-frame private-page guard probe failed: %s",

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -426,6 +426,18 @@ def browser_cdp(
     """
     effective_task_id = task_id or "default"
 
+    # Validate params before any path (including frame_id early-return).
+    # A non-dict would AttributeError inside _browser_cdp_private_guard's
+    # (params or {}).get(...); that probe's broad except fail-opens, so
+    # rejecting here keeps the SSRF/private-page boundary fail-closed and
+    # matches the clear input-validation error the stateless path already
+    # returned.
+    call_params: Dict[str, Any] = params or {}
+    if not isinstance(call_params, dict):
+        return tool_error(
+            f"'params' must be an object/dict, got {type(call_params).__name__}"
+        )
+
     # --- Route iframe-scoped calls through the supervisor ---------------
     if frame_id:
         # Same private-page/SSRF boundary as the stateless path below —
@@ -433,7 +445,7 @@ def browser_cdp(
         blocked = _browser_cdp_private_guard(
             task_id=effective_task_id,
             method=method,
-            params=params or {},
+            params=call_params,
         )
         if blocked:
             return blocked
@@ -441,7 +453,7 @@ def browser_cdp(
             task_id=effective_task_id,
             frame_id=frame_id,
             method=method,
-            params=params,
+            params=call_params,
             timeout=timeout,
         )
 
@@ -473,12 +485,6 @@ def browser_cdp(
             "Expected ws://... or wss://... — the /browser connect "
             "resolver should have rewritten this. Check that a Chromium-family "
             "browser is actually listening on the debug port."
-        )
-
-    call_params: Dict[str, Any] = params or {}
-    if not isinstance(call_params, dict):
-        return tool_error(
-            f"'params' must be an object/dict, got {type(call_params).__name__}"
         )
 
     blocked = _browser_cdp_private_guard(

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -124,6 +124,53 @@ def _private_page_guard_error(blocked_url: str, method: str) -> str:
     )
 
 
+def _private_address_from_candidates(*candidates: Any) -> Optional[str]:
+    """Return the first private/always-blocked URL-or-origin among candidates."""
+    from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+    for raw in candidates:
+        candidate = str(raw or "").strip()
+        if not candidate:
+            continue
+        if bt._is_always_blocked_url(candidate) or not bt._is_safe_url(candidate):  # type: ignore[attr-defined]
+            return candidate
+    return None
+
+
+def _browser_cdp_selected_frame_private_guard(
+    *,
+    task_id: str,
+    method: str,
+    frame_info: Dict[str, Any],
+) -> Optional[str]:
+    """Block page-content CDP calls against a private selected OOPIF frame.
+
+    Top-level ``_current_page_private_url`` is not enough for ``frame_id``
+    routing: a public parent can embed a private OOPIF, and the supervisor
+    dispatches into that child session independently. Navigation/inspection
+    allowlisted methods still pass so the model can leave or inspect tabs.
+    """
+    try:
+        from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+        if not bt._eval_ssrf_guard_active(task_id):  # type: ignore[attr-defined]
+            return None
+        if method in _CDP_PRIVATE_PAGE_ALLOWED_METHODS:
+            return None
+        blocked = _private_address_from_candidates(
+            frame_info.get("url"),
+            frame_info.get("origin"),
+        )
+        if blocked:
+            return _private_page_guard_error(blocked, method)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "browser_cdp: selected-frame private-page guard probe failed: %s",
+            exc,
+        )
+    return None
+
+
 def _browser_cdp_private_guard(
     *,
     task_id: str,
@@ -336,6 +383,17 @@ def _browser_cdp_via_supervisor(
             f"frame_id {frame_id!r} not found in supervisor state. "
             f"Call browser_snapshot to see current frame_tree."
         )
+
+    # Validate the selected frame (frame_tree hit or raw _frames fallback)
+    # before any child-session dispatch. A public top-level page can embed a
+    # private OOPIF; top-page probing alone would miss that boundary.
+    blocked_frame = _browser_cdp_selected_frame_private_guard(
+        task_id=task_id,
+        method=method,
+        frame_info=frame_info,
+    )
+    if blocked_frame:
+        return blocked_frame
 
     child_sid = frame_info.get("session_id")
     if not child_sid:


### PR DESCRIPTION
## What does this PR do?

`browser_cdp(..., frame_id=...)` had two private-page / SSRF gaps on the OOPIF path: (1) a non-dict `params` value skipped the clear validation error and could let the guard fail open, and (2) even with valid params, the guard only checked the top-level page URL before supervisor dispatch, so a public parent could embed a private OOPIF and still receive page-content CDP such as `Runtime.evaluate`. This PR closes both paths with shared fail-closed checks before child-session dispatch.

### Symptom

A `browser_cdp` call that sets `frame_id` and passes a truthy non-dict `params` (for example a string) does not return `'params' must be an object/dict`. Separately, when the top-level page is public but the selected OOPIF URL/origin is private (or still empty), page-content CDP can still reach the child session.

### Impact

Malformed `params` on the `frame_id` path can silently skip the private-page / SSRF boundary that other `browser_cdp` entry points enforce after validating `params`. A public top-level page with a private child OOPIF can also expose private frame content through `frame_id` routing. Blast radius beyond these paths was not measured.

### Bug Cause

**Trigger:** `tools/browser_cdp_tool.py` `browser_cdp()` / `_browser_cdp_via_supervisor()` - `frame_id` early-return before `isinstance(params, dict)`; private-page guard uses top-level `_current_page_private_url` only; selected-frame metadata is available but was not checked before child-session dispatch.

**Causal chain:**
1. Caller passes `frame_id` with either non-dict `params`, or a well-formed call targeting a private OOPIF under a public top page.
2. Non-dict `params` AttributeErrors inside the guard probe; broad except fail-opens. Or the top-page probe returns public while the child frame is private / metadata-empty.
3. Call reaches `_browser_cdp_via_supervisor` and dispatches into the child CDP session without a validation error or frame-level private-page block.

**Why it is wrong:** Params validation lived only on the post-early-return / stateless branch, while the guard is intentionally fail-open for probe failures. Frame routing resolves child URL/origin but never validated them before page-content sinks.

**Working sibling / contrast:** Without `frame_id`, non-dict `params` already returned a clear validation error. Top-level private pages already blocked restricted methods; the gap is specifically the selected OOPIF address.

**Ruled out:** Not a missing private-page guard call on `frame_id` for well-formed top-level-private cases - that path already invoked the top-page guard. The remaining gaps are malformed params + child-frame address coverage.

### Fix

Validate `params` as a dict before the `frame_id` early-return. After resolving the selected frame (frame_tree or raw `_frames` fallback), validate URL/origin for private/internal addresses before dispatch; fail closed when an OOPIF has a `session_id` but empty URL/origin metadata. Retain `_CDP_PRIVATE_PAGE_ALLOWED_METHODS` so navigation/inspection still works on blocked frames.

## Related Issue

Fixes #80846

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `tools/browser_cdp_tool.py` - move params dict validation above the `frame_id` early-return; validate selected frame URL/origin (and empty-metadata OOPIF) before supervisor dispatch; keep navigation/inspection allowlist
- `tests/tools/test_browser_cdp_tool.py` - regression coverage for non-dict params, public-top/private-child OOPIF, raw `_frames` fallback, allowlist survival, and empty URL/origin fail-closed

## How to Test

1. Manual: with the private-page guard active, call `browser_cdp(method='Runtime.evaluate', params='not-a-dict', frame_id='...')` and confirm the tool returns a params object/dict validation error (not a successful supervisor dispatch).
2. Manual / unit: public top-level page + private OOPIF `frame_id` must block `Runtime.evaluate` / `DOM.getDocument`; allowlisted methods such as `Page.reload` must still dispatch; OOPIF with `session_id` but empty url/origin must block page-content CDP.
3. Automated:

```bash
scripts/run_tests.sh tests/tools/test_browser_cdp_tool.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A (validation helpers are platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A (behavior matches the documented params object contract and private-page boundary on sibling paths)
