### PR TITLE
fix(tools): diff /reload-mcp against config, not the connection registry

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11820,7 +11820,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         sees the updated tools on the next turn.
         """
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import (
+                shutdown_mcp_servers,
+                discover_mcp_tools,
+                summarize_mcp_reload,
+                _servers,
+                _lock,
+            )
 
             # Capture old server names
             with _lock:
@@ -11835,13 +11841,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Reconnect (reads config.yaml fresh)
             new_tools = discover_mcp_tools()
 
-            # Compute what changed
-            with _lock:
-                connected_servers = set(_servers.keys())
-
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            # Compute what changed — against config.yaml, not just the live
+            # connection registry, so a server that is merely slow, disabled or
+            # failed isn't reported as removed (#80771).
+            diff = summarize_mcp_reload(old_servers)
+            connected_servers = diff["connected"]
+            added = diff["added"]
+            removed = diff["removed"]
+            reconnected = diff["reconnected"]
+            pending = ", ".join(f"{n} ({st})" for n, st in sorted(diff["pending"].items()))
 
             if reconnected:
                 print(f"  ♻️  Reconnected: {', '.join(sorted(reconnected))}")
@@ -11849,6 +11857,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 print(f"  ➕ Added: {', '.join(sorted(added))}")
             if removed:
                 print(f"  ➖ Removed: {', '.join(sorted(removed))}")
+            if pending:
+                print(f"  ⏳ Still configured, not connected: {pending}")
             if not connected_servers:
                 print("  No MCP servers connected.")
             else:
@@ -11894,6 +11904,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 change_parts.append(f"Removed servers: {', '.join(sorted(removed))}")
             if reconnected:
                 change_parts.append(f"Reconnected servers: {', '.join(sorted(reconnected))}")
+            if pending:
+                change_parts.append(f"Still configured but not connected: {pending}")
             tool_summary = f"{len(new_tools)} MCP tool(s) now available" if new_tools else "No MCP tools available"
             change_detail = ". ".join(change_parts) + ". " if change_parts else ""
             self.conversation_history.append({

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20364,7 +20364,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         loop = asyncio.get_running_loop()
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import (
+                shutdown_mcp_servers,
+                discover_mcp_tools,
+                summarize_mcp_reload,
+                _servers,
+                _lock,
+            )
 
             # Capture old server names before shutdown
             with _lock:
@@ -20377,13 +20383,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Reconnect by discovering tools (reads config.yaml fresh)
             new_tools = await loop.run_in_executor(None, discover_mcp_tools)
 
-            # Compute what changed
-            with _lock:
-                connected_servers = set(_servers.keys())
-
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            # Compute what changed — against config.yaml, not just the live
+            # connection registry, so a server that is merely slow, disabled or
+            # failed isn't reported as removed (#80771).
+            diff = await loop.run_in_executor(None, summarize_mcp_reload, old_servers)
+            connected_servers = diff["connected"]
+            added = diff["added"]
+            removed = diff["removed"]
+            reconnected = diff["reconnected"]
+            pending = ", ".join(f"{n} ({st})" for n, st in sorted(diff["pending"].items()))
 
             lines = [t("gateway.reload_mcp.header")]
             if reconnected:
@@ -20392,6 +20400,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 lines.append(t("gateway.reload_mcp.added", names=", ".join(sorted(added))))
             if removed:
                 lines.append(t("gateway.reload_mcp.removed", names=", ".join(sorted(removed))))
+            if pending:
+                lines.append(t("gateway.reload_mcp.pending", names=pending))
             if not connected_servers:
                 lines.append(t("gateway.reload_mcp.none_connected"))
             else:
@@ -20442,6 +20452,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 change_parts.append(f"Removed servers: {', '.join(sorted(removed))}")
             if reconnected:
                 change_parts.append(f"Reconnected servers: {', '.join(sorted(reconnected))}")
+            if pending:
+                change_parts.append(f"Still configured but not connected: {pending}")
             tool_summary = f"{len(new_tools)} MCP tool(s) now available" if new_tools else "No MCP tools available"
             change_detail = ". ".join(change_parts) + ". " if change_parts else ""
             reload_msg = {

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Herverbind: {names}"
     added:                 "➕ Bygevoeg: {names}"
     removed:               "➖ Verwyder: {names}"
+    pending:               "⏳ Steeds gekonfigureer, nie gekoppel nie: {names}"
     none_connected:        "Geen MCP-bedieners verbind nie."
     tools_available:       "\n🔧 {tools} gereedskap beskikbaar van {servers} bediener(s)"
     failed:                "❌ MCP-herlaai het misluk: {error}"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -238,6 +238,7 @@ gateway:
     reconnected:           "♻️ أُعيد الاتصال: {names}"
     added:                 "➕ أُضيف: {names}"
     removed:               "➖ أُزيل: {names}"
+    pending:               "⏳ لا تزال مُهيّأة لكنها غير متصلة: {names}"
     none_connected:        "لا توجد خوادم MCP متصلة."
     tools_available:       "\n🔧 {tools} أداة متاحة من {servers} خادم"
     failed:                "❌ فشلت إعادة تحميل MCP: {error}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Wiederverbunden: {names}"
     added:                 "➕ Hinzugefügt: {names}"
     removed:               "➖ Entfernt: {names}"
+    pending:               "⏳ Weiterhin konfiguriert, nicht verbunden: {names}"
     none_connected:        "Keine MCP-Server verbunden."
     tools_available:       "\n🔧 {tools} Tool(s) von {servers} Server(n) verfügbar"
     failed:                "❌ MCP-Neuladen fehlgeschlagen: {error}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -230,6 +230,7 @@ gateway:
     reconnected:           "♻️ Reconnected: {names}"
     added:                 "➕ Added: {names}"
     removed:               "➖ Removed: {names}"
+    pending:               "⏳ Still configured, not connected: {names}"
     none_connected:        "No MCP servers connected."
     tools_available:       "\n🔧 {tools} tool(s) available from {servers} server(s)"
     failed:                "❌ MCP reload failed: {error}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Reconectados: {names}"
     added:                 "➕ Añadidos: {names}"
     removed:               "➖ Eliminados: {names}"
+    pending:               "⏳ Aún configurados, sin conectar: {names}"
     none_connected:        "No hay servidores MCP conectados."
     tools_available:       "\n🔧 {tools} herramienta(s) disponibles de {servers} servidor(es)"
     failed:                "❌ Falló la recarga de MCP: {error}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Reconnectés : {names}"
     added:                 "➕ Ajoutés : {names}"
     removed:               "➖ Supprimés : {names}"
+    pending:               "⏳ Toujours configurés, non connectés : {names}"
     none_connected:        "Aucun serveur MCP connecté."
     tools_available:       "\n🔧 {tools} outil(s) disponible(s) sur {servers} serveur(s)"
     failed:                "❌ Échec du rechargement MCP : {error}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -219,6 +219,7 @@ gateway:
     reconnected:           "♻️ Athcheanglaithe: {names}"
     added:                 "➕ Curtha leis: {names}"
     removed:               "➖ Bainte: {names}"
+    pending:               "⏳ Cumraithe fós, gan ceangal: {names}"
     none_connected:        "Níl aon fhreastalaí MCP ceangailte."
     tools_available:       "\n🔧 {tools} uirlis(í) ar fáil ó {servers} freastalaí(thí)"
     failed:                "❌ Theip ar athlódáil MCP: {error}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Újracsatlakozva: {names}"
     added:                 "➕ Hozzáadva: {names}"
     removed:               "➖ Eltávolítva: {names}"
+    pending:               "⏳ Továbbra is beállítva, nincs csatlakozva: {names}"
     none_connected:        "Nincsenek csatlakoztatott MCP-szerverek."
     tools_available:       "\n🔧 {tools} eszköz érhető el {servers} szerverről"
     failed:                "❌ MCP újratöltés sikertelen: {error}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Riconnessi: {names}"
     added:                 "➕ Aggiunti: {names}"
     removed:               "➖ Rimossi: {names}"
+    pending:               "⏳ Ancora configurati, non connessi: {names}"
     none_connected:        "Nessun server MCP connesso."
     tools_available:       "\n🔧 {tools} strumento/i disponibile/i da {servers} server"
     failed:                "❌ Ricaricamento MCP non riuscito: {error}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ 再接続: {names}"
     added:                 "➕ 追加: {names}"
     removed:               "➖ 削除: {names}"
+    pending:               "⏳ 設定には残っていますが未接続: {names}"
     none_connected:        "接続中の MCP サーバーはありません。"
     tools_available:       "\n🔧 {servers} 台のサーバーから {tools} 個のツールが利用可能"
     failed:                "❌ MCP の再読み込みに失敗しました: {error}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ 재연결됨: {names}"
     added:                 "➕ 추가됨: {names}"
     removed:               "➖ 제거됨: {names}"
+    pending:               "⏳ 설정에는 남아 있으나 연결되지 않음: {names}"
     none_connected:        "연결된 MCP 서버가 없습니다."
     tools_available:       "\n🔧 {servers}개 서버에서 {tools}개 도구 사용 가능"
     failed:                "❌ MCP 재로드 실패: {error}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Reconectados: {names}"
     added:                 "➕ Adicionados: {names}"
     removed:               "➖ Removidos: {names}"
+    pending:               "⏳ Ainda configurados, não conectados: {names}"
     none_connected:        "Não há servidores MCP ligados."
     tools_available:       "\n🔧 {tools} ferramenta(s) disponíveis de {servers} servidor(es)"
     failed:                "❌ Falha ao recarregar MCP: {error}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Переподключено: {names}"
     added:                 "➕ Добавлено: {names}"
     removed:               "➖ Удалено: {names}"
+    pending:               "⏳ Всё ещё в конфигурации, не подключены: {names}"
     none_connected:        "Нет подключённых MCP-серверов."
     tools_available:       "\n🔧 {tools} инструмент(ов) доступно с {servers} сервер(ов)"
     failed:                "❌ Ошибка перезагрузки MCP: {error}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Yeniden bağlanan: {names}"
     added:                 "➕ Eklenen: {names}"
     removed:               "➖ Kaldırılan: {names}"
+    pending:               "⏳ Hâlâ yapılandırılmış, bağlı değil: {names}"
     none_connected:        "Bağlı MCP sunucusu yok."
     tools_available:       "\n🔧 {servers} sunucudan {tools} araç kullanılabilir"
     failed:                "❌ MCP yeniden yükleme başarısız: {error}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ Перепідключено: {names}"
     added:                 "➕ Додано: {names}"
     removed:               "➖ Видалено: {names}"
+    pending:               "⏳ Досі в конфігурації, не підключені: {names}"
     none_connected:        "Немає підключених MCP-серверів."
     tools_available:       "\n🔧 {tools} інструмент(ів) доступно з {servers} сервер(ів)"
     failed:                "❌ Помилка перезавантаження MCP: {error}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ 已重新連線：{names}"
     added:                 "➕ 已新增：{names}"
     removed:               "➖ 已移除：{names}"
+    pending:               "⏳ 仍在設定中但未連線: {names}"
     none_connected:        "沒有已連線的 MCP 伺服器。"
     tools_available:       "\n🔧 來自 {servers} 個伺服器的 {tools} 個工具可用"
     failed:                "❌ MCP 重新載入失敗：{error}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -215,6 +215,7 @@ gateway:
     reconnected:           "♻️ 已重新连接：{names}"
     added:                 "➕ 已添加：{names}"
     removed:               "➖ 已移除：{names}"
+    pending:               "⏳ 仍在配置中但未连接: {names}"
     none_connected:        "没有连接的 MCP 服务器。"
     tools_available:       "\n🔧 来自 {servers} 个服务器的 {tools} 个工具可用"
     failed:                "❌ MCP 重新加载失败：{error}"

--- a/tests/tools/test_mcp_reload_diff.py
+++ b/tests/tools/test_mcp_reload_diff.py
@@ -1,0 +1,49 @@
+"""Tests for summarize_mcp_reload() -- the /reload-mcp diff (#80771)."""
+
+from unittest.mock import patch
+
+
+def _run(statuses, old, lazy=()):
+    """Diff `statuses` (a get_mcp_status() snapshot) against `old`, the set of
+    servers that were in ``_servers`` before the reload."""
+    import tools.mcp_tool as mcp
+
+    with patch.object(
+        mcp, "get_mcp_status",
+        return_value=[{"name": n, "status": s} for n, s in statuses.items()],
+    ), patch.object(mcp, "_lazy_server_configs", {n: {} for n in lazy}):
+        return mcp.summarize_mcp_reload(set(old))
+
+
+def test_still_configured_servers_are_pending_not_removed():
+    """Slow/failed/disabled servers stay in config -- they are not removals."""
+    diff = _run(
+        {"slow": "connecting", "broken": "failed", "off": "disabled", "ok": "connected"},
+        old={"slow", "broken", "off", "ok"},
+    )
+    assert diff["removed"] == set()
+    assert diff["pending"] == {
+        "slow": "connecting", "broken": "failed", "off": "disabled",
+    }
+    assert diff["connected"] == {"ok"}
+    assert diff["reconnected"] == {"ok"}
+
+
+def test_server_dropped_from_config_is_removed():
+    diff = _run({"ok": "connected"}, old={"ok", "gone"})
+    assert diff["removed"] == {"gone"}
+    assert diff["pending"] == {}
+    assert diff["added"] == set()
+
+
+def test_newly_connected_server_is_added():
+    diff = _run({"fresh": "connected"}, old=set())
+    assert diff["added"] == {"fresh"}
+    assert diff["removed"] == set()
+
+
+def test_lazy_server_counts_as_connected():
+    """Lazy servers register tools from cache with no session -- available."""
+    diff = _run({"notion": "configured"}, old=set(), lazy={"notion"})
+    assert diff["connected"] == {"notion"}
+    assert diff["pending"] == {}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6614,6 +6614,37 @@ def get_mcp_status() -> List[dict]:
     return result
 
 
+def summarize_mcp_reload(old_servers: set) -> Dict[str, Any]:
+    """Classify servers after a reload against config.yaml, not just ``_servers``.
+
+    Diffing ``_servers`` alone reports a still-configured server as removed
+    whenever it is slow to connect, lazily registered from the schema cache,
+    ``enabled: false``, or failed (#80771).  Only a name that vanished from
+    config counts as removed; every other configured-but-not-connected server
+    is returned in ``pending`` with its real status from :func:`get_mcp_status`
+    ("connecting"/"failed"/"disabled"/"configured").
+
+    Availability comes from one :func:`get_mcp_status` snapshot rather than
+    ``_servers`` membership: a parked/mid-reconnect server sits in ``_servers``
+    with ``session=None`` (so it is NOT available), while a lazily-registered
+    one has live tools with no ``_servers`` entry at all (so it IS).
+
+    Returns ``{"connected", "added", "reconnected", "removed", "pending"}``.
+    """
+    statuses = {s["name"]: s.get("status", "configured") for s in get_mcp_status()}
+    with _lock:
+        lazy = set(_lazy_server_configs)
+    connected = {n for n, st in statuses.items() if st == "connected"}
+    connected |= lazy & set(statuses)
+    return {
+        "connected": connected,
+        "added": connected - old_servers,
+        "reconnected": connected & old_servers,
+        "removed": {n for n in old_servers - connected if n not in statuses},
+        "pending": {n: st for n, st in statuses.items() if n not in connected},
+    }
+
+
 def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     """Temporarily connect to configured MCP servers and list their tools.
 


### PR DESCRIPTION
## What does this PR do?

`/reload-mcp` diffed `_servers`, the live connection registry, which only holds servers with an established session. Anything configured but not connected at that moment printed as `➖ Removed`: still mid-connect, `enabled: false`, serving a post-failure backoff, or lazily registered from the schema cache.
The same wording went into conversation history, which tells the model a working server is gone.

Now only a name absent from `config.yaml` counts as a removal. Anything else still in config shows its real state:

```
♻️ Reconnected: github
⏳ Still configured, not connected: notion (connecting), linear (disabled)
```

`cli.py:_reload_mcp` and `gateway/run.py:_execute_mcp_reload` held identical copies of the diff, so both now call `tools/mcp_tool.py:summarize_mcp_reload()`.

Availability comes from one `get_mcp_status()` snapshot rather than `_servers` membership, which is wrong in both directions.
A parked server sits in `_servers` with `session=None`, so a membership check calls it reconnected while `/mcp` shows it failed.
A lazily registered server has callable tools and no `_servers` entry at all, so a healthy `lazy: true` config would report it as not connected on every reload.

## Related Issue

Fixes #80771

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: `summarize_mcp_reload(old_servers)` returns `connected` / `added` / `reconnected` / `removed` / `pending`.
- `cli.py`, `gateway/run.py`: both reload paths call it and print the new line in the output and in the history note.
  The helper blocks on `_lock`, so the gateway calls it through `run_in_executor`.
- `locales/*.yaml`: `gateway.reload_mcp.pending` in all 17 catalogs (`tests/agent/test_i18n.py` asserts parity).
- `tests/tools/test_mcp_reload_diff.py`: still configured, dropped from config, newly added, lazy.

## How to Test

A deterministic version of the issue's timing-dependent repro:

1. Start `hermes` with a working MCP server and confirm it with `/mcp`.
2. Set `enabled: false` on that server in `config.yaml`.
3. Run `/reload-mcp`.

Before: `➖ Removed: <server>`.
After: `⏳ Still configured, not connected: <server> (disabled)`.

Also worth checking: an unreachable `command` reports `(failed)`, and deleting the server from `config.yaml` still reports `➖ Removed`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**


## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_mcp_reload_diff.py tests/agent/test_i18n.py
=== Summary: 2 files, 40 tests passed, 0 failed (100% complete) in 11.1s (16 workers) ===
```