### PR TITLE
fix: replace assert with runtime guards in computer_use (browser_route, doctor)

### DIFF
--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -478,7 +478,11 @@ class CuaTypedBrowserRoute:
         )
         if refusal is not None:
             return refusal
-        assert selected_tab is not None and self.state.target_id is not None
+        if selected_tab is None or self.state.target_id is None:
+            return _refusal(
+                "browser_state_missing",
+                "Internal state error: no selected tab or target id after mutation check.",
+            )
 
         ref = call_args.get("ref")
         supports_trust_choice = tool in {"browser_click", "browser_pointer"}

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -223,7 +223,11 @@ def _open_mcp(binary: str) -> subprocess.Popen:
 
 def _mcp_rpc(proc: subprocess.Popen, msg_id: int, method: str, params: Any = None) -> Dict[str, Any]:
     """Write one JSON-RPC request and read one response line."""
-    assert proc.stdin is not None and proc.stdout is not None
+    if proc.stdin is None or proc.stdout is None:
+        raise RuntimeError(
+            "_mcp_rpc: subprocess stdin or stdout is None — "
+            "cannot communicate with MCP server"
+        )
     payload: Dict[str, Any] = {"jsonrpc": "2.0", "id": msg_id, "method": method}
     if params is not None:
         payload["params"] = params


### PR DESCRIPTION
## Summary

Replace `assert` statements with explicit runtime guards in `tools/computer_use/` — two sites not covered by prior assert-cleanup PRs (#56736, #56866, #61983, #62001, #62659, #64818).

`assert` is stripped by `python -O`, silently removing invariant checks in production.

## Changes

| File | Line | Old | New |
|------|------|-----|-----|
| `tools/computer_use/browser_route.py` | 481 | `assert selected_tab is not None and self.state.target_id is not None` | `if ... is None: return _refusal(...)` |
| `tools/computer_use/doctor.py` | 226 | `assert proc.stdin is not None and proc.stdout is not None` | `if ... is None: raise RuntimeError(...)` |

## Why these matter

- **browser_route.py**: After `_require_mutation()` returns with no refusal, subsequent code dereferences `selected_tab` and `self.state.target_id`. Under `python -O`, if either is None, the code crashes with `AttributeError` deep in the browser tool dispatch — a confusing error with no context. The guard returns a clear refusal dict.

- **doctor.py**: `_mcp_rpc()` writes to `proc.stdin` and reads from `proc.stdout`. If either is None (e.g. subprocess started with `stdin=DEVNULL`), the code crashes with `AttributeError: 'NoneType' object has no attribute 'write'`. The guard raises `RuntimeError` with a descriptive message.

## Test Plan

- [ ] `python3 -c "import ast; ast.parse(open('tools/computer_use/browser_route.py').read())"` — syntax OK
- [ ] `python3 -c "import ast; ast.parse(open('tools/computer_use/doctor.py').read())"` — syntax OK
- [ ] Both files pass `ruff check`