### PR TITLE
feat(blooio): add Blooio as an in-tree iMessage gateway platform (v4 + OAuth)

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -34,6 +34,19 @@ function PhotonIcon(props: React.SVGProps<SVGSVGElement>) {
   )
 }
 
+// ---------------------------------------------------------------------------
+// Blooio brand icon — a rounded chat bubble with a tail. Blooio delivers
+// iMessage over its hosted API, so the mark reads as a soft speech bubble
+// (distinct from Photon's diagonal bars and BlueBubbles' Apple glyph).
+// ---------------------------------------------------------------------------
+function BlooioIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg fill="currentColor" viewBox="0 0 24 24" {...props}>
+      <path d="M12 3.75c-4.83 0-8.75 3.08-8.75 6.88 0 2.16 1.27 4.09 3.26 5.35-.14 1.16-.68 2.2-1.5 3-.28.27-.09.74.3.71 1.7-.12 3.2-.68 4.34-1.57.75.18 1.54.28 2.35.28 4.83 0 8.75-3.08 8.75-6.88S16.83 3.75 12 3.75Z" />
+    </svg>
+  )
+}
+
 // We render simpleicons.org brand glyphs for platforms whose owners publish a
 // usable mark (telegram, discord, matrix, ...). A few brands — Slack, Dingtalk,
 // Feishu, WeCom — have been removed from Simple Icons at the brand owner's
@@ -62,6 +75,7 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   whatsapp: { Icon: SiWhatsapp, color: '#25D366', kind: 'brand' },
   bluebubbles: { Icon: SiApple, color: '#0BD318', kind: 'brand' },
   photon: { Icon: PhotonIcon, color: '#6366F1', kind: 'brand' },
+  blooio: { Icon: BlooioIcon, color: '#0A84FF', kind: 'brand' },
   homeassistant: { Icon: SiHomeassistant, color: '#18BCF2', kind: 'brand' },
   email: { Icon: SiGmail, color: '#EA4335', kind: 'brand' },
   sms: { Icon: MessageSquareText, color: '#F43F5E', kind: 'generic' },

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -33,3 +33,26 @@ describe('photon messaging source registration', () => {
     expect(isMessagingSource(undefined)).toBe(false)
   })
 })
