### PR TITLE
fix(skill-manage): resolve skills behind directory symlinks

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -18,6 +18,7 @@ from tools.skill_manager_tool import (
     _delete_skill,
     _write_file,
     _remove_file,
+    _find_skill,
     skill_manage,
 )
 from agent.skill_utils import (
@@ -68,6 +69,57 @@ description: Use when deploying multi-region Kubernetes clusters with custom CNI
 
 Step 1.
 """
+
+
+# ---------------------------------------------------------------------------
+# _find_skill
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkill:
+    def _make_skill(self, path: Path) -> Path:
+        path.mkdir(parents=True)
+        (path / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        return path
+
+    def test_find_skill_behind_flat_symlink(self, tmp_path):
+        """A skill whose directory is a symlink (farm-style, e.g.
+        ~/.hermes/skills/<name> -> ~/.agents/skills/<cat>/<name>) must be
+        found. rglob() skips symlinked dirs; the walker must follow them."""
+        real = self._make_skill(tmp_path / "real-dir" / "demo-skill")
+        (tmp_path / "demo-skill").symlink_to(real, target_is_directory=True)
+
+        with _skill_dir(tmp_path):
+            found = _find_skill("demo-skill")
+        assert found is not None
+        assert found["path"] == tmp_path / "demo-skill"
+
+    def test_find_skill_behind_shell_symlink(self, tmp_path):
+        """A skill inside a real category shell whose entry is a symlink
+        (~/.hermes/skills/<cat>/<name> -> ~/.agents/skills/<cat>/<name>)
+        must be found."""
+        real = self._make_skill(tmp_path / "real-dir" / "cat" / "demo-skill")
+        shell = tmp_path / "cat"
+        shell.mkdir()
+        (shell / "demo-skill").symlink_to(real, target_is_directory=True)
+
+        with _skill_dir(tmp_path):
+            found = _find_skill("demo-skill")
+        assert found is not None
+        assert found["path"] == tmp_path / "cat" / "demo-skill"
+
+    def test_find_skill_plain_dir_still_found(self, tmp_path):
+        """Regression guard: non-symlinked skills keep resolving."""
+        real = self._make_skill(tmp_path / "plain-skill")
+
+        with _skill_dir(tmp_path):
+            found = _find_skill("plain-skill")
+        assert found is not None
+        assert found["path"] == tmp_path / "plain-skill"
+
+    def test_find_skill_missing_returns_none(self, tmp_path):
+        with _skill_dir(tmp_path):
+            assert _find_skill("no-such-skill") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,11 +650,19 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+    )
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        # iter_skill_index_files walks with followlinks=True so skills
+        # living behind directory symlinks (symlink-farm setups such as
+        # ~/.hermes/skills -> ~/.agents/skills) are found, matching the
+        # indexer that skill_view() uses. rglob() would skip them.
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -749,7 +757,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import is_excluded_skill_path, iter_skill_index_files
     except Exception:
         return matches
 
@@ -793,7 +801,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:


### PR DESCRIPTION
## Problem

`_find_skill()` and `_find_skill_in_other_profiles()` in `tools/skill_manager_tool.py` locate skills with `Path.rglob("SKILL.md")`. `pathlib.rglob` does not descend into symlinked directories (Python < 3.13 has no `recurse_symlinks` parameter; 3.13 defaults it to `False`).

Consequence: in symlink-farm layouts (e.g. `~/.hermes/skills/<name>` pointing at `~/.agents/skills/<cat>/<name>`), every farm skill is invisible to `skill_manage` — `patch`, `edit`, `delete`, `write_file` and `remove_file` all fail with `Skill '<name>' not found in active profile` — while `skill_view` resolves the same skills fine, because the indexer (`agent.skill_utils.iter_skill_index_files`) walks with `os.walk(..., followlinks=True)`.

## Fix

Switch both lookups to `agent.skill_utils.iter_skill_index_files()`, the same follow-symlinks walker the skill indexer uses, so `skill_manage` and `skill_view` agree on what exists. The walker already prunes metadata dirs (`.git`, `.hub`, `.archive`, ...) and skill support dirs (`references/`, `scripts/`, ...).

## Tests

Adds `TestFindSkill` regression tests covering:

- flat symlink layout (`<root>/<name>` -> `<real>`)
- category-shell symlink layout (`<root>/<cat>/<name>` -> `<real>`)
- plain (non-symlinked) skills still resolving
- missing skill returns `None`

All 51 tests in `tests/tools/test_skill_manager_tool.py` pass (4 new), and adjacent skill-view suites stay green (53 passed, 1 skipped).

## Notes

Other `rglob("SKILL.md")` call sites exist in `skills_sync.py`, `skill_usage.py`, `skills_hub.py`, `curator_backup.py` and `learning_graph.py` — left unchanged (usage telemetry / sync / backup semantics may intentionally not follow links); follow-up candidate.
