### PR TITLE
fix(signal): render Note to Self replies as incoming

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -82,6 +82,12 @@ def _parse_comma_list(value: str) -> List[str]:
     return [v.strip() for v in value.split(",") if v.strip()]
 
 
+def set_signal_notify_self(params: Dict[str, Any], account: str, chat_id: str) -> None:
+    """Render linked-device self-chat replies as incoming on the primary device."""
+    if str(chat_id).strip() == str(account).strip():
+        params["notifySelf"] = True
+
+
 def _guess_extension(data: bytes) -> str:
     """Guess file extension from magic bytes.
 
@@ -1077,6 +1083,7 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            set_signal_notify_self(params, self.account, chat_id)
 
         logger.info("[Signal] Sending response (%d chars) to %s", len(plain_text), chat_id)
         result = await self._rpc("send", params)
@@ -1251,6 +1258,7 @@ class SignalAdapter(BasePlatformAdapter):
             base_params["groupId"] = chat_id[6:]
         else:
             base_params["recipient"] = [await self._resolve_recipient(chat_id)]
+            set_signal_notify_self(base_params, self.account, chat_id)
 
         att_batches = [
             attachments[i:i + SIGNAL_MAX_ATTACHMENTS_PER_MSG]
@@ -1403,6 +1411,7 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            set_signal_notify_self(params, self.account, chat_id)
 
         result = await self._rpc("send", params)
         if result is not None:
@@ -1445,6 +1454,7 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            set_signal_notify_self(params, self.account, chat_id)
 
         result = await self._rpc("send", params)
         if result is not None:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -363,7 +363,7 @@ class TestSignalSendImageFile:
     @pytest.mark.asyncio
     async def test_send_image_file_sends_via_rpc(self, monkeypatch, tmp_path):
         """send_image_file should send image as attachment via signal-cli RPC."""
-        adapter = _make_signal_adapter(monkeypatch)
+        adapter = _make_signal_adapter(monkeypatch, account="self-account")
         mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
@@ -371,17 +371,20 @@ class TestSignalSendImageFile:
         img_path = tmp_path / "chart.png"
         img_path.write_bytes(b"\x89PNG" + b"\x00" * 100)
 
-        result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
+        result = await adapter.send_image_file(
+            chat_id=adapter.account, image_path=str(img_path)
+        )
 
         assert result.success is True
         assert len(captured) == 1
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["account"] == adapter.account
-        assert captured[0]["params"]["recipient"] == ["+155****4567"]
+        assert captured[0]["params"]["recipient"] == [adapter.account]
+        assert captured[0]["params"]["notifySelf"] is True
         assert captured[0]["params"]["attachments"] == [str(img_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
         # Typing indicator must be stopped before sending
-        adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
+        adapter._stop_typing_indicator.assert_awaited_once_with(adapter.account)
         # Timestamp must be tracked for echo-back prevention
         assert 1234567890 in adapter._recent_sent_timestamps
 
@@ -405,6 +408,25 @@ class TestSignalSendImageFile:
 
         assert result.success is False
         assert "too large" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_other_recipient_omits_notify_self(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        img_path = tmp_path / "chart.png"
+        img_path.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        result = await adapter.send_image_file(
+            chat_id="other-recipient", image_path=str(img_path)
+        )
+
+        assert result.success is True
+        assert "notifySelf" not in captured[0]["params"]
 
 
 class TestSignalRecipientResolution:
@@ -438,6 +460,36 @@ class TestSignalRecipientResolution:
         assert captured[1]["method"] == "send"
         assert captured[1]["params"]["recipient"] == ["68680952-6d86-45bc-85e0-1a4d186d53ee"]
 
+    @pytest.mark.asyncio
+    async def test_self_chat_keeps_notify_self_after_uuid_resolution(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+        captured = []
+        self_uuid = "68680952-6d86-45bc-85e0-1a4d186d53ee"
+
+        async def mock_rpc(method, params, rpc_id=None, **kwargs):
+            captured.append({"method": method, "params": dict(params)})
+            if method == "listContacts":
+                return [
+                    {
+                        "number": adapter.account,
+                        "uuid": self_uuid,
+                        "isRegistered": True,
+                    }
+                ]
+            if method == "send":
+                return {"timestamp": 1234567890}
+            return None
+
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send(chat_id=adapter.account, content="hello")
+
+        assert result.success is True
+        assert captured[1]["method"] == "send"
+        assert captured[1]["params"]["recipient"] == [self_uuid]
+        assert captured[1]["params"]["notifySelf"] is True
+
 
 # ---------------------------------------------------------------------------
 # send_voice method (#5105)
@@ -447,7 +499,7 @@ class TestSignalSendVoice:
     @pytest.mark.asyncio
     async def test_send_voice_sends_via_rpc(self, monkeypatch, tmp_path):
         """send_voice should send audio as attachment via signal-cli RPC."""
-        adapter = _make_signal_adapter(monkeypatch)
+        adapter = _make_signal_adapter(monkeypatch, account="self-account")
         mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
@@ -455,13 +507,16 @@ class TestSignalSendVoice:
         audio_path = tmp_path / "reply.ogg"
         audio_path.write_bytes(b"OggS" + b"\x00" * 100)
 
-        result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
+        result = await adapter.send_voice(
+            chat_id=adapter.account, audio_path=str(audio_path)
+        )
 
         assert result.success is True
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["attachments"] == [str(audio_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
-        adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
+        assert captured[0]["params"]["notifySelf"] is True
+        adapter._stop_typing_indicator.assert_awaited_once_with(adapter.account)
         assert 1234567890 in adapter._recent_sent_timestamps
 
 
@@ -674,15 +729,28 @@ class TestSignalSendReturnsMessageId:
 
     @pytest.mark.asyncio
     async def test_send_returns_none_message_id_even_with_timestamp(self, monkeypatch):
-        adapter = _make_signal_adapter(monkeypatch)
-        mock_rpc, _ = _stub_rpc({"timestamp": 1712345678000})
+        adapter = _make_signal_adapter(monkeypatch, account="self-account")
+        mock_rpc, captured = _stub_rpc({"timestamp": 1712345678000})
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
 
-        result = await adapter.send(chat_id="+155****4567", content="hello")
+        result = await adapter.send(chat_id=adapter.account, content="hello")
 
         assert result.success is True
         assert result.message_id is None
+        assert captured[0]["params"]["notifySelf"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_other_recipient_omits_notify_self(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1712345678000})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        result = await adapter.send(chat_id="other-recipient", content="hello")
+
+        assert result.success is True
+        assert "notifySelf" not in captured[0]["params"]
 
 
 class TestSignalSendResultValidation:
@@ -1055,17 +1123,18 @@ class TestSignalSendMultipleImages:
 
     @pytest.mark.asyncio
     async def test_single_batch_under_limit(self, monkeypatch, tmp_path):
-        adapter = _make_signal_adapter(monkeypatch)
+        adapter = _make_signal_adapter(monkeypatch, account="self-account")
         mock_rpc, captured = _stub_rpc_responses([{"timestamp": 1}])
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
 
         images = _make_image_files(tmp_path, 5)
-        await adapter.send_multiple_images(chat_id="+155****4567", images=images)
+        await adapter.send_multiple_images(chat_id=adapter.account, images=images)
 
         assert len(captured) == 1
         params = captured[0]["params"]
-        assert params["recipient"] == ["+155****4567"]
+        assert params["recipient"] == [adapter.account]
+        assert params["notifySelf"] is True
         assert params["message"] == ""
         assert len(params["attachments"]) == 5
         # raise_on_rate_limit must be opted into so the retry loop sees 429s

--- a/tests/tools/test_signal_media.py
+++ b/tests/tools/test_signal_media.py
@@ -12,6 +12,7 @@ from gateway.config import Platform
 
 def _make_httpx_mock():
     """Create a mock httpx module with proper sync json()."""
+    requests = []
 
     class AsyncBaseTransport:
         pass
@@ -32,19 +33,23 @@ def _make_httpx_mock():
         async def __aexit__(self, *a):
             pass
         async def post(self, *args, **kwargs):
+            requests.append(kwargs.get("json"))
             return MockResp()
 
     httpx_mock = ModuleType("httpx")
     httpx_mock.AsyncClient = lambda timeout=None: MockClient()
     httpx_mock.AsyncBaseTransport = AsyncBaseTransport  # Needed by Telegram adapter
     httpx_mock.Proxy = Proxy  # Needed by telegram-bot library
+    setattr(httpx_mock, "requests", requests)
     return httpx_mock
 
 
 @pytest.fixture(autouse=True)
 def inject_httpx(monkeypatch):
     """Inject mock httpx into sys.modules before imports."""
-    monkeypatch.setitem(sys.modules, "httpx", _make_httpx_mock())
+    httpx_mock = _make_httpx_mock()
+    monkeypatch.setitem(sys.modules, "httpx", httpx_mock)
+    return httpx_mock
 
 
 class TestSendSignalMediaFiles:
@@ -76,6 +81,29 @@ class TestSendSignalMediaFiles:
         assert result["success"] is True  # Should succeed despite missing file
         assert "warnings" in result
         assert "Some media files were skipped" in str(result["warnings"])
+
+    def test_send_signal_self_chat_sets_notify_self(self, inject_httpx):
+        from tools.send_message_tool import _send_signal
+
+        account = "test-account"
+        extra = {"http_url": "http://localhost:8080", "account": account}
+
+        result = asyncio.run(_send_signal(extra, account, "Hello self"))
+
+        assert result["success"] is True
+        requests = getattr(inject_httpx, "requests")
+        assert requests[0]["params"]["notifySelf"] is True
+
+    def test_send_signal_other_recipient_omits_notify_self(self, inject_httpx):
+        from tools.send_message_tool import _send_signal
+
+        extra = {"http_url": "http://localhost:8080", "account": "test-account"}
+
+        result = asyncio.run(_send_signal(extra, "other-recipient", "Hello other"))
+
+        assert result["success"] is True
+        requests = getattr(inject_httpx, "requests")
+        assert "notifySelf" not in requests[0]["params"]
 
 
 class TestSendSignalMediaRestrictions:
@@ -179,7 +207,7 @@ class TestSendSignalMediaWarningMessages:
 class TestSendSignalGroupChats:
     """Test that _send_signal handles group chats correctly."""
 
-    def test_send_signal_group_with_attachments(self, tmp_path):
+    def test_send_signal_group_with_attachments(self, tmp_path, inject_httpx):
         """Group chat messages with attachments should use groupId parameter."""
         from tools.send_message_tool import _send_signal
 
@@ -193,6 +221,9 @@ class TestSendSignalGroupChats:
         )
 
         assert result["success"] is True
+        requests = getattr(inject_httpx, "requests")
+        assert requests[0]["params"]["groupId"] == "abc123=="
+        assert "notifySelf" not in requests[0]["params"]
 
 
 class TestSendSignalConfigLoading:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1619,6 +1619,7 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         _signal_send_timeout,
         get_scheduler,
     )
+    from gateway.platforms.signal import set_signal_notify_self
     from gateway.platforms.signal_format import markdown_to_signal
 
     try:
@@ -1659,6 +1660,7 @@ async def _send_signal(extra, chat_id, message, media_files=None):
                 params["groupId"] = chat_id[6:]
             else:
                 params["recipient"] = [chat_id]
+                set_signal_notify_self(params, account, chat_id)
             if batch_attachments:
                 params["attachments"] = batch_attachments
 
@@ -1681,6 +1683,7 @@ async def _send_signal(extra, chat_id, message, media_files=None):
                 notice_params["groupId"] = chat_id[6:]
             else:
                 notice_params["recipient"] = [chat_id]
+                set_signal_notify_self(notice_params, account, chat_id)
             try:
                 async with httpx.AsyncClient(timeout=30.0) as _client:
                     await _client.post(


### PR DESCRIPTION
## Summary

Fixes Signal Note to Self replies being rendered as self-authored sync activity on the primary device.

- add `notifySelf: true` only for direct sends where `chat_id` matches the configured Signal account
- apply the same rule to gateway text, single attachments, multi-image batches, and the standalone `send_message` Signal path
- preserve existing payloads for groups and all other recipients

Fixes #80845.

Related: #51667 improves inbound self-message UUID/echo handling. This change is intentionally limited to outbound JSON-RPC payload construction and does not alter inbound filtering or timestamp tracking.

## Testing

- `tests/gateway/test_signal.py`: 55 passed
- `tests/tools/test_signal_media.py`: 6 passed, 3 skipped
- combined Signal suite: 61 passed, 3 skipped
- `ruff==0.15.10 check` on all four changed files: passed
- `git diff --check`: passed
- `py_compile` on all four changed files: passed
- manual end-to-end validation with signal-cli 0.14.7 confirmed that `notifySelf: true` renders both text/attachment self-chat replies as incoming messages on the primary device

## Checklist

### Testing
- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Tested edge cases (groups and non-self recipients omit `notifySelf`)
- [x] Error messages are clear and actionable (N/A: no new error path)
- [x] Tested on Linux/macOS/Windows if applicable (N/A: JSON-RPC payload-only change)

### Documentation
- [x] Added/updated comments where needed
- [x] Updated README.md if adding new features (N/A: automatic Signal transport behavior)
- [x] Updated API documentation if changing interfaces (N/A: no public API change)

### Code Quality
- [x] Code follows project style
- [x] No unnecessary dependencies added
- [x] Backward compatible
- [x] No breaking changes

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Other (please describe):

## PR Size

- [ ] Small (< 100 lines)
- [x] Medium (100-500 lines)
- [ ] Large (> 500 lines)
