### PR TITLE
fix(gateway): flush SSE response headers immediately on /v1/runs/events (#80757)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6767,6 +6767,11 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         )
         await response.prepare(request)
+        # #80757: Flush headers immediately so clients don't hang waiting
+        # for the first event.  Without this initial write, Nagle/delayed-ACK
+        # interaction can defer the HTTP response headers until the first
+        # real event arrives (or the 30 s keepalive fires).
+        await response.write(b": connected\n\n")
 
         try:
             while True:


### PR DESCRIPTION
Fixes #80757

## Root cause

`_handle_run_events` calls `await response.prepare(request)` then enters a `q.get()` loop without writing any bytes first. When no event is queued yet, aiohttp holds the response headers in its internal buffer. Due to Nagle / delayed-ACK interaction, clients using `fetch()` or `EventSource` never see the response — they appear hung until the first event arrives (or the 30 s keepalive timeout fires).

## Fix

Write an initial SSE comment (`": connected\n\n"`) immediately after `response.prepare(request)` to flush the HTTP response headers to the client. This is standard SSE practice and costs zero application semantics (SSE comments are ignored by clients).

## Impact

- Approval flows no longer appear dead while the agent thinks (20–60 s)
- Web dashboards / desktop clients show "connected" immediately
- `EventSource` consumers get their `onopen` event right away
