### PR TITLE
feat(hindsight): add usage guidance to system_prompt_block

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1702,15 +1702,25 @@ class HindsightMemoryProvider(MemoryProvider):
             return (
                 f"# Hindsight Memory\n"
                 f"Active (tools mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
-                f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-                f"hindsight_retain to store facts."
+                f"For cross-session facts, user preferences, and past decisions, "
+                f"prefer hindsight_recall over session_search — it returns "
+                f"deduplicated, high-density observations across sessions. "
+                f"Use hindsight_reflect for cross-session pattern synthesis. "
+                f"Use session_search only when you need verbatim transcripts or "
+                f"exact wording from a specific conversation.\n"
+                f"Use hindsight_retain to store facts."
             )
         return (
             f"# Hindsight Memory\n"
             f"Active. Bank: {self._bank_id}, budget: {self._budget}.\n"
             f"Relevant memories are automatically injected into context. "
-            f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-            f"hindsight_retain to store facts."
+            f"For cross-session facts, user preferences, and past decisions, "
+            f"prefer hindsight_recall over session_search — it returns "
+            f"deduplicated, high-density observations across sessions. "
+            f"Use hindsight_reflect for cross-session pattern synthesis. "
+            f"Use session_search only when you need verbatim transcripts or "
+            f"exact wording from a specific conversation. "
+            f"Use hindsight_retain to store facts."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -282,11 +282,21 @@ _METADATA_ATTRS = (
 )
 _SYSTEM_PROMPT_TAILS = {
     "context": "Relevant memories are automatically injected into context.",
-    "tools": ("Use hindsight_recall to search, hindsight_reflect for synthesis, "
-              "hindsight_retain to store facts."),
+    "tools": ("For cross-session facts, user preferences, and past decisions, "
+              "prefer hindsight_recall over session_search — it returns "
+              "deduplicated, high-density observations across sessions. "
+              "Use hindsight_reflect for cross-session pattern synthesis. "
+              "Use session_search only when you need verbatim transcripts or "
+              "exact wording from a specific conversation.\n"
+              "Use hindsight_retain to store facts."),
     "hybrid": ("Relevant memories are automatically injected into context. "
-               "Use hindsight_recall to search, hindsight_reflect for synthesis, "
-               "hindsight_retain to store facts."),
+               "For cross-session facts, user preferences, and past decisions, "
+               "prefer hindsight_recall over session_search — it returns "
+               "deduplicated, high-density observations across sessions. "
+               "Use hindsight_reflect for cross-session pattern synthesis. "
+               "Use session_search only when you need verbatim transcripts or "
+               "exact wording from a specific conversation. "
+               "Use hindsight_retain to store facts."),
 }
 
 


### PR DESCRIPTION
## Summary

The Hindsight memory plugin's `system_prompt_block()` only listed tool names (`hindsight_recall to search, hindsight_reflect for synthesis, hindsight_retain to store facts`) without explaining **when** to prefer them. Other in-tree providers already include scenario-based guidance:

- **Mem0**: `"You should call mem0_search before answering anything that could depend on prior context"`
- **OpenViking**: `"For questions about remembered people, preferences, projects, events, or prior user context, search OpenViking before asking the user to repeat context"`

## Problem

Without usage guidance, LLMs that have both Hindsight and a built-in session search tool tend to default to the session search (raw transcript retrieval) for all history queries, even when Hindsight's deduplicated observations would be more appropriate. This is a real observed behavior — the LLM picks the more familiar tool name from the system prompt and ignores the provider tools unless explicitly told when to use them.

## Change

Add scenario-based guidance to `system_prompt_block()` for `hybrid` and `tools` memory modes:

- **When to prefer hindsight_recall**: cross-session facts, user preferences, past decisions — returns deduplicated, high-density observations across sessions
- **When to prefer hindsight_reflect**: cross-session pattern synthesis
- **When to fall back to session_search**: verbatim transcripts or exact wording from a specific conversation

`context` mode is unchanged (no tools exposed, nothing to guide).

## Design boundary

The guidance names `session_search` explicitly so the LLM understands the division of labor between Hindsight's semantic memory and the host framework's verbatim transcript search. `session_search` is the only host-framework tool referenced, and only as a contrast to guide tool selection — the guidance still centers on Hindsight's own tools (`hindsight_recall`, `hindsight_reflect`, `hindsight_retain`) and their scenarios.

## Checklist

- [x] Syntax check passes (`ast.parse`)
- [x] Only modifies `system_prompt_block()` return text — no logic changes
- [x] `context` mode unchanged
- [x] No new dependencies, no config changes