+
+// Blooio (iMessage over the hosted Blooio API) also keeps its own sidebar
+// section — same contract as Photon above.
+describe('blooio messaging source registration', () => {
+  it('treats blooio as a messaging source (own sidebar section)', () => {
+    expect(isMessagingSource('blooio')).toBe(true)
+  })
+
+  it('is case/space insensitive on the source id', () => {
+    expect(isMessagingSource('BLOOIO')).toBe(true)
+    expect(isMessagingSource('  blooio ')).toBe(true)
+  })
+
+  it('exposes the iMessage/messages search aliases so Blooio sessions are findable', () => {
+    const terms = sessionSourceSearchTerms('blooio')
+    expect(terms).toContain('imessage')
+    expect(terms).toContain('messages')
+  })
+
+  it('is registered in the messaging source id list', () => {
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('blooio')
+  })
+})

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -2,6 +2,7 @@ import { normalize } from '@/lib/text'
 
 const SOURCE_LABELS: Record<string, string> = {
   api_server: 'API',
+  blooio: 'Blooio',
   bluebubbles: 'iMessage',
   cli: 'CLI',
   codex: 'Codex',
@@ -27,6 +28,7 @@ const SOURCE_LABELS: Record<string, string> = {
 }
 
 const SOURCE_ALIASES: Record<string, string[]> = {
+  blooio: ['imessage', 'messages'],
   bluebubbles: ['apple messages', 'imessage'],
   photon: ['imessage', 'messages'],
   cli: ['terminal'],
@@ -59,6 +61,7 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'whatsapp',
   'bluebubbles',
   'photon',
+  'blooio',
   'homeassistant',
   'email',
   'sms',

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -159,13 +159,15 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # status update as a separate message. Promote to TIER_MEDIUM once
     # Cloud's edit_message lands.
     "whatsapp_cloud":  _TIER_LOW,
-    # Photon (managed iMessage over the gRPC sidecar) and BlueBubbles are both
-    # permanent-message iMessage inboxes with no message-edit support, so both
-    # stay TIER_LOW. This keeps tool progress, interim scratch commentary,
-    # "still working" heartbeats, and busy-ack iteration detail out of the
-    # user's iMessage thread. Without this entry Photon inherited the noisy
-    # global ("all") defaults and compacted/narrated on nearly every turn.
+    # Photon (managed iMessage over the gRPC sidecar), Blooio (managed iMessage
+    # over REST + webhooks), and BlueBubbles are all permanent-message iMessage
+    # inboxes with no message-edit support, so they stay TIER_LOW. This keeps
+    # tool progress, interim scratch commentary, "still working" heartbeats,
+    # and busy-ack iteration detail out of the user's iMessage thread. Without
+    # this entry they'd inherit the noisy global ("all") defaults and
+    # compacted/narrated on nearly every turn.
     "photon":          _TIER_LOW,
+    "blooio":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
     "wecom":           _TIER_LOW,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8599,6 +8599,10 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         "description": "Use Hermes through iMessage via Photon's managed Spectrum platform.",
         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/photon",
     },
+    "blooio": {
+        "description": "Use Hermes through iMessage via Blooio's hosted API (OAuth login).",
+        "docs_url": "https://github.com/Blooio/hermes-blooio",
+    },
     "raft": {
         "description": "Join a Raft workspace as an external agent.",
         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft",

--- a/plugins/platforms/blooio/README.md
+++ b/plugins/platforms/blooio/README.md
@@ -1,0 +1,102 @@
+# iMessage via Blooio
+
+A Hermes Agent platform plugin that connects your agent to **iMessage** (with
+SMS/RCS fallback) through [Blooio](https://blooio.com) — a hosted iMessage API.
+No Mac, no jailbreak, no local BlueBubbles server: Blooio runs the iMessage
+infrastructure and exposes a REST API + inbound webhooks, and this plugin bridges
+it to Hermes.
+
+It's the twin of the built-in **BlueBubbles** iMessage channel and the
+**Photon** Spectrum plugin — same conversational behavior, same group-mention
+gating, same tapback reactions — but talks to Blooio's **v4 REST API** and
+authenticates with the official **"Blooio for Hermes" OAuth app**.
+
+## Quick start
+
+```bash
+# 1. Connect Blooio (opens your browser, one-click consent → tokens stored)
+hermes blooio login
+
+# 2. Expose Hermes at a public HTTPS URL (Blooio delivers inbound via webhook)
+export BLOOIO_PUBLIC_URL="https://your-tunnel.example.com"     # Cloudflare Tunnel / ngrok / Tailscale Funnel
+export BLOOIO_AUTO_REGISTER_WEBHOOK=true                       # auto-create the webhook + capture its signing secret
+
+# 3. (optional) lock the bot to specific senders
+export BLOOIO_ALLOWED_USERS="+15551234567,teammate@example.com"
+
+# 4. Run the gateway as usual — "iMessage via Blooio" is now a channel.
+```
+
+`hermes blooio status` shows the current auth state; `hermes blooio logout`
+revokes and clears the stored tokens.
+
+## Authentication
+
+Two modes, resolved in this order:
+
+1. **OAuth (default, recommended).** `hermes blooio login` runs the standard
+   native-app flow — Authorization Code + **PKCE (S256)** on a loopback redirect
+   (`http://127.0.0.1:8765/callback`). Tokens are stored in `~/.hermes/auth.json`
+   (`0o600`) under `credential_pool.blooio`; the access token auto-refreshes via
+   the rotating refresh token. If your OAuth app is installed on more than one
+   organization, set `BLOOIO_ORG_ID=org_…` (sent as `X-Organization-Id`).
+2. **API key (headless / CI).** Set `BLOOIO_API_KEY` and skip the browser login
+   entirely.
+
+## How it works
+
+* **Inbound = webhooks.** The plugin runs a small `aiohttp` server and (with
+  `BLOOIO_AUTO_REGISTER_WEBHOOK=true`) registers `/blooio/webhook` with Blooio.
+  Every event is HMAC-SHA256 signature-verified (Stripe-style
+  `X-Blooio-Signature: t=<ts>,v1=<hex>` over `"{ts}.{rawBody}"`), deduped on
+  `message_id`, and dispatched as a normalized Hermes `MessageEvent`. Blooio v4
+  delivers a typed envelope (`{type, created_at, organization_id, data:{…}}`);
+  `message.received` becomes an inbound message and `message.reaction` on one of
+  the bot's own messages becomes a synthetic `reaction:add:<emoji>` event.
+* **Outbound = REST (v4).** Replies POST to `/v4/chats/{chat_id}/messages` (the
+  `chat_…` handle carried by every inbound event; the sender is inferred from
+  the chat). Cron / home-channel delivery to a bare phone/email uses
+  `POST /v4/messages` with `to` (+ optional `from` channel). Long replies are
+  chunked. Typing indicators, read receipts, and tapback/emoji reactions each
+  map to a dedicated v4 chat endpoint.
+* **Media.** Blooio attachments are HTTPS URLs. Remote image/file URLs pass
+  straight through; local files are served from the same `aiohttp` app
+  (`/blooio/media/<token>/<name>`, with a path-traversal guard) — which is why a
+  public `BLOOIO_PUBLIC_URL` is required to send local files.
+
+## Requirements
+
+* A public HTTPS hostname reachable by Blooio (inbound webhooks + local-file
+  attachment URLs). Use Cloudflare Tunnel, Tailscale Funnel, or ngrok and set
+  `BLOOIO_PUBLIC_URL`.
+* `aiohttp` and `httpx` (declared by Hermes; already present in the standard
+  install).
+
+## Configuration
+
+All settings are environment variables (see `plugin.yaml` for the full list with
+prompts). The most useful:
+
+| Variable | Purpose |
+| --- | --- |
+| `BLOOIO_PUBLIC_URL` | Public HTTPS base URL Blooio can reach (required for inbound + local media). |
+| `BLOOIO_AUTO_REGISTER_WEBHOOK` | Auto-create the webhook and capture its signing secret on connect (`true`/`false`). |
+| `BLOOIO_WEBHOOK_SECRET` | Webhook signing secret (`whsec_…`) if you register the webhook manually. |
+| `BLOOIO_ORG_ID` | Organization id (`org_…`); needed only for multi-org OAuth tokens. |
+| `BLOOIO_API_KEY` | Headless/CI auth instead of OAuth login. |
+| `BLOOIO_CHANNEL` | Channel id (`ch_…`) / phone to send *from* for routed (non-reply) sends. |
+| `BLOOIO_ALLOWED_USERS` | Comma-separated senders (phone/email) allowed to DM the bot. |
+| `BLOOIO_ALLOWED_GROUPS` | Comma-separated group ids (`grp_…`) the bot responds in. |
+| `BLOOIO_ALLOW_ALL_USERS` | Disable the allowlist (dev only). |
+| `BLOOIO_REQUIRE_MENTION` | Ignore group messages without a wake word (`hermes …`). |
+| `BLOOIO_REACTIONS` | 👀/👍/👎 processing tapbacks + route reactions on the bot's messages back to the agent. |
+| `BLOOIO_SEND_READ_RECEIPTS` | Send iMessage read receipts for processed inbound messages. |
+| `BLOOIO_HOME_CHANNEL` | Default target (`chat_…`, phone, or email) for cron / notifications. |
+
+## Notes
+
+* iMessage identifiers are E.164 phone numbers / emails, so the channel is
+  treated as **PII-sensitive** (redacted before reaching the LLM), matching the
+  BlueBubbles and Photon channels.
+* iMessage does **not** render Markdown — replies are sent as plain text (markup
+  is stripped); bare URLs still get a rich preview.

--- a/plugins/platforms/blooio/__init__.py
+++ b/plugins/platforms/blooio/__init__.py
@@ -1,0 +1,4 @@
+"""Blooio (iMessage via Blooio) platform plugin entry point."""
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/blooio/adapter.py
+++ b/plugins/platforms/blooio/adapter.py
@@ -1,0 +1,1519 @@
+"""
+Blooio (iMessage) platform adapter for Hermes Agent.
+
+Blooio is a hosted iMessage API — you send and receive real iMessages (with
+SMS/RCS fallback) through a REST API and inbound webhooks, without running a
+Mac yourself. This adapter is the twin of the built-in BlueBubbles iMessage
+channel and the Photon Spectrum plugin, but talks to Blooio's v4 REST API
+(``https://api.blooio.com/v4``) and authenticates via the official "Blooio
+for Hermes" OAuth app (Authorization Code + PKCE), with an API key as a
+headless fallback. See ``auth.py`` for the OAuth/token handling.
+
+Design
+------
+
+**Inbound = webhooks.** The adapter runs a small ``aiohttp`` webhook server
+and registers ``/blooio/webhook`` with Blooio. Each event is HMAC-SHA256
+signature-verified (Stripe-style ``X-Blooio-Signature: t=<ts>,v1=<hex>``
+over ``"{ts}.{rawBody}"``) using the webhook's signing secret, deduped on
+``message_id``, and dispatched to the gateway as a normalized
+``MessageEvent``. v4 delivers a typed envelope
+(``{type, created_at, organization_id, data:{…}}``); ``message.received``
+becomes an inbound message, ``message.reaction`` on one of the bot's own
+messages becomes a synthetic ``reaction:add:<emoji>`` event (same pattern as
+Photon/Feishu), and delivery receipts are ignored.
+
+**Outbound = REST.** Replies POST to ``/chats/{chat_id}/messages`` (the
+``chat_…`` handle carried by every inbound event; the sender is inferred from
+the chat). Cron / home-channel delivery to a bare phone/email instead uses
+``POST /messages`` with ``to`` (+ optional ``from`` channel). Long replies are
+chunked and sent sequentially. Typing indicators, read receipts, and
+tapback/emoji reactions each map to a dedicated v4 chat endpoint. Requests are
+scoped with ``X-Organization-Id`` when the token/config carries an org id.
+
+**Media.** Blooio attachments are HTTPS URLs. Sending a remote image URL is a
+straight pass-through; sending a local file requires a publicly reachable
+``BLOOIO_PUBLIC_URL`` — the file is registered and served from the same
+aiohttp app (``/blooio/media/<token>/<name>``) with a traversal guard, exactly
+like the LINE plugin.
+
+**Requires a public HTTPS host.** Inbound webhooks and local-file attachment
+URLs both need Blooio to reach this process, so a laptop-only Hermes must be
+exposed via Cloudflare Tunnel / Tailscale Funnel / ngrok. Set
+``BLOOIO_PUBLIC_URL`` to that hostname.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import mimetypes
+import os
+import re
+import secrets
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import quote as _urlquote
+
+logger = logging.getLogger(__name__)
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
+    cache_video_from_bytes,
+)
+from gateway.platforms.helpers import strip_markdown
+from gateway.config import Platform
+
+from . import auth as _auth
+from .auth import BlooioAuth, BlooioAuthError
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_API_BASE_URL = "https://api.blooio.com/v4"
+
+DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WEBHOOK_PORT = 8647
+DEFAULT_WEBHOOK_PATH = "/blooio/webhook"
+DEFAULT_MEDIA_PATH_PREFIX = "/blooio/media"
+
+# Webhook events are small JSON payloads; attachments arrive as URLs, not
+# inline bytes, so a 1 MiB cap is generous headroom.
+WEBHOOK_BODY_MAX_BYTES = 1_048_576
+
+# iMessage has no documented hard cap, but the protocol gets unhappy past
+# ~16 KB. Match the BlueBubbles channel's conservative per-bubble limit.
+MAX_TEXT_LENGTH = 4000
+
+# Reject webhook events whose signature timestamp is too old/new — bounds a
+# replay window. Blooio signs with seconds since epoch.
+_SIGNATURE_TOLERANCE_SECONDS = 5 * 60
+
+# Bounded dedup of processed message ids (webhooks are at-least-once).
+_DEDUP_MAX_SIZE = 2000
+
+# iMessage classic tapbacks. Blooio accepts these names (prefixed ``+``/``-``)
+# or any emoji. We keep the set so a plugin-side reaction request can validate
+# a friendly name before falling back to treating the value as an emoji.
+_CLASSIC_TAPBACKS = {
+    "love", "like", "dislike", "laugh", "emphasize", "question",
+}
+
+# Lifecycle-hook tapbacks (opt-in via BLOOIO_REACTIONS). iMessage renders
+# these emoji as native reactions.
+_REACTION_WORKING = "👀"
+_REACTION_SUCCESS = "👍"
+_REACTION_FAILURE = "👎"
+
+# Group-chat mention wake words — identical defaults to the BlueBubbles and
+# Photon iMessage channels so all three gate group chats the same way.
+DEFAULT_MENTION_PATTERNS = [
+    r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
+    r"(?<![\w@])@?hermes\b[,:\-]?",
+]
+
+# Log redaction — iMessage identifiers are phone numbers / emails (PII).
+_PHONE_RE = re.compile(r"\+?\d{7,15}")
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
+
+# Minimum seconds between typing-indicator calls for the same chat.
+_TYPING_COOLDOWN_SECONDS = 5.0
+
+
+def _redact(text: str) -> str:
+    """Mask phone numbers and emails in log output."""
+    if not text:
+        return text
+    text = _PHONE_RE.sub("[redacted]", text)
+    text = _EMAIL_RE.sub("[redacted]", text)
+    return text
+
+
+def _csv_set(value: str) -> Set[str]:
+    if not value:
+        return set()
+    return {x.strip() for x in value.split(",") if x.strip()}
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification
+# ---------------------------------------------------------------------------
+
+def verify_blooio_signature(
+    body: bytes,
+    signature_header: str,
+    signing_secret: str,
+    *,
+    tolerance_seconds: int = _SIGNATURE_TOLERANCE_SECONDS,
+    now: Optional[float] = None,
+) -> bool:
+    """Verify a Blooio ``X-Blooio-Signature`` header.
+
+    Blooio signs the *raw* request body Stripe-style: the header is
+    ``t=<unix_seconds>,v1=<hex>`` where ``v1`` is the hex HMAC-SHA256 of
+    ``"{t}.{raw_body}"`` keyed by the webhook's signing secret
+    (``whsec_…``). The timestamp is checked against ``tolerance_seconds`` to
+    bound replay, and the digest is compared in constant time.
+    """
+    if not signature_header or not signing_secret or body is None:
+        return False
+
+    parsed: Dict[str, str] = {}
+    for part in signature_header.split(","):
+        key, _, val = part.strip().partition("=")
+        if key and val:
+            parsed[key.strip()] = val.strip()
+
+    timestamp = parsed.get("t")
+    provided = parsed.get("v1")
+    if not timestamp or not provided:
+        return False
+
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+
+    current = time.time() if now is None else now
+    if tolerance_seconds and abs(current - ts) > tolerance_seconds:
+        return False
+
+    try:
+        signed_payload = f"{timestamp}.".encode("utf-8") + body
+        expected = hmac.new(
+            signing_secret.encode("utf-8"),
+            signed_payload,
+            hashlib.sha256,
+        ).hexdigest()
+    except Exception:
+        return False
+    return hmac.compare_digest(expected, provided)
+
+
+# ---------------------------------------------------------------------------
+# Inbound dedup
+# ---------------------------------------------------------------------------
+
+class _MessageDeduplicator:
+    """Bounded LRU of processed ids to drop at-least-once webhook retries."""
+
+    def __init__(self, max_size: int = _DEDUP_MAX_SIZE) -> None:
+        self._seen: Dict[str, float] = {}
+        self._max = max_size
+
+    def is_duplicate(self, key: str) -> bool:
+        if not key:
+            return False
+        if key in self._seen:
+            return True
+        if len(self._seen) >= self._max:
+            cutoff = sorted(self._seen.values())[len(self._seen) // 10 or 1]
+            self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+        self._seen[key] = time.time()
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Blooio REST client
+# ---------------------------------------------------------------------------
+
+class _BlooioClient:
+    """Thin async wrapper over the Blooio v4 REST API (httpx).
+
+    Auth is resolved per request from a :class:`BlooioAuth` (API key or an
+    auto-refreshing OAuth access token). When the auth carries an organization
+    id it is sent as ``X-Organization-Id`` — required when an OAuth token is
+    installed on more than one org.
+    """
+
+    def __init__(self, auth: BlooioAuth, base_url: str, *, timeout: float = 30.0) -> None:
+        self._auth = auth
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {await self._auth.bearer()}",
+            "Content-Type": "application/json",
+        }
+        if self._auth.organization_id:
+            headers["X-Organization-Id"] = self._auth.organization_id
+        return headers
+
+    async def _request(
+        self, method: str, path: str, *, json_body: Optional[dict] = None
+    ) -> Dict[str, Any]:
+        import httpx
+
+        url = f"{self._base}{path}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.request(
+                method, url, headers=await self._headers(), json=json_body
+            )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Blooio {method} {path} → {resp.status_code}: {resp.text[:200]}"
+            )
+        try:
+            return resp.json() or {}
+        except Exception:
+            return {}
+
+    async def get_me(self) -> Dict[str, Any]:
+        return await self._request("GET", "/me")
+
+    async def send_to_chat(self, chat_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Reply into an existing v4 chat (``chat_…``); sender is implicit."""
+        return await self._request(
+            "POST", f"/chats/{_urlquote(chat_id, safe='')}/messages", json_body=body
+        )
+
+    async def send_agnostic(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Routed send: ``POST /messages`` with ``to`` (+ optional ``from``)."""
+        return await self._request("POST", "/messages", json_body=body)
+
+    async def set_typing(self, chat_id: str, active: bool) -> None:
+        if active:
+            await self._request(
+                "POST",
+                f"/chats/{_urlquote(chat_id, safe='')}/typing",
+                json_body={"state": "started"},
+            )
+        else:
+            await self._request("DELETE", f"/chats/{_urlquote(chat_id, safe='')}/typing")
+
+    async def mark_read(self, chat_id: str) -> None:
+        await self._request("POST", f"/chats/{_urlquote(chat_id, safe='')}/read")
+
+    async def react(
+        self, chat_id: str, message_id: str, reaction: str,
+    ) -> Dict[str, Any]:
+        # v4 encodes add/remove in the reaction value's +/- prefix (no
+        # separate direction field, unlike v2).
+        return await self._request(
+            "POST",
+            f"/chats/{_urlquote(chat_id, safe='')}/messages/"
+            f"{_urlquote(str(message_id), safe='')}/reactions",
+            json_body={"reaction": reaction},
+        )
+
+    async def create_webhook(self, webhook_url: str) -> Dict[str, Any]:
+        # v4 webhooks receive all events; the body is just the target url.
+        return await self._request(
+            "POST", "/webhooks", json_body={"url": webhook_url}
+        )
+
+    async def download(self, url: str) -> bytes:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=self._timeout, follow_redirects=True) as client:
+            resp = await client.get(url)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Blooio attachment download {resp.status_code}")
+            return resp.content
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class BlooioAdapter(BasePlatformAdapter):
+    """Blooio iMessage gateway adapter (webhook in, REST out)."""
+
+    SUPPORTS_MESSAGE_EDITING = False
+    MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
+    splits_long_messages = True
+
+    _SENT_IDS_MAX = 1000
+    _LAST_INBOUND_CHATS_MAX = 200
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config=config, platform=Platform("blooio"))
+        extra = getattr(config, "extra", {}) or {}
+
+        # Auth (OAuth access token or API-key fallback) is resolved on connect.
+        self._auth: Optional[BlooioAuth] = None
+        self.organization_id = (
+            os.getenv("BLOOIO_ORG_ID") or extra.get("organization_id", "") or ""
+        )
+        self.signing_secret = (
+            os.getenv("BLOOIO_WEBHOOK_SECRET") or extra.get("webhook_secret", "")
+        )
+        self.api_base_url = (
+            os.getenv("BLOOIO_API_BASE_URL")
+            or extra.get("api_base_url")
+            or DEFAULT_API_BASE_URL
+        )
+        # Optional explicit sender for routed (non-reply) sends: a channel id
+        # (``ch_…``), phone number, or alias. Replies into an existing chat
+        # infer the sender from the chat, so this only matters for cron /
+        # home-channel delivery via ``POST /messages``.
+        self.channel_ref = (
+            os.getenv("BLOOIO_CHANNEL")
+            or os.getenv("BLOOIO_FROM_NUMBER")
+            or extra.get("channel")
+            or extra.get("from_number", "")
+            or ""
+        )
+
+        # Webhook server
+        self.webhook_host = os.getenv("BLOOIO_HOST") or extra.get("host", DEFAULT_WEBHOOK_HOST)
+        try:
+            self.webhook_port = int(
+                os.getenv("BLOOIO_PORT") or extra.get("port", DEFAULT_WEBHOOK_PORT)
+            )
+        except (TypeError, ValueError):
+            self.webhook_port = DEFAULT_WEBHOOK_PORT
+        self.webhook_path = extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
+        if not str(self.webhook_path).startswith("/"):
+            self.webhook_path = f"/{self.webhook_path}"
+
+        self.public_base_url = (
+            os.getenv("BLOOIO_PUBLIC_URL") or extra.get("public_url", "") or ""
+        ).rstrip("/")
+        self.auto_register_webhook = _truthy(
+            os.getenv("BLOOIO_AUTO_REGISTER_WEBHOOK"),
+            bool(extra.get("auto_register_webhook", False)),
+        )
+
+        # Allowlist gating (phones/emails for DMs, grp_ ids for groups)
+        self.allow_all = _truthy(
+            os.getenv("BLOOIO_ALLOW_ALL_USERS"), bool(extra.get("allow_all_users", False))
+        )
+        self.allowed_users = _csv_set(os.getenv("BLOOIO_ALLOWED_USERS", "")) | set(
+            extra.get("allowed_users", [])
+        )
+        self.allowed_groups = _csv_set(os.getenv("BLOOIO_ALLOWED_GROUPS", "")) | set(
+            extra.get("allowed_groups", [])
+        )
+
+        # Group-mention gating (parity with BlueBubbles / Photon). DMs never gated.
+        _require_mention = extra.get("require_mention")
+        if _require_mention is None:
+            _require_mention = os.getenv("BLOOIO_REQUIRE_MENTION")
+        self.require_mention = _truthy(_require_mention)
+        self._mention_patterns = self._compile_mention_patterns(
+            extra["mention_patterns"]
+            if "mention_patterns" in extra
+            else os.getenv("BLOOIO_MENTION_PATTERNS")
+        )
+
+        # Read receipts + reactions are opt-in.
+        self.send_read_receipts = _truthy(
+            os.getenv("BLOOIO_SEND_READ_RECEIPTS"),
+            bool(extra.get("send_read_receipts", False)),
+        )
+
+        # Runtime state
+        self._client: Optional[_BlooioClient] = None
+        self._app = None
+        self._runner = None
+        self._site = None
+        self._dedup = _MessageDeduplicator()
+        self._sent_message_ids: Dict[str, float] = {}
+        self._last_inbound_by_chat: Dict[str, str] = {}
+        self._typing_last_sent: Dict[str, float] = {}
+
+        # Media serving state (local files → public HTTPS for Blooio to fetch)
+        self._media_tokens: Dict[str, Tuple[str, float]] = {}
+        self._media_temp_paths: Set[str] = set()
+        self._media_ttl = 1800
+
+    # -- Group-mention gating -------------------------------------------------
+
+    @staticmethod
+    def _compile_mention_patterns(raw: Any) -> "list[re.Pattern]":
+        if raw is None:
+            patterns: List[Any] = list(DEFAULT_MENTION_PATTERNS)
+        elif isinstance(raw, str):
+            text = raw.strip()
+            try:
+                loaded = json.loads(text) if text else []
+            except Exception:
+                loaded = None
+            patterns = loaded if isinstance(loaded, list) else [
+                part.strip()
+                for line in text.splitlines()
+                for part in line.split(",")
+            ]
+        elif isinstance(raw, list):
+            patterns = raw
+        else:
+            patterns = [raw]
+
+        compiled: "list[re.Pattern]" = []
+        for pattern in patterns:
+            token = str(pattern).strip()
+            if not token:
+                continue
+            try:
+                compiled.append(re.compile(token, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning("[blooio] invalid mention pattern %r: %s", token, exc)
+        return compiled
+
+    def _matches_mention(self, text: str) -> bool:
+        if not text or not self._mention_patterns:
+            return False
+        return any(p.search(text) for p in self._mention_patterns)
+
+    def _clean_mention_text(self, text: str) -> str:
+        if not text:
+            return text
+        for pattern in self._mention_patterns:
+            match = pattern.match(text.lstrip())
+            if match:
+                cleaned = text.lstrip()[match.end():].lstrip(" ,:-")
+                return cleaned or text
+        return text
+
+    # -- Connection lifecycle -------------------------------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._auth = _auth.resolve_auth(self.config)
+        if self._auth is None:
+            self._set_fatal_error(
+                "config_missing",
+                "Blooio is not authenticated. Run `hermes blooio login` (OAuth) "
+                "or set BLOOIO_API_KEY for headless use.",
+                retryable=False,
+            )
+            return False
+        # An explicit org (BLOOIO_ORG_ID / config) overrides the stored default.
+        if self.organization_id:
+            self._auth.organization_id = self.organization_id
+
+        try:
+            from aiohttp import web  # noqa: F401
+        except ImportError:
+            self._set_fatal_error(
+                "missing_dep",
+                "aiohttp is required for the Blooio adapter — `pip install aiohttp`",
+                retryable=False,
+            )
+            return False
+
+        self._client = _BlooioClient(self._auth, self.api_base_url)
+
+        # Spin up the webhook server.
+        from aiohttp import web
+
+        self._app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
+        self._app.router.add_post(self.webhook_path, self._handle_webhook)
+        self._app.router.add_get(f"{self.webhook_path}/health", self._handle_health)
+        self._app.router.add_get(
+            f"{DEFAULT_MEDIA_PATH_PREFIX}/{{token}}/{{filename}}", self._handle_media
+        )
+
+        self._runner = web.AppRunner(self._app)
+        try:
+            await self._runner.setup()
+            self._site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
+            await self._site.start()
+        except OSError as exc:
+            self._set_fatal_error(
+                "bind_failed",
+                f"Could not bind Blooio webhook on {self.webhook_host}:{self.webhook_port}: {exc}",
+                retryable=True,
+            )
+            return False
+
+        if not self.signing_secret:
+            logger.warning(
+                "[blooio] BLOOIO_WEBHOOK_SECRET not set — inbound webhook "
+                "signatures will NOT be verified. Set the signing secret from "
+                "your Blooio webhook for production."
+            )
+
+        # Optional convenience: register our public webhook URL with Blooio and
+        # capture the returned signing secret (shown once) for verification.
+        if self.auto_register_webhook and not is_reconnect:
+            await self._maybe_register_webhook()
+
+        self._mark_connected()
+        logger.info(
+            "[blooio] webhook listening on %s:%s%s%s",
+            self.webhook_host,
+            self.webhook_port,
+            self.webhook_path,
+            f" (public: {self.public_base_url})" if self.public_base_url else "",
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+        if self._site is not None:
+            try:
+                await self._site.stop()
+            except Exception:
+                pass
+            self._site = None
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+        self._app = None
+        for path in list(self._media_temp_paths):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self._media_temp_paths.clear()
+        self._media_tokens.clear()
+
+    async def _maybe_register_webhook(self) -> None:
+        if not self.public_base_url:
+            logger.warning(
+                "[blooio] auto-register requested but BLOOIO_PUBLIC_URL is unset — skipping"
+            )
+            return
+        webhook_url = f"{self.public_base_url}{self.webhook_path}"
+        try:
+            data = await self._client.create_webhook(webhook_url)
+        except Exception as exc:
+            logger.warning("[blooio] webhook auto-registration failed: %s", exc)
+            return
+        # v4 wraps the created webhook (incl. one-time signing_secret) in `data`.
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        secret = payload.get("signing_secret") or (payload.get("webhook") or {}).get(
+            "signing_secret"
+        )
+        if secret:
+            self.signing_secret = secret
+            logger.info(
+                "[blooio] registered webhook %s and captured signing secret",
+                webhook_url,
+            )
+        else:
+            logger.info("[blooio] registered webhook %s", webhook_url)
+
+    # -- Webhook handlers -----------------------------------------------------
+
+    async def _handle_health(self, request) -> Any:
+        from aiohttp import web
+
+        return web.json_response({"status": "ok", "platform": "blooio"})
+
+    async def _handle_webhook(self, request) -> Any:
+        from aiohttp import web
+
+        try:
+            body = await request.read()
+        except Exception as exc:
+            logger.debug("[blooio] webhook read failed: %s", exc)
+            return web.Response(status=400, text="bad request")
+        if len(body) > WEBHOOK_BODY_MAX_BYTES:
+            return web.Response(status=413, text="payload too large")
+
+        # Verify signature when a secret is configured.
+        if self.signing_secret:
+            signature = request.headers.get("X-Blooio-Signature", "")
+            if not verify_blooio_signature(body, signature, self.signing_secret):
+                return web.Response(status=401, text="invalid signature")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return web.Response(status=400, text="bad json")
+
+        # Blooio may deliver one event or a batch under "events".
+        events = payload.get("events") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            events = [payload]
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            try:
+                await self._dispatch_event(event)
+            except Exception:
+                logger.exception("[blooio] dispatch_event failed")
+
+        return web.Response(status=200, text="ok")
+
+    async def _dispatch_event(self, event: Dict[str, Any]) -> None:
+        # v4 native envelope: {id, type, created_at, organization_id, data:{…}}.
+        # Legacy/flat delivery: {event, …fields…}. Support both.
+        event_type = event.get("type") or event.get("event") or ""
+        data = event.get("data") if isinstance(event.get("data"), dict) else event
+        if "timestamp" not in data and event.get("created_at") is not None:
+            data = {**data, "timestamp": event.get("created_at")}
+
+        if event_type == "message.received":
+            await self._handle_inbound_message(data)
+        elif event_type == "message.reaction":
+            await self._handle_inbound_reaction(data)
+        else:
+            # Delivery receipts (queued/sent/delivered/read/failed), typing,
+            # and everything else are not agent-actionable.
+            logger.debug("[blooio] ignoring event type %r", event_type)
+
+    # ---- inbound message ----------------------------------------------------
+
+    def _resolve_chat(self, event: Dict[str, Any]) -> Tuple[str, str, str, str]:
+        """Return ``(chat_id, chat_type, user_id, group_id)`` for a v4 event.
+
+        The v4 ``chat_id`` (``chat_…``) is the handle used for replies,
+        typing, read receipts, and reactions. ``group_id`` (``grp_…``) is set
+        only for group chats and is what the group allowlist matches;
+        ``user_id`` is the sending party's identifier (phone/email).
+        """
+        chat_id = event.get("chat_id") or ""
+        group_id = event.get("group_id") or ""
+        is_group = bool(group_id) or bool(event.get("is_group"))
+        sender = event.get("sender")
+        if isinstance(sender, dict):
+            sender = sender.get("identifier") or sender.get("address") or ""
+        user_id = sender or (event.get("contact") or {}).get("identifier") or ""
+        return chat_id, ("group" if is_group else "dm"), user_id, group_id
+
+    def _is_allowed(self, chat_type: str, group_id: str, user_id: str) -> bool:
+        if self.allow_all:
+            return True
+        if chat_type == "group":
+            return bool(group_id) and group_id in self.allowed_groups
+        return bool(user_id) and user_id in self.allowed_users
+
+    async def _handle_inbound_message(self, event: Dict[str, Any]) -> None:
+        message_id = event.get("message_id") or ""
+        if message_id and self._dedup.is_duplicate(message_id):
+            logger.debug("[blooio] dropping duplicate message %s", message_id)
+            return
+
+        chat_id, chat_type, user_id, group_id = self._resolve_chat(event)
+        if not chat_id:
+            logger.warning("[blooio] inbound message missing chat id")
+            return
+
+        if not self._is_allowed(chat_type, group_id, user_id):
+            logger.info(
+                "[blooio] rejecting unauthorized %s message from %s",
+                chat_type, _redact(user_id or chat_id),
+            )
+            return
+
+        # Track the last inbound message id per chat so agent-facing reactions
+        # (and read receipts) can default to it.
+        self._record_last_inbound(chat_id, message_id)
+
+        text = event.get("text") or ""
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        mtype = MessageType.TEXT
+
+        for attachment in event.get("attachments") or []:
+            if not isinstance(attachment, dict):
+                continue
+            url = attachment.get("url")
+            if not url:
+                continue
+            hint_name = attachment.get("name") or attachment.get("caption")
+            cached, cached_type = await self._cache_attachment(
+                url, hint_name, media_type=attachment.get("media_type"),
+            )
+            if cached:
+                media_urls.append(cached)
+                media_types.append(cached_type)
+                if mtype == MessageType.TEXT:
+                    mtype = _mime_message_type(cached_type)
+            else:
+                marker = f"[Blooio attachment: {hint_name or url}]"
+                text = f"{text}\n{marker}".strip() if text else marker
+
+        if not text and media_urls:
+            text = "(attachment)"
+
+        # Group-mention gating (DMs never gated).
+        if chat_type == "group" and self.require_mention:
+            if not self._matches_mention(text):
+                logger.debug(
+                    "[blooio] ignoring group message (require_mention, no match)"
+                )
+                return
+            text = self._clean_mention_text(text)
+
+        # Best-effort read receipt.
+        if self.send_read_receipts and self._client:
+            asyncio.create_task(self._safe_mark_read(chat_id))
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=event.get("group_name") or chat_id,
+            chat_type=chat_type,
+            user_id=user_id or chat_id,
+            user_name=user_id or None,
+        )
+        await self.handle_message(
+            MessageEvent(
+                text=text,
+                message_type=mtype,
+                source=source,
+                message_id=message_id,
+                raw_message=event,
+                media_urls=media_urls,
+                media_types=media_types,
+                timestamp=_event_timestamp(event),
+            )
+        )
+
+    async def _handle_inbound_reaction(self, event: Dict[str, Any]) -> None:
+        """Route a tapback/emoji reaction — only on messages the bot sent.
+
+        Reactions on human↔human messages aren't addressed to us. A reaction
+        that targets one of our own sent messages becomes a synthetic
+        ``reaction:added:<value>`` text event (same shape as Photon/Feishu).
+        """
+        message_id = event.get("message_id") or ""
+        action = event.get("action") or "add"
+        reaction_id = f"{message_id}:{event.get('reaction')}:{action}:{event.get('timestamp')}"
+        if self._dedup.is_duplicate(reaction_id):
+            return
+
+        # Only surface reactions on OUR outbound messages.
+        if not message_id or message_id not in self._sent_message_ids:
+            logger.debug("[blooio] ignoring reaction on a message we didn't send")
+            return
+
+        # No allowlist gate here: a reaction on one of OUR messages is
+        # implicitly addressed to the bot (the sent-id check above is the
+        # real gate), same as the Photon iMessage plugin.
+        chat_id, chat_type, user_id, _group_id = self._resolve_chat(event)
+        if not chat_id:
+            return
+
+        reaction = event.get("reaction") or ""
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=event.get("group_name") or chat_id,
+            chat_type=chat_type,
+            user_id=user_id or chat_id,
+            user_name=user_id or None,
+        )
+        await self.handle_message(
+            MessageEvent(
+                text=f"reaction:{action}:{reaction}",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=message_id,
+                reply_to_message_id=message_id,
+                reply_to_text=event.get("original_text") or None,
+                reply_to_is_own_message=True,
+                raw_message=event,
+                timestamp=_event_timestamp(event),
+            )
+        )
+
+    async def _safe_mark_read(self, chat_id: str) -> None:
+        try:
+            await self._client.mark_read(chat_id)
+        except Exception as exc:
+            logger.debug("[blooio] mark_read failed: %s", exc)
+
+    async def _cache_attachment(
+        self, url: str, name: Optional[str], *, media_type: Optional[str] = None
+    ) -> Tuple[Optional[str], str]:
+        """Download a Blooio attachment URL and cache it as a local path."""
+        if not self._client:
+            return None, ""
+        try:
+            raw = await self._client.download(url)
+        except Exception as exc:
+            logger.warning("[blooio] attachment download failed: %s", exc)
+            return None, ""
+        # v4 attachments carry an explicit media_type; fall back to guessing
+        # from the name/url when absent.
+        mime = (media_type or "").lower()
+        if not mime:
+            guessed, _ = mimetypes.guess_type(name or url)
+            mime = (guessed or "").lower()
+        suffix = Path(name).suffix if name else ""
+        try:
+            if mime.startswith("image/"):
+                return cache_image_from_bytes(raw, suffix or ".jpg"), mime
+            if mime.startswith("audio/"):
+                return cache_audio_from_bytes(raw, suffix or ".m4a"), mime
+            if mime.startswith("video/"):
+                return cache_video_from_bytes(raw, suffix or ".mp4"), mime
+            return cache_document_from_bytes(raw, name or "attachment"), (
+                mime or "application/octet-stream"
+            )
+        except Exception as exc:
+            logger.warning("[blooio] failed to cache attachment: %s", exc)
+            return None, ""
+
+    # -- Sent-id + last-inbound tracking --------------------------------------
+
+    def _record_sent_message(self, message_id: Optional[str]) -> None:
+        if not message_id:
+            return
+        sent = self._sent_message_ids
+        sent.pop(message_id, None)
+        sent[message_id] = time.time()
+        if len(sent) > self._SENT_IDS_MAX:
+            for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
+                del sent[old]
+
+    def _record_last_inbound(self, chat_id: str, message_id: str) -> None:
+        if not chat_id or not message_id:
+            return
+        last = self._last_inbound_by_chat
+        last.pop(chat_id, None)
+        last[chat_id] = message_id
+        if len(last) > self._LAST_INBOUND_CHATS_MAX:
+            for old in list(last.keys())[: len(last) - self._LAST_INBOUND_CHATS_MAX]:
+                del last[old]
+
+    # -- Outbound: text -------------------------------------------------------
+
+    async def _send_body(self, chat_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Route a send: reply into a ``chat_…`` handle, else address by ``to``.
+
+        Replies into an existing chat (the common case — inbound events carry a
+        ``chat_…`` id) infer the sender from the chat. When ``chat_id`` is a
+        bare recipient (phone/email, e.g. cron / home-channel delivery) we fall
+        back to ``POST /messages`` with ``to`` (+ optional ``from``).
+        """
+        if str(chat_id).startswith("chat_"):
+            return await self._client.send_to_chat(chat_id, body)
+        payload = {**body, "to": chat_id}
+        if self.channel_ref:
+            payload["from"] = self.channel_ref
+        return await self._client.send_agnostic(payload)
+
+    @staticmethod
+    def _extract_message_id(data: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        mid = payload.get("id") or payload.get("message_id")
+        if not mid:
+            ids = payload.get("message_ids") or []
+            mid = ids[-1] if ids else None
+        return mid, payload
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._client:
+            return SendResult(success=False, error="Blooio adapter not connected")
+
+        text = self.format_message(content)
+        chunks = self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
+        if not chunks:
+            return SendResult(success=True, message_id=None)
+
+        last_id: Optional[str] = None
+        last_data: Dict[str, Any] = {}
+        for idx, chunk in enumerate(chunks):
+            body: Dict[str, Any] = {"text": chunk}
+            if reply_to and idx == 0:
+                body["reply_to"] = reply_to
+            try:
+                data = await self._send_body(chat_id, body)
+            except Exception as exc:
+                logger.error("[blooio] send failed: %s", _redact(str(exc)))
+                return SendResult(success=False, error=str(exc))
+            mid, _ = self._extract_message_id(data)
+            self._record_sent_message(mid)
+            last_id, last_data = (mid or last_id), data
+        return SendResult(success=True, message_id=last_id, raw_response=last_data)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        now = time.time()
+        if now - self._typing_last_sent.get(chat_id, 0.0) < _TYPING_COOLDOWN_SECONDS:
+            return
+        self._typing_last_sent[chat_id] = now
+        if self._client:
+            try:
+                await self._client.set_typing(chat_id, True)
+            except Exception as exc:
+                logger.debug("[blooio] send_typing failed: %s", exc)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        self._typing_last_sent.pop(chat_id, None)
+        if self._client:
+            try:
+                await self._client.set_typing(chat_id, False)
+            except Exception as exc:
+                logger.debug("[blooio] stop_typing failed: %s", exc)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        chat_type = "group" if str(chat_id).startswith("grp_") else "dm"
+        return {"name": chat_id, "type": chat_type, "id": chat_id}
+
+    def format_message(self, content: str) -> str:
+        # iMessage renders plain text — strip Markdown the client can't show.
+        return strip_markdown(content)
+
+    # -- Outbound: media ------------------------------------------------------
+
+    async def _send_attachment_urls(
+        self,
+        chat_id: str,
+        urls: List[str],
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        if not self._client:
+            return SendResult(success=False, error="Blooio adapter not connected")
+        body: Dict[str, Any] = {"attachments": urls}
+        if caption:
+            body["text"] = self.format_message(caption)
+        try:
+            data = await self._send_body(chat_id, body)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+        message_id, _ = self._extract_message_id(data)
+        self._record_sent_message(message_id)
+        return SendResult(success=True, message_id=message_id, raw_response=data)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # Blooio ingests attachment URLs directly — pass a remote URL through.
+        if _is_http_url(image_url):
+            return await self._send_attachment_urls(chat_id, [image_url], caption)
+        return await self.send_image_file(chat_id, image_url, caption)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, image_path, caption)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(video_path):
+            return await self._send_attachment_urls(chat_id, [video_path], caption)
+        return await self._send_local_file(chat_id, video_path, caption)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(audio_path):
+            return await self._send_attachment_urls(chat_id, [audio_path], caption)
+        return await self._send_local_file(chat_id, audio_path, caption)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(file_path):
+            return await self._send_attachment_urls(chat_id, [file_path], caption)
+        return await self._send_local_file(chat_id, file_path, caption, name=file_name)
+
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # iMessage renders GIFs inline as ordinary image attachments.
+        return await self.send_image(chat_id, animation_url, caption, reply_to, metadata)
+
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        path: str,
+        caption: Optional[str],
+        *,
+        name: Optional[str] = None,
+    ) -> SendResult:
+        """Serve a local file over the public URL, then send it as an attachment."""
+        safe_path = self.validate_media_delivery_path(str(path))
+        if not safe_path:
+            return SendResult(success=False, error=f"unsafe or missing path: {path}")
+        if not self.public_base_url:
+            return SendResult(
+                success=False,
+                error="BLOOIO_PUBLIC_URL must be set to send local files "
+                "(Blooio fetches attachments from a public HTTPS URL)",
+            )
+        token = self._register_media(safe_path)
+        url = self._media_url(token, name or Path(safe_path).name)
+        if not url.lower().startswith("https://"):
+            return SendResult(
+                success=False, error=f"Blooio attachment URL must be HTTPS: {url}"
+            )
+        return await self._send_attachment_urls(chat_id, [url], caption)
+
+    def _register_media(self, file_path: str) -> str:
+        now = time.time()
+        for token in list(self._media_tokens.keys()):
+            _, exp = self._media_tokens[token]
+            if now > exp:
+                self._media_tokens.pop(token, None)
+        resolved = str(Path(file_path).resolve())
+        token = secrets.token_urlsafe(32)
+        self._media_tokens[token] = (resolved, now + self._media_ttl)
+        return token
+
+    def _media_url(self, token: str, filename: str) -> str:
+        base = self.public_base_url
+        safe_name = _urlquote(filename, safe="")
+        return f"{base}{DEFAULT_MEDIA_PATH_PREFIX}/{token}/{safe_name}"
+
+    async def _handle_media(self, request) -> Any:
+        from aiohttp import web
+
+        token = request.match_info["token"]
+        entry = self._media_tokens.get(token)
+        if not entry:
+            return web.Response(status=404, text="not found")
+        file_path, expires_at = entry
+        if time.time() > expires_at:
+            self._media_tokens.pop(token, None)
+            return web.Response(status=410, text="gone")
+        path = Path(file_path)
+        if not path.exists() or not path.is_file():
+            return web.Response(status=404, text="not found")
+
+        try:
+            from hermes_constants import get_hermes_home
+
+            hermes_home = Path(get_hermes_home()).resolve()
+        except Exception:
+            hermes_home = Path.home().joinpath(".hermes").resolve()
+        allowed_roots = {
+            Path(tempfile.gettempdir()).resolve(),
+            Path("/tmp").resolve(),
+            hermes_home,
+        }
+        resolved = path.resolve()
+        if not any(_is_relative_to(resolved, r) for r in allowed_roots):
+            logger.warning("[blooio] refusing to serve outside allowed roots")
+            return web.Response(status=403, text="forbidden")
+        content_type, _ = mimetypes.guess_type(str(path))
+        return web.FileResponse(
+            path, headers={"Content-Type": content_type or "application/octet-stream"}
+        )
+
+    # -- Reactions ------------------------------------------------------------
+
+    def _reactions_enabled(self) -> bool:
+        return _truthy(os.getenv("BLOOIO_REACTIONS"), False)
+
+    @staticmethod
+    def _normalize_reaction(value: str) -> str:
+        """Return a Blooio reaction token (classic tapback name or emoji).
+
+        Values already prefixed with ``+``/``-`` are respected. Bare classic
+        tapback names and bare emoji default to ``+`` (add).
+        """
+        value = (value or "").strip()
+        if value[:1] in {"+", "-"}:
+            return value
+        return f"+{value}"
+
+    async def _react(
+        self, chat_id: str, message_id: str, reaction: str,
+    ) -> bool:
+        if not self._client:
+            return False
+        try:
+            await self._client.react(
+                chat_id, message_id, self._normalize_reaction(reaction),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("[blooio] react failed: %s", exc)
+            return False
+
+    async def _unreact(self, chat_id: str, message_id: str, reaction: str) -> bool:
+        if not self._client:
+            return False
+        value = (reaction or "").strip().lstrip("+")
+        try:
+            await self._client.react(chat_id, message_id, f"-{value}")
+            return True
+        except Exception as exc:
+            logger.debug("[blooio] unreact failed: %s", exc)
+            return False
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Agent-facing tapback/emoji reaction on a message in ``chat_id``.
+
+        Without an explicit ``message_id`` we target the chat's most recent
+        inbound message (v4 reactions require a concrete ``msg_…`` id). ``emoji``
+        may be a classic tapback name (``love``, ``like``, …) or any emoji,
+        with an optional ``+``/``-`` prefix.
+        """
+        target = message_id or self._last_inbound_by_chat.get(chat_id)
+        if not target:
+            return {"success": False, "error": "no message to react to"}
+        ok = await self._react(chat_id, target, emoji)
+        if not ok:
+            return {"success": False, "error": "reaction failed (see debug log)"}
+        return {"success": True, "message_id": target}
+
+    async def remove_reaction(
+        self, chat_id: str, emoji: str = "", message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        target = message_id or self._last_inbound_by_chat.get(chat_id)
+        if not target:
+            return {"success": False, "error": "no message to unreact"}
+        ok = await self._unreact(chat_id, target, emoji or _REACTION_WORKING)
+        if not ok:
+            return {"success": False, "error": "unreact failed (see debug log)"}
+        return {"success": True, "message_id": target}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        if not self._reactions_enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if chat_id and message_id:
+            await self._react(chat_id, message_id, _REACTION_WORKING)
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        if not self._reactions_enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not chat_id or not message_id:
+            return
+        await self._unreact(chat_id, message_id, _REACTION_WORKING)
+        if outcome == ProcessingOutcome.SUCCESS:
+            await self._react(chat_id, message_id, _REACTION_SUCCESS)
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self._react(chat_id, message_id, _REACTION_FAILURE)
+        # CANCELLED: leave unreacted.
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+def _is_http_url(value: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(("http://", "https://"))
+
+
+def _mime_message_type(mime: str) -> MessageType:
+    mime = (mime or "").lower()
+    if mime.startswith("image/"):
+        return MessageType.PHOTO
+    if mime.startswith("video/"):
+        return MessageType.VIDEO
+    if mime.startswith("audio/"):
+        return MessageType.AUDIO
+    return MessageType.DOCUMENT
+
+
+def _event_timestamp(event: Dict[str, Any]):
+    from datetime import datetime, timezone
+
+    raw = event.get("timestamp")
+    if isinstance(raw, (int, float)):
+        try:
+            # Blooio timestamps are milliseconds since epoch.
+            return datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            pass
+    return datetime.now(tz=timezone.utc)
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        return child.resolve().is_relative_to(parent.resolve())
+    except (AttributeError, ValueError):
+        try:
+            child.resolve().relative_to(parent.resolve())
+            return True
+        except ValueError:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry-point hooks
+# ---------------------------------------------------------------------------
+
+def check_requirements() -> bool:
+    """Plugin gate: OAuth token (or API key) plus aiohttp + httpx at runtime."""
+    if not _auth.has_credentials():
+        return False
+    try:
+        import aiohttp  # noqa: F401
+        import httpx  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        os.getenv("BLOOIO_API_KEY") or extra.get("api_key") or _auth.has_credentials()
+    )
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    """Auto-seed PlatformConfig.extra from an env-only / OAuth Blooio setup."""
+    if not _auth.has_credentials():
+        return None
+    seeded: Dict[str, Any] = {}
+    if os.getenv("BLOOIO_PORT"):
+        try:
+            seeded["port"] = int(os.environ["BLOOIO_PORT"])
+        except ValueError:
+            pass
+    if os.getenv("BLOOIO_HOST"):
+        seeded["host"] = os.environ["BLOOIO_HOST"]
+    if os.getenv("BLOOIO_PUBLIC_URL"):
+        seeded["public_url"] = os.environ["BLOOIO_PUBLIC_URL"]
+    if os.getenv("BLOOIO_HOME_CHANNEL"):
+        seeded["home_channel"] = {
+            "chat_id": os.environ["BLOOIO_HOME_CHANNEL"],
+            "name": os.getenv("BLOOIO_HOME_CHANNEL_NAME", "Home"),
+        }
+    return seeded or {}
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[Any]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process send for cron jobs detached from the gateway.
+
+    Resolves auth the same way the gateway does (OAuth token or API key) and
+    sends via the Blooio v4 REST API. A ``chat_…`` target replies into that
+    chat; a bare phone/email is addressed via ``POST /messages``. Remote media
+    URLs are forwarded as attachments; local files can't be served without the
+    gateway's webhook server bound, so we note them as a text hint instead.
+    """
+    auth = _auth.resolve_auth(pconfig)
+    if auth is None or not chat_id:
+        return {"error": "Blooio standalone send: not authenticated or missing chat_id"}
+    extra = getattr(pconfig, "extra", {}) or {}
+    org = os.getenv("BLOOIO_ORG_ID") or extra.get("organization_id", "")
+    if org:
+        auth.organization_id = org
+
+    base_url = (
+        os.getenv("BLOOIO_API_BASE_URL")
+        or extra.get("api_base_url")
+        or DEFAULT_API_BASE_URL
+    )
+    client = _BlooioClient(auth, base_url)
+
+    body: Dict[str, Any] = {}
+    text = strip_markdown(message or "")
+    remote_urls: List[str] = []
+    local_hint = 0
+    for item in media_files or []:
+        path = item[0] if isinstance(item, (list, tuple)) else item
+        if _is_http_url(str(path)):
+            remote_urls.append(str(path))
+        else:
+            local_hint += 1
+    if local_hint:
+        hint = f"[{local_hint} attachment(s) generated; not deliverable from cron]"
+        text = f"{text}\n{hint}".strip() if text else hint
+    if text:
+        body["text"] = text[:MAX_TEXT_LENGTH]
+    if remote_urls:
+        body["attachments"] = remote_urls
+    if not body:
+        return {"error": "Blooio standalone send: nothing to send"}
+
+    channel_ref = (
+        os.getenv("BLOOIO_CHANNEL")
+        or os.getenv("BLOOIO_FROM_NUMBER")
+        or extra.get("channel")
+        or extra.get("from_number", "")
+    )
+    try:
+        if str(chat_id).startswith("chat_"):
+            data = await client.send_to_chat(chat_id, body)
+        else:
+            payload = {**body, "to": chat_id}
+            if channel_ref:
+                payload["from"] = channel_ref
+            data = await client.send_agnostic(payload)
+    except Exception as exc:
+        return {"error": str(exc)}
+    payload = data.get("data") if isinstance(data.get("data"), dict) else data
+    message_id = payload.get("id") or payload.get("message_id") or (
+        payload.get("message_ids") or [None]
+    )[-1]
+    return {"success": True, "message_id": message_id}
+
+
+def interactive_setup() -> None:
+    """Stdin wizard for ``hermes setup blooio`` / gateway setup.
+
+    OAuth is the default: unless ``BLOOIO_API_KEY`` is already set, this runs
+    the one-click ``hermes blooio login`` flow, then captures the inbound-webhook
+    settings (public URL + optional allowlist).
+    """
+    print()
+    print("Blooio (iMessage) setup")
+    print("-----------------------")
+    print("Blooio delivers inbound messages via webhooks, so Hermes must be")
+    print("reachable at a public HTTPS URL (Cloudflare Tunnel, ngrok, etc.).")
+    print()
+
+    if not os.getenv("BLOOIO_API_KEY"):
+        try:
+            import asyncio
+
+            asyncio.run(_auth.login())
+        except Exception as exc:
+            print(f"OAuth login skipped ({exc}). You can retry with `hermes blooio login`.")
+
+    try:
+        from hermes_cli.config import get_env_value, save_env_value
+    except ImportError:
+        print("hermes_cli.config not available; set BLOOIO_* vars manually in ~/.hermes/.env")
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_value(var) if callable(get_env_value) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            save_env_value(var, value)
+
+    # OAuth (above) is the default; only prompt for an API key when OAuth
+    # didn't produce credentials (headless/CI use).
+    if not _auth.has_credentials():
+        _prompt("BLOOIO_API_KEY", "Blooio API key (headless alternative to OAuth)", secret=True)
+    _prompt("BLOOIO_PUBLIC_URL", "Public HTTPS base URL (e.g. https://my-tunnel.example.com)")
+    _prompt("BLOOIO_ALLOWED_USERS", "Allowed sender phone numbers/emails (comma-separated; blank=skip)")
+    print(
+        "\nInbound webhook: set BLOOIO_AUTO_REGISTER_WEBHOOK=true to have Hermes "
+        "create the webhook (and capture its signing secret) on connect, or add "
+        "one in the dashboard pointing at <your-public-url>/blooio/webhook and "
+        "copy its signing secret into BLOOIO_WEBHOOK_SECRET."
+    )
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    from . import cli as _cli
+
+    ctx.register_platform(
+        name="blooio",
+        label="iMessage via Blooio",
+        adapter_factory=lambda cfg: BlooioAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        # OAuth stores its tokens in ~/.hermes/auth.json (not .env), so there is
+        # no hard-required env var; the check/validate hooks gate on either the
+        # OAuth token or an API key. (BLOOIO_API_KEY remains a headless option.)
+        required_env=[],
+        install_hint=(
+            "Run: hermes blooio login  (one-click OAuth with the official "
+            "Blooio app). Blooio delivers inbound messages via webhook, so "
+            "expose Hermes at a public HTTPS URL (Cloudflare Tunnel/ngrok) and "
+            "set BLOOIO_PUBLIC_URL. Headless/CI alternative: set BLOOIO_API_KEY."
+        ),
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="BLOOIO_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="BLOOIO_ALLOWED_USERS",
+        allow_all_env="BLOOIO_ALLOW_ALL_USERS",
+        max_message_length=MAX_TEXT_LENGTH,
+        emoji="💬",
+        # iMessage identifiers are E.164 phone numbers / emails → PII-sensitive,
+        # matching the BlueBubbles and Photon iMessage channels.
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint=(
+            "You are communicating over iMessage via Blooio. Treat replies "
+            "like normal text messages — short, friendly, and conversational. "
+            "iMessage does NOT render Markdown, so avoid ** or # markup; bare "
+            "URLs are fine and get a rich preview. Recipient identifiers are "
+            "E.164 phone numbers or emails — never expose them unless asked. "
+            "You can react to messages with tapbacks (love, like, dislike, "
+            "laugh, emphasize, question) or emoji."
+        ),
+    )
+
+    # `hermes blooio login|logout|status|setup`
+    ctx.register_cli_command(
+        name="blooio",
+        help="Connect and manage the Blooio iMessage integration (OAuth)",
+        setup_fn=_cli.register_cli,
+        handler_fn=_cli.dispatch,
+    )

--- a/plugins/platforms/blooio/adapter.py
+++ b/plugins/platforms/blooio/adapter.py
@@ -1,0 +1,1519 @@
+"""
+Blooio (iMessage) platform adapter for Hermes Agent.
+
+Blooio is a hosted iMessage API — you send and receive real iMessages (with
+SMS/RCS fallback) through a REST API and inbound webhooks, without running a
+Mac yourself. This adapter is the twin of the built-in BlueBubbles iMessage
+channel and the Photon Spectrum plugin, but talks to Blooio's v4 REST API
+(``https://api.blooio.com/v4``) and authenticates via the official "Blooio
+for Hermes" OAuth app (Authorization Code + PKCE), with an API key as a
+headless fallback. See ``auth.py`` for the OAuth/token handling.
+
+Design
+------
+
+**Inbound = webhooks.** The adapter runs a small ``aiohttp`` webhook server
+and registers ``/blooio/webhook`` with Blooio. Each event is HMAC-SHA256
+signature-verified (Stripe-style ``X-Blooio-Signature: t=<ts>,v1=<hex>``
+over ``"{ts}.{rawBody}"``) using the webhook's signing secret, deduped on
+``message_id``, and dispatched to the gateway as a normalized
+``MessageEvent``. v4 delivers a typed envelope
+(``{type, created_at, organization_id, data:{…}}``); ``message.received``
+becomes an inbound message, ``message.reaction`` on one of the bot's own
+messages becomes a synthetic ``reaction:add:<emoji>`` event (same pattern as
+Photon/Feishu), and delivery receipts are ignored.
+
+**Outbound = REST.** Replies POST to ``/chats/{chat_id}/messages`` (the
+``chat_…`` handle carried by every inbound event; the sender is inferred from
+the chat). Cron / home-channel delivery to a bare phone/email instead uses
+``POST /messages`` with ``to`` (+ optional ``from`` channel). Long replies are
+chunked and sent sequentially. Typing indicators, read receipts, and
+tapback/emoji reactions each map to a dedicated v4 chat endpoint. Requests are
+scoped with ``X-Organization-Id`` when the token/config carries an org id.
+
+**Media.** Blooio attachments are HTTPS URLs. Sending a remote image URL is a
+straight pass-through; sending a local file requires a publicly reachable
+``BLOOIO_PUBLIC_URL`` — the file is registered and served from the same
+aiohttp app (``/blooio/media/<token>/<name>``) with a traversal guard, exactly
+like the LINE plugin.
+
+**Requires a public HTTPS host.** Inbound webhooks and local-file attachment
+URLs both need Blooio to reach this process, so a laptop-only Hermes must be
+exposed via Cloudflare Tunnel / Tailscale Funnel / ngrok. Set
+``BLOOIO_PUBLIC_URL`` to that hostname.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import mimetypes
+import os
+import re
+import secrets
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import quote as _urlquote
+
+logger = logging.getLogger(__name__)
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
+    cache_video_from_bytes,
+)
+from gateway.platforms.helpers import strip_markdown
+from gateway.config import Platform
+
+from . import auth as _auth
+from .auth import BlooioAuth, BlooioAuthError
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_API_BASE_URL = "https://api.blooio.com/v4"
+
+DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WEBHOOK_PORT = 8647
+DEFAULT_WEBHOOK_PATH = "/blooio/webhook"
+DEFAULT_MEDIA_PATH_PREFIX = "/blooio/media"
+
+# Webhook events are small JSON payloads; attachments arrive as URLs, not
+# inline bytes, so a 1 MiB cap is generous headroom.
+WEBHOOK_BODY_MAX_BYTES = 1_048_576
+
+# iMessage has no documented hard cap, but the protocol gets unhappy past
+# ~16 KB. Match the BlueBubbles channel's conservative per-bubble limit.
+MAX_TEXT_LENGTH = 4000
+
+# Reject webhook events whose signature timestamp is too old/new — bounds a
+# replay window. Blooio signs with seconds since epoch.
+_SIGNATURE_TOLERANCE_SECONDS = 5 * 60
+
+# Bounded dedup of processed message ids (webhooks are at-least-once).
+_DEDUP_MAX_SIZE = 2000
+
+# iMessage classic tapbacks. Blooio accepts these names (prefixed ``+``/``-``)
+# or any emoji. We keep the set so a plugin-side reaction request can validate
+# a friendly name before falling back to treating the value as an emoji.
+_CLASSIC_TAPBACKS = {
+    "love", "like", "dislike", "laugh", "emphasize", "question",
+}
+
+# Lifecycle-hook tapbacks (opt-in via BLOOIO_REACTIONS). iMessage renders
+# these emoji as native reactions.
+_REACTION_WORKING = "👀"
+_REACTION_SUCCESS = "👍"
+_REACTION_FAILURE = "👎"
+
+# Group-chat mention wake words — identical defaults to the BlueBubbles and
+# Photon iMessage channels so all three gate group chats the same way.
+DEFAULT_MENTION_PATTERNS = [
+    r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
+    r"(?<![\w@])@?hermes\b[,:\-]?",
+]
+
+# Log redaction — iMessage identifiers are phone numbers / emails (PII).
+_PHONE_RE = re.compile(r"\+?\d{7,15}")
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
+
+# Minimum seconds between typing-indicator calls for the same chat.
+_TYPING_COOLDOWN_SECONDS = 5.0
+
+
+def _redact(text: str) -> str:
+    """Mask phone numbers and emails in log output."""
+    if not text:
+        return text
+    text = _PHONE_RE.sub("[redacted]", text)
+    text = _EMAIL_RE.sub("[redacted]", text)
+    return text
+
+
+def _csv_set(value: str) -> Set[str]:
+    if not value:
+        return set()
+    return {x.strip() for x in value.split(",") if x.strip()}
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification
+# ---------------------------------------------------------------------------
+
+def verify_blooio_signature(
+    body: bytes,
+    signature_header: str,
+    signing_secret: str,
+    *,
+    tolerance_seconds: int = _SIGNATURE_TOLERANCE_SECONDS,
+    now: Optional[float] = None,
+) -> bool:
+    """Verify a Blooio ``X-Blooio-Signature`` header.
+
+    Blooio signs the *raw* request body Stripe-style: the header is
+    ``t=<unix_seconds>,v1=<hex>`` where ``v1`` is the hex HMAC-SHA256 of
+    ``"{t}.{raw_body}"`` keyed by the webhook's signing secret
+    (``whsec_…``). The timestamp is checked against ``tolerance_seconds`` to
+    bound replay, and the digest is compared in constant time.
+    """
+    if not signature_header or not signing_secret or body is None:
+        return False
+
+    parsed: Dict[str, str] = {}
+    for part in signature_header.split(","):
+        key, _, val = part.strip().partition("=")
+        if key and val:
+            parsed[key.strip()] = val.strip()
+
+    timestamp = parsed.get("t")
+    provided = parsed.get("v1")
+    if not timestamp or not provided:
+        return False
+
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+
+    current = time.time() if now is None else now
+    if tolerance_seconds and abs(current - ts) > tolerance_seconds:
+        return False
+
+    try:
+        signed_payload = f"{timestamp}.".encode("utf-8") + body
+        expected = hmac.new(
+            signing_secret.encode("utf-8"),
+            signed_payload,
+            hashlib.sha256,
+        ).hexdigest()
+    except Exception:
+        return False
+    return hmac.compare_digest(expected, provided)
+
+
+# ---------------------------------------------------------------------------
+# Inbound dedup
+# ---------------------------------------------------------------------------
+
+class _MessageDeduplicator:
+    """Bounded LRU of processed ids to drop at-least-once webhook retries."""
+
+    def __init__(self, max_size: int = _DEDUP_MAX_SIZE) -> None:
+        self._seen: Dict[str, float] = {}
+        self._max = max_size
+
+    def is_duplicate(self, key: str) -> bool:
+        if not key:
+            return False
+        if key in self._seen:
+            return True
+        if len(self._seen) >= self._max:
+            cutoff = sorted(self._seen.values())[len(self._seen) // 10 or 1]
+            self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+        self._seen[key] = time.time()
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Blooio REST client
+# ---------------------------------------------------------------------------
+
+class _BlooioClient:
+    """Thin async wrapper over the Blooio v4 REST API (httpx).
+
+    Auth is resolved per request from a :class:`BlooioAuth` (API key or an
+    auto-refreshing OAuth access token). When the auth carries an organization
+    id it is sent as ``X-Organization-Id`` — required when an OAuth token is
+    installed on more than one org.
+    """
+
+    def __init__(self, auth: BlooioAuth, base_url: str, *, timeout: float = 30.0) -> None:
+        self._auth = auth
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {await self._auth.bearer()}",
+            "Content-Type": "application/json",
+        }
+        if self._auth.organization_id:
+            headers["X-Organization-Id"] = self._auth.organization_id
+        return headers
+
+    async def _request(
+        self, method: str, path: str, *, json_body: Optional[dict] = None
+    ) -> Dict[str, Any]:
+        import httpx
+
+        url = f"{self._base}{path}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.request(
+                method, url, headers=await self._headers(), json=json_body
+            )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Blooio {method} {path} → {resp.status_code}: {resp.text[:200]}"
+            )
+        try:
+            return resp.json() or {}
+        except Exception:
+            return {}
+
+    async def get_me(self) -> Dict[str, Any]:
+        return await self._request("GET", "/me")
+
+    async def send_to_chat(self, chat_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Reply into an existing v4 chat (``chat_…``); sender is implicit."""
+        return await self._request(
+            "POST", f"/chats/{_urlquote(chat_id, safe='')}/messages", json_body=body
+        )
+
+    async def send_agnostic(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Routed send: ``POST /messages`` with ``to`` (+ optional ``from``)."""
+        return await self._request("POST", "/messages", json_body=body)
+
+    async def set_typing(self, chat_id: str, active: bool) -> None:
+        if active:
+            await self._request(
+                "POST",
+                f"/chats/{_urlquote(chat_id, safe='')}/typing",
+                json_body={"state": "started"},
+            )
+        else:
+            await self._request("DELETE", f"/chats/{_urlquote(chat_id, safe='')}/typing")
+
+    async def mark_read(self, chat_id: str) -> None:
+        await self._request("POST", f"/chats/{_urlquote(chat_id, safe='')}/read")
+
+    async def react(
+        self, chat_id: str, message_id: str, reaction: str,
+    ) -> Dict[str, Any]:
+        # v4 encodes add/remove in the reaction value's +/- prefix (no
+        # separate direction field, unlike v2).
+        return await self._request(
+            "POST",
+            f"/chats/{_urlquote(chat_id, safe='')}/messages/"
+            f"{_urlquote(str(message_id), safe='')}/reactions",
+            json_body={"reaction": reaction},
+        )
+
+    async def create_webhook(self, webhook_url: str) -> Dict[str, Any]:
+        # v4 webhooks receive all events; the body is just the target url.
+        return await self._request(
+            "POST", "/webhooks", json_body={"url": webhook_url}
+        )
+
+    async def download(self, url: str) -> bytes:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=self._timeout, follow_redirects=True) as client:
+            resp = await client.get(url)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Blooio attachment download {resp.status_code}")
+            return resp.content
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class BlooioAdapter(BasePlatformAdapter):
+    """Blooio iMessage gateway adapter (webhook in, REST out)."""
+
+    SUPPORTS_MESSAGE_EDITING = False
+    MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
+    splits_long_messages = True
+
+    _SENT_IDS_MAX = 1000
+    _LAST_INBOUND_CHATS_MAX = 200
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config=config, platform=Platform("blooio"))
+        extra = getattr(config, "extra", {}) or {}
+
+        # Auth (OAuth access token or API-key fallback) is resolved on connect.
+        self._auth: Optional[BlooioAuth] = None
+        self.organization_id = (
+            os.getenv("BLOOIO_ORG_ID") or extra.get("organization_id", "") or ""
+        )
+        self.signing_secret = (
+            os.getenv("BLOOIO_WEBHOOK_SECRET") or extra.get("webhook_secret", "")
+        )
+        self.api_base_url = (
+            os.getenv("BLOOIO_API_BASE_URL")
+            or extra.get("api_base_url")
+            or DEFAULT_API_BASE_URL
+        )
+        # Optional explicit sender for routed (non-reply) sends: a channel id
+        # (``ch_…``), phone number, or alias. Replies into an existing chat
+        # infer the sender from the chat, so this only matters for cron /
+        # home-channel delivery via ``POST /messages``.
+        self.channel_ref = (
+            os.getenv("BLOOIO_CHANNEL")
+            or os.getenv("BLOOIO_FROM_NUMBER")
+            or extra.get("channel")
+            or extra.get("from_number", "")
+            or ""
+        )
+
+        # Webhook server
+        self.webhook_host = os.getenv("BLOOIO_HOST") or extra.get("host", DEFAULT_WEBHOOK_HOST)
+        try:
+            self.webhook_port = int(
+                os.getenv("BLOOIO_PORT") or extra.get("port", DEFAULT_WEBHOOK_PORT)
+            )
+        except (TypeError, ValueError):
+            self.webhook_port = DEFAULT_WEBHOOK_PORT
+        self.webhook_path = extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
+        if not str(self.webhook_path).startswith("/"):
+            self.webhook_path = f"/{self.webhook_path}"
+
+        self.public_base_url = (
+            os.getenv("BLOOIO_PUBLIC_URL") or extra.get("public_url", "") or ""
+        ).rstrip("/")
+        self.auto_register_webhook = _truthy(
+            os.getenv("BLOOIO_AUTO_REGISTER_WEBHOOK"),
+            bool(extra.get("auto_register_webhook", False)),
+        )
+
+        # Allowlist gating (phones/emails for DMs, grp_ ids for groups)
+        self.allow_all = _truthy(
+            os.getenv("BLOOIO_ALLOW_ALL_USERS"), bool(extra.get("allow_all_users", False))
+        )
+        self.allowed_users = _csv_set(os.getenv("BLOOIO_ALLOWED_USERS", "")) | set(
+            extra.get("allowed_users", [])
+        )
+        self.allowed_groups = _csv_set(os.getenv("BLOOIO_ALLOWED_GROUPS", "")) | set(
+            extra.get("allowed_groups", [])
+        )
+
+        # Group-mention gating (parity with BlueBubbles / Photon). DMs never gated.
+        _require_mention = extra.get("require_mention")
+        if _require_mention is None:
+            _require_mention = os.getenv("BLOOIO_REQUIRE_MENTION")
+        self.require_mention = _truthy(_require_mention)
+        self._mention_patterns = self._compile_mention_patterns(
+            extra["mention_patterns"]
+            if "mention_patterns" in extra
+            else os.getenv("BLOOIO_MENTION_PATTERNS")
+        )
+
+        # Read receipts + reactions are opt-in.
+        self.send_read_receipts = _truthy(
+            os.getenv("BLOOIO_SEND_READ_RECEIPTS"),
+            bool(extra.get("send_read_receipts", False)),
+        )
+
+        # Runtime state
+        self._client: Optional[_BlooioClient] = None
+        self._app = None
+        self._runner = None
+        self._site = None
+        self._dedup = _MessageDeduplicator()
+        self._sent_message_ids: Dict[str, float] = {}
+        self._last_inbound_by_chat: Dict[str, str] = {}
+        self._typing_last_sent: Dict[str, float] = {}
+
+        # Media serving state (local files → public HTTPS for Blooio to fetch)
+        self._media_tokens: Dict[str, Tuple[str, float]] = {}
+        self._media_temp_paths: Set[str] = set()
+        self._media_ttl = 1800
+
+    # -- Group-mention gating -------------------------------------------------
+
+    @staticmethod
+    def _compile_mention_patterns(raw: Any) -> "list[re.Pattern]":
+        if raw is None:
+            patterns: List[Any] = list(DEFAULT_MENTION_PATTERNS)
+        elif isinstance(raw, str):
+            text = raw.strip()
+            try:
+                loaded = json.loads(text) if text else []
+            except Exception:
+                loaded = None
+            patterns = loaded if isinstance(loaded, list) else [
+                part.strip()
+                for line in text.splitlines()
+                for part in line.split(",")
+            ]
+        elif isinstance(raw, list):
+            patterns = raw
+        else:
+            patterns = [raw]
+
+        compiled: "list[re.Pattern]" = []
+        for pattern in patterns:
+            token = str(pattern).strip()
+            if not token:
+                continue
+            try:
+                compiled.append(re.compile(token, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning("[blooio] invalid mention pattern %r: %s", token, exc)
+        return compiled
+
+    def _matches_mention(self, text: str) -> bool:
+        if not text or not self._mention_patterns:
+            return False
+        return any(p.search(text) for p in self._mention_patterns)
+
+    def _clean_mention_text(self, text: str) -> str:
+        if not text:
+            return text
+        for pattern in self._mention_patterns:
+            match = pattern.match(text.lstrip())
+            if match:
+                cleaned = text.lstrip()[match.end():].lstrip(" ,:-")
+                return cleaned or text
+        return text
+
+    # -- Connection lifecycle -------------------------------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._auth = _auth.resolve_auth(self.config)
+        if self._auth is None:
+            self._set_fatal_error(
+                "config_missing",
+                "Blooio is not authenticated. Run `hermes blooio login` (OAuth) "
+                "or set BLOOIO_API_KEY for headless use.",
+                retryable=False,
+            )
+            return False
+        # An explicit org (BLOOIO_ORG_ID / config) overrides the stored default.
+        if self.organization_id:
+            self._auth.organization_id = self.organization_id
+
+        try:
+            from aiohttp import web  # noqa: F401
+        except ImportError:
+            self._set_fatal_error(
+                "missing_dep",
+                "aiohttp is required for the Blooio adapter — `pip install aiohttp`",
+                retryable=False,
+            )
+            return False
+
+        self._client = _BlooioClient(self._auth, self.api_base_url)
+
+        # Spin up the webhook server.
+        from aiohttp import web
+
+        self._app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
+        self._app.router.add_post(self.webhook_path, self._handle_webhook)
+        self._app.router.add_get(f"{self.webhook_path}/health", self._handle_health)
+        self._app.router.add_get(
+            f"{DEFAULT_MEDIA_PATH_PREFIX}/{{token}}/{{filename}}", self._handle_media
+        )
+
+        self._runner = web.AppRunner(self._app)
+        try:
+            await self._runner.setup()
+            self._site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
+            await self._site.start()
+        except OSError as exc:
+            self._set_fatal_error(
+                "bind_failed",
+                f"Could not bind Blooio webhook on {self.webhook_host}:{self.webhook_port}: {exc}",
+                retryable=True,
+            )
+            return False
+
+        if not self.signing_secret:
+            logger.warning(
+                "[blooio] BLOOIO_WEBHOOK_SECRET not set — inbound webhook "
+                "signatures will NOT be verified. Set the signing secret from "
+                "your Blooio webhook for production."
+            )
+
+        # Optional convenience: register our public webhook URL with Blooio and
+        # capture the returned signing secret (shown once) for verification.
+        if self.auto_register_webhook and not is_reconnect:
+            await self._maybe_register_webhook()
+
+        self._mark_connected()
+        logger.info(
+            "[blooio] webhook listening on %s:%s%s%s",
+            self.webhook_host,
+            self.webhook_port,
+            self.webhook_path,
+            f" (public: {self.public_base_url})" if self.public_base_url else "",
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+        if self._site is not None:
+            try:
+                await self._site.stop()
+            except Exception:
+                pass
+            self._site = None
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+        self._app = None
+        for path in list(self._media_temp_paths):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self._media_temp_paths.clear()
+        self._media_tokens.clear()
+
+    async def _maybe_register_webhook(self) -> None:
+        if not self.public_base_url:
+            logger.warning(
+                "[blooio] auto-register requested but BLOOIO_PUBLIC_URL is unset — skipping"
+            )
+            return
+        webhook_url = f"{self.public_base_url}{self.webhook_path}"
+        try:
+            data = await self._client.create_webhook(webhook_url)
+        except Exception as exc:
+            logger.warning("[blooio] webhook auto-registration failed: %s", exc)
+            return
+        # v4 wraps the created webhook (incl. one-time signing_secret) in `data`.
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        secret = payload.get("signing_secret") or (payload.get("webhook") or {}).get(
+            "signing_secret"
+        )
+        if secret:
+            self.signing_secret = secret
+            logger.info(
+                "[blooio] registered webhook %s and captured signing secret",
+                webhook_url,
+            )
+        else:
+            logger.info("[blooio] registered webhook %s", webhook_url)
+
+    # -- Webhook handlers -----------------------------------------------------
+
+    async def _handle_health(self, request) -> Any:
+        from aiohttp import web
+
+        return web.json_response({"status": "ok", "platform": "blooio"})
+
+    async def _handle_webhook(self, request) -> Any:
+        from aiohttp import web
+
+        try:
+            body = await request.read()
+        except Exception as exc:
+            logger.debug("[blooio] webhook read failed: %s", exc)
+            return web.Response(status=400, text="bad request")
+        if len(body) > WEBHOOK_BODY_MAX_BYTES:
+            return web.Response(status=413, text="payload too large")
+
+        # Verify signature when a secret is configured.
+        if self.signing_secret:
+            signature = request.headers.get("X-Blooio-Signature", "")
+            if not verify_blooio_signature(body, signature, self.signing_secret):
+                return web.Response(status=401, text="invalid signature")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return web.Response(status=400, text="bad json")
+
+        # Blooio may deliver one event or a batch under "events".
+        events = payload.get("events") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            events = [payload]
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            try:
+                await self._dispatch_event(event)
+            except Exception:
+                logger.exception("[blooio] dispatch_event failed")
+
+        return web.Response(status=200, text="ok")
+
+    async def _dispatch_event(self, event: Dict[str, Any]) -> None:
+        # v4 native envelope: {id, type, created_at, organization_id, data:{…}}.
+        # Legacy/flat delivery: {event, …fields…}. Support both.
+        event_type = event.get("type") or event.get("event") or ""
+        data = event.get("data") if isinstance(event.get("data"), dict) else event
+        if "timestamp" not in data and event.get("created_at") is not None:
+            data = {**data, "timestamp": event.get("created_at")}
+
+        if event_type == "message.received":
+            await self._handle_inbound_message(data)
+        elif event_type == "message.reaction":
+            await self._handle_inbound_reaction(data)
+        else:
+            # Delivery receipts (queued/sent/delivered/read/failed), typing,
+            # and everything else are not agent-actionable.
+            logger.debug("[blooio] ignoring event type %r", event_type)
+
+    # ---- inbound message ----------------------------------------------------
+
+    def _resolve_chat(self, event: Dict[str, Any]) -> Tuple[str, str, str, str]:
+        """Return ``(chat_id, chat_type, user_id, group_id)`` for a v4 event.
+
+        The v4 ``chat_id`` (``chat_…``) is the handle used for replies,
+        typing, read receipts, and reactions. ``group_id`` (``grp_…``) is set
+        only for group chats and is what the group allowlist matches;
+        ``user_id`` is the sending party's identifier (phone/email).
+        """
+        chat_id = event.get("chat_id") or ""
+        group_id = event.get("group_id") or ""
+        is_group = bool(group_id) or bool(event.get("is_group"))
+        sender = event.get("sender")
+        if isinstance(sender, dict):
+            sender = sender.get("identifier") or sender.get("address") or ""
+        user_id = sender or (event.get("contact") or {}).get("identifier") or ""
+        return chat_id, ("group" if is_group else "dm"), user_id, group_id
+
+    def _is_allowed(self, chat_type: str, group_id: str, user_id: str) -> bool:
+        if self.allow_all:
+            return True
+        if chat_type == "group":
+            return bool(group_id) and group_id in self.allowed_groups
+        return bool(user_id) and user_id in self.allowed_users
+
+    async def _handle_inbound_message(self, event: Dict[str, Any]) -> None:
+        message_id = event.get("message_id") or ""
+        if message_id and self._dedup.is_duplicate(message_id):
+            logger.debug("[blooio] dropping duplicate message %s", message_id)
+            return
+
+        chat_id, chat_type, user_id, group_id = self._resolve_chat(event)
+        if not chat_id:
+            logger.warning("[blooio] inbound message missing chat id")
+            return
+
+        if not self._is_allowed(chat_type, group_id, user_id):
+            logger.info(
+                "[blooio] rejecting unauthorized %s message from %s",
+                chat_type, _redact(user_id or chat_id),
+            )
+            return
+
+        # Track the last inbound message id per chat so agent-facing reactions
+        # (and read receipts) can default to it.
+        self._record_last_inbound(chat_id, message_id)
+
+        text = event.get("text") or ""
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        mtype = MessageType.TEXT
+
+        for attachment in event.get("attachments") or []:
+            if not isinstance(attachment, dict):
+                continue
+            url = attachment.get("url")
+            if not url:
+                continue
+            hint_name = attachment.get("name") or attachment.get("caption")
+            cached, cached_type = await self._cache_attachment(
+                url, hint_name, media_type=attachment.get("media_type"),
+            )
+            if cached:
+                media_urls.append(cached)
+                media_types.append(cached_type)
+                if mtype == MessageType.TEXT:
+                    mtype = _mime_message_type(cached_type)
+            else:
+                marker = f"[Blooio attachment: {hint_name or url}]"
+                text = f"{text}\n{marker}".strip() if text else marker
+
+        if not text and media_urls:
+            text = "(attachment)"
+
+        # Group-mention gating (DMs never gated).
+        if chat_type == "group" and self.require_mention:
+            if not self._matches_mention(text):
+                logger.debug(
+                    "[blooio] ignoring group message (require_mention, no match)"
+                )
+                return
+            text = self._clean_mention_text(text)
+
+        # Best-effort read receipt.
+        if self.send_read_receipts and self._client:
+            asyncio.create_task(self._safe_mark_read(chat_id))
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=event.get("group_name") or chat_id,
+            chat_type=chat_type,
+            user_id=user_id or chat_id,
+            user_name=user_id or None,
+        )
+        await self.handle_message(
+            MessageEvent(
+                text=text,
+                message_type=mtype,
+                source=source,
+                message_id=message_id,
+                raw_message=event,
+                media_urls=media_urls,
+                media_types=media_types,
+                timestamp=_event_timestamp(event),
+            )
+        )
+
+    async def _handle_inbound_reaction(self, event: Dict[str, Any]) -> None:
+        """Route a tapback/emoji reaction — only on messages the bot sent.
+
+        Reactions on human↔human messages aren't addressed to us. A reaction
+        that targets one of our own sent messages becomes a synthetic
+        ``reaction:added:<value>`` text event (same shape as Photon/Feishu).
+        """
+        message_id = event.get("message_id") or ""
+        action = event.get("action") or "add"
+        reaction_id = f"{message_id}:{event.get('reaction')}:{action}:{event.get('timestamp')}"
+        if self._dedup.is_duplicate(reaction_id):
+            return
+
+        # Only surface reactions on OUR outbound messages.
+        if not message_id or message_id not in self._sent_message_ids:
+            logger.debug("[blooio] ignoring reaction on a message we didn't send")
+            return
+
+        # No allowlist gate here: a reaction on one of OUR messages is
+        # implicitly addressed to the bot (the sent-id check above is the
+        # real gate), same as the Photon iMessage plugin.
+        chat_id, chat_type, user_id, _group_id = self._resolve_chat(event)
+        if not chat_id:
+            return
+
+        reaction = event.get("reaction") or ""
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=event.get("group_name") or chat_id,
+            chat_type=chat_type,
+            user_id=user_id or chat_id,
+            user_name=user_id or None,
+        )
+        await self.handle_message(
+            MessageEvent(
+                text=f"reaction:{action}:{reaction}",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=message_id,
+                reply_to_message_id=message_id,
+                reply_to_text=event.get("original_text") or None,
+                reply_to_is_own_message=True,
+                raw_message=event,
+                timestamp=_event_timestamp(event),
+            )
+        )
+
+    async def _safe_mark_read(self, chat_id: str) -> None:
+        try:
+            await self._client.mark_read(chat_id)
+        except Exception as exc:
+            logger.debug("[blooio] mark_read failed: %s", exc)
+
+    async def _cache_attachment(
+        self, url: str, name: Optional[str], *, media_type: Optional[str] = None
+    ) -> Tuple[Optional[str], str]:
+        """Download a Blooio attachment URL and cache it as a local path."""
+        if not self._client:
+            return None, ""
+        try:
+            raw = await self._client.download(url)
+        except Exception as exc:
+            logger.warning("[blooio] attachment download failed: %s", exc)
+            return None, ""
+        # v4 attachments carry an explicit media_type; fall back to guessing
+        # from the name/url when absent.
+        mime = (media_type or "").lower()
+        if not mime:
+            guessed, _ = mimetypes.guess_type(name or url)
+            mime = (guessed or "").lower()
+        suffix = Path(name).suffix if name else ""
+        try:
+            if mime.startswith("image/"):
+                return cache_image_from_bytes(raw, suffix or ".jpg"), mime
+            if mime.startswith("audio/"):
+                return cache_audio_from_bytes(raw, suffix or ".m4a"), mime
+            if mime.startswith("video/"):
+                return cache_video_from_bytes(raw, suffix or ".mp4"), mime
+            return cache_document_from_bytes(raw, name or "attachment"), (
+                mime or "application/octet-stream"
+            )
+        except Exception as exc:
+            logger.warning("[blooio] failed to cache attachment: %s", exc)
+            return None, ""
+
+    # -- Sent-id + last-inbound tracking --------------------------------------
+
+    def _record_sent_message(self, message_id: Optional[str]) -> None:
+        if not message_id:
+            return
+        sent = self._sent_message_ids
+        sent.pop(message_id, None)
+        sent[message_id] = time.time()
+        if len(sent) > self._SENT_IDS_MAX:
+            for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
+                del sent[old]
+
+    def _record_last_inbound(self, chat_id: str, message_id: str) -> None:
+        if not chat_id or not message_id:
+            return
+        last = self._last_inbound_by_chat
+        last.pop(chat_id, None)
+        last[chat_id] = message_id
+        if len(last) > self._LAST_INBOUND_CHATS_MAX:
+            for old in list(last.keys())[: len(last) - self._LAST_INBOUND_CHATS_MAX]:
+                del last[old]
+
+    # -- Outbound: text -------------------------------------------------------
+
+    async def _send_body(self, chat_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Route a send: reply into a ``chat_…`` handle, else address by ``to``.
+
+        Replies into an existing chat (the common case — inbound events carry a
+        ``chat_…`` id) infer the sender from the chat. When ``chat_id`` is a
+        bare recipient (phone/email, e.g. cron / home-channel delivery) we fall
+        back to ``POST /messages`` with ``to`` (+ optional ``from``).
+        """
+        if str(chat_id).startswith("chat_"):
+            return await self._client.send_to_chat(chat_id, body)
+        payload = {**body, "to": chat_id}
+        if self.channel_ref:
+            payload["from"] = self.channel_ref
+        return await self._client.send_agnostic(payload)
+
+    @staticmethod
+    def _extract_message_id(data: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        mid = payload.get("id") or payload.get("message_id")
+        if not mid:
+            ids = payload.get("message_ids") or []
+            mid = ids[-1] if ids else None
+        return mid, payload
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._client:
+            return SendResult(success=False, error="Blooio adapter not connected")
+
+        text = self.format_message(content)
+        chunks = self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
+        if not chunks:
+            return SendResult(success=True, message_id=None)
+
+        last_id: Optional[str] = None
+        last_data: Dict[str, Any] = {}
+        for idx, chunk in enumerate(chunks):
+            body: Dict[str, Any] = {"text": chunk}
+            if reply_to and idx == 0:
+                body["reply_to"] = reply_to
+            try:
+                data = await self._send_body(chat_id, body)
+            except Exception as exc:
+                logger.error("[blooio] send failed: %s", _redact(str(exc)))
+                return SendResult(success=False, error=str(exc))
+            mid, _ = self._extract_message_id(data)
+            self._record_sent_message(mid)
+            last_id, last_data = (mid or last_id), data
+        return SendResult(success=True, message_id=last_id, raw_response=last_data)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        now = time.time()
+        if now - self._typing_last_sent.get(chat_id, 0.0) < _TYPING_COOLDOWN_SECONDS:
+            return
+        self._typing_last_sent[chat_id] = now
+        if self._client:
+            try:
+                await self._client.set_typing(chat_id, True)
+            except Exception as exc:
+                logger.debug("[blooio] send_typing failed: %s", exc)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        self._typing_last_sent.pop(chat_id, None)
+        if self._client:
+            try:
+                await self._client.set_typing(chat_id, False)
+            except Exception as exc:
+                logger.debug("[blooio] stop_typing failed: %s", exc)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        chat_type = "group" if str(chat_id).startswith("grp_") else "dm"
+        return {"name": chat_id, "type": chat_type, "id": chat_id}
+
+    def format_message(self, content: str) -> str:
+        # iMessage renders plain text — strip Markdown the client can't show.
+        return strip_markdown(content)
+
+    # -- Outbound: media ------------------------------------------------------
+
+    async def _send_attachment_urls(
+        self,
+        chat_id: str,
+        urls: List[str],
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        if not self._client:
+            return SendResult(success=False, error="Blooio adapter not connected")
+        body: Dict[str, Any] = {"attachments": urls}
+        if caption:
+            body["text"] = self.format_message(caption)
+        try:
+            data = await self._send_body(chat_id, body)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+        message_id, _ = self._extract_message_id(data)
+        self._record_sent_message(message_id)
+        return SendResult(success=True, message_id=message_id, raw_response=data)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # Blooio ingests attachment URLs directly — pass a remote URL through.
+        if _is_http_url(image_url):
+            return await self._send_attachment_urls(chat_id, [image_url], caption)
+        return await self.send_image_file(chat_id, image_url, caption)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, image_path, caption)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(video_path):
+            return await self._send_attachment_urls(chat_id, [video_path], caption)
+        return await self._send_local_file(chat_id, video_path, caption)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(audio_path):
+            return await self._send_attachment_urls(chat_id, [audio_path], caption)
+        return await self._send_local_file(chat_id, audio_path, caption)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        if _is_http_url(file_path):
+            return await self._send_attachment_urls(chat_id, [file_path], caption)
+        return await self._send_local_file(chat_id, file_path, caption, name=file_name)
+
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # iMessage renders GIFs inline as ordinary image attachments.
+        return await self.send_image(chat_id, animation_url, caption, reply_to, metadata)
+
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        path: str,
+        caption: Optional[str],
+        *,
+        name: Optional[str] = None,
+    ) -> SendResult:
+        """Serve a local file over the public URL, then send it as an attachment."""
+        safe_path = self.validate_media_delivery_path(str(path))
+        if not safe_path:
+            return SendResult(success=False, error=f"unsafe or missing path: {path}")
+        if not self.public_base_url:
+            return SendResult(
+                success=False,
+                error="BLOOIO_PUBLIC_URL must be set to send local files "
+                "(Blooio fetches attachments from a public HTTPS URL)",
+            )
+        token = self._register_media(safe_path)
+        url = self._media_url(token, name or Path(safe_path).name)
+        if not url.lower().startswith("https://"):
+            return SendResult(
+                success=False, error=f"Blooio attachment URL must be HTTPS: {url}"
+            )
+        return await self._send_attachment_urls(chat_id, [url], caption)
+
+    def _register_media(self, file_path: str) -> str:
+        now = time.time()
+        for token in list(self._media_tokens.keys()):
+            _, exp = self._media_tokens[token]
+            if now > exp:
+                self._media_tokens.pop(token, None)
+        resolved = str(Path(file_path).resolve())
+        token = secrets.token_urlsafe(32)
+        self._media_tokens[token] = (resolved, now + self._media_ttl)
+        return token
+
+    def _media_url(self, token: str, filename: str) -> str:
+        base = self.public_base_url
+        safe_name = _urlquote(filename, safe="")
+        return f"{base}{DEFAULT_MEDIA_PATH_PREFIX}/{token}/{safe_name}"
+
+    async def _handle_media(self, request) -> Any:
+        from aiohttp import web
+
+        token = request.match_info["token"]
+        entry = self._media_tokens.get(token)
+        if not entry:
+            return web.Response(status=404, text="not found")
+        file_path, expires_at = entry
+        if time.time() > expires_at:
+            self._media_tokens.pop(token, None)
+            return web.Response(status=410, text="gone")
+        path = Path(file_path)
+        if not path.exists() or not path.is_file():
+            return web.Response(status=404, text="not found")
+
+        try:
+            from hermes_constants import get_hermes_home
+
+            hermes_home = Path(get_hermes_home()).resolve()
+        except Exception:
+            hermes_home = Path.home().joinpath(".hermes").resolve()
+        allowed_roots = {
+            Path(tempfile.gettempdir()).resolve(),
+            Path("/tmp").resolve(),
+            hermes_home,
+        }
+        resolved = path.resolve()
+        if not any(_is_relative_to(resolved, r) for r in allowed_roots):
+            logger.warning("[blooio] refusing to serve outside allowed roots")
+            return web.Response(status=403, text="forbidden")
+        content_type, _ = mimetypes.guess_type(str(path))
+        return web.FileResponse(
+            path, headers={"Content-Type": content_type or "application/octet-stream"}
+        )
+
+    # -- Reactions ------------------------------------------------------------
+
+    def _reactions_enabled(self) -> bool:
+        return _truthy(os.getenv("BLOOIO_REACTIONS"), False)
+
+    @staticmethod
+    def _normalize_reaction(value: str) -> str:
+        """Return a Blooio reaction token (classic tapback name or emoji).
+
+        Values already prefixed with ``+``/``-`` are respected. Bare classic
+        tapback names and bare emoji default to ``+`` (add).
+        """
+        value = (value or "").strip()
+        if value[:1] in {"+", "-"}:
+            return value
+        return f"+{value}"
+
+    async def _react(
+        self, chat_id: str, message_id: str, reaction: str,
+    ) -> bool:
+        if not self._client:
+            return False
+        try:
+            await self._client.react(
+                chat_id, message_id, self._normalize_reaction(reaction),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("[blooio] react failed: %s", exc)
+            return False
+
+    async def _unreact(self, chat_id: str, message_id: str, reaction: str) -> bool:
+        if not self._client:
+            return False
+        value = (reaction or "").strip().lstrip("+")
+        try:
+            await self._client.react(chat_id, message_id, f"-{value}")
+            return True
+        except Exception as exc:
+            logger.debug("[blooio] unreact failed: %s", exc)
+            return False
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Agent-facing tapback/emoji reaction on a message in ``chat_id``.
+
+        Without an explicit ``message_id`` we target the chat's most recent
+        inbound message (v4 reactions require a concrete ``msg_…`` id). ``emoji``
+        may be a classic tapback name (``love``, ``like``, …) or any emoji,
+        with an optional ``+``/``-`` prefix.
+        """
+        target = message_id or self._last_inbound_by_chat.get(chat_id)
+        if not target:
+            return {"success": False, "error": "no message to react to"}
+        ok = await self._react(chat_id, target, emoji)
+        if not ok:
+            return {"success": False, "error": "reaction failed (see debug log)"}
+        return {"success": True, "message_id": target}
+
+    async def remove_reaction(
+        self, chat_id: str, emoji: str = "", message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        target = message_id or self._last_inbound_by_chat.get(chat_id)
+        if not target:
+            return {"success": False, "error": "no message to unreact"}
+        ok = await self._unreact(chat_id, target, emoji or _REACTION_WORKING)
+        if not ok:
+            return {"success": False, "error": "unreact failed (see debug log)"}
+        return {"success": True, "message_id": target}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        if not self._reactions_enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if chat_id and message_id:
+            await self._react(chat_id, message_id, _REACTION_WORKING)
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        if not self._reactions_enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not chat_id or not message_id:
+            return
+        await self._unreact(chat_id, message_id, _REACTION_WORKING)
+        if outcome == ProcessingOutcome.SUCCESS:
+            await self._react(chat_id, message_id, _REACTION_SUCCESS)
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self._react(chat_id, message_id, _REACTION_FAILURE)
+        # CANCELLED: leave unreacted.
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+def _is_http_url(value: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(("http://", "https://"))
+
+
+def _mime_message_type(mime: str) -> MessageType:
+    mime = (mime or "").lower()
+    if mime.startswith("image/"):
+        return MessageType.PHOTO
+    if mime.startswith("video/"):
+        return MessageType.VIDEO
+    if mime.startswith("audio/"):
+        return MessageType.AUDIO
+    return MessageType.DOCUMENT
+
+
+def _event_timestamp(event: Dict[str, Any]):
+    from datetime import datetime, timezone
+
+    raw = event.get("timestamp")
+    if isinstance(raw, (int, float)):
+        try:
+            # Blooio timestamps are milliseconds since epoch.
+            return datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            pass
+    return datetime.now(tz=timezone.utc)
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        return child.resolve().is_relative_to(parent.resolve())
+    except (AttributeError, ValueError):
+        try:
+            child.resolve().relative_to(parent.resolve())
+            return True
+        except ValueError:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry-point hooks
+# ---------------------------------------------------------------------------
+
+def check_requirements() -> bool:
+    """Plugin gate: OAuth token (or API key) plus aiohttp + httpx at runtime."""
+    if not _auth.has_credentials():
+        return False
+    try:
+        import aiohttp  # noqa: F401
+        import httpx  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        os.getenv("BLOOIO_API_KEY") or extra.get("api_key") or _auth.has_credentials()
+    )
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    """Auto-seed PlatformConfig.extra from an env-only / OAuth Blooio setup."""
+    if not _auth.has_credentials():
+        return None
+    seeded: Dict[str, Any] = {}
+    if os.getenv("BLOOIO_PORT"):
+        try:
+            seeded["port"] = int(os.environ["BLOOIO_PORT"])
+        except ValueError:
+            pass
+    if os.getenv("BLOOIO_HOST"):
+        seeded["host"] = os.environ["BLOOIO_HOST"]
+    if os.getenv("BLOOIO_PUBLIC_URL"):
+        seeded["public_url"] = os.environ["BLOOIO_PUBLIC_URL"]
+    if os.getenv("BLOOIO_HOME_CHANNEL"):
+        seeded["home_channel"] = {
+            "chat_id": os.environ["BLOOIO_HOME_CHANNEL"],
+            "name": os.getenv("BLOOIO_HOME_CHANNEL_NAME", "Home"),
+        }
+    return seeded or {}
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[Any]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process send for cron jobs detached from the gateway.
+
+    Resolves auth the same way the gateway does (OAuth token or API key) and
+    sends via the Blooio v4 REST API. A ``chat_…`` target replies into that
+    chat; a bare phone/email is addressed via ``POST /messages``. Remote media
+    URLs are forwarded as attachments; local files can't be served without the
+    gateway's webhook server bound, so we note them as a text hint instead.
+    """
+    auth = _auth.resolve_auth(pconfig)
+    if auth is None or not chat_id:
+        return {"error": "Blooio standalone send: not authenticated or missing chat_id"}
+    extra = getattr(pconfig, "extra", {}) or {}
+    org = os.getenv("BLOOIO_ORG_ID") or extra.get("organization_id", "")
+    if org:
+        auth.organization_id = org
+
+    base_url = (
+        os.getenv("BLOOIO_API_BASE_URL")
+        or extra.get("api_base_url")
+        or DEFAULT_API_BASE_URL
+    )
+    client = _BlooioClient(auth, base_url)
+
+    body: Dict[str, Any] = {}
+    text = strip_markdown(message or "")
+    remote_urls: List[str] = []
+    local_hint = 0
+    for item in media_files or []:
+        path = item[0] if isinstance(item, (list, tuple)) else item
+        if _is_http_url(str(path)):
+            remote_urls.append(str(path))
+        else:
+            local_hint += 1
+    if local_hint:
+        hint = f"[{local_hint} attachment(s) generated; not deliverable from cron]"
+        text = f"{text}\n{hint}".strip() if text else hint
+    if text:
+        body["text"] = text[:MAX_TEXT_LENGTH]
+    if remote_urls:
+        body["attachments"] = remote_urls
+    if not body:
+        return {"error": "Blooio standalone send: nothing to send"}
+
+    channel_ref = (
+        os.getenv("BLOOIO_CHANNEL")
+        or os.getenv("BLOOIO_FROM_NUMBER")
+        or extra.get("channel")
+        or extra.get("from_number", "")
+    )
+    try:
+        if str(chat_id).startswith("chat_"):
+            data = await client.send_to_chat(chat_id, body)
+        else:
+            payload = {**body, "to": chat_id}
+            if channel_ref:
+                payload["from"] = channel_ref
+            data = await client.send_agnostic(payload)
+    except Exception as exc:
+        return {"error": str(exc)}
+    payload = data.get("data") if isinstance(data.get("data"), dict) else data
+    message_id = payload.get("id") or payload.get("message_id") or (
+        payload.get("message_ids") or [None]
+    )[-1]
+    return {"success": True, "message_id": message_id}
+
+
+def interactive_setup() -> None:
+    """Stdin wizard for ``hermes setup blooio`` / gateway setup.
+
+    OAuth is the default: unless ``BLOOIO_API_KEY`` is already set, this runs
+    the one-click ``hermes blooio login`` flow, then captures the inbound-webhook
+    settings (public URL + optional allowlist).
+    """
+    print()
+    print("Blooio (iMessage) setup")
+    print("-----------------------")
+    print("Blooio delivers inbound messages via webhooks, so Hermes must be")
+    print("reachable at a public HTTPS URL (Cloudflare Tunnel, ngrok, etc.).")
+    print()
+
+    if not os.getenv("BLOOIO_API_KEY"):
+        try:
+            import asyncio
+
+            asyncio.run(_auth.login())
+        except Exception as exc:
+            print(f"OAuth login skipped ({exc}). You can retry with `hermes blooio login`.")
+
+    try:
+        from hermes_cli.config import get_env_var, set_env_var
+    except ImportError:
+        print("hermes_cli.config not available; set BLOOIO_* vars manually in ~/.hermes/.env")
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_var(var) if callable(get_env_var) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            set_env_var(var, value)
+
+    # OAuth (above) is the default; only prompt for an API key when OAuth
+    # didn't produce credentials (headless/CI use).
+    if not _auth.has_credentials():
+        _prompt("BLOOIO_API_KEY", "Blooio API key (headless alternative to OAuth)", secret=True)
+    _prompt("BLOOIO_PUBLIC_URL", "Public HTTPS base URL (e.g. https://my-tunnel.example.com)")
+    _prompt("BLOOIO_ALLOWED_USERS", "Allowed sender phone numbers/emails (comma-separated; blank=skip)")
+    print(
+        "\nInbound webhook: set BLOOIO_AUTO_REGISTER_WEBHOOK=true to have Hermes "
+        "create the webhook (and capture its signing secret) on connect, or add "
+        "one in the dashboard pointing at <your-public-url>/blooio/webhook and "
+        "copy its signing secret into BLOOIO_WEBHOOK_SECRET."
+    )
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    from . import cli as _cli
+
+    ctx.register_platform(
+        name="blooio",
+        label="iMessage via Blooio",
+        adapter_factory=lambda cfg: BlooioAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        # OAuth stores its tokens in ~/.hermes/auth.json (not .env), so there is
+        # no hard-required env var; the check/validate hooks gate on either the
+        # OAuth token or an API key. (BLOOIO_API_KEY remains a headless option.)
+        required_env=[],
+        install_hint=(
+            "Run: hermes blooio login  (one-click OAuth with the official "
+            "Blooio app). Blooio delivers inbound messages via webhook, so "
+            "expose Hermes at a public HTTPS URL (Cloudflare Tunnel/ngrok) and "
+            "set BLOOIO_PUBLIC_URL. Headless/CI alternative: set BLOOIO_API_KEY."
+        ),
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="BLOOIO_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="BLOOIO_ALLOWED_USERS",
+        allow_all_env="BLOOIO_ALLOW_ALL_USERS",
+        max_message_length=MAX_TEXT_LENGTH,
+        emoji="💬",
+        # iMessage identifiers are E.164 phone numbers / emails → PII-sensitive,
+        # matching the BlueBubbles and Photon iMessage channels.
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint=(
+            "You are communicating over iMessage via Blooio. Treat replies "
+            "like normal text messages — short, friendly, and conversational. "
+            "iMessage does NOT render Markdown, so avoid ** or # markup; bare "
+            "URLs are fine and get a rich preview. Recipient identifiers are "
+            "E.164 phone numbers or emails — never expose them unless asked. "
+            "You can react to messages with tapbacks (love, like, dislike, "
+            "laugh, emphasize, question) or emoji."
+        ),
+    )
+
+    # `hermes blooio login|logout|status|setup`
+    ctx.register_cli_command(
+        name="blooio",
+        help="Connect and manage the Blooio iMessage integration (OAuth)",
+        setup_fn=_cli.register_cli,
+        handler_fn=_cli.dispatch,
+    )

--- a/plugins/platforms/blooio/auth.py
+++ b/plugins/platforms/blooio/auth.py
@@ -1,0 +1,490 @@
+"""
+Blooio Apps OAuth 2.0 client for Hermes Agent.
+
+Blooio's OAuth server (``https://api.blooio.com/oauth``) implements the
+Authorization Code grant with PKCE (S256) plus rotating refresh tokens — the
+standard native-app flow (RFC 8252). This module drives that flow from the CLI:
+
+  * ``login()``   opens the browser to the consent screen, captures the code on
+                  a loopback redirect, exchanges it (PKCE) for an access +
+                  refresh token, and persists them.
+  * ``logout()``  revokes + clears the stored tokens.
+  * ``status()``  reports the current auth state.
+
+Runtime auth is resolved by :func:`resolve_auth`, which returns a
+:class:`BlooioAuth` that yields a fresh bearer token (auto-refreshing the OAuth
+access token as it nears expiry) and the organization id to scope requests
+with. An API key (``BLOOIO_API_KEY``) is honored as a headless/CI fallback.
+
+Tokens are stored in ``~/.hermes/auth.json`` under ``credential_pool.blooio``
+(0o600, atomic write), mirroring the Photon plugin's credential handling.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# The public, official "Blooio for Hermes" OAuth app. Overridable for staging
+# via BLOOIO_CLIENT_ID. Public client => PKCE, no client secret is shipped.
+DEFAULT_CLIENT_ID = "bloapp_iJGDMbM_iT9i7HH_cVr55GXI"
+
+DEFAULT_API_HOST = "https://api.blooio.com"
+
+# Scopes the iMessage gateway needs: send/read messages + reactions, manage
+# chats (typing/read/contact-card), read channels, and manage the inbound
+# webhook (create + rotate signing secret).
+DEFAULT_SCOPES = [
+    "messages:read",
+    "messages:write",
+    "chats:read",
+    "chats:write",
+    "channels:read",
+    "webhooks:read",
+    "webhooks:write",
+]
+
+# Loopback redirect ports registered on the app (exact-match). The CLI binds
+# the first free one. Keep in sync with the app's registered redirect_uris.
+LOOPBACK_PORTS = [8765, 8766, 8767]
+REDIRECT_PATH = "/callback"
+
+# Refresh the access token this many seconds before its stated expiry.
+_REFRESH_SKEW_SECONDS = 120
+
+
+def _api_host() -> str:
+    return (os.getenv("BLOOIO_API_HOST") or DEFAULT_API_HOST).rstrip("/")
+
+
+def _client_id() -> str:
+    return os.getenv("BLOOIO_CLIENT_ID") or DEFAULT_CLIENT_ID
+
+
+def authorize_url() -> str:
+    return f"{_api_host()}/oauth/authorize"
+
+
+def token_url() -> str:
+    return f"{_api_host()}/oauth/token"
+
+
+def revoke_url() -> str:
+    return f"{_api_host()}/oauth/revoke"
+
+
+# ---------------------------------------------------------------------------
+# Token storage (auth.json credential_pool.blooio)
+# ---------------------------------------------------------------------------
+
+def _load_auth() -> Dict[str, Any]:
+    try:
+        from hermes_cli.auth import _load_auth_store
+
+        return _load_auth_store() or {}
+    except Exception:
+        path = _auth_path()
+        if path.exists():
+            try:
+                return json.loads(path.read_text(encoding="utf-8")) or {}
+            except Exception:
+                return {}
+        return {}
+
+
+def _auth_path():
+    from pathlib import Path
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home()) / "auth.json"
+    except Exception:
+        return Path.home() / ".hermes" / "auth.json"
+
+
+def _save_auth(data: Dict[str, Any]) -> None:
+    try:
+        from hermes_cli.auth import _save_auth_store
+
+        _save_auth_store(data)
+        return
+    except Exception:
+        pass
+    # Fallback: atomic 0o600 write.
+    import stat
+    import uuid
+
+    path = _auth_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+        fh.flush()
+        os.fsync(fh.fileno())
+    tmp.replace(path)
+
+
+def _store_tokens(record: Dict[str, Any]) -> None:
+    auth = _load_auth()
+    auth.setdefault("credential_pool", {})["blooio"] = [record]
+    _save_auth(auth)
+
+
+def _load_tokens() -> Optional[Dict[str, Any]]:
+    auth = _load_auth()
+    pool = auth.get("credential_pool", {}).get("blooio") or []
+    if isinstance(pool, list) and pool:
+        return pool[0]
+    return None
+
+
+def clear_tokens() -> None:
+    auth = _load_auth()
+    pool = auth.get("credential_pool", {})
+    if pool.get("blooio"):
+        pool["blooio"] = []
+        _save_auth(auth)
+
+
+# ---------------------------------------------------------------------------
+# PKCE helpers
+# ---------------------------------------------------------------------------
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce() -> Tuple[str, str]:
+    """Return ``(code_verifier, code_challenge)`` for PKCE S256."""
+    verifier = _b64url(secrets.token_bytes(64))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# ---------------------------------------------------------------------------
+# Runtime auth resolution
+# ---------------------------------------------------------------------------
+
+class BlooioAuth:
+    """Resolved runtime auth: yields a bearer token + organization scope.
+
+    ``mode`` is ``"api_key"`` (static bearer) or ``"oauth"`` (auto-refreshing
+    access token). ``organization_id`` scopes requests via ``X-Organization-Id``
+    when set (required for OAuth tokens installed on multiple orgs).
+    """
+
+    def __init__(
+        self,
+        mode: str,
+        *,
+        api_key: str = "",
+        organization_id: str = "",
+    ) -> None:
+        self.mode = mode
+        self._api_key = api_key
+        self.organization_id = organization_id or os.getenv("BLOOIO_ORG_ID", "") or ""
+        self._lock = threading.Lock()
+
+    async def bearer(self) -> str:
+        if self.mode == "api_key":
+            return self._api_key
+        return await self._oauth_bearer()
+
+    async def _oauth_bearer(self) -> str:
+        record = _load_tokens()
+        if not record:
+            raise BlooioAuthError(
+                "Not authenticated with Blooio. Run `hermes blooio login`."
+            )
+        now = time.time()
+        expires_at = float(record.get("expires_at", 0) or 0)
+        if record.get("access_token") and expires_at - now > _REFRESH_SKEW_SECONDS:
+            return str(record["access_token"])
+        refreshed = await _refresh_tokens(record)
+        return str(refreshed["access_token"])
+
+
+class BlooioAuthError(Exception):
+    """Raised when Blooio auth is missing or cannot be refreshed."""
+
+
+def resolve_auth(config: Any = None) -> Optional[BlooioAuth]:
+    """Determine runtime auth: API key first (headless), else stored OAuth."""
+    extra = getattr(config, "extra", {}) or {}
+    api_key = os.getenv("BLOOIO_API_KEY") or extra.get("api_key", "")
+    if api_key:
+        org = os.getenv("BLOOIO_ORG_ID") or extra.get("organization_id", "") or ""
+        return BlooioAuth("api_key", api_key=api_key, organization_id=org)
+    if _load_tokens():
+        org = (
+            os.getenv("BLOOIO_ORG_ID")
+            or extra.get("organization_id", "")
+            or (_load_tokens() or {}).get("organization_id", "")
+            or ""
+        )
+        return BlooioAuth("oauth", organization_id=org)
+    return None
+
+
+def has_credentials() -> bool:
+    return bool(os.getenv("BLOOIO_API_KEY") or _load_tokens())
+
+
+# ---------------------------------------------------------------------------
+# Token exchange / refresh (async, httpx)
+# ---------------------------------------------------------------------------
+
+async def _post_token(form: Dict[str, str]) -> Dict[str, Any]:
+    import httpx
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            token_url(),
+            data=form,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    if resp.status_code >= 400:
+        raise BlooioAuthError(f"token endpoint {resp.status_code}: {resp.text[:200]}")
+    return resp.json() or {}
+
+
+def _token_record(
+    payload: Dict[str, Any],
+    *,
+    code_verifier: str,
+    organization_id: str = "",
+) -> Dict[str, Any]:
+    now = time.time()
+    expires_in = float(payload.get("expires_in", 3600) or 3600)
+    return {
+        "access_token": payload.get("access_token"),
+        "refresh_token": payload.get("refresh_token"),
+        "expires_at": now + expires_in,
+        "scope": payload.get("scope", ""),
+        "code_verifier": code_verifier,
+        "organization_id": organization_id,
+        "issued_at": int(now),
+    }
+
+
+async def _refresh_tokens(record: Dict[str, Any]) -> Dict[str, Any]:
+    refresh_token = record.get("refresh_token")
+    if not refresh_token:
+        raise BlooioAuthError("No refresh token; run `hermes blooio login` again.")
+    # Public-client refresh requires a code_verifier to be *present* (PKCE was
+    # validated at code exchange; refresh only checks presence). Reuse the one
+    # captured at login.
+    form = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": _client_id(),
+        "code_verifier": record.get("code_verifier") or "pkce",
+    }
+    payload = await _post_token(form)
+    updated = _token_record(
+        payload,
+        code_verifier=record.get("code_verifier") or "pkce",
+        organization_id=record.get("organization_id", ""),
+    )
+    _store_tokens(updated)
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Interactive login (loopback PKCE)
+# ---------------------------------------------------------------------------
+
+def _pick_free_port() -> Tuple[int, Any]:
+    """Bind the first free registered loopback port; return (port, socket)."""
+    import socket
+
+    last_err: Optional[Exception] = None
+    for port in LOOPBACK_PORTS:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+            sock.listen(1)
+            return port, sock
+        except OSError as exc:
+            last_err = exc
+            sock.close()
+    raise BlooioAuthError(
+        f"No registered loopback port is free ({LOOPBACK_PORTS}): {last_err}"
+    )
+
+
+def _capture_code(sock: Any, expected_state: str, timeout: float = 300.0) -> str:
+    """Accept one loopback request, return the ?code=, and close the browser tab."""
+    sock.settimeout(timeout)
+    conn, _ = sock.accept()
+    try:
+        conn.settimeout(10.0)
+        data = b""
+        while b"\r\n\r\n" not in data and len(data) < 65536:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        request_line = data.split(b"\r\n", 1)[0].decode("latin-1", "replace")
+        path = request_line.split(" ")[1] if " " in request_line else ""
+        query = urllib.parse.urlparse(path).query
+        params = urllib.parse.parse_qs(query)
+        code = (params.get("code") or [""])[0]
+        state = (params.get("state") or [""])[0]
+        err = (params.get("error") or [""])[0]
+
+        if err:
+            body = f"Authorization failed: {err}. You can close this tab."
+        elif not code or state != expected_state:
+            body = "Authorization failed (state mismatch). You can close this tab."
+            code = ""
+        else:
+            body = "Blooio connected to Hermes. You can close this tab and return to the terminal."
+        conn.sendall(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
+            b"Connection: close\r\n\r\n"
+            + f"<html><body style='font-family:sans-serif'>{body}</body></html>".encode("utf-8")
+        )
+        if not code:
+            raise BlooioAuthError(body)
+        return code
+    finally:
+        conn.close()
+
+
+async def login(
+    *,
+    scopes: Optional[List[str]] = None,
+    open_browser: bool = True,
+    organization_id: str = "",
+) -> Dict[str, Any]:
+    """Run the loopback PKCE authorization-code flow and persist tokens."""
+    verifier, challenge = generate_pkce()
+    state = secrets.token_urlsafe(24)
+    port, sock = _pick_free_port()
+    try:
+        redirect_uri = f"http://127.0.0.1:{port}{REDIRECT_PATH}"
+        params = {
+            "response_type": "code",
+            "client_id": _client_id(),
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": " ".join(scopes or DEFAULT_SCOPES),
+            "state": state,
+        }
+        url = f"{authorize_url()}?{urllib.parse.urlencode(params)}"
+        print("\nOpen this URL to connect Blooio to Hermes:\n")
+        print(f"  {url}\n")
+        if open_browser:
+            try:
+                import webbrowser
+
+                webbrowser.open(url, new=2)
+            except Exception:
+                pass
+        print("Waiting for authorization…")
+
+        import asyncio
+
+        code = await asyncio.get_event_loop().run_in_executor(
+            None, _capture_code, sock, state
+        )
+    finally:
+        sock.close()
+
+    payload = await _post_token(
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": f"http://127.0.0.1:{port}{REDIRECT_PATH}",
+            "client_id": _client_id(),
+            "code_verifier": verifier,
+        }
+    )
+    record = _token_record(payload, code_verifier=verifier, organization_id=organization_id)
+    # Resolve the org the token acts on (auto for single-install) unless given.
+    if not record["organization_id"]:
+        record["organization_id"] = await _discover_organization(record["access_token"])
+    _store_tokens(record)
+    return record
+
+
+async def _discover_organization(access_token: str) -> str:
+    """Best-effort: read the token's org from GET /v4/me (single-install auto-resolves)."""
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                f"{_api_host()}/v4/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+        if resp.status_code == 400:
+            # Multi-org install: server returns the list; caller must pick one.
+            body = resp.json()
+            orgs = body.get("organization_ids") or []
+            if orgs:
+                logger.warning(
+                    "[blooio] token spans multiple orgs %s — set BLOOIO_ORG_ID.", orgs
+                )
+            return ""
+        data = (resp.json() or {}).get("data") or {}
+        return data.get("organization_id") or (data.get("organization") or {}).get(
+            "organization_id", ""
+        ) or ""
+    except Exception as exc:
+        logger.debug("[blooio] org discovery failed: %s", exc)
+        return ""
+
+
+async def logout() -> None:
+    """Revoke the stored refresh token and clear local credentials."""
+    record = _load_tokens()
+    if record and record.get("refresh_token"):
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                await client.post(
+                    revoke_url(),
+                    data={
+                        "token": record["refresh_token"],
+                        "client_id": _client_id(),
+                        "code_verifier": record.get("code_verifier") or "pkce",
+                    },
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+        except Exception as exc:
+            logger.debug("[blooio] revoke failed: %s", exc)
+    clear_tokens()
+
+
+def status() -> Dict[str, Any]:
+    """Return a non-secret snapshot of the current auth state."""
+    if os.getenv("BLOOIO_API_KEY"):
+        return {"mode": "api_key", "organization_id": os.getenv("BLOOIO_ORG_ID", "")}
+    record = _load_tokens()
+    if not record:
+        return {"mode": "none"}
+    now = time.time()
+    return {
+        "mode": "oauth",
+        "organization_id": record.get("organization_id", ""),
+        "scope": record.get("scope", ""),
+        "access_expires_in": max(0, int(float(record.get("expires_at", 0) or 0) - now)),
+        "has_refresh_token": bool(record.get("refresh_token")),
+    }

--- a/plugins/platforms/blooio/cli.py
+++ b/plugins/platforms/blooio/cli.py
@@ -1,0 +1,104 @@
+"""
+``hermes blooio ...`` CLI subcommands — registered by the plugin via
+``ctx.register_cli_command()``.
+
+Subcommands:
+
+    login     one-click OAuth: opens the browser to the Blooio consent screen,
+              captures the code on a loopback redirect, and stores the tokens
+    logout    revoke + clear the stored OAuth tokens
+    status    show the current auth state (mode, org, token expiry)
+    setup     alias for `login` plus the inbound-webhook / public-URL guidance
+
+Blooio auth is OAuth by default (public app + PKCE). ``BLOOIO_API_KEY`` remains
+a headless/CI fallback; when it is set, ``login`` is unnecessary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from hermes_cli.colors import Colors, color
+
+from . import auth as blooio_auth
+
+
+def register_cli(parser: argparse.ArgumentParser) -> None:
+    """Wire up `hermes blooio ...` subcommands."""
+    subs = parser.add_subparsers(dest="blooio_command", required=False)
+
+    p_login = subs.add_parser("login", help="Connect Blooio via OAuth (opens a browser)")
+    p_login.add_argument("--no-browser", action="store_true",
+                         help="Print the authorize URL instead of opening a browser")
+    p_login.add_argument("--org", default="",
+                         help="Organization id to scope the token to (org_…); "
+                              "needed only if the app is installed on multiple orgs")
+
+    subs.add_parser("logout", help="Revoke and clear stored Blooio credentials")
+    subs.add_parser("status", help="Show Blooio auth state")
+
+    p_setup = subs.add_parser("setup", help="Connect Blooio + inbound-webhook guidance")
+    p_setup.add_argument("--no-browser", action="store_true")
+    p_setup.add_argument("--org", default="")
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    command = getattr(args, "blooio_command", None)
+    if command in (None, "status"):
+        return _cmd_status(args)
+    if command in ("login", "setup"):
+        return _cmd_login(args)
+    if command == "logout":
+        return _cmd_logout(args)
+    return 2
+
+
+def _cmd_login(args: argparse.Namespace) -> int:
+    if blooio_auth.os.getenv("BLOOIO_API_KEY"):
+        print(color("BLOOIO_API_KEY is set — OAuth login isn't needed.", Colors.YELLOW))
+        return 0
+    try:
+        record = asyncio.run(
+            blooio_auth.login(
+                open_browser=not getattr(args, "no_browser", False),
+                organization_id=getattr(args, "org", "") or "",
+            )
+        )
+    except blooio_auth.BlooioAuthError as exc:
+        print(color(f"Login failed: {exc}", Colors.RED))
+        return 1
+    org = record.get("organization_id") or "(resolve at first request)"
+    print(color("\n✓ Connected Blooio to Hermes.", Colors.GREEN))
+    print(f"  organization: {org}")
+    print(f"  scopes:       {record.get('scope', '')}")
+    if getattr(args, "blooio_command", None) == "setup":
+        print(
+            "\nInbound messages arrive via webhook, so Hermes needs a public "
+            "HTTPS URL. Expose it (Cloudflare Tunnel / ngrok), set "
+            "BLOOIO_PUBLIC_URL, and set BLOOIO_AUTO_REGISTER_WEBHOOK=true to "
+            "auto-create the webhook and capture its signing secret on connect."
+        )
+    return 0
+
+
+def _cmd_logout(_args: argparse.Namespace) -> int:
+    asyncio.run(blooio_auth.logout())
+    print(color("Signed out of Blooio.", Colors.GREEN))
+    return 0
+
+
+def _cmd_status(_args: argparse.Namespace) -> int:
+    st = blooio_auth.status()
+    mode = st.get("mode")
+    if mode == "none":
+        print(color("Blooio: not connected. Run `hermes blooio login`.", Colors.YELLOW))
+        return 0
+    print(color(f"Blooio auth: {mode}", Colors.GREEN))
+    if st.get("organization_id"):
+        print(f"  organization: {st['organization_id']}")
+    if mode == "oauth":
+        print(f"  scopes:            {st.get('scope', '')}")
+        print(f"  access expires in: {st.get('access_expires_in', 0)}s")
+        print(f"  refresh token:     {'present' if st.get('has_refresh_token') else 'missing'}")
+    return 0

--- a/plugins/platforms/blooio/plugin.yaml
+++ b/plugins/platforms/blooio/plugin.yaml
@@ -1,0 +1,103 @@
+name: blooio-platform
+label: iMessage via Blooio
+kind: platform
+version: 1.0.0
+description: >
+  Blooio iMessage gateway adapter for Hermes Agent. Blooio is a hosted iMessage
+  API — send and receive real iMessages (with SMS/RCS fallback) through a REST
+  API and inbound webhooks, no Mac required. Connect it in one click with the
+  official "Blooio for Hermes" OAuth app (`hermes blooio login`); an API key is
+  supported as a headless/CI fallback. The adapter runs an aiohttp webhook
+  server that receives HMAC-SHA256 signature-verified Blooio events
+  (Stripe-style `X-Blooio-Signature`) and relays messages to/from the agent
+  over the Blooio v4 REST API. It supports text, attachments, typing
+  indicators, read receipts, and tapback/emoji reactions, plus group-chat
+  mention gating with parity to the built-in BlueBubbles iMessage channel.
+
+  Because Blooio delivers inbound messages via webhooks (and fetches outbound
+  local-file attachments from a public URL), Hermes must be reachable at a
+  public HTTPS hostname — expose it via Cloudflare Tunnel, Tailscale Funnel, or
+  ngrok and set `BLOOIO_PUBLIC_URL`.
+author: Hermes Agent contributors
+# OAuth stores its tokens in ~/.hermes/auth.json (via `hermes blooio login`),
+# so there is no hard-required env var. Set BLOOIO_API_KEY only for headless
+# use where an interactive browser login isn't possible.
+optional_env:
+  - name: BLOOIO_API_KEY
+    description: "Blooio API key (bearer token) — headless/CI alternative to OAuth login. Create one in the Blooio dashboard."
+    prompt: "Blooio API key (leave blank to use OAuth)"
+    url: "https://app.blooio.com/"
+    password: true
+  - name: BLOOIO_ORG_ID
+    description: "Organization id (org_…) to scope requests to. Required only when your OAuth token is installed on more than one organization."
+    prompt: "Organization id (org_…)"
+    password: false
+  - name: BLOOIO_CLIENT_ID
+    description: "Override the OAuth client id (defaults to the official Blooio for Hermes app). For staging/self-hosted only."
+    prompt: "OAuth client id"
+    password: false
+  - name: BLOOIO_WEBHOOK_SECRET
+    description: "Webhook signing secret (whsec_…) shown once when you create the webhook. Used to verify inbound X-Blooio-Signature HMAC-SHA256 headers. Strongly recommended."
+    prompt: "Webhook signing secret"
+    url: "https://app.blooio.com/"
+    password: true
+  - name: BLOOIO_PUBLIC_URL
+    description: "Public HTTPS base URL where Blooio can reach this Hermes instance (e.g. https://my-tunnel.example.com). Required for inbound webhooks and local-file attachment sending."
+    prompt: "Public HTTPS base URL"
+    password: false
+  - name: BLOOIO_CHANNEL
+    description: "Channel id (ch_…) or E.164 phone number to send from for routed (non-reply) sends, e.g. cron / home-channel delivery. Replies infer the sender from the chat."
+    prompt: "Default send-from channel (ch_… or E.164)"
+    password: false
+  - name: BLOOIO_HOST
+    description: "Webhook bind host (default: 0.0.0.0)"
+    prompt: "Webhook host"
+    password: false
+  - name: BLOOIO_PORT
+    description: "Webhook listen port (default: 8647)"
+    prompt: "Webhook port"
+    password: false
+  - name: BLOOIO_AUTO_REGISTER_WEBHOOK
+    description: "Auto-register BLOOIO_PUBLIC_URL/blooio/webhook with Blooio on connect and capture its signing secret (true/false, default false)"
+    prompt: "Auto-register webhook? (true/false)"
+    password: false
+  - name: BLOOIO_ALLOWED_USERS
+    description: "Comma-separated sender phone numbers/emails allowed to DM the bot"
+    prompt: "Allowed senders (comma-separated)"
+    password: false
+  - name: BLOOIO_ALLOWED_GROUPS
+    description: "Comma-separated Blooio group IDs (grp_…) the bot will respond in"
+    prompt: "Allowed group IDs (comma-separated)"
+    password: false
+  - name: BLOOIO_ALLOW_ALL_USERS
+    description: "Allow any sender to talk to the bot (dev only — disables the allowlist)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: BLOOIO_REQUIRE_MENTION
+    description: "Ignore group-chat messages unless they match a mention wake word (true/false, default false)"
+    prompt: "Require a mention in group chats? (true/false)"
+    password: false
+  - name: BLOOIO_MENTION_PATTERNS
+    description: "Mention wake-word regexes for group chats (JSON list or comma/newline-separated; defaults to Hermes wake words)"
+    prompt: "Group mention patterns"
+    password: false
+  - name: BLOOIO_SEND_READ_RECEIPTS
+    description: "Send iMessage read receipts for inbound messages the agent processes (true/false, default false)"
+    prompt: "Send read receipts? (true/false)"
+    password: false
+  - name: BLOOIO_REACTIONS
+    description: "Tapback 👀/👍/👎 on messages as processing status, and route reactions on the bot's own messages back to the agent (true/false, default false)"
+    prompt: "Enable reaction tapbacks? (true/false)"
+    password: false
+  - name: BLOOIO_HOME_CHANNEL
+    description: "Default target (chat_ id, phone number, or email) for cron / notification delivery"
+    prompt: "Home channel target"
+    password: false
+  - name: BLOOIO_HOME_CHANNEL_NAME
+    description: "Human label for the home channel"
+    prompt: "Home channel display name"
+    password: false
+  - name: BLOOIO_API_BASE_URL
+    description: "Override the Blooio API base URL (default: https://api.blooio.com/v4)"
+    prompt: "Blooio API base URL"
+    password: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "FEISHU_ALLOWED_USERS",
     "WECOM_ALLOWED_USERS",
     "PHOTON_ALLOWED_USERS",
+    "BLOOIO_ALLOWED_USERS",
     "GATEWAY_ALLOWED_USERS",
     "GATEWAY_ALLOW_ALL_USERS",
     "TELEGRAM_ALLOW_ALL_USERS",
@@ -370,6 +371,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "EMAIL_ALLOW_ALL_USERS",
     "SMS_ALLOW_ALL_USERS",
     "PHOTON_ALLOW_ALL_USERS",
+    "BLOOIO_ALLOW_ALL_USERS",
     # Gateway home channels are set by /sethome in real profiles. Tests that
     # exercise dashboard notification toggles must opt in explicitly or they
     # can accidentally subscribe against a developer's real home channel.
@@ -413,6 +415,9 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "PHOTON_HOME_CHANNEL",
     "PHOTON_HOME_CHANNEL_THREAD_ID",
     "PHOTON_HOME_CHANNEL_NAME",
+    "BLOOIO_HOME_CHANNEL",
+    "BLOOIO_HOME_CHANNEL_THREAD_ID",
+    "BLOOIO_HOME_CHANNEL_NAME",
     # API server bind/auth settings are common in local gateway profiles and
     # change adapter defaults plus load_gateway_config() enablement. Tests that
     # need them set opt in explicitly with monkeypatch.

--- a/tests/plugins/platforms/blooio/test_blooio_plugin.py
+++ b/tests/plugins/platforms/blooio/test_blooio_plugin.py
@@ -1,0 +1,552 @@
+"""Tests for the Blooio (iMessage via Blooio) platform plugin — v4 + OAuth.
+
+Covers:
+
+1. webhook signature verification (Stripe-style HMAC-SHA256) + tamper/replay
+2. v4 inbound chat resolution (chat_id / group_id / sender) + allowlist gating
+3. inbound dedup on message_id
+4. Markdown stripping (iMessage renders plain text)
+5. outbound send routing: reply into chat_… vs. addressed POST /messages,
+   chunking, sent-id tracking
+6. reaction normalization + agent-facing add_reaction targeting
+7. v4 typed-envelope dispatch + inbound reaction routing (own-message gate)
+8. register() metadata (+ CLI command) / standalone_send / env_enablement
+9. OAuth: PKCE generation, auth resolution precedence, org header,
+   access-token refresh
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import plugins.platforms.blooio.adapter as _blooio
+import plugins.platforms.blooio.auth as _auth
+
+verify_blooio_signature = _blooio.verify_blooio_signature
+BlooioAdapter = _blooio.BlooioAdapter
+_MessageDeduplicator = _blooio._MessageDeduplicator
+register = _blooio.register
+check_requirements = _blooio.check_requirements
+validate_config = _blooio.validate_config
+_env_enablement = _blooio._env_enablement
+_standalone_send = _blooio._standalone_send
+MAX_TEXT_LENGTH = _blooio.MAX_TEXT_LENGTH
+
+
+def _sign(body: bytes, secret: str, ts: int) -> str:
+    payload = f"{ts}.".encode() + body
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def _header(body: bytes, secret: str, ts: int) -> str:
+    return f"t={ts},v1={_sign(body, secret, ts)}"
+
+
+@pytest.fixture
+def cfg():
+    c = MagicMock()
+    c.extra = {}
+    return c
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("BLOOIO_"):
+            monkeypatch.delenv(key, raising=False)
+    # No stored OAuth tokens by default (avoid reading a real ~/.hermes).
+    monkeypatch.setattr(_auth, "_load_tokens", lambda: None)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# 1. Signature verification
+# ---------------------------------------------------------------------------
+
+class TestSignature:
+    SECRET = "whsec_deadbeef"
+
+    def test_valid_signature_passes(self):
+        body = b'{"type":"message.received"}'
+        ts = int(time.time())
+        assert verify_blooio_signature(body, _header(body, self.SECRET, ts), self.SECRET)
+
+    def test_tampered_body_fails(self):
+        body = b'{"type":"message.received"}'
+        ts = int(time.time())
+        header = _header(body, self.SECRET, ts)
+        assert not verify_blooio_signature(b'{"type":"tampered"}', header, self.SECRET)
+
+    def test_wrong_secret_fails(self):
+        body = b'{"a":1}'
+        ts = int(time.time())
+        assert not verify_blooio_signature(body, _header(body, self.SECRET, ts), "whsec_other")
+
+    def test_stale_timestamp_fails(self):
+        body = b'{"a":1}'
+        ts = int(time.time()) - 3600
+        assert not verify_blooio_signature(body, _header(body, self.SECRET, ts), self.SECRET)
+
+    def test_malformed_header_fails(self):
+        body = b'{"a":1}'
+        assert not verify_blooio_signature(body, "garbage", self.SECRET)
+        assert not verify_blooio_signature(body, "", self.SECRET)
+        assert not verify_blooio_signature(body, "t=123", self.SECRET)
+
+
+# ---------------------------------------------------------------------------
+# 2. v4 chat resolution + allowlist gating
+# ---------------------------------------------------------------------------
+
+class TestResolveAndAllow:
+    def test_resolve_dm(self, cfg):
+        a = BlooioAdapter(cfg)
+        chat_id, chat_type, user_id, group_id = a._resolve_chat(
+            {"chat_id": "chat_abc", "sender": "+15551234567"}
+        )
+        assert (chat_id, chat_type, user_id, group_id) == (
+            "chat_abc", "dm", "+15551234567", "",
+        )
+
+    def test_resolve_dm_contact_identifier(self, cfg):
+        a = BlooioAdapter(cfg)
+        _, chat_type, user_id, _ = a._resolve_chat(
+            {"chat_id": "chat_abc", "contact": {"identifier": "user@example.com"}}
+        )
+        assert chat_type == "dm" and user_id == "user@example.com"
+
+    def test_resolve_group(self, cfg):
+        a = BlooioAdapter(cfg)
+        chat_id, chat_type, user_id, group_id = a._resolve_chat(
+            {"chat_id": "chat_g", "group_id": "grp_abc", "sender": "+15559999999"}
+        )
+        assert (chat_id, chat_type, user_id, group_id) == (
+            "chat_g", "group", "+15559999999", "grp_abc",
+        )
+
+    def test_allowlist_dm(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOWED_USERS", "+15551234567")
+        a = BlooioAdapter(cfg)
+        assert a._is_allowed("dm", "", "+15551234567")
+        assert not a._is_allowed("dm", "", "+19998887777")
+
+    def test_allow_all(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOW_ALL_USERS", "true")
+        a = BlooioAdapter(cfg)
+        assert a._is_allowed("dm", "", "+1")
+        assert a._is_allowed("group", "grp_x", "+2")
+
+    def test_group_allowlist(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOWED_GROUPS", "grp_ok")
+        a = BlooioAdapter(cfg)
+        assert a._is_allowed("group", "grp_ok", "+1")
+        assert not a._is_allowed("group", "grp_no", "+1")
+
+
+# ---------------------------------------------------------------------------
+# 3. Dedup
+# ---------------------------------------------------------------------------
+
+class TestDedup:
+    def test_dedup(self):
+        d = _MessageDeduplicator(max_size=100)
+        assert not d.is_duplicate("m1")
+        assert d.is_duplicate("m1")
+        assert not d.is_duplicate("m2")
+
+    def test_empty_never_duplicate(self):
+        d = _MessageDeduplicator()
+        assert not d.is_duplicate("")
+        assert not d.is_duplicate("")
+
+
+# ---------------------------------------------------------------------------
+# 4. Markdown stripping
+# ---------------------------------------------------------------------------
+
+class TestFormat:
+    def test_strips_markdown(self, cfg):
+        a = BlooioAdapter(cfg)
+        out = a.format_message("**bold** and `code`")
+        assert "**" not in out
+        assert "`" not in out
+
+
+# ---------------------------------------------------------------------------
+# 5. Outbound send routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSend:
+    async def test_reply_into_chat_uses_chat_route(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock(return_value={"id": "msg_1", "status": "queued"})
+        a._client.send_agnostic = AsyncMock()
+        res = await a.send("chat_abc", "hello world")
+        assert res.success and res.message_id == "msg_1"
+        chat_id, body = a._client.send_to_chat.call_args[0]
+        assert chat_id == "chat_abc" and body["text"] == "hello world"
+        a._client.send_agnostic.assert_not_called()
+        assert "msg_1" in a._sent_message_ids
+
+    async def test_addressed_send_uses_messages_route(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_CHANNEL", "ch_xyz")
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock()
+        a._client.send_agnostic = AsyncMock(return_value={"id": "m"})
+        await a.send("+15551234567", "hi")
+        (body,) = a._client.send_agnostic.call_args[0]
+        assert body["to"] == "+15551234567" and body["from"] == "ch_xyz"
+        a._client.send_to_chat.assert_not_called()
+
+    async def test_reply_to_is_message_id(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock(return_value={"id": "m"})
+        await a.send("chat_abc", "yo", reply_to="msg_prev")
+        _, body = a._client.send_to_chat.call_args[0]
+        assert body["reply_to"] == "msg_prev"
+
+    async def test_send_long_text_chunks_sequentially(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock(return_value={"id": "b"})
+        res = await a.send("chat_abc", "x " * MAX_TEXT_LENGTH)
+        assert a._client.send_to_chat.await_count >= 2
+        assert res.success and res.message_id == "b"
+
+    async def test_send_failure_returns_error(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock(side_effect=RuntimeError("boom"))
+        res = await a.send("chat_abc", "hi")
+        assert not res.success and "boom" in res.error
+
+    async def test_remote_image_url_passthrough(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.send_to_chat = AsyncMock(return_value={"id": "m"})
+        await a.send_image("chat_abc", "https://cdn.example.com/cat.jpg", caption="cat")
+        _, body = a._client.send_to_chat.call_args[0]
+        assert body["attachments"] == ["https://cdn.example.com/cat.jpg"]
+        assert body["text"] == "cat"
+
+
+# ---------------------------------------------------------------------------
+# 6. Reactions
+# ---------------------------------------------------------------------------
+
+class TestReactionNormalize:
+    def test_normalize(self):
+        assert BlooioAdapter._normalize_reaction("love") == "+love"
+        assert BlooioAdapter._normalize_reaction("+👍") == "+👍"
+        assert BlooioAdapter._normalize_reaction("-🔥") == "-🔥"
+
+
+@pytest.mark.asyncio
+class TestAddReaction:
+    async def test_add_reaction_defaults_to_last_inbound(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.react = AsyncMock(return_value={})
+        a._last_inbound_by_chat["chat_abc"] = "msg_in"
+        res = await a.add_reaction("chat_abc", "love")
+        assert res["success"] and res["message_id"] == "msg_in"
+        args = a._client.react.call_args[0]
+        assert args[1] == "msg_in" and args[2] == "+love"
+
+    async def test_add_reaction_without_target_errors(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._client = MagicMock()
+        a._client.react = AsyncMock(return_value={})
+        res = await a.add_reaction("chat_abc", "👍")
+        assert res["success"] is False
+        a._client.react.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestInboundReaction:
+    async def test_reaction_on_own_message_is_dispatched(self, cfg):
+        a = BlooioAdapter(cfg)
+        a._record_sent_message("msg_out")
+        a.handle_message = AsyncMock()
+        await a._handle_inbound_reaction(
+            {
+                "message_id": "msg_out",
+                "chat_id": "chat_abc",
+                "sender": "+15551234567",
+                "reaction": "love",
+                "action": "add",
+                "timestamp": 1,
+            }
+        )
+        assert a.handle_message.await_count == 1
+        evt = a.handle_message.await_args[0][0]
+        assert evt.text == "reaction:add:love"
+        assert evt.reply_to_is_own_message is True
+
+    async def test_reaction_on_foreign_message_ignored(self, cfg):
+        a = BlooioAdapter(cfg)
+        a.handle_message = AsyncMock()
+        await a._handle_inbound_reaction(
+            {
+                "message_id": "not_ours",
+                "chat_id": "chat_abc",
+                "sender": "+15551234567",
+                "reaction": "love",
+                "action": "add",
+                "timestamp": 1,
+            }
+        )
+        assert a.handle_message.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Inbound dispatch (v4 typed envelope)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestInboundMessage:
+    async def test_v4_envelope_dispatched(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOW_ALL_USERS", "true")
+        a = BlooioAdapter(cfg)
+        a.handle_message = AsyncMock()
+        await a._dispatch_event(
+            {
+                "type": "message.received",
+                "created_at": 1000,
+                "organization_id": "org_1",
+                "data": {
+                    "message_id": "m1",
+                    "chat_id": "chat_abc",
+                    "sender": "+15551234567",
+                    "text": "hey",
+                },
+            }
+        )
+        assert a.handle_message.await_count == 1
+        evt = a.handle_message.await_args[0][0]
+        assert evt.text == "hey"
+        assert evt.source.chat_id == "chat_abc"
+
+    async def test_unauthorized_dropped(self, cfg):
+        a = BlooioAdapter(cfg)  # no allowlist → nothing allowed
+        a.handle_message = AsyncMock()
+        await a._handle_inbound_message(
+            {"message_id": "m", "chat_id": "chat_x", "sender": "+1", "text": "x"}
+        )
+        assert a.handle_message.await_count == 0
+
+    async def test_duplicate_dropped(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOW_ALL_USERS", "true")
+        a = BlooioAdapter(cfg)
+        a.handle_message = AsyncMock()
+        event = {"message_id": "dup", "chat_id": "chat_x", "sender": "+1", "text": "x"}
+        await a._handle_inbound_message(dict(event))
+        await a._handle_inbound_message(dict(event))
+        assert a.handle_message.await_count == 1
+
+    async def test_group_require_mention_gate(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_ALLOW_ALL_USERS", "true")
+        monkeypatch.setenv("BLOOIO_REQUIRE_MENTION", "true")
+        a = BlooioAdapter(cfg)
+        a.handle_message = AsyncMock()
+        await a._handle_inbound_message(
+            {
+                "message_id": "g1",
+                "chat_id": "chat_g",
+                "group_id": "grp_x",
+                "sender": "+1",
+                "text": "just chatting",
+            }
+        )
+        assert a.handle_message.await_count == 0
+        await a._handle_inbound_message(
+            {
+                "message_id": "g2",
+                "chat_id": "chat_g",
+                "group_id": "grp_x",
+                "sender": "+1",
+                "text": "hermes what's up",
+            }
+        )
+        assert a.handle_message.await_count == 1
+        assert a.handle_message.await_args[0][0].text == "what's up"
+
+
+# ---------------------------------------------------------------------------
+# 8. Registration + standalone + env
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_register_metadata(self):
+        captured = {}
+        cli = {}
+
+        class Ctx:
+            def register_platform(self, **kw):
+                captured.update(kw)
+
+            def register_cli_command(self, **kw):
+                cli.update(kw)
+
+        register(Ctx())
+        assert captured["name"] == "blooio"
+        assert captured["required_env"] == []
+        assert captured["allowed_users_env"] == "BLOOIO_ALLOWED_USERS"
+        assert captured["cron_deliver_env_var"] == "BLOOIO_HOME_CHANNEL"
+        assert captured["pii_safe"] is True
+        assert captured["max_message_length"] == MAX_TEXT_LENGTH
+        assert callable(captured["standalone_sender_fn"])
+        # `hermes blooio ...` CLI is wired up.
+        assert cli["name"] == "blooio"
+        assert callable(cli["setup_fn"]) and callable(cli["handler_fn"])
+
+    def test_validate_config_api_key(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_API_KEY", "api_x")
+        assert validate_config(cfg)
+
+    def test_validate_config_oauth_token(self, cfg, monkeypatch):
+        monkeypatch.setattr(_auth, "_load_tokens", lambda: {"access_token": "t"})
+        assert validate_config(cfg)
+
+    def test_env_enablement(self, monkeypatch):
+        assert _env_enablement() is None
+        monkeypatch.setenv("BLOOIO_API_KEY", "api_x")
+        monkeypatch.setenv("BLOOIO_PUBLIC_URL", "https://x.example.com")
+        monkeypatch.setenv("BLOOIO_HOME_CHANNEL", "chat_abc")
+        seeded = _env_enablement()
+        assert seeded["public_url"] == "https://x.example.com"
+        assert seeded["home_channel"]["chat_id"] == "chat_abc"
+
+
+@pytest.mark.asyncio
+class TestStandaloneSend:
+    async def test_missing_auth(self, monkeypatch):
+        pconfig = MagicMock()
+        pconfig.extra = {}
+        res = await _standalone_send(pconfig, "chat_abc", "hi")
+        assert "error" in res
+
+    async def test_sends_into_chat(self, monkeypatch):
+        monkeypatch.setenv("BLOOIO_API_KEY", "api_x")
+        pconfig = MagicMock()
+        pconfig.extra = {}
+        sent = {}
+
+        async def fake_send_to_chat(self, chat_id, body):
+            sent["chat_id"] = chat_id
+            sent["body"] = body
+            return {"id": "m1"}
+
+        monkeypatch.setattr(_blooio._BlooioClient, "send_to_chat", fake_send_to_chat)
+        res = await _standalone_send(pconfig, "chat_abc", "**hi** there")
+        assert res["success"] and res["message_id"] == "m1"
+        assert sent["chat_id"] == "chat_abc"
+        assert "**" not in sent["body"]["text"]
+
+    async def test_sends_addressed(self, monkeypatch):
+        monkeypatch.setenv("BLOOIO_API_KEY", "api_x")
+        monkeypatch.setenv("BLOOIO_CHANNEL", "ch_z")
+        pconfig = MagicMock()
+        pconfig.extra = {}
+        sent = {}
+
+        async def fake_send_agnostic(self, body):
+            sent["body"] = body
+            return {"id": "m2"}
+
+        monkeypatch.setattr(_blooio._BlooioClient, "send_agnostic", fake_send_agnostic)
+        res = await _standalone_send(pconfig, "+15551234567", "hello")
+        assert res["success"] and res["message_id"] == "m2"
+        assert sent["body"]["to"] == "+15551234567" and sent["body"]["from"] == "ch_z"
+
+
+# ---------------------------------------------------------------------------
+# 9. OAuth / auth
+# ---------------------------------------------------------------------------
+
+class TestAuthResolution:
+    def test_pkce_shape(self):
+        verifier, challenge = _auth.generate_pkce()
+        assert 43 <= len(verifier) <= 128
+        assert "=" not in challenge and "+" not in challenge and "/" not in challenge
+
+    def test_api_key_precedence(self, cfg, monkeypatch):
+        monkeypatch.setenv("BLOOIO_API_KEY", "api_x")
+        monkeypatch.setenv("BLOOIO_ORG_ID", "org_9")
+        au = _auth.resolve_auth(cfg)
+        assert au.mode == "api_key" and au.organization_id == "org_9"
+
+    def test_oauth_when_no_key(self, cfg, monkeypatch):
+        monkeypatch.setattr(
+            _auth, "_load_tokens",
+            lambda: {"access_token": "t", "organization_id": "org_5"},
+        )
+        au = _auth.resolve_auth(cfg)
+        assert au.mode == "oauth" and au.organization_id == "org_5"
+
+    def test_no_credentials_returns_none(self, cfg):
+        assert _auth.resolve_auth(cfg) is None
+
+
+@pytest.mark.asyncio
+class TestAuthRuntime:
+    async def test_org_header_present(self):
+        au = _auth.BlooioAuth("api_key", api_key="k", organization_id="org_1")
+        client = _blooio._BlooioClient(au, "https://api.blooio.com/v4")
+        headers = await client._headers()
+        assert headers["Authorization"] == "Bearer k"
+        assert headers["X-Organization-Id"] == "org_1"
+
+    async def test_org_header_absent_when_unscoped(self):
+        au = _auth.BlooioAuth("api_key", api_key="k")
+        client = _blooio._BlooioClient(au, "https://api.blooio.com/v4")
+        headers = await client._headers()
+        assert "X-Organization-Id" not in headers
+
+    async def test_access_token_refresh(self, monkeypatch):
+        stored = {}
+        expired = {
+            "access_token": "old",
+            "refresh_token": "r1",
+            "expires_at": time.time() - 10,  # already expired
+            "code_verifier": "v1",
+            "organization_id": "org_1",
+        }
+        monkeypatch.setattr(_auth, "_load_tokens", lambda: dict(expired))
+        monkeypatch.setattr(_auth, "_store_tokens", lambda rec: stored.update(rec))
+
+        async def fake_post_token(form):
+            assert form["grant_type"] == "refresh_token"
+            assert form["refresh_token"] == "r1"
+            assert form["code_verifier"] == "v1"  # public-client refresh needs it
+            return {"access_token": "new", "refresh_token": "r2", "expires_in": 3600}
+
+        monkeypatch.setattr(_auth, "_post_token", fake_post_token)
+        au = _auth.BlooioAuth("oauth", organization_id="org_1")
+        token = await au.bearer()
+        assert token == "new"
+        assert stored["access_token"] == "new" and stored["refresh_token"] == "r2"
+
+    async def test_valid_access_token_not_refreshed(self, monkeypatch):
+        calls = {"post": 0}
+        fresh = {"access_token": "good", "expires_at": time.time() + 3600}
+        monkeypatch.setattr(_auth, "_load_tokens", lambda: dict(fresh))
+
+        async def fake_post_token(form):
+            calls["post"] += 1
+            return {}
+
+        monkeypatch.setattr(_auth, "_post_token", fake_post_token)
+        au = _auth.BlooioAuth("oauth")
+        assert await au.bearer() == "good"
+        assert calls["post"] == 0

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -25,6 +25,30 @@ def test_photon_e164_target_is_explicit() -> None:
     assert is_explicit is True
 
 
+def test_blooio_e164_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("blooio", "+15551234567")
+
+    assert chat_id == "+15551234567"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_blooio_chat_handle_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("blooio", "chat_abc123")
+
+    assert chat_id == "chat_abc123"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_blooio_email_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("blooio", "alice@example.com")
+
+    assert chat_id == "alice@example.com"
+    assert thread_id is None
+    assert is_explicit is True
+
+
 def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -888,6 +888,8 @@ class TestParseTargetRef:
             ("sms", "+15551234567", "+15551234567", None),
             ("whatsapp", "+15551234567", "+15551234567", None),
             ("photon", "+15551234567", "+15551234567", None),
+            ("blooio", "+15551234567", "+15551234567", None),
+            ("blooio", "chat_abc123", "chat_abc123", None),
             # WhatsApp native JIDs. Regression: group (@g.us) and linked-identity
             # (@lid) JIDs matched no branch and silently fell through to the
             # configured home DM instead of the requested group.

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -41,7 +41,7 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # below and falls through to channel-name resolution, which has no way to
 # resolve a raw phone number. Keeping the '+' preserves the E.164 form that
 # downstream adapters (signal, etc.) expect.
-_PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
+_PHONE_PLATFORMS = frozenset({"photon", "blooio", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # Photon DM chat GUID (mirrors _DM_CHAT_GUID_RE in the photon adapter).
 _PHOTON_DM_GUID_RE = re.compile(r"^any;-;\+\d{6,}$")
@@ -612,6 +612,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # them off the channel directory (mirrors the react handler).
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
+    if platform_name == "blooio":
+        # Blooio chat handles ('chat_…') and email addresses are explicit,
+        # adapter-resolved targets; E.164 '+' numbers are handled by the
+        # _PHONE_PLATFORMS branch above.
+        trimmed = target_ref.strip()
+        if trimmed.startswith("chat_") or _EMAIL_TARGET_RE.fullmatch(trimmed):
+            return trimmed, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -40,7 +40,7 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # below and falls through to channel-name resolution, which has no way to
 # resolve a raw phone number. Keeping the '+' preserves the E.164 form that
 # downstream adapters (signal, etc.) expect.
-_PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
+_PHONE_PLATFORMS = frozenset({"photon", "blooio", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # Photon DM chat GUID (mirrors _DM_CHAT_GUID_RE in the photon adapter).
 _PHOTON_DM_GUID_RE = re.compile(r"^any;-;\+\d{6,}$")
@@ -609,6 +609,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # them off the channel directory (mirrors the react handler).
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
+    if platform_name == "blooio":
+        # Blooio chat handles ('chat_…') and email addresses are explicit,
+        # adapter-resolved targets; E.164 '+' numbers are handled by the
+        # _PHONE_PLATFORMS branch above.
+        trimmed = target_ref.strip()
+        if trimmed.startswith("chat_") or _EMAIL_TARGET_RE.fullmatch(trimmed):
+            return trimmed, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## Summary

Adds **Blooio** as a first-class, in-tree iMessage gateway platform, living under `plugins/platforms/blooio/` and mirroring the existing **Photon** plugin's layout (`adapter.py`, `auth.py`, `cli.py`, `plugin.yaml`, `README.md`, `__init__.py`). Blooio is a hosted iMessage API (REST + inbound webhooks, with SMS/RCS fallback) — so this gives Hermes real iMessage send/receive with **no Mac and no local BlueBubbles server**.

This is the in-tree counterpart to the earlier standalone plugin. Per the "let the market decide" guidance on gateway channels, it ships alongside the other iMessage options (BlueBubbles, Photon) rather than being gated out.

### Auth — one-click OAuth (official Blooio app)
- Uses the official **"Blooio for Hermes"** public OAuth app via **Authorization Code + PKCE (S256)** on a loopback redirect (RFC 8252) — `hermes blooio login` opens the browser, captures the code, and stores rotating tokens in `~/.hermes/auth.json` (0o600). Access tokens auto-refresh.
- `hermes blooio login | logout | status` CLI (registered via `ctx.register_cli_command`).
- `BLOOIO_API_KEY` remains a headless/CI fallback.
- Multi-org tokens are scoped with `X-Organization-Id` (`BLOOIO_ORG_ID`).

### Transport — Blooio v4 REST API (`https://api.blooio.com/v4`)
- Replies POST to `/chats/{chat_id}/messages` (the `chat_…` handle every inbound event carries; sender inferred from the chat). Addressed / cron sends use `POST /messages` with `to` (+ optional `from` channel).
- Typing indicators, read receipts, and tapback/emoji reactions each map to a dedicated v4 chat endpoint.

### Inbound — signed webhooks
- Small `aiohttp` webhook server with HMAC-SHA256 signature verification (Stripe-style `X-Blooio-Signature: t=<ts>,v1=<hex>` over `"{ts}.{rawBody}"`), `message_id` dedup, v4 typed-envelope parsing, allowlist + group mention gating, and local-file attachment serving — parity with the BlueBubbles and Photon channels.

### Core touches (minimal, mirroring Photon)
- `gateway/display_config.py`: Blooio is a no-edit iMessage inbox → `_TIER_LOW` (like Photon/BlueBubbles).
- `tools/send_message_tool.py`: recognizes Blooio's `+E.164` / `chat_…` / email send targets.

PII-safety is honored through the platform registry's `pii_safe=True` flag (no static list edit needed).

## Test plan
- [x] `pytest tests/plugins/platforms/blooio/` — 44 unit tests pass (signature verify + tamper/replay, v4 typed-envelope dispatch + dedup, DM/group resolution + allowlist, send routing chat-vs-addressed + chunking, reaction normalize/target, registration + CLI wiring, standalone send, OAuth resolution + access-token refresh).
- [x] `ruff check plugins/platforms/blooio/ tools/send_message_tool.py gateway/display_config.py` — clean.
- [x] Adapter imports and registers against the plugin loader (`PlatformEntry` accepts all kwargs; `Platform("blooio")` resolves via `_missing_`).
- [x] Live-verified the OAuth endpoints with the real client id: `/oauth/authorize` 302s to consent (client id + loopback redirect + PKCE challenge accepted) and `/oauth/token` returns `invalid_grant` (not `invalid_client`) for a bogus code.
- [ ] Maintainer smoke test: `hermes blooio login` → send/receive an iMessage end-to-end.

Made with [Cursor](https://cursor.com)