### PR TITLE
fix(gateway): gate relay-only rename kwargs to the relay lane (#78487)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19957,13 +19957,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_name,
         )
         try:
-            renamed = await rename_thread(
-                target_thread_id,
-                thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
-            )
+            # The relay connector adapter accepts prefer_connector_created /
+            # parent_chat_id; the native Discord plugin adapter does NOT
+            # (its rename_thread signature only has only_if_current_name).
+            # Passing the connector kwargs unconditionally TypeErrors on the
+            # native lane and silently kills every native thread rename —
+            # the exception is swallowed by the except below without ever
+            # logging the "rename result" line. Gate them to the relay lane.
+            if use_connector_guard:
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    prefer_connector_created=True,
+                    parent_chat_id=parent_chat_id,
+                )
+            else:
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    only_if_current_name=guard_name,
+                )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,

--- a/tests/gateway/relay/test_native_lane_rename_kwargs.py
+++ b/tests/gateway/relay/test_native_lane_rename_kwargs.py
@@ -1,0 +1,148 @@
+"""Regression test: native Discord lane rename must not receive relay-only kwargs.
+
+The gateway's _rename_discord_auto_thread_for_session_title used to pass
+prefer_connector_created / parent_chat_id on EVERY lane. The native Discord
+plugin adapter's rename_thread only accepts only_if_current_name, so every
+native rename raised TypeError, was swallowed by the generic except, and the
+thread was silently never renamed (no "rename result" log line either).
+
+Only the relay connector adapter accepts the connector kwargs; the native
+lane must call rename_thread with only the kwargs that adapter supports.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gateway.config import Platform
+
+
+def _mk_native_stub():
+    """Stub runner whose _adapter_for_source returns the NATIVE adapter."""
+    from gateway.run import GatewayRunner
+
+    class _Stub:
+        _is_relay_discord_channel_lane = GatewayRunner._is_relay_discord_channel_lane
+        _relay_auto_thread_info = GatewayRunner._relay_auto_thread_info
+        _is_discord_auto_thread_lane = GatewayRunner._is_discord_auto_thread_lane
+        _sanitize_discord_thread_title = GatewayRunner._sanitize_discord_thread_title
+        _rename_discord_auto_thread_for_session_title = (
+            GatewayRunner._rename_discord_auto_thread_for_session_title
+        )
+
+        def __init__(self, adapter):
+            self.adapters = {Platform.DISCORD: adapter}
+
+        def _adapter_for_source(self, source):
+            return self.adapters.get(source.platform)
+
+    return _Stub
+
+
+def _native_thread_source() -> SimpleNamespace:
+    """A source carrying the native auto-thread markers (as the bundled
+    Discord plugin adapter stamps on the SessionSource at ingest)."""
+    return SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="th-native",
+        chat_type="thread",
+        thread_id="th-native",
+        auto_thread_created=True,
+        auto_thread_initial_name="Initial Words",
+        delivered_via_upstream_relay=False,
+    )
+
+
+class _NativeAdapter:
+    """Signature mirror of the bundled Discord plugin adapter's rename_thread:
+
+    async def rename_thread(self, thread_id, name, *, only_if_current_name=None)
+    """
+
+    def __init__(self):
+        self.calls: list = []
+
+    async def rename_thread(
+        self,
+        thread_id: str,
+        name: str,
+        *,
+        only_if_current_name: Optional[str] = None,
+    ) -> bool:
+        self.calls.append(
+            {"thread_id": thread_id, "name": name, "only_if_current_name": only_if_current_name}
+        )
+        return True
+
+
+@pytest.mark.asyncio
+async def test_native_lane_rename_no_connector_kwargs():
+    """The gateway's rename lane must not send relay-only kwargs to the native
+    adapter — that TypeError silently killed every native thread rename."""
+    adapter = _NativeAdapter()
+    runner = _mk_native_stub()(adapter)
+    src = _native_thread_source()
+
+    await runner._rename_discord_auto_thread_for_session_title(
+        src, "sess-native", "Real Session Title"
+    )
+
+    # The rename must have been issued with the native-only signature.
+    assert len(adapter.calls) == 1
+    call = adapter.calls[0]
+    assert call["thread_id"] == "th-native"
+    assert call["name"] == "Real Session Title"
+    # The connector-owned guard must NOT be smuggled onto the native lane;
+    # the initial-name string guard is the native adapter's contract.
+    assert call["only_if_current_name"] == "Initial Words"
+
+
+@pytest.mark.asyncio
+async def test_native_lane_rename_survives_plugin_signature_strictness():
+    """Pre-fix, passing prefer_connector_created to a signature-strict adapter
+    raised TypeError -> rename never happened. This pins the contract so the
+    gateway call stays compatible with the plugin adapter's signature."""
+    adapter = _NativeAdapter()
+    runner = _mk_native_stub()(adapter)
+    src = _native_thread_source()
+
+    # Would raise TypeError pre-fix (unexpected keyword argument
+    # 'prefer_connector_created'); must complete cleanly post-fix.
+    await runner._rename_discord_auto_thread_for_session_title(
+        src, "sess2", "Native rename still works"
+    )
+    assert [c["name"] for c in adapter.calls] == ["Native rename still works"]
+
+
+@pytest.mark.asyncio
+async def test_relay_lane_still_uses_connector_guard():
+    """Sanity: the relay lane keeps its connector-owned guard behavior —
+    the fix must not have degraded it."""
+    from tests.gateway.relay.test_relay_threads import _adapter, _mk_runner_stub, _relay_channel_source
+
+    adapter, stub_conn = _adapter()
+    renames: list = []
+
+    async def rename_thread(
+        thread_id,
+        name,
+        *,
+        only_if_current_name=None,
+        prefer_connector_created=False,
+        parent_chat_id=None,
+    ):
+        renames.append((thread_id, name, prefer_connector_created, parent_chat_id))
+        return True
+
+    adapter.rename_thread = rename_thread  # type: ignore[method-assign]
+    runner = _mk_runner_stub()(adapter)
+    src = _relay_channel_source()
+    adapter._auto_thread_by_chat["chan-parent"] = ("th-9", "Initial words")
+
+    await runner._rename_discord_auto_thread_for_session_title(
+        src, "sess1", "Relay title"
+    )
+    assert renames == [("th-9", "Relay title", True, "chan-parent")]


