### PR TITLE
feat(plugins): add durable external background-task lifecycle API

### DIFF
--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -1,0 +1,617 @@
+"""Durable plugin API for external background-task lifecycle.
+
+Plugin-facing service exposed lazily as ``PluginContext.background_tasks``.
+It lets a trusted plugin register an EXTERNAL background task (a run owned by
+a separate system — a detached Code Agent run, a remote job, a queued worker),
+immediately hand the parent agent an unguessable handle, and later complete,
+fail, or request cancellation of that task through the SAME durable
+parent-session completion delivery Hermes already uses for
+``delegate_task(background=True)``.
+
+Design rules honored here (see the goal brief):
+
+- **Parent/session binding is host-owned.** Registration binds ONLY to the
+  currently active host parent (``agent.host_context``), never to platform /
+  chat / session values supplied by the plugin. The method signature has no
+  session parameters at all, so the active parent cannot be forged.
+- **Plugin ownership.** Every handle is bound to the registering plugin's
+  identity (captured from ``PluginContext``). A plugin may list, complete,
+  fail, or cancel only handles it owns; cross-plugin access is rejected
+  without leaking whether another plugin owns a handle.
+- **Unguessable, tamper-evident handles.** Each handle carries an opaque
+  ``task_id`` plus an HMAC signature computed with a persisted profile-local
+  key (``state.db`` ``state_meta``), so handles stay valid across process
+  restarts and cannot be forged by a plugin that never sees the key.
+- **Durability + idempotency.** Registrations and terminal completion intent
+  live in a profile-local ``external_background_tasks`` table in ``state.db``
+  (the same profile-local state SQLite file the async-delegation registry
+  uses; see ``agent.background_tasks_store``). Registration is idempotent by
+  (plugin, active parent, request key, canonical payload hash); conflicting
+  replays fail. Terminal events carry a caller ``event_id`` and are
+  idempotent. Terminal transitions are atomic and single: a completed task
+  cannot fail later or emit a second parent completion.
+- **Delivery reuses the existing rail.** The terminal completion is written as
+  a normal async-delegation row (``tools.async_delegation``
+  ``insert_external_completion_row``) and enqueued onto the shared
+  ``process_registry.completion_queue``, so the CLI / gateway / TUI drains,
+  the claim / ack / release / retry machinery, and restart recovery all apply
+  unchanged. No second completion rail exists.
+
+The service never exposes private ``tools.async_delegation`` internals as its
+public API; it returns stable frozen dataclasses with ``to_dict()`` JSON-safe
+mappings (see ``agent.background_tasks_types``).
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import secrets
+import time
+import uuid
+from collections.abc import Mapping
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from agent.background_tasks_store import (
+    _DB_LOCK,
+    canonical_hash,
+    load_or_create_hmac_key,
+    row_to_dict,
+    terminal_hash,
+    transaction,
+)
+from agent.background_tasks_types import (
+    MAX_ERROR_CHARS,
+    MAX_EVENT_ID_CHARS,
+    MAX_EXTERNAL_ID_CHARS,
+    MAX_IDEMPOTENCY_KEY_CHARS,
+    MAX_LABEL_CHARS,
+    MAX_PAYLOAD_BYTES,
+    MAX_SUMMARY_CHARS,
+    PUBLIC_CONTRACT_VERSION,
+    BackgroundTaskError,
+    ExternalTaskHandle,
+    ExternalTaskResult,
+    ExternalTaskState,
+    ExternalTaskStatus,
+    coerce_handle,
+    handle_from_row,
+    sign as _sign_handle,
+)
+from tools.async_delegation import (
+    capture_parent_session_routing,
+    enqueue_completion_event,
+    insert_external_completion_row,
+)
+
+logger = logging.getLogger(__name__)
+
+# Re-export the public contract so `from agent.background_tasks import
+# ExternalTaskHandle, ...` keeps working.
+__all__ = [
+    "PUBLIC_CONTRACT_VERSION",
+    "BackgroundTaskError",
+    "ExternalBackgroundTasksService",
+    "ExternalTaskHandle",
+    "ExternalTaskResult",
+    "ExternalTaskState",
+    "ExternalTaskStatus",
+]
+
+
+def _sign(key: bytes, task_id: str, plugin_id: str, parent_session_id: str, created_at: float) -> str:
+    return _sign_handle(key, task_id, plugin_id, parent_session_id, created_at)
+
+
+class ExternalBackgroundTasksService:
+    """Stable public service returned by :attr:`PluginContext.background_tasks`.
+
+    ``plugin_id`` is captured from the ``PluginContext`` manifest (never passed
+    by the caller per call); ``parent_agent_resolver`` is the host-owned
+    ``agent.host_context.get_active_host_parent``.
+    """
+
+    def __init__(
+        self,
+        plugin_id: str,
+        parent_agent_resolver: Callable[[], Any],
+    ) -> None:
+        if not isinstance(plugin_id, str) or not plugin_id:
+            raise BackgroundTaskError("plugin_id must be a non-empty string.")
+        if not callable(parent_agent_resolver):
+            raise BackgroundTaskError("parent_agent_resolver must be callable.")
+        self.plugin_id = plugin_id
+        self._parent_agent_resolver = parent_agent_resolver
+
+    # -- registration -------------------------------------------------------
+
+    def register_external(
+        self,
+        *,
+        external_id: str,
+        payload: Optional[Mapping[str, Any]] = None,
+        idempotency_key: str = "",
+        label: str = "",
+    ) -> ExternalTaskHandle:
+        """Register an external background task bound to the ACTIVE parent.
+
+        The parent/session routing is captured from the currently active host
+        parent supplied by Hermes; no session value is accepted from the
+        caller. Returns immediately with an unguessable handle the plugin
+        persists and later passes to ``complete`` / ``fail`` /
+        ``request_cancel``.
+
+        Idempotent by (plugin, active parent, ``idempotency_key`` or
+        ``external_id``) + canonical payload hash: a replay returns the same
+        handle; the same key with a different payload raises
+        :class:`BackgroundTaskError`.
+        """
+        parent = self._parent_agent_resolver()
+        if parent is None:
+            raise BackgroundTaskError(
+                "No active Hermes parent session is available. register_external "
+                "must be called while an agent turn is running so Hermes can "
+                "bind the task to the ACTIVE parent session; it cannot accept "
+                "session values from the caller."
+            )
+        self._validate_register_inputs(external_id, payload, idempotency_key, label)
+        parent_session_id = str(getattr(parent, "session_id", "") or "")
+        if not parent_session_id:
+            raise BackgroundTaskError(
+                "The active Hermes parent session has no durable session id; "
+                "registration is not possible."
+            )
+        routing = capture_parent_session_routing(parent)
+        dedup_key = idempotency_key or external_id
+        payload_hash = canonical_hash(dict(payload) if payload is not None else {})
+        now = time.time()
+        task_id = secrets.token_hex(16)
+        with _DB_LOCK, transaction() as conn:
+            key = load_or_create_hmac_key(conn)
+            signature = _sign(key, task_id, self.plugin_id, parent_session_id, now)
+            cur = conn.execute(
+                """INSERT OR IGNORE INTO external_background_tasks
+                   (task_id, plugin_id, parent_session_id, session_key,
+                    origin_ui_session_id, origin_session_id, external_id,
+                    idempotency_key, label, payload_hash, payload_json,
+                    state, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'registered', ?, ?)""",
+                (
+                    task_id, self.plugin_id, parent_session_id,
+                    routing["session_key"], routing["origin_ui_session_id"],
+                    routing["origin_session_id"], external_id, dedup_key, label,
+                    payload_hash,
+                    json.dumps(dict(payload)) if payload is not None else "{}",
+                    now, now,
+                ),
+            )
+            if cur.rowcount == 0:
+                row = conn.execute(
+                    """SELECT * FROM external_background_tasks
+                       WHERE plugin_id=? AND parent_session_id=? AND idempotency_key=?""",
+                    (self.plugin_id, parent_session_id, dedup_key),
+                ).fetchone()
+                if row is None:
+                    raise BackgroundTaskError(
+                        "Conflicting registration: the idempotency key was "
+                        "taken by another task in this parent session."
+                    )
+                existing = row_to_dict(row)
+                if existing["payload_hash"] != payload_hash:
+                    raise BackgroundTaskError(
+                        "Conflicting replay: the same idempotency key was "
+                        "already registered with a different payload."
+                    )
+                logger.info(
+                    "External background task %s re-registered idempotently "
+                    "(plugin=%s, external_id=%s)",
+                    existing["task_id"][:12], self.plugin_id, external_id,
+                )
+                return handle_from_row(key, existing)
+        logger.info(
+            "Registered external background task %s (plugin=%s, external_id=%s)",
+            task_id[:12], self.plugin_id, external_id,
+        )
+        return ExternalTaskHandle(
+            PUBLIC_CONTRACT_VERSION, task_id, self.plugin_id,
+            parent_session_id, now, signature,
+        )
+
+    # -- terminal transitions -----------------------------------------------
+
+    def complete(
+        self,
+        handle: Any,
+        *,
+        event_id: str,
+        summary: str = "",
+        result_payload: Optional[Mapping[str, Any]] = None,
+    ) -> ExternalTaskResult:
+        """Record a successful terminal completion and deliver it to the parent.
+
+        Idempotent by (event_id, payload): a duplicate event with the same
+        payload is harmless; the same event_id with a different payload
+        conflicts. Emits at most one parent completion.
+        """
+        self._validate_terminal_inputs(
+            event_id=event_id, summary=summary, error=None, result_payload=result_payload
+        )
+        resolved = self._resolve_handle(handle)
+        if resolved is None:
+            return ExternalTaskResult(unknown_handle=True)
+        row, coerced = resolved
+        payload_hash = terminal_hash(
+            ExternalTaskState.COMPLETED.value, event_id, summary, None, result_payload
+        )
+        return self._transition_terminal(
+            row, coerced, ExternalTaskState.COMPLETED.value, event_id, payload_hash,
+            summary=summary, error=None, result_payload=result_payload,
+        )
+
+    def fail(
+        self,
+        handle: Any,
+        *,
+        event_id: str,
+        error: str = "",
+    ) -> ExternalTaskResult:
+        """Record a terminal failure and deliver it to the parent.
+
+        Same idempotency contract as :meth:`complete`.
+        """
+        self._validate_terminal_inputs(
+            event_id=event_id, summary=None, error=error, result_payload=None
+        )
+        resolved = self._resolve_handle(handle)
+        if resolved is None:
+            return ExternalTaskResult(unknown_handle=True)
+        row, coerced = resolved
+        payload_hash = terminal_hash(
+            ExternalTaskState.FAILED.value, event_id, None, error, None
+        )
+        return self._transition_terminal(
+            row, coerced, ExternalTaskState.FAILED.value, event_id, payload_hash,
+            summary=None, error=error, result_payload=None,
+        )
+
+    def request_cancel(self, handle: Any) -> ExternalTaskResult:
+        """Record durable cancellation INTENT for a task.
+
+        Only records the intent; it does NOT claim the external system was
+        cancelled. The plugin/consumer still performs the actual external
+        cancellation and later reports the real terminal state via
+        ``complete`` or ``fail``. Idempotent.
+        """
+        resolved = self._resolve_handle(handle)
+        if resolved is None:
+            return ExternalTaskResult(unknown_handle=True)
+        row, coerced = resolved
+        task_id = row["task_id"]
+        if row["state"] in (
+            ExternalTaskState.COMPLETED.value, ExternalTaskState.FAILED.value,
+        ):
+            return ExternalTaskResult(
+                handle=coerced, accepted=False, already_terminal=True,
+                state=row["state"],
+            )
+        now = time.time()
+        with _DB_LOCK, transaction() as conn:
+            cur = conn.execute(
+                """UPDATE external_background_tasks
+                   SET state='cancel_requested', updated_at=?,
+                       cancel_requested_at=COALESCE(cancel_requested_at, ?)
+                   WHERE task_id=? AND state='registered'""",
+                (now, now, task_id),
+            )
+            already = cur.rowcount == 0
+        if already:
+            fresh = self._read_row(task_id)
+            if fresh is not None and fresh["state"] in (
+                ExternalTaskState.COMPLETED.value, ExternalTaskState.FAILED.value,
+            ):
+                return ExternalTaskResult(
+                    handle=coerced, accepted=False, already_terminal=True,
+                    state=fresh["state"],
+                )
+        return ExternalTaskResult(
+            handle=coerced, accepted=True,
+            state=ExternalTaskState.CANCEL_REQUESTED.value,
+            cancel_already_requested=already,
+        )
+
+    # -- listing ------------------------------------------------------------
+
+    def list_pending(self) -> List[ExternalTaskStatus]:
+        """Return this plugin's non-terminal OR undelivered task handles.
+
+        A terminal task stays listed until its completion has been delivered
+        to the parent session (claimed and acknowledged by a drain consumer).
+        After a process restart this returns the same handles, restored from
+        durable profile-local state.
+        """
+        with _DB_LOCK, transaction() as conn:
+            rows = [
+                row_to_dict(r)
+                for r in conn.execute(
+                    "SELECT * FROM external_background_tasks WHERE plugin_id=?",
+                    (self.plugin_id,),
+                ).fetchall()
+            ]
+            key = load_or_create_hmac_key(conn)
+        statuses: List[ExternalTaskStatus] = []
+        for row in rows:
+            if row["state"] not in (
+                ExternalTaskState.REGISTERED.value,
+                ExternalTaskState.CANCEL_REQUESTED.value,
+            ):
+                self._sync_delivery_state(row)
+            if (
+                row["state"] in (
+                    ExternalTaskState.REGISTERED.value,
+                    ExternalTaskState.CANCEL_REQUESTED.value,
+                )
+                or row["delivery_state"] != "delivered"
+            ):
+                statuses.append(
+                    ExternalTaskStatus(
+                        handle=handle_from_row(key, row),
+                        state=ExternalTaskState(row["state"]),
+                        delivery_state=row["delivery_state"],
+                        external_id=row["external_id"],
+                        created_at=row["created_at"],
+                        updated_at=row["updated_at"],
+                        completed_at=row["completed_at"],
+                    )
+                )
+        return statuses
+
+    # -- internals ----------------------------------------------------------
+
+    def _resolve_handle(self, value: Any) -> Optional[Tuple[Dict[str, Any], ExternalTaskHandle]]:
+        """Verify handle shape, plugin ownership, signature, and row existence.
+
+        Returns ``None`` for anything that does not positively resolve —
+        foreign-plugin handles, tampered signatures, unknown task ids — so
+        callers never learn whether another plugin owns a handle.
+        """
+        handle = coerce_handle(value)
+        if handle is None or handle.plugin_id != self.plugin_id:
+            return None
+        with _DB_LOCK, transaction() as conn:
+            key = load_or_create_hmac_key(conn)
+            row = conn.execute(
+                "SELECT * FROM external_background_tasks WHERE task_id=?",
+                (handle.task_id,),
+            ).fetchone()
+        if not hmac.compare_digest(
+            handle.signature,
+            _sign(
+                key, handle.task_id, handle.plugin_id,
+                handle.parent_session_id, handle.created_at,
+            ),
+        ):
+            return None
+        if row is None:
+            return None
+        data = row_to_dict(row)
+        if (
+            data["plugin_id"] != handle.plugin_id
+            or data["parent_session_id"] != handle.parent_session_id
+        ):
+            return None
+        return data, handle
+
+    def _read_row(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with _DB_LOCK, transaction() as conn:
+            row = conn.execute(
+                "SELECT * FROM external_background_tasks WHERE task_id=?",
+                (task_id,),
+            ).fetchone()
+        return row_to_dict(row) if row is not None else None
+
+    def _transition_terminal(
+        self,
+        row: Dict[str, Any],
+        handle: ExternalTaskHandle,
+        status: str,
+        event_id: str,
+        payload_hash: str,
+        *,
+        summary: Optional[str],
+        error: Optional[str],
+        result_payload: Optional[Mapping[str, Any]],
+    ) -> ExternalTaskResult:
+        """Atomically flip the task to terminal and persist its delivery row.
+
+        The task-state transition and the async-delegation delivery-row insert
+        share one SQLite transaction, so a crash can never leave a terminal
+        task without a durable completion (or vice versa). The completion is
+        enqueued only AFTER commit; a failed enqueue is recovered by the
+        durable restart-restore rail.
+        """
+        task_id = row["task_id"]
+        now = time.time()
+        delegation_id = f"ext_{uuid.uuid4().hex[:12]}"
+        evt = self._build_completion_event(
+            row, delegation_id, status, summary, error, result_payload, now
+        )
+        result = {
+            "status": status,
+            "summary": summary,
+            "error": error,
+            "result_payload": result_payload,
+        }
+        with _DB_LOCK, transaction() as conn:
+            cur = conn.execute(
+                """UPDATE external_background_tasks
+                   SET state=?, completed_at=?, updated_at=?,
+                       terminal_event_id=?, terminal_payload_hash=?,
+                       summary=?, error=?, result_json=?,
+                       delivery_delegation_id=?, delivery_state='pending'
+                   WHERE task_id=? AND state IN ('registered','cancel_requested')""",
+                (
+                    status, now, now, event_id, payload_hash, summary, error,
+                    json.dumps(result_payload) if result_payload is not None else None,
+                    delegation_id, task_id,
+                ),
+            )
+            if cur.rowcount == 1:
+                insert_external_completion_row(conn, evt, result)
+                committed = True
+            else:
+                committed = False
+        if committed:
+            enqueue_completion_event(evt)
+            return ExternalTaskResult(handle=handle, accepted=True, state=status)
+        # Lost the terminal race (or already terminal) — resolve honestly.
+        fresh = self._read_row(task_id)
+        if fresh is None:
+            return ExternalTaskResult(unknown_handle=True)
+        if fresh["terminal_event_id"] == event_id:
+            if fresh["terminal_payload_hash"] == payload_hash:
+                return ExternalTaskResult(
+                    handle=handle, accepted=True, already_terminal=True,
+                    state=fresh["state"],
+                )
+            return ExternalTaskResult(
+                handle=handle, accepted=False, conflict=True,
+                state=fresh["state"],
+                message="The same event id was already applied with a "
+                "different payload.",
+            )
+        return ExternalTaskResult(
+            handle=handle, accepted=False, already_terminal=True,
+            state=fresh["state"],
+            message="Task already reached a terminal state.",
+        )
+
+    def _build_completion_event(
+        self,
+        row: Dict[str, Any],
+        delegation_id: str,
+        status: str,
+        summary: Optional[str],
+        error: Optional[str],
+        result_payload: Optional[Mapping[str, Any]],
+        now: float,
+    ) -> Dict[str, Any]:
+        evt: Dict[str, Any] = {
+            "type": "async_delegation",
+            "delegation_id": delegation_id,
+            "session_key": row["session_key"],
+            "origin_ui_session_id": row["origin_ui_session_id"],
+            "origin_session_id": row["origin_session_id"],
+            "parent_session_id": row["parent_session_id"],
+            "goal": row["label"] or f"external task {row['external_id']}",
+            "status": status,
+            "summary": summary,
+            "error": error,
+            "api_calls": 0,
+            "duration_seconds": round(max(0.0, now - row["created_at"]), 2),
+            "dispatched_at": row["created_at"],
+            "completed_at": now,
+            "external_background_task": True,
+        }
+        if result_payload is not None:
+            evt["result_payload"] = result_payload
+        return evt
+
+    def _sync_delivery_state(self, row: Dict[str, Any]) -> None:
+        """Refresh a terminal row's delivery state from the shared rail."""
+        if row["delivery_state"] == "delivered":
+            return
+        delegation_id = row.get("delivery_delegation_id") or ""
+        if not delegation_id:
+            return
+        from tools.async_delegation import get_durable_delegation
+
+        info = get_durable_delegation(delegation_id)
+        if info is None:
+            # The async-delegation row was pruned after delivery (or after a
+            # dropped terminal disposition) — treat as delivered.
+            new_state = "delivered"
+        else:
+            new_state = info.get("delivery_state") or "pending"
+        if new_state != row["delivery_state"]:
+            with _DB_LOCK, transaction() as conn:
+                conn.execute(
+                    "UPDATE external_background_tasks SET delivery_state=?, "
+                    "updated_at=? WHERE task_id=?",
+                    (new_state, time.time(), row["task_id"]),
+                )
+            row["delivery_state"] = new_state
+
+    @staticmethod
+    def _validate_register_inputs(
+        external_id: str, payload: Optional[Mapping[str, Any]],
+        idempotency_key: str, label: str,
+    ) -> None:
+        if not isinstance(external_id, str) or not external_id.strip():
+            raise BackgroundTaskError("external_id must be a non-empty string.")
+        if len(external_id) > MAX_EXTERNAL_ID_CHARS:
+            raise BackgroundTaskError(
+                f"external_id exceeds {MAX_EXTERNAL_ID_CHARS} characters."
+            )
+        if not isinstance(idempotency_key, str):
+            raise BackgroundTaskError("idempotency_key must be a string.")
+        if len(idempotency_key) > MAX_IDEMPOTENCY_KEY_CHARS:
+            raise BackgroundTaskError(
+                f"idempotency_key exceeds {MAX_IDEMPOTENCY_KEY_CHARS} characters."
+            )
+        if not isinstance(label, str):
+            raise BackgroundTaskError("label must be a string.")
+        if len(label) > MAX_LABEL_CHARS:
+            raise BackgroundTaskError(f"label exceeds {MAX_LABEL_CHARS} characters.")
+        if payload is not None:
+            if not isinstance(payload, Mapping):
+                raise BackgroundTaskError("payload must be a JSON object (mapping).")
+            try:
+                raw = json.dumps(dict(payload), sort_keys=True)
+            except (TypeError, ValueError) as exc:
+                raise BackgroundTaskError("payload must be JSON-serializable.") from exc
+            if len(raw.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+                raise BackgroundTaskError(
+                    f"payload exceeds {MAX_PAYLOAD_BYTES} bytes."
+                )
+
+    @staticmethod
+    def _validate_terminal_inputs(
+        *, event_id: str, summary: Optional[str], error: Optional[str],
+        result_payload: Optional[Mapping[str, Any]],
+    ) -> None:
+        if not isinstance(event_id, str) or not event_id.strip():
+            raise BackgroundTaskError("event_id must be a non-empty string.")
+        if len(event_id) > MAX_EVENT_ID_CHARS:
+            raise BackgroundTaskError(
+                f"event_id exceeds {MAX_EVENT_ID_CHARS} characters."
+            )
+        if summary is not None:
+            if not isinstance(summary, str):
+                raise BackgroundTaskError("summary must be a string.")
+            if len(summary) > MAX_SUMMARY_CHARS:
+                raise BackgroundTaskError(
+                    f"summary exceeds {MAX_SUMMARY_CHARS} characters."
+                )
+        if error is not None:
+            if not isinstance(error, str):
+                raise BackgroundTaskError("error must be a string.")
+            if len(error) > MAX_ERROR_CHARS:
+                raise BackgroundTaskError(
+                    f"error exceeds {MAX_ERROR_CHARS} characters."
+                )
+        if result_payload is not None:
+            if not isinstance(result_payload, Mapping):
+                raise BackgroundTaskError(
+                    "result_payload must be a JSON object (mapping)."
+                )
+            try:
+                raw = json.dumps(dict(result_payload), sort_keys=True)
+            except (TypeError, ValueError) as exc:
+                raise BackgroundTaskError(
+                    "result_payload must be JSON-serializable."
+                ) from exc
+            if len(raw.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+                raise BackgroundTaskError(
+                    f"result_payload exceeds {MAX_PAYLOAD_BYTES} bytes."
+                )

--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -92,7 +92,6 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "PUBLIC_CONTRACT_VERSION",
     "BackgroundTaskError",
-    "ExternalBackgroundTasksService",
     "ExternalTaskHandle",
     "ExternalTaskResult",
     "ExternalTaskState",
@@ -111,17 +110,17 @@ _HOST_SERVICE_CAPABILITY = object()
 
 def _create_external_background_tasks_service(
     *, plugin_id: str, parent_agent_resolver: Callable[[], Any]
-) -> "ExternalBackgroundTasksService":
+) -> "_ExternalBackgroundTasksService":
     """Host-private constructor used by :class:`PluginContext` and core tests."""
 
-    return ExternalBackgroundTasksService(
+    return _ExternalBackgroundTasksService(
         plugin_id=plugin_id,
         parent_agent_resolver=parent_agent_resolver,
         _host_capability=_HOST_SERVICE_CAPABILITY,
     )
 
 
-class ExternalBackgroundTasksService:
+class _ExternalBackgroundTasksService:
     """Stable public service returned by :attr:`PluginContext.background_tasks`.
 
     ``plugin_id`` is captured from the ``PluginContext`` manifest (never passed

--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -123,8 +123,14 @@ class ExternalBackgroundTasksService:
             raise BackgroundTaskError("plugin_id must be a non-empty string.")
         if not callable(parent_agent_resolver):
             raise BackgroundTaskError("parent_agent_resolver must be callable.")
-        self.plugin_id = plugin_id
+        self._plugin_id = plugin_id
         self._parent_agent_resolver = parent_agent_resolver
+
+    @property
+    def plugin_id(self) -> str:
+        """Plugin identity captured at construction and immutable via the public API."""
+
+        return self._plugin_id
 
     # -- registration -------------------------------------------------------
 

--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -100,7 +100,9 @@ __all__ = [
 ]
 
 
-def _sign(key: bytes, task_id: str, plugin_id: str, parent_session_id: str, created_at: float) -> str:
+def _sign(
+    key: bytes, task_id: str, plugin_id: str, parent_session_id: str, created_at: float
+) -> str:
     return _sign_handle(key, task_id, plugin_id, parent_session_id, created_at)
 
 
@@ -178,12 +180,19 @@ class ExternalBackgroundTasksService:
                     state, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'registered', ?, ?)""",
                 (
-                    task_id, self.plugin_id, parent_session_id,
-                    routing["session_key"], routing["origin_ui_session_id"],
-                    routing["origin_session_id"], external_id, dedup_key, label,
+                    task_id,
+                    self.plugin_id,
+                    parent_session_id,
+                    routing["session_key"],
+                    routing["origin_ui_session_id"],
+                    routing["origin_session_id"],
+                    external_id,
+                    dedup_key,
+                    label,
                     payload_hash,
                     json.dumps(dict(payload)) if payload is not None else "{}",
-                    now, now,
+                    now,
+                    now,
                 ),
             )
             if cur.rowcount == 0:
@@ -206,16 +215,24 @@ class ExternalBackgroundTasksService:
                 logger.info(
                     "External background task %s re-registered idempotently "
                     "(plugin=%s, external_id=%s)",
-                    existing["task_id"][:12], self.plugin_id, external_id,
+                    existing["task_id"][:12],
+                    self.plugin_id,
+                    external_id,
                 )
                 return handle_from_row(key, existing)
         logger.info(
             "Registered external background task %s (plugin=%s, external_id=%s)",
-            task_id[:12], self.plugin_id, external_id,
+            task_id[:12],
+            self.plugin_id,
+            external_id,
         )
         return ExternalTaskHandle(
-            PUBLIC_CONTRACT_VERSION, task_id, self.plugin_id,
-            parent_session_id, now, signature,
+            PUBLIC_CONTRACT_VERSION,
+            task_id,
+            self.plugin_id,
+            parent_session_id,
+            now,
+            signature,
         )
 
     # -- terminal transitions -----------------------------------------------
@@ -235,7 +252,10 @@ class ExternalBackgroundTasksService:
         conflicts. Emits at most one parent completion.
         """
         self._validate_terminal_inputs(
-            event_id=event_id, summary=summary, error=None, result_payload=result_payload
+            event_id=event_id,
+            summary=summary,
+            error=None,
+            result_payload=result_payload,
         )
         resolved = self._resolve_handle(handle)
         if resolved is None:
@@ -245,8 +265,14 @@ class ExternalBackgroundTasksService:
             ExternalTaskState.COMPLETED.value, event_id, summary, None, result_payload
         )
         return self._transition_terminal(
-            row, coerced, ExternalTaskState.COMPLETED.value, event_id, payload_hash,
-            summary=summary, error=None, result_payload=result_payload,
+            row,
+            coerced,
+            ExternalTaskState.COMPLETED.value,
+            event_id,
+            payload_hash,
+            summary=summary,
+            error=None,
+            result_payload=result_payload,
         )
 
     def fail(
@@ -271,8 +297,14 @@ class ExternalBackgroundTasksService:
             ExternalTaskState.FAILED.value, event_id, None, error, None
         )
         return self._transition_terminal(
-            row, coerced, ExternalTaskState.FAILED.value, event_id, payload_hash,
-            summary=None, error=error, result_payload=None,
+            row,
+            coerced,
+            ExternalTaskState.FAILED.value,
+            event_id,
+            payload_hash,
+            summary=None,
+            error=error,
+            result_payload=None,
         )
 
     def request_cancel(self, handle: Any) -> ExternalTaskResult:
@@ -289,10 +321,13 @@ class ExternalBackgroundTasksService:
         row, coerced = resolved
         task_id = row["task_id"]
         if row["state"] in (
-            ExternalTaskState.COMPLETED.value, ExternalTaskState.FAILED.value,
+            ExternalTaskState.COMPLETED.value,
+            ExternalTaskState.FAILED.value,
         ):
             return ExternalTaskResult(
-                handle=coerced, accepted=False, already_terminal=True,
+                handle=coerced,
+                accepted=False,
+                already_terminal=True,
                 state=row["state"],
             )
         now = time.time()
@@ -308,14 +343,18 @@ class ExternalBackgroundTasksService:
         if already:
             fresh = self._read_row(task_id)
             if fresh is not None and fresh["state"] in (
-                ExternalTaskState.COMPLETED.value, ExternalTaskState.FAILED.value,
+                ExternalTaskState.COMPLETED.value,
+                ExternalTaskState.FAILED.value,
             ):
                 return ExternalTaskResult(
-                    handle=coerced, accepted=False, already_terminal=True,
+                    handle=coerced,
+                    accepted=False,
+                    already_terminal=True,
                     state=fresh["state"],
                 )
         return ExternalTaskResult(
-            handle=coerced, accepted=True,
+            handle=coerced,
+            accepted=True,
             state=ExternalTaskState.CANCEL_REQUESTED.value,
             cancel_already_requested=already,
         )
@@ -347,7 +386,8 @@ class ExternalBackgroundTasksService:
             ):
                 self._sync_delivery_state(row)
             if (
-                row["state"] in (
+                row["state"]
+                in (
                     ExternalTaskState.REGISTERED.value,
                     ExternalTaskState.CANCEL_REQUESTED.value,
                 )
@@ -368,7 +408,9 @@ class ExternalBackgroundTasksService:
 
     # -- internals ----------------------------------------------------------
 
-    def _resolve_handle(self, value: Any) -> Optional[Tuple[Dict[str, Any], ExternalTaskHandle]]:
+    def _resolve_handle(
+        self, value: Any
+    ) -> Optional[Tuple[Dict[str, Any], ExternalTaskHandle]]:
         """Verify handle shape, plugin ownership, signature, and row existence.
 
         Returns ``None`` for anything that does not positively resolve —
@@ -387,8 +429,11 @@ class ExternalBackgroundTasksService:
         if not hmac.compare_digest(
             handle.signature,
             _sign(
-                key, handle.task_id, handle.plugin_id,
-                handle.parent_session_id, handle.created_at,
+                key,
+                handle.task_id,
+                handle.plugin_id,
+                handle.parent_session_id,
+                handle.created_at,
             ),
         ):
             return None
@@ -451,9 +496,16 @@ class ExternalBackgroundTasksService:
                        delivery_delegation_id=?, delivery_state='pending'
                    WHERE task_id=? AND state IN ('registered','cancel_requested')""",
                 (
-                    status, now, now, event_id, payload_hash, summary, error,
+                    status,
+                    now,
+                    now,
+                    event_id,
+                    payload_hash,
+                    summary,
+                    error,
                     json.dumps(result_payload) if result_payload is not None else None,
-                    delegation_id, task_id,
+                    delegation_id,
+                    task_id,
                 ),
             )
             if cur.rowcount == 1:
@@ -471,17 +523,23 @@ class ExternalBackgroundTasksService:
         if fresh["terminal_event_id"] == event_id:
             if fresh["terminal_payload_hash"] == payload_hash:
                 return ExternalTaskResult(
-                    handle=handle, accepted=True, already_terminal=True,
+                    handle=handle,
+                    accepted=True,
+                    already_terminal=True,
                     state=fresh["state"],
                 )
             return ExternalTaskResult(
-                handle=handle, accepted=False, conflict=True,
+                handle=handle,
+                accepted=False,
+                conflict=True,
                 state=fresh["state"],
                 message="The same event id was already applied with a "
                 "different payload.",
             )
         return ExternalTaskResult(
-            handle=handle, accepted=False, already_terminal=True,
+            handle=handle,
+            accepted=False,
+            already_terminal=True,
             state=fresh["state"],
             message="Task already reached a terminal state.",
         )
@@ -544,8 +602,10 @@ class ExternalBackgroundTasksService:
 
     @staticmethod
     def _validate_register_inputs(
-        external_id: str, payload: Optional[Mapping[str, Any]],
-        idempotency_key: str, label: str,
+        external_id: str,
+        payload: Optional[Mapping[str, Any]],
+        idempotency_key: str,
+        label: str,
     ) -> None:
         if not isinstance(external_id, str) or not external_id.strip():
             raise BackgroundTaskError("external_id must be a non-empty string.")
@@ -567,17 +627,18 @@ class ExternalBackgroundTasksService:
             if not isinstance(payload, Mapping):
                 raise BackgroundTaskError("payload must be a JSON object (mapping).")
             try:
-                raw = json.dumps(dict(payload), sort_keys=True)
+                raw = json.dumps(dict(payload), sort_keys=True, allow_nan=False)
             except (TypeError, ValueError) as exc:
                 raise BackgroundTaskError("payload must be JSON-serializable.") from exc
             if len(raw.encode("utf-8")) > MAX_PAYLOAD_BYTES:
-                raise BackgroundTaskError(
-                    f"payload exceeds {MAX_PAYLOAD_BYTES} bytes."
-                )
+                raise BackgroundTaskError(f"payload exceeds {MAX_PAYLOAD_BYTES} bytes.")
 
     @staticmethod
     def _validate_terminal_inputs(
-        *, event_id: str, summary: Optional[str], error: Optional[str],
+        *,
+        event_id: str,
+        summary: Optional[str],
+        error: Optional[str],
         result_payload: Optional[Mapping[str, Any]],
     ) -> None:
         if not isinstance(event_id, str) or not event_id.strip():
@@ -606,7 +667,7 @@ class ExternalBackgroundTasksService:
                     "result_payload must be a JSON object (mapping)."
                 )
             try:
-                raw = json.dumps(dict(result_payload), sort_keys=True)
+                raw = json.dumps(dict(result_payload), sort_keys=True, allow_nan=False)
             except (TypeError, ValueError) as exc:
                 raise BackgroundTaskError(
                     "result_payload must be JSON-serializable."

--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -106,6 +106,21 @@ def _sign(
     return _sign_handle(key, task_id, plugin_id, parent_session_id, created_at)
 
 
+_HOST_SERVICE_CAPABILITY = object()
+
+
+def _create_external_background_tasks_service(
+    *, plugin_id: str, parent_agent_resolver: Callable[[], Any]
+) -> "ExternalBackgroundTasksService":
+    """Host-private constructor used by :class:`PluginContext` and core tests."""
+
+    return ExternalBackgroundTasksService(
+        plugin_id=plugin_id,
+        parent_agent_resolver=parent_agent_resolver,
+        _host_capability=_HOST_SERVICE_CAPABILITY,
+    )
+
+
 class ExternalBackgroundTasksService:
     """Stable public service returned by :attr:`PluginContext.background_tasks`.
 
@@ -118,7 +133,13 @@ class ExternalBackgroundTasksService:
         self,
         plugin_id: str,
         parent_agent_resolver: Callable[[], Any],
+        *,
+        _host_capability: object | None = None,
     ) -> None:
