### PR TITLE
fix(kanban): enforce max_spawn against remaining in-progress capacity

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8350,7 +8350,7 @@ def _dispatch_once_locked(
     # they sit in status='running' until the worker calls
     # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -8365,15 +8365,13 @@ def _dispatch_once_locked(
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
+    # pile up and time out. Compute remaining capacity once per dispatch pass,
+    # before both ready and review candidate loops.
+    if max_in_progress is not None:
+        if running_count >= max_in_progress:
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
+        remaining = max_in_progress - running_count
         if max_spawn is None or max_spawn > remaining:
             max_spawn = remaining
     spawned = 0
@@ -8414,7 +8412,7 @@ def _dispatch_once_locked(
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
     for row in ready_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if max_spawn is not None and spawned >= max_spawn:
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -8605,7 +8603,7 @@ def _dispatch_once_locked(
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     for row in review_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if max_spawn is not None and spawned >= max_spawn:
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -98,3 +98,80 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+def test_max_spawn_does_not_count_running_tasks_twice(isolated_kanban_home_with_profiles):
+    """Dispatch's max_spawn clamp for total progress should not include
+    already-running tasks in the per-tick spawn counter."""
+    import time
+
+    kb = isolated_kanban_home_with_profiles
+
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        running = [kb.create_task(conn, title=f"running-{i}", assignee="alpha") for i in range(2)]
+        for tid in running:
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock='lock', claim_expires=?, worker_pid=? "
+                "WHERE id=?",
+                (now + 3600, 42, tid),
+            )
+
+        for i in range(3):
+            kb.create_task(conn, title=f"ready-{i}", assignee="alpha")
+
+    with kb.connect_closing() as conn:
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            max_in_progress=4,
+            max_spawn=3,
+            dry_run=False,
+        )
+
+    # existing behavior clamped max_spawn to remaining (2) but counted both
+    # running and spawned in the loop guard, causing 0 spawns. Fixed behavior
+    # spawns 2 tasks this tick (to reach max_in_progress=4).
+    assert len(result.spawned) == 2
+
+
+def test_review_dispatch_respects_max_in_progress_with_running_tasks(
+    isolated_kanban_home_with_profiles,
+):
+    """Review-only ticks should also respect max_in_progress via remaining capacity."""
+    import time
+
+    kb = isolated_kanban_home_with_profiles
+    now = int(time.time())
+
+    with kb.connect_closing() as conn:
+        for i in range(2):
+            running = kb.create_task(
+                conn,
+                title=f"running-review-{i}",
+                assignee="alpha",
+            )
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock='lock', claim_expires=?, worker_pid=? "
+                "WHERE id=?",
+                (now + 3600, 99, running),
+            )
+
+        for i in range(3):
+            review_id = kb.create_task(conn, title=f"review-{i}", assignee="alpha")
+            conn.execute(
+                "UPDATE tasks SET status='review' WHERE id=?",
+                (review_id,),
+            )
+
+    with kb.connect_closing() as conn:
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            max_in_progress=4,
+            max_spawn=3,
+            dry_run=False,
+        )
+
+    # Remaining capacity is 2, so only two review tasks may be spawned.
+    assert len(result.spawned) == 2
+
+


### PR DESCRIPTION
## Summary
- Fix dispatcher `max_spawn` budgeting to avoid double-counting already-running tasks when enforcing in-progress limits.
- Apply the same effective remaining-cap logic to both ready and review dispatch paths.
- Add regression coverage for ready and review dispatch behavior when running tasks already consume capacity.

## Test Plan
- [x] python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_per_profile_cap.py
- [x] python3 -m pytest tests/hermes_cli/test_kanban_per_profile_cap.py

Closes #80650