### PR DESCRIPTION
## What does this PR do?

Fixes #78487: native Discord auto-thread semantic renames were silently dying since the connector-guard refactor. `gateway/run.py` passes `prefer_connector_created` / `parent_chat_id` to `rename_thread` unconditionally, but the **native** Discord adapter's `rename_thread` only accepts `only_if_current_name`. Every native-lane rename raised `TypeError`, swallowed by the bare `except Exception` (debug-level log only) — the "rename result" log line never fires and threads keep their initial auto-thread name.

This PR takes the **call-site gating approach** (option 2 from the issue): the connector-owned kwargs are passed only on the relay lane; the native lane calls with `only_if_current_name` only.

## Why this approach vs #78495

#78495 makes the native adapter silently accept/ignore the connector kwargs (single call-site preserved). This PR instead gates at the call site, keeping the native adapter's signature strict — a future relay/native mismatch will fail loudly at the boundary rather than being papered over by ignored parameters. Both approaches fix the bug; maintainers can pick or combine (the gating + adapter tolerance compose cleanly).

## Changes Made

- `gateway/run.py`: branch the `rename_thread` call on `use_connector_guard` — relay lane keeps `prefer_connector_created=True` + `parent_chat_id`; native lane passes only `only_if_current_name`.
- `tests/gateway/relay/test_native_lane_rename_kwargs.py`: regression tests — (1) native lane receives no connector kwargs with the string guard intact, (2) signature-strict native adapter completes without TypeError, (3) relay lane keeps connector-guard behavior.

## How to Test

```bash
./venv/bin/python -m pytest tests/gateway/relay/test_native_lane_rename_kwargs.py -v
# 3 passed

# Live: restart gateway, create a Discord auto-thread via the native lane,
# confirm "discord auto-thread rename result: ... applied=True" at INFO
# (previously the attempt line fired with no result line).
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added/updated and passing
- [x] No new dependencies
- [x] Bug fix verified against live native-lane Discord renames (gateway restarted with this patch; rename result lines present, no TypeError)