+        if _host_capability is not _HOST_SERVICE_CAPABILITY:
+            raise BackgroundTaskError(
+                "External background-task services are host-owned; use PluginContext.background_tasks."
+            )
         if not isinstance(plugin_id, str) or not plugin_id:
             raise BackgroundTaskError("plugin_id must be a non-empty string.")
         if not callable(parent_agent_resolver):

--- a/agent/background_tasks_store.py
+++ b/agent/background_tasks_store.py
@@ -1,0 +1,151 @@
+"""Durable profile-local store for external background tasks.
+
+Owns the SQLite plumbing (schema, connections, transactions) for the plugin
+external background-task lifecycle API in ``agent/background_tasks``. The
+delivery rail itself stays in ``tools.async_delegation``; this module only
+stores the plugin-owned task lifecycle rows and the persisted handle HMAC key.
+
+The table lives in the SAME profile-local ``state.db`` as the async-delegation
+registry so a terminal transition and its delivery-row insert are atomic in
+one transaction. Everything here is private to the lifecycle API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
+
+from hermes_constants import get_hermes_home
+
+_HMAC_META_KEY = "ext_background_tasks.hmac_key"
+
+_DB_LOCK = threading.Lock()
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS state_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+CREATE TABLE IF NOT EXISTS external_background_tasks (
+    task_id TEXT PRIMARY KEY,
+    plugin_id TEXT NOT NULL,
+    parent_session_id TEXT NOT NULL,
+    session_key TEXT NOT NULL DEFAULT '',
+    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+    origin_session_id TEXT NOT NULL DEFAULT '',
+    external_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    label TEXT NOT NULL DEFAULT '',
+    payload_hash TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    cancel_requested_at REAL,
+    completed_at REAL,
+    terminal_event_id TEXT,
+    terminal_payload_hash TEXT,
+    summary TEXT,
+    error TEXT,
+    result_json TEXT,
+    delivery_delegation_id TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_tasks_dedup
+    ON external_background_tasks(plugin_id, parent_session_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS idx_ext_tasks_plugin_state
+    ON external_background_tasks(plugin_id, state);
+"""
+
+_ROW_COLUMNS = (
+    "task_id", "plugin_id", "parent_session_id", "session_key",
+    "origin_ui_session_id", "origin_session_id", "external_id",
+    "idempotency_key", "label", "payload_hash", "payload_json", "state",
+    "created_at", "updated_at", "cancel_requested_at", "completed_at",
+    "terminal_event_id", "terminal_payload_hash", "summary", "error",
+    "result_json", "delivery_delegation_id", "delivery_state",
+)
+
+
+def _db_path():
+    return get_hermes_home() / "state.db"
+
+
+def connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    try:
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(conn, db_label="state.db (background_tasks)")
+        conn.execute("PRAGMA busy_timeout=10000")
+        conn.executescript(_SCHEMA)
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    """Open a connection, commit/rollback on exit, and ALWAYS close it."""
+    conn = connect()
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
+
+
+def load_or_create_hmac_key(conn: sqlite3.Connection) -> bytes:
+    """Load the persisted profile-local handle key, creating it on first use."""
+    row = conn.execute(
+        "SELECT value FROM state_meta WHERE key=?", (_HMAC_META_KEY,)
+    ).fetchone()
+    if row is not None:
+        return bytes.fromhex(row[0])
+    key = secrets.token_bytes(32)
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
+        (_HMAC_META_KEY, key.hex()),
+    )
+    return key
+
+
+def sign_handle(
+    key: bytes, task_id: str, plugin_id: str, parent_session_id: str, created_at: float
+) -> str:
+    value = f"{task_id}|{plugin_id}|{parent_session_id}|{created_at:.6f}".encode(
+        "utf-8"
+    )
+    return hmac.new(key, value, hashlib.sha256).hexdigest()
+
+
+def row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    return dict(zip(_ROW_COLUMNS, row))
+
+
+def canonical_hash(payload: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def terminal_hash(status: str, event_id: str, summary: Any, error: Any, result_payload: Any) -> str:
+    payload = {
+        "status": status,
+        "event_id": event_id,
+        "summary": summary,
+        "error": error,
+        "result_payload": result_payload,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()

--- a/agent/background_tasks_store.py
+++ b/agent/background_tasks_store.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
+import random
 import secrets
 import sqlite3
 import threading
+import time
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator
 
@@ -101,8 +104,17 @@ def connect() -> sqlite3.Connection:
     try:
         from hermes_state import apply_wal_with_fallback
 
-        apply_wal_with_fallback(conn, db_label="state.db (background_tasks)")
         conn.execute("PRAGMA busy_timeout=10000")
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                apply_wal_with_fallback(conn, db_label="state.db (background_tasks)")
+                break
+            except sqlite3.OperationalError as exc:
+                lock_contention = "locked" in str(exc).lower() or "busy" in str(exc).lower()
+                if not lock_contention or time.monotonic() >= deadline:
+                    raise
+                time.sleep(random.uniform(0.01, 0.05))
         conn.executescript(_SCHEMA)
     except Exception:
         conn.close()

--- a/agent/background_tasks_store.py
+++ b/agent/background_tasks_store.py
@@ -123,17 +123,27 @@ def transaction() -> Iterator[sqlite3.Connection]:
 
 def load_or_create_hmac_key(conn: sqlite3.Connection) -> bytes:
     """Load the persisted profile-local handle key, creating it on first use."""
-    row = conn.execute(
-        "SELECT value FROM state_meta WHERE key=?", (_HMAC_META_KEY,)
-    ).fetchone()
-    if row is not None:
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        candidate = secrets.token_bytes(32)
+        conn.execute(
+            "INSERT OR IGNORE INTO state_meta (key, value) VALUES (?, ?)",
+            (_HMAC_META_KEY, candidate.hex()),
+        )
+        row = conn.execute(
+            "SELECT value FROM state_meta WHERE key=?", (_HMAC_META_KEY,)
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("background-task HMAC key initialization failed")
+        if owns_transaction:
+            conn.commit()
         return bytes.fromhex(row[0])
-    key = secrets.token_bytes(32)
-    conn.execute(
-        "INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
-        (_HMAC_META_KEY, key.hex()),
-    )
-    return key
+    except Exception:
+        if owns_transaction:
+            conn.rollback()
+        raise
 
 
 def sign_handle(

--- a/agent/background_tasks_store.py
+++ b/agent/background_tasks_store.py
@@ -64,12 +64,29 @@ CREATE INDEX IF NOT EXISTS idx_ext_tasks_plugin_state
 """
 
 _ROW_COLUMNS = (
-    "task_id", "plugin_id", "parent_session_id", "session_key",
-    "origin_ui_session_id", "origin_session_id", "external_id",
-    "idempotency_key", "label", "payload_hash", "payload_json", "state",
-    "created_at", "updated_at", "cancel_requested_at", "completed_at",
-    "terminal_event_id", "terminal_payload_hash", "summary", "error",
-    "result_json", "delivery_delegation_id", "delivery_state",
+    "task_id",
+    "plugin_id",
+    "parent_session_id",
+    "session_key",
+    "origin_ui_session_id",
+    "origin_session_id",
+    "external_id",
+    "idempotency_key",
+    "label",
+    "payload_hash",
+    "payload_json",
+    "state",
+    "created_at",
+    "updated_at",
+    "cancel_requested_at",
+    "completed_at",
+    "terminal_event_id",
+    "terminal_payload_hash",
+    "summary",
+    "error",
+    "result_json",
+    "delivery_delegation_id",
+    "delivery_state",
 )
 
 
@@ -138,7 +155,9 @@ def canonical_hash(payload: Any) -> str:
     ).hexdigest()
 
 
-def terminal_hash(status: str, event_id: str, summary: Any, error: Any, result_payload: Any) -> str:
+def terminal_hash(
+    status: str, event_id: str, summary: Any, error: Any, result_payload: Any
+) -> str:
     payload = {
         "status": status,
         "event_id": event_id,

--- a/agent/background_tasks_types.py
+++ b/agent/background_tasks_types.py
@@ -72,6 +72,9 @@ class ExternalTaskStatus:
     updated_at: float
     completed_at: Optional[float] = None
 
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
 
 @dataclasses.dataclass(frozen=True)
 class ExternalTaskResult:
@@ -85,6 +88,9 @@ class ExternalTaskResult:
     unknown_handle: bool = False
     cancel_already_requested: bool = False
     message: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
 
 
 def sign(
@@ -101,7 +107,10 @@ def handle_from_row(key: bytes, row: Mapping[str, Any]) -> ExternalTaskHandle:
         parent_session_id=row["parent_session_id"],
         created_at=row["created_at"],
         signature=sign(
-            key, row["task_id"], row["plugin_id"], row["parent_session_id"],
+            key,
+            row["task_id"],
+            row["plugin_id"],
+            row["parent_session_id"],
             row["created_at"],
         ),
     )

--- a/agent/background_tasks_types.py
+++ b/agent/background_tasks_types.py
@@ -1,0 +1,139 @@
+"""Public contract types for the external background-task lifecycle API.
+
+Holders of the stable, plugin-facing dataclasses and the handle signing /
+validation helpers for :mod:`agent.background_tasks`. Kept separate so the
+service module stays focused on orchestration and size/schema validation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import math
+from collections.abc import Mapping
+from typing import Any, Dict, Optional
+
+from agent.background_tasks_store import sign_handle
+
+PUBLIC_CONTRACT_VERSION = 1
+
+# Bounded text/schema sizes enforced BEFORE any persistence or queue write.
+MAX_EXTERNAL_ID_CHARS = 200
+MAX_IDEMPOTENCY_KEY_CHARS = 200
+MAX_EVENT_ID_CHARS = 200
+MAX_LABEL_CHARS = 500
+MAX_SUMMARY_CHARS = 32_000
+MAX_ERROR_CHARS = 32_000
+MAX_PAYLOAD_BYTES = 32_000
+
+
+class BackgroundTaskError(ValueError):
+    """A request cannot be safely accepted by the external background-task API."""
+
+
+class ExternalTaskState(str, enum.Enum):
+    """Durable lifecycle state of an external background task."""
+
+    REGISTERED = "registered"
+    CANCEL_REQUESTED = "cancel_requested"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalTaskHandle:
+    """Opaque, tamper-evident reference to one registered external task.
+
+    The ``signature`` is an HMAC over the other fields using a persisted
+    profile-local key; plugins never see the key and cannot forge handles for
+    tasks they do not own. Handles remain valid across process restarts.
+    """
+
+    contract_version: int
+    task_id: str
+    plugin_id: str
+    parent_session_id: str
+    created_at: float
+    signature: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalTaskStatus:
+    """Read-only snapshot of one external task for the owning plugin."""
+
+    handle: ExternalTaskHandle
+    state: ExternalTaskState
+    delivery_state: str
+    external_id: str
+    created_at: float
+    updated_at: float
+    completed_at: Optional[float] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalTaskResult:
+    """Outcome of a lifecycle operation; all fields are JSON-safe."""
+
+    handle: Optional[ExternalTaskHandle] = None
+    accepted: bool = False
+    state: str = ""
+    already_terminal: bool = False
+    conflict: bool = False
+    unknown_handle: bool = False
+    cancel_already_requested: bool = False
+    message: str = ""
+
+
+def sign(
+    key: bytes, task_id: str, plugin_id: str, parent_session_id: str, created_at: float
+) -> str:
+    return sign_handle(key, task_id, plugin_id, parent_session_id, created_at)
+
+
+def handle_from_row(key: bytes, row: Mapping[str, Any]) -> ExternalTaskHandle:
+    return ExternalTaskHandle(
+        contract_version=PUBLIC_CONTRACT_VERSION,
+        task_id=row["task_id"],
+        plugin_id=row["plugin_id"],
+        parent_session_id=row["parent_session_id"],
+        created_at=row["created_at"],
+        signature=sign(
+            key, row["task_id"], row["plugin_id"], row["parent_session_id"],
+            row["created_at"],
+        ),
+    )
+
+
+def valid_handle_shape(handle: ExternalTaskHandle) -> bool:
+    return (
+        isinstance(handle, ExternalTaskHandle)
+        and type(handle.contract_version) is int
+        and handle.contract_version == PUBLIC_CONTRACT_VERSION
+        and isinstance(handle.task_id, str)
+        and bool(handle.task_id)
+        and isinstance(handle.plugin_id, str)
+        and bool(handle.plugin_id)
+        and isinstance(handle.parent_session_id, str)
+        and isinstance(handle.created_at, (int, float))
+        and not isinstance(handle.created_at, bool)
+        and math.isfinite(handle.created_at)
+        and isinstance(handle.signature, str)
+        and bool(handle.signature)
+    )
+
+
+def coerce_handle(value: Any) -> Optional[ExternalTaskHandle]:
+    """Parse a handle passed as an object or a JSON-safe mapping."""
+    if isinstance(value, ExternalTaskHandle):
+        handle = value
+    elif isinstance(value, Mapping):
+        try:
+            handle = ExternalTaskHandle(**dict(value))
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    return handle if valid_handle_shape(handle) else None

--- a/agent/host_context.py
+++ b/agent/host_context.py
@@ -1,0 +1,43 @@
+"""Shared active-host-parent binding for plugin-facing lifecycle APIs.
+
+Hermes binds the currently running parent agent for the duration of an agent
+turn (``run_agent.run_conversation``). Plugin-facing services that must bind a
+registration to the *active* host parent — the subagent lifecycle API and the
+durable external background-task API — resolve that parent through this module
+instead of reading arbitrary platform/chat/session values from the caller.
+
+The binding is deliberately host-owned: plugins never set it, and never pass a
+parent/session identity into the service methods. See
+``agent.subagent_lifecycle.bind_subagent_parent`` for the historical wrapper
+that delegates here.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Any, Optional
+
+
+_ACTIVE_HOST_PARENT: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "hermes_host_parent", default=None
+)
+
+
+@contextmanager
+def bind_host_parent(parent_agent: Any):
+    """Bind the host-owned parent for the current agent turn.
+
+    Restores the previous value on exit. Safe to nest: each call saves and
+    restores its own token.
+    """
+    token = _ACTIVE_HOST_PARENT.set(parent_agent)
+    try:
+        yield
+    finally:
+        _ACTIVE_HOST_PARENT.reset(token)
+
+
+def get_active_host_parent() -> Optional[Any]:
+    """Return the parent bound to this execution context, if any."""
+    return _ACTIVE_HOST_PARENT.get()

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -7,7 +7,6 @@ sessions; plugins must obtain it from ``PluginContext.subagent_lifecycle``.
 
 from __future__ import annotations
 
-import contextvars
 import dataclasses
 import enum
 import hashlib
@@ -164,24 +163,28 @@ from tools.daemon_pool import DaemonThreadPoolExecutor as _DaemonExecutor
 
 _EXECUTOR = _DaemonExecutor(max_workers=8, thread_name_prefix="hermes-lifecycle")
 _SECRET = secrets.token_bytes(32)
-_ACTIVE_PARENT_AGENT: contextvars.ContextVar[Any] = contextvars.ContextVar(
-    "hermes_subagent_lifecycle_parent", default=None
-)
 
 
 @contextmanager
 def bind_subagent_parent(parent_agent: Any):
-    """Bind the host-owned parent for the current agent turn."""
-    token = _ACTIVE_PARENT_AGENT.set(parent_agent)
-    try:
+    """Bind the host-owned parent for the current agent turn.
+
+    Backward-compatible wrapper around the shared host-parent binding
+    (``agent.host_context``). The subagent lifecycle API and the external
+    background-task API share the same turn-scoped parent so a plugin can
+    register durable work from the same active turn.
+    """
+    from agent.host_context import bind_host_parent
+
+    with bind_host_parent(parent_agent):
         yield
-    finally:
-        _ACTIVE_PARENT_AGENT.reset(token)
 
 
 def get_active_subagent_parent() -> Any:
     """Return the parent bound to this execution context, if any."""
-    return _ACTIVE_PARENT_AGENT.get()
+    from agent.host_context import get_active_host_parent
+
+    return get_active_host_parent()
 
 
 class SubagentLifecycleService:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -348,6 +348,7 @@ class PluginContext:
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+        self._background_tasks: Any = None
 
     # -- host-owned LLM access ----------------------------------------------
 
@@ -385,6 +386,32 @@ class PluginContext:
                 get_active_subagent_parent
             )
         return self._subagent_lifecycle
+
+    @property
+    def background_tasks(self) -> Any:
+        """Return the plugin's durable external background-task service.
+
+        Lets trusted plugins register an EXTERNAL background task (a run owned
+        by a separate system), immediately hand the parent agent an
+        unguessable handle, and later complete / fail / cancel it through the
+        same durable parent-session completion delivery Hermes uses for
+        ``delegate_task(background=True)``.
+
+        The service captures this plugin's identity from the manifest and
+        binds each registration to the ACTIVE host parent supplied by Hermes —
+        never to platform/chat/session values supplied by the plugin. Every
+        handle is plugin-owned and tamper-evident. No model tool is added.
+        """
+        if self._background_tasks is None:
+            from agent.background_tasks import ExternalBackgroundTasksService
+            from agent.host_context import get_active_host_parent
+
+            plugin_id = self.manifest.key or self.manifest.name
+            self._background_tasks = ExternalBackgroundTasksService(
+                plugin_id=plugin_id,
+                parent_agent_resolver=get_active_host_parent,
+            )
+        return self._background_tasks
 
     # -- profile awareness --------------------------------------------------
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -344,6 +344,7 @@ class PluginContext:
 
     def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
         self.manifest = manifest
+        self._plugin_id = manifest.key or manifest.name
         self._manager = manager
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
@@ -403,12 +404,11 @@ class PluginContext:
         handle is plugin-owned and tamper-evident. No model tool is added.
         """
         if self._background_tasks is None:
-            from agent.background_tasks import ExternalBackgroundTasksService
+            from agent.background_tasks import _create_external_background_tasks_service
             from agent.host_context import get_active_host_parent
 
-            plugin_id = self.manifest.key or self.manifest.name
-            self._background_tasks = ExternalBackgroundTasksService(
-                plugin_id=plugin_id,
+            self._background_tasks = _create_external_background_tasks_service(
+                plugin_id=self._plugin_id,
                 parent_agent_resolver=get_active_host_parent,
             )
         return self._background_tasks

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -351,6 +351,43 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+-- Durable external background-task lifecycle store (agent/background_tasks.py).
+-- Profile-local state for plugin-registered external tasks. Completion
+-- DELIVERY reuses the async_delegations rail above (a terminal row is written
+-- there); this table owns registration, plugin ownership, idempotency, and
+-- terminal intent. Created here so a fresh state.db has it from the start;
+-- agent/background_tasks._connect also creates it lazily on existing DBs.
+CREATE TABLE IF NOT EXISTS external_background_tasks (
+    task_id TEXT PRIMARY KEY,
+    plugin_id TEXT NOT NULL,
+    parent_session_id TEXT NOT NULL,
+    session_key TEXT NOT NULL DEFAULT '',
+    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+    origin_session_id TEXT NOT NULL DEFAULT '',
+    external_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    label TEXT NOT NULL DEFAULT '',
+    payload_hash TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    cancel_requested_at REAL,
+    completed_at REAL,
+    terminal_event_id TEXT,
+    terminal_payload_hash TEXT,
+    summary TEXT,
+    error TEXT,
+    result_json TEXT,
+    delivery_delegation_id TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_tasks_dedup
+    ON external_background_tasks(plugin_id, parent_session_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS idx_ext_tasks_plugin_state
+    ON external_background_tasks(plugin_id, state);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);

--- a/run_agent.py
+++ b/run_agent.py
@@ -7784,7 +7784,7 @@ class AIAgent:
             finish_task_run,
             start_task_run,
         )
-        from agent.subagent_lifecycle import bind_subagent_parent
+        from agent.host_context import bind_host_parent
         effective_task_id = task_id or str(uuid.uuid4())
         session_id = str(getattr(self, "session_id", None) or "")
         task_context = {
@@ -7849,7 +7849,7 @@ class AIAgent:
             # replaces the value with the live runtime after fallback restoration.
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}):
+            with bind_host_parent(self), scoped_runtime_main({}):
                 result = run_conversation(
                     self,
                     user_message,

--- a/tests/agent/test_background_tasks.py
+++ b/tests/agent/test_background_tasks.py
@@ -64,6 +64,7 @@ def _drain_one():
 # PluginContext exposure
 # ---------------------------------------------------------------------------
 
+
 def test_plugin_context_lazily_exposes_service_and_captures_identity():
     from hermes_cli.plugins import PluginContext, PluginManifest
 
@@ -97,6 +98,7 @@ def test_plugin_context_service_is_per_plugin_identity():
 # Parent binding
 # ---------------------------------------------------------------------------
 
+
 def test_register_outside_active_parent_fails():
     svc = _service()
     with pytest.raises(BackgroundTaskError):
@@ -116,6 +118,52 @@ def test_register_binds_only_the_active_host_parent():
     assert handle.plugin_id == "test-plugin"
 
 
+def test_public_contract_results_are_json_serializable_mappings():
+    svc = _service()
+    with bind_host_parent(_parent("parent-a")):
+        handle = svc.register_external(external_id="run-1")
+
+    status = svc.list_pending()[0]
+    completed = svc.complete(handle, event_id="event-1", summary="done")
+
+    assert json.loads(json.dumps(status.to_dict()))["state"] == "registered"
+    assert json.loads(json.dumps(completed.to_dict()))["state"] == "completed"
+
+
+def test_public_contract_rejects_non_finite_json_numbers():
+    svc = _service()
+    with bind_host_parent(_parent("parent-a")):
+        with pytest.raises(BackgroundTaskError):
+            svc.register_external(
+                external_id="run-nan", payload={"value": float("nan")}
+            )
+
+        handle = svc.register_external(external_id="run-1")
+
+    with pytest.raises(BackgroundTaskError):
+        svc.complete(
+            handle,
+            event_id="event-nan",
+            summary="done",
+            result_payload={"value": float("inf")},
+        )
+
+
+def test_external_failure_message_uses_generic_background_task_wording():
+    from tools.process_registry import _format_async_delegation
+
+    svc = _service()
+    with bind_host_parent(_parent("parent-a")):
+        handle = svc.register_external(external_id="run-1", label="code run")
+    assert svc.fail(handle, event_id="event-1", error="provider failed").accepted
+    event = _drain_one()
+    assert event is not None
+
+    rendered = _format_async_delegation(event)
+    assert "The background task did not complete successfully" in rendered
+    assert "The subagent did not complete successfully" not in rendered
+
+
 def test_register_cannot_be_forged_through_method_parameters():
     """The public surface has no parent/session parameters at all."""
     import inspect
@@ -123,7 +171,11 @@ def test_register_cannot_be_forged_through_method_parameters():
     sig = inspect.signature(ExternalBackgroundTasksService.register_external)
     params = set(sig.parameters)
     assert params == {
-        "self", "external_id", "payload", "idempotency_key", "label",
+        "self",
+        "external_id",
+        "payload",
+        "idempotency_key",
+        "label",
     }
     with bind_host_parent(_parent("parent-a")):
         handle = _service().register_external(external_id="run-1")
@@ -167,6 +219,7 @@ def test_register_captures_gateway_session_routing_from_parent_context():
 # ---------------------------------------------------------------------------
 # Plugin ownership / handle security
 # ---------------------------------------------------------------------------
+
 
 def test_cross_plugin_operations_rejected_without_existence_leak():
     owner = _service("owner-plugin")
@@ -242,6 +295,7 @@ def test_malformed_handle_is_unknown_not_crash():
 # Registration idempotency
 # ---------------------------------------------------------------------------
 
+
 def test_registration_replay_returns_same_handle():
     svc = _service()
     with bind_host_parent(_parent("parent-1")):
@@ -279,19 +333,24 @@ def test_distinct_external_ids_are_distinct_tasks():
 # Terminal transitions: idempotency + atomicity
 # ---------------------------------------------------------------------------
 
+
 def test_complete_event_replay_is_harmless():
     svc = _service()
     with bind_host_parent(_parent("parent-1")):
         handle = svc.register_external(external_id="run-1")
 
-    first = svc.complete(handle, event_id="e1", summary="done", result_payload={"k": "v"})
+    first = svc.complete(
+        handle, event_id="e1", summary="done", result_payload={"k": "v"}
+    )
     assert first.accepted is True
     assert first.state == ExternalTaskState.COMPLETED.value
     evt1 = _drain_one()
     assert evt1 is not None
     assert evt1["summary"] == "done"
 
-    replay = svc.complete(handle, event_id="e1", summary="done", result_payload={"k": "v"})
+    replay = svc.complete(
+        handle, event_id="e1", summary="done", result_payload={"k": "v"}
+    )
     assert replay.accepted is True
     assert replay.already_terminal is True
     assert replay.conflict is False
@@ -398,6 +457,7 @@ def test_concurrent_register_same_key_is_idempotent():
 # Size / schema limits
 # ---------------------------------------------------------------------------
 
+
 def test_oversized_payload_fails_before_persistence():
     svc = _service()
     with bind_host_parent(_parent("parent-1")):
@@ -437,7 +497,9 @@ def test_oversized_result_payload_fails_before_queue_side_effect():
 
     with pytest.raises(BackgroundTaskError):
         svc.complete(
-            handle, event_id="e1", summary="ok",
+            handle,
+            event_id="e1",
+            summary="ok",
             result_payload={"blob": "y" * 40_000},
         )
     assert _drain_one() is None
@@ -464,6 +526,7 @@ def test_missing_event_id_rejected():
 # Cancel intent
 # ---------------------------------------------------------------------------
 
+
 def test_cancel_intent_is_durable_but_distinct_from_cancel_success():
     svc = _service()
     with bind_host_parent(_parent("parent-1")):
@@ -485,7 +548,10 @@ def test_cancel_intent_is_durable_but_distinct_from_cancel_success():
     assert len(statuses) == 1
     assert statuses[0].state is ExternalTaskState.CANCEL_REQUESTED
 
-    assert svc.complete(handle, event_id="e1", summary="cancelled externally").accepted is True
+    assert (
+        svc.complete(handle, event_id="e1", summary="cancelled externally").accepted
+        is True
+    )
     evt = _drain_one()
     assert evt is not None and evt["summary"] == "cancelled externally"
 
@@ -505,9 +571,11 @@ def test_cancel_on_terminal_task_is_rejected():
 # list_pending
 # ---------------------------------------------------------------------------
 
+
 def test_list_pending_scope_and_lifecycle():
     from tools.async_delegation import (
-        claim_event_delivery, complete_event_delivery,
+        claim_event_delivery,
+        complete_event_delivery,
     )
 
     svc = _service("owner")
@@ -540,8 +608,10 @@ def test_list_pending_includes_undelivered_terminal_until_delivered():
 
     # Ack delivery the way a drain consumer does, then it drops off the list.
     from tools.async_delegation import (
-        claim_event_delivery, complete_event_delivery,
+        claim_event_delivery,
+        complete_event_delivery,
     )
+
     claim = claim_event_delivery(evt, "test-consumer")
     assert claim is not None
     complete_event_delivery(evt, claim)
@@ -571,12 +641,13 @@ def test_list_pending_returns_stable_handles_after_restart(tmp_path, monkeypatch
 # Restart restore (real subprocess)
 # ---------------------------------------------------------------------------
 
+
 def test_real_restart_restores_undelivered_completion_and_pending_state(tmp_path):
     """A fresh interpreter restores a pending external completion + handle."""
     repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": repo}
 
-    producer = r'''
+    producer = r"""
 import json
 from types import SimpleNamespace
 from agent.background_tasks import ExternalBackgroundTasksService
@@ -591,14 +662,20 @@ with bind_host_parent(SimpleNamespace(session_id="parent-1")):
     print(json.dumps(handle.to_dict()))
     res = svc.complete(handle, event_id="e1", summary="completed before restart")
     assert res.accepted is True
-'''
+"""
     first = subprocess.run(
-        [sys.executable, "-c", producer], cwd=repo, env=env,
-        text=True, capture_output=True, timeout=20, check=True,
+        [sys.executable, "-c", producer],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=True,
     )
     handle_json = first.stdout.strip().splitlines()[-1]
 
-    consumer = r'''
+    consumer = (
+        r"""
 import json
 import sys
 from types import SimpleNamespace
@@ -634,10 +711,17 @@ assert evt["summary"] == "completed before restart"
 text = format_process_notification(evt)
 assert "durable run" in text
 print("OK")
-''' % handle_json
+"""
+        % handle_json
+    )
     second = subprocess.run(
-        [sys.executable, "-c", consumer], cwd=repo, env=env,
-        text=True, capture_output=True, timeout=20, check=True,
+        [sys.executable, "-c", consumer],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=True,
     )
     assert second.stdout.strip().splitlines()[-1] == "OK"
 
@@ -645,6 +729,7 @@ print("OK")
 # ---------------------------------------------------------------------------
 # HERMES_HOME isolation
 # ---------------------------------------------------------------------------
+
 
 def test_tests_never_touch_the_real_profile(tmp_path):
     from pathlib import Path

--- a/tests/agent/test_background_tasks.py
+++ b/tests/agent/test_background_tasks.py
@@ -22,6 +22,7 @@ import pytest
 from agent.background_tasks import (
     BackgroundTaskError,
     ExternalBackgroundTasksService,
+    _create_external_background_tasks_service,
     ExternalTaskHandle,
     ExternalTaskResult,
     ExternalTaskState,
@@ -47,7 +48,7 @@ def _parent(session_id="parent-1"):
 
 
 def _service(plugin_id="test-plugin", resolver=None):
-    return ExternalBackgroundTasksService(
+    return _create_external_background_tasks_service(
         plugin_id=plugin_id,
         parent_agent_resolver=resolver or get_active_host_parent,
     )
@@ -101,11 +102,30 @@ def test_plugin_context_service_is_per_plugin_identity():
     mgr = MagicMock()
     a = PluginContext(PluginManifest(name="plugin-a", key="plugin-a"), mgr)
     b = PluginContext(PluginManifest(name="plugin-b", key="plugin-b"), mgr)
+
     assert a.background_tasks.plugin_id == "plugin-a"
     assert b.background_tasks.plugin_id == "plugin-b"
 
 
-def test_plugin_identity_is_read_only_after_service_creation():
+def test_plugin_context_snapshots_identity_before_lazy_service_access():
+    from hermes_cli.plugins import PluginContext, PluginManifest
+
+    manifest = PluginManifest(name="plugin-a", key="plugin-a")
+    ctx = PluginContext(manifest, MagicMock())
+    manifest.key = "plugin-b"
+
+    assert ctx.background_tasks.plugin_id == "plugin-a"
+
+
+def test_direct_service_construction_is_host_only():
+    with pytest.raises(BackgroundTaskError, match="host-owned"):
+        ExternalBackgroundTasksService(
+            plugin_id="plugin-b",
+            parent_agent_resolver=get_active_host_parent,
+        )
+
+
+def test_plugin_service_identity_is_read_only():
     service = _service("plugin-a")
 
     with pytest.raises(AttributeError):
@@ -679,10 +699,10 @@ def test_real_restart_restores_undelivered_completion_and_pending_state(tmp_path
     producer = r"""
 import json
 from types import SimpleNamespace
-from agent.background_tasks import ExternalBackgroundTasksService
+from agent.background_tasks import _create_external_background_tasks_service
 from agent.host_context import bind_host_parent
 
-svc = ExternalBackgroundTasksService(
+svc = _create_external_background_tasks_service(
     plugin_id="restart-plugin",
     parent_agent_resolver=lambda: SimpleNamespace(session_id="parent-1"),
 )
@@ -708,10 +728,10 @@ with bind_host_parent(SimpleNamespace(session_id="parent-1")):
 import json
 import sys
 from types import SimpleNamespace
-from agent.background_tasks import ExternalBackgroundTasksService
+from agent.background_tasks import _create_external_background_tasks_service
 from tools.process_registry import process_registry, format_process_notification
 
-svc = ExternalBackgroundTasksService(
+svc = _create_external_background_tasks_service(
     plugin_id="restart-plugin",
     parent_agent_resolver=lambda: SimpleNamespace(session_id="parent-1"),
 )

--- a/tests/agent/test_background_tasks.py
+++ b/tests/agent/test_background_tasks.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import threading
 import time
+from concurrent.futures import ProcessPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -26,6 +27,7 @@ from agent.background_tasks import (
     ExternalTaskState,
     ExternalTaskStatus,
 )
+from agent.background_tasks_store import connect, load_or_create_hmac_key
 from agent.host_context import bind_host_parent, get_active_host_parent
 from hermes_constants import get_hermes_home
 from tools.process_registry import process_registry
@@ -49,6 +51,15 @@ def _service(plugin_id="test-plugin", resolver=None):
         plugin_id=plugin_id,
         parent_agent_resolver=resolver or get_active_host_parent,
     )
+
+
+def _load_hmac_key_from_process(hermes_home: str) -> bytes:
+    os.environ["HERMES_HOME"] = hermes_home
+    connection = connect()
+    try:
+        return load_or_create_hmac_key(connection)
+    finally:
+        connection.close()
 
 
 def _drain_one():
@@ -92,6 +103,24 @@ def test_plugin_context_service_is_per_plugin_identity():
     b = PluginContext(PluginManifest(name="plugin-b", key="plugin-b"), mgr)
     assert a.background_tasks.plugin_id == "plugin-a"
     assert b.background_tasks.plugin_id == "plugin-b"
+
+
+def test_plugin_identity_is_read_only_after_service_creation():
+    service = _service("plugin-a")
+
+    with pytest.raises(AttributeError):
+        service.plugin_id = "plugin-b"  # type: ignore[misc]
+
+    assert service.plugin_id == "plugin-a"
+
+
+def test_hmac_key_initialization_is_atomic_across_processes(tmp_path):
+    hermes_home = str(tmp_path / "shared-home")
+
+    with ProcessPoolExecutor(max_workers=4) as executor:
+        keys = list(executor.map(_load_hmac_key_from_process, [hermes_home] * 8))
+
+    assert len(set(keys)) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_background_tasks.py
+++ b/tests/agent/test_background_tasks.py
@@ -21,7 +21,7 @@ import pytest
 
 from agent.background_tasks import (
     BackgroundTaskError,
-    ExternalBackgroundTasksService,
+    _ExternalBackgroundTasksService,
     _create_external_background_tasks_service,
     ExternalTaskHandle,
     ExternalTaskResult,
@@ -88,7 +88,7 @@ def test_plugin_context_lazily_exposes_service_and_captures_identity():
 
     assert ctx._background_tasks is None
     svc = ctx.background_tasks
-    assert isinstance(svc, ExternalBackgroundTasksService)
+    assert isinstance(svc, _ExternalBackgroundTasksService)
     assert svc is ctx.background_tasks  # cached, built once
     assert svc.plugin_id == "ext-tasks-plugin"
 
@@ -119,10 +119,17 @@ def test_plugin_context_snapshots_identity_before_lazy_service_access():
 
 def test_direct_service_construction_is_host_only():
     with pytest.raises(BackgroundTaskError, match="host-owned"):
-        ExternalBackgroundTasksService(
+        _ExternalBackgroundTasksService(
             plugin_id="plugin-b",
             parent_agent_resolver=get_active_host_parent,
         )
+
+
+def test_service_implementation_is_not_a_public_module_export():
+    import agent.background_tasks as background_tasks
+
+    assert "ExternalBackgroundTasksService" not in background_tasks.__all__
+    assert not hasattr(background_tasks, "ExternalBackgroundTasksService")
 
 
 def test_plugin_service_identity_is_read_only():
@@ -217,7 +224,7 @@ def test_register_cannot_be_forged_through_method_parameters():
     """The public surface has no parent/session parameters at all."""
     import inspect
 
-    sig = inspect.signature(ExternalBackgroundTasksService.register_external)
+    sig = inspect.signature(_ExternalBackgroundTasksService.register_external)
     params = set(sig.parameters)
     assert params == {
         "self",

--- a/tests/agent/test_background_tasks.py
+++ b/tests/agent/test_background_tasks.py
@@ -1,0 +1,660 @@
+"""Contract tests for the plugin durable external background-task API.
+
+Covers the public surface on ``PluginContext.background_tasks``:
+registration bound to the ACTIVE host parent, plugin-owned unguessable
+tamper-evident handles, idempotent registration / terminal events, bounded
+payloads, atomic single terminal transitions, durable cancel intent, restart
+restore, and temp ``HERMES_HOME`` isolation.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.background_tasks import (
+    BackgroundTaskError,
+    ExternalBackgroundTasksService,
+    ExternalTaskHandle,
+    ExternalTaskResult,
+    ExternalTaskState,
+    ExternalTaskStatus,
+)
+from agent.host_context import bind_host_parent, get_active_host_parent
+from hermes_constants import get_hermes_home
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_queue():
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _parent(session_id="parent-1"):
+    return SimpleNamespace(session_id=session_id)
+
+
+def _service(plugin_id="test-plugin", resolver=None):
+    return ExternalBackgroundTasksService(
+        plugin_id=plugin_id,
+        parent_agent_resolver=resolver or get_active_host_parent,
+    )
+
+
+def _drain_one():
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            return process_registry.completion_queue.get_nowait()
+        time.sleep(0.01)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PluginContext exposure
+# ---------------------------------------------------------------------------
+
+def test_plugin_context_lazily_exposes_service_and_captures_identity():
+    from hermes_cli.plugins import PluginContext, PluginManifest
+
+    mgr = MagicMock()
+    manifest = PluginManifest(
+        name="ext-tasks-plugin", key="ext-tasks-plugin", source="user"
+    )
+    ctx = PluginContext(manifest, mgr)
+
+    assert ctx._background_tasks is None
+    svc = ctx.background_tasks
+    assert isinstance(svc, ExternalBackgroundTasksService)
+    assert svc is ctx.background_tasks  # cached, built once
+    assert svc.plugin_id == "ext-tasks-plugin"
+
+    # The service resolves the ACTIVE host parent supplied by Hermes.
+    assert svc._parent_agent_resolver is get_active_host_parent
+
+
+def test_plugin_context_service_is_per_plugin_identity():
+    from hermes_cli.plugins import PluginContext, PluginManifest
+
+    mgr = MagicMock()
+    a = PluginContext(PluginManifest(name="plugin-a", key="plugin-a"), mgr)
+    b = PluginContext(PluginManifest(name="plugin-b", key="plugin-b"), mgr)
+    assert a.background_tasks.plugin_id == "plugin-a"
+    assert b.background_tasks.plugin_id == "plugin-b"
+
+
+# ---------------------------------------------------------------------------
+# Parent binding
+# ---------------------------------------------------------------------------
+
+def test_register_outside_active_parent_fails():
+    svc = _service()
+    with pytest.raises(BackgroundTaskError):
+        svc.register_external(external_id="run-1")
+
+
+def test_register_binds_only_the_active_host_parent():
+    svc = _service()
+    with bind_host_parent(_parent("parent-a")):
+        handle = svc.register_external(external_id="run-1", payload={"q": 1})
+    assert handle.parent_session_id == "parent-a"
+
+    with bind_host_parent(_parent("parent-b")):
+        handle_b = svc.register_external(external_id="run-1", payload={"q": 1})
+    assert handle_b.parent_session_id == "parent-b"
+    assert handle_b.task_id != handle.task_id
+    assert handle.plugin_id == "test-plugin"
+
+
+def test_register_cannot_be_forged_through_method_parameters():
+    """The public surface has no parent/session parameters at all."""
+    import inspect
+
+    sig = inspect.signature(ExternalBackgroundTasksService.register_external)
+    params = set(sig.parameters)
+    assert params == {
+        "self", "external_id", "payload", "idempotency_key", "label",
+    }
+    with bind_host_parent(_parent("parent-a")):
+        handle = _service().register_external(external_id="run-1")
+    assert handle.parent_session_id == "parent-a"
+
+
+def test_registration_requires_a_durable_parent_session():
+    svc = _service()
+    with bind_host_parent(_parent("")):
+        with pytest.raises(BackgroundTaskError):
+            svc.register_external(external_id="run-1")
+
+
+def test_register_captures_gateway_session_routing_from_parent_context():
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    tokens = set_session_vars(
+        platform="telegram",
+        source="telegram",
+        session_key="agent:main:telegram:dm:12345:678",
+        ui_session_id="desktop-sid-9",
+    )
+    try:
+        svc = _service()
+        with bind_host_parent(_parent("parent-telegram")):
+            handle = svc.register_external(
+                external_id="run-1", label="classify the image"
+            )
+        svc.complete(handle, event_id="e1", summary="done")
+    finally:
+        clear_session_vars(tokens)
+
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["session_key"] == "agent:main:telegram:dm:12345:678"
+    assert evt["origin_ui_session_id"] == "desktop-sid-9"
+    assert evt["parent_session_id"] == "parent-telegram"
+    assert evt["type"] == "async_delegation"
+
+
+# ---------------------------------------------------------------------------
+# Plugin ownership / handle security
+# ---------------------------------------------------------------------------
+
+def test_cross_plugin_operations_rejected_without_existence_leak():
+    owner = _service("owner-plugin")
+    intruder = _service("intruder-plugin")
+    with bind_host_parent(_parent("parent-1")):
+        handle = owner.register_external(external_id="run-1")
+
+    assert intruder.list_pending() == []
+
+    res = intruder.complete(handle, event_id="e1", summary="x")
+    assert res.unknown_handle is True
+    assert res.accepted is False
+
+    res = intruder.fail(handle, event_id="e1", error="x")
+    assert res.unknown_handle is True
+
+    res = intruder.request_cancel(handle)
+    assert res.unknown_handle is True
+
+    # A forged handle claiming the intruder's own plugin id but the owner's
+    # task_id must also be unknown (signature mismatch) and still leak nothing.
+    forged = ExternalTaskHandle(
+        contract_version=1,
+        task_id=handle.task_id,
+        plugin_id="intruder-plugin",
+        parent_session_id="parent-1",
+        created_at=handle.created_at,
+        signature="0" * 64,
+    )
+    res = intruder.complete(forged, event_id="e1", summary="x")
+    assert res.unknown_handle is True
+    assert intruder.list_pending() == []
+
+
+def test_handle_tampering_is_rejected():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    cases = []
+    d = handle.to_dict()
+    d2 = dict(d)
+    d2["signature"] = "0" * 64
+    cases.append(d2)
+    d3 = dict(d)
+    d3["parent_session_id"] = "parent-forged"
+    cases.append(d3)
+    d4 = dict(d)
+    d4["task_id"] = "deadbeef" * 4
+    cases.append(d4)
+    d5 = dict(d)
+    d5["plugin_id"] = "other-plugin"
+    cases.append(d5)
+
+    for forged in cases:
+        res = svc.complete(forged, event_id="e1", summary="x")
+        assert res.unknown_handle is True
+        assert res.accepted is False
+
+
+def test_malformed_handle_is_unknown_not_crash():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+    res = svc.complete(handle.to_dict(), event_id="e1", summary="x")
+    assert res.accepted is True
+    # Unknown/garbage handles are rejected cleanly.
+    res = svc.complete("garbage", event_id="e1", summary="x")
+    assert res.unknown_handle is True
+
+
+# ---------------------------------------------------------------------------
+# Registration idempotency
+# ---------------------------------------------------------------------------
+
+def test_registration_replay_returns_same_handle():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        a = svc.register_external(external_id="run-1", payload={"q": 1})
+        b = svc.register_external(external_id="run-1", payload={"q": 1})
+    assert a == b
+    assert a.task_id == b.task_id
+
+
+def test_registration_conflicting_replay_fails():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        svc.register_external(external_id="run-1", payload={"q": 1})
+        with pytest.raises(BackgroundTaskError):
+            svc.register_external(external_id="run-1", payload={"q": 2})
+
+
+def test_registration_idempotency_key_defaults_to_external_id():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        a = svc.register_external(external_id="run-1", idempotency_key="k-1")
+        b = svc.register_external(external_id="run-1", idempotency_key="k-1")
+    assert a == b
+
+
+def test_distinct_external_ids_are_distinct_tasks():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        a = svc.register_external(external_id="run-1")
+        b = svc.register_external(external_id="run-2")
+    assert a.task_id != b.task_id
+
+
+# ---------------------------------------------------------------------------
+# Terminal transitions: idempotency + atomicity
+# ---------------------------------------------------------------------------
+
+def test_complete_event_replay_is_harmless():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    first = svc.complete(handle, event_id="e1", summary="done", result_payload={"k": "v"})
+    assert first.accepted is True
+    assert first.state == ExternalTaskState.COMPLETED.value
+    evt1 = _drain_one()
+    assert evt1 is not None
+    assert evt1["summary"] == "done"
+
+    replay = svc.complete(handle, event_id="e1", summary="done", result_payload={"k": "v"})
+    assert replay.accepted is True
+    assert replay.already_terminal is True
+    assert replay.conflict is False
+    assert _drain_one() is None  # no second completion event
+
+
+def test_complete_same_event_id_different_payload_conflicts():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    assert svc.complete(handle, event_id="e1", summary="done").accepted is True
+    assert _drain_one() is not None
+    res = svc.complete(handle, event_id="e1", summary="DIFFERENT")
+    assert res.accepted is False
+    assert res.conflict is True
+    assert _drain_one() is None
+
+
+def test_completed_task_cannot_fail_later():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    svc.complete(handle, event_id="e1", summary="done")
+    assert _drain_one() is not None
+
+    res = svc.fail(handle, event_id="e2", error="late failure")
+    assert res.accepted is False
+    assert res.already_terminal is True
+    assert _drain_one() is None  # no second completion event
+
+
+def test_fail_event_replay_and_conflict():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    assert svc.fail(handle, event_id="f1", error="boom").accepted is True
+    evt = _drain_one()
+    assert evt["status"] == "failed"
+    assert evt["error"] == "boom"
+
+    replay = svc.fail(handle, event_id="f1", error="boom")
+    assert replay.accepted is True and replay.already_terminal is True
+
+    conflict = svc.fail(handle, event_id="f1", error="different boom")
+    assert conflict.conflict is True
+    assert _drain_one() is None
+
+
+def test_atomic_single_terminal_completion_under_concurrency():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    n = 8
+    results = []
+
+    def worker(idx):
+        res = svc.complete(handle, event_id=f"e-{idx}", summary=f"summary {idx}")
+        results.append(res)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    accepted = [r for r in results if r.accepted and not r.already_terminal]
+    already_terminal = [r for r in results if r.already_terminal]
+    conflicts = [r for r in results if r.conflict]
+    assert len(accepted) == 1
+    assert len(already_terminal) + len(conflicts) == n - 1
+
+    events = []
+    while not process_registry.completion_queue.empty():
+        events.append(process_registry.completion_queue.get_nowait())
+    assert len(events) == 1  # exactly one parent completion emitted
+    assert events[0]["summary"].startswith("summary ")
+
+
+def test_concurrent_register_same_key_is_idempotent():
+    svc = _service()
+    handles = []
+    lock = threading.Lock()
+
+    def worker():
+        with bind_host_parent(_parent("parent-1")):
+            h = svc.register_external(external_id="run-x", payload={"n": 1})
+        with lock:
+            handles.append(h)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len({h.task_id for h in handles}) == 1
+
+
+# ---------------------------------------------------------------------------
+# Size / schema limits
+# ---------------------------------------------------------------------------
+
+def test_oversized_payload_fails_before_persistence():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        with pytest.raises(BackgroundTaskError):
+            svc.register_external(external_id="run-1", payload={"blob": "x" * 40_000})
+    assert svc.list_pending() == []
+
+
+def test_oversized_summary_fails_before_queue_side_effect():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    with pytest.raises(BackgroundTaskError):
+        svc.complete(handle, event_id="e1", summary="x" * 40_000)
+    assert _drain_one() is None  # nothing persisted or queued
+
+
+def test_oversized_error_fails_before_queue_side_effect():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    with pytest.raises(BackgroundTaskError):
+        svc.fail(handle, event_id="e1", error="x" * 40_000)
+    assert _drain_one() is None
+
+    # The task is still completable after the rejected attempt.
+    assert svc.complete(handle, event_id="e1", summary="ok").accepted is True
+    assert _drain_one() is not None
+
+
+def test_oversized_result_payload_fails_before_queue_side_effect():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    with pytest.raises(BackgroundTaskError):
+        svc.complete(
+            handle, event_id="e1", summary="ok",
+            result_payload={"blob": "y" * 40_000},
+        )
+    assert _drain_one() is None
+
+
+def test_non_mapping_payload_rejected():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        with pytest.raises(BackgroundTaskError):
+            svc.register_external(external_id="run-1", payload="not-a-mapping")
+
+
+def test_missing_event_id_rejected():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+    with pytest.raises(BackgroundTaskError):
+        svc.complete(handle, event_id="", summary="x")
+    with pytest.raises(BackgroundTaskError):
+        svc.fail(handle, event_id="", error="x")
+
+
+# ---------------------------------------------------------------------------
+# Cancel intent
+# ---------------------------------------------------------------------------
+
+def test_cancel_intent_is_durable_but_distinct_from_cancel_success():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    res = svc.request_cancel(handle)
+    assert res.accepted is True
+    assert res.state == ExternalTaskState.CANCEL_REQUESTED.value
+    assert _drain_one() is None  # no completion emitted for a cancel request
+
+    # Idempotent.
+    again = svc.request_cancel(handle)
+    assert again.accepted is True
+    assert again.cancel_already_requested is True
+
+    # Still listed as non-terminal work, and can still be finalized with the
+    # REAL outcome (the plugin performs the external cancellation itself).
+    statuses = svc.list_pending()
+    assert len(statuses) == 1
+    assert statuses[0].state is ExternalTaskState.CANCEL_REQUESTED
+
+    assert svc.complete(handle, event_id="e1", summary="cancelled externally").accepted is True
+    evt = _drain_one()
+    assert evt is not None and evt["summary"] == "cancelled externally"
+
+
+def test_cancel_on_terminal_task_is_rejected():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+    svc.complete(handle, event_id="e1", summary="done")
+    _drain_one()
+    res = svc.request_cancel(handle)
+    assert res.accepted is False
+    assert res.already_terminal is True
+
+
+# ---------------------------------------------------------------------------
+# list_pending
+# ---------------------------------------------------------------------------
+
+def test_list_pending_scope_and_lifecycle():
+    from tools.async_delegation import (
+        claim_event_delivery, complete_event_delivery,
+    )
+
+    svc = _service("owner")
+    other = _service("other")
+    with bind_host_parent(_parent("parent-1")):
+        running = svc.register_external(external_id="run-1")
+        other.register_external(external_id="run-2")
+
+    statuses = svc.list_pending()
+    assert [s.handle for s in statuses] == [running]
+    assert statuses[0].state is ExternalTaskState.REGISTERED
+
+    assert svc.complete(running, event_id="e1", summary="done").accepted is True
+    evt = _drain_one()
+    claim = claim_event_delivery(evt, "test-consumer")
+    assert claim is not None
+    complete_event_delivery(evt, claim)
+    assert svc.list_pending() == []
+
+
+def test_list_pending_includes_undelivered_terminal_until_delivered():
+    svc = _service()
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    svc.complete(handle, event_id="e1", summary="done")
+    # Terminal but NOT yet delivered: still listed.
+    assert len(svc.list_pending()) == 1
+    evt = _drain_one()
+
+    # Ack delivery the way a drain consumer does, then it drops off the list.
+    from tools.async_delegation import (
+        claim_event_delivery, complete_event_delivery,
+    )
+    claim = claim_event_delivery(evt, "test-consumer")
+    assert claim is not None
+    complete_event_delivery(evt, claim)
+    assert svc.list_pending() == []
+
+
+def test_list_pending_returns_stable_handles_after_restart(tmp_path, monkeypatch):
+    """A fresh store over the same profile DB returns operable handles."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+    svc = _service("restart-plugin")
+    with bind_host_parent(_parent("parent-1")):
+        handle = svc.register_external(external_id="run-1")
+
+    # Simulate process restart: a NEW service instance over the SAME profile.
+    svc2 = _service("restart-plugin")
+    statuses = svc2.list_pending()
+    assert len(statuses) == 1
+    assert statuses[0].handle == handle
+
+    res = svc2.complete(statuses[0].handle, event_id="e1", summary="done")
+    assert res.accepted is True
+
+
+# ---------------------------------------------------------------------------
+# Restart restore (real subprocess)
+# ---------------------------------------------------------------------------
+
+def test_real_restart_restores_undelivered_completion_and_pending_state(tmp_path):
+    """A fresh interpreter restores a pending external completion + handle."""
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": repo}
+
+    producer = r'''
+import json
+from types import SimpleNamespace
+from agent.background_tasks import ExternalBackgroundTasksService
+from agent.host_context import bind_host_parent
+
+svc = ExternalBackgroundTasksService(
+    plugin_id="restart-plugin",
+    parent_agent_resolver=lambda: SimpleNamespace(session_id="parent-1"),
+)
+with bind_host_parent(SimpleNamespace(session_id="parent-1")):
+    handle = svc.register_external(external_id="run-1", label="durable run")
+    print(json.dumps(handle.to_dict()))
+    res = svc.complete(handle, event_id="e1", summary="completed before restart")
+    assert res.accepted is True
+'''
+    first = subprocess.run(
+        [sys.executable, "-c", producer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=20, check=True,
+    )
+    handle_json = first.stdout.strip().splitlines()[-1]
+
+    consumer = r'''
+import json
+import sys
+from types import SimpleNamespace
+from agent.background_tasks import ExternalBackgroundTasksService
+from tools.process_registry import process_registry, format_process_notification
+
+svc = ExternalBackgroundTasksService(
+    plugin_id="restart-plugin",
+    parent_agent_resolver=lambda: SimpleNamespace(session_id="parent-1"),
+)
+pending = svc.list_pending()
+assert len(pending) == 1, pending
+handle = pending[0].handle
+assert handle.to_dict()["task_id"] == json.loads(%r)["task_id"]
+
+# The undelivered completion is restored onto the shared queue by the fresh
+# process's registry, exactly like a durable async-delegation completion.
+deadline = 0
+evt = None
+while True:
+    import time
+    if not process_registry.completion_queue.empty():
+        evt = process_registry.completion_queue.get_nowait()
+        break
+    if deadline > 5.0:
+        break
+    time.sleep(0.05)
+    deadline += 0.05
+assert evt is not None
+assert evt["type"] == "async_delegation"
+assert evt["status"] == "completed"
+assert evt["summary"] == "completed before restart"
+text = format_process_notification(evt)
+assert "durable run" in text
+print("OK")
+''' % handle_json
+    second = subprocess.run(
+        [sys.executable, "-c", consumer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=20, check=True,
+    )
+    assert second.stdout.strip().splitlines()[-1] == "OK"
+
+
+# ---------------------------------------------------------------------------
+# HERMES_HOME isolation
+# ---------------------------------------------------------------------------
+
+def test_tests_never_touch_the_real_profile(tmp_path):
+    from pathlib import Path
+
+    real_default = Path.home() / ".hermes"
+    home = Path(get_hermes_home())
+    assert home != real_default
+    assert str(home).startswith(str(tmp_path)) or home != real_default
+    # Registration state lands under the temp HERMES_HOME, never the profile.
+    with bind_host_parent(_parent("parent-1")):
+        handle = _service().register_external(external_id="run-1")
+    state_db = home / "state.db"
+    assert state_db.exists()

--- a/tests/cli/test_background_tasks_cli_delivery.py
+++ b/tests/cli/test_background_tasks_cli_delivery.py
@@ -10,7 +10,7 @@ import queue
 from cli import HermesCLI
 from types import SimpleNamespace
 
-from agent.background_tasks import ExternalBackgroundTasksService
+from agent.background_tasks import _create_external_background_tasks_service
 from agent.host_context import bind_host_parent
 from tools.process_registry import process_registry
 from tools.async_delegation import get_durable_delegation
@@ -29,7 +29,7 @@ def _drain_one():
 
 def test_cli_delivery_reaches_bound_parent_once():
     parent = SimpleNamespace(session_id="cli-session-1")
-    svc = ExternalBackgroundTasksService(
+    svc = _create_external_background_tasks_service(
         plugin_id="cli-plugin",
         parent_agent_resolver=lambda: parent,
     )
@@ -66,7 +66,7 @@ def test_cli_delivery_reaches_bound_parent_once():
 def test_cli_delivery_rejects_foreign_session():
     """A different CLI window cannot claim the completion."""
     parent = SimpleNamespace(session_id="cli-session-a")
-    svc = ExternalBackgroundTasksService(
+    svc = _create_external_background_tasks_service(
         plugin_id="cli-plugin",
         parent_agent_resolver=lambda: parent,
     )

--- a/tests/cli/test_background_tasks_cli_delivery.py
+++ b/tests/cli/test_background_tasks_cli_delivery.py
@@ -1,0 +1,97 @@
+"""CLI delivery integration for external background-task completions.
+
+A plugin-registered external task completed in a CLI parent session must reach
+the owning CLI window exactly once through the existing idle completion drain
+(``HermesCLI._drain_process_notifications``) and be durably acknowledged.
+"""
+
+import queue
+
+from cli import HermesCLI
+from types import SimpleNamespace
+
+from agent.background_tasks import ExternalBackgroundTasksService
+from agent.host_context import bind_host_parent
+from tools.process_registry import process_registry
+from tools.async_delegation import get_durable_delegation
+
+
+def _drain_one():
+    import time
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            return process_registry.completion_queue.get_nowait()
+        time.sleep(0.01)
+    return None
+
+
+def test_cli_delivery_reaches_bound_parent_once():
+    parent = SimpleNamespace(session_id="cli-session-1")
+    svc = ExternalBackgroundTasksService(
+        plugin_id="cli-plugin",
+        parent_agent_resolver=lambda: parent,
+    )
+    with bind_host_parent(parent):
+        handle = svc.register_external(external_id="run-1", label="cli run")
+
+    assert svc.complete(handle, event_id="e1", summary="cli summary").accepted is True
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["session_key"] == "cli-session-1"
+    process_registry.completion_queue.put(evt)  # restore for the drain under test
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "cli-session-1"
+    cli._session_db = None
+    cli._pending_input = queue.Queue()
+
+    cli._drain_process_notifications("test-cli")
+    message = cli._pending_input.get_nowait()
+    assert "cli summary" in message
+    assert "cli run" in message
+    assert cli._pending_input.empty()
+
+    # Durable row is acknowledged as delivered.
+    info = get_durable_delegation(evt["delegation_id"])
+    assert info is not None
+    assert info["delivery_state"] == "delivered"
+
+    # A second drain delivers nothing (delivered once).
+    cli._drain_process_notifications("test-cli")
+    assert cli._pending_input.empty()
+
+
+def test_cli_delivery_rejects_foreign_session():
+    """A different CLI window cannot claim the completion."""
+    parent = SimpleNamespace(session_id="cli-session-a")
+    svc = ExternalBackgroundTasksService(
+        plugin_id="cli-plugin",
+        parent_agent_resolver=lambda: parent,
+    )
+    with bind_host_parent(parent):
+        handle = svc.register_external(external_id="run-1")
+
+    assert svc.complete(handle, event_id="e1", summary="for session a").accepted is True
+    evt = _drain_one()
+    process_registry.completion_queue.put(evt)  # restore for the drain under test
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "cli-session-b"
+    cli._session_db = None
+    cli._pending_input = queue.Queue()
+
+    cli._drain_process_notifications("test-cli")
+    assert cli._pending_input.empty()
+
+    # The owning session can still drain it.
+    owner = HermesCLI.__new__(HermesCLI)
+    owner.session_id = "cli-session-a"
+    owner._session_db = None
+    owner._pending_input = queue.Queue()
+    owner._drain_process_notifications("test-cli")
+    assert not owner._pending_input.empty()
+    assert owner._pending_input.get_nowait()
+    info = get_durable_delegation(evt["delegation_id"])
+    assert info["delivery_state"] == "delivered"

--- a/tests/gateway/test_background_tasks_delivery.py
+++ b/tests/gateway/test_background_tasks_delivery.py
@@ -151,7 +151,9 @@ def test_gateway_delivery_is_delivered_once_for_duplicate_queue_replay(monkeypat
     isolated.put(dict(evt))
     import tools.process_registry as pr_module
 
-    monkeypatch.setattr(pr_module, "process_registry", type("R", (), {"completion_queue": isolated})())
+    monkeypatch.setattr(
+        pr_module, "process_registry", type("R", (), {"completion_queue": isolated})()
+    )
 
     runner = _runner(adapter, live_parent="parent-telegram")
     _stop_after_sleeps(monkeypatch, runner, count=2)

--- a/tests/gateway/test_background_tasks_delivery.py
+++ b/tests/gateway/test_background_tasks_delivery.py
@@ -1,0 +1,180 @@
+"""Gateway session binding/delivery for external background-task completions.
+
+An external task registered from a gateway-bound parent session must reach the
+ORIGINAL platform / chat / thread session exactly once through the existing
+``_async_delegation_watcher`` delivery rail, be durably claimed/acknowledged,
+and never be injected twice.
+"""
+
+import asyncio
+import queue
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.background_tasks import ExternalBackgroundTasksService
+from agent.host_context import bind_host_parent
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools.async_delegation import get_durable_delegation
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_queue():
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _drain_one():
+    import time
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            return process_registry.completion_queue.get_nowait()
+        time.sleep(0.01)
+    return None
+
+
+def _runner(adapter, *, live_parent):
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={},
+    )
+    runner._session_sources = None
+    runner._completion_delivery_lock = __import__("threading").Lock()
+    runner._completion_deliveries_inflight = set()
+    runner._completion_deliveries_delivered = OrderedDict()
+    runner._completion_delivery_retention = 2048
+
+    class _SessionDB:
+        def __init__(self, live):
+            self.live = live
+
+        async def get_session(self, session_id):
+            if session_id == self.live:
+                return {"id": session_id, "ended_at": None}
+            return None
+
+        async def get_compression_tip(self, session_id):
+            return None
+
+    runner._session_db = _SessionDB(live_parent)
+    return runner
+
+
+def _stop_after_sleeps(monkeypatch, runner, count):
+    sleep_calls = 0
+
+    async def _bounded_sleep(_delay):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= count:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _bounded_sleep)
+
+
+def _register_and_complete(*, plugin_id, parent_session_id, label, summary):
+    parent = SimpleNamespace(session_id=parent_session_id)
+    svc = ExternalBackgroundTasksService(
+        plugin_id=plugin_id,
+        parent_agent_resolver=lambda: parent,
+    )
+    tokens = set_session_vars(
+        platform="telegram",
+        source="telegram",
+        session_key="agent:main:telegram:dm:12345:678",
+    )
+    try:
+        with bind_host_parent(parent):
+            handle = svc.register_external(external_id="run-1", label=label)
+        result = svc.complete(handle, event_id="e1", summary=summary)
+    finally:
+        clear_session_vars(tokens)
+    assert result.accepted is True
+    evt = _drain_one()
+    assert evt is not None
+    process_registry.completion_queue.put(evt)  # restore for the watcher under test
+    return evt
+
+
+def test_gateway_delivery_reaches_original_platform_chat_thread_once(monkeypatch):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    evt = _register_and_complete(
+        plugin_id="gw-plugin",
+        parent_session_id="parent-telegram",
+        label="gateway run",
+        summary="gateway summary",
+    )
+
+    runner = _runner(adapter, live_parent="parent-telegram")
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    injected = adapter.handle_message.await_args.args[0]
+    assert injected.source.platform is Platform.TELEGRAM
+    assert injected.source.chat_id == "12345"
+    assert injected.source.thread_id == "678"
+    assert "gateway summary" in injected.text
+    assert "BACKGROUND TASK COMPLETE" in injected.text
+
+    info = get_durable_delegation(evt["delegation_id"])
+    assert info is not None
+    assert info["delivery_state"] == "delivered"
+
+
+def test_gateway_delivery_is_delivered_once_for_duplicate_queue_replay(monkeypatch):
+    """Byte-identical queue replays of one external completion inject once."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    evt = _register_and_complete(
+        plugin_id="gw-plugin",
+        parent_session_id="parent-telegram",
+        label="gateway run",
+        summary="gateway summary",
+    )
+    # Replay the same event (as restore_undelivered_completions would re-enqueue
+    # the exact persisted payload after a restart).
+    isolated = queue.Queue()
+    isolated.put(dict(evt))
+    isolated.put(dict(evt))
+    import tools.process_registry as pr_module
+
+    monkeypatch.setattr(pr_module, "process_registry", type("R", (), {"completion_queue": isolated})())
+
+    runner = _runner(adapter, live_parent="parent-telegram")
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_gateway_drop_when_parent_session_gone(monkeypatch):
+    """A completion pinned to a permanently-gone session is terminally dropped."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    evt = _register_and_complete(
+        plugin_id="gw-plugin",
+        parent_session_id="parent-gone",
+        label="gateway run",
+        summary="gateway summary",
+    )
+
+    runner = _runner(adapter, live_parent="some-other-live")
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_not_awaited()
+    info = get_durable_delegation(evt["delegation_id"])
+    assert info is not None
+    assert info["delivery_state"] == "dropped"

--- a/tests/gateway/test_background_tasks_delivery.py
+++ b/tests/gateway/test_background_tasks_delivery.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from agent.background_tasks import ExternalBackgroundTasksService
+from agent.background_tasks import _create_external_background_tasks_service
 from agent.host_context import bind_host_parent
 from gateway.config import Platform
 from gateway.run import GatewayRunner
@@ -87,7 +87,7 @@ def _stop_after_sleeps(monkeypatch, runner, count):
 
 def _register_and_complete(*, plugin_id, parent_session_id, label, summary):
     parent = SimpleNamespace(session_id=parent_session_id)
-    svc = ExternalBackgroundTasksService(
+    svc = _create_external_background_tasks_service(
         plugin_id=plugin_id,
         parent_agent_resolver=lambda: parent,
     )

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -282,6 +282,73 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def insert_external_completion_row(
+    conn: sqlite3.Connection, event: Dict[str, Any], result: Dict[str, Any]
+) -> None:
+    """Insert a terminal async-delegation delivery row into an OPEN connection.
+
+    Used by external background-task consumers that must persist the delivery
+    row atomically with their own task-state transition (same transaction, so
+    a crash can never leave a terminal task without a durable completion, or a
+    delivery row for a task that is still non-terminal).
+
+    The row is written TERMINAL (never ``running``/``finalizing``), so
+    ``recover_abandoned_delegations`` — which only classifies rows owned by a
+    live in-process runner — never misclassifies an external completion whose
+    registering process has since restarted. From here the row flows through
+    the exact claim / ack / release / restart-restore rail used by
+    ``delegate_task(background=True)``.
+    """
+    _initialize_schema(conn)
+    now = time.time()
+    conn.execute(
+        """INSERT OR REPLACE INTO async_delegations
+           (delegation_id, origin_session, origin_ui_session_id,
+            parent_session_id, state, dispatched_at, completed_at,
+            updated_at, event_json, result_json, delivery_state,
+            delivery_attempts, origin_session_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?)""",
+        (
+            event["delegation_id"],
+            event.get("session_key", ""),
+            event.get("origin_ui_session_id", ""),
+            event.get("parent_session_id"),
+            event.get("status", "completed"),
+            event.get("dispatched_at", now),
+            event.get("completed_at", now),
+            now,
+            json.dumps(event),
+            json.dumps(result or {}),
+            event.get("origin_session_id", ""),
+        ),
+    )
+
+
+def enqueue_completion_event(event: Dict[str, Any]) -> None:
+    """Best-effort publish of a completion event onto the shared queue.
+
+    A failure here must not crash the caller, but it WOULD mean a silently
+    lost result (recoverable across a restart for durable rows), so we log
+    loudly.
+    """
+    try:
+        from tools.process_registry import process_registry
+    except Exception as exc:  # pragma: no cover
+        logger.error(
+            "Completion for %s: process_registry import failed; result lost: %s",
+            event.get("delegation_id") or event.get("session_id"), exc,
+        )
+        return
+    try:
+        process_registry.completion_queue.put(event)
+    except Exception as exc:  # pragma: no cover
+        logger.error(
+            "Completion for %s: failed to enqueue completion event; result "
+            "lost: %s",
+            event.get("delegation_id") or event.get("session_id"), exc,
+        )
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -674,6 +741,46 @@ def _current_origin_session_id() -> str:
         return ""
 
 
+def capture_parent_session_routing(parent_agent) -> Dict[str, str]:
+    """Capture the routing fields a durable completion needs from the parent.
+
+    Mirrors the capture ``delegate_tool`` performs at background-dispatch time
+    so an EXTERNAL completion routes to the SAME target: the gateway platform
+    conversation key (or the durable parent session id for CLI/TUI), the
+    originating UI session id, and the raw api_server wake session id.
+
+    This is the small stable seam that lets durable consumers outside
+    ``delegate_task`` reuse the completion rail without re-deriving the
+    routing rules in parallel code.
+    """
+    from tools.approval import get_current_session_key
+
+    session_key = get_current_session_key(default="")
+    try:
+        from gateway.session_context import get_session_env
+
+        source = get_session_env("HERMES_SESSION_SOURCE", "")
+        origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+    except Exception:
+        source = ""
+        origin_ui_session_id = ""
+    agent_session_id = str(getattr(parent_agent, "session_id", "") or "")
+    # In desktop/TUI, the routable session key is the durable agent session id
+    # (compression can rotate it mid-turn; the drain side resolves lineage).
+    if source == "tui" and agent_session_id:
+        session_key = agent_session_id
+    if not session_key and agent_session_id:
+        # CLI (single-process) path: the approval contextvar is unbound and the
+        # CLI drain owns completions by matching this durable session id.
+        session_key = agent_session_id
+    return {
+        "session_key": session_key,
+        "parent_session_id": agent_session_id,
+        "origin_ui_session_id": origin_ui_session_id,
+        "origin_session_id": _current_origin_session_id(),
+    }
+
+
 def dispatch_async_delegation(
     *,
     goal: str,
@@ -868,16 +975,6 @@ def _push_completion_event(
     Best-effort: a failure here must not crash the worker, but it WOULD mean a
     silently-lost result, so we log loudly.
     """
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation %s finished but process_registry import failed; "
-            "result lost: %s",
-            record.get("delegation_id"), exc,
-        )
-        return
-
     summary = result.get("summary")
     error = result.get("error")
     dispatched_at = record.get("dispatched_at") or time.time()
@@ -919,14 +1016,7 @@ def _push_completion_event(
         if _k in result:
             evt[_k] = result[_k]
     _persist_completion(evt, result)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation %s: failed to enqueue completion event; "
-            "result lost: %s",
-            record.get("delegation_id"), exc,
-        )
+    enqueue_completion_event(evt)
 
 
 def dispatch_async_delegation_batch(
@@ -1078,16 +1168,6 @@ def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
     """Push a combined async-delegation batch completion event."""
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s finished but process_registry import "
-            "failed; result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
-        return
-
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
     evt = {
@@ -1128,14 +1208,7 @@ def _push_batch_completion_event(
         if _k in combined:
             evt[_k] = combined[_k]
     _persist_completion(evt, combined)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s: failed to enqueue completion event; "
-            "result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
+    enqueue_completion_event(evt)
 
 
 def _ensure_stale_monitor() -> None:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2339,11 +2339,12 @@ def _format_async_delegation(evt: dict) -> str:
     lines.append(f"Role: {role}   Model: {model}")
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s")
     lines.append("--- RESULT ---")
+    task_subject = "background task" if evt.get("external_background_task") else "subagent"
     if status in ("completed", "success") and summary:
         lines.append(summary)
     elif status == "interrupted":
         lines.append(
-            "The subagent was interrupted before completing"
+            f"The {task_subject} was interrupted before completing"
             + (f": {error}" if error else ".")
         )
         if summary:
@@ -2352,7 +2353,7 @@ def _format_async_delegation(evt: dict) -> str:
     else:
         # error / timeout / failed
         lines.append(
-            f"The subagent did not complete successfully (status={status})."
+            f"The {task_subject} did not complete successfully (status={status})."
             + (f"\n{error}" if error else "")
         )
         if summary:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2306,11 +2306,26 @@ def _format_async_delegation(evt: dict) -> str:
     if isinstance(dispatched_at, (int, float)):
         age = f" ({_format_age(completed_at - dispatched_at)} ago)"
 
+    if evt.get("external_background_task"):
+        header = f"[BACKGROUND TASK COMPLETE — {deleg_id}]"
+        intro = (
+            "A background task you registered earlier has finished. You may "
+            "have moved on since registering it; the original request is "
+            "below so you can act on the result or re-register it if things "
+            "have changed."
+        )
+    else:
+        header = f"[ASYNC DELEGATION COMPLETE — {deleg_id}]"
+        intro = (
+            "A background subagent you dispatched earlier has finished. You "
+            "may have moved on since dispatching it; the full task source is "
+            "below so you can act on the result or re-dispatch if things have "
+            "changed."
+        )
+
     lines = [
-        f"[ASYNC DELEGATION COMPLETE — {deleg_id}]",
-        "A background subagent you dispatched earlier has finished. You may "
-        "have moved on since dispatching it; the full task source is below so "
-        "you can act on the result or re-dispatch if things have changed.",
+        header,
+        intro,
         "",
     ]
     if isinstance(dispatched_at, (int, float)):


### PR DESCRIPTION
## Summary

- add a generic plugin-facing API for durable external background tasks
- let plugins register provider-owned runs before dispatch, poll durable task state, publish terminal completion, cancel, and claim signed control handles
- reuse the active host-parent binding so delivery remains attached to the originating session/topic
- persist task ownership and completion state in SQLite with per-plugin isolation
- harden ownership and serialization boundaries after adversarial review

## Concrete consumer

This is used by a standalone `code-agent-bridge` profile plugin that submits durable code-agent runs through an Access Gateway provider. The provider process may outlive the Hermes process, so the existing in-process delegation lifecycle cannot provide restart-safe completion delivery. The consumer stays outside Hermes core; this PR only adds the generic plugin lifecycle surface.

## Security and durability properties

- plugin identity is validated and snapshotted by the host
- public plugin code cannot construct a task service for another plugin identity
- task rows and control handles are scoped to the owning plugin
- signed control handles use a startup-safe, atomically initialized HMAC key
- terminal completion is idempotent and durable
- JSON payloads reject NaN/Infinity and round-trip through `json.dumps`
- SQLite WAL/busy initialization uses bounded retry only for lock/busy failures
- active host-parent registration is bound before external dispatch

## Test plan

- [x] `uv run pytest -q tests/agent/test_background_tasks.py tests/cli/test_background_tasks_cli_delivery.py tests/gateway/test_background_tasks_delivery.py tests/hermes_cli/test_plugins.py tests/tools/test_async_delegation.py tests/gateway/test_async_delegation_session_binding.py` — 109 passed
- [x] `uv run ruff check agent/background_tasks.py agent/background_tasks_store.py agent/background_tasks_types.py agent/host_context.py hermes_cli/plugins.py tools/async_delegation.py tools/process_registry.py tests/agent/test_background_tasks.py tests/cli/test_background_tasks_cli_delivery.py tests/gateway/test_background_tasks_delivery.py`
- [x] `git diff --check origin/main...HEAD`
- [x] rebased onto current `origin/main`

## Review notes

The API intentionally does not add a model-visible core tool. It is available only through `PluginContext.background_tasks`. Provider-specific HTTP, routing, models, and run IDs stay in the standalone consumer plugin.
