### PR TITLE
fix(desktop): bound the in-flight turn journal and stop rewriting it every 400ms

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from typing import Iterator, Mapping, MutableMapping
+from typing import Iterator, Mapping, MutableMapping, Sequence
 
 _DELEGATED_CHILD_CONTEXT: ContextVar[bool] = ContextVar(
     "hermes_delegated_child_context",
@@ -128,6 +128,65 @@ def is_delegated_child_process_context() -> bool:
     return bool(_DELEGATED_CHILD_CONTEXT.get()) or bool(
         os.environ.get(DELEGATED_CHILD_ENV_MARKER)
     )
+
+
+# Entrypoints that start a long-lived Hermes *server* rather than doing agent
+# work.  ``gateway`` is deliberately absent — only ``gateway run`` qualifies,
+# which :func:`is_server_role_argv` special-cases; ``gateway restart|status``
+# are ordinary short-lived CLI calls.
+SERVER_ROLE_COMMANDS: frozenset[str] = frozenset({
+    "serve",
+    "dashboard",
+    "gui",
+    "desktop",
+})
+
+
+def is_server_role_argv(argv: Sequence[str]) -> bool:
+    """Return True when *argv* starts a long-lived Hermes server process.
+
+    *argv* is the argument list WITHOUT the program name (``sys.argv[1:]``).
+    Only the leading positional words matter, so flags anywhere are ignored.
+    """
+    positionals = [arg for arg in argv if not arg.startswith("-")]
+    if not positionals:
+        return False
+    command = positionals[0]
+    if command == "gateway":
+        return len(positionals) > 1 and positionals[1] == "run"
+    return command in SERVER_ROLE_COMMANDS
+
+
+def clear_delegated_child_marker_for_server_role() -> bool:
+    """Drop an inherited lineage marker in a server-role process. Returns True if one was cleared.
+
+    A long-lived Hermes server is a fresh root of trust, not delegate_task
+    child work — it serves the user's browser and desktop app, not the agent
+    that happened to launch it.  Such a server is routinely started *from* an
+    agent: a delegated child that runs ``hermes serve`` or launches the desktop
+    app through the terminal tool spawns it with
+    :data:`DELEGATED_CHILD_ENV_MARKER` in its environment, because
+    :func:`delegated_child_subprocess_env` stamps the marker into every child
+    env so the lineage survives a fork.  Nothing ever unsets it, so the marker
+    outlives the delegated child by hours and permanently poisons the server's
+    Kanban path: ``kanban_db.connect()`` runs its first-open migration pass
+    through ``write_txn``, so the delegated-child guard fails the whole *read*
+    path, not just mutations, and the dashboard event stream errors on every
+    reconnect.
+
+    ``tests/conftest.py`` drops the marker for exactly this reason (pytest is
+    routinely launched from a delegated worker).  This is the same fix for the
+    other long-lived process that is not agent work.
+
+    Deliberately narrow: only the server entrypoints in
+    :func:`is_server_role_argv` call this.  Everything an agent actually
+    delegates — a ``hermes kanban`` CLI call, a python subprocess importing
+    ``kanban_db``, a grandchild of either — keeps the marker and stays rejected
+    by the guard.
+    """
+    import os
+
+    return os.environ.pop(DELEGATED_CHILD_ENV_MARKER, None) is not None
 
 
 def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[str, str]:

--- a/apps/desktop/electron/diagnostics-capture.test.ts
+++ b/apps/desktop/electron/diagnostics-capture.test.ts
@@ -1,0 +1,470 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  classifyTransportError,
+  createCaptureController,
+  createMainRing,
+  routePrefix,
+  sanitizeAppMetrics
+} from './diagnostics-capture'
+
+// A minimal fake BrowserWindow: records everything main sent it and lets a test
+// fire the webContents responsiveness edges, mirroring the slice of the
+// Electron API the controller actually touches (see session-windows.test.ts).
+function makeFakeWindow(id: number) {
+  const sent: { channel: string; payload: any }[] = []
+  const contentsListeners: Record<string, () => void> = {}
+  let destroyed = false
+
+  return {
+    id,
+    sent,
+    isDestroyed: () => destroyed,
+    destroy() {
+      destroyed = true
+    },
+    on() {},
+    emitContents(event: string) {
+      contentsListeners[event]?.()
+    },
+    collectRequests: () => sent.filter(entry => entry.channel === 'diagnostics:collect'),
+    webContents: {
+      isDestroyed: () => destroyed,
+      send(channel: string, payload: any) {
+        sent.push({ channel, payload })
+      },
+      on(event: string, listener: () => void) {
+        contentsListeners[event] = listener
+      }
+    }
+  }
+}
+
+// Hand-driven timers: nothing fires until the test says so, so "sampled only
+// while armed" is an assertion about registration AND about firing.
+function makeFakeTimers() {
+  const intervals = new Map<number, { fn: () => void; ms: number }>()
+  const timeouts = new Map<number, { fn: () => void; ms: number }>()
+  let nextHandle = 1
+
+  return {
+    intervals,
+    timeouts,
+    tickIntervals(times = 1) {
+      for (let i = 0; i < times; i += 1) {
+        for (const entry of [...intervals.values()]) {
+          entry.fn()
+        }
+      }
+    },
+    fireTimeouts() {
+      for (const entry of [...timeouts.values()]) {
+        entry.fn()
+      }
+    },
+    timers: {
+      setInterval(fn: () => void, ms: number) {
+        const handle = nextHandle++
+        intervals.set(handle, { fn, ms })
+
+        return handle
+      },
+      clearInterval(handle: any) {
+        intervals.delete(handle)
+      },
+      setTimeout(fn: () => void, ms: number) {
+        const handle = nextHandle++
+        timeouts.set(handle, { fn, ms })
+
+        return handle
+      },
+      clearTimeout(handle: any) {
+        timeouts.delete(handle)
+      }
+    }
+  }
+}
+
+function makeFakeGateway(overrides: any = {}) {
+  const calls: string[] = []
+
+  return {
+    calls,
+    client: {
+      async arm(input) {
+        calls.push('arm')
+
+        return overrides.arm ? overrides.arm(input) : { ok: true, monotonicAnchorMs: 500 }
+      },
+      async collect(captureId) {
+        calls.push('collect')
+
+        return overrides.collect
+          ? overrides.collect(captureId)
+          : { ok: true, stream: { captureId, monotonicAnchorMs: 500, events: [], dropped: 0 } }
+      },
+      async disarm() {
+        calls.push('disarm')
+      }
+    }
+  }
+}
+
+function makeController(options: any = {}) {
+  const timers = makeFakeTimers()
+  const windows = options.windows ?? []
+  let clock = 1000
+
+  const controller = createCaptureController({
+    now: () => clock,
+    wallClock: () => 1_700_000_000_000,
+    randomUUID: () => 'cap-test',
+    listWindows: () => windows,
+    timers: timers.timers,
+    ...options.controller
+  })
+
+  return {
+    controller,
+    timers,
+    windows,
+    advance(ms: number) {
+      clock += ms
+    },
+    setClock(value: number) {
+      clock = value
+    }
+  }
+}
+
+/** Answer every outstanding collect request for a window with `snapshot`. */
+function answerCollect(controller: any, win: any, snapshot: any) {
+  for (const request of win.collectRequests()) {
+    controller.handleCollectResult({ requestId: request.payload.requestId, snapshot })
+  }
+}
+
+const rendererSnapshot = {
+  captureId: 'cap-test',
+  wallClockAnchorMs: 1_700_000_000_000,
+  monotonicAnchorMs: 10,
+  events: [{ type: 'long_frame', t: 42 }],
+  droppedEvents: 2
+}
+
+test('arming pushes the capture id and wall-clock anchor to every window', async () => {
+  const a = makeFakeWindow(1)
+  const b = makeFakeWindow(2)
+  const harness = makeController({ windows: [a, b] })
+
+  const started = await harness.controller.start()
+
+  assert.equal(started.captureId, 'cap-test')
+  assert.equal(started.wallClockAnchorMs, 1_700_000_000_000)
+
+  for (const win of [a, b]) {
+    assert.deepEqual(win.sent, [
+      { channel: 'diagnostics:arm', payload: { captureId: 'cap-test', wallClockAnchorMs: 1_700_000_000_000 } }
+    ])
+  }
+
+  assert.equal(harness.controller.isArmed(), true)
+})
+
+test('a window opened mid-capture is armed as it attaches', async () => {
+  const a = makeFakeWindow(1)
+  const harness = makeController({ windows: [a] })
+  await harness.controller.start()
+
+  const late = makeFakeWindow(2)
+  harness.controller.attachWindow(late as never)
+
+  assert.deepEqual(late.sent[0], {
+    channel: 'diagnostics:arm',
+    payload: { captureId: 'cap-test', wallClockAnchorMs: 1_700_000_000_000 }
+  })
+})
+
+test('stopping disarms every window and clears the armed state', async () => {
+  const a = makeFakeWindow(1)
+  const harness = makeController({ windows: [a] })
+  await harness.controller.start()
+
+  const stopping = harness.controller.stop()
+  answerCollect(harness.controller, a, rendererSnapshot)
+  const bundle = await stopping
+
+  assert.equal(harness.controller.isArmed(), false)
+  assert.equal(harness.controller.captureId(), null)
+  assert.equal(a.sent.at(-1)?.channel, 'diagnostics:disarm')
+  assert.deepEqual(bundle?.renderer, [{ windowId: 1, ...rendererSnapshot }])
+  assert.deepEqual(bundle?.anchors, { wallClockAnchorMs: 1_700_000_000_000, mainMonotonicAnchorMs: 1000 })
+})
+
+test('a renderer that never answers is skipped instead of hanging the export', async () => {
+  const a = makeFakeWindow(1)
+  const b = makeFakeWindow(2)
+  const harness = makeController({ windows: [a, b] })
+  await harness.controller.start()
+
+  const stopping = harness.controller.stop()
+  answerCollect(harness.controller, a, rendererSnapshot)
+  // b is wedged: fire its collect timeout instead of replying.
+  harness.timers.fireTimeouts()
+  const bundle = await stopping
+
+  assert.deepEqual(
+    bundle?.renderer.map(stream => stream.windowId),
+    [1]
+  )
+})
+
+test('app metrics are sampled only while armed', async () => {
+  let samples = 0
+
+  const harness = makeController({
+    windows: [],
+    controller: {
+      getAppMetrics: () => {
+        samples += 1
+
+        return [{ pid: 10, type: 'Browser', cpu: { percentCPUUsage: 1 }, memory: { workingSetSize: 2048 } }]
+      }
+    }
+  })
+
+  // Disarmed: no interval exists at all, so nothing can sample.
+  assert.equal(harness.timers.intervals.size, 0)
+  harness.timers.tickIntervals()
+  assert.equal(samples, 0)
+
+  await harness.controller.start()
+  assert.equal(harness.timers.intervals.size, 1)
+  harness.timers.tickIntervals(2)
+
+  const stopping = harness.controller.stop()
+  const bundle = await stopping
+
+  // Two ticks plus the closing sample taken by stop().
+  assert.equal(samples, 3)
+  assert.equal(harness.timers.intervals.size, 0)
+  assert.equal(bundle?.main.filter(event => event.type === 'app_metrics').length, 3)
+
+  harness.timers.tickIntervals()
+  assert.equal(samples, 3)
+})
+
+test('window responsiveness edges are recorded with the blocked duration', async () => {
+  const a = makeFakeWindow(1)
+  const harness = makeController({ windows: [a] })
+  await harness.controller.start()
+
+  a.emitContents('unresponsive')
+  harness.advance(2500)
+  a.emitContents('responsive')
+
+  const stopping = harness.controller.stop()
+  answerCollect(harness.controller, a, rendererSnapshot)
+  const bundle = await stopping
+
+  assert.deepEqual(bundle?.main, [
+    { type: 'window_unresponsive', t: 1000, windowId: 1 },
+    { type: 'window_responsive', t: 3500, windowId: 1, blockedMs: 2500 }
+  ])
+})
+
+test('responsiveness edges outside a capture are dropped', async () => {
+  const a = makeFakeWindow(1)
+  const harness = makeController({ windows: [a] })
+
+  harness.controller.attachWindow(a as never)
+  a.emitContents('unresponsive')
+  a.emitContents('responsive')
+
+  await harness.controller.start()
+  const stopping = harness.controller.stop()
+  answerCollect(harness.controller, a, rendererSnapshot)
+  const bundle = await stopping
+
+  assert.deepEqual(bundle?.main, [])
+})
+
+test('renderer transport failures become sanitized transport events', async () => {
+  const harness = makeController({ windows: [] })
+
+  // Disarmed failures cost nothing and are not retained.
+  harness.controller.recordTransportError({
+    channel: 'hermes:api',
+    path: '/api/sessions/abc/messages',
+    durationMs: 10,
+    error: new Error('boom')
+  })
+
+  await harness.controller.start()
+  harness.controller.recordTransportError({
+    channel: 'hermes:api',
+    path: '/api/sessions/abc-123/messages?limit=50',
+    durationMs: 60_004,
+    error: new Error('Timed out connecting to Hermes backend after 60000ms')
+  })
+  harness.controller.recordTransportError({
+    channel: 'hermes:api',
+    path: '/api/status',
+    durationMs: 12,
+    error: new Error('502: bad gateway')
+  })
+
+  const bundle = await harness.controller.stop()
+  const transport = bundle?.main.filter(event => event.type === 'transport_error')
+
+  assert.deepEqual(transport, [
+    {
+      type: 'transport_error',
+      t: 1000,
+      channel: 'hermes:api',
+      route: '/api/sessions',
+      durationMs: 60_004,
+      errorClass: 'timeout'
+    },
+    {
+      type: 'transport_error',
+      t: 1000,
+      channel: 'hermes:api',
+      route: '/api/status',
+      durationMs: 12,
+      errorClass: 'http_502'
+    }
+  ])
+})
+
+test('a remote gateway is never armed and its stream is marked absent', async () => {
+  const gateway = makeFakeGateway()
+
+  const harness = makeController({
+    windows: [],
+    controller: { gateway: gateway.client, isRemoteGateway: () => true }
+  })
+
+  await harness.controller.start()
+  const bundle = await harness.controller.stop()
+
+  assert.deepEqual(bundle?.gateway, { absent: 'remote-gateway' })
+  assert.deepEqual(gateway.calls, [])
+})
+
+test('a local gateway ring is pulled into the bundle', async () => {
+  const gateway = makeFakeGateway({
+    collect: captureId => ({
+      ok: true,
+      stream: { captureId, monotonicAnchorMs: 500, events: [{ type: 'loop_stall', t: 7 }], dropped: 1 }
+    })
+  })
+
+  const harness = makeController({
+    windows: [],
+    controller: { gateway: gateway.client, isRemoteGateway: () => false }
+  })
+
+  await harness.controller.start()
+  const bundle = await harness.controller.stop()
+
+  assert.deepEqual(bundle?.gateway, {
+    captureId: 'cap-test',
+    monotonicAnchorMs: 500,
+    events: [{ type: 'loop_stall', t: 7 }],
+    dropped: 1
+  })
+  assert.deepEqual(gateway.calls, ['arm', 'collect', 'disarm'])
+})
+
+test('a gateway that refuses to arm is marked absent and never pulled', async () => {
+  const gateway = makeFakeGateway({ arm: () => ({ ok: false, reason: 'unauthenticated' }) })
+
+  const harness = makeController({
+    windows: [],
+    controller: { gateway: gateway.client, isRemoteGateway: () => false }
+  })
+
+  await harness.controller.start()
+  const bundle = await harness.controller.stop()
+
+  assert.deepEqual(bundle?.gateway, { absent: 'unauthenticated' })
+  assert.equal(gateway.calls.includes('collect'), false)
+})
+
+test('no gateway client at all still produces a complete bundle', async () => {
+  const harness = makeController({ windows: [], controller: { gateway: null } })
+
+  await harness.controller.start()
+  const bundle = await harness.controller.stop()
+
+  assert.deepEqual(bundle?.gateway, { absent: 'disabled' })
+  assert.equal(bundle?.captureId, 'cap-test')
+})
+
+test('the completed bundle stays readable for the exporter', async () => {
+  const harness = makeController({ windows: [] })
+
+  assert.equal(harness.controller.lastCapture(), null)
+  await harness.controller.start()
+  const bundle = await harness.controller.stop()
+
+  assert.equal(harness.controller.lastCapture(), bundle)
+  assert.equal(await harness.controller.stop(), null)
+})
+
+test('the main ring is bounded by count and by age', () => {
+  const ring = createMainRing({ maxEvents: 3, maxAgeMs: 1000 })
+
+  for (let i = 0; i < 5; i += 1) {
+    ring.push({ type: 'app_metrics', t: i, processes: [] } as never)
+  }
+
+  assert.equal(ring.size, 3)
+  assert.equal(ring.dropped, 2)
+  assert.deepEqual(
+    ring.entries().map(event => event.t),
+    [2, 3, 4]
+  )
+
+  ring.push({ type: 'app_metrics', t: 9000, processes: [] } as never)
+
+  assert.deepEqual(
+    ring.entries().map(event => event.t),
+    [9000]
+  )
+  assert.equal(ring.dropped, 5)
+})
+
+test('metrics samples keep numbers only', () => {
+  assert.deepEqual(
+    sanitizeAppMetrics([
+      {
+        pid: 42,
+        type: 'Utility',
+        name: 'Network Service',
+        cpu: { percentCPUUsage: 1.23456 },
+        memory: { workingSetSize: 8192 }
+      } as never
+    ]),
+    [{ pid: 42, type: 'Utility', percentCpu: 1.23, workingSetKb: 8192 }]
+  )
+  assert.deepEqual(sanitizeAppMetrics(undefined), [])
+})
+
+test('route prefixes drop ids, queries and fragments', () => {
+  assert.equal(routePrefix('/api/sessions/abc-123/messages?limit=50#x'), '/api/sessions')
+  assert.equal(routePrefix('/api/status'), '/api/status')
+  assert.equal(routePrefix('/'), '/')
+  assert.equal(routePrefix(undefined), null)
+})
+
+test('transport errors are classified without keeping their message', () => {
+  assert.equal(classifyTransportError(new Error('Timed out connecting to Hermes backend after 60000ms')), 'timeout')
+  assert.equal(classifyTransportError(new Error('404: not found')), 'http_404')
+  assert.equal(classifyTransportError(Object.assign(new Error('x'), { code: 'ECONNREFUSED' })), 'connect_ECONNREFUSED')
+  assert.equal(classifyTransportError(Object.assign(new Error('x'), { code: 'ETIMEDOUT' })), 'timeout')
+  assert.equal(classifyTransportError(new Error('something else')), 'error')
+})

--- a/apps/desktop/electron/diagnostics-capture.ts
+++ b/apps/desktop/electron/diagnostics-capture.ts
@@ -1,0 +1,616 @@
+// Main-process half of the hitch-capture controller (U3, KTD2/KTD3).
+//
+// Main is the only process that can reach BOTH the renderers and the gateway,
+// so it owns the capture: it mints the capture id and the wall-clock anchor,
+// pushes them down to every chat window over IPC, arms the gateway over the
+// existing authenticated channel, records its own boundary signals into a
+// bounded ring, and — on stop — gathers all three streams into one bundle for
+// the exporter (U4).
+//
+// Two invariants shape the design:
+//
+//   * Zero cost while disarmed (KTD2). Nothing samples, nothing accumulates.
+//     `app.getAppMetrics()` walks every process in the app and is far too
+//     expensive to poll around the clock, so the sampler only exists between
+//     start and stop, and window responsiveness edges are dropped on the floor
+//     unless a capture is running.
+//   * Correlate by capture id + per-process monotonic clocks (KTD3). Each
+//     process stamps its own monotonic clock and reports the anchor it had at
+//     arm time; nothing here rewrites another process's timestamps. The
+//     exporter aligns the streams afterwards.
+//
+// Sanitization: main records durations, counts, pids and error classes only —
+// never request bodies, responses, URLs with credentials, or argv. The
+// transport recorder deliberately keeps a coarse route prefix instead of the
+// full path, because Hermes REST paths carry session ids.
+//
+// Electron-free (windows, metrics, timers and the gateway client are all
+// injected) so it unit-tests under the `electron` vitest project the same way
+// stream-throttle.ts and session-windows.ts do.
+
+import type { GatewayAbsentReason, GatewayDiagnosticsClient, GatewayDiagnosticsStream } from './diagnostics-gateway'
+
+/** Ring window, matching the renderer's (~300s around the reported hitch). */
+const DEFAULT_MAX_AGE_MS = 300_000
+/** Count cap. Main's streams are sparse next to the renderer's long frames. */
+const DEFAULT_MAX_EVENTS = 4_000
+/** `app.getAppMetrics()` cadence while armed. Low on purpose: this call is not
+ * cheap, and memory/CPU drift is the slow-moving signal in the bundle. */
+const DEFAULT_METRICS_INTERVAL_MS = 5_000
+/** How long a renderer gets to answer a snapshot pull before it is skipped —
+ * a renderer wedged by the very hitch under investigation must not hang the
+ * export. */
+const DEFAULT_COLLECT_TIMEOUT_MS = 3_000
+
+/** main -> renderer: arm/disarm/collect. Mirrored by preload.ts. */
+const ARM_CHANNEL = 'diagnostics:arm'
+const DISARM_CHANNEL = 'diagnostics:disarm'
+const COLLECT_CHANNEL = 'diagnostics:collect'
+/** renderer -> main: the answer to one `diagnostics:collect` request. */
+const COLLECT_RESULT_CHANNEL = 'diagnostics:collect:result'
+
+export interface MainDiagnosticsEventBase {
+  /** Main's monotonic clock, same units as `anchors.mainMonotonicAnchorMs`. */
+  t: number
+  type: string
+}
+
+export interface WindowResponsivenessEvent extends MainDiagnosticsEventBase {
+  type: 'window_responsive' | 'window_unresponsive'
+  windowId: number
+  /** How long the window was unresponsive; only on the 'responsive' edge. */
+  blockedMs?: number
+}
+
+export interface ProcessMetricSample {
+  pid: number
+  /** Electron's process type ('Browser', 'Tab', 'GPU', 'Utility', ...). */
+  type: string
+  percentCpu: number
+  workingSetKb: number
+}
+
+export interface AppMetricsEvent extends MainDiagnosticsEventBase {
+  type: 'app_metrics'
+  processes: ProcessMetricSample[]
+}
+
+export interface TransportErrorEvent extends MainDiagnosticsEventBase {
+  type: 'transport_error'
+  /** IPC channel the failure surfaced on, e.g. 'hermes:api'. */
+  channel: string
+  /** Coarse route prefix ('/api/sessions'), never the full path + query. */
+  route: null | string
+  durationMs: number
+  /** 'timeout' | 'http_<status>' | 'connect' | 'error' — no messages. */
+  errorClass: string
+}
+
+export type MainDiagnosticsEvent = AppMetricsEvent | TransportErrorEvent | WindowResponsivenessEvent
+
+export interface RendererCaptureSnapshot {
+  captureId: string
+  wallClockAnchorMs: number
+  monotonicAnchorMs: number
+  events: unknown[]
+  droppedEvents: number
+}
+
+export type RendererCaptureStream = RendererCaptureSnapshot & { windowId: number }
+
+export interface DiagnosticsCaptureBundle {
+  captureId: string
+  anchors: {
+    wallClockAnchorMs: number
+    mainMonotonicAnchorMs: number
+  }
+  renderer: RendererCaptureStream[]
+  main: MainDiagnosticsEvent[]
+  /** Main-ring events evicted by the caps, so the bundle is honest. */
+  mainDropped: number
+  gateway: GatewayDiagnosticsStream | { absent: GatewayAbsentReason }
+}
+
+export interface CaptureWebContentsLike {
+  isDestroyed(): boolean
+  send(channel: string, payload?: unknown): void
+  on?(event: string, listener: () => void): void
+  removeListener?(event: string, listener: () => void): void
+}
+
+export interface CaptureWindowLike {
+  id: number
+  isDestroyed(): boolean
+  webContents?: CaptureWebContentsLike | null
+  on?(event: string, listener: () => void): void
+}
+
+/** Raw `app.getAppMetrics()` entry — only the fields main keeps. */
+export interface RawAppMetric {
+  pid?: number
+  type?: string
+  cpu?: { percentCPUUsage?: number }
+  memory?: { workingSetSize?: number }
+}
+
+interface TimersLike {
+  clearInterval(handle: unknown): void
+  clearTimeout(handle: unknown): void
+  setInterval(fn: () => void, ms: number): unknown
+  setTimeout(fn: () => void, ms: number): unknown
+}
+
+export interface CaptureControllerOptions {
+  /** Monotonic clock for main's own stream (`performance.now()` in prod). */
+  now: () => number
+  /** Wall clock at capture start — the anchor every process aligns onto. */
+  wallClock?: () => number
+  randomUUID?: () => string
+  /** Every window that should be armed: primary + session + instance windows. */
+  listWindows: () => CaptureWindowLike[]
+  getAppMetrics?: () => RawAppMetric[]
+  /** Null when this build has no gateway client at all. */
+  gateway?: GatewayDiagnosticsClient | null
+  /**
+   * True when the active connection is a remote/SSH gateway. The gateway ring
+   * is supported only for the locally-spawned backend, so a remote connection
+   * skips arming entirely and the stream is marked absent (`remote-gateway`).
+   */
+  isRemoteGateway?: () => boolean
+  timers?: TimersLike
+  maxEvents?: number
+  maxAgeMs?: number
+  metricsIntervalMs?: number
+  collectTimeoutMs?: number
+}
+
+export interface CaptureController {
+  /** Track a window: responsiveness edges, plus live-arming a window that
+   * opened mid-capture. Safe to call for every window in the app. */
+  attachWindow(win: CaptureWindowLike): void
+  isArmed(): boolean
+  captureId(): null | string
+  /** Arm renderers + gateway + the main sampler. Idempotent-ish: a second
+   * call while armed returns the running capture's descriptor. */
+  start(): Promise<{ captureId: string; wallClockAnchorMs: number; mainMonotonicAnchorMs: number }>
+  /** Disarm everything and gather the bundle. Null when nothing was armed. */
+  stop(): Promise<DiagnosticsCaptureBundle | null>
+  /** The last completed bundle — U4's export/UI reads this. */
+  lastCapture(): DiagnosticsCaptureBundle | null
+  /** Wire to `ipcMain.on('diagnostics:collect:result')`. */
+  handleCollectResult(payload: unknown): void
+  /** Record a renderer->backend transport failure (durations/classes only). */
+  recordTransportError(input: { channel: string; path?: null | string; durationMs: number; error: unknown }): void
+}
+
+/**
+ * Classify a transport failure without keeping its message. `fetchJson` rejects
+ * HTTP errors as `Error('<status>: <body>')` and its own timeout as "Timed out
+ * connecting to Hermes backend after Nms"; Node socket failures carry a `code`.
+ */
+export function classifyTransportError(error: unknown): string {
+  const code = (error as { code?: unknown })?.code
+
+  if (typeof code === 'string' && code) {
+    return code === 'ETIMEDOUT' ? 'timeout' : `connect_${code}`
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  if (/timed out/i.test(message)) {
+    return 'timeout'
+  }
+
+  const status = /^\s*(\d{3})\b/.exec(message)?.[1]
+
+  if (status) {
+    return `http_${status}`
+  }
+
+  return 'error'
+}
+
+/**
+ * Reduce a REST path to a coarse route prefix: two segments, no query, no
+ * fragment. `/api/sessions/abc123/messages?x=y` -> `/api/sessions`. Session ids
+ * and tokens live in the parts this drops.
+ */
+export function routePrefix(rawPath: unknown): null | string {
+  const text = typeof rawPath === 'string' ? rawPath : ''
+
+  if (!text) {
+    return null
+  }
+
+  const withoutQuery = text.split(/[?#]/, 1)[0]
+  const segments = withoutQuery.split('/').filter(Boolean).slice(0, 2)
+
+  return segments.length ? `/${segments.join('/')}` : '/'
+}
+
+/** Keep only the numeric shape of a metrics sample — no process names or
+ * command lines (they routinely carry paths and, for utility processes,
+ * extension identities). */
+export function sanitizeAppMetrics(metrics: RawAppMetric[] | undefined): ProcessMetricSample[] {
+  if (!Array.isArray(metrics)) {
+    return []
+  }
+
+  return metrics.map(entry => ({
+    pid: Number(entry?.pid) || 0,
+    type: typeof entry?.type === 'string' ? entry.type : 'unknown',
+    percentCpu: Math.round((Number(entry?.cpu?.percentCPUUsage) || 0) * 100) / 100,
+    workingSetKb: Math.round(Number(entry?.memory?.workingSetSize) || 0)
+  }))
+}
+
+/**
+ * Bounded, oldest-first event store for the main stream. Count cap + age cap,
+ * both enforced on push so the ring can never grow between captures.
+ */
+export function createMainRing(limits: { maxEvents: number; maxAgeMs: number }) {
+  const events: MainDiagnosticsEvent[] = []
+  let dropped = 0
+
+  function trim(nowT: number) {
+    while (events.length && (events.length > limits.maxEvents || nowT - events[0].t > limits.maxAgeMs)) {
+      events.shift()
+      dropped += 1
+    }
+  }
+
+  return {
+    push(event: MainDiagnosticsEvent) {
+      events.push(event)
+      trim(event.t)
+    },
+    entries: () => events.slice(),
+    get dropped() {
+      return dropped
+    },
+    get size() {
+      return events.length
+    },
+    reset() {
+      events.length = 0
+      dropped = 0
+    }
+  }
+}
+
+const defaultTimers: TimersLike = {
+  clearInterval: handle => clearInterval(handle as never),
+  clearTimeout: handle => clearTimeout(handle as never),
+  setInterval,
+  setTimeout
+}
+
+function normalizeRendererSnapshot(value: unknown): RendererCaptureSnapshot | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const snapshot = value as Partial<RendererCaptureSnapshot>
+
+  if (typeof snapshot.captureId !== 'string' || !snapshot.captureId) {
+    return null
+  }
+
+  return {
+    captureId: snapshot.captureId,
+    wallClockAnchorMs: Number(snapshot.wallClockAnchorMs) || 0,
+    monotonicAnchorMs: Number(snapshot.monotonicAnchorMs) || 0,
+    events: Array.isArray(snapshot.events) ? snapshot.events : [],
+    droppedEvents: Number(snapshot.droppedEvents) || 0
+  }
+}
+
+export function createCaptureController(options: CaptureControllerOptions): CaptureController {
+  const now = options.now
+  const wallClock = options.wallClock ?? (() => Date.now())
+  const randomUUID = options.randomUUID ?? (() => globalThis.crypto.randomUUID())
+  const timers = options.timers ?? defaultTimers
+  const metricsIntervalMs = options.metricsIntervalMs ?? DEFAULT_METRICS_INTERVAL_MS
+  const collectTimeoutMs = options.collectTimeoutMs ?? DEFAULT_COLLECT_TIMEOUT_MS
+
+  const ring = createMainRing({
+    maxEvents: options.maxEvents ?? DEFAULT_MAX_EVENTS,
+    maxAgeMs: options.maxAgeMs ?? DEFAULT_MAX_AGE_MS
+  })
+
+  const attached = new Set<CaptureWindowLike>()
+  // Windows already told about the running capture. Arming is reached from two
+  // directions — the start() sweep and a window attaching mid-capture — and a
+  // renderer that gets armed twice would reset its ring mid-hitch.
+  const armedWindows = new Set<CaptureWindowLike>()
+  const pendingCollects = new Map<string, (snapshot: null | RendererCaptureSnapshot) => void>()
+  const unresponsiveSince = new Map<number, number>()
+
+  let armed = false
+  let activeCaptureId: null | string = null
+  let wallClockAnchorMs = 0
+  let mainMonotonicAnchorMs = 0
+  let metricsHandle: unknown = null
+  let gatewayAbsent: GatewayAbsentReason | null = 'disabled'
+  let lastBundle: DiagnosticsCaptureBundle | null = null
+  let collectSeq = 0
+
+  function liveWebContents(win: CaptureWindowLike): CaptureWebContentsLike | null {
+    if (win.isDestroyed()) {
+      return null
+    }
+
+    const contents = win.webContents
+
+    return contents && !contents.isDestroyed() ? contents : null
+  }
+
+  function sendToWindow(win: CaptureWindowLike, channel: string, payload?: unknown) {
+    const contents = liveWebContents(win)
+
+    if (!contents) {
+      return false
+    }
+
+    try {
+      contents.send(channel, payload)
+
+      return true
+    } catch {
+      // A window mid-teardown can throw; it is leaving the capture anyway.
+      return false
+    }
+  }
+
+  function sampleMetrics() {
+    if (!armed || !options.getAppMetrics) {
+      return
+    }
+
+    let raw: RawAppMetric[] = []
+
+    try {
+      raw = options.getAppMetrics() ?? []
+    } catch {
+      return
+    }
+
+    ring.push({ type: 'app_metrics', t: now(), processes: sanitizeAppMetrics(raw) })
+  }
+
+  function pushArm(win: CaptureWindowLike) {
+    if (!armed || !activeCaptureId || armedWindows.has(win)) {
+      return
+    }
+
+    armedWindows.add(win)
+    sendToWindow(win, ARM_CHANNEL, { captureId: activeCaptureId, wallClockAnchorMs })
+  }
+
+  function attachWindow(win: CaptureWindowLike) {
+    if (!win) {
+      return
+    }
+
+    if (attached.has(win)) {
+      // Already tracked, but a capture may have started since — arm it now.
+      pushArm(win)
+
+      return
+    }
+
+    attached.add(win)
+    win.on?.('closed', () => {
+      attached.delete(win)
+      armedWindows.delete(win)
+      unresponsiveSince.delete(win.id)
+    })
+
+    const contents = win.webContents
+
+    contents?.on?.('unresponsive', () => {
+      unresponsiveSince.set(win.id, now())
+
+      if (armed) {
+        ring.push({ type: 'window_unresponsive', t: now(), windowId: win.id })
+      }
+    })
+
+    contents?.on?.('responsive', () => {
+      const startedAt = unresponsiveSince.get(win.id)
+      unresponsiveSince.delete(win.id)
+
+      if (!armed) {
+        return
+      }
+
+      const t = now()
+
+      ring.push({
+        type: 'window_responsive',
+        t,
+        windowId: win.id,
+        ...(startedAt === undefined ? {} : { blockedMs: Math.max(0, Math.round(t - startedAt)) })
+      })
+    })
+
+    // A window opened mid-capture still owes the bundle its stream.
+    pushArm(win)
+  }
+
+  async function armGateway(captureId: string): Promise<GatewayAbsentReason | null> {
+    if (options.isRemoteGateway?.()) {
+      // The gateway ring is supported only for the locally-spawned backend; a
+      // remote/SSH host is not asked at all (never mind that its ring would be
+      // on the wrong machine's clock).
+      return 'remote-gateway'
+    }
+
+    if (!options.gateway) {
+      return 'disabled'
+    }
+
+    const result = await options.gateway.arm({ captureId, wallClockAnchorMs })
+
+    return result.ok ? null : (result.reason ?? 'unavailable')
+  }
+
+  async function collectRenderer(win: CaptureWindowLike): Promise<null | RendererCaptureStream> {
+    const requestId = `${activeCaptureId}:${(collectSeq += 1)}`
+
+    const snapshot = await new Promise<null | RendererCaptureSnapshot>(resolve => {
+      let settled = false
+
+      const finish = (value: null | RendererCaptureSnapshot) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        pendingCollects.delete(requestId)
+        timers.clearTimeout(handle)
+        resolve(value)
+      }
+
+      const handle = timers.setTimeout(() => finish(null), collectTimeoutMs)
+
+      pendingCollects.set(requestId, finish)
+
+      if (!sendToWindow(win, COLLECT_CHANNEL, { requestId, captureId: activeCaptureId })) {
+        finish(null)
+      }
+    })
+
+    return snapshot ? { windowId: win.id, ...snapshot } : null
+  }
+
+  return {
+    attachWindow,
+
+    isArmed: () => armed,
+
+    captureId: () => activeCaptureId,
+
+    lastCapture: () => lastBundle,
+
+    handleCollectResult(payload) {
+      const body = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null
+      const requestId = typeof body?.requestId === 'string' ? body.requestId : ''
+      const resolve = requestId ? pendingCollects.get(requestId) : undefined
+
+      resolve?.(normalizeRendererSnapshot(body?.snapshot))
+    },
+
+    recordTransportError({ channel, path, durationMs, error }) {
+      if (!armed) {
+        return
+      }
+
+      ring.push({
+        type: 'transport_error',
+        t: now(),
+        channel: String(channel || 'unknown'),
+        route: routePrefix(path),
+        durationMs: Math.max(0, Math.round(durationMs)),
+        errorClass: classifyTransportError(error)
+      })
+    },
+
+    async start() {
+      if (armed && activeCaptureId) {
+        return { captureId: activeCaptureId, wallClockAnchorMs, mainMonotonicAnchorMs }
+      }
+
+      ring.reset()
+      unresponsiveSince.clear()
+      armedWindows.clear()
+      activeCaptureId = randomUUID()
+      wallClockAnchorMs = wallClock()
+      mainMonotonicAnchorMs = now()
+      armed = true
+
+      for (const win of options.listWindows()) {
+        attachWindow(win)
+      }
+
+      gatewayAbsent = await armGateway(activeCaptureId).catch(() => 'unavailable' as GatewayAbsentReason)
+
+      // Sampling exists only between start and stop (KTD2): armed is the only
+      // state in which main pays for diagnostics.
+      metricsHandle = timers.setInterval(sampleMetrics, metricsIntervalMs)
+
+      return { captureId: activeCaptureId, wallClockAnchorMs, mainMonotonicAnchorMs }
+    },
+
+    async stop() {
+      if (!armed || !activeCaptureId) {
+        return null
+      }
+
+      const captureIdAtStop = activeCaptureId
+
+      if (metricsHandle !== null) {
+        timers.clearInterval(metricsHandle)
+        metricsHandle = null
+      }
+
+      // One last sample so the bundle brackets the hitch on both sides.
+      sampleMetrics()
+
+      const windows = options.listWindows()
+
+      for (const win of windows) {
+        attachWindow(win)
+      }
+
+      const rendererStreams = (await Promise.all(windows.map(win => collectRenderer(win)))).filter(
+        (stream): stream is RendererCaptureStream => Boolean(stream)
+      )
+
+      let gateway: DiagnosticsCaptureBundle['gateway'] = { absent: gatewayAbsent ?? 'unavailable' }
+
+      if (!gatewayAbsent && options.gateway) {
+        const collected = await options.gateway.collect(captureIdAtStop).catch(() => null)
+
+        gateway = collected?.ok && collected.stream ? collected.stream : { absent: collected?.reason ?? 'unavailable' }
+      }
+
+      if (!options.isRemoteGateway?.() && options.gateway) {
+        await options.gateway.disarm()
+      }
+
+      for (const win of windows) {
+        sendToWindow(win, DISARM_CHANNEL)
+      }
+
+      const bundle: DiagnosticsCaptureBundle = {
+        captureId: captureIdAtStop,
+        anchors: { wallClockAnchorMs, mainMonotonicAnchorMs },
+        renderer: rendererStreams,
+        main: ring.entries(),
+        mainDropped: ring.dropped,
+        gateway
+      }
+
+      armed = false
+      activeCaptureId = null
+      gatewayAbsent = 'disabled'
+      unresponsiveSince.clear()
+      armedWindows.clear()
+      lastBundle = bundle
+
+      return bundle
+    }
+  }
+}
+
+export {
+  ARM_CHANNEL,
+  COLLECT_CHANNEL,
+  COLLECT_RESULT_CHANNEL,
+  DEFAULT_COLLECT_TIMEOUT_MS,
+  DEFAULT_MAX_AGE_MS,
+  DEFAULT_MAX_EVENTS,
+  DEFAULT_METRICS_INTERVAL_MS,
+  DISARM_CHANNEL
+}

--- a/apps/desktop/electron/diagnostics-classify.test.ts
+++ b/apps/desktop/electron/diagnostics-classify.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyCapture } from './diagnostics-classify'
+
+// Fixtures are single-signal on purpose: the point of each is that the
+// classifier reaches for the RIGHT label, which only means something when the
+// other four have nothing to go on.
+function bundle(overrides: any = {}) {
+  return {
+    captureId: 'cap-1',
+    anchors: { wallClockAnchorMs: 1_700_000_000_000, mainMonotonicAnchorMs: 0 },
+    renderer: [],
+    main: [],
+    mainDropped: 0,
+    gateway: { absent: 'disabled' },
+    ...overrides
+  } as any
+}
+
+function rendererStream(events: any[]) {
+  return [{ windowId: 1, captureId: 'cap-1', wallClockAnchorMs: 0, monotonicAnchorMs: 0, droppedEvents: 0, events }]
+}
+
+function longFrame(t: number, ms: number) {
+  return { type: 'long_frame', t, ms, styleMs: 1, blockingMs: ms - 10, scripts: [] }
+}
+
+function loopDrift(t: number, driftS: number) {
+  return { kind: 'loop_drift', t_monotonic: t, drift_s: driftS }
+}
+
+test('renderer long-frame spikes only -> renderer-bound', () => {
+  const result = classifyCapture(
+    bundle({ renderer: rendererStream([longFrame(100, 180), longFrame(400, 260), longFrame(900, 95)]) })
+  )
+
+  assert.equal(result.primary, 'renderer-bound')
+  assert.deepEqual(result.labels, ['renderer-bound'])
+  assert.equal(result.counts.rendererLongFrames, 3)
+  assert.equal(result.counts.rendererMaxFrameMs, 260)
+})
+
+test('gateway loop stalls only -> gateway-bound', () => {
+  const result = classifyCapture(
+    bundle({
+      gateway: {
+        captureId: 'cap-1',
+        monotonicAnchorMs: 0,
+        dropped: 0,
+        events: [loopDrift(10, 0.6), loopDrift(20, 1.4), loopDrift(30, 0.3)]
+      }
+    })
+  )
+
+  assert.equal(result.primary, 'gateway-bound')
+  assert.deepEqual(result.labels, ['gateway-bound'])
+  assert.equal(result.counts.gatewayLoopDrifts, 3)
+  assert.equal(result.counts.gatewayMaxDriftS, 1.4)
+})
+
+test('a single severe frame is enough, a single mild one is not', () => {
+  assert.deepEqual(classifyCapture(bundle({ renderer: rendererStream([longFrame(1, 420)]) })).labels, ['renderer-bound'])
+  assert.deepEqual(classifyCapture(bundle({ renderer: rendererStream([longFrame(1, 60)]) })).labels, ['unclassified'])
+})
+
+test('one transport timeout -> ipc-transport-bound', () => {
+  const result = classifyCapture(
+    bundle({
+      main: [{ type: 'transport_error', t: 5, channel: 'hermes:api', route: '/api/sessions', durationMs: 60_000, errorClass: 'timeout' }]
+    })
+  )
+
+  assert.equal(result.primary, 'ipc-transport-bound')
+  assert.equal(result.signals[0].evidence.timeouts, 1)
+})
+
+test('a single non-timeout transport error is below the bar', () => {
+  const result = classifyCapture(
+    bundle({ main: [{ type: 'transport_error', t: 5, channel: 'hermes:api', route: '/api', durationMs: 12, errorClass: 'http_500' }] })
+  )
+
+  assert.deepEqual(result.labels, ['unclassified'])
+  assert.equal(result.counts.mainTransportErrors, 1)
+})
+
+test('heap growth across the capture -> memory-gc-bound', () => {
+  const samples = [120, 260, 340, 410].map((usedMb, index) => ({
+    type: 'memory_sample',
+    t: index * 5_000,
+    usedMb,
+    totalMb: usedMb + 40,
+    limitMb: 4_096
+  }))
+
+  const result = classifyCapture(bundle({ renderer: rendererStream(samples) }))
+
+  assert.equal(result.primary, 'memory-gc-bound')
+  assert.equal(result.signals[0].evidence.growthMb, 290)
+})
+
+test('flat heap samples do not label', () => {
+  const samples = [300, 302, 299, 301].map((usedMb, index) => ({
+    type: 'memory_sample',
+    t: index * 5_000,
+    usedMb,
+    totalMb: usedMb + 40,
+    limitMb: 4_096
+  }))
+
+  assert.deepEqual(classifyCapture(bundle({ renderer: rendererStream(samples) })).labels, ['unclassified'])
+})
+
+test('commit cost that tracks transcript length -> history-bound', () => {
+  // Same flush size throughout; only the transcript grows, and only the cost
+  // above the median transcript length is expensive.
+  const deltas = [
+    { historyMessages: 20, commitMs: 6, writeMs: 2 },
+    { historyMessages: 40, commitMs: 8, writeMs: 2 },
+    { historyMessages: 900, commitMs: 70, writeMs: 4 },
+    { historyMessages: 1_100, commitMs: 90, writeMs: 4 }
+  ].map((delta, index) => ({
+    type: 'stream_delta_applied',
+    t: index * 1_000,
+    sessions: 1,
+    queuedChars: 400,
+    rafGapMs: 8,
+    ...delta
+  }))
+
+  const result = classifyCapture(bundle({ renderer: rendererStream(deltas) }))
+
+  assert.equal(result.primary, 'history-bound')
+  assert.equal(result.signals[0].evidence.samples, 4)
+})
+
+test('uniformly cheap flushes do not label history-bound', () => {
+  const deltas = [20, 40, 900, 1_100].map((historyMessages, index) => ({
+    type: 'stream_delta_applied',
+    t: index * 1_000,
+    sessions: 1,
+    queuedChars: 400,
+    rafGapMs: 8,
+    historyMessages,
+    commitMs: 5,
+    writeMs: 1
+  }))
+
+  assert.deepEqual(classifyCapture(bundle({ renderer: rendererStream(deltas) })).labels, ['unclassified'])
+})
+
+test('multiple mechanisms are multi-labelled, strongest first', () => {
+  const result = classifyCapture(
+    bundle({
+      renderer: rendererStream([longFrame(1, 90), longFrame(2, 95), longFrame(3, 110)]),
+      gateway: { captureId: 'cap-1', monotonicAnchorMs: 0, dropped: 0, events: [loopDrift(1, 2.5), loopDrift(2, 3)] }
+    })
+  )
+
+  assert.deepEqual(result.labels, ['gateway-bound', 'renderer-bound'])
+  assert.equal(result.primary, 'gateway-bound')
+})
+
+test('an empty capture is unclassified, with zeroed counts', () => {
+  const result = classifyCapture(bundle())
+
+  assert.deepEqual(result.labels, ['unclassified'])
+  assert.equal(result.primary, null)
+  assert.deepEqual(result.signals, [])
+  assert.equal(result.counts.rendererLongFrames, 0)
+  assert.equal(result.counts.gatewayLoopDrifts, 0)
+})

--- a/apps/desktop/electron/diagnostics-classify.ts
+++ b/apps/desktop/electron/diagnostics-classify.ts
@@ -1,0 +1,316 @@
+// Post-processing classification of a capture bundle (U4, R3).
+//
+// R3 asks the exported bundle to be *sufficient to classify* a hitch. This
+// module is the reference reading of that bundle: it walks the three streams
+// and answers "which subsystem was busy" with a small set of threshold
+// heuristics. It is deliberately dumb — no statistics, no model, no tuning
+// knobs in a config file — because its job is to give a reviewer a starting
+// point they can immediately check against the raw JSONL beside it, not to be
+// authoritative.
+//
+// Multi-label on purpose: a renderer that spikes *because* the gateway stalled
+// and the transcript is huge should say so three times rather than pick one
+// winner. `labels` is ordered by descending signal strength, and `primary` is
+// simply `labels[0]` (null when nothing crossed a threshold).
+//
+// Every threshold below is a judgement call, and each one is named so a future
+// reader can move it with intent rather than guessing which magic number did
+// what. All of them describe *perceptible* trouble: the floor everywhere is
+// roughly "a user would have seen this frame drop".
+//
+// Electron-free and pure (bundle in, summary out) so it unit-tests under the
+// `electron` vitest project alongside diagnostics-capture.ts.
+
+import type { DiagnosticsCaptureBundle } from './diagnostics-capture'
+
+/** The five R3 buckets, plus the honest fallback. */
+export type HitchLabel =
+  | 'gateway-bound'
+  | 'history-bound'
+  | 'ipc-transport-bound'
+  | 'memory-gc-bound'
+  | 'renderer-bound'
+  | 'unclassified'
+
+/** A frame that took this long is a visible hitch, not jitter. Matches the
+ * renderer's own "long frame" intuition (~3 dropped frames at 60Hz). */
+const LONG_FRAME_MS = 50
+/** A frame this long is unmistakable on its own — one is enough to label. */
+const SEVERE_FRAME_MS = 300
+/** Below this many long frames the capture is noise (a single 60ms frame at
+ * app start is not a renderer-bound hitch). */
+const MIN_LONG_FRAMES = 3
+
+/** The gateway ring's own capture floor (`_CAPTURE_FLOOR_S` = 0.25s), so any
+ * loop_drift event that reached the ring already cleared it. Restated here so
+ * the classifier does not silently inherit a threshold it cannot see. */
+const LOOP_DRIFT_S = 0.25
+/** A single stall this long blocks every in-flight turn — label on one. */
+const SEVERE_DRIFT_S = 1.0
+const MIN_DRIFT_EVENTS = 2
+
+/** Transport failures are rare enough that two inside one capture window is
+ * already the story; a timeout is severe on its own (the observed 60s
+ * `hermes:api` timeouts are exactly this signal). */
+const MIN_TRANSPORT_ERRORS = 2
+
+/** Heap growth across the capture that is hard to explain as churn. */
+const MEMORY_GROWTH_MB = 150
+/** Sitting this close to the heap limit means GC pressure regardless of slope. */
+const MEMORY_PRESSURE_RATIO = 0.85
+/** Fewer samples than this cannot describe a trend (5s cadence → ~15s). */
+const MIN_MEMORY_SAMPLES = 3
+
+/** A commit costing this long is what "the app hitches when I type" looks like. */
+const SLOW_COMMIT_MS = 40
+/** How much more expensive the long-transcript half must be before transcript
+ * size — rather than flush size — is the plausible cause. */
+const HISTORY_COST_RATIO = 2
+const MIN_DELTA_SAMPLES = 4
+
+export interface HitchSignal {
+  label: HitchLabel
+  /** Why this label fired, in reviewer-readable terms. */
+  reason: string
+  /** Ordering key only — comparable *within* a label, not across labels in any
+   * physical sense. Higher means "more of the thing". */
+  strength: number
+  /** The raw counts/durations the reason was computed from. */
+  evidence: Record<string, number>
+}
+
+export interface HitchClassification {
+  /** Labels that crossed a threshold, strongest first. */
+  labels: HitchLabel[]
+  /** `labels[0]`, or null when the capture is unclassified. */
+  primary: HitchLabel | null
+  /** One entry per fired label, in the same order. */
+  signals: HitchSignal[]
+  /** Per-stream tallies, emitted whether or not anything fired — an empty
+   * classification with a populated tally reads very differently from an
+   * empty classification with nothing in the streams at all. */
+  counts: {
+    rendererLongFrames: number
+    rendererMaxFrameMs: number
+    rendererStreamDeltas: number
+    rendererMemorySamples: number
+    mainTransportErrors: number
+    mainUnresponsiveEdges: number
+    gatewayLoopDrifts: number
+    gatewayMaxDriftS: number
+    gatewayWsWriteSlow: number
+  }
+}
+
+function num(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function eventType(event: unknown): string {
+  const record = event && typeof event === 'object' ? (event as Record<string, unknown>) : null
+
+  // Renderer/main events are tagged `type`; the gateway ring tags `kind`.
+  const tag = record?.type ?? record?.kind
+
+  return typeof tag === 'string' ? tag : ''
+}
+
+function rendererEvents(bundle: DiagnosticsCaptureBundle): unknown[] {
+  return (bundle.renderer ?? []).flatMap(stream => (Array.isArray(stream.events) ? stream.events : []))
+}
+
+function gatewayEvents(bundle: DiagnosticsCaptureBundle): unknown[] {
+  const gateway = bundle.gateway as { events?: unknown }
+
+  return Array.isArray(gateway?.events) ? gateway.events : []
+}
+
+function median(values: number[]): number {
+  if (!values.length) {
+    return 0
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+function mean(values: number[]): number {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0
+}
+
+function round(value: number, places = 2): number {
+  const factor = 10 ** places
+
+  return Math.round(value * factor) / factor
+}
+
+/**
+ * Classify one capture bundle. Pure; safe to call on a partially-populated
+ * bundle (an absent gateway stream, a window that never answered its collect).
+ */
+export function classifyCapture(bundle: DiagnosticsCaptureBundle): HitchClassification {
+  const renderer = rendererEvents(bundle)
+  const main = Array.isArray(bundle.main) ? bundle.main : []
+  const gateway = gatewayEvents(bundle)
+
+  const longFrames = renderer.filter(event => eventType(event) === 'long_frame').map(event => num((event as any).ms))
+
+  const memory = renderer
+    .filter(event => eventType(event) === 'memory_sample')
+    .map(event => ({ usedMb: num((event as any).usedMb), limitMb: num((event as any).limitMb) }))
+
+  const deltas = renderer
+    .filter(event => eventType(event) === 'stream_delta_applied')
+    .map(event => ({
+      commitMs: num((event as any).commitMs),
+      writeMs: num((event as any).writeMs),
+      historyMessages: num((event as any).historyMessages)
+    }))
+
+  const transportErrors = main.filter(event => event?.type === 'transport_error')
+  const unresponsive = main.filter(event => event?.type === 'window_unresponsive')
+
+  const drifts = gateway.filter(event => eventType(event) === 'loop_drift').map(event => num((event as any).drift_s))
+  const wsWriteSlow = gateway.filter(event => eventType(event) === 'ws_write_slow')
+
+  const maxFrameMs = longFrames.length ? Math.max(...longFrames) : 0
+  const maxDriftS = drifts.length ? Math.max(...drifts) : 0
+
+  const signals: HitchSignal[] = []
+
+  // ── renderer-bound ────────────────────────────────────────────────
+  // Long animation frames are direct evidence of main-thread work in the
+  // renderer. Either enough of them to be a pattern, or one bad enough that
+  // the pattern is beside the point.
+  const spikes = longFrames.filter(ms => ms >= LONG_FRAME_MS)
+
+  if (spikes.length >= MIN_LONG_FRAMES || maxFrameMs >= SEVERE_FRAME_MS) {
+    signals.push({
+      label: 'renderer-bound',
+      reason: `${spikes.length} long frame(s) >= ${LONG_FRAME_MS}ms, worst ${round(maxFrameMs)}ms`,
+      strength: maxFrameMs,
+      evidence: { spikes: spikes.length, maxFrameMs: round(maxFrameMs), totalFrames: longFrames.length }
+    })
+  }
+
+  // ── gateway-bound ─────────────────────────────────────────────────
+  // The gateway's heartbeat drift is the only signal in the bundle that names
+  // the backend event loop directly. `ws_write_slow` is counted as supporting
+  // evidence rather than a trigger: a slow write is as often the *consumer*
+  // stalling as the producer.
+  const stalls = drifts.filter(driftS => driftS >= LOOP_DRIFT_S)
+
+  if (stalls.length >= MIN_DRIFT_EVENTS || maxDriftS >= SEVERE_DRIFT_S) {
+    signals.push({
+      label: 'gateway-bound',
+      reason: `${stalls.length} loop stall(s) >= ${LOOP_DRIFT_S}s, worst ${round(maxDriftS, 3)}s`,
+      strength: maxDriftS * 1000,
+      evidence: { stalls: stalls.length, maxDriftMs: round(maxDriftS * 1000), wsWriteSlow: wsWriteSlow.length }
+    })
+  }
+
+  // ── ipc-transport-bound ───────────────────────────────────────────
+  // Main records renderer->backend failures with a duration and an error class
+  // only. A timeout means the renderer sat waiting for a reply that never came,
+  // which presents to the user as a frozen pane rather than a dropped frame —
+  // a different bug from either of the two above.
+  const timeouts = transportErrors.filter(event => (event as any).errorClass === 'timeout')
+
+  if (transportErrors.length >= MIN_TRANSPORT_ERRORS || timeouts.length >= 1) {
+    const worstMs = transportErrors.length ? Math.max(...transportErrors.map(event => num((event as any).durationMs))) : 0
+
+    signals.push({
+      label: 'ipc-transport-bound',
+      reason: `${transportErrors.length} transport failure(s) (${timeouts.length} timeout), worst ${round(worstMs)}ms`,
+      strength: worstMs,
+      evidence: { errors: transportErrors.length, timeouts: timeouts.length, worstMs: round(worstMs) }
+    })
+  }
+
+  // ── memory-gc-bound ───────────────────────────────────────────────
+  // Two independent readings of the heap samples: a growth slope across the
+  // capture (a leak the GC keeps chasing), and proximity to the heap limit
+  // (pressure regardless of slope). Either one labels.
+  if (memory.length >= MIN_MEMORY_SAMPLES) {
+    const used = memory.map(sample => sample.usedMb)
+    const growthMb = Math.max(...used) - Math.min(...used)
+    const limitMb = Math.max(...memory.map(sample => sample.limitMb))
+    const ratio = limitMb > 0 ? Math.max(...used) / limitMb : 0
+
+    if (growthMb >= MEMORY_GROWTH_MB || ratio >= MEMORY_PRESSURE_RATIO) {
+      signals.push({
+        label: 'memory-gc-bound',
+        reason: `heap grew ${round(growthMb)}MB, peak ${round(ratio * 100)}% of limit`,
+        strength: growthMb,
+        evidence: { growthMb: round(growthMb), peakUsedMb: round(Math.max(...used)), limitMb: round(limitMb) }
+      })
+    }
+  }
+
+  // ── history-bound ─────────────────────────────────────────────────
+  // The distinguishing question is whether commit cost tracks *transcript
+  // size* or *flush size*. Split the flushes at the median transcript length
+  // and compare mean commit cost: if the long-transcript half costs materially
+  // more, the transcript itself is the cost driver, which is a different fix
+  // from making the flush smaller. Needs enough samples to have two halves.
+  if (deltas.length >= MIN_DELTA_SAMPLES) {
+    const cut = median(deltas.map(delta => delta.historyMessages))
+    const longHalf = deltas.filter(delta => delta.historyMessages >= cut)
+    const shortHalf = deltas.filter(delta => delta.historyMessages < cut)
+    const longCost = mean(longHalf.map(delta => delta.commitMs + delta.writeMs))
+    const shortCost = mean(shortHalf.map(delta => delta.commitMs + delta.writeMs))
+
+    if (longHalf.length && shortHalf.length && longCost >= SLOW_COMMIT_MS && longCost >= shortCost * HISTORY_COST_RATIO) {
+      signals.push({
+        label: 'history-bound',
+        reason: `commit cost ${round(longCost)}ms at >=${round(cut)} messages vs ${round(shortCost)}ms below`,
+        strength: longCost,
+        evidence: {
+          samples: deltas.length,
+          medianHistoryMessages: round(cut),
+          longHalfCostMs: round(longCost),
+          shortHalfCostMs: round(shortCost)
+        }
+      })
+    }
+  }
+
+  signals.sort((a, b) => b.strength - a.strength)
+
+  const labels = signals.map(signal => signal.label)
+
+  return {
+    labels: labels.length ? labels : ['unclassified'],
+    primary: labels.length ? labels[0] : null,
+    signals,
+    counts: {
+      rendererLongFrames: longFrames.length,
+      rendererMaxFrameMs: round(maxFrameMs),
+      rendererStreamDeltas: deltas.length,
+      rendererMemorySamples: memory.length,
+      mainTransportErrors: transportErrors.length,
+      mainUnresponsiveEdges: unresponsive.length,
+      gatewayLoopDrifts: drifts.length,
+      gatewayMaxDriftS: round(maxDriftS, 3),
+      gatewayWsWriteSlow: wsWriteSlow.length
+    }
+  }
+}
+
+export {
+  HISTORY_COST_RATIO,
+  LONG_FRAME_MS,
+  LOOP_DRIFT_S,
+  MEMORY_GROWTH_MB,
+  MEMORY_PRESSURE_RATIO,
+  MIN_DRIFT_EVENTS,
+  MIN_LONG_FRAMES,
+  MIN_TRANSPORT_ERRORS,
+  SEVERE_DRIFT_S,
+  SEVERE_FRAME_MS,
+  SLOW_COMMIT_MS
+}

--- a/apps/desktop/electron/diagnostics-export.test.ts
+++ b/apps/desktop/electron/diagnostics-export.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  alignEvent,
+  electronProcessTree,
+  executableBasename,
+  exportDiagnosticsBundle,
+  sanitizeProcessTree
+} from './diagnostics-export'
+
+// In-memory fs: the exporter's whole contract is "which files, with what
+// bytes", so the test asserts on a map rather than a temp directory (and stays
+// as fast and platform-neutral as the rest of the `electron` project).
+function makeFakeFs() {
+  const dirs: string[] = []
+  const files = new Map<string, string>()
+
+  return {
+    dirs,
+    files,
+    fs: {
+      async mkdir(dir: string) {
+        dirs.push(dir)
+      },
+      async writeFile(file: string, data: string) {
+        files.set(file, data)
+      }
+    },
+    // POSIX join regardless of host, so the assertions read the same on Windows.
+    join: (...parts: string[]) => parts.join('/')
+  }
+}
+
+function makeBundle(overrides: any = {}) {
+  return {
+    captureId: 'cap-1234',
+    anchors: { wallClockAnchorMs: 1_700_000_000_000, mainMonotonicAnchorMs: 1_000 },
+    renderer: [
+      {
+        windowId: 7,
+        captureId: 'cap-1234',
+        wallClockAnchorMs: 1_700_000_000_000,
+        monotonicAnchorMs: 500,
+        droppedEvents: 2,
+        events: [
+          { type: 'long_frame', t: 700, ms: 120, styleMs: 4, blockingMs: 90, scripts: [] },
+          { type: 'memory_sample', t: 900, usedMb: 300, totalMb: 400, limitMb: 4_096 }
+        ]
+      }
+    ],
+    main: [{ type: 'transport_error', t: 1_200, channel: 'hermes:api', route: '/api/sessions', durationMs: 60_000, errorClass: 'timeout' }],
+    mainDropped: 0,
+    gateway: {
+      captureId: 'cap-1234',
+      monotonicAnchorMs: 42_000,
+      dropped: 1,
+      events: [{ kind: 'loop_drift', t_monotonic: 43.5, drift_s: 0.9 }]
+    },
+    ...overrides
+  } as any
+}
+
+function parseJsonl(text: string) {
+  return text
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line))
+}
+
+// ── happy path ────────────────────────────────────────────────────────
+
+test('export writes a manifest whose streams parse and share the capture id', async () => {
+  const { fs, join, files, dirs } = makeFakeFs()
+
+  const result = await exportDiagnosticsBundle({
+    bundle: makeBundle(),
+    userDataPath: '/userData',
+    appVersion: '9.9.9',
+    platform: 'win32',
+    wallClock: () => 1_700_000_123_456,
+    fs,
+    join
+  })
+
+  assert.equal(result.directory, '/userData/diagnostics/cap-1234')
+  assert.deepEqual(dirs, ['/userData/diagnostics/cap-1234'])
+
+  const manifest = JSON.parse(files.get('/userData/diagnostics/cap-1234/manifest.json')!)
+
+  assert.equal(manifest.capture_id, 'cap-1234')
+  assert.equal(manifest.app_version, '9.9.9')
+  assert.equal(manifest.platform, 'win32')
+  assert.equal(manifest.exported_at_ms, 1_700_000_123_456)
+  assert.equal(manifest.anchors.wall_clock_anchor_ms, 1_700_000_000_000)
+
+  // Every non-absent stream file named by the manifest exists and parses.
+  for (const stream of manifest.streams) {
+    if (!stream.file) {
+      continue
+    }
+
+    const body = files.get(`/userData/diagnostics/cap-1234/${stream.file}`)
+
+    assert.ok(body !== undefined, `missing ${stream.file}`)
+    assert.equal(parseJsonl(body!).length, stream.events)
+  }
+
+  assert.deepEqual(
+    manifest.streams.map((stream: any) => stream.name),
+    ['renderer-7', 'main', 'gateway']
+  )
+  assert.equal(manifest.streams.find((s: any) => s.name === 'renderer-7').dropped, 2)
+  assert.equal(manifest.streams.find((s: any) => s.name === 'gateway').dropped, 1)
+
+  // Classification rides along in its own file, keyed to the same capture.
+  const classification = JSON.parse(files.get('/userData/diagnostics/cap-1234/classification.json')!)
+
+  assert.ok(Array.isArray(classification.labels))
+})
+
+test('export aligns each stream onto the shared wall clock (KTD3)', async () => {
+  const { fs, join, files } = makeFakeFs()
+
+  await exportDiagnosticsBundle({ bundle: makeBundle(), userDataPath: '/u', fs, join })
+
+  // renderer: anchor 500ms, event t=700 -> +200ms past the wall-clock anchor.
+  const renderer = parseJsonl(files.get('/u/diagnostics/cap-1234/renderer-7.jsonl')!)
+
+  assert.equal(renderer[0].wall_clock_ms, 1_700_000_000_200)
+  assert.equal(renderer[0].t, 700, 'raw monotonic value must survive untouched')
+
+  // main: anchor 1000ms, event t=1200 -> +200ms.
+  const main = parseJsonl(files.get('/u/diagnostics/cap-1234/main.jsonl')!)
+
+  assert.equal(main[0].wall_clock_ms, 1_700_000_000_200)
+
+  // gateway: anchor 42000ms, event t_monotonic 43.5s = 43500ms -> +1500ms.
+  const gateway = parseJsonl(files.get('/u/diagnostics/cap-1234/gateway.jsonl')!)
+
+  assert.equal(gateway[0].wall_clock_ms, 1_700_000_001_500)
+})
+
+// ── error path: absent gateway ────────────────────────────────────────
+
+test('an absent gateway stream still exports and is marked absent', async () => {
+  const { fs, join, files } = makeFakeFs()
+
+  const result = await exportDiagnosticsBundle({
+    bundle: makeBundle({ gateway: { absent: 'remote-gateway' } }),
+    userDataPath: '/u',
+    fs,
+    join
+  })
+
+  assert.equal(files.has('/u/diagnostics/cap-1234/gateway.jsonl'), false)
+
+  const gateway = result.manifest.streams.find(stream => stream.name === 'gateway')!
+
+  assert.equal(gateway.file, null)
+  assert.equal(gateway.absent, 'remote-gateway')
+  assert.equal(gateway.events, 0)
+  // The rest of the bundle is unaffected.
+  assert.ok(files.has('/u/diagnostics/cap-1234/main.jsonl'))
+  assert.ok(files.has('/u/diagnostics/cap-1234/manifest.json'))
+})
+
+test('an empty gateway ring exports as a present but empty stream', async () => {
+  const { fs, join, files } = makeFakeFs()
+
+  const result = await exportDiagnosticsBundle({
+    bundle: makeBundle({ gateway: { captureId: 'cap-1234', monotonicAnchorMs: 10, dropped: 0, events: [] } }),
+    userDataPath: '/u',
+    fs,
+    join
+  })
+
+  assert.equal(files.get('/u/diagnostics/cap-1234/gateway.jsonl'), '')
+  assert.equal(result.manifest.streams.find(stream => stream.name === 'gateway')!.absent, undefined)
+})
+
+test('a capture with no renderer streams at all still exports', async () => {
+  const { fs, join } = makeFakeFs()
+
+  const result = await exportDiagnosticsBundle({
+    bundle: makeBundle({ renderer: [], gateway: { absent: 'unavailable' } }),
+    userDataPath: '/u',
+    fs,
+    join
+  })
+
+  assert.deepEqual(
+    result.manifest.streams.map(stream => stream.name),
+    ['main', 'gateway']
+  )
+})
+
+// ── sanitization ──────────────────────────────────────────────────────
+
+test('executableBasename strips directories and any argv tail', () => {
+  assert.equal(executableBasename('C:\\Users\\me\\AppData\\Local\\hermes\\Hermes.exe'), 'Hermes.exe')
+  assert.equal(executableBasename('/opt/hermes/bin/hermes'), 'hermes')
+  assert.equal(executableBasename('/opt/hermes/bin/hermes --token=SECRET123'), 'hermes')
+  assert.equal(executableBasename('Hermes.exe'), 'Hermes.exe')
+  assert.equal(executableBasename(''), 'unknown')
+  assert.equal(executableBasename(undefined), 'unknown')
+})
+
+test('sanitizeProcessTree rebuilds entries, dropping every unlisted field', () => {
+  const tree = sanitizeProcessTree([
+    {
+      pid: 4242,
+      ppid: 1,
+      name: 'C:\\Program Files\\Hermes\\Hermes.exe',
+      // Fields a future probe might add. None may survive.
+      cmdline: '--api-key=sk-MARKER --home=C:\\Users\\me',
+      exe: 'C:\\Program Files\\Hermes\\Hermes.exe',
+      environ: { HERMES_TOKEN: 'MARKER' }
+    } as never
+  ])
+
+  assert.deepEqual(tree, [{ pid: 4242, ppid: 1, name: 'Hermes.exe' }])
+})
+
+test('a marker string in a process command line never reaches the bundle', async () => {
+  const { fs, join, files } = makeFakeFs()
+  const MARKER = 'HERMES-SANITIZATION-CANARY-9f3a'
+
+  await exportDiagnosticsBundle({
+    bundle: makeBundle(),
+    userDataPath: '/u',
+    fs,
+    join,
+    processes: [
+      { pid: 11, ppid: 1, name: `/opt/hermes/bin/hermes --secret=${MARKER}` } as never,
+      { pid: 12, ppid: 11, name: 'C:\\hermes\\Hermes.exe', cmdline: MARKER, argv: ['hermes', MARKER] } as never
+    ]
+  })
+
+  for (const [file, body] of files) {
+    assert.equal(body.includes(MARKER), false, `${MARKER} leaked into ${file}`)
+  }
+
+  const manifest = JSON.parse(files.get('/u/diagnostics/cap-1234/manifest.json')!)
+
+  assert.deepEqual(manifest.process_tree, [
+    { pid: 11, ppid: 1, name: 'hermes' },
+    { pid: 12, ppid: 11, name: 'Hermes.exe' }
+  ])
+
+  // No entry carries an argv-ish or path-ish key, whatever it is called.
+  for (const entry of manifest.process_tree) {
+    assert.deepEqual(Object.keys(entry).sort(), ['name', 'pid', 'ppid'])
+    assert.equal(/[\\/]/.test(entry.name), false, 'process name must be a basename, not a path')
+  }
+})
+
+test('electronProcessTree parents every metrics process on main', () => {
+  const tree = electronProcessTree({
+    mainPid: 100,
+    mainPpid: 4,
+    execPath: 'C:\\Program Files\\Hermes\\Hermes.exe',
+    metrics: [{ pid: 100, type: 'Browser' }, { pid: 101, type: 'Tab' }, { pid: 102, type: 'Utility', name: 'Network Service' }]
+  })
+
+  assert.deepEqual(sanitizeProcessTree(tree), [
+    { pid: 100, ppid: 4, name: 'Hermes.exe' },
+    { pid: 101, ppid: 100, name: 'Tab' },
+    // Whitespace in a utility's role name is not a path tail; the basename rule
+    // keeps the first token, which is enough to tell the roles apart.
+    { pid: 102, ppid: 100, name: 'Network' }
+  ])
+})
+
+// ── alignment helper ──────────────────────────────────────────────────
+
+test('alignEvent leaves events without a monotonic stamp alone', () => {
+  assert.deepEqual(alignEvent({ type: 'weird' }, 1_000, 0), { type: 'weird' })
+  assert.equal(alignEvent(null, 1_000, 0), null)
+  assert.equal(alignEvent('scalar', 1_000, 0), 'scalar')
+})

--- a/apps/desktop/electron/diagnostics-export.ts
+++ b/apps/desktop/electron/diagnostics-export.ts
@@ -1,0 +1,347 @@
+// Sanitized local export of a capture bundle (U4, R2/R3, KTD3).
+//
+// The controller (diagnostics-capture.ts) hands over three streams stamped on
+// three different monotonic clocks. This module is the only place that turns
+// them into files, which makes it the only place the sanitization contract has
+// to hold:
+//
+//   * Nothing outbound. The bundle is a directory under Electron's userData;
+//     the user attaches it by hand or does not.
+//   * The MANIFEST IS INSIDE THE CONTRACT. The process tree records pid, ppid
+//     and the executable BASENAME — never argv, never a full path. Command
+//     lines on this machine routinely carry API tokens, worktree paths and
+//     session ids, so `sanitizeProcessTree` drops every field it is not
+//     explicitly told to keep rather than filtering known-bad ones.
+//   * Stream events are already sanitized at record time in each process
+//     (counts/sizes/durations/ids only); the exporter never enriches them.
+//
+// Layout, one directory per capture:
+//
+//   diagnostics/<captureId>/
+//     manifest.json        capture id, anchors, app version, process tree, stream index
+//     classification.json  the R3 summary (see diagnostics-classify.ts)
+//     renderer-<windowId>.jsonl
+//     main.jsonl
+//     gateway.jsonl        absent when the gateway stream is absent
+//
+// JSONL rather than one JSON blob because the streams are the part a reviewer
+// greps, sorts and pipes; the manifest is the part they read.
+//
+// Alignment (KTD3): every stream file carries an added `wall_clock_ms` beside
+// the process's own monotonic `t`, computed as
+// `wallClockAnchorMs + (t - <that stream's> monotonicAnchorMs)`. The original
+// monotonic value is preserved untouched so a reviewer can always fall back to
+// the raw stream if an anchor turns out to be wrong.
+//
+// fs/path/process are injected so this unit-tests under the `electron` vitest
+// project without Electron or a real temp directory.
+
+import nodeFs from 'node:fs/promises'
+import nodePath from 'node:path'
+
+import type { DiagnosticsCaptureBundle } from './diagnostics-capture'
+import { classifyCapture, type HitchClassification } from './diagnostics-classify'
+
+/** Bumped when the on-disk shape changes in a way a reader must notice. */
+const BUNDLE_SCHEMA_VERSION = 1
+
+/** Directory under userData that holds one subdirectory per capture. */
+const BUNDLE_DIR_NAME = 'diagnostics'
+
+/** Raw process description, as a platform probe hands it over. Only the three
+ * named fields are ever read; anything else on the object is dropped. */
+export interface RawProcessEntry {
+  pid?: unknown
+  ppid?: unknown
+  /** Executable path OR name. Reduced to its basename either way. */
+  name?: unknown
+}
+
+export interface SanitizedProcessEntry {
+  pid: number
+  ppid: number
+  /** Executable basename ONLY, e.g. `hermes.exe`. Never a path, never argv. */
+  name: string
+}
+
+interface FsLike {
+  mkdir(dir: string, options: { recursive: boolean }): Promise<unknown>
+  writeFile(file: string, data: string, encoding: string): Promise<void>
+}
+
+export interface ExportDiagnosticsOptions {
+  bundle: DiagnosticsCaptureBundle
+  /** Electron's `app.getPath('userData')`. */
+  userDataPath: string
+  appVersion?: string
+  /** `app.getAppMetrics()`-shaped or probe-shaped process list. Optional: an
+   * export with no process tree is still a valid bundle. */
+  processes?: RawProcessEntry[]
+  /** Wall clock for the manifest's `exported_at_ms`. */
+  wallClock?: () => number
+  platform?: string
+  fs?: FsLike
+  join?: (...parts: string[]) => string
+}
+
+export interface StreamIndexEntry {
+  name: string
+  kind: 'gateway' | 'main' | 'renderer'
+  /** Relative to the bundle directory; null when the stream is absent. */
+  file: null | string
+  events: number
+  dropped: number
+  /** That stream's own monotonic clock at arm time (KTD3). */
+  monotonic_anchor_ms: number
+  window_id?: number
+  /** Set only when `file` is null. */
+  absent?: string
+}
+
+export interface DiagnosticsManifest {
+  schema_version: number
+  capture_id: string
+  exported_at_ms: number
+  app_version: string
+  platform: string
+  anchors: {
+    wall_clock_anchor_ms: number
+    main_monotonic_anchor_ms: number
+  }
+  process_tree: SanitizedProcessEntry[]
+  streams: StreamIndexEntry[]
+}
+
+export interface ExportResult {
+  /** Absolute path of the bundle directory — what the UI shows the user. */
+  directory: string
+  manifestPath: string
+  manifest: DiagnosticsManifest
+  classification: HitchClassification
+  /** Absolute paths of every file written, manifest first. */
+  files: string[]
+}
+
+/**
+ * Reduce an executable path or name to its basename. Handles both separators
+ * regardless of host platform, because a bundle exported on Windows can be read
+ * on a Mac and a probe can report either form.
+ */
+export function executableBasename(value: unknown): string {
+  const text = typeof value === 'string' ? value.trim() : ''
+
+  if (!text) {
+    return 'unknown'
+  }
+
+  const parts = text.split(/[\\/]/).filter(Boolean)
+  const basename = parts.length ? parts[parts.length - 1] : ''
+
+  // A basename is one token. Anything with whitespace in it is a command line
+  // that was handed over as if it were a path, and its tail is argv — drop it.
+  return (basename.split(/\s/)[0] || 'unknown').slice(0, 128)
+}
+
+/**
+ * Whitelist a raw process list down to {pid, ppid, name-basename}. This is a
+ * REBUILD, not a filter: the returned objects share no fields with the input,
+ * so a probe that starts reporting `cmdline` cannot leak it through here.
+ */
+export function sanitizeProcessTree(entries: RawProcessEntry[] | undefined): SanitizedProcessEntry[] {
+  if (!Array.isArray(entries)) {
+    return []
+  }
+
+  return entries.map(entry => ({
+    pid: Math.trunc(Number(entry?.pid)) || 0,
+    ppid: Math.trunc(Number(entry?.ppid)) || 0,
+    name: executableBasename(entry?.name)
+  }))
+}
+
+/**
+ * Shift one stream's monotonic timestamps onto the shared wall clock (KTD3).
+ * `t` survives untouched; `wall_clock_ms` is added beside it.
+ */
+export function alignEvent(event: unknown, wallClockAnchorMs: number, monotonicAnchorMs: number): unknown {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    return event
+  }
+
+  const record = event as Record<string, unknown>
+
+  // Renderer/main stamp `t` in MILLISECONDS (`performance.now()`); the gateway
+  // ring stamps `t_monotonic` in SECONDS (`time.monotonic()`) while reporting
+  // its anchor already scaled to ms. Normalize the event, never the anchor.
+  const monotonicMs =
+    typeof record.t === 'number'
+      ? record.t
+      : typeof record.t_monotonic === 'number'
+        ? record.t_monotonic * 1000
+        : null
+
+  if (monotonicMs === null || !Number.isFinite(wallClockAnchorMs)) {
+    return record
+  }
+
+  return { ...record, wall_clock_ms: Math.round(wallClockAnchorMs + (monotonicMs - monotonicAnchorMs)) }
+}
+
+function toJsonl(events: unknown[], wallClockAnchorMs: number, monotonicAnchorMs: number): string {
+  return events.map(event => JSON.stringify(alignEvent(event, wallClockAnchorMs, monotonicAnchorMs))).join('\n')
+}
+
+/** The gateway already scales its anchor to ms on the wire
+ * (`monotonic_anchor_ms = time.monotonic() * 1000`), so no conversion here —
+ * only the per-event `t_monotonic` seconds need scaling, in `alignEvent`. */
+function gatewayAnchorMs(stream: { monotonicAnchorMs?: unknown }): number {
+  const raw = Number(stream?.monotonicAnchorMs)
+
+  return Number.isFinite(raw) ? raw : 0
+}
+
+/**
+ * Write the bundle. Creates `<userData>/diagnostics/<captureId>/`, one JSONL
+ * per stream, `classification.json` and `manifest.json`, and returns the paths.
+ *
+ * An absent gateway stream is NOT an error (R2 error path): no `gateway.jsonl`
+ * is written and the manifest's stream entry carries `absent: <reason>`.
+ */
+export async function exportDiagnosticsBundle(options: ExportDiagnosticsOptions): Promise<ExportResult> {
+  const fs = options.fs ?? (nodeFs as unknown as FsLike)
+  const join = options.join ?? nodePath.join
+  const wallClock = options.wallClock ?? (() => Date.now())
+  const bundle = options.bundle
+  const wallClockAnchorMs = Number(bundle.anchors?.wallClockAnchorMs) || 0
+  const mainMonotonicAnchorMs = Number(bundle.anchors?.mainMonotonicAnchorMs) || 0
+
+  const directory = join(options.userDataPath, BUNDLE_DIR_NAME, bundle.captureId)
+
+  await fs.mkdir(directory, { recursive: true })
+
+  const files: string[] = []
+  const streams: StreamIndexEntry[] = []
+
+  async function writeStream(fileName: string, body: string) {
+    const target = join(directory, fileName)
+
+    await fs.writeFile(target, body ? `${body}\n` : '', 'utf8')
+    files.push(target)
+  }
+
+  for (const stream of bundle.renderer ?? []) {
+    const fileName = `renderer-${stream.windowId}.jsonl`
+    const events = Array.isArray(stream.events) ? stream.events : []
+
+    await writeStream(fileName, toJsonl(events, wallClockAnchorMs, Number(stream.monotonicAnchorMs) || 0))
+    streams.push({
+      name: `renderer-${stream.windowId}`,
+      kind: 'renderer',
+      file: fileName,
+      events: events.length,
+      dropped: Number(stream.droppedEvents) || 0,
+      monotonic_anchor_ms: Number(stream.monotonicAnchorMs) || 0,
+      window_id: stream.windowId
+    })
+  }
+
+  const mainEvents = Array.isArray(bundle.main) ? bundle.main : []
+
+  await writeStream('main.jsonl', toJsonl(mainEvents, wallClockAnchorMs, mainMonotonicAnchorMs))
+  streams.push({
+    name: 'main',
+    kind: 'main',
+    file: 'main.jsonl',
+    events: mainEvents.length,
+    dropped: Number(bundle.mainDropped) || 0,
+    monotonic_anchor_ms: mainMonotonicAnchorMs
+  })
+
+  const gateway = bundle.gateway as { absent?: string; events?: unknown[]; dropped?: unknown; monotonicAnchorMs?: unknown }
+
+  if (gateway && !gateway.absent && Array.isArray(gateway.events)) {
+    const anchorMs = gatewayAnchorMs(gateway)
+
+    await writeStream('gateway.jsonl', toJsonl(gateway.events, wallClockAnchorMs, anchorMs))
+    streams.push({
+      name: 'gateway',
+      kind: 'gateway',
+      file: 'gateway.jsonl',
+      events: gateway.events.length,
+      dropped: Number(gateway.dropped) || 0,
+      monotonic_anchor_ms: anchorMs
+    })
+  } else {
+    streams.push({
+      name: 'gateway',
+      kind: 'gateway',
+      file: null,
+      events: 0,
+      dropped: 0,
+      monotonic_anchor_ms: 0,
+      absent: typeof gateway?.absent === 'string' ? gateway.absent : 'unavailable'
+    })
+  }
+
+  const classification = classifyCapture(bundle)
+  const classificationPath = join(directory, 'classification.json')
+
+  await fs.writeFile(classificationPath, `${JSON.stringify(classification, null, 2)}\n`, 'utf8')
+  files.push(classificationPath)
+
+  const manifest: DiagnosticsManifest = {
+    schema_version: BUNDLE_SCHEMA_VERSION,
+    capture_id: bundle.captureId,
+    exported_at_ms: wallClock(),
+    app_version: options.appVersion ?? 'unknown',
+    platform: options.platform ?? process.platform,
+    anchors: {
+      wall_clock_anchor_ms: wallClockAnchorMs,
+      main_monotonic_anchor_ms: mainMonotonicAnchorMs
+    },
+    process_tree: sanitizeProcessTree(options.processes),
+    streams
+  }
+
+  const manifestPath = join(directory, 'manifest.json')
+
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+
+  return { directory, manifestPath, manifest, classification, files: [manifestPath, ...files] }
+}
+
+/**
+ * Build the manifest's process tree from what Electron can see of itself:
+ * this process, plus every process `app.getAppMetrics()` reports. Electron
+ * spawns all of them (renderers, GPU, utility) as children of main, so main's
+ * pid is their ppid.
+ *
+ * `getAppMetrics()` reports a `name` for utility processes only ("Audio
+ * Service", "Network Service"), which is a role rather than an executable; the
+ * process `type` is the honest label for the rest. Neither is a path and
+ * neither is argv, which is the property that matters here.
+ */
+export function electronProcessTree(input: {
+  mainPid: number
+  mainPpid: number
+  execPath: string
+  metrics?: { pid?: unknown; type?: unknown; name?: unknown }[]
+}): RawProcessEntry[] {
+  const tree: RawProcessEntry[] = [
+    { pid: input.mainPid, ppid: input.mainPpid, name: input.execPath }
+  ]
+
+  for (const metric of input.metrics ?? []) {
+    const pid = Math.trunc(Number(metric?.pid)) || 0
+
+    if (!pid || pid === input.mainPid) {
+      continue
+    }
+
+    tree.push({ pid, ppid: input.mainPid, name: metric?.name || metric?.type })
+  }
+
+  return tree
+}
+
+export { BUNDLE_DIR_NAME, BUNDLE_SCHEMA_VERSION }

--- a/apps/desktop/electron/diagnostics-gateway.test.ts
+++ b/apps/desktop/electron/diagnostics-gateway.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyGatewayFailure, createGatewayDiagnosticsClient, gatewayDiagnosticsPath } from './diagnostics-gateway'
+
+// Records every (method, params) pair so a test can assert the exact wire shape
+// the Python gateway has to answer.
+function recordingTransport(answers: Record<string, unknown | (() => never)>) {
+  const calls: { method: string; params: Record<string, unknown> }[] = []
+
+  const request = async (method, params) => {
+    calls.push({ method, params })
+
+    const answer = answers[method]
+
+    if (typeof answer === 'function') {
+      return (answer as () => never)()
+    }
+
+    return answer
+  }
+
+  return { calls, request }
+}
+
+test('methods map onto the gateway REST paths', () => {
+  assert.equal(gatewayDiagnosticsPath('diagnostics/arm'), '/api/diagnostics/arm')
+  assert.equal(gatewayDiagnosticsPath('diagnostics/disarm'), '/api/diagnostics/disarm')
+  assert.equal(gatewayDiagnosticsPath('diagnostics/collect'), '/api/diagnostics/collect')
+})
+
+test('arm sends snake_case params and returns the gateway monotonic anchor', async () => {
+  const transport = recordingTransport({ 'diagnostics/arm': { monotonic_anchor_ms: 1234.5 } })
+  const client = createGatewayDiagnosticsClient(transport.request)
+
+  const result = await client.arm({ captureId: 'cap-1', wallClockAnchorMs: 1_700_000_000_000 })
+
+  assert.deepEqual(result, { ok: true, monotonicAnchorMs: 1234.5 })
+  assert.deepEqual(transport.calls, [
+    {
+      method: 'diagnostics/arm',
+      params: { capture_id: 'cap-1', wall_clock_anchor_ms: 1_700_000_000_000 }
+    }
+  ])
+})
+
+test('a gateway that does not know the endpoint degrades to unsupported', async () => {
+  const client = createGatewayDiagnosticsClient(async () => {
+    throw new Error('404: Not Found')
+  })
+
+  assert.deepEqual(await client.arm({ captureId: 'cap-1', wallClockAnchorMs: 1 }), {
+    ok: false,
+    reason: 'unsupported'
+  })
+})
+
+test('an unauthenticated pull degrades rather than failing the capture', async () => {
+  const client = createGatewayDiagnosticsClient(async () => {
+    throw new Error('401: {"detail":"no_cookie"}')
+  })
+
+  assert.deepEqual(await client.collect('cap-1'), { ok: false, reason: 'unauthenticated' })
+})
+
+test('a transport failure degrades to unavailable', async () => {
+  const client = createGatewayDiagnosticsClient(async () => {
+    throw new Error('Timed out connecting to Hermes backend after 10000ms')
+  })
+
+  assert.deepEqual(await client.arm({ captureId: 'cap-1', wallClockAnchorMs: 1 }), {
+    ok: false,
+    reason: 'unavailable'
+  })
+})
+
+test('an answer without a monotonic anchor is unusable for alignment', async () => {
+  const client = createGatewayDiagnosticsClient(async () => ({ ok: true }))
+
+  assert.deepEqual(await client.arm({ captureId: 'cap-1', wallClockAnchorMs: 1 }), {
+    ok: false,
+    reason: 'unsupported'
+  })
+})
+
+test('collect normalizes the ring payload', async () => {
+  const transport = recordingTransport({
+    'diagnostics/collect': {
+      capture_id: 'cap-1',
+      monotonic_anchor_ms: 42,
+      events: [{ type: 'loop_stall', t: 99 }],
+      dropped: 3
+    }
+  })
+
+  const client = createGatewayDiagnosticsClient(transport.request)
+
+  const result = await client.collect('cap-1')
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.ok && result.stream, {
+    captureId: 'cap-1',
+    monotonicAnchorMs: 42,
+    events: [{ type: 'loop_stall', t: 99 }],
+    dropped: 3
+  })
+  assert.deepEqual(transport.calls[0].params, { capture_id: 'cap-1' })
+})
+
+test('collect tolerates a ring with no events and no dropped counter', async () => {
+  const client = createGatewayDiagnosticsClient(async () => ({ capture_id: 'cap-9', monotonic_anchor_ms: 0 }))
+
+  const result = await client.collect('cap-9')
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.ok && result.stream.events, [])
+  assert.equal(result.ok && result.stream.dropped, 0)
+})
+
+test('disarm never throws', async () => {
+  const client = createGatewayDiagnosticsClient(async () => {
+    throw new Error('500: boom')
+  })
+
+  await client.disarm()
+})
+
+test('failure classification reads the status prefix fetchJson rejects with', () => {
+  assert.equal(classifyGatewayFailure(new Error('405: Method Not Allowed')), 'unsupported')
+  assert.equal(classifyGatewayFailure(new Error('403: forbidden')), 'unauthenticated')
+  assert.equal(classifyGatewayFailure(new Error('ECONNREFUSED')), 'unavailable')
+  assert.equal(classifyGatewayFailure(null), 'unavailable')
+})

--- a/apps/desktop/electron/diagnostics-gateway.ts
+++ b/apps/desktop/electron/diagnostics-gateway.ts
@@ -1,0 +1,164 @@
+// Main-process client for the gateway's diagnostics ring (U3, KTD2/KTD3).
+//
+// The gateway half of a hitch capture is pulled over the gateway's EXISTING
+// authenticated channel — the same base URL + session token the rest of main
+// already uses for `hermes:api` — so no new listener, port, or credential is
+// introduced for diagnostics. Three methods, mapped onto REST paths:
+//
+//   diagnostics/arm      { capture_id, wall_clock_anchor_ms } -> { monotonic_anchor_ms }
+//   diagnostics/disarm   { }                                  -> { }
+//   diagnostics/collect  { capture_id }                       -> { capture_id, monotonic_anchor_ms, events, dropped }
+//
+// Everything degrades: a gateway that predates the endpoints (404), refuses the
+// caller (401/403), or simply cannot be reached must not fail the capture — the
+// exporter (U4) marks the gateway stream absent with a reason instead. That is
+// why every method here resolves to a tagged result rather than throwing.
+//
+// The transport is injected so this module stays Electron-free and unit
+// testable, mirroring gateway-ws-probe.ts / stream-throttle.ts.
+
+/** The wire methods, spelled exactly as the gateway advertises them. */
+export type GatewayDiagnosticsMethod = 'diagnostics/arm' | 'diagnostics/collect' | 'diagnostics/disarm'
+
+/** Why a gateway stream is missing from a capture bundle. */
+export type GatewayAbsentReason = 'disabled' | 'remote-gateway' | 'unauthenticated' | 'unavailable' | 'unsupported'
+
+export interface GatewayDiagnosticsStream {
+  captureId: string
+  /** The gateway's own monotonic clock at arm time, for KTD3 alignment. */
+  monotonicAnchorMs: number
+  events: unknown[]
+  dropped: number
+}
+
+// Tagged results rather than discriminated unions: the electron tsconfig runs
+// with `strictNullChecks: false`, under which a boolean discriminant does not
+// narrow, so the optional-field shape is the one callers can actually read.
+export interface GatewayArmResult {
+  ok: boolean
+  /** Set when ok. */
+  monotonicAnchorMs?: number
+  /** Set when not ok. */
+  reason?: GatewayAbsentReason
+}
+
+export interface GatewayCollectResult {
+  ok: boolean
+  /** Set when ok. */
+  stream?: GatewayDiagnosticsStream
+  /** Set when not ok. */
+  reason?: GatewayAbsentReason
+}
+
+/** Issues one authenticated request against the live gateway. */
+export type GatewayDiagnosticsRequest = (
+  method: GatewayDiagnosticsMethod,
+  params: Record<string, unknown>
+) => Promise<unknown>
+
+export interface GatewayDiagnosticsClient {
+  arm(input: { captureId: string; wallClockAnchorMs: number }): Promise<GatewayArmResult>
+  collect(captureId: string): Promise<GatewayCollectResult>
+  /** Best-effort; a gateway that never armed is happy to be told to disarm. */
+  disarm(): Promise<void>
+}
+
+/** REST path a method rides. Kept next to the method names so the two can
+ * never drift apart in opposite directions. */
+export function gatewayDiagnosticsPath(method: GatewayDiagnosticsMethod): string {
+  return `/api/${method}`
+}
+
+/**
+ * Map a transport failure onto an absent-stream reason. `fetchJson` rejects
+ * HTTP errors as `Error('<status>: <body>')`, so the status is recoverable from
+ * the message without threading a richer error type through main.
+ */
+export function classifyGatewayFailure(error: unknown): GatewayAbsentReason {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  const status = /^\s*(\d{3})\b/.exec(message)?.[1]
+
+  if (status === '404' || status === '405' || status === '501') {
+    return 'unsupported'
+  }
+
+  if (status === '401' || status === '403') {
+    return 'unauthenticated'
+  }
+
+  return 'unavailable'
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function finiteNumber(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value)
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function createGatewayDiagnosticsClient(request: GatewayDiagnosticsRequest): GatewayDiagnosticsClient {
+  return {
+    async arm({ captureId, wallClockAnchorMs }) {
+      let answer: unknown
+
+      try {
+        answer = await request('diagnostics/arm', {
+          capture_id: captureId,
+          wall_clock_anchor_ms: wallClockAnchorMs
+        })
+      } catch (error) {
+        return { ok: false, reason: classifyGatewayFailure(error) }
+      }
+
+      // A gateway that answers 200 with a body this client cannot anchor on is
+      // no more usable than one that 404s: without the monotonic anchor the
+      // stream cannot be aligned (KTD3), so treat it as unsupported.
+      const monotonicAnchorMs = finiteNumber(asRecord(answer)?.monotonic_anchor_ms)
+
+      if (monotonicAnchorMs === null) {
+        return { ok: false, reason: 'unsupported' }
+      }
+
+      return { ok: true, monotonicAnchorMs }
+    },
+
+    async collect(captureId) {
+      let answer: unknown
+
+      try {
+        answer = await request('diagnostics/collect', { capture_id: captureId })
+      } catch (error) {
+        return { ok: false, reason: classifyGatewayFailure(error) }
+      }
+
+      const body = asRecord(answer)
+      const monotonicAnchorMs = finiteNumber(body?.monotonic_anchor_ms)
+
+      if (!body || monotonicAnchorMs === null) {
+        return { ok: false, reason: 'unsupported' }
+      }
+
+      return {
+        ok: true,
+        stream: {
+          captureId: typeof body.capture_id === 'string' ? body.capture_id : captureId,
+          monotonicAnchorMs,
+          events: Array.isArray(body.events) ? body.events : [],
+          dropped: finiteNumber(body.dropped) ?? 0
+        }
+      }
+    },
+
+    async disarm() {
+      try {
+        await request('diagnostics/disarm', {})
+      } catch {
+        // Disarm is advisory: the gateway drops its ring on the next arm
+        // anyway, and a capture must never fail on the way out.
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -89,6 +89,8 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import { COLLECT_RESULT_CHANNEL, createCaptureController } from './diagnostics-capture'
+import { createGatewayDiagnosticsClient, gatewayDiagnosticsPath } from './diagnostics-gateway'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import { findGitBash as _findGitBash } from './find-git-bash'
@@ -10247,7 +10249,7 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   return { ...(base as any), sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
 }
 
-ipcMain.handle('hermes:api', async (_event, request) => {
+async function handleHermesApiRequest(request) {
   // Remote-profile session requests would otherwise hit the local primary off
   // each profile's on-disk state.db — fine for local profiles, but a remote
   // profile's sessions live on its remote host, so the UI's IDs 404 (or mutations
@@ -10316,6 +10318,28 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     upload: request?.upload,
     timeoutMs
   })
+}
+
+// The renderer's REST calls are the one transport main can actually see, so a
+// failure here (the observed 60s "Timed out connecting to Hermes backend") is
+// recorded as a diagnostics transport event — duration, coarse route prefix and
+// error class only, never the request or its body. While disarmed the recorder
+// returns immediately, so the failure path is unchanged.
+ipcMain.handle('hermes:api', async (_event, request) => {
+  const startedAt = Date.now()
+
+  try {
+    return await handleHermesApiRequest(request)
+  } catch (error) {
+    diagnosticsCapture.recordTransportError({
+      channel: 'hermes:api',
+      path: request?.path,
+      durationMs: Date.now() - startedAt,
+      error
+    })
+
+    throw error
+  }
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main
@@ -10588,6 +10612,45 @@ const activeWorkByWebContents = new Map<number, ActiveWork>()
 // unthrottled while any turn is in flight (streaming must paint while hidden)
 // and fall back to Chromium's default throttling at idle. See stream-throttle.ts.
 const streamThrottle = createStreamThrottle()
+
+// Hitch capture (U3). Disarmed the app costs nothing: no sampler runs, no
+// window edge is recorded, and the gateway is never asked anything. Armed, main
+// contributes its own ring (window responsiveness, app metrics, transport
+// failures), pushes the capture id + wall-clock anchor to every renderer, and
+// pulls the gateway ring over the SAME authenticated channel `hermes:api`
+// already uses — no new listener or credential. See diagnostics-capture.ts.
+const gatewayDiagnostics = createGatewayDiagnosticsClient(async (method, params) => {
+  const connection = await startHermes()
+
+  return fetchJson(`${connection.baseUrl}${gatewayDiagnosticsPath(method)}`, connection.token, {
+    method: 'POST',
+    body: params,
+    timeoutMs: 10_000
+  })
+})
+
+const diagnosticsCapture = createCaptureController({
+  now: () => performance.now(),
+  listWindows: () => BrowserWindow.getAllWindows() as never,
+  getAppMetrics: () => app.getAppMetrics() as never,
+  gateway: gatewayDiagnostics,
+  // The gateway ring is local-backend only; a remote/SSH host is not asked and
+  // the exporter marks the stream absent with reason 'remote-gateway'.
+  isRemoteGateway: () => primaryBackendIsRemote()
+})
+
+app.on('browser-window-created', (_event, win) => diagnosticsCapture.attachWindow(win as never))
+
+ipcMain.on(COLLECT_RESULT_CHANNEL, (_event, payload) => diagnosticsCapture.handleCollectResult(payload))
+
+// U4 builds the capture UI and the sanitized export on top of these; main only
+// owns arm/disarm and the gathered bundle.
+ipcMain.handle('hermes:diagnostics:start', () => diagnosticsCapture.start())
+ipcMain.handle('hermes:diagnostics:stop', () => diagnosticsCapture.stop())
+ipcMain.handle('hermes:diagnostics:status', () => ({
+  armed: diagnosticsCapture.isArmed(),
+  captureId: diagnosticsCapture.captureId()
+}))
 
 function updateStreamThrottleFromActiveWork() {
   streamThrottle.update(mergeActiveWork(activeWorkByWebContents.values()).count > 0)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -90,6 +90,7 @@ import {
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { COLLECT_RESULT_CHANNEL, createCaptureController } from './diagnostics-capture'
+import { electronProcessTree, exportDiagnosticsBundle } from './diagnostics-export'
 import { createGatewayDiagnosticsClient, gatewayDiagnosticsPath } from './diagnostics-gateway'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
@@ -10643,10 +10644,51 @@ app.on('browser-window-created', (_event, win) => diagnosticsCapture.attachWindo
 
 ipcMain.on(COLLECT_RESULT_CHANNEL, (_event, payload) => diagnosticsCapture.handleCollectResult(payload))
 
-// U4 builds the capture UI and the sanitized export on top of these; main only
-// owns arm/disarm and the gathered bundle.
+// Stop gathers the bundle AND writes it (U4): the Diagnostics settings section
+// is a one-action flow, so there is no separate "export" step for the user to
+// forget. The bundle goes to `<userData>/diagnostics/<captureId>/` and nothing
+// leaves the machine; the renderer gets back only the path plus the R3
+// classification, never any captured events.
 ipcMain.handle('hermes:diagnostics:start', () => diagnosticsCapture.start())
-ipcMain.handle('hermes:diagnostics:stop', () => diagnosticsCapture.stop())
+ipcMain.handle('hermes:diagnostics:stop', async () => {
+  const bundle = await diagnosticsCapture.stop()
+
+  if (!bundle) {
+    return null
+  }
+
+  let metrics = []
+
+  try {
+    metrics = app.getAppMetrics() as never
+  } catch {
+    // A process tree is nice to have, not a reason to lose the capture.
+  }
+
+  const result = await exportDiagnosticsBundle({
+    bundle,
+    userDataPath: app.getPath('userData'),
+    appVersion: app.getVersion(),
+    processes: electronProcessTree({
+      mainPid: process.pid,
+      mainPpid: process.ppid,
+      execPath: process.execPath,
+      metrics
+    })
+  })
+
+  return {
+    captureId: bundle.captureId,
+    directory: result.directory,
+    labels: result.classification.labels,
+    primary: result.classification.primary,
+    streams: result.manifest.streams.map(stream => ({
+      name: stream.name,
+      events: stream.events,
+      ...(stream.absent ? { absent: stream.absent } : {})
+    }))
+  }
+})
 ipcMain.handle('hermes:diagnostics:status', () => ({
   armed: diagnosticsCapture.isArmed(),
   captureId: diagnosticsCapture.captureId()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -351,5 +351,57 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     ipcRenderer.on('hermes:found-in-page', listener)
 
     return () => ipcRenderer.removeListener('hermes:found-in-page', listener)
+  },
+  // Hitch capture (U3). The capture controller lives in MAIN — it is the only
+  // process that can reach both the renderers and the gateway — so all three
+  // messages here are main-initiated:
+  //
+  //   main -> renderer  'diagnostics:arm'     { captureId, wallClockAnchorMs }
+  //   main -> renderer  'diagnostics:disarm'
+  //   main -> renderer  'diagnostics:collect' { requestId, captureId }
+  //   renderer -> main  'diagnostics:collect:result' { requestId, snapshot }
+  //
+  // Collect is a pull, not a push, because only main knows when the capture
+  // ends. Electron has no main->renderer invoke, so the request carries a
+  // `requestId` the reply echoes back and main correlates on (the same
+  // send-both-ways idiom the pet overlay and quick entry use). The renderer
+  // hands its snapshot source down once via `setSnapshotProvider`; preload
+  // holds it and answers on main's behalf, so the renderer never has to know
+  // the channel names. No provider registered (older renderer, harness) is not
+  // an error: preload answers with a null snapshot and the capture proceeds
+  // without that window's stream.
+  diagnostics: {
+    onArm: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('diagnostics:arm', listener)
+
+      return () => ipcRenderer.removeListener('diagnostics:arm', listener)
+    },
+    onDisarm: callback => {
+      const listener = () => callback()
+      ipcRenderer.on('diagnostics:disarm', listener)
+
+      return () => ipcRenderer.removeListener('diagnostics:disarm', listener)
+    },
+    setSnapshotProvider: provider => {
+      const listener = async (_event, request) => {
+        const requestId = request?.requestId
+        let snapshot = null
+
+        try {
+          snapshot = (await provider(request?.captureId)) ?? null
+        } catch {
+          // A renderer that cannot snapshot itself still owes main an answer,
+          // otherwise the export waits out the full collect timeout.
+          snapshot = null
+        }
+
+        ipcRenderer.send('diagnostics:collect:result', { requestId, snapshot })
+      }
+
+      ipcRenderer.on('diagnostics:collect', listener)
+
+      return () => ipcRenderer.removeListener('diagnostics:collect', listener)
+    }
   }
 })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -403,5 +403,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
       return () => ipcRenderer.removeListener('diagnostics:collect', listener)
     }
+  },
+  // Capture control for the Diagnostics settings section (U4). Separate from
+  // the `diagnostics` namespace above because that one is main-driven push and
+  // this one is renderer-driven request/response. `stop` also writes the
+  // sanitized bundle and answers with its path + classification — one action,
+  // no separate export step.
+  diagnosticsCapture: {
+    start: () => ipcRenderer.invoke('hermes:diagnostics:start'),
+    stop: () => ipcRenderer.invoke('hermes:diagnostics:stop'),
+    status: () => ipcRenderer.invoke('hermes:diagnostics:status')
   }
 })

--- a/apps/desktop/scripts/perf/README.md
+++ b/apps/desktop/scripts/perf/README.md
@@ -54,6 +54,7 @@ directly via `window.__PERF_DRIVE__`, so no LLM credits are spent.
 | `render-churn` | ci | per-component render attribution + store churn while N tabs stream | (new) |
 | `idle-cost` | report | busy-but-silent tiles: idle commit rate, + fps while resizing / typing | (new) |
 | `right-pane` | report | file tree + persistent xterm tabs under chat/terminal output and split dragging | (new) |
+| `hitch-classify` | report | injects renderer / gateway hitches and ASSERTS the capture bundle's classification (U5) | (new) |
 | `cold-start` | cold | launch → CDP → driver → first paint (fresh spawn/run) | (new) |
 | `first-token` | backend | Enter → first assistant token painted (TTFT) | (new) |
 | `submit` | backend | Enter → cleared → user msg painted, scroll jump | measure-submit, measure-jump |
@@ -65,6 +66,12 @@ directly via `window.__PERF_DRIVE__`, so no LLM credits are spent.
 `baseline.json` (`cold-start` requires `--spawn` since it measures a fresh
 launch, and must be run in its own invocation). `backend` scenarios need a live
 backend (and `--spawn` or a real session/credits) and are report-only.
+
+`hitch-classify` is the odd one out: it asserts instead of measuring, and it
+needs `--spawn` because the gateway's loop-block test hook is mounted only when
+the backend process is started with `HERMES_DIAGNOSTICS_TEST_HOOKS=1`, which the
+runner sets for that scenario's isolated instance and nowhere else. It exits
+nonzero when a case is misclassified.
 
 CPU profiling is a cross-cutting `--cpuprofile` flag on any scenario (it wraps
 the run in `Profiler.start/stop` and prints a top-self-time table), replacing

--- a/apps/desktop/scripts/perf/lib/launch.mjs
+++ b/apps/desktop/scripts/perf/lib/launch.mjs
@@ -22,6 +22,59 @@ import { CDP, requireDriver, sleep } from './cdp.mjs'
 
 const require = createRequire(import.meta.url)
 const DESKTOP_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const REPO_ROOT = resolve(DESKTOP_DIR, '..', '..')
+
+/** Where the CLI installs itself — the app's own ACTIVE_HERMES_ROOT default. */
+function activeHermesRoot() {
+  const home =
+    process.env.HERMES_HOME ||
+    (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'), 'hermes')
+      : join(homedir(), '.hermes'))
+
+  return join(home, 'hermes-agent')
+}
+
+/** A python that has Hermes' dependencies installed, or null. */
+function findBackendPython() {
+  const rel =
+    process.platform === 'win32' ? join('Scripts', 'python.exe') : join('bin', 'python')
+
+  for (const root of [REPO_ROOT, activeHermesRoot()]) {
+    for (const venv of ['venv', '.venv']) {
+      const candidate = join(root, venv, rel)
+
+      if (existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Env that pins the spawned instance's BACKEND to this checkout.
+ *
+ * Normally the app resolves a backend by its own precedence and lands on the
+ * installed runtime — which is a different source tree. A scenario that asserts
+ * on gateway-side behaviour (hitch-classify) would then be testing the
+ * installed gateway, not the one in this working tree, so it pins the source
+ * root explicitly. The checkout has no venv of its own, so the interpreter
+ * falls back to the installed runtime's — same dependencies, this repo's code.
+ */
+function backendSourcePinEnv() {
+  const python = process.env.HERMES_DESKTOP_PYTHON || findBackendPython()
+
+  if (!python) {
+    throw new Error(
+      'no python with Hermes dependencies found (looked for venv/.venv in the checkout and in the installed ' +
+        'runtime) — set HERMES_DESKTOP_PYTHON to one'
+    )
+  }
+
+  return { HERMES_DESKTOP_HERMES_ROOT: REPO_ROOT, HERMES_DESKTOP_PYTHON: python }
+}
 
 async function reachable(url) {
   try {
@@ -161,12 +214,15 @@ const ANTI_THROTTLE_FLAGS = [
  * `coldStart: true` skips the gateway-connect wait and settle (for launch-time
  * measurement) and returns `timings` (spawn→CDP, spawn→driver) plus renderer
  * boot marks (FCP, time-to-composer).
+ * `gatewayTestHooks: true` starts this instance's backend with the diagnostics
+ * test hooks enabled — only the U5 proof scenario asks for it.
  */
 export async function startIsolatedInstance({
   port = 9222,
   devPort = 5174,
   prod = false,
   coldStart = false,
+  gatewayTestHooks = false,
   hermesHome,
   userDataDir,
   seedConfig = true,
@@ -243,6 +299,16 @@ export async function startIsolatedInstance({
 
     if (devUrl) {
       env.HERMES_DESKTOP_DEV_SERVER = devUrl
+    }
+
+    // Electron passes its whole environment to the backend it spawns, so this
+    // is what mounts the gateway's guarded loop-block route in THIS isolated
+    // instance's gateway and nowhere else (the user's own gateway is a
+    // different process that never sees it). The hook only exists in this
+    // checkout's `hermes_cli`, so the backend is pinned to it as well.
+    if (gatewayTestHooks) {
+      env.HERMES_DIAGNOSTICS_TEST_HOOKS = '1'
+      Object.assign(env, backendSourcePinEnv())
     }
 
     const spawnAt = Date.now()

--- a/apps/desktop/scripts/perf/run.mjs
+++ b/apps/desktop/scripts/perf/run.mjs
@@ -158,8 +158,20 @@ async function main() {
 
   // Steady-state scenarios share one persistent connection.
   if (liveNames.length) {
+    // Needing a gateway-side fault injector is a property of the scenario
+    // (hitch-classify), so the runner reads it off the registry rather than
+    // taking a flag — and it only reaches the backend of an instance we spawn.
+    const gatewayTestHooks = liveNames.some(n => SCENARIOS[n].gatewayTestHooks)
+
+    if (gatewayTestHooks && !flags.spawn) {
+      console.error(
+        'hitch-classify requires --spawn: its gateway test hook is enabled through the spawned backend’s environment'
+      )
+      process.exit(2)
+    }
+
     const connection = flags.spawn
-      ? await startIsolatedInstance({ port, devPort, prod })
+      ? await startIsolatedInstance({ port, devPort, prod, gatewayTestHooks })
       : await attach({ port, match: prod ? undefined : String(devPort) })
 
     const { cdp, teardown } = connection

--- a/apps/desktop/scripts/perf/scenarios/hitch-classify.mjs
+++ b/apps/desktop/scripts/perf/scenarios/hitch-classify.mjs
@@ -1,0 +1,308 @@
+// Proof harness for the hitch diagnostics (U5, R5): cause a hitch on purpose,
+// in a known process, and check the exported bundle blames that process.
+//
+// Every other scenario here measures. This one ASSERTS. The capture stack
+// (renderer ring → main controller → gateway ring → sanitized bundle →
+// classifier) is only worth anything if its answer is right, and the only way
+// to know that is to hand it a hitch whose true cause is already known:
+//
+//   control       nothing at all                        → not gateway-bound
+//   renderer      3 x 400ms busy loops in the page      → renderer-bound
+//   gateway       one 6s event-loop block in the gateway → gateway-bound
+//   gateway-floor 3 x 600ms blocks — each one BELOW the  → gateway-bound
+//                 gateway's 5s "event loop stalled" log
+//                 threshold, so this is exactly the CF-1
+//                 blind spot the ring was added to close
+//   combined      both at once                          → both labels
+//
+// Each case runs a real capture through the app's own IPC — the scenario calls
+// `window.hermesDesktop.diagnosticsCapture.start()` / `.stop()` in the page,
+// which is the same path the Diagnostics settings section uses — and reads the
+// labels off `stop()`'s export result. A case FAILs on the labels, and the
+// scenario throws at the end if any case failed, so the harness exits nonzero.
+//
+// The gateway block needs the gateway's guarded test hook, which is mounted
+// only when the backend process has HERMES_DIAGNOSTICS_TEST_HOOKS=1. That env
+// var is set for this scenario by `startIsolatedInstance` (see the
+// `gatewayTestHooks` flag below), so it requires --spawn:
+//
+//   node scripts/perf/run.mjs hitch-classify --spawn
+//   node scripts/perf/run.mjs hitch-classify --spawn --prod
+
+import { sleep } from '../lib/cdp.mjs'
+
+/** The gateway's test hook. Absent from a normally started gateway. */
+const BLOCK_LOOP_PATH = '/api/diagnostics/test/block-loop'
+
+/** How long after arming before injecting. The gateway's CF-1 heartbeat only
+ *  tightens to its armed 20Hz cadence on its NEXT tick, and that tick is up to
+ *  the production 2.0s interval away — inject sooner and the drift is measured
+ *  against the slow tick (or missed entirely). */
+const ARM_SETTLE_MS = 3000
+
+/** Drain time after the last injection: one armed heartbeat tick to record the
+ *  drift, and one frame plus the LoAF queue for the renderer's side. */
+const DRAIN_MS = 1500
+
+const START = `(async () => JSON.stringify(await window.hermesDesktop.diagnosticsCapture.start()))()`
+const STOP = `(async () => JSON.stringify(await window.hermesDesktop.diagnosticsCapture.stop()))()`
+const STATUS = `(async () => JSON.stringify(await window.hermesDesktop.diagnosticsCapture.status()))()`
+
+/** Busy-loop the renderer's main thread inside a real rendering frame.
+ *
+ *  Deliberately a rAF callback and not a bare timer: a Long Animation Frame
+ *  entry — the renderer capture's only source of `long_frame` events — is
+ *  reported for a *frame*, so the block has to happen inside one and be
+ *  followed by work the engine must render. A timer fallback keeps the case
+ *  from hanging if rAF never fires (a throttled/hidden renderer would be a
+ *  finding of its own, reported as a short burst rather than a timeout). */
+const rendererBurst = (ms, count) => `
+  (async () => {
+    const spent = []
+    for (let i = 0; i < ${count}; i++) {
+      await new Promise(resolve => {
+        let ran = false
+        const run = () => {
+          if (ran) return
+          ran = true
+          const t0 = performance.now()
+          while (performance.now() - t0 < ${ms}) {}
+          // Force style + layout so the blocked frame is a rendering frame.
+          document.body.style.setProperty('--perf-hitch', String(i))
+          void document.body.offsetHeight
+          spent.push(Math.round(performance.now() - t0))
+          resolve()
+        }
+        const timer = setTimeout(run, 1200)
+        requestAnimationFrame(() => { clearTimeout(timer); run() })
+      })
+      await new Promise(r => setTimeout(r, 300))
+    }
+    return spent.join(',')
+  })()
+`
+
+/** Block the GATEWAY's event loop via its guarded test hook, over the app's own
+ *  authenticated backend channel (`hermes:api` → main → gateway). The response
+ *  cannot arrive until the loop it is blocking runs again, so the timeout has
+ *  to clear the block itself with room to spare. */
+const gatewayBlock = (seconds, count) => `
+  (async () => {
+    const out = []
+    for (let i = 0; i < ${count}; i++) {
+      try {
+        out.push(await window.hermesDesktop.api({
+          path: ${JSON.stringify(BLOCK_LOOP_PATH)},
+          method: 'POST',
+          body: { seconds: ${seconds} },
+          timeoutMs: ${Math.round(seconds * 1000) + 15000}
+        }))
+      } catch (error) {
+        return 'error:' + (error && error.message ? error.message : String(error))
+      }
+      await new Promise(r => setTimeout(r, 400))
+    }
+    return JSON.stringify(out)
+  })()
+`
+
+async function evalJson(cdp, expression) {
+  const raw = await cdp.eval(expression)
+
+  return raw === undefined || raw === null ? null : JSON.parse(raw)
+}
+
+/** Run one case: arm a capture, inject, stop, and read the classification. */
+async function capture(cdp, inject) {
+  const started = await evalJson(cdp, START)
+
+  if (!started?.captureId) {
+    throw new Error('diagnosticsCapture.start() returned no captureId — is this build missing the U3 controller?')
+  }
+
+  let injected = null
+  let stopped = null
+
+  try {
+    await sleep(ARM_SETTLE_MS)
+    injected = await inject()
+    await sleep(DRAIN_MS)
+    stopped = await evalJson(cdp, STOP)
+  } catch (error) {
+    // A throw mid-injection must not leave the app (and the gateway's 20Hz
+    // armed heartbeat) running for the rest of the harness run.
+    await evalJson(cdp, STOP).catch(() => null)
+
+    throw error
+  }
+
+  if (!stopped) {
+    throw new Error(`capture ${started.captureId} exported nothing — stop() returned null`)
+  }
+
+  return { ...stopped, injected }
+}
+
+const gatewayStream = result => result.streams?.find(s => s.name === 'gateway') ?? null
+
+/** Turn a case's export into a PASS/FAIL row. `expect` lists labels that must
+ *  be present; `reject` lists labels that must not be. */
+function check(name, result, { expect, reject = [] }) {
+  const labels = result.labels ?? []
+  const missing = expect.filter(label => !labels.includes(label))
+  const unwanted = reject.filter(label => labels.includes(label))
+  const gateway = gatewayStream(result)
+  const problems = [
+    ...missing.map(label => `missing ${label}`),
+    ...unwanted.map(label => `unexpected ${label}`),
+    ...(expect.includes('gateway-bound') && gateway?.absent ? [`gateway stream absent (${gateway.absent})`] : [])
+  ]
+
+  const ok = problems.length === 0
+  const streams = (result.streams ?? []).map(s => `${s.name}=${s.absent ? `absent:${s.absent}` : s.events}`).join(' ')
+
+  console.log(
+    `   ${ok ? '✓ PASS' : '✗ FAIL'}  ${name.padEnd(14)} ` +
+      `primary=${String(result.primary)} labels=[${labels.join(', ')}] ${streams}` +
+      (ok ? '' : `\n            ${problems.join('; ')}`)
+  )
+
+  return {
+    name,
+    ok,
+    labels,
+    primary: result.primary,
+    problems,
+    streams: result.streams,
+    injected: result.injected,
+    // Where the sanitized bundle landed, for a reviewer who wants to read the
+    // raw JSONL behind a label (inside the instance's temp user-data dir, so it
+    // only exists until teardown).
+    directory: result.directory
+  }
+}
+
+export default {
+  name: 'hitch-classify',
+  // Not 'ci': it needs a live local gateway (with the test hook enabled) and it
+  // asserts rather than measures, so there is nothing to gate on a baseline.
+  tier: 'report',
+  // Asks the runner to start the isolated instance's backend with the gateway
+  // diagnostics test hooks enabled. Nothing else in the harness sets it.
+  gatewayTestHooks: true,
+  description: 'Synthetic renderer / gateway hitches, asserted against the capture bundle classification.',
+  async run(cdp, opts = {}) {
+    const burstMs = Number(opts.burstMs ?? 400)
+    const bursts = Number(opts.bursts ?? 3)
+    const blockSeconds = Number(opts.blockSeconds ?? 6)
+    const floorSeconds = Number(opts.floorSeconds ?? 0.6)
+    const floorBlocks = Number(opts.floorBlocks ?? 3)
+
+    await cdp.send('Runtime.enable')
+
+    const hasCapture = await cdp.eval('!!(window.hermesDesktop && window.hermesDesktop.diagnosticsCapture)')
+
+    if (!hasCapture) {
+      throw new Error(
+        'window.hermesDesktop.diagnosticsCapture is missing — the diagnostics capture IPC (U3/U4) is not in this build.'
+      )
+    }
+
+    const status = await evalJson(cdp, STATUS)
+
+    if (status?.armed) {
+      await evalJson(cdp, STOP)
+    }
+
+    const renderer = () => cdp.eval(rendererBurst(burstMs, bursts))
+    const gateway = (seconds, count) =>
+      cdp.eval(gatewayBlock(seconds, count)).then(answer => {
+        if (typeof answer === 'string' && answer.startsWith('error:')) {
+          throw new Error(
+            `gateway block hook failed (${answer.slice(6)}). ${BLOCK_LOOP_PATH} is mounted only when the ` +
+              'backend process has HERMES_DIAGNOSTICS_TEST_HOOKS=1 — run this scenario with --spawn so the ' +
+              'harness sets it.'
+          )
+        }
+
+        return answer
+      })
+
+    console.log('\n[hitch-classify] injected hitches vs. the bundle classification')
+
+    const rows = []
+
+    // 0. Control: a capture of the same length with NOTHING injected. It is
+    //    what makes the rest readable — gateway-bound must be a consequence of
+    //    blocking the gateway and of nothing else, and whatever labels the idle
+    //    app earns on its own are printed here rather than being quietly
+    //    inherited by the injected cases.
+    rows.push(
+      check('control', await capture(cdp, async () => null), {
+        expect: [],
+        reject: ['gateway-bound']
+      })
+    )
+
+    // 1. Renderer only. The gateway is untouched, so a gateway-bound label here
+    //    would mean the classifier is reading the wrong stream.
+    rows.push(
+      check('renderer', await capture(cdp, renderer), {
+        expect: ['renderer-bound'],
+        reject: ['gateway-bound']
+      })
+    )
+
+    // 2. Gateway only, well past the 5s log threshold.
+    rows.push(
+      check('gateway', await capture(cdp, () => gateway(blockSeconds, 1)), {
+        expect: ['gateway-bound']
+      })
+    )
+
+    // 3. Gateway only, every block BELOW the 5s log threshold — the CF-1 blind
+    //    spot. The ring's 0.25s capture floor is what makes this classifiable.
+    rows.push(
+      check('gateway-floor', await capture(cdp, () => gateway(floorSeconds, floorBlocks)), {
+        expect: ['gateway-bound']
+      })
+    )
+
+    // 4. Both at once: the classifier must report both rather than pick one.
+    rows.push(
+      check(
+        'combined',
+        await capture(cdp, async () => {
+          const both = await Promise.all([gateway(blockSeconds, 1), renderer()])
+
+          return both.join(' | ')
+        }),
+        { expect: ['gateway-bound', 'renderer-bound'] }
+      )
+    )
+
+    const failed = rows.filter(r => !r.ok)
+
+    if (failed.length) {
+      throw new Error(
+        `hitch-classify: ${failed.length}/${rows.length} case(s) misclassified — ` +
+          failed.map(r => `${r.name}: ${r.problems.join(', ')}`).join(' | ')
+      )
+    }
+
+    return {
+      metrics: {
+        cases: rows.length,
+        cases_failed: failed.length
+      },
+      detail: {
+        burstMs,
+        bursts,
+        blockSeconds,
+        floorSeconds,
+        floorBlocks,
+        cases: rows
+      }
+    }
+  }
+}

--- a/apps/desktop/scripts/perf/scenarios/index.mjs
+++ b/apps/desktop/scripts/perf/scenarios/index.mjs
@@ -3,6 +3,7 @@
 
 import coldStart from './cold-start.mjs'
 import firstToken from './first-token.mjs'
+import hitchClassify from './hitch-classify.mjs'
 import idleCost from './idle-cost.mjs'
 import keystroke from './keystroke.mjs'
 import multitab from './multitab.mjs'
@@ -23,6 +24,7 @@ export const SCENARIOS = {
   [transcript.name]: transcript,
   [multitab.name]: multitab,
   [renderChurn.name]: renderChurn,
+  [hitchClassify.name]: hitchClassify,
   [rightPane.name]: rightPane,
   [idleCost.name]: idleCost,
   [coldStart.name]: coldStart,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import { isDiagnosticsArmed, recordStreamDeltaApplied } from '@/diagnostics'
 import { translateNow } from '@/i18n'
 import {
   appendAssistantTextPart,
@@ -62,6 +63,23 @@ interface QueuedStreamDeltas {
 let streamMessageSeq = 0
 
 const nextStreamMessageId = (prefix: string) => `${prefix}-${Date.now()}-${++streamMessageSeq}`
+
+// Diagnostics only, and only while a capture is armed: how big the flush about
+// to run is, in sessions and characters. Sizes, never the delta text — the
+// capture ring buffer must never hold message content (see src/diagnostics).
+const queuedDeltaSizes = (queue: Map<string, QueuedStreamDeltas>) => {
+  let queuedChars = 0
+
+  for (const queued of queue.values()) {
+    queuedChars += queued.assistant.length
+
+    for (const delta of queued.reasoning) {
+      queuedChars += delta.text.length
+    }
+  }
+
+  return { queuedChars, sessions: queue.size, sessionIds: [...queue.keys()] }
+}
 
 export function useMessageStream({
   activeGatewayProfile = 'default',
@@ -273,6 +291,9 @@ export function useMessageStream({
       flushHandleRef.current = null
       const startedAt = performance.now()
       lastFlushAtRef.current = startedAt
+      // Diagnostics reads the queue before it drains. Guarded on the armed flag
+      // so a normal build does one boolean test per flush and allocates nothing.
+      const pending = isDiagnosticsArmed() ? queuedDeltaSizes(queuedDeltasRef.current) : null
       flushQueuedDeltas()
       // The store write above is only the cheap half of a flush. While a
       // session streams, syncSessionStateToView defers the $messages publish
@@ -287,6 +308,22 @@ export function useMessageStream({
       // stays as the fallback.
       const writeCost = performance.now() - startedAt
       lastFlushCostRef.current = writeCost
+
+      // One capture event per flush, carrying the costs this path ALREADY
+      // measures. `commitMs`/`rafGapMs` are filled in place by the same
+      // measurement frame below — no second measurement pass, and a hidden
+      // renderer (no frame) still leaves the write-cost half on the record.
+      const sample = pending
+        ? recordStreamDeltaApplied({
+            historyMessages: pending.sessionIds.reduce(
+              (total, id) => total + (sessionStateByRuntimeIdRef.current.get(id)?.messages.length ?? 0),
+              0
+            ),
+            queuedChars: pending.queuedChars,
+            sessions: pending.sessions,
+            writeMs: writeCost
+          })
+        : null
 
       // At most one measurement rAF may be pending: only the newest flush's
       // measurement matters (the guard below discards stale frames), and a
@@ -305,7 +342,13 @@ export function useMessageStream({
           return
         }
 
-        lastFlushCostRef.current = writeCost + Math.max(0, performance.now() - frameStart)
+        const commitCost = Math.max(0, performance.now() - frameStart)
+        lastFlushCostRef.current = writeCost + commitCost
+
+        if (sample) {
+          sample.commitMs = Math.round(commitCost * 100) / 100
+          sample.rafGapMs = Math.round(Math.max(0, frameStart - startedAt) * 100) / 100
+        }
       })
     }
 
@@ -326,7 +369,7 @@ export function useMessageStream({
     // in the worst case (a delta arriving before the unthrottle lands) the
     // clamp only stretches one flush to ~1s in a window nobody can see.
     flushHandleRef.current = window.setTimeout(runFlush, Math.max(0, adaptiveFloor - sinceLast))
-  }, [flushQueuedDeltas])
+  }, [flushQueuedDeltas, sessionStateByRuntimeIdRef])
 
   const queueDelta = useCallback(
     (sessionId: string, key: keyof QueuedStreamDeltas, delta: string) => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
-import { isDiagnosticsArmed, recordStreamDeltaApplied } from '@/diagnostics'
+import { isDiagnosticsArmed, recordGatewayEventApplied, recordStreamDeltaApplied } from '@/diagnostics'
 import { translateNow } from '@/i18n'
 import {
   appendAssistantTextPart,
@@ -27,6 +27,7 @@ import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { upsertSubagent } from '@/store/subagents'
 import { setSessionTodos } from '@/store/todos'
+import type { RpcEvent } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -80,6 +81,12 @@ const queuedDeltaSizes = (queue: Map<string, QueuedStreamDeltas>) => {
 
   return { queuedChars, sessions: queue.size, sessionIds: [...queue.keys()] }
 }
+
+// Recording a gateway-event dispatch below this cost would be ring churn: a
+// streaming turn emits dozens of sub-millisecond queue pushes per second, and
+// the interesting rows are the ones that plausibly contributed to a dropped
+// frame. A quarter of a 16ms frame is where "contributed" starts.
+const GATEWAY_EVENT_RECORD_MIN_MS = 4
 
 export function useMessageStream({
   activeGatewayProfile = 'default',
@@ -216,16 +223,52 @@ export function useMessageStream({
   // relocating the SAME session (follow it) from a session switch (don't yank).
   const lastCwdInfoSessionRef = useRef<null | string>(null)
 
+  // Diagnostics only: how many sessions have a turn in flight right now.
+  // `busy` covers tool-call turns too, so this counts concurrent threads even
+  // when a thread contributes render load without queueing any text — the
+  // signal the `sessions` (queue size) field structurally cannot carry.
+  const countBusySessions = useCallback(() => {
+    let busy = 0
+
+    for (const state of sessionStateByRuntimeIdRef.current.values()) {
+      if (state.busy) {
+        busy += 1
+      }
+    }
+
+    return busy
+  }, [sessionStateByRuntimeIdRef])
+
   const flushQueuedDeltas = useCallback(
-    (sessionId?: string) => {
+    (sessionId?: string, source: 'eager' | 'timer' = 'eager') => {
       const queue = queuedDeltasRef.current
       const ids = sessionId ? [sessionId] : [...queue.keys()]
+
+      // Ordering-sensitive events (tool rows, interim seals, completion) drain
+      // the queue OUTSIDE the instrumented timer flush — under an agentic turn
+      // that is where most of the apply cost actually runs, and it removes the
+      // session from the queue before the next timer flush can count it. Record
+      // these drains too (path: 'eager') or a tool-heavy thread is invisible.
+      // Same armed-guard economics as runFlush: one boolean test when disarmed.
+      const eager =
+        source === 'eager' && isDiagnosticsArmed()
+          ? { historyMessages: 0, queuedChars: 0, sessions: 0, startedAt: performance.now() }
+          : null
 
       for (const id of ids) {
         const queued = queue.get(id)
 
         if (!queued) {
           continue
+        }
+
+        if (eager) {
+          eager.sessions += 1
+          eager.queuedChars += queued.assistant.length
+
+          for (const delta of queued.reasoning) {
+            eager.queuedChars += delta.text.length
+          }
         }
 
         queue.delete(id)
@@ -245,9 +288,24 @@ export function useMessageStream({
             () => [reasoningPart(queued.reasoning)]
           )
         }
+
+        if (eager) {
+          eager.historyMessages += sessionStateByRuntimeIdRef.current.get(id)?.messages.length ?? 0
+        }
+      }
+
+      if (eager && eager.sessions > 0) {
+        recordStreamDeltaApplied({
+          busySessions: countBusySessions(),
+          historyMessages: eager.historyMessages,
+          path: 'eager',
+          queuedChars: eager.queuedChars,
+          sessions: eager.sessions,
+          writeMs: performance.now() - eager.startedAt
+        })
       }
     },
-    [mutateStream]
+    [countBusySessions, mutateStream, sessionStateByRuntimeIdRef]
   )
 
   const scheduleDeltaFlush = useCallback(() => {
@@ -294,7 +352,7 @@ export function useMessageStream({
       // Diagnostics reads the queue before it drains. Guarded on the armed flag
       // so a normal build does one boolean test per flush and allocates nothing.
       const pending = isDiagnosticsArmed() ? queuedDeltaSizes(queuedDeltasRef.current) : null
-      flushQueuedDeltas()
+      flushQueuedDeltas(undefined, 'timer')
       // The store write above is only the cheap half of a flush. While a
       // session streams, syncSessionStateToView defers the $messages publish
       // (and with it the React commit + Streamdown re-parse the floor is meant
@@ -315,10 +373,12 @@ export function useMessageStream({
       // renderer (no frame) still leaves the write-cost half on the record.
       const sample = pending
         ? recordStreamDeltaApplied({
+            busySessions: countBusySessions(),
             historyMessages: pending.sessionIds.reduce(
               (total, id) => total + (sessionStateByRuntimeIdRef.current.get(id)?.messages.length ?? 0),
               0
             ),
+            path: 'timer',
             queuedChars: pending.queuedChars,
             sessions: pending.sessions,
             writeMs: writeCost
@@ -369,7 +429,7 @@ export function useMessageStream({
     // in the worst case (a delta arriving before the unthrottle lands) the
     // clamp only stretches one flush to ~1s in a window nobody can see.
     flushHandleRef.current = window.setTimeout(runFlush, Math.max(0, adaptiveFloor - sinceLast))
-  }, [flushQueuedDeltas, sessionStateByRuntimeIdRef])
+  }, [countBusySessions, flushQueuedDeltas, sessionStateByRuntimeIdRef])
 
   const queueDelta = useCallback(
     (sessionId: string, key: keyof QueuedStreamDeltas, delta: string) => {
@@ -793,7 +853,7 @@ export function useMessageStream({
     [updateSessionState]
   )
 
-  const handleGatewayEvent = useGatewayEventHandler({
+  const dispatchGatewayEvent = useGatewayEventHandler({
     activeGatewayProfile,
     appendAssistantDelta,
     appendReasoningDelta,
@@ -812,6 +872,40 @@ export function useMessageStream({
     updateSessionState,
     upsertToolCall
   })
+
+  // Diagnostics wrapper around the dispatcher. The delta queue's flush events
+  // only see text streaming; everything else the gateway drives — tool-row
+  // upserts, subagent progress, session.info patches, terminal chunks — is
+  // applied synchronously inside the dispatch below and was invisible to a
+  // capture. Timing the dispatch as a whole covers every one of those paths by
+  // construction, with a floor so the ring only keeps rows that plausibly
+  // contributed to a dropped frame. Disarmed cost: one boolean test per event.
+  const handleGatewayEvent = useCallback(
+    (event: RpcEvent) => {
+      if (!isDiagnosticsArmed()) {
+        dispatchGatewayEvent(event)
+
+        return
+      }
+
+      const startedAt = performance.now()
+
+      try {
+        dispatchGatewayEvent(event)
+      } finally {
+        const durationMs = performance.now() - startedAt
+
+        if (durationMs >= GATEWAY_EVENT_RECORD_MIN_MS) {
+          recordGatewayEventApplied({
+            busySessions: countBusySessions(),
+            durationMs,
+            eventType: typeof event.type === 'string' ? event.type : 'unknown'
+          })
+        }
+      }
+    },
+    [countBusySessions, dispatchGatewayEvent]
+  )
 
   return {
     appendAssistantDelta,

--- a/apps/desktop/src/app/settings/diagnostics-settings.tsx
+++ b/apps/desktop/src/app/settings/diagnostics-settings.tsx
@@ -1,0 +1,178 @@
+// Local-only hitch-capture surface (U4).
+//
+// One action either way: "Start capture" arms the renderer, main and gateway
+// rings; "Stop & export" gathers all three, writes a sanitized bundle under
+// userData and reports where it landed plus how the exporter classified it.
+// There is no separate export step and nothing is uploaded — the user attaches
+// the directory by hand or does not.
+//
+// Deliberately minimal: no charts, no live event feed. Anything richer would
+// have to sample while a capture is running, which is exactly the cost the
+// whole design exists to avoid. Copy is hardcoded English, matching
+// `uninstall-section.tsx` — this is a support/triage surface, not product UI.
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import type { DesktopDiagnosticsExport } from '@/global'
+import { Activity, Bug, Loader2 } from '@/lib/icons'
+
+import { ListRow, Pill, SectionHeading, SettingsContent } from './primitives'
+
+/** Plain-English gloss per R3 label, so the classification is actionable
+ *  without opening classification.json. */
+const LABEL_HINTS: Record<string, string> = {
+  'gateway-bound': 'The backend event loop stalled — work on the gateway blocked everything downstream.',
+  'history-bound': 'Commit cost tracked transcript length — long sessions, not big updates.',
+  'ipc-transport-bound': 'Requests to the backend failed or timed out — the UI was waiting, not busy.',
+  'memory-gc-bound': 'Renderer heap grew or sat near its limit — GC pressure.',
+  'renderer-bound': 'The renderer main thread was busy — long animation frames.',
+  unclassified: 'Nothing crossed a threshold. Either the capture missed the hitch, or it was mild.'
+}
+
+export function DiagnosticsSettings() {
+  const bridge = window.hermesDesktop?.diagnosticsCapture
+
+  const [armed, setArmed] = useState(false)
+  const [captureId, setCaptureId] = useState<null | string>(null)
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<DesktopDiagnosticsExport | null>(null)
+  const [error, setError] = useState<null | string>(null)
+
+  useEffect(() => {
+    let alive = true
+
+    if (!bridge) {
+      return
+    }
+
+    void bridge
+      .status()
+      .then(status => {
+        if (alive) {
+          setArmed(Boolean(status?.armed))
+          setCaptureId(status?.captureId ?? null)
+        }
+      })
+      .catch(() => {
+        // A status probe that fails tells us nothing worth showing; the
+        // buttons still work and will report their own errors.
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [bridge])
+
+  if (!bridge) {
+    return null
+  }
+
+  const start = async () => {
+    setBusy(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const started = await bridge.start()
+
+      setArmed(true)
+      setCaptureId(started?.captureId ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const stop = async () => {
+    setBusy(true)
+    setError(null)
+
+    try {
+      const exported = await bridge.stop()
+
+      setArmed(false)
+      setCaptureId(null)
+      setResult(exported)
+
+      if (!exported) {
+        setError('No capture was running.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <SettingsContent>
+      <SectionHeading icon={Activity} title="Diagnostics capture" />
+
+      <p className="mb-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+        Records renderer, app and gateway timing into memory while armed, then writes a sanitized bundle to this
+        machine. Sizes, counts and durations only — no message text, tool output, credentials or paths. Nothing is
+        uploaded.
+      </p>
+
+      <ListRow
+        action={
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button disabled={busy || armed} onClick={() => void start()} size="sm" type="button" variant="outline">
+              {busy && !armed && <Loader2 className="size-3 animate-spin" />}
+              Start capture
+            </Button>
+            <Button disabled={busy || !armed} onClick={() => void stop()} size="sm" type="button" variant="outline">
+              {busy && armed && <Loader2 className="size-3 animate-spin" />}
+              Stop &amp; export
+            </Button>
+          </div>
+        }
+        description={
+          armed
+            ? 'Recording. Reproduce the hitch, then stop and export.'
+            : 'Start before the hitch — the buffer holds roughly the last five minutes.'
+        }
+        title={
+          <span className="flex items-center gap-2">
+            Capture
+            <Pill tone={armed ? 'primary' : 'muted'}>{armed ? 'Armed' : 'Idle'}</Pill>
+          </span>
+        }
+      />
+
+      {captureId && (
+        <p className="mt-1 font-mono text-[0.68rem] text-muted-foreground/60">Capture ID: {captureId}</p>
+      )}
+
+      {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+
+      {result && (
+        <div className="mt-4 rounded-xl border border-border/60 bg-background/40 px-4 py-3">
+          <SectionHeading icon={Bug} title="Last export" />
+
+          <p className="text-xs text-muted-foreground">
+            {result.labels.map(label => LABEL_HINTS[label] ?? label).join(' ')}
+          </p>
+
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {result.labels.map(label => (
+              <Pill key={label} tone={label === 'unclassified' ? 'muted' : 'warn'}>
+                {label}
+              </Pill>
+            ))}
+          </div>
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            {result.streams
+              .map(stream => `${stream.name}: ${stream.absent ? `absent (${stream.absent})` : `${stream.events} events`}`)
+              .join(' · ')}
+          </p>
+
+          <p className="mt-2 font-mono text-[0.68rem] break-all text-muted-foreground/60">{result.directory}</p>
+        </div>
+      )}
+    </SettingsContent>
+  )
+}

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -7,6 +7,7 @@ import { getHermesConfigDefaults, getHermesConfigRecord, saveHermesConfig } from
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import {
+  Activity,
   Archive,
   BarChart3,
   Bell,
@@ -35,6 +36,7 @@ import { AppearanceSettings } from './appearance-settings'
 import { BillingSettings } from './billing'
 import { ConfigSettings } from './config-settings'
 import { SECTIONS } from './constants'
+import { DiagnosticsSettings } from './diagnostics-settings'
 import { GatewaySettings } from './gateway-settings'
 import { KeybindSettings } from './keybind-settings'
 import { KEYS_VIEWS, KeysSettings, type KeysView } from './keys-settings'
@@ -54,6 +56,7 @@ const SETTINGS_VIEWS: readonly SettingsViewId[] = [
   'billing',
   'plugins',
   'sessions',
+  'diagnostics',
   'about'
 ]
 
@@ -251,8 +254,15 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
         onSelect: () => setActiveView('sessions')
       },
       {
-        active: activeView === 'about',
+        active: activeView === 'diagnostics',
         gapBefore: true,
+        icon: Activity,
+        id: 'diagnostics',
+        label: 'Diagnostics',
+        onSelect: () => setActiveView('diagnostics')
+      },
+      {
+        active: activeView === 'about',
         icon: Info,
         id: 'about',
         label: t.settings.nav.about,
@@ -330,6 +340,8 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
             <BillingSettings />
           ) : activeView === 'plugins' ? (
             <PluginsSettings />
+          ) : activeView === 'diagnostics' ? (
+            <DiagnosticsSettings />
           ) : (
             <SessionsSettings />
           )}

--- a/apps/desktop/src/app/settings/types.ts
+++ b/apps/desktop/src/app/settings/types.ts
@@ -7,6 +7,7 @@ import type { EnvVarInfo } from '@/types/hermes'
 export type SettingsView =
   | 'about'
   | 'billing'
+  | 'diagnostics'
   | 'gateway'
   | 'keybinds'
   | 'keys'

--- a/apps/desktop/src/debug/perf-live.ts
+++ b/apps/desktop/src/debug/perf-live.ts
@@ -15,7 +15,12 @@
 //   window.__PERF_LIVE__.off()
 //   window.__PERF_LIVE__.last()    the most recent report as an object
 //
-// Dev-only; the whole debug/ graph is aliased out of production builds.
+// Dev-only; the whole debug/ graph is aliased out of production builds. The
+// LoAF observer + attribution core it uses is NOT dev-only: it lives in
+// `@/diagnostics` so the production capture module shares one implementation
+// (KTD1).
+
+import { createLongFrameObserver, type LongFrameSample } from '@/diagnostics/long-frames'
 
 interface Sample {
   kind: string
@@ -30,17 +35,11 @@ interface Sample {
   longFrames: LongFrame[]
 }
 
-/** One Long Animation Frame, attributed. `styleMs` is the engine's style+layout
- *  time inside the frame; `scripts` names who ran JS and for how long. This is
- *  the half the render counter cannot see — a frame can cost 900ms with almost
- *  no React in it, and only LoAF says whether that was layout, a ResizeObserver
- *  callback loop, or some timer. */
-interface LongFrame {
-  ms: number
-  styleMs: number
-  blockingMs: number
-  scripts: Array<{ invoker: string; ms: number; src: string }>
-}
+/** One Long Animation Frame, attributed — see `@/diagnostics/long-frames`.
+ *  This is the half the render counter cannot see: a frame can cost 900ms with
+ *  almost no React in it, and only LoAF says whether that was layout, a
+ *  ResizeObserver callback loop, or some timer. */
+type LongFrame = LongFrameSample
 
 const RESIZE_SELECTOR =
   '[role="separator"], [data-slot="pane-resize-handle"], [class*="cursor-col-resize"], [class*="cursor-row-resize"]'
@@ -70,44 +69,13 @@ let lastReport: null | Sample = null
 // half of a frame the render counter cannot see.
 let longFrames: LongFrame[] = []
 
-const loafObserver =
-  typeof PerformanceObserver !== 'undefined' &&
-  PerformanceObserver.supportedEntryTypes?.includes('long-animation-frame')
-    ? new PerformanceObserver(list => {
-        if (!active) {
-          return
-        }
+const loafObserver = createLongFrameObserver(sample => {
+  if (!active) {
+    return
+  }
 
-        for (const entry of list.getEntries()) {
-          const e = entry as PerformanceEntry & {
-            blockingDuration?: number
-            styleAndLayoutStart?: number
-            renderStart?: number
-            scripts?: Array<{
-              duration: number
-              invoker?: string
-              invokerType?: string
-              sourceURL?: string
-              sourceFunctionName?: string
-            }>
-          }
-
-          longFrames.push({
-            blockingMs: Math.round(e.blockingDuration ?? 0),
-            ms: Math.round(e.duration),
-            scripts: (e.scripts ?? [])
-              .filter(s => s.duration >= 5)
-              .map(s => ({
-                invoker: `${s.invokerType ?? ''}:${s.invoker ?? s.sourceFunctionName ?? '?'}`,
-                ms: Math.round(s.duration),
-                src: (s.sourceURL ?? '').split('/').pop() ?? ''
-              })),
-            // styleAndLayoutStart -> frame end is the engine's style+layout tail.
-            styleMs: e.styleAndLayoutStart ? Math.round(e.startTime + e.duration - e.styleAndLayoutStart) : 0
-          })
-        }
-      })
-    : null
+  longFrames.push(sample)
+})
 
 const pct = (sorted: number[], p: number) =>
   sorted.length ? sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] : 0
@@ -120,7 +88,7 @@ function finish() {
   const { kind, startedAt, frames, raf } = active
   active = null
   cancelAnimationFrame(raf)
-  loafObserver?.disconnect()
+  loafObserver?.stop()
   const capturedLongFrames = longFrames
   longFrames = []
 
@@ -193,13 +161,10 @@ function begin(kind: string) {
 
   window.__RENDER_COUNTS__?.start()
 
-  try {
-    // Buffered so a long frame already in flight when the gesture starts is
-    // still attributed to it.
-    loafObserver?.observe({ buffered: true, type: 'long-animation-frame' })
-  } catch {
-    // Older runtime without LoAF — headline still works, attribution is empty.
-  }
+  // Buffered observation (a long frame already in flight when the gesture
+  // starts is still attributed to it) is handled inside the shared observer;
+  // on a runtime without LoAF there is no observer and attribution is empty.
+  loafObserver?.start()
 
   const now = performance.now()
 

--- a/apps/desktop/src/diagnostics/arming-bridge.test.ts
+++ b/apps/desktop/src/diagnostics/arming-bridge.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The bridge memoises its teardown at module scope, so each test imports a
+// fresh copy after installing its own fake preload. `capture` comes from the
+// SAME fresh registry — the bridge closes over that instance's module-level
+// `armed`, so a stale import would arm a different module.
+async function loadBridge() {
+  vi.resetModules()
+
+  const [bridge, capture] = await Promise.all([import('./arming-bridge'), import('./capture')])
+
+  return { ...bridge, ...capture }
+}
+
+function installBridge(overrides: Record<string, unknown> = {}) {
+  const state: {
+    arm?: (payload: unknown) => void
+    disarm?: () => void
+    provider?: (captureId: string) => unknown
+    unsubscribed: string[]
+  } = { unsubscribed: [] }
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      diagnostics: {
+        onArm: (callback: (payload: unknown) => void) => {
+          state.arm = callback
+
+          return () => state.unsubscribed.push('arm')
+        },
+        onDisarm: (callback: () => void) => {
+          state.disarm = callback
+
+          return () => state.unsubscribed.push('disarm')
+        },
+        setSnapshotProvider: (provider: (captureId: string) => unknown) => {
+          state.provider = provider
+
+          return () => state.unsubscribed.push('snapshot')
+        },
+        ...overrides
+      }
+    }
+  })
+
+  return state
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window as never, 'hermesDesktop')
+  vi.resetModules()
+})
+
+describe('initDiagnosticsSnapshots', () => {
+  it('answers main with the running capture snapshot', async () => {
+    const state = installBridge()
+    const { armDiagnostics, initDiagnosticsSnapshots } = await loadBridge()
+
+    initDiagnosticsSnapshots()
+    expect(state.provider).toBeTypeOf('function')
+
+    armDiagnostics('cap-abc', 1_700_000_000_000)
+
+    const snapshot = state.provider!('cap-abc') as { captureId: string; events: unknown[] }
+
+    expect(snapshot.captureId).toBe('cap-abc')
+    expect(Array.isArray(snapshot.events)).toBe(true)
+  })
+
+  it('answers null while disarmed', async () => {
+    const state = installBridge()
+    const { initDiagnosticsSnapshots } = await loadBridge()
+
+    initDiagnosticsSnapshots()
+
+    expect(state.provider!('cap-abc')).toBeNull()
+  })
+
+  it('refuses to answer for a different capture id', async () => {
+    const state = installBridge()
+    const { armDiagnostics, initDiagnosticsSnapshots } = await loadBridge()
+
+    initDiagnosticsSnapshots()
+    armDiagnostics('cap-abc', 1_700_000_000_000)
+
+    // A stale snapshot filed under the wrong capture would break the KTD3
+    // alignment silently; contributing nothing is the safe answer.
+    expect(state.provider!('cap-other')).toBeNull()
+    expect((state.provider!('cap-abc') as { captureId: string }).captureId).toBe('cap-abc')
+  })
+
+  it('is idempotent and unsubscribes on teardown', async () => {
+    const state = installBridge()
+    const { initDiagnosticsSnapshots } = await loadBridge()
+
+    const first = initDiagnosticsSnapshots()
+
+    expect(initDiagnosticsSnapshots()).toBe(first)
+
+    first()
+    expect(state.unsubscribed).toContain('snapshot')
+  })
+
+  it('is a no-op against a preload without setSnapshotProvider', async () => {
+    installBridge({ setSnapshotProvider: undefined })
+    const { initDiagnosticsSnapshots } = await loadBridge()
+
+    expect(() => initDiagnosticsSnapshots()()).not.toThrow()
+  })
+
+  it('is a no-op with no diagnostics bridge at all', async () => {
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: {} })
+    const { initDiagnosticsSnapshots } = await loadBridge()
+
+    expect(() => initDiagnosticsSnapshots()()).not.toThrow()
+  })
+})

--- a/apps/desktop/src/diagnostics/arming-bridge.ts
+++ b/apps/desktop/src/diagnostics/arming-bridge.ts
@@ -1,0 +1,53 @@
+// Renderer end of the diagnostics arming contract.
+//
+// The capture controller lives in Electron main (it is the only process that
+// can reach the renderer AND the gateway), so main owns the capture id and the
+// wall-clock anchor and pushes them down:
+//
+//   main → renderer  'diagnostics:arm'     { captureId, wallClockAnchorMs }
+//   main → renderer  'diagnostics:disarm'  (no payload)
+//
+// Both arrive through the usual preload subscription shape
+// (`window.hermesDesktop.diagnostics.onArm/onDisarm`, each returning its own
+// unsubscribe). The bridge is optional at runtime: a renderer running against a
+// preload without the diagnostics surface (older shell, tests, the browser
+// harness) simply never arms, which is the disarmed — zero cost — state.
+
+import { armDiagnostics, disarmDiagnostics } from './capture'
+
+export interface DiagnosticsArmPayload {
+  captureId: string
+  wallClockAnchorMs: number
+}
+
+let teardown: null | (() => void) = null
+
+/** Subscribe to main's arm/disarm pushes. Idempotent; returns the unsubscribe. */
+export function initDiagnosticsArming(): () => void {
+  if (teardown) {
+    return teardown
+  }
+
+  const bridge = typeof window === 'undefined' ? undefined : window.hermesDesktop?.diagnostics
+
+  if (!bridge) {
+    return () => undefined
+  }
+
+  const offArm = bridge.onArm(payload => {
+    if (payload && typeof payload.captureId === 'string') {
+      armDiagnostics(payload.captureId, Number(payload.wallClockAnchorMs) || Date.now())
+    }
+  })
+
+  const offDisarm = bridge.onDisarm(() => disarmDiagnostics())
+
+  teardown = () => {
+    offArm()
+    offDisarm()
+    teardown = null
+    disarmDiagnostics()
+  }
+
+  return teardown
+}

--- a/apps/desktop/src/diagnostics/arming-bridge.ts
+++ b/apps/desktop/src/diagnostics/arming-bridge.ts
@@ -6,14 +6,22 @@
 //
 //   main → renderer  'diagnostics:arm'     { captureId, wallClockAnchorMs }
 //   main → renderer  'diagnostics:disarm'  (no payload)
+//   main → renderer  'diagnostics:collect' { requestId, captureId }  (U4)
 //
-// Both arrive through the usual preload subscription shape
+// The first two arrive through the usual preload subscription shape
 // (`window.hermesDesktop.diagnostics.onArm/onDisarm`, each returning its own
 // unsubscribe). The bridge is optional at runtime: a renderer running against a
 // preload without the diagnostics surface (older shell, tests, the browser
 // harness) simply never arms, which is the disarmed — zero cost — state.
+//
+// The third is a PULL at export time, and preload answers it on this module's
+// behalf: `setSnapshotProvider` hands preload a function, preload owns the
+// channel and the reply correlation. Without this registration a window is
+// armed but silent — it records events into its ring and never contributes
+// them to a bundle — so `initDiagnosticsSnapshots()` runs beside
+// `initDiagnosticsArming()` at renderer startup.
 
-import { armDiagnostics, disarmDiagnostics } from './capture'
+import { armDiagnostics, disarmDiagnostics, readDiagnosticsCapture } from './capture'
 
 export interface DiagnosticsArmPayload {
   captureId: string
@@ -21,6 +29,7 @@ export interface DiagnosticsArmPayload {
 }
 
 let teardown: null | (() => void) = null
+let snapshotTeardown: null | (() => void) = null
 
 /** Subscribe to main's arm/disarm pushes. Idempotent; returns the unsubscribe. */
 export function initDiagnosticsArming(): () => void {
@@ -50,4 +59,42 @@ export function initDiagnosticsArming(): () => void {
   }
 
   return teardown
+}
+
+/**
+ * Register this renderer's snapshot source for main's export-time collect pull.
+ * Idempotent; returns the unsubscribe.
+ *
+ * The provider answers with the running capture's snapshot, or null when this
+ * window is disarmed or is answering for a *different* capture — a stale
+ * snapshot would land in the bundle under the wrong capture id and silently
+ * corrupt the KTD3 alignment, so it is better to contribute nothing.
+ */
+export function initDiagnosticsSnapshots(): () => void {
+  if (snapshotTeardown) {
+    return snapshotTeardown
+  }
+
+  const register = typeof window === 'undefined' ? undefined : window.hermesDesktop?.diagnostics?.setSnapshotProvider
+
+  if (!register) {
+    return () => undefined
+  }
+
+  const off = register(captureId => {
+    const snapshot = readDiagnosticsCapture()
+
+    if (!snapshot || (captureId && snapshot.captureId !== captureId)) {
+      return null
+    }
+
+    return snapshot
+  })
+
+  snapshotTeardown = () => {
+    off()
+    snapshotTeardown = null
+  }
+
+  return snapshotTeardown
 }

--- a/apps/desktop/src/diagnostics/capture.test.ts
+++ b/apps/desktop/src/diagnostics/capture.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  armDiagnostics,
+  disarmDiagnostics,
+  isDiagnosticsArmed,
+  type LongFrameEvent,
+  readDiagnosticsCapture,
+  recordStreamDeltaApplied
+} from './capture'
+
+// jsdom ships no PerformanceObserver, and even where it does there is no way to
+// provoke a real Long Animation Frame in a test environment. Stand in for the
+// engine: count constructions (the "zero observers when disarmed" claim) and
+// feed a synthetic LoAF entry shaped exactly like Chromium's.
+class FakePerformanceObserver {
+  static supportedEntryTypes = ['long-animation-frame', 'longtask']
+  static instances: FakePerformanceObserver[] = []
+
+  observed: PerformanceObserverInit[] = []
+  disconnected = false
+
+  constructor(private readonly callback: PerformanceObserverCallback) {
+    FakePerformanceObserver.instances.push(this)
+  }
+
+  observe(options: PerformanceObserverInit) {
+    this.observed.push(options)
+  }
+
+  disconnect() {
+    this.disconnected = true
+  }
+
+  takeRecords() {
+    return [] as PerformanceEntryList
+  }
+
+  emit(entries: unknown[]) {
+    this.callback(
+      { getEntries: () => entries as PerformanceEntryList } as PerformanceObserverEntryList,
+      this as unknown as PerformanceObserver
+    )
+  }
+}
+
+// A 200ms long animation frame whose script attribution names a bundle behind a
+// deep path — the path must not survive into the buffer.
+const longAnimationFrameEntry = {
+  blockingDuration: 154,
+  duration: 204,
+  scripts: [
+    {
+      duration: 198,
+      invoker: 'TIMER',
+      invokerType: 'user-callback',
+      sourceFunctionName: 'runFlush',
+      sourceURL: 'https://app.local/home/PRIVATE_MARKER/assets/index-abc123.js'
+    },
+    // Below the 5ms attribution floor: noise in every real frame.
+    { duration: 1, invoker: 'IntersectionObserver', invokerType: 'user-callback', sourceURL: 'https://app.local/x.js' }
+  ],
+  startTime: 1_000,
+  styleAndLayoutStart: 1_180
+}
+
+const originalPerformanceObserver = globalThis.PerformanceObserver
+
+describe('renderer diagnostics capture', () => {
+  beforeEach(() => {
+    FakePerformanceObserver.instances = []
+    globalThis.PerformanceObserver = FakePerformanceObserver as unknown as typeof PerformanceObserver
+  })
+
+  afterEach(() => {
+    disarmDiagnostics()
+    globalThis.PerformanceObserver = originalPerformanceObserver
+    vi.restoreAllMocks()
+  })
+
+  it('registers no observers and records nothing while disarmed', () => {
+    expect(isDiagnosticsArmed()).toBe(false)
+
+    // The per-delta entry point on the stream flush path: a single boolean read
+    // and out, with nowhere for the sample to land.
+    expect(recordStreamDeltaApplied({ historyMessages: 40, queuedChars: 12, sessions: 1, writeMs: 3 })).toBeNull()
+
+    expect(FakePerformanceObserver.instances).toHaveLength(0)
+    expect(readDiagnosticsCapture()).toBeNull()
+  })
+
+  it('registers the LoAF observer on the arm edge and tears it down on disarm', () => {
+    armDiagnostics('capture-1', 1_700_000_000_000)
+
+    expect(isDiagnosticsArmed()).toBe(true)
+    expect(FakePerformanceObserver.instances).toHaveLength(1)
+    expect(FakePerformanceObserver.instances[0].observed).toEqual([{ buffered: true, type: 'long-animation-frame' }])
+
+    disarmDiagnostics()
+
+    expect(isDiagnosticsArmed()).toBe(false)
+    expect(FakePerformanceObserver.instances[0].disconnected).toBe(true)
+    expect(readDiagnosticsCapture()).toBeNull()
+  })
+
+  it('records a 200ms long frame with attribution while armed', () => {
+    armDiagnostics('capture-2', 1_700_000_000_000)
+    FakePerformanceObserver.instances[0].emit([longAnimationFrameEntry])
+
+    const snapshot = readDiagnosticsCapture()
+    expect(snapshot?.captureId).toBe('capture-2')
+
+    const longFrames = (snapshot?.events ?? []).filter((e): e is LongFrameEvent => e.type === 'long_frame')
+    expect(longFrames).toHaveLength(1)
+
+    const [frame] = longFrames
+    expect(frame.ms).toBe(204)
+    expect(frame.blockingMs).toBe(154)
+    // startTime + duration - styleAndLayoutStart = the style+layout tail.
+    expect(frame.styleMs).toBe(24)
+    expect(frame.t).toBeGreaterThanOrEqual(0)
+    // Only the >=5ms script is attributed.
+    expect(frame.scripts).toHaveLength(1)
+    expect(frame.scripts[0].ms).toBe(198)
+    expect(frame.scripts[0].invoker).toBe('user-callback:TIMER')
+  })
+
+  it('sanitizes attribution at record time — no paths reach the buffer', () => {
+    armDiagnostics('capture-3', 1_700_000_000_000)
+    FakePerformanceObserver.instances[0].emit([longAnimationFrameEntry])
+
+    const serialized = JSON.stringify(readDiagnosticsCapture()?.events ?? [])
+
+    expect(serialized).not.toContain('PRIVATE_MARKER')
+    expect(serialized).not.toContain('https://')
+    expect(serialized).not.toContain('/')
+    // The bare file name survives — that is the useful, non-identifying part.
+    expect(serialized).toContain('index-abc123.js')
+  })
+
+  it('records stream-delta samples as counts and durations only', () => {
+    armDiagnostics('capture-4', 1_700_000_000_000)
+
+    const event = recordStreamDeltaApplied({ historyMessages: 412, queuedChars: 87, sessions: 2, writeMs: 4.567 })
+
+    expect(event).not.toBeNull()
+    expect(event).toMatchObject({
+      commitMs: 0,
+      historyMessages: 412,
+      queuedChars: 87,
+      rafGapMs: 0,
+      sessions: 2,
+      type: 'stream_delta_applied',
+      writeMs: 4.57
+    })
+
+    // The caller's existing measurement rAF fills the commit half in place —
+    // one event per flush, not two.
+    event!.commitMs = 61.2
+    expect(readDiagnosticsCapture()?.events).toEqual([expect.objectContaining({ commitMs: 61.2 })])
+  })
+
+  it('re-arms with a fresh buffer under a new capture id without a reload', () => {
+    armDiagnostics('capture-5', 1_700_000_000_000)
+    recordStreamDeltaApplied({ historyMessages: 1, queuedChars: 1, sessions: 1, writeMs: 1 })
+    expect(readDiagnosticsCapture()?.events).toHaveLength(1)
+
+    armDiagnostics('capture-6', 1_700_000_000_001)
+
+    expect(readDiagnosticsCapture()?.captureId).toBe('capture-6')
+    expect(readDiagnosticsCapture()?.events).toHaveLength(0)
+    expect(FakePerformanceObserver.instances).toHaveLength(2)
+    expect(FakePerformanceObserver.instances[0].disconnected).toBe(true)
+  })
+
+  it('samples the heap on a timer while armed and stops on disarm', () => {
+    vi.useFakeTimers()
+
+    Object.defineProperty(performance, 'memory', {
+      configurable: true,
+      value: {
+        jsHeapSizeLimit: 4 * 1024 * 1024 * 1024,
+        totalJSHeapSize: 900 * 1024 * 1024,
+        usedJSHeapSize: 762 * 1024 * 1024
+      }
+    })
+
+    try {
+      armDiagnostics('capture-7', 1_700_000_000_000)
+
+      expect(readDiagnosticsCapture()?.events).toEqual([
+        expect.objectContaining({ limitMb: 4096, totalMb: 900, type: 'memory_sample', usedMb: 762 })
+      ])
+
+      vi.advanceTimersByTime(15_000)
+      expect(readDiagnosticsCapture()?.events).toHaveLength(4)
+
+      disarmDiagnostics()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      Reflect.deleteProperty(performance, 'memory')
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/desktop/src/diagnostics/capture.test.ts
+++ b/apps/desktop/src/diagnostics/capture.test.ts
@@ -6,6 +6,7 @@ import {
   isDiagnosticsArmed,
   type LongFrameEvent,
   readDiagnosticsCapture,
+  recordGatewayEventApplied,
   recordStreamDeltaApplied
 } from './capture'
 
@@ -83,7 +84,19 @@ describe('renderer diagnostics capture', () => {
 
     // The per-delta entry point on the stream flush path: a single boolean read
     // and out, with nowhere for the sample to land.
-    expect(recordStreamDeltaApplied({ historyMessages: 40, queuedChars: 12, sessions: 1, writeMs: 3 })).toBeNull()
+    expect(
+      recordStreamDeltaApplied({
+        busySessions: 1,
+        historyMessages: 40,
+        path: 'timer',
+        queuedChars: 12,
+        sessions: 1,
+        writeMs: 3
+      })
+    ).toBeNull()
+
+    // Same contract for the dispatch-cost entry point.
+    recordGatewayEventApplied({ busySessions: 1, durationMs: 12, eventType: 'tool.complete' })
 
     expect(FakePerformanceObserver.instances).toHaveLength(0)
     expect(readDiagnosticsCapture()).toBeNull()
@@ -141,12 +154,21 @@ describe('renderer diagnostics capture', () => {
   it('records stream-delta samples as counts and durations only', () => {
     armDiagnostics('capture-4', 1_700_000_000_000)
 
-    const event = recordStreamDeltaApplied({ historyMessages: 412, queuedChars: 87, sessions: 2, writeMs: 4.567 })
+    const event = recordStreamDeltaApplied({
+      busySessions: 3,
+      historyMessages: 412,
+      path: 'eager',
+      queuedChars: 87,
+      sessions: 2,
+      writeMs: 4.567
+    })
 
     expect(event).not.toBeNull()
     expect(event).toMatchObject({
+      busySessions: 3,
       commitMs: 0,
       historyMessages: 412,
+      path: 'eager',
       queuedChars: 87,
       rafGapMs: 0,
       sessions: 2,
@@ -160,9 +182,24 @@ describe('renderer diagnostics capture', () => {
     expect(readDiagnosticsCapture()?.events).toEqual([expect.objectContaining({ commitMs: 61.2 })])
   })
 
+  it('records gateway-event dispatch costs as type tags and durations only', () => {
+    armDiagnostics('capture-events', 1_700_000_000_000)
+
+    recordGatewayEventApplied({ busySessions: 2, durationMs: 17.456, eventType: 'subagent.progress' })
+
+    expect(readDiagnosticsCapture()?.events).toEqual([
+      expect.objectContaining({
+        busySessions: 2,
+        durationMs: 17.46,
+        eventType: 'subagent.progress',
+        type: 'gateway_event_applied'
+      })
+    ])
+  })
+
   it('re-arms with a fresh buffer under a new capture id without a reload', () => {
     armDiagnostics('capture-5', 1_700_000_000_000)
-    recordStreamDeltaApplied({ historyMessages: 1, queuedChars: 1, sessions: 1, writeMs: 1 })
+    recordStreamDeltaApplied({ busySessions: 1, historyMessages: 1, path: 'timer', queuedChars: 1, sessions: 1, writeMs: 1 })
     expect(readDiagnosticsCapture()?.events).toHaveLength(1)
 
     armDiagnostics('capture-6', 1_700_000_000_001)

--- a/apps/desktop/src/diagnostics/capture.ts
+++ b/apps/desktop/src/diagnostics/capture.ts
@@ -1,0 +1,228 @@
+// Renderer-side diagnostics capture — the production half of what
+// `src/debug/perf-live.ts` does in dev.
+//
+// The point of this module is that it ships. Hitches happen in the packaged
+// app, where the dev profiler and the CDP harness do not exist, so the capture
+// has to be present in a normal build and cost nothing until the user arms it.
+// Two properties keep that honest:
+//
+//   1. Disarmed means ZERO observers, ZERO timers, ZERO allocation. Every
+//      record entry point returns on a single boolean read; the LoAF observer
+//      and the memory sampler are constructed on the arm edge and torn down on
+//      the disarm edge, so arming needs no restart.
+//   2. Sanitization happens at RECORD time, not export time (R2). Only counts,
+//      sizes, durations and IDs are ever written into the ring buffer, so a
+//      buffer that leaks (a crash dump, a bug report) cannot leak content.
+//
+// The capture id and wall-clock anchor come from the capture controller in
+// Electron main (KTD3), so this stream can be aligned against the main-process
+// and gateway streams at export despite each process using its own monotonic
+// clock.
+
+import { createLongFrameObserver, type LongFrameScript } from './long-frames'
+import { DiagnosticsRingBuffer } from './ring-buffer'
+
+// ~300s of events (KTD2). The count/byte caps are what actually bound memory;
+// the age cap is what keeps a capture left armed all afternoon relevant.
+const CAPTURE_WINDOW_MS = 300_000
+const MAX_EVENTS = 6_000
+const MAX_BYTES = 2_000_000
+const MEMORY_SAMPLE_INTERVAL_MS = 5_000
+
+const BYTES_PER_MB = 1024 * 1024
+
+interface DiagnosticsEventBase {
+  /** `performance.now()` at record time — monotonic, aligned at export. */
+  t: number
+}
+
+export interface LongFrameEvent extends DiagnosticsEventBase {
+  type: 'long_frame'
+  ms: number
+  styleMs: number
+  blockingMs: number
+  scripts: LongFrameScript[]
+}
+
+export interface StreamDeltaAppliedEvent extends DiagnosticsEventBase {
+  type: 'stream_delta_applied'
+  /** Sessions whose queued deltas this flush applied. */
+  sessions: number
+  /** Characters applied — a size, never the text. */
+  queuedChars: number
+  /** Transcript length those sessions carry after the apply. */
+  historyMessages: number
+  /** Synchronous store-write cost of the flush. */
+  writeMs: number
+  /** In-frame cost of the deferred view sync + React commit, or 0 while the
+   *  measurement frame is still pending (or never fires — hidden renderer). */
+  commitMs: number
+  /** Flush start → the measurement frame's start: how long the commit waited
+   *  for a frame. Stays 0 when no frame arrives. */
+  rafGapMs: number
+}
+
+export interface MemorySampleEvent extends DiagnosticsEventBase {
+  type: 'memory_sample'
+  usedMb: number
+  totalMb: number
+  limitMb: number
+}
+
+export type DiagnosticsEvent = LongFrameEvent | MemorySampleEvent | StreamDeltaAppliedEvent
+
+export interface DiagnosticsCaptureSnapshot {
+  captureId: string
+  /** Date.now() at arm time, supplied by main — the cross-process anchor. */
+  wallClockAnchorMs: number
+  /** performance.now() at arm time, so event `t` values can be shifted onto
+   *  the wall clock without trusting this renderer's Date.now(). */
+  monotonicAnchorMs: number
+  events: DiagnosticsEvent[]
+  droppedEvents: number
+}
+
+interface ArmedCapture {
+  captureId: string
+  wallClockAnchorMs: number
+  monotonicAnchorMs: number
+  buffer: DiagnosticsRingBuffer<DiagnosticsEvent>
+  longFrames: null | { stop: () => void }
+  memoryTimer: null | ReturnType<typeof setInterval>
+}
+
+// The single hot-path read. Module-level so `isDiagnosticsArmed()` compiles to
+// a null check, not a lookup through a store or a React context.
+let armed: ArmedCapture | null = null
+
+/** Cheap guard for instrumentation on hot paths: skip all sampling work when
+ *  no capture is running. */
+export const isDiagnosticsArmed = () => armed !== null
+
+/** The running capture's id, or null. */
+export const activeCaptureId = () => armed?.captureId ?? null
+
+interface MemoryPerformance extends Performance {
+  memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number }
+}
+
+function sampleMemory(): void {
+  const memory = (performance as MemoryPerformance).memory
+
+  if (!armed || !memory) {
+    return
+  }
+
+  armed.buffer.push({
+    limitMb: Math.round(memory.jsHeapSizeLimit / BYTES_PER_MB),
+    t: performance.now(),
+    totalMb: Math.round(memory.totalJSHeapSize / BYTES_PER_MB),
+    type: 'memory_sample',
+    usedMb: Math.round(memory.usedJSHeapSize / BYTES_PER_MB)
+  })
+}
+
+/** Start a capture. Re-arming with the same id is a no-op; re-arming with a new
+ *  id restarts cleanly, so main can drive this without a renderer reload. */
+export function armDiagnostics(captureId: string, wallClockAnchorMs: number): void {
+  if (armed?.captureId === captureId) {
+    return
+  }
+
+  disarmDiagnostics()
+
+  const capture: ArmedCapture = {
+    buffer: new DiagnosticsRingBuffer<DiagnosticsEvent>({
+      maxAgeMs: CAPTURE_WINDOW_MS,
+      maxBytes: MAX_BYTES,
+      maxEvents: MAX_EVENTS
+    }),
+    captureId,
+    longFrames: null,
+    memoryTimer: null,
+    monotonicAnchorMs: performance.now(),
+    wallClockAnchorMs
+  }
+
+  armed = capture
+
+  const longFrames = createLongFrameObserver(sample => {
+    if (armed !== capture) {
+      return
+    }
+
+    capture.buffer.push({ ...sample, t: performance.now(), type: 'long_frame' })
+  })
+
+  if (longFrames) {
+    longFrames.start()
+    capture.longFrames = longFrames
+  }
+
+  // A periodic heap sample is what separates "memory/GC-bound" from the other
+  // classifications (R3); Chromium only exposes it in the renderer.
+  if ((performance as MemoryPerformance).memory) {
+    capture.memoryTimer = setInterval(sampleMemory, MEMORY_SAMPLE_INTERVAL_MS)
+    sampleMemory()
+  }
+}
+
+/** Stop the capture and release every observer/timer it registered. The buffer
+ *  goes with it — read it with `readDiagnosticsCapture()` first. */
+export function disarmDiagnostics(): void {
+  if (!armed) {
+    return
+  }
+
+  armed.longFrames?.stop()
+
+  if (armed.memoryTimer !== null) {
+    clearInterval(armed.memoryTimer)
+  }
+
+  armed.buffer.clear()
+  armed = null
+}
+
+/** Snapshot the running capture for export (U4). Null when disarmed. */
+export function readDiagnosticsCapture(): DiagnosticsCaptureSnapshot | null {
+  if (!armed) {
+    return null
+  }
+
+  return {
+    captureId: armed.captureId,
+    droppedEvents: armed.buffer.droppedCount,
+    events: armed.buffer.entries(),
+    monotonicAnchorMs: armed.monotonicAnchorMs,
+    wallClockAnchorMs: armed.wallClockAnchorMs
+  }
+}
+
+export interface StreamDeltaSample {
+  sessions: number
+  queuedChars: number
+  historyMessages: number
+  writeMs: number
+}
+
+/** Record one applied stream-delta flush. Returns the stored event so the
+ *  caller's existing commit-cost rAF can fill `commitMs`/`rafGapMs` in place
+ *  when the frame lands — one event per flush, and no second measurement pass.
+ *  Returns null when disarmed, which is the caller's cue to do nothing. */
+export function recordStreamDeltaApplied(sample: StreamDeltaSample): StreamDeltaAppliedEvent | null {
+  if (!armed) {
+    return null
+  }
+
+  return armed.buffer.push({
+    commitMs: 0,
+    historyMessages: Math.round(sample.historyMessages),
+    queuedChars: Math.round(sample.queuedChars),
+    rafGapMs: 0,
+    sessions: Math.round(sample.sessions),
+    t: performance.now(),
+    type: 'stream_delta_applied',
+    writeMs: Math.round(sample.writeMs * 100) / 100
+  }) as StreamDeltaAppliedEvent
+}

--- a/apps/desktop/src/diagnostics/capture.ts
+++ b/apps/desktop/src/diagnostics/capture.ts
@@ -60,6 +60,29 @@ export interface StreamDeltaAppliedEvent extends DiagnosticsEventBase {
   /** Flush start → the measurement frame's start: how long the commit waited
    *  for a frame. Stays 0 when no frame arrives. */
   rafGapMs: number
+  /** Which flush drained the queue: the batched timer flush, or an eager
+   *  drain forced by an ordering-sensitive event (tool rows, interim seals,
+   *  turn completion). Eager drains skip the commit-measurement frame, so
+   *  their `commitMs`/`rafGapMs` stay 0 by construction. */
+  path: 'eager' | 'timer'
+  /** Sessions with a turn in flight at record time — concurrent threads, not
+   *  just the ones with text queued in THIS flush (`sessions` above). This is
+   *  the multi-chat attribution signal: a second thread doing tool-call work
+   *  contributes render load without ever entering the delta queue. */
+  busySessions: number
+}
+
+export interface GatewayEventAppliedEvent extends DiagnosticsEventBase {
+  type: 'gateway_event_applied'
+  /** The gateway event's type tag (`tool.complete`, `subagent.progress`, …) —
+   *  an identifier, never payload content. */
+  eventType: string
+  /** Synchronous main-thread cost of dispatching the event: store writes,
+   *  eager flushes, tool-row upserts — everything the handler did in place. */
+  durationMs: number
+  /** Sessions with a turn in flight at record time (see
+   *  StreamDeltaAppliedEvent.busySessions). */
+  busySessions: number
 }
 
 export interface MemorySampleEvent extends DiagnosticsEventBase {
@@ -69,7 +92,7 @@ export interface MemorySampleEvent extends DiagnosticsEventBase {
   limitMb: number
 }
 
-export type DiagnosticsEvent = LongFrameEvent | MemorySampleEvent | StreamDeltaAppliedEvent
+export type DiagnosticsEvent = GatewayEventAppliedEvent | LongFrameEvent | MemorySampleEvent | StreamDeltaAppliedEvent
 
 export interface DiagnosticsCaptureSnapshot {
   captureId: string
@@ -204,6 +227,8 @@ export interface StreamDeltaSample {
   queuedChars: number
   historyMessages: number
   writeMs: number
+  path: 'eager' | 'timer'
+  busySessions: number
 }
 
 /** Record one applied stream-delta flush. Returns the stored event so the
@@ -216,8 +241,10 @@ export function recordStreamDeltaApplied(sample: StreamDeltaSample): StreamDelta
   }
 
   return armed.buffer.push({
+    busySessions: Math.round(sample.busySessions),
     commitMs: 0,
     historyMessages: Math.round(sample.historyMessages),
+    path: sample.path,
     queuedChars: Math.round(sample.queuedChars),
     rafGapMs: 0,
     sessions: Math.round(sample.sessions),
@@ -225,4 +252,28 @@ export function recordStreamDeltaApplied(sample: StreamDeltaSample): StreamDelta
     type: 'stream_delta_applied',
     writeMs: Math.round(sample.writeMs * 100) / 100
   }) as StreamDeltaAppliedEvent
+}
+
+export interface GatewayEventSample {
+  eventType: string
+  durationMs: number
+  busySessions: number
+}
+
+/** Record one costly gateway-event dispatch. The caller thresholds on
+ *  duration BEFORE calling (a streaming turn emits dozens of sub-millisecond
+ *  events per second; recording them all would be ring churn for nothing), so
+ *  reaching this function already means "worth a row". */
+export function recordGatewayEventApplied(sample: GatewayEventSample): void {
+  if (!armed) {
+    return
+  }
+
+  armed.buffer.push({
+    busySessions: Math.round(sample.busySessions),
+    durationMs: Math.round(sample.durationMs * 100) / 100,
+    eventType: sample.eventType,
+    t: performance.now(),
+    type: 'gateway_event_applied'
+  })
 }

--- a/apps/desktop/src/diagnostics/capture.ts
+++ b/apps/desktop/src/diagnostics/capture.ts
@@ -92,8 +92,10 @@ export interface JournalWriteEvent extends DiagnosticsEventBase {
   /** Serialized entry length (UTF-16 code units) — a size, never the text. */
   bytes: number
   /** `quota`/`error` mean the synchronous cost was paid but recovery is
-   *  degraded — exactly the failure mode that stays invisible in logs. */
-  outcome: 'error' | 'ok' | 'quota' | 'skipped'
+   *  degraded — exactly the failure mode that stays invisible in logs.
+   *  `oversize` means the entry blew the hard ceiling even after tight
+   *  re-projection and the write was skipped to protect the main thread. */
+  outcome: 'error' | 'ok' | 'oversize' | 'quota' | 'skipped'
   /** Sessions with a journal write in flight at record time (see
    *  StreamDeltaAppliedEvent.busySessions). */
   busySessions: number

--- a/apps/desktop/src/diagnostics/capture.ts
+++ b/apps/desktop/src/diagnostics/capture.ts
@@ -85,6 +85,20 @@ export interface GatewayEventAppliedEvent extends DiagnosticsEventBase {
   busySessions: number
 }
 
+export interface JournalWriteEvent extends DiagnosticsEventBase {
+  type: 'journal_write'
+  /** Projection + stringify + setItem, end to end. */
+  durationMs: number
+  /** Serialized entry length (UTF-16 code units) — a size, never the text. */
+  bytes: number
+  /** `quota`/`error` mean the synchronous cost was paid but recovery is
+   *  degraded — exactly the failure mode that stays invisible in logs. */
+  outcome: 'error' | 'ok' | 'quota' | 'skipped'
+  /** Sessions with a journal write in flight at record time (see
+   *  StreamDeltaAppliedEvent.busySessions). */
+  busySessions: number
+}
+
 export interface MemorySampleEvent extends DiagnosticsEventBase {
   type: 'memory_sample'
   usedMb: number
@@ -92,7 +106,12 @@ export interface MemorySampleEvent extends DiagnosticsEventBase {
   limitMb: number
 }
 
-export type DiagnosticsEvent = GatewayEventAppliedEvent | LongFrameEvent | MemorySampleEvent | StreamDeltaAppliedEvent
+export type DiagnosticsEvent =
+  | GatewayEventAppliedEvent
+  | JournalWriteEvent
+  | LongFrameEvent
+  | MemorySampleEvent
+  | StreamDeltaAppliedEvent
 
 export interface DiagnosticsCaptureSnapshot {
   captureId: string
@@ -275,5 +294,29 @@ export function recordGatewayEventApplied(sample: GatewayEventSample): void {
     eventType: sample.eventType,
     t: performance.now(),
     type: 'gateway_event_applied'
+  })
+}
+
+export interface JournalWriteSample {
+  durationMs: number
+  bytes: number
+  outcome: JournalWriteEvent['outcome']
+  busySessions: number
+}
+
+/** Record one in-flight-journal write (throttled to ≥400ms apart per session
+ *  by the journal itself, so no extra thresholding is needed here). */
+export function recordJournalWrite(sample: JournalWriteSample): void {
+  if (!armed) {
+    return
+  }
+
+  armed.buffer.push({
+    busySessions: Math.round(sample.busySessions),
+    bytes: Math.round(sample.bytes),
+    durationMs: Math.round(sample.durationMs * 100) / 100,
+    outcome: sample.outcome,
+    t: performance.now(),
+    type: 'journal_write'
   })
 }

--- a/apps/desktop/src/diagnostics/index.ts
+++ b/apps/desktop/src/diagnostics/index.ts
@@ -9,10 +9,12 @@ export {
   type DiagnosticsCaptureSnapshot,
   type DiagnosticsEvent,
   disarmDiagnostics,
+  type GatewayEventAppliedEvent,
   isDiagnosticsArmed,
   type LongFrameEvent,
   type MemorySampleEvent,
   readDiagnosticsCapture,
+  recordGatewayEventApplied,
   recordStreamDeltaApplied,
   type StreamDeltaAppliedEvent
 } from './capture'

--- a/apps/desktop/src/diagnostics/index.ts
+++ b/apps/desktop/src/diagnostics/index.ts
@@ -11,10 +11,12 @@ export {
   disarmDiagnostics,
   type GatewayEventAppliedEvent,
   isDiagnosticsArmed,
+  type JournalWriteEvent,
   type LongFrameEvent,
   type MemorySampleEvent,
   readDiagnosticsCapture,
   recordGatewayEventApplied,
+  recordJournalWrite,
   recordStreamDeltaApplied,
   type StreamDeltaAppliedEvent
 } from './capture'

--- a/apps/desktop/src/diagnostics/index.ts
+++ b/apps/desktop/src/diagnostics/index.ts
@@ -1,0 +1,25 @@
+// Production renderer diagnostics: a ring-buffered hitch capture that ships in
+// the packaged app and costs nothing until main arms it. See `capture.ts` for
+// the cost/sanitization contract and `arming-bridge.ts` for the IPC surface.
+
+export { type DiagnosticsArmPayload, initDiagnosticsArming } from './arming-bridge'
+export {
+  activeCaptureId,
+  armDiagnostics,
+  type DiagnosticsCaptureSnapshot,
+  type DiagnosticsEvent,
+  disarmDiagnostics,
+  isDiagnosticsArmed,
+  type LongFrameEvent,
+  type MemorySampleEvent,
+  readDiagnosticsCapture,
+  recordStreamDeltaApplied,
+  type StreamDeltaAppliedEvent
+} from './capture'
+export {
+  createLongFrameObserver,
+  type LongFrameSample,
+  type LongFrameScript,
+  supportsLongAnimationFrames,
+  toLongFrameSample
+} from './long-frames'

--- a/apps/desktop/src/diagnostics/index.ts
+++ b/apps/desktop/src/diagnostics/index.ts
@@ -2,7 +2,7 @@
 // the packaged app and costs nothing until main arms it. See `capture.ts` for
 // the cost/sanitization contract and `arming-bridge.ts` for the IPC surface.
 
-export { type DiagnosticsArmPayload, initDiagnosticsArming } from './arming-bridge'
+export { type DiagnosticsArmPayload, initDiagnosticsArming, initDiagnosticsSnapshots } from './arming-bridge'
 export {
   activeCaptureId,
   armDiagnostics,

--- a/apps/desktop/src/diagnostics/long-frames.ts
+++ b/apps/desktop/src/diagnostics/long-frames.ts
@@ -1,0 +1,114 @@
+// Long Animation Frame observation + attribution, shared by the dev-only
+// profiler (`src/debug/perf-live.ts`) and the production capture module.
+//
+// This is the half of a hitch the render counter cannot see: a frame can cost
+// 900ms with almost no React in it, and only LoAF says whether that was
+// style/layout, a ResizeObserver callback loop, or some timer. The attribution
+// pitfalls (entry-type support probing, `buffered` so a frame already in flight
+// is still caught, the styleAndLayoutStart → frame-end tail) are solved once
+// here rather than duplicated per consumer.
+//
+// Unlike `debug/`, this module IS production-buildable: it registers nothing
+// until a consumer calls `start()`.
+
+/** One Long Animation Frame, attributed. `styleMs` is the engine's style+layout
+ *  time inside the frame; `scripts` names who ran JS and for how long. */
+export interface LongFrameSample {
+  ms: number
+  styleMs: number
+  blockingMs: number
+  scripts: LongFrameScript[]
+}
+
+export interface LongFrameScript {
+  invoker: string
+  ms: number
+  src: string
+}
+
+export interface LongFrameObserver {
+  start: () => void
+  stop: () => void
+}
+
+// Scripts cheaper than this are noise in every real frame.
+const MIN_SCRIPT_MS = 5
+
+// Attribution strings come from the engine, so they can carry element ids,
+// handler names and script URLs. Capture records only counts/durations/IDs
+// (R2), so every attribution token is reduced at record time to a bounded
+// identifier-shaped string and every source URL to its bare file name — no
+// path, no query, no origin.
+const UNSAFE_TOKEN_CHARS = /[^A-Za-z0-9_.:#$-]+/g
+const MAX_TOKEN_LENGTH = 64
+
+const sanitizeToken = (value: string) => value.replace(UNSAFE_TOKEN_CHARS, '_').slice(0, MAX_TOKEN_LENGTH)
+
+const sanitizeSource = (sourceURL: string) => sanitizeToken((sourceURL.split(/[?#]/)[0].split('/').pop() ?? '').trim())
+
+interface LongAnimationFrameEntry extends PerformanceEntry {
+  blockingDuration?: number
+  styleAndLayoutStart?: number
+  renderStart?: number
+  scripts?: Array<{
+    duration: number
+    invoker?: string
+    invokerType?: string
+    sourceURL?: string
+    sourceFunctionName?: string
+  }>
+}
+
+/** True when this runtime reports `long-animation-frame` entries at all. */
+export const supportsLongAnimationFrames = () =>
+  typeof PerformanceObserver !== 'undefined' &&
+  Boolean(PerformanceObserver.supportedEntryTypes?.includes('long-animation-frame'))
+
+/** Shape one raw LoAF entry into a sanitized sample. Exported for tests and for
+ *  consumers that receive entries from somewhere other than the observer. */
+export function toLongFrameSample(entry: PerformanceEntry): LongFrameSample {
+  const e = entry as LongAnimationFrameEntry
+
+  return {
+    blockingMs: Math.round(e.blockingDuration ?? 0),
+    ms: Math.round(e.duration),
+    scripts: (e.scripts ?? [])
+      .filter(s => s.duration >= MIN_SCRIPT_MS)
+      .map(s => ({
+        invoker: sanitizeToken(`${s.invokerType ?? ''}:${s.invoker ?? s.sourceFunctionName ?? '?'}`),
+        ms: Math.round(s.duration),
+        src: sanitizeSource(s.sourceURL ?? '')
+      })),
+    // styleAndLayoutStart -> frame end is the engine's style+layout tail.
+    styleMs: e.styleAndLayoutStart ? Math.round(e.startTime + e.duration - e.styleAndLayoutStart) : 0
+  }
+}
+
+/** Create a LoAF observer that hands each attributed frame to `onSample`.
+ *  Returns null when the runtime has no LoAF support — callers keep working
+ *  with empty attribution. NOTHING is registered until `start()` is called. */
+export function createLongFrameObserver(onSample: (sample: LongFrameSample) => void): LongFrameObserver | null {
+  if (!supportsLongAnimationFrames()) {
+    return null
+  }
+
+  const observer = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) {
+      onSample(toLongFrameSample(entry))
+    }
+  })
+
+  return {
+    start: () => {
+      try {
+        // Buffered so a long frame already in flight when observation starts is
+        // still attributed to it.
+        observer.observe({ buffered: true, type: 'long-animation-frame' })
+      } catch {
+        // Older runtime without LoAF — the caller still works, attribution is
+        // simply empty.
+      }
+    },
+    stop: () => observer.disconnect()
+  }
+}

--- a/apps/desktop/src/diagnostics/ring-buffer.test.ts
+++ b/apps/desktop/src/diagnostics/ring-buffer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { DiagnosticsRingBuffer, estimateEventBytes } from './ring-buffer'
+
+interface Probe {
+  t: number
+  type: 'probe'
+  n: number
+}
+
+const probe = (n: number, t = n): Probe => ({ n, t, type: 'probe' })
+
+const generous = { maxAgeMs: 300_000, maxBytes: 10_000_000, maxEvents: 1_000_000 }
+
+describe('DiagnosticsRingBuffer', () => {
+  it('evicts the oldest events at the count cap instead of growing', () => {
+    const buffer = new DiagnosticsRingBuffer<Probe>({ ...generous, maxEvents: 4 })
+
+    for (let n = 0; n < 500; n += 1) {
+      buffer.push(probe(n))
+    }
+
+    expect(buffer.size).toBe(4)
+    expect(buffer.entries().map(e => e.n)).toEqual([496, 497, 498, 499])
+    expect(buffer.droppedCount).toBe(496)
+  })
+
+  it('evicts at the byte cap and keeps the tracked byte total bounded', () => {
+    const oneEvent = estimateEventBytes(probe(0))
+    const buffer = new DiagnosticsRingBuffer<Probe>({ ...generous, maxBytes: oneEvent * 3 })
+
+    for (let n = 0; n < 100; n += 1) {
+      buffer.push(probe(n))
+    }
+
+    expect(buffer.size).toBe(3)
+    expect(buffer.byteSize).toBeLessThanOrEqual(oneEvent * 3)
+    expect(buffer.entries().map(e => e.n)).toEqual([97, 98, 99])
+  })
+
+  it('drops events older than the capture window relative to the newest', () => {
+    const buffer = new DiagnosticsRingBuffer<Probe>({ ...generous, maxAgeMs: 300_000 })
+
+    buffer.push(probe(1, 0))
+    buffer.push(probe(2, 50_000))
+    buffer.push(probe(3, 250_000))
+    // 400s in: the first two are outside the 300s window, the third is not.
+    buffer.push(probe(4, 400_000))
+
+    expect(buffer.entries().map(e => e.n)).toEqual([3, 4])
+  })
+
+  it('reports a stable size after compaction churn', () => {
+    const buffer = new DiagnosticsRingBuffer<Probe>({ ...generous, maxEvents: 8 })
+
+    for (let n = 0; n < 10_000; n += 1) {
+      buffer.push(probe(n))
+      expect(buffer.size).toBeLessThanOrEqual(8)
+    }
+
+    expect(buffer.entries()).toHaveLength(8)
+    expect(buffer.entries()[0].n).toBe(9_992)
+  })
+
+  it('clears back to empty', () => {
+    const buffer = new DiagnosticsRingBuffer<Probe>(generous)
+    buffer.push(probe(1))
+    buffer.clear()
+
+    expect(buffer.size).toBe(0)
+    expect(buffer.byteSize).toBe(0)
+    expect(buffer.entries()).toEqual([])
+  })
+})

--- a/apps/desktop/src/diagnostics/ring-buffer.ts
+++ b/apps/desktop/src/diagnostics/ring-buffer.ts
@@ -1,0 +1,128 @@
+// Bounded in-memory event store for a diagnostics capture.
+//
+// Three caps, all enforced on push so the buffer can never grow between
+// captures: a count cap, a byte cap (estimated at record time — a capture that
+// fires thousands of long frames must not turn into a heap problem of its own),
+// and an age cap so a capture left armed for an hour still exports only the
+// last ~300s around the hitch the user reported.
+//
+// Eviction is oldest-first. Nothing here formats or serialises: the export step
+// (U4) reads `entries()` and writes JSONL.
+
+export interface RingBufferLimits {
+  /** Hard cap on retained events. */
+  maxEvents: number
+  /** Hard cap on the estimated retained bytes. */
+  maxBytes: number
+  /** Retain only events within this window of the newest event. */
+  maxAgeMs: number
+}
+
+/** Every diagnostics event carries a monotonic `performance.now()` stamp. */
+interface TimestampedEvent {
+  t: number
+}
+
+// Rough sizing, not exact: numbers are 8 bytes, strings 2 bytes per code unit,
+// plus a flat per-object tax for keys/headers. Exact accounting would mean
+// JSON.stringify on the hot path, which is the sort of cost this module exists
+// to avoid attributing to the app.
+const OBJECT_OVERHEAD_BYTES = 48
+
+export function estimateEventBytes(value: unknown): number {
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return 8
+  }
+
+  if (typeof value === 'string') {
+    return value.length * 2
+  }
+
+  if (Array.isArray(value)) {
+    return value.reduce<number>((total, item) => total + estimateEventBytes(item), OBJECT_OVERHEAD_BYTES)
+  }
+
+  if (value && typeof value === 'object') {
+    let total = OBJECT_OVERHEAD_BYTES
+
+    for (const [key, entry] of Object.entries(value)) {
+      total += key.length * 2 + estimateEventBytes(entry)
+    }
+
+    return total
+  }
+
+  return 0
+}
+
+export class DiagnosticsRingBuffer<T extends TimestampedEvent> {
+  private readonly limits: RingBufferLimits
+  // Deque backed by an array plus a read cursor: dropping the oldest event is
+  // an index bump, not an O(n) shift, and the dead prefix is compacted only
+  // when it grows past the live window.
+  private items: T[] = []
+  private head = 0
+  private bytes = 0
+  private byteSizes: number[] = []
+  private dropped = 0
+
+  constructor(limits: RingBufferLimits) {
+    this.limits = limits
+  }
+
+  push(event: T): T {
+    const size = estimateEventBytes(event)
+    this.items.push(event)
+    this.byteSizes.push(size)
+    this.bytes += size
+    this.evict(event.t)
+
+    return event
+  }
+
+  entries(): T[] {
+    return this.items.slice(this.head)
+  }
+
+  get size(): number {
+    return this.items.length - this.head
+  }
+
+  get byteSize(): number {
+    return this.bytes
+  }
+
+  /** How many events eviction has discarded since the buffer was created. */
+  get droppedCount(): number {
+    return this.dropped
+  }
+
+  clear(): void {
+    this.items = []
+    this.byteSizes = []
+    this.head = 0
+    this.bytes = 0
+    this.dropped = 0
+  }
+
+  private evict(newestAt: number): void {
+    while (
+      this.size > 0 &&
+      (this.size > this.limits.maxEvents ||
+        this.bytes > this.limits.maxBytes ||
+        newestAt - this.items[this.head].t > this.limits.maxAgeMs)
+    ) {
+      this.bytes -= this.byteSizes[this.head]
+      this.head += 1
+      this.dropped += 1
+    }
+
+    // Compact once the discarded prefix outweighs the live window, so the
+    // backing arrays track the retained events rather than the whole capture.
+    if (this.head > 0 && this.head >= this.items.length - this.head) {
+      this.items = this.items.slice(this.head)
+      this.byteSizes = this.byteSizes.slice(this.head)
+      this.head = 0
+    }
+  }
+}

--- a/apps/desktop/src/diagnostics/stream-delta.test.tsx
+++ b/apps/desktop/src/diagnostics/stream-delta.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMessageStream } from '@/app/session/hooks/use-message-stream'
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { armDiagnostics, disarmDiagnostics, readDiagnosticsCapture, type StreamDeltaAppliedEvent } from './capture'
+
+// The sanitization proof: this string is the entire content of a streamed
+// delta, so if ANY of it reaches the ring buffer the capture leaks message text.
+const MARKER = 'PRIVATE_MARKER_9137 the user asked about their salary'
+
+const SID = 'session-1'
+
+let appendAssistantDelta: ((sessionId: string, delta: string) => void) | null = null
+let states: Map<string, ClientSessionState>
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(states)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const next = updater(states.get(sessionId) ?? createClientSessionState())
+      states.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    appendAssistantDelta = stream.appendAssistantDelta
+  }, [stream.appendAssistantDelta])
+
+  return null
+}
+
+const streamDeltaEvents = () =>
+  (readDiagnosticsCapture()?.events ?? []).filter(
+    (event): event is StreamDeltaAppliedEvent => event.type === 'stream_delta_applied'
+  )
+
+describe('stream-delta diagnostics on the real flush path', () => {
+  let rafCallbacks: FrameRequestCallback[]
+  let now: number
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appendAssistantDelta = null
+    states = new Map()
+    rafCallbacks = []
+    now = 1_000
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      rafCallbacks.push(cb)
+
+      return rafCallbacks.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    disarmDiagnostics()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('records counts and durations for an applied flush — never the delta text', async () => {
+    armDiagnostics('capture-stream-1', 1_700_000_000_000)
+
+    render(<Harness />)
+    expect(appendAssistantDelta).not.toBeNull()
+
+    act(() => appendAssistantDelta!(SID, MARKER))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    const [event] = streamDeltaEvents()
+    expect(event).toBeDefined()
+    expect(event.sessions).toBe(1)
+    expect(event.queuedChars).toBe(MARKER.length)
+    expect(event.historyMessages).toBe(1)
+    expect(event.writeMs).toBeGreaterThanOrEqual(0)
+
+    // The deferred commit frame lands 40ms later and runs for 60ms; both come
+    // from the flush path's EXISTING measurement, filled into the same event.
+    now = 1_100
+    act(() => rafCallbacks[0](1_040))
+
+    expect(event.rafGapMs).toBe(40)
+    expect(event.commitMs).toBe(60)
+    expect(streamDeltaEvents()).toHaveLength(1)
+
+    // The proof: nothing the user typed or the model said is in the buffer.
+    expect(JSON.stringify(readDiagnosticsCapture())).not.toContain('PRIVATE_MARKER_9137')
+    expect(JSON.stringify(readDiagnosticsCapture())).not.toContain('salary')
+  })
+
+  it('does no per-delta recording work while disarmed', async () => {
+    render(<Harness />)
+
+    act(() => appendAssistantDelta!(SID, MARKER))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    now = 1_100
+    act(() => rafCallbacks[0](1_040))
+
+    // The delta still applied normally...
+    const part = states.get(SID)?.messages.at(-1)?.parts.at(-1)
+    expect(part?.type === 'text' ? part.text : '').toBe(MARKER)
+    // ...and the capture side did nothing at all.
+    expect(readDiagnosticsCapture()).toBeNull()
+  })
+})

--- a/apps/desktop/src/diagnostics/stream-delta.test.tsx
+++ b/apps/desktop/src/diagnostics/stream-delta.test.tsx
@@ -6,16 +6,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMessageStream } from '@/app/session/hooks/use-message-stream'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
 
-import { armDiagnostics, disarmDiagnostics, readDiagnosticsCapture, type StreamDeltaAppliedEvent } from './capture'
+import {
+  armDiagnostics,
+  disarmDiagnostics,
+  type GatewayEventAppliedEvent,
+  readDiagnosticsCapture,
+  type StreamDeltaAppliedEvent
+} from './capture'
 
 // The sanitization proof: this string is the entire content of a streamed
 // delta, so if ANY of it reaches the ring buffer the capture leaks message text.
 const MARKER = 'PRIVATE_MARKER_9137 the user asked about their salary'
 
 const SID = 'session-1'
+const SID2 = 'session-2'
 
 let appendAssistantDelta: ((sessionId: string, delta: string) => void) | null = null
+let handleEvent: ((event: RpcEvent) => void) | null = null
 let states: Map<string, ClientSessionState>
 
 function Harness() {
@@ -40,7 +49,8 @@ function Harness() {
 
   useEffect(() => {
     appendAssistantDelta = stream.appendAssistantDelta
-  }, [stream.appendAssistantDelta])
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.appendAssistantDelta, stream.handleGatewayEvent])
 
   return null
 }
@@ -50,6 +60,11 @@ const streamDeltaEvents = () =>
     (event): event is StreamDeltaAppliedEvent => event.type === 'stream_delta_applied'
   )
 
+const gatewayEventEvents = () =>
+  (readDiagnosticsCapture()?.events ?? []).filter(
+    (event): event is GatewayEventAppliedEvent => event.type === 'gateway_event_applied'
+  )
+
 describe('stream-delta diagnostics on the real flush path', () => {
   let rafCallbacks: FrameRequestCallback[]
   let now: number
@@ -57,6 +72,7 @@ describe('stream-delta diagnostics on the real flush path', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     appendAssistantDelta = null
+    handleEvent = null
     states = new Map()
     rafCallbacks = []
     now = 1_000
@@ -93,6 +109,8 @@ describe('stream-delta diagnostics on the real flush path', () => {
     expect(event.queuedChars).toBe(MARKER.length)
     expect(event.historyMessages).toBe(1)
     expect(event.writeMs).toBeGreaterThanOrEqual(0)
+    expect(event.path).toBe('timer')
+    expect(event.busySessions).toBe(0)
 
     // The deferred commit frame lands 40ms later and runs for 60ms; both come
     // from the flush path's EXISTING measurement, filled into the same event.
@@ -106,6 +124,66 @@ describe('stream-delta diagnostics on the real flush path', () => {
     // The proof: nothing the user typed or the model said is in the buffer.
     expect(JSON.stringify(readDiagnosticsCapture())).not.toContain('PRIVATE_MARKER_9137')
     expect(JSON.stringify(readDiagnosticsCapture())).not.toContain('salary')
+  })
+
+  it('attributes a second busy thread: eager tool-boundary drains and busySessions', async () => {
+    armDiagnostics('capture-threads', 1_700_000_000_000)
+
+    render(<Harness />)
+    expect(handleEvent).not.toBeNull()
+
+    // Two threads with turns in flight — the second is the one the old
+    // instrumentation could not see (its text drains on tool boundaries,
+    // outside the timer flush, so `sessions` always read 1).
+    act(() => handleEvent!({ payload: {}, session_id: SID, type: 'message.start' }))
+    act(() => handleEvent!({ payload: {}, session_id: SID2, type: 'message.start' }))
+
+    act(() => appendAssistantDelta!(SID, MARKER))
+    act(() => appendAssistantDelta!(SID2, MARKER))
+
+    // Thread 2 hits a tool call: its queued text flushes eagerly, right now,
+    // and leaves the queue before the timer flush can count it.
+    act(() => handleEvent!({ payload: { name: 'terminal' }, session_id: SID2, type: 'tool.start' }))
+
+    const [eagerEvent] = streamDeltaEvents()
+    expect(eagerEvent).toMatchObject({ busySessions: 2, path: 'eager', queuedChars: MARKER.length, sessions: 1 })
+    // Eager drains skip the commit-measurement frame by design.
+    expect(eagerEvent.commitMs).toBe(0)
+
+    // The timer flush then only sees thread 1 — but busySessions still says 2.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    const [, timerEvent] = streamDeltaEvents()
+    expect(timerEvent).toMatchObject({ busySessions: 2, path: 'timer', queuedChars: MARKER.length, sessions: 1 })
+
+    // Sanitization holds on the new path too.
+    expect(JSON.stringify(readDiagnosticsCapture())).not.toContain('PRIVATE_MARKER_9137')
+  })
+
+  it('records costly gateway-event dispatches with their type tag', async () => {
+    armDiagnostics('capture-dispatch', 1_700_000_000_000)
+
+    render(<Harness />)
+    expect(handleEvent).not.toBeNull()
+
+    // Advance the mocked clock on every read: the wrapper's start/end reads
+    // alone make any dispatch look 5ms+, which clears the 4ms recording floor
+    // deterministically — no reliance on real handler cost in jsdom.
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5
+
+      return now
+    })
+
+    act(() => handleEvent!({ payload: {}, session_id: SID, type: 'thinking.delta' }))
+
+    const [event] = gatewayEventEvents()
+    expect(event).toBeDefined()
+    expect(event.eventType).toBe('thinking.delta')
+    expect(event.durationMs).toBeGreaterThanOrEqual(4)
+    expect(event.busySessions).toBe(0)
   })
 
   it('does no per-delta recording work while disarmed', async () => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -307,6 +307,14 @@ declare global {
       findInPage: (query: string, options?: { forward?: boolean; findNext?: boolean }) => Promise<{ count: number }>
       stopFindInPage: () => Promise<void>
       onFoundInPage: (callback: (result: { activeMatchOrdinal: number; count: number }) => void) => () => void
+      // Hitch-capture arming, pushed by the capture controller in main. Optional
+      // because the renderer must keep working against a preload that predates
+      // the diagnostics surface — no bridge simply means never armed, which is
+      // the zero-cost state. Wired by `initDiagnosticsArming` in src/diagnostics.
+      diagnostics?: {
+        onArm: (callback: (payload: { captureId: string; wallClockAnchorMs: number }) => void) => () => void
+        onDisarm: (callback: () => void) => () => void
+      }
     }
   }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -314,9 +314,40 @@ declare global {
       diagnostics?: {
         onArm: (callback: (payload: { captureId: string; wallClockAnchorMs: number }) => void) => () => void
         onDisarm: (callback: () => void) => () => void
+        // Registers the source preload answers main's 'diagnostics:collect'
+        // pulls from, so the renderer never has to know the channel names.
+        // Returns the unsubscribe. Optional for the same reason the bridge
+        // itself is: an older preload simply contributes no renderer stream.
+        setSnapshotProvider?: (provider: (captureId: string) => unknown) => () => void
+      }
+      // Local-only capture control for the Diagnostics settings section (U4):
+      // start/stop the capture and write a sanitized bundle under userData.
+      // Optional so the section can hide itself on an older preload.
+      diagnosticsCapture?: {
+        start: () => Promise<{ captureId: string; wallClockAnchorMs: number; mainMonotonicAnchorMs: number }>
+        stop: () => Promise<DesktopDiagnosticsExport | null>
+        status: () => Promise<DesktopDiagnosticsStatus>
       }
     }
   }
+}
+
+export interface DesktopDiagnosticsStatus {
+  armed: boolean
+  captureId: null | string
+}
+
+/** What `diagnosticsCapture.stop()` reports back: where the bundle landed and
+ *  how the exporter classified it (R3). Never any captured content. */
+export interface DesktopDiagnosticsExport {
+  captureId: string
+  /** Absolute path of the exported bundle directory. */
+  directory: string
+  /** Labels strongest-first; `['unclassified']` when nothing fired. */
+  labels: string[]
+  primary: null | string
+  /** Per-stream event counts, for the status line. */
+  streams: { name: string; events: number; absent?: string }[]
 }
 
 export interface DesktopMarketplaceSearchItem {

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -533,3 +533,164 @@ describe('mid-turn redirect corrections', () => {
     expect(journaled.map(message => message.id)).toEqual(['user-1', 'assistant-stream-1'])
   })
 })
+
+describe('external review hardening', () => {
+  it('previews object-valued tool results without traversing the full structure', () => {
+    let elementReads = 0
+    const bigArray = Array.from({ length: 200_000 }, (_, index) => `row-${index}-${'z'.repeat(24)}`)
+
+    const counted = new Proxy(bigArray, {
+      get(target, prop, receiver) {
+        if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+          elementReads += 1
+        }
+
+        return Reflect.get(target, prop, receiver)
+      }
+    })
+
+    persistInFlightTurnState(
+      journalState({
+        messages: [
+          user('u1', 'run it'),
+          {
+            id: 'assistant-stream-1',
+            role: 'assistant',
+            pending: true,
+            parts: [
+              {
+                type: 'tool-call',
+                toolCallId: 'tc-obj',
+                toolName: 'terminal',
+                args: {},
+                result: counted as unknown as string
+              },
+              { type: 'text', text: 'reading' }
+            ]
+          }
+        ]
+      })
+    )
+    vi.advanceTimersByTime(400)
+
+    const raw = window.localStorage.getItem(sessionKey('stored-1'))!
+    expect(raw.length).toBeLessThan(256 * 1024)
+    // The 2KB preview budget stops the walk after ~70 rows of ~30 chars; a
+    // full JSON.stringify of the object would have read all 200k elements.
+    expect(elementReads).toBeLessThan(1000)
+
+    const entry = readInFlightTurnJournal('stored-1')!
+    const tool = entry.messages.at(-1)!.parts[0] as { result?: string; toolCallId: string }
+    expect(tool.toolCallId).toBe('tc-obj')
+    expect((tool.result ?? '').length).toBeLessThanOrEqual(2 * 1024 + 20)
+  })
+
+  it('skips the write entirely when even the tight projection exceeds the hard ceiling', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Only an un-truncatable user prompt can defeat the tight caps.
+    const enormousPrompt = 'w'.repeat(600 * 1024)
+
+    try {
+      persistInFlightTurnState(
+        journalState({
+          messages: [user('u1', enormousPrompt), assistant('assistant-stream-1', 'ok', { pending: true })]
+        })
+      )
+      vi.advanceTimersByTime(400)
+
+      expect(window.localStorage.getItem(sessionKey('stored-1'))).toBeNull()
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(String(warn.mock.calls[0][0])).toContain('hard size ceiling')
+
+      // Once per session, not once per tick.
+      persistInFlightTurnState(
+        journalState({
+          messages: [user('u1', enormousPrompt), assistant('assistant-stream-1', 'ok then', { pending: true })]
+        })
+      )
+      vi.advanceTimersByTime(400)
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('degrades to no journal when a storage read fails during recovery', () => {
+    persistInFlightTurnState(journalState())
+    vi.advanceTimersByTime(400)
+    expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
+
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+
+    try {
+      expect(() => readInFlightTurnJournal('stored-1')).not.toThrow()
+      expect(readInFlightTurnJournal('stored-1')).toBeNull()
+
+      const recovered = recoverInFlightTurnJournal('stored-1', [user('db-u1', 'do the thing')])
+      expect(recovered.applied).toBe(false)
+      expect(recovered.messages).toHaveLength(1)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('enforces the global entry cap at runtime, not only at boot', () => {
+    for (let index = 0; index < 25; index += 1) {
+      persistInFlightTurnState(journalState({ storedSessionId: `stored-cap-${index}` }))
+      // Each write lands at a distinct Date.now() so eviction order is stable.
+      vi.advanceTimersByTime(401)
+    }
+
+    const journalKeys = Object.keys(window.localStorage).filter(key => key.startsWith(KEY_PREFIX))
+    expect(journalKeys).toHaveLength(24)
+    // The oldest write was evicted by the sweep the 25th session triggered.
+    expect(window.localStorage.getItem(sessionKey('stored-cap-0'))).toBeNull()
+    expect(window.localStorage.getItem(sessionKey('stored-cap-24'))).not.toBeNull()
+
+    for (let index = 0; index < 25; index += 1) {
+      clearInFlightTurnJournal(`stored-cap-${index}`)
+    }
+  })
+
+  it('does nothing at boot when the kill switch is set — no migration, no sweep', () => {
+    const legacyBlob = JSON.stringify({
+      version: 1,
+      entries: {
+        'stored-legacy': {
+          messages: [user('u1', 'legacy'), assistant('a1', 'legacy partial')],
+          streamId: null,
+          turnStartedAt: 1,
+          updatedAt: Date.now()
+        }
+      }
+    })
+
+    window.localStorage.setItem(LEGACY_KEY, legacyBlob)
+    window.localStorage.setItem(KILL_SWITCH_KEY, '1')
+    resetInFlightTurnJournalForTests()
+
+    const getItem = vi.spyOn(Storage.prototype, 'getItem')
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem')
+
+    try {
+      persistInFlightTurnState(journalState())
+      vi.advanceTimersByTime(1000)
+
+      // The kill-switch probe is the subsystem's ONLY storage access.
+      expect(getItem).toHaveBeenCalledTimes(1)
+      expect(getItem).toHaveBeenCalledWith(KILL_SWITCH_KEY)
+      expect(setItem).not.toHaveBeenCalled()
+      expect(removeItem).not.toHaveBeenCalled()
+    } finally {
+      getItem.mockRestore()
+      setItem.mockRestore()
+      removeItem.mockRestore()
+    }
+
+    // The legacy blob is untouched, preserved for the revert case.
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe(legacyBlob)
+  })
+})

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -7,10 +7,15 @@ import {
   mergeInFlightMessages,
   persistInFlightTurnState,
   readInFlightTurnJournal,
-  recoverInFlightTurnJournal
+  recoverInFlightTurnJournal,
+  resetInFlightTurnJournalForTests
 } from '@/lib/inflight-turn-journal'
 
-const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+const LEGACY_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+const KEY_PREFIX = 'hermes.desktop.inflightTurnJournal.v2.'
+const KILL_SWITCH_KEY = 'hermes.desktop.inflightTurnJournal.disabled'
+
+const sessionKey = (id: string) => `${KEY_PREFIX}${id}`
 
 function user(id: string, text: string): ChatMessage {
   return { id, role: 'user', parts: [{ type: 'text', text }] }
@@ -47,6 +52,7 @@ function journalState(overrides: Partial<JournalableSessionState> = {}): Journal
 beforeEach(() => {
   vi.useFakeTimers()
   window.localStorage.clear()
+  resetInFlightTurnJournalForTests()
 })
 
 afterEach(() => {
@@ -67,6 +73,19 @@ describe('persistInFlightTurnState', () => {
     expect(entry?.streamId).toBe('assistant-stream-1')
     expect(entry?.turnStartedAt).toBe(1000)
     expect(entry?.messages.map(m => m.role)).toEqual(['user', 'assistant'])
+  })
+
+  it('writes one v2 key per session and never an aggregate key', () => {
+    persistInFlightTurnState(journalState())
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-2' }))
+
+    vi.advanceTimersByTime(400)
+
+    expect(window.localStorage.getItem(sessionKey('stored-1'))).not.toBeNull()
+    expect(window.localStorage.getItem(sessionKey('stored-2'))).not.toBeNull()
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull()
+
+    clearInFlightTurnJournal('stored-2')
   })
 
   it('coalesces rapid updates into one write carrying the latest state', () => {
@@ -112,11 +131,205 @@ describe('persistInFlightTurnState', () => {
     persistInFlightTurnState(journalState())
     vi.advanceTimersByTime(400)
 
-    const raw = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)
-    raw.entries['stored-1'].updatedAt = Date.now() - 8 * 24 * 60 * 60 * 1000
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(raw))
+    const raw = JSON.parse(window.localStorage.getItem(sessionKey('stored-1'))!)
+    raw.updatedAt = Date.now() - 8 * 24 * 60 * 60 * 1000
+    window.localStorage.setItem(sessionKey('stored-1'), JSON.stringify(raw))
 
     expect(readInFlightTurnJournal('stored-1')).toBeNull()
+    expect(window.localStorage.getItem(sessionKey('stored-1'))).toBeNull()
+  })
+
+  it('honors the kill switch without touching storage', () => {
+    window.localStorage.setItem(KILL_SWITCH_KEY, '1')
+    resetInFlightTurnJournalForTests()
+
+    persistInFlightTurnState(journalState())
+    vi.advanceTimersByTime(400)
+
+    expect(window.localStorage.getItem(sessionKey('stored-1'))).toBeNull()
+  })
+})
+
+describe('bounded projection', () => {
+  it('bounds a multi-megabyte tool result while preserving tool identity and recovery', () => {
+    const hugeResult = 'x'.repeat(5 * 1024 * 1024)
+
+    const messages: ChatMessage[] = [
+      user('u1', 'run the big thing'),
+      {
+        id: 'assistant-stream-1',
+        role: 'assistant',
+        pending: true,
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tc-big',
+            toolName: 'terminal',
+            args: { command: 'dump' },
+            argsText: '{"command":"dump"}',
+            result: hugeResult,
+            isError: false
+          },
+          { type: 'text', text: 'digesting the output' }
+        ]
+      }
+    ]
+
+    persistInFlightTurnState(journalState({ messages }))
+    vi.advanceTimersByTime(400)
+
+    const raw = window.localStorage.getItem(sessionKey('stored-1'))!
+    expect(raw.length).toBeLessThan(256 * 1024)
+
+    const entry = readInFlightTurnJournal('stored-1')!
+    const tool = entry.messages.at(-1)!.parts[0] as { isError: boolean; result?: string; toolCallId: string; toolName: string }
+    expect(tool.toolCallId).toBe('tc-big')
+    expect(tool.toolName).toBe('terminal')
+    expect(tool.isError).toBe(false)
+    expect((tool.result ?? '').length).toBeLessThanOrEqual(2 * 1024 + 20)
+
+    // The bounded entry still merges back onto a restored transcript.
+    const recovered = recoverInFlightTurnJournal('stored-1', [user('db-u1', 'run the big thing')])
+    expect(recovered.applied).toBe(true)
+    expect(recovered.messages.at(-1)!.parts[0]).toMatchObject({ type: 'tool-call', toolCallId: 'tc-big' })
+  })
+
+  it('keeps the user prompt in full so recovery matching still works', () => {
+    const longPrompt = 'p'.repeat(100 * 1024)
+
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('u1', longPrompt), assistant('assistant-stream-1', 'ok', { pending: true })]
+      })
+    )
+    vi.advanceTimersByTime(400)
+
+    const recovered = recoverInFlightTurnJournal('stored-1', [
+      user('db-u1', longPrompt),
+      assistant('db-a1', 'full committed reply')
+    ])
+
+    expect(recovered.caughtUp).toBe(true)
+  })
+})
+
+describe('boot migration from the v1 aggregate blob', () => {
+  it('migrates non-expired entries to bounded v2 keys and deletes the v1 key', () => {
+    const hugeResult = 'y'.repeat(3 * 1024 * 1024)
+
+    const v1 = {
+      version: 1,
+      entries: {
+        'stored-normal': {
+          messages: [user('u1', 'small turn'), assistant('assistant-stream-1', 'partial', { pending: true })],
+          streamId: 'assistant-stream-1',
+          turnStartedAt: 111,
+          updatedAt: Date.now()
+        },
+        'stored-oversized': {
+          messages: [
+            user('u2', 'big turn'),
+            {
+              id: 'assistant-stream-2',
+              role: 'assistant',
+              pending: true,
+              parts: [
+                { type: 'tool-call', toolCallId: 'tc-2', toolName: 'terminal', args: {}, result: hugeResult },
+                { type: 'text', text: 'working' }
+              ]
+            }
+          ],
+          streamId: 'assistant-stream-2',
+          turnStartedAt: 222,
+          updatedAt: Date.now()
+        },
+        'stored-expired': {
+          messages: [user('u3', 'old'), assistant('a3', 'stale')],
+          streamId: null,
+          turnStartedAt: null,
+          updatedAt: Date.now() - 8 * 24 * 60 * 60 * 1000
+        }
+      }
+    }
+
+    window.localStorage.setItem(LEGACY_KEY, JSON.stringify(v1))
+    resetInFlightTurnJournalForTests()
+
+    // Any journal entry point boots the module.
+    expect(readInFlightTurnJournal('stored-normal')).not.toBeNull()
+
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull()
+    expect(window.localStorage.getItem(sessionKey('stored-expired'))).toBeNull()
+
+    const oversized = window.localStorage.getItem(sessionKey('stored-oversized'))!
+    expect(oversized.length).toBeLessThan(256 * 1024)
+    expect(readInFlightTurnJournal('stored-oversized')?.turnStartedAt).toBe(222)
+
+    clearInFlightTurnJournal('stored-normal')
+    clearInFlightTurnJournal('stored-oversized')
+  })
+
+  it('respects new-key-wins when a v2 key already exists', () => {
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-dup' }))
+    vi.advanceTimersByTime(400)
+    const existing = window.localStorage.getItem(sessionKey('stored-dup'))!
+
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          'stored-dup': {
+            messages: [user('legacy-u', 'legacy turn'), assistant('legacy-a', 'legacy partial')],
+            streamId: null,
+            turnStartedAt: 999,
+            updatedAt: Date.now()
+          }
+        }
+      })
+    )
+    resetInFlightTurnJournalForTests()
+
+    expect(readInFlightTurnJournal('stored-dup')).not.toBeNull()
+    expect(window.localStorage.getItem(sessionKey('stored-dup'))).toBe(existing)
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull()
+
+    clearInFlightTurnJournal('stored-dup')
+  })
+
+  it('deletes an unparseable v1 blob instead of keeping it around', () => {
+    window.localStorage.setItem(LEGACY_KEY, '{not json at all')
+    resetInFlightTurnJournalForTests()
+
+    expect(readInFlightTurnJournal('anything')).toBeNull()
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull()
+  })
+})
+
+describe('quota and write failures', () => {
+  it('keeps streaming unaffected when setItem throws', () => {
+    persistInFlightTurnState(journalState())
+
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError')
+    })
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      expect(() => vi.advanceTimersByTime(400)).not.toThrow()
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      spy.mockRestore()
+      warn.mockRestore()
+    }
+
+    expect(readInFlightTurnJournal('stored-1')).toBeNull()
+
+    // A later write (storage healthy again) succeeds.
+    persistInFlightTurnState(journalState())
+    vi.advanceTimersByTime(400)
+    expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
   })
 })
 
@@ -263,6 +476,7 @@ describe('mergeInFlightMessages', () => {
 describe('mid-turn redirect corrections', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    resetInFlightTurnJournalForTests()
     vi.useFakeTimers()
   })
 

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -1,3 +1,4 @@
+import { recordJournalWrite } from '@/diagnostics/capture'
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
 
 /**
@@ -9,15 +10,35 @@ import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/c
  * journaled tail back onto the restored transcript, so streamed progress is
  * not silently lost. The backend's own `inflight` snapshot (merged by
  * `appendLiveSessionProjection`) covers reconnects while the backend is alive;
- * this journal covers the cases where the backend died too — and it is richer,
- * because the backend snapshot carries text only while the journal keeps the
- * full part structure.
+ * this journal covers the cases where the backend died too.
+ *
+ * Storage layout (v2): one localStorage key PER SESSION
+ * (`hermes.desktop.inflightTurnJournal.v2.<storedSessionId>`), each holding a
+ * BOUNDED recovery projection of the turn tail. The v1 layout — every
+ * session's full tail in one aggregate key — grew to many megabytes, and its
+ * per-tick read-clone-stringify-write of the whole store blocked the renderer
+ * main thread for hundreds of ms (the 2026-08-06 hitching root cause). The
+ * hot path is now write-only: build a small projection, stringify it once,
+ * `setItem` one key. No journal key is read before writing, and there is
+ * deliberately NO in-memory aggregate cache — secondary/peer windows share
+ * the storage partition, and a renderer-local cache could clobber or
+ * resurrect entries another window owns.
+ *
+ * The projection keeps what recovery actually needs — the user prompt in full
+ * (recovery matching compares its text), message ids/roles/order, assistant
+ * text, bounded reasoning, and tool-call identity (id/name/error) with short
+ * arg/result previews — and drops what it does not: multi-megabyte tool
+ * results, terminal dumps, inline diffs, embedded data.
  *
  * Best-effort by design: storage failures must never break chat streaming.
+ * Kill switch for A/B diagnosis: set localStorage key
+ * `hermes.desktop.inflightTurnJournal.disabled` to `'1'` and reload.
  */
 
-const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
-const STORE_VERSION = 1
+const LEGACY_STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+const KEY_PREFIX = 'hermes.desktop.inflightTurnJournal.v2.'
+const KILL_SWITCH_KEY = 'hermes.desktop.inflightTurnJournal.disabled'
+const STORE_VERSION = 2
 const MAX_ENTRIES = 24
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 /** Streaming repaints arrive every ~33ms; localStorage writes are synchronous.
@@ -25,11 +46,26 @@ const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
  *  most this much of the newest tail. */
 const PERSIST_THROTTLE_MS = 400
 
+// Projection bounds, in UTF-16 code units (what localStorage quota counts).
+// Normal caps first; the `tight` pass applies when a projected entry still
+// exceeds the serialized budget (e.g. an enormous streamed answer).
+const ASSISTANT_TEXT_CAP = 64 * 1024
+const ASSISTANT_TEXT_CAP_TIGHT = 8 * 1024
+const REASONING_CAP = 16 * 1024
+const TOOL_PREVIEW_CAP = 2 * 1024
+/** Fail-safe for one serialized entry. An entry can exceed it only when the
+ *  user prompt alone does (kept in full — recovery matching needs it). */
+const ENTRY_BUDGET = 256 * 1024
+
 export interface InFlightTurnSnapshot {
   messages: ChatMessage[]
   streamId: null | string
   turnStartedAt: null | number
   updatedAt: number
+}
+
+interface StoredJournalEntry extends InFlightTurnSnapshot {
+  version: typeof STORE_VERSION
 }
 
 export interface JournalableSessionState {
@@ -39,11 +75,6 @@ export interface JournalableSessionState {
   storedSessionId: null | string
   streamId: null | string
   turnStartedAt: null | number
-}
-
-interface JournalStore {
-  entries: Record<string, InFlightTurnSnapshot>
-  version: typeof STORE_VERSION
 }
 
 export interface InFlightRecoveryResult {
@@ -64,74 +95,108 @@ function storage(): Storage | null {
   }
 }
 
-function emptyStore(): JournalStore {
-  return { entries: {}, version: STORE_VERSION }
-}
-
-function loadStore(): JournalStore {
-  const store = storage()
-
-  if (!store) {
-    return emptyStore()
-  }
-
-  try {
-    const raw = store.getItem(STORAGE_KEY)
-
-    if (!raw) {
-      return emptyStore()
-    }
-
-    const parsed = JSON.parse(raw)
-
-    if (
-      !parsed ||
-      parsed.version !== STORE_VERSION ||
-      typeof parsed.entries !== 'object' ||
-      Array.isArray(parsed.entries)
-    ) {
-      return emptyStore()
-    }
-
-    return {
-      entries: parsed.entries as Record<string, InFlightTurnSnapshot>,
-      version: STORE_VERSION
-    }
-  } catch {
-    return emptyStore()
-  }
-}
-
-function saveStore(journal: JournalStore): void {
-  const store = storage()
-
-  if (!store) {
-    return
-  }
-
-  try {
-    const entries = Object.fromEntries(
-      Object.entries(journal.entries)
-        .filter(([, entry]) => !isExpired(entry))
-        .sort((a, b) => b[1].updatedAt - a[1].updatedAt)
-        .slice(0, MAX_ENTRIES)
-    )
-
-    if (Object.keys(entries).length === 0) {
-      store.removeItem(STORAGE_KEY)
-
-      return
-    }
-
-    store.setItem(STORAGE_KEY, JSON.stringify({ entries, version: STORE_VERSION }))
-  } catch {
-    // Quota/private-mode failures: the journal is a recovery aid, not truth.
-  }
+function sessionKey(storedSessionId: string): string {
+  return `${KEY_PREFIX}${storedSessionId}`
 }
 
 function isExpired(entry: InFlightTurnSnapshot, now = Date.now()): boolean {
   return now - entry.updatedAt > MAX_AGE_MS
 }
+
+// --- Bounded recovery projection --------------------------------------------
+
+function truncated(text: string, cap: number): string {
+  return text.length > cap ? `${text.slice(0, cap)}…[truncated]` : text
+}
+
+function previewOf(value: unknown, cap: number): null | string {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    return truncated(value, cap)
+  }
+
+  try {
+    return truncated(JSON.stringify(value), cap)
+  } catch {
+    return null
+  }
+}
+
+/** Project one part into its bounded journal form, or null to drop it.
+ *  Builds fresh small objects — this replaces the old JSON deep clone, so
+ *  multi-megabyte payloads are never copied at all. */
+function projectPart(part: ChatMessagePart, role: ChatMessage['role'], tight: boolean): ChatMessagePart | null {
+  if (part.type === 'text') {
+    const text = typeof part.text === 'string' ? part.text : ''
+
+    // The user prompt stays IN FULL: recovery matching (`userMessagesMatch`)
+    // normalizes and compares the whole text, and truncating it would orphan
+    // the journaled turn from its transcript row.
+    return {
+      type: 'text',
+      text: role === 'user' ? text : truncated(text, tight ? ASSISTANT_TEXT_CAP_TIGHT : ASSISTANT_TEXT_CAP)
+    }
+  }
+
+  if (part.type === 'reasoning') {
+    if (tight) {
+      return null
+    }
+
+    const text = typeof part.text === 'string' ? part.text : ''
+
+    return { type: 'reasoning', text: truncated(text, REASONING_CAP) }
+  }
+
+  if (part.type === 'tool-call') {
+    // Identity + status survive; large bodies (args, results, terminal dumps,
+    // inline diffs) shrink to short previews or are dropped outright.
+    const argsPreview = tight ? null : previewOf(part.argsText ?? part.args, TOOL_PREVIEW_CAP)
+    const resultPreview = tight ? undefined : (previewOf(part.result, TOOL_PREVIEW_CAP) ?? undefined)
+
+    return {
+      // Renderers read `argsText`; an empty args object keeps the part shape
+      // valid without copying a potentially huge original.
+      args: {} as never,
+      argsText: argsPreview ?? '',
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      type: 'tool-call',
+      ...(resultPreview !== undefined && { result: resultPreview }),
+      ...('isError' in part && { isError: Boolean(part.isError) })
+    } as ChatMessagePart
+  }
+
+  // Anything else (images, files, attachments-as-parts) is bulk the journal
+  // does not need — recovery only inspects text/reasoning/tool-call parts.
+  return null
+}
+
+function projectMessage(message: ChatMessage, tight: boolean): ChatMessage {
+  const parts = message.parts
+    .map(part => projectPart(part, message.role, tight))
+    .filter((part): part is ChatMessagePart => part !== null)
+
+  return {
+    id: message.id,
+    parts,
+    role: message.role,
+    ...(message.timestamp !== undefined && { timestamp: message.timestamp }),
+    ...(message.pending !== undefined && { pending: message.pending }),
+    ...(message.error !== undefined && { error: message.error }),
+    ...(message.interim !== undefined && { interim: message.interim }),
+    ...(message.attachmentRefs !== undefined && { attachmentRefs: [...message.attachmentRefs] })
+  }
+}
+
+function projectTail(messages: ChatMessage[], tight: boolean): ChatMessage[] {
+  return messages.map(message => projectMessage(message, tight))
+}
+
+// --- Recovery-tail extraction and merge (semantics unchanged) ----------------
 
 function cloneMessages(messages: ChatMessage[]): ChatMessage[] {
   try {
@@ -181,7 +246,9 @@ function isLiveProjectionRow(message: ChatMessage): boolean {
 }
 
 /** Visible tail of the running turn: the streaming assistant row (plus any
- *  interim rows sealed after it) back to the user prompt that started it. */
+ *  interim rows sealed after it) back to the user prompt that started it.
+ *  Returns the live rows BY REFERENCE — the caller projects them into the
+ *  bounded journal form, so no deep clone happens here. */
 function recoverableTail(messages: ChatMessage[], streamId: null | string): ChatMessage[] {
   const visible = messages.filter(message => !message.hidden)
   let assistantIndex = -1
@@ -228,7 +295,7 @@ function recoverableTail(messages: ChatMessage[], streamId: null | string): Chat
     }
   }
 
-  return cloneMessages(visible.slice(start))
+  return visible.slice(start)
 }
 
 function normalizeRecoveredTail(tail: ChatMessage[], keepPending: boolean): ChatMessage[] {
@@ -409,30 +476,268 @@ export function mergeInFlightMessages(
   return { applied: true, caughtUp: false, messages, streamId: merged.id, turnStartedAt: null }
 }
 
-const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
-const persistLatest = new Map<string, JournalableSessionState>()
+// --- Boot: kill switch, legacy migration, global sweep -----------------------
 
-function writeSnapshot(storedSessionId: string, state: JournalableSessionState): void {
-  const tail = recoverableTail(state.messages, state.streamId)
+let booted = false
+let journalDisabled = false
 
-  if (tail.length === 0) {
+function parseStoredEntry(raw: null | string): null | StoredJournalEntry {
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+
+    if (
+      !parsed ||
+      parsed.version !== STORE_VERSION ||
+      !Array.isArray(parsed.messages) ||
+      typeof parsed.updatedAt !== 'number'
+    ) {
+      return null
+    }
+
+    return parsed as StoredJournalEntry
+  } catch {
+    return null
+  }
+}
+
+/** One-shot v1 → v2 migration ("just boot and migrate"): every non-expired
+ *  legacy entry runs through the SAME bounded projection — so a multi-MB
+ *  legacy blob comes out KB-class — and lands on its per-session key
+ *  (new-key-wins). The v1 key is then deleted unconditionally: this is a
+ *  best-effort journal, and an unparseable or quota-broken blob is worth less
+ *  than an unblocked main thread. Idempotent by construction — the v1 key is
+ *  gone after the first run. */
+function migrateLegacyStore(store: Storage): void {
+  let raw: null | string = null
+
+  try {
+    raw = store.getItem(LEGACY_STORAGE_KEY)
+
+    if (raw) {
+      const parsed = JSON.parse(raw) as { entries?: Record<string, InFlightTurnSnapshot>; version?: number }
+
+      if (parsed && parsed.version === 1 && parsed.entries && typeof parsed.entries === 'object') {
+        for (const [storedSessionId, entry] of Object.entries(parsed.entries)) {
+          if (!entry || !Array.isArray(entry.messages) || typeof entry.updatedAt !== 'number' || isExpired(entry)) {
+            continue
+          }
+
+          const key = sessionKey(storedSessionId)
+
+          if (store.getItem(key) !== null) {
+            continue
+          }
+
+          const migrated: StoredJournalEntry = {
+            messages: projectTail(entry.messages, false),
+            streamId: entry.streamId ?? null,
+            turnStartedAt: entry.turnStartedAt ?? null,
+            updatedAt: entry.updatedAt,
+            version: STORE_VERSION
+          }
+
+          let serialized = JSON.stringify(migrated)
+
+          if (serialized.length > ENTRY_BUDGET) {
+            serialized = JSON.stringify({ ...migrated, messages: projectTail(entry.messages, true) })
+          }
+
+          try {
+            store.setItem(key, serialized)
+          } catch {
+            // Quota mid-migration: keep going — later entries may be smaller.
+          }
+        }
+      }
+    }
+  } catch {
+    // Unparseable legacy blob: fall through to the delete.
+  }
+
+  if (raw !== null) {
+    try {
+      store.removeItem(LEGACY_STORAGE_KEY)
+    } catch {
+      // Nothing left to do.
+    }
+  }
+}
+
+/** Startup sweep over v2 keys: drop expired/malformed entries and enforce the
+ *  global entry cap. This replaces the v1 per-write filter/sort/slice — which
+ *  was exactly the work that made every 400ms tick pay for all sessions. */
+function sweepJournalKeys(store: Storage): void {
+  const keys: string[] = []
+
+  for (let index = 0; index < store.length; index += 1) {
+    const key = store.key(index)
+
+    if (key && key.startsWith(KEY_PREFIX)) {
+      keys.push(key)
+    }
+  }
+
+  const alive: { key: string; updatedAt: number }[] = []
+
+  for (const key of keys) {
+    const entry = parseStoredEntry(store.getItem(key))
+
+    if (!entry || isExpired(entry)) {
+      try {
+        store.removeItem(key)
+      } catch {
+        // Best effort.
+      }
+
+      continue
+    }
+
+    alive.push({ key, updatedAt: entry.updatedAt })
+  }
+
+  if (alive.length > MAX_ENTRIES) {
+    alive.sort((a, b) => b.updatedAt - a.updatedAt)
+
+    for (const { key } of alive.slice(MAX_ENTRIES)) {
+      try {
+        store.removeItem(key)
+      } catch {
+        // Best effort.
+      }
+    }
+  }
+}
+
+function ensureBooted(): void {
+  if (booted) {
     return
   }
 
-  const journal = loadStore()
+  booted = true
 
-  journal.entries[storedSessionId] = {
-    messages: tail,
+  const store = storage()
+
+  if (!store) {
+    return
+  }
+
+  try {
+    journalDisabled = store.getItem(KILL_SWITCH_KEY) === '1'
+    migrateLegacyStore(store)
+    sweepJournalKeys(store)
+  } catch {
+    // Boot housekeeping is best-effort; the write path guards itself.
+  }
+}
+
+// --- Hot path ----------------------------------------------------------------
+
+const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const persistLatest = new Map<string, JournalableSessionState>()
+const quotaWarned = new Set<string>()
+
+/** Test hook: re-run boot (kill switch, migration, sweep) on next use and
+ *  drop all pending timers/state. */
+export function resetInFlightTurnJournalForTests(): void {
+  booted = false
+  journalDisabled = false
+
+  for (const timer of persistTimers.values()) {
+    clearTimeout(timer)
+  }
+
+  persistTimers.clear()
+  persistLatest.clear()
+  quotaWarned.clear()
+}
+
+function isQuotaError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED' || error.code === 22)
+  )
+}
+
+function writeSnapshot(storedSessionId: string, state: JournalableSessionState): void {
+  const store = storage()
+
+  if (!store) {
+    return
+  }
+
+  const started = performance.now()
+  const tail = recoverableTail(state.messages, state.streamId)
+
+  // `persistTimers` no longer holds this session (its timer just fired), so
+  // `size + 1` is the number of sessions currently journaling — the journal's
+  // own busy-session signal, mirroring StreamDeltaAppliedEvent.busySessions.
+  const busySessions = persistTimers.size + 1
+
+  if (tail.length === 0) {
+    recordJournalWrite({
+      busySessions,
+      bytes: 0,
+      durationMs: performance.now() - started,
+      outcome: 'skipped'
+    })
+
+    return
+  }
+
+  const entry: StoredJournalEntry = {
+    messages: projectTail(tail, false),
     streamId: state.streamId,
     turnStartedAt: state.turnStartedAt,
-    updatedAt: Date.now()
+    updatedAt: Date.now(),
+    version: STORE_VERSION
   }
-  saveStore(journal)
+
+  let serialized = JSON.stringify(entry)
+
+  if (serialized.length > ENTRY_BUDGET) {
+    // Structural reduction, never byte-slicing the JSON: re-project with the
+    // tight caps (drops reasoning and tool previews, shrinks assistant text).
+    serialized = JSON.stringify({ ...entry, messages: projectTail(tail, true) })
+  }
+
+  let outcome: 'error' | 'ok' | 'quota' = 'ok'
+
+  try {
+    store.setItem(sessionKey(storedSessionId), serialized)
+  } catch (error) {
+    outcome = isQuotaError(error) ? 'quota' : 'error'
+
+    if (!quotaWarned.has(storedSessionId)) {
+      quotaWarned.add(storedSessionId)
+      console.warn(
+        `[hermes] in-flight turn journal write failed (${outcome}) for session ${storedSessionId}; ` +
+          'crash recovery for this turn is degraded.',
+        error
+      )
+    }
+  }
+
+  recordJournalWrite({
+    busySessions,
+    bytes: serialized.length,
+    durationMs: performance.now() - started,
+    outcome
+  })
 }
 
 /** Persist the running turn's visible tail (throttled), or clear the entry the
  *  moment the turn settles. Call on every session-state commit. */
 export function persistInFlightTurnState(state: JournalableSessionState): void {
+  ensureBooted()
+
+  if (journalDisabled) {
+    return
+  }
+
   const storedSessionId = state.storedSessionId
 
   if (!storedSessionId) {
@@ -467,25 +772,41 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
 }
 
 export function readInFlightTurnJournal(storedSessionId: null | string): InFlightTurnSnapshot | null {
+  ensureBooted()
+
   if (!storedSessionId) {
     return null
   }
 
-  const journal = loadStore()
-  const entry = journal.entries[storedSessionId]
+  const store = storage()
+
+  if (!store) {
+    return null
+  }
+
+  const key = sessionKey(storedSessionId)
+  const entry = parseStoredEntry(store.getItem(key))
 
   if (!entry) {
     return null
   }
 
   if (isExpired(entry)) {
-    delete journal.entries[storedSessionId]
-    saveStore(journal)
+    try {
+      store.removeItem(key)
+    } catch {
+      // Best effort.
+    }
 
     return null
   }
 
-  return entry
+  return {
+    messages: entry.messages,
+    streamId: entry.streamId,
+    turnStartedAt: entry.turnStartedAt,
+    updatedAt: entry.updatedAt
+  }
 }
 
 /** Fold a journaled in-flight tail back onto a restored transcript. A no-op
@@ -521,6 +842,8 @@ export function recoverInFlightTurnJournal(
 }
 
 export function clearInFlightTurnJournal(storedSessionId: null | string): void {
+  ensureBooted()
+
   if (!storedSessionId) {
     return
   }
@@ -534,12 +857,15 @@ export function clearInFlightTurnJournal(storedSessionId: null | string): void {
 
   persistLatest.delete(storedSessionId)
 
-  const journal = loadStore()
+  const store = storage()
 
-  if (!(storedSessionId in journal.entries)) {
+  if (!store) {
     return
   }
 
-  delete journal.entries[storedSessionId]
-  saveStore(journal)
+  try {
+    store.removeItem(sessionKey(storedSessionId))
+  } catch {
+    // Best effort.
+  }
 }

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -56,6 +56,13 @@ const TOOL_PREVIEW_CAP = 2 * 1024
 /** Fail-safe for one serialized entry. An entry can exceed it only when the
  *  user prompt alone does (kept in full — recovery matching needs it). */
 const ENTRY_BUDGET = 256 * 1024
+/** Hard ceiling after the tight re-projection. Above this the write is
+ *  SKIPPED: a pathological prompt's crash recovery is worth less than paying
+ *  a multi-megabyte synchronous setItem every tick — the exact stall this
+ *  file exists to prevent. */
+const ENTRY_HARD_CEILING = 2 * ENTRY_BUDGET
+/** Preview walker depth limit — deeper structure collapses to a placeholder. */
+const PREVIEW_MAX_DEPTH = 6
 
 export interface InFlightTurnSnapshot {
   messages: ChatMessage[]
@@ -109,6 +116,126 @@ function truncated(text: string, cap: number): string {
   return text.length > cap ? `${text.slice(0, cap)}…[truncated]` : text
 }
 
+/** JSON-ish preview of an arbitrary value that never does more work than the
+ *  cap allows: emission and traversal are the same loop, so a multi-megabyte
+ *  tool result costs ~cap code units of walking, not a full `JSON.stringify`
+ *  of the whole structure first. Output is display text, not guaranteed
+ *  parseable JSON — every `argsText` consumer already JSON.parses inside a
+ *  try/catch with an `{}` fallback, and the pre-existing `…[truncated]`
+ *  marker broke parseability anyway. */
+function boundedJsonPreview(value: unknown, cap: number): string {
+  const out: string[] = []
+  let used = 0
+  let full = false
+
+  const emit = (text: string): void => {
+    if (full) {
+      return
+    }
+
+    if (used + text.length >= cap) {
+      out.push(`${text.slice(0, Math.max(0, cap - used))}…[truncated]`)
+      full = true
+
+      return
+    }
+
+    out.push(text)
+    used += text.length
+  }
+
+  const seen = new Set<object>()
+
+  const walk = (node: unknown, depth: number): void => {
+    if (full) {
+      return
+    }
+
+    if (node === null || node === undefined) {
+      emit('null')
+
+      return
+    }
+
+    if (typeof node === 'string') {
+      // Slice BEFORE stringify so a giant string never gets fully escaped.
+      emit(JSON.stringify(node.length > cap ? node.slice(0, cap) : node))
+
+      return
+    }
+
+    if (typeof node === 'number' || typeof node === 'boolean' || typeof node === 'bigint') {
+      emit(String(node))
+
+      return
+    }
+
+    if (typeof node !== 'object') {
+      emit('null')
+
+      return
+    }
+
+    if (seen.has(node) || depth >= PREVIEW_MAX_DEPTH) {
+      emit(Array.isArray(node) ? '[…]' : '{…}')
+
+      return
+    }
+
+    seen.add(node)
+
+    if (Array.isArray(node)) {
+      emit('[')
+
+      for (let index = 0; index < node.length && !full; index += 1) {
+        if (index > 0) {
+          emit(',')
+        }
+
+        walk(node[index], depth + 1)
+      }
+
+      emit(']')
+
+      return
+    }
+
+    emit('{')
+
+    let first = true
+
+    // `for…in` walks keys lazily — `Object.keys` would allocate the full key
+    // array of a huge object even when the budget stops us after a few.
+    for (const key in node) {
+      if (full) {
+        break
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(node, key)) {
+        continue
+      }
+
+      if (!first) {
+        emit(',')
+      }
+
+      first = false
+      emit(`${JSON.stringify(key)}:`)
+      walk((node as Record<string, unknown>)[key], depth + 1)
+    }
+
+    emit('}')
+  }
+
+  try {
+    walk(value, 0)
+  } catch {
+    // A throwing getter mid-walk: keep whatever was emitted so far.
+  }
+
+  return out.join('')
+}
+
 function previewOf(value: unknown, cap: number): null | string {
   if (value === undefined || value === null) {
     return null
@@ -118,11 +245,7 @@ function previewOf(value: unknown, cap: number): null | string {
     return truncated(value, cap)
   }
 
-  try {
-    return truncated(JSON.stringify(value), cap)
-  } catch {
-    return null
-  }
+  return boundedJsonPreview(value, cap)
 }
 
 /** Project one part into its bounded journal form, or null to drop it.
@@ -627,6 +750,19 @@ function ensureBooted(): void {
 
   try {
     journalDisabled = store.getItem(KILL_SWITCH_KEY) === '1'
+  } catch {
+    // Unreadable kill switch: treat as enabled.
+  }
+
+  if (journalDisabled) {
+    // A/B isolation: when disabled, the journal subsystem does NOTHING —
+    // no migration (the legacy blob stays put for the revert case), no
+    // sweep, no writes. The kill-switch read above is the only storage
+    // access the whole subsystem performs.
+    return
+  }
+
+  try {
     migrateLegacyStore(store)
     sweepJournalKeys(store)
   } catch {
@@ -639,6 +775,11 @@ function ensureBooted(): void {
 const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const persistLatest = new Map<string, JournalableSessionState>()
 const quotaWarned = new Set<string>()
+const oversizeWarned = new Set<string>()
+/** Distinct sessions this renderer has journaled since boot — when a NEW one
+ *  pushes the count past the global cap, the sweep runs once more so a
+ *  long-lived renderer cannot accumulate unbounded keys between reloads. */
+const sessionsWrittenSinceBoot = new Set<string>()
 
 /** Test hook: re-run boot (kill switch, migration, sweep) on next use and
  *  drop all pending timers/state. */
@@ -653,6 +794,8 @@ export function resetInFlightTurnJournalForTests(): void {
   persistTimers.clear()
   persistLatest.clear()
   quotaWarned.clear()
+  oversizeWarned.clear()
+  sessionsWrittenSinceBoot.clear()
 }
 
 function isQuotaError(error: unknown): boolean {
@@ -702,12 +845,45 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
     // Structural reduction, never byte-slicing the JSON: re-project with the
     // tight caps (drops reasoning and tool previews, shrinks assistant text).
     serialized = JSON.stringify({ ...entry, messages: projectTail(tail, true) })
+
+    if (serialized.length > ENTRY_HARD_CEILING) {
+      // Still enormous after the tight pass — only an un-truncatable user
+      // prompt can do this. Skip the write outright: recovery for a
+      // pathological prompt is worth less than a multi-MB setItem per tick.
+      if (!oversizeWarned.has(storedSessionId)) {
+        oversizeWarned.add(storedSessionId)
+        console.warn(
+          `[hermes] in-flight turn journal entry exceeds the hard size ceiling for session ${storedSessionId}; ` +
+            'skipping journal writes for this turn (crash recovery degraded).'
+        )
+      }
+
+      recordJournalWrite({
+        busySessions,
+        bytes: serialized.length,
+        durationMs: performance.now() - started,
+        outcome: 'oversize'
+      })
+
+      return
+    }
   }
 
   let outcome: 'error' | 'ok' | 'quota' = 'ok'
 
   try {
     store.setItem(sessionKey(storedSessionId), serialized)
+
+    // Runtime enforcement of the global entry cap: only when a NEW session
+    // key appears while over the cap (rare, and each surviving entry is
+    // budget-bounded), so the hot path stays a single setItem.
+    if (!sessionsWrittenSinceBoot.has(storedSessionId)) {
+      sessionsWrittenSinceBoot.add(storedSessionId)
+
+      if (sessionsWrittenSinceBoot.size > MAX_ENTRIES) {
+        sweepJournalKeys(store)
+      }
+    }
   } catch (error) {
     outcome = isQuotaError(error) ? 'quota' : 'error'
 
@@ -785,7 +961,17 @@ export function readInFlightTurnJournal(storedSessionId: null | string): InFligh
   }
 
   const key = sessionKey(storedSessionId)
-  const entry = parseStoredEntry(store.getItem(key))
+  let raw: null | string = null
+
+  try {
+    raw = store.getItem(key)
+  } catch {
+    // A Web Storage read failure degrades to "no journal" — recovery is
+    // optional and must never break session resume.
+    return null
+  }
+
+  const entry = parseStoredEntry(raw)
 
   if (!entry) {
     return null

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -22,7 +22,7 @@ import App from './app'
 import { ErrorBoundary } from './components/error-boundary'
 import { HapticsProvider } from './components/haptics-provider'
 import { RootTooltipProvider } from './components/ui/tooltip'
-import { initDiagnosticsArming } from './diagnostics'
+import { initDiagnosticsArming, initDiagnosticsSnapshots } from './diagnostics'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
@@ -33,7 +33,10 @@ installClipboardShim()
 // Hitch capture. Unlike the dev-only probes above this SHIPS — hitches happen
 // in the packaged app — but it registers no observers and does no per-delta
 // work until the capture controller in main pushes 'diagnostics:arm'.
+// The snapshot provider is the other half: without it this window records into
+// its ring but never hands the ring to the exporter (U4).
 initDiagnosticsArming()
+initDiagnosticsSnapshots()
 
 // The perf probe ships in dev, and in a production build ONLY when explicitly
 // opted in (VITE_PERF_PROBE=1) — this lets the perf harness measure a real,

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -22,12 +22,18 @@ import App from './app'
 import { ErrorBoundary } from './components/error-boundary'
 import { HapticsProvider } from './components/haptics-provider'
 import { RootTooltipProvider } from './components/ui/tooltip'
+import { initDiagnosticsArming } from './diagnostics'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
+
+// Hitch capture. Unlike the dev-only probes above this SHIPS — hitches happen
+// in the packaged app — but it registers no observers and does no per-delta
+// work until the capture controller in main pushes 'diagnostics:arm'.
+initDiagnosticsArming()
 
 // The perf probe ships in dev, and in a production build ONLY when explicitly
 // opted in (VITE_PERF_PROBE=1) — this lets the perf harness measure a real,

--- a/docs/observability/desktop-hitch-diagnostics.md
+++ b/docs/observability/desktop-hitch-diagnostics.md
@@ -1,0 +1,146 @@
+# Desktop Hitch Diagnostics
+
+An opt-in, local-only capture that records why the desktop app hitched, and
+exports a sanitized bundle a reviewer can read. Nothing is uploaded, and
+nothing is recorded until a capture is explicitly armed.
+
+## The flow
+
+1. Open **Settings → Diagnostics** in the desktop app.
+2. Press **Start capture** *before* reproducing the hitch. The ring buffers
+   hold roughly the last five minutes, so starting a little early is free and
+   starting late loses the event.
+3. Reproduce the hitch.
+4. Press **Stop & export**. This gathers all three streams, writes the bundle,
+   and shows the directory path plus the classification.
+
+There is no separate export step. Stopping *is* exporting.
+
+While disarmed the capture costs nothing: no observers are registered in the
+renderer, no metrics sampler runs in the main process, and the gateway's
+heartbeat stays at its normal cadence.
+
+## What is captured
+
+Three streams, one per process, each stamped on that process's own monotonic
+clock and aligned at export against a shared wall-clock anchor.
+
+| Stream | Source | Records |
+| --- | --- | --- |
+| `renderer-<windowId>` | each chat window | long animation frames (with attribution), heap samples, stream-delta flush costs |
+| `main` | Electron main | window responsive/unresponsive edges, per-process CPU + working set, backend transport failures |
+| `gateway` | the Hermes backend | event-loop heartbeat drift with sampled stacks, slow WS writes |
+
+The gateway stream is pulled over the gateway's existing authenticated channel.
+It is available only for a locally-spawned backend; a remote/SSH gateway is not
+asked, and the stream is marked absent with reason `remote-gateway`.
+
+## What the bundle contains
+
+`<userData>/diagnostics/<capture-id>/`
+
+| File | Contents |
+| --- | --- |
+| `manifest.json` | capture id, clock anchors, app version, platform, process tree, stream index |
+| `classification.json` | the labels and the evidence behind them |
+| `renderer-<windowId>.jsonl` | one JSON event per line |
+| `main.jsonl` | one JSON event per line |
+| `gateway.jsonl` | one JSON event per line; absent when the gateway stream is |
+
+Every event carries its original monotonic `t` (or `t_monotonic`) plus an added
+`wall_clock_ms`, so the three streams sort into one timeline without anyone
+having to trust a second machine's `Date.now()`.
+
+## Sanitization contract
+
+Sanitization happens at **record** time, in each process, not at export time.
+Only counts, sizes, durations and opaque ids are ever written into a ring
+buffer, so a buffer that escapes some other way (a crash dump, a core file)
+cannot leak content either.
+
+The bundle therefore contains **no**:
+
+- message text, prompts, model output or tool output
+- credentials, tokens or API keys
+- file paths, worktree paths or full URLs (REST routes are truncated to a
+  two-segment prefix, because Hermes paths carry session ids)
+- process command lines or argv
+
+**The manifest is inside this contract.** Its `process_tree` records `pid`,
+`ppid` and the executable **basename** only. Entries are rebuilt field by field
+rather than filtered, so a future probe that starts reporting a command line
+cannot leak it through.
+
+Worth spot-checking before you attach a bundle anywhere: grep it for a phrase
+you know you typed during the capture. It should not be there.
+
+## Classification
+
+`classification.json` labels the capture against the five mechanisms, using
+threshold heuristics over the streams. Multiple labels are normal and useful —
+`labels` is ordered strongest-first and `primary` is simply the first.
+
+| Label | Fires on |
+| --- | --- |
+| `renderer-bound` | ≥3 long frames ≥50ms, or any single frame ≥300ms |
+| `gateway-bound` | ≥2 loop-drift stalls ≥0.25s, or any single stall ≥1s |
+| `ipc-transport-bound` | ≥2 backend transport failures, or any single timeout |
+| `memory-gc-bound` | renderer heap grew ≥150MB, or peaked ≥85% of its limit |
+| `history-bound` | commit cost above the median transcript length is ≥2× the cost below it, and ≥40ms |
+| `unclassified` | nothing crossed a threshold |
+
+Each fired label carries a `reason` in plain terms and the `evidence` numbers it
+was computed from, so a threshold that looks wrong can be argued with against
+the raw JSONL sitting beside it.
+
+## `hermes debug diagnose`
+
+The host-side companion, for the questions that cannot be answered from inside
+one Electron process.
+
+```
+hermes debug diagnose                      # process tree only
+hermes debug diagnose --wpr                # + a 30s WPR trace (Windows, elevated)
+hermes debug diagnose --wpr --wpr-seconds 60 --out ./capture
+```
+
+It writes `diagnose.json` containing:
+
+- the **Hermes process tree** — pid, ppid and executable basename, following
+  the same rule as the desktop manifest. Command lines are never read.
+- the **WPR trace status**.
+
+Run it alongside a desktop capture, not instead of one: it has no access to the
+in-app rings.
+
+### ⚠ The WPR trace is UNSANITIZED and unsafe to share
+
+WPR (Windows Performance Recorder) records the **whole machine**, not just
+Hermes. An ETL trace contains other applications' activity, full image paths,
+and **command lines** — which on a developer machine routinely carry API keys
+and tokens.
+
+For that reason:
+
+- it is produced only on the explicit per-invocation `--wpr` opt-in;
+- it is written to a separate `unsafe-to-share/` subdirectory, never into a
+  sanitized bundle;
+- that directory gets a `README.txt` repeating this warning.
+
+Open the ETL locally in Windows Performance Analyzer, or delete it. Do not
+attach it to a bug report, a paste, or a chat message.
+
+The trace is bounded in both directions: a fixed recording duration, and a hard
+timeout on each `wpr` invocation after which the child is killed and the
+system-wide session is cancelled. If `wpr.exe` is missing (non-Windows host, no
+Windows Performance Toolkit) or the shell is not elevated, the trace is skipped
+with a note and the process tree is still written.
+
+## Related
+
+- `apps/desktop/src/diagnostics/` — renderer ring + arming bridge
+- `apps/desktop/electron/diagnostics-capture.ts` — capture controller
+- `apps/desktop/electron/diagnostics-export.ts` — bundle writer + sanitization
+- `apps/desktop/electron/diagnostics-classify.ts` — the heuristics above
+- `hermes_cli/diagnostics_ring.py` — gateway-side ring
+- `hermes_cli/diagnostics_diagnose.py` — the CLI subcommand

--- a/docs/observability/desktop-hitch-diagnostics.md
+++ b/docs/observability/desktop-hitch-diagnostics.md
@@ -27,7 +27,7 @@ clock and aligned at export against a shared wall-clock anchor.
 
 | Stream | Source | Records |
 | --- | --- | --- |
-| `renderer-<windowId>` | each chat window | long animation frames (with attribution), heap samples, stream-delta flush costs, costly gateway-event dispatches |
+| `renderer-<windowId>` | each chat window | long animation frames (with attribution), heap samples, stream-delta flush costs, costly gateway-event dispatches, in-flight journal writes (`journal_write`) |
 | `main` | Electron main | window responsive/unresponsive edges, per-process CPU + working set, backend transport failures |
 | `gateway` | the Hermes backend | event-loop heartbeat drift with sampled stacks, slow WS writes |
 
@@ -113,6 +113,38 @@ threshold heuristics over the streams. Multiple labels are normal and useful —
 Each fired label carries a `reason` in plain terms and the `evidence` numbers it
 was computed from, so a threshold that looks wrong can be argued with against
 the raw JSONL sitting beside it.
+
+## The in-flight turn journal
+
+The 2026-08-06 hitching investigation traced sustained 250–400ms renderer
+stalls to the crash-recovery journal (`src/lib/inflight-turn-journal.ts`): its
+v1 layout kept **every** session's full turn tail — tool bodies included — in
+one aggregate localStorage key, and re-read, re-cloned, re-stringified and
+synchronously rewrote the whole multi-megabyte blob every 400ms per busy
+session.
+
+The v2 layout removes that class of stall:
+
+- one key per session (`hermes.desktop.inflightTurnJournal.v2.<sessionId>`),
+  written blind (no read-before-write, no aggregate cache);
+- a bounded recovery projection built before any clone — full user prompt,
+  capped assistant text/reasoning, tool-call identity with ~2KB previews —
+  with a ~256KB serialized fail-safe per entry;
+- the legacy v1 blob is migrated through the same projection once at boot and
+  then deleted, whatever state it is in;
+- expiry and the 24-entry global cap are enforced by a startup sweep, not on
+  the hot path.
+
+Each write records a `journal_write` event into the renderer stream:
+`durationMs`, `bytes`, `outcome` (`ok` / `quota` / `error` / `skipped`) and
+`busySessions`. A capture showing `quota` outcomes means the entry exceeded
+the origin's storage quota and crash recovery is degraded — previously that
+failure was silent.
+
+Kill switch for A/B diagnosis: set localStorage key
+`hermes.desktop.inflightTurnJournal.disabled` to `'1'` (DevTools console:
+`localStorage.setItem('hermes.desktop.inflightTurnJournal.disabled','1')`) and
+reload; journaling is skipped entirely until the key is cleared.
 
 ## `hermes debug diagnose`
 

--- a/docs/observability/desktop-hitch-diagnostics.md
+++ b/docs/observability/desktop-hitch-diagnostics.md
@@ -27,7 +27,7 @@ clock and aligned at export against a shared wall-clock anchor.
 
 | Stream | Source | Records |
 | --- | --- | --- |
-| `renderer-<windowId>` | each chat window | long animation frames (with attribution), heap samples, stream-delta flush costs |
+| `renderer-<windowId>` | each chat window | long animation frames (with attribution), heap samples, stream-delta flush costs, costly gateway-event dispatches |
 | `main` | Electron main | window responsive/unresponsive edges, per-process CPU + working set, backend transport failures |
 | `gateway` | the Hermes backend | event-loop heartbeat drift with sampled stacks, slow WS writes |
 
@@ -50,6 +50,27 @@ asked, and the stream is marked absent with reason `remote-gateway`.
 Every event carries its original monotonic `t` (or `t_monotonic`) plus an added
 `wall_clock_ms`, so the three streams sort into one timeline without anyone
 having to trust a second machine's `Date.now()`.
+
+### Renderer events for multi-thread attribution
+
+Two renderer event details exist specifically to attribute hitches when more
+than one chat/thread runs at once:
+
+- `stream_delta_applied` rows carry `path` (`timer` for the batched flush,
+  `eager` for a drain forced by an ordering-sensitive event such as a tool row
+  or turn completion — under an agentic turn most applies run eagerly) and
+  `busySessions` (sessions with a turn in flight at record time, not just the
+  ones with text queued in that flush). Eager rows have `commitMs`/`rafGapMs`
+  fixed at 0 — they skip the commit-measurement frame.
+- `gateway_event_applied` records any single gateway-event dispatch whose
+  synchronous main-thread cost reached 4ms — tool-row upserts, subagent
+  progress, session.info patches, terminal chunks — with `eventType` (the type
+  tag only, never payload), `durationMs` and `busySessions`. Cheaper
+  dispatches are deliberately not recorded.
+
+Reading a multi-thread capture: correlate long_frame bursts with
+`busySessions > 1`, then look at which `gateway_event_applied.eventType` and
+`path: 'eager'` rows cluster inside the bursts.
 
 ## Sanitization contract
 

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -1026,13 +1026,18 @@ def run_debug(args):
         run_debug_share(args)
     elif subcmd == "delete":
         run_debug_delete(args)
+    elif subcmd == "diagnose":
+        from hermes_cli.diagnostics_diagnose import run_diagnose
+
+        run_diagnose(args)
     else:
         # Default: show help
         print("Usage: hermes debug <command>")
         print()
         print("Commands:")
-        print("  share    Upload debug report to a paste service and print URL")
-        print("  delete   Delete a previously uploaded paste")
+        print("  share     Upload debug report to a paste service and print URL")
+        print("  delete    Delete a previously uploaded paste")
+        print("  diagnose  Snapshot the Hermes process tree (+ optional WPR trace)")
         print()
         print("Options (share):")
         print("  --lines N    Number of log lines to include (default: 200)")
@@ -1044,3 +1049,9 @@ def run_debug(args):
         print()
         print("Options (delete):")
         print("  <url> ...    One or more paste URLs to delete")
+        print()
+        print("Options (diagnose):")
+        print("  --out DIR       Where to write the report")
+        print("  --wpr           Also record a bounded WPR trace (UNSANITIZED,")
+        print("                  system-wide; written to unsafe-to-share/)")
+        print("  --wpr-seconds N How long to record (default: 30)")

--- a/hermes_cli/diagnostics_diagnose.py
+++ b/hermes_cli/diagnostics_diagnose.py
@@ -1,0 +1,385 @@
+"""``hermes debug diagnose`` — host-side companion to the desktop hitch capture.
+
+The desktop app already exports a *sanitized* bundle of its own (renderer /
+main / gateway rings, see ``apps/desktop/electron/diagnostics-export.ts``).
+This module adds the two things that bundle cannot contain because they live
+outside the app process (U4 / KTD6):
+
+1. **A Hermes process tree.** Which Hermes-ish processes exist, and who is
+   whose parent — the question "is a second gateway running?" is unanswerable
+   from inside one Electron app. It follows the SAME sanitization rule as the
+   desktop manifest: pid, ppid and executable BASENAME only. Command lines are
+   never read, let alone written; on this machine they routinely carry tokens,
+   worktree paths and session ids.
+
+2. **An optional, time-bounded WPR (Windows Performance Recorder) trace.**
+   WPR answers questions no in-process ring can — kernel scheduling, GPU work,
+   other processes stealing the CPU. It is also, for exactly that reason, a
+   SYSTEM-WIDE capture: the ETL contains other applications' activity, full
+   image paths and command lines.
+
+Therefore the ETL is **not** part of any sanitized bundle. It is written to a
+separate ``unsafe-to-share/`` subdirectory with a README saying so, and only
+when the invocation explicitly opts in with ``--wpr``. Everything degrades: no
+``wpr.exe`` (non-Windows, N-edition, unelevated) means the trace is skipped and
+the process tree is still written.
+
+Nothing here uploads anything. ``hermes debug share`` is the upload path and it
+does not know about these files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+# Executables whose basename marks a process as part of the Hermes tree. The
+# match is on the BASENAME only — never the command line — so the selection
+# itself cannot read a secret.
+_NAME_HINTS = ("hermes",)
+
+# WPR's stock profile. `GeneralProfile` is the broad "why is this machine
+# slow" recording; a caller who knows what they want can pass another.
+DEFAULT_WPR_PROFILE = "GeneralProfile"
+
+# How long to record by default. Long enough to contain a reproduced hitch,
+# short enough that the ETL stays a few hundred MB rather than a few GB.
+DEFAULT_WPR_SECONDS = 30
+
+# Hard ceiling on ANY single wpr invocation. `wpr -stop` on a large trace is
+# genuinely slow (it merges), so this is generous — but it is a ceiling, not a
+# guideline: a wpr that blows through it is killed, because a diagnostics tool
+# that itself hangs is worse than no diagnostics tool.
+DEFAULT_WPR_TIMEOUT_S = 300
+
+_UNSAFE_DIR_NAME = "unsafe-to-share"
+
+_UNSAFE_README = """\
+UNSANITIZED — DO NOT SHARE
+==========================
+
+This directory holds a Windows Performance Recorder (WPR) ETL trace.
+
+A WPR trace is a SYSTEM-WIDE kernel capture. It records every process on this
+machine for the duration of the recording, including:
+
+  * full executable paths and COMMAND LINES (which routinely carry API keys,
+    tokens and file paths)
+  * file and registry activity of unrelated applications
+  * window titles and, depending on the profile, network endpoints
+
+Nothing in here has been sanitized, redacted or reviewed.
+
+The sanitized diagnostics bundle exported by the desktop app (sizes, counts and
+durations only) is the artifact that is safe to attach to a bug report. This
+directory is NOT. Open the ETL locally in Windows Performance Analyzer, or
+delete it.
+"""
+
+
+# ── process tree ─────────────────────────────────────────────────────
+
+
+def basename_only(value: Any) -> str:
+    """Reduce an executable path or name to its bare basename.
+
+    Mirrors ``executableBasename`` in the desktop exporter, including the
+    whitespace rule: anything past the first token is argv that arrived
+    disguised as a path, and is dropped.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    tail = text.replace("\\", "/").rsplit("/", 1)[-1]
+    return (tail.split()[0] if tail.split() else "unknown")[:128]
+
+
+def _iter_psutil_processes() -> Iterable[dict[str, Any]]:
+    """Default process source: pid/ppid/name/exe, and deliberately nothing else.
+
+    ``cmdline`` is not requested. That is the whole point.
+    """
+    try:
+        import psutil
+    except Exception:
+        return []
+
+    found: list[dict[str, Any]] = []
+    for proc in psutil.process_iter(["pid", "ppid", "name", "exe"]):
+        try:
+            info = proc.info
+        except Exception:
+            continue
+        found.append(
+            {
+                "pid": info.get("pid"),
+                "ppid": info.get("ppid"),
+                "name": info.get("name"),
+                "exe": info.get("exe"),
+            }
+        )
+    return found
+
+
+def collect_process_tree(
+    iter_processes: Callable[[], Iterable[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Snapshot the Hermes process tree, sanitized to {pid, ppid, name}.
+
+    Selection is "any process whose executable basename looks like Hermes",
+    plus each match's ancestors (so a launcher/shell parent is visible) and its
+    direct children (so a spawned gateway or Electron helper is visible).
+    Entries are REBUILT rather than filtered, so a psutil field this function
+    never asked for cannot leak through.
+    """
+    source = iter_processes or _iter_psutil_processes
+    try:
+        raw = list(source())
+    except Exception:
+        return []
+
+    by_pid: dict[int, dict[str, Any]] = {}
+    children: dict[int, list[int]] = {}
+    for entry in raw:
+        try:
+            pid = int(entry.get("pid"))
+        except (TypeError, ValueError):
+            continue
+        ppid = entry.get("ppid")
+        try:
+            ppid = int(ppid)
+        except (TypeError, ValueError):
+            ppid = 0
+        by_pid[pid] = {
+            "pid": pid,
+            "ppid": ppid,
+            "name": basename_only(entry.get("exe") or entry.get("name")),
+        }
+        children.setdefault(ppid, []).append(pid)
+
+    seeds = {pid for pid, entry in by_pid.items() if any(hint in entry["name"].lower() for hint in _NAME_HINTS)}
+
+    selected: set[int] = set()
+    for pid in seeds:
+        selected.add(pid)
+        # Ancestors, with a visited guard: a pid/ppid map read from a live
+        # machine is a snapshot of a moving target and can contain a cycle.
+        cursor = by_pid[pid]["ppid"]
+        while cursor in by_pid and cursor not in selected:
+            selected.add(cursor)
+            cursor = by_pid[cursor]["ppid"]
+        selected.update(children.get(pid, []))
+
+    return [by_pid[pid] for pid in sorted(selected)]
+
+
+# ── WPR ──────────────────────────────────────────────────────────────
+
+
+def find_wpr(which: Callable[[str], str | None] | None = None) -> str | None:
+    """Locate ``wpr.exe``, or None when this host cannot trace.
+
+    PATH first, then the canonical System32 location — a non-elevated shell on
+    a stock Windows install has wpr.exe on PATH but may still fail to start a
+    session, which is handled as a run-time degradation, not a lookup failure.
+    """
+    lookup = which or shutil.which
+    found = lookup("wpr")
+    if found:
+        return found
+    system_root = os.environ.get("SystemRoot") or os.environ.get("SYSTEMROOT")
+    if system_root:
+        candidate = Path(system_root) / "system32" / "wpr.exe"
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+class CommandResult:
+    """Outcome of one bounded child process."""
+
+    __slots__ = ("returncode", "output", "timed_out")
+
+    def __init__(self, returncode: int | None, output: str, timed_out: bool) -> None:
+        self.returncode = returncode
+        self.output = output
+        self.timed_out = timed_out
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0 and not self.timed_out
+
+
+def run_bounded(
+    cmd: list[str],
+    timeout_s: float,
+    popen: Callable[..., Any] | None = None,
+) -> CommandResult:
+    """Run *cmd* with a HARD timeout, killing it rather than waiting forever.
+
+    ``subprocess.run(timeout=...)`` would do the killing itself, but doing it
+    here keeps the kill observable (and testable) and lets the caller see that
+    the timeout — not a non-zero exit — is what happened.
+    """
+    spawn = popen or subprocess.Popen
+    proc = spawn(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        output, _ = proc.communicate(timeout=timeout_s)
+        return CommandResult(proc.returncode, output or "", False)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            output, _ = proc.communicate(timeout=10)
+        except Exception:
+            output = ""
+        return CommandResult(None, output or "", True)
+
+
+def run_wpr_trace(
+    out_dir: Path,
+    *,
+    profile: str = DEFAULT_WPR_PROFILE,
+    seconds: int = DEFAULT_WPR_SECONDS,
+    timeout_s: float = DEFAULT_WPR_TIMEOUT_S,
+    wpr_path: str | None = None,
+    popen: Callable[..., Any] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> dict[str, Any]:
+    """Record a bounded WPR trace into *out_dir*.
+
+    Returns a status dict — never raises for an unavailable or failing wpr.
+    ``status`` is one of ``recorded`` / ``skipped`` / ``failed`` / ``timeout``.
+
+    On any failure after ``-start`` the session is cancelled, because a WPR
+    session left running keeps buffering system-wide until the machine reboots.
+    """
+    exe = wpr_path or find_wpr()
+    if not exe:
+        return {
+            "status": "skipped",
+            "reason": "wpr.exe not found (non-Windows host, or WPT not installed)",
+        }
+
+    pause = sleep or time.sleep
+    out_dir.mkdir(parents=True, exist_ok=True)
+    etl = out_dir / "trace.etl"
+
+    start = run_bounded([exe, "-start", profile, "-filemode"], timeout_s, popen=popen)
+    if not start.ok:
+        # The overwhelmingly common cause is "not elevated" (wpr requires an
+        # administrator session); the second is a session already running.
+        return {
+            "status": "timeout" if start.timed_out else "failed",
+            "phase": "start",
+            "reason": _first_line(start.output) or "wpr -start failed (elevation required?)",
+        }
+
+    try:
+        pause(max(0, int(seconds)))
+    except KeyboardInterrupt:
+        run_bounded([exe, "-cancel"], timeout_s, popen=popen)
+        raise
+
+    stop = run_bounded([exe, "-stop", str(etl)], timeout_s, popen=popen)
+    if not stop.ok:
+        run_bounded([exe, "-cancel"], timeout_s, popen=popen)
+        return {
+            "status": "timeout" if stop.timed_out else "failed",
+            "phase": "stop",
+            "reason": _first_line(stop.output) or "wpr -stop failed",
+        }
+
+    return {
+        "status": "recorded",
+        "profile": profile,
+        "seconds": int(seconds),
+        # Basename only, consistent with everything else this module writes;
+        # the caller already knows the directory it asked for.
+        "file": etl.name,
+    }
+
+
+def _first_line(text: str) -> str:
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:400]
+    return ""
+
+
+# ── command ──────────────────────────────────────────────────────────
+
+
+def default_output_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return get_hermes_home() / "diagnostics" / f"diagnose-{stamp}"
+
+
+def run_diagnose(args) -> int:
+    """``hermes debug diagnose`` entry point. Returns a process exit code."""
+    out_dir = Path(getattr(args, "out", None) or default_output_dir()).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tree = collect_process_tree()
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "platform": platform.system().lower(),
+        # pid/ppid/basename only — same rule as the desktop bundle manifest.
+        "process_tree": tree,
+        "wpr": {"status": "skipped", "reason": "not requested (pass --wpr)"},
+    }
+
+    if getattr(args, "wpr", False):
+        report["wpr"] = run_wpr_trace(
+            out_dir / _UNSAFE_DIR_NAME,
+            profile=getattr(args, "wpr_profile", None) or DEFAULT_WPR_PROFILE,
+            seconds=getattr(args, "wpr_seconds", None) or DEFAULT_WPR_SECONDS,
+            timeout_s=getattr(args, "timeout", None) or DEFAULT_WPR_TIMEOUT_S,
+        )
+        if report["wpr"]["status"] == "recorded":
+            unsafe = out_dir / _UNSAFE_DIR_NAME
+            unsafe.mkdir(parents=True, exist_ok=True)
+            (unsafe / "README.txt").write_text(_UNSAFE_README, encoding="utf-8")
+
+    report_path = out_dir / "diagnose.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print(f"✓ Process tree: {len(tree)} Hermes-related process(es)")
+    for entry in tree:
+        print(f"    {entry['pid']:>7}  parent {entry['ppid']:>7}  {entry['name']}")
+
+    wpr = report["wpr"]
+    if wpr["status"] == "recorded":
+        print(f"✓ WPR trace: {wpr['seconds']}s of {wpr['profile']}")
+        print(f"  ⚠ UNSANITIZED — {out_dir / _UNSAFE_DIR_NAME}")
+        print("    A WPR ETL is a system-wide kernel capture (other processes'")
+        print("    command lines and paths included). Do NOT attach it to a bug")
+        print("    report. See README.txt in that directory.")
+    elif wpr["status"] == "skipped":
+        print(f"⏱ WPR trace skipped — {wpr.get('reason', 'unavailable')}")
+    else:
+        print(f"✗ WPR trace {wpr['status']} during {wpr.get('phase', '?')} — {wpr.get('reason', '')}", file=sys.stderr)
+
+    print(f"\nWrote {report_path}")
+    print("The desktop app's Settings → Diagnostics section exports the sanitized")
+    print("capture bundle that pairs with this report.")
+
+    # A failed optional trace is not a failed diagnose: the process tree, which
+    # is the part that always works, was written.
+    return 0

--- a/hermes_cli/diagnostics_ring.py
+++ b/hermes_cli/diagnostics_ring.py
@@ -1,0 +1,421 @@
+"""Bounded in-memory diagnostics ring for gateway-side hitch capture (U3/KTD2).
+
+The gateway already detects the two boundary signals that matter for the
+desktop hitching investigation — the CF-1 loop heartbeat ("event loop stalled
+Ns") in :mod:`hermes_cli.web_server` and the WS write timeout ("ws write slow")
+in :mod:`tui_gateway.ws` — but both only reach a log file, at thresholds tuned
+for *incidents* (5s / 10s). A 400ms hitch never leaves a trace anywhere.
+
+This module adds the machine-readable sink those detectors lack (KTD4), under
+an explicit arm/disarm capture so the cost is paid only while someone is
+looking:
+
+* **Disarmed** (the normal state) the whole module is one global bool read on
+  the two hot paths. No thread, no timer change, no allocation.
+* **Armed** the heartbeat tightens to :data:`_ARMED_HB_INTERVAL_S` and every
+  drift sample above :data:`_CAPTURE_FLOOR_S` becomes a ring event, a watchdog
+  *thread* (deliberately off the event loop — the loop is exactly what is
+  blocked) samples the stalled loop thread's stack for attribution, and WS
+  write-slow events join the ring with their peer identifier HMAC'd under a
+  random per-capture key.
+
+The ring is pulled over the gateway's existing authenticated JSON-RPC surface
+(``/api/ws`` → ``tui_gateway.server.dispatch``) via the three methods installed
+by :func:`install_rpc_methods` — there is no new listener and no new auth path.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+import sys
+import threading
+import time
+from collections import deque
+from hashlib import sha256
+from typing import Any
+
+# Fast-path flag read by the heartbeat and the WS write timeout. Kept as a
+# plain module global (not a function call, not an object attribute) so the
+# disarmed cost is a single LOAD_GLOBAL on paths that run per tick / per frame.
+ARMED = False
+
+# Ring bounds (KTD2: fixed-size, ~300s). Whichever limit is hit first evicts
+# the oldest event and increments the dropped counter, so a capture left armed
+# overnight costs a constant amount of memory.
+_MAX_EVENTS = 4096
+_MAX_AGE_S = 300.0
+
+# Events below this drift never reach the ring: at 20Hz a healthy loop produces
+# a sample every 50ms and none of them are interesting. 250ms is the floor the
+# plan sets — below the perceptible-hitch threshold, far below the 5s log line.
+_CAPTURE_FLOOR_S = 0.25
+
+# Heartbeat tick while armed. The production 2.0s tick cannot resolve a 400ms
+# block at all (its drift measurement is `elapsed - interval`, so a sub-interval
+# block is invisible or under-reported); 20Hz makes every block above the floor
+# observable while costing ~20 trivial loop wakeups per second for the length of
+# a capture only.
+_ARMED_HB_INTERVAL_S = 0.05
+
+# Watchdog cadence. Same order as the armed tick so a stall is noticed within
+# ~one floor of starting, while the sampling itself is capped at one stack grab
+# per stall episode.
+_WATCHDOG_POLL_S = 0.05
+
+# Depth cap for a sanitized stack summary. Deep enough to cross the asyncio
+# frames and name real work, shallow enough to stay a small dict list.
+_MAX_FRAMES = 16
+
+# Truncated HMAC width. 16 hex chars (64 bits) is plenty to correlate peers
+# inside one capture and keeps the exported bundle readable.
+_TOKEN_HEX = 16
+_TOKEN_CACHE_MAX = 512
+
+# Repo root, used to turn an absolute source path into a package-relative
+# dotted module name. Frame summaries must never carry absolute paths.
+_SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_lock = threading.RLock()
+_capture: "_Capture | None" = None
+
+
+class _Capture:
+    """One armed capture window. Guarded by the module ``_lock``."""
+
+    __slots__ = (
+        "capture_id",
+        "monotonic_anchor",
+        "wall_clock_anchor_ms",
+        "events",
+        "dropped",
+        "key",
+        "tokens",
+        "last_tick",
+        "loop_thread_id",
+        "pending_frames",
+        "sampled_episode",
+        "stop",
+        "thread",
+    )
+
+    def __init__(self, capture_id: str, wall_clock_anchor_ms: float | None) -> None:
+        self.capture_id = capture_id
+        self.monotonic_anchor = time.monotonic()
+        self.wall_clock_anchor_ms = wall_clock_anchor_ms
+        self.events: deque[dict[str, Any]] = deque()
+        self.dropped = 0
+        # Random per-capture HMAC key. Never returned by any method, never
+        # written anywhere, discarded on disarm — identifiers correlate inside
+        # one capture and are not reversible outside it.
+        self.key = secrets.token_bytes(32)
+        self.tokens: dict[str, str] = {}
+        self.last_tick = self.monotonic_anchor
+        self.loop_thread_id: int | None = None
+        self.pending_frames: list[dict[str, Any]] | None = None
+        self.sampled_episode = False
+        self.stop = threading.Event()
+        self.thread: threading.Thread | None = None
+
+
+# ── Sanitization ─────────────────────────────────────────────────────
+
+
+def _module_name(filename: str) -> str:
+    """Dotted, package-relative module name for a frame's source file.
+
+    Absolute path components outside the source tree are dropped entirely: a
+    stdlib or site-packages frame collapses to its bare module name. Nothing
+    that leaves this function can leak a home directory or a checkout path.
+    """
+    try:
+        path = os.path.abspath(filename)
+    except Exception:
+        return "<unknown>"
+    if path.startswith(_SRC_ROOT + os.sep):
+        path = path[len(_SRC_ROOT) + 1:]
+    else:
+        path = os.path.basename(path)
+    if path.endswith(".py"):
+        path = path[:-3]
+    return path.replace(os.sep, ".").replace("/", ".")
+
+
+def _sample_frames(thread_id: int) -> list[dict[str, Any]] | None:
+    """Sanitized stack summary for *thread_id* — module/function/line only.
+
+    No arguments, no locals, no source text: a frame summary is three scalars
+    per level, which is what makes the stall attribution safe to ship inside a
+    capture bundle.
+    """
+    frame = sys._current_frames().get(thread_id)
+    if frame is None:
+        return None
+    out: list[dict[str, Any]] = []
+    while frame is not None and len(out) < _MAX_FRAMES:
+        code = frame.f_code
+        out.append({
+            "module": _module_name(code.co_filename),
+            "function": code.co_name,
+            "line": frame.f_lineno,
+        })
+        frame = frame.f_back
+    return out
+
+
+# ── Ring writes ──────────────────────────────────────────────────────
+
+
+def _append(cap: _Capture, event: dict[str, Any]) -> None:
+    """Append under ``_lock``, evicting by count and by age."""
+    cap.events.append(event)
+    cutoff = event["t_monotonic"] - _MAX_AGE_S
+    while cap.events and (
+        len(cap.events) > _MAX_EVENTS or cap.events[0]["t_monotonic"] < cutoff
+    ):
+        cap.events.popleft()
+        cap.dropped += 1
+
+
+def _token(cap: _Capture, value: str) -> str:
+    """HMAC-SHA256 a peer/stream identifier under the per-capture key."""
+    cached = cap.tokens.get(value)
+    if cached is not None:
+        return cached
+    digest = hmac.new(cap.key, value.encode("utf-8", "replace"), sha256).hexdigest()
+    token = digest[:_TOKEN_HEX]
+    if len(cap.tokens) >= _TOKEN_CACHE_MAX:
+        cap.tokens.clear()
+    cap.tokens[value] = token
+    return token
+
+
+# ── Watchdog thread ──────────────────────────────────────────────────
+
+
+def _watchdog(cap: _Capture) -> None:
+    """Off-loop stall detector + stack sampler.
+
+    Runs in its own thread precisely because the event loop is the thing that
+    stalls: a loop-scheduled sampler cannot observe its own block. It watches
+    the gap since the last heartbeat tick and, once per stall episode, grabs a
+    sanitized stack of the loop thread. The heartbeat attaches that summary to
+    the drift event it records when the loop finally breathes.
+    """
+    while not cap.stop.wait(_WATCHDOG_POLL_S):
+        with _lock:
+            tid = cap.loop_thread_id
+            gap = time.monotonic() - cap.last_tick
+            if gap <= _CAPTURE_FLOOR_S:
+                # Episode over — re-arm sampling for the next one.
+                cap.sampled_episode = False
+                continue
+            if cap.sampled_episode or tid is None:
+                continue
+            cap.sampled_episode = True
+        # Sample outside the lock: sys._current_frames() walks every thread and
+        # we do not want the blocked loop's next tick queuing behind us.
+        frames = _sample_frames(tid)
+        if frames is None:
+            continue
+        with _lock:
+            if cap.stop.is_set():
+                return
+            cap.pending_frames = frames
+
+
+# ── Arm / disarm / collect ───────────────────────────────────────────
+
+
+def arm(capture_id: str, wall_clock_anchor_ms: float | None = None) -> dict[str, Any]:
+    """Start (or re-confirm) a capture window. Idempotent per capture_id.
+
+    Returns the monotonic anchor the exporter aligns this stream on (KTD3).
+    Re-arming the same capture_id is a no-op that returns the original anchor;
+    arming a different capture_id replaces the window and drops the old ring.
+    """
+    global ARMED, _capture
+    if not capture_id or not isinstance(capture_id, str):
+        raise ValueError("capture_id must be a non-empty string")
+    with _lock:
+        cap = _capture
+        if cap is not None and cap.capture_id == capture_id:
+            return {"monotonic_anchor_ms": cap.monotonic_anchor * 1000.0}
+        if cap is not None:
+            _stop_locked(cap)
+        cap = _Capture(capture_id, wall_clock_anchor_ms)
+        cap.thread = threading.Thread(
+            target=_watchdog, args=(cap,), daemon=True,
+            name=f"hermes-diag-watchdog-{capture_id[:8]}",
+        )
+        _capture = cap
+        ARMED = True
+        cap.thread.start()
+        return {"monotonic_anchor_ms": cap.monotonic_anchor * 1000.0}
+
+
+def _stop_locked(cap: _Capture) -> None:
+    """Signal the watchdog and forget the per-capture key. Caller holds _lock."""
+    cap.stop.set()
+    cap.key = b""
+    cap.tokens.clear()
+
+
+def disarm() -> dict[str, Any]:
+    """End the capture window. Idempotent; safe to call when never armed."""
+    global ARMED, _capture
+    with _lock:
+        cap = _capture
+        _capture = None
+        ARMED = False
+        if cap is None:
+            return {"armed": False}
+        _stop_locked(cap)
+        return {"armed": False, "capture_id": cap.capture_id}
+
+
+def collect(capture_id: str) -> dict[str, Any]:
+    """Snapshot the ring for *capture_id*.
+
+    Non-draining: the desktop capture controller pulls once at export, and a
+    retried pull must not come back empty. Raises :class:`LookupError` when no
+    capture is armed under that id.
+    """
+    with _lock:
+        cap = _capture
+        if cap is None or cap.capture_id != capture_id:
+            raise LookupError(f"no armed capture for capture_id={capture_id!r}")
+        # Age out before snapshotting so a long-idle capture reports the same
+        # bounded window it would have reported on the next write.
+        cutoff = time.monotonic() - _MAX_AGE_S
+        while cap.events and cap.events[0]["t_monotonic"] < cutoff:
+            cap.events.popleft()
+            cap.dropped += 1
+        return {
+            "capture_id": cap.capture_id,
+            "monotonic_anchor_ms": cap.monotonic_anchor * 1000.0,
+            "wall_clock_anchor_ms": cap.wall_clock_anchor_ms,
+            "events": list(cap.events),
+            "dropped": cap.dropped,
+        }
+
+
+def is_armed() -> bool:
+    """Test/introspection helper — hot paths read :data:`ARMED` directly."""
+    return ARMED
+
+
+def armed_heartbeat_interval() -> float:
+    """Heartbeat interval to use while a capture is armed."""
+    return _ARMED_HB_INTERVAL_S
+
+
+# ── Detector entry points ────────────────────────────────────────────
+
+
+def note_loop_tick() -> None:
+    """Record loop liveness for the watchdog. Called from the heartbeat tick."""
+    with _lock:
+        cap = _capture
+        if cap is None:
+            return
+        cap.last_tick = time.monotonic()
+        cap.loop_thread_id = threading.get_ident()
+
+
+def record_loop_drift(drift_s: float) -> dict[str, Any] | None:
+    """Record a heartbeat drift sample above the capture floor.
+
+    Returns the event (for tests) or None when the sample is below the floor.
+    The caller's 5s log threshold is unrelated and unchanged — this is a
+    strictly additional, strictly in-memory sink.
+    """
+    if drift_s < _CAPTURE_FLOOR_S:
+        return None
+    with _lock:
+        cap = _capture
+        if cap is None:
+            return None
+        event: dict[str, Any] = {
+            "kind": "loop_drift",
+            "t_monotonic": time.monotonic(),
+            "drift_s": round(float(drift_s), 6),
+        }
+        frames = cap.pending_frames
+        if frames is not None:
+            cap.pending_frames = None
+            event["frames"] = frames
+        _append(cap, event)
+        return event
+
+
+def record_ws_write_slow(peer: Any, timeout_s: float, stream: Any = None) -> None:
+    """Record a ``ws write slow`` / write-timeout event.
+
+    ``peer`` (and ``stream``, when given) are HMAC'd under the per-capture key,
+    never stored in the clear: an exported bundle correlates the frames of one
+    connection without ever naming the address they went to.
+    """
+    with _lock:
+        cap = _capture
+        if cap is None:
+            return
+        event: dict[str, Any] = {
+            "kind": "ws_write_slow",
+            "t_monotonic": time.monotonic(),
+            "timeout_s": round(float(timeout_s), 6),
+            "peer": _token(cap, str(peer)),
+        }
+        if stream is not None:
+            event["stream"] = _token(cap, str(stream))
+        _append(cap, event)
+
+
+# ── JSON-RPC surface ─────────────────────────────────────────────────
+
+# The desktop capture controller drove these as ``diagnostics/arm`` etc.; the
+# gateway's own convention is dotted (``session.create``, ``config.get``). Both
+# spellings are registered onto the same handlers so neither side has to guess.
+_METHOD_ALIASES = {
+    "arm": ("diagnostics.arm", "diagnostics/arm"),
+    "disarm": ("diagnostics.disarm", "diagnostics/disarm"),
+    "collect": ("diagnostics.collect", "diagnostics/collect"),
+}
+
+# JSON-RPC error code for a bad/absent capture, in the gateway's 5xxx band.
+_ERR_NO_CAPTURE = 5091
+
+
+def install_rpc_methods(server) -> None:
+    """Register arm/disarm/collect on ``tui_gateway.server``'s method table.
+
+    Deliberately *only* the existing surface: these ride ``/api/ws``, which is
+    gated by ``web_server._ws_auth_ok`` before a single frame is dispatched, so
+    an unauthenticated caller never reaches a handler. No HTTP route, no second
+    listener, no per-capture bearer token to leak (KTD4 / U3 step 4).
+    """
+
+    def _arm(rid, params: dict):
+        try:
+            result = arm(
+                params.get("capture_id"),
+                params.get("wall_clock_anchor_ms"),
+            )
+        except ValueError as exc:
+            return server._err(rid, _ERR_NO_CAPTURE, str(exc))
+        return server._ok(rid, result)
+
+    def _disarm(rid, params: dict):
+        return server._ok(rid, disarm())
+
+    def _collect(rid, params: dict):
+        try:
+            return server._ok(rid, collect(params.get("capture_id")))
+        except LookupError as exc:
+            return server._err(rid, _ERR_NO_CAPTURE, str(exc))
+
+    handlers = {"arm": _arm, "disarm": _disarm, "collect": _collect}
+    for key, names in _METHOD_ALIASES.items():
+        for name in names:
+            server._methods[name] = handlers[key]

--- a/hermes_cli/diagnostics_ring.py
+++ b/hermes_cli/diagnostics_ring.py
@@ -419,3 +419,70 @@ def install_rpc_methods(server) -> None:
     for key, names in _METHOD_ALIASES.items():
         for name in names:
             server._methods[name] = handlers[key]
+
+
+# ── Test-only loop block (U5) ────────────────────────────────────────
+#
+# The proof harness has to show that a *gateway* stall is attributed to the
+# gateway, which means it needs to cause one on demand. Nothing in normal
+# operation can be asked to block the loop, so this hook exists — and it is
+# dangerous by construction, so it is not reachable at all unless the process
+# was started with :data:`_TEST_HOOKS_ENV` set to ``1``. The guard is checked
+# once, at *registration* time: without the env var the route is never mounted,
+# so a normally started gateway answers 404 rather than "refused".
+
+_TEST_HOOKS_ENV = "HERMES_DIAGNOSTICS_TEST_HOOKS"
+
+# The harness blocks for ~1-6s; anything longer is a mistake, not a scenario.
+_MAX_TEST_BLOCK_S = 30.0
+
+_TEST_BLOCK_PATH = "/api/diagnostics/test/block-loop"
+
+
+def test_hooks_enabled() -> bool:
+    """True only when this process opted into the diagnostics test hooks."""
+    return os.environ.get(_TEST_HOOKS_ENV) == "1"
+
+
+def block_event_loop(seconds: Any) -> dict[str, Any]:
+    """Hold the calling thread for *seconds* — test hook only.
+
+    Called from an ``async def`` route it holds the *event loop*, which is
+    exactly the condition the CF-1 heartbeat measures as drift and the armed
+    ring records as a ``loop_drift`` event.
+    """
+    try:
+        duration = float(seconds)
+    except (TypeError, ValueError):
+        raise ValueError("seconds must be a number")
+    if not 0 < duration <= _MAX_TEST_BLOCK_S:
+        raise ValueError(f"seconds must be within (0, {_MAX_TEST_BLOCK_S}]")
+    started = time.monotonic()
+    time.sleep(duration)
+    return {"blocked_s": round(time.monotonic() - started, 6)}
+
+
+def install_test_routes(app) -> bool:
+    """Mount the guarded test hook on *app*. Returns whether it was mounted.
+
+    A no-op — and therefore an unmounted, unreachable path — unless
+    :func:`test_hooks_enabled`. The route sits under ``/api/`` like the rest of
+    the ring, so when it *is* mounted it still rides ``auth_middleware``.
+    """
+    if not test_hooks_enabled():
+        return False
+
+    # Imported here, not at module scope: this module is loaded by the TUI
+    # gateway too, and nothing outside this branch needs FastAPI. `seconds` is
+    # taken as an embedded body field rather than through a `Request` so the
+    # signature stays resolvable under `from __future__ import annotations`.
+    from fastapi import Body, HTTPException
+
+    @app.post(_TEST_BLOCK_PATH)
+    async def diagnostics_test_block_loop(seconds: float = Body(embed=True)):
+        try:
+            return block_event_loop(seconds)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    return True

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -740,6 +740,24 @@ try:
 except Exception:
     pass  # best-effort — redaction stays at default (enabled) on config errors
 
+# A long-lived Hermes server is a fresh root of trust, not delegate_task child
+# work, so it must not inherit the delegated-child lineage marker from whatever
+# agent happened to launch it. Left in place the marker never expires and every
+# Kanban open in this process fails closed (connect()'s first-open migration
+# pass runs through write_txn), which is what made the dashboard event stream
+# error on every reconnect. Agent-delegated subprocesses are unaffected — see
+# agent.delegation_context.clear_delegated_child_marker_for_server_role.
+try:
+    from agent.delegation_context import (
+        clear_delegated_child_marker_for_server_role as _clear_delegated_marker,
+        is_server_role_argv as _is_server_role_argv,
+    )
+
+    if _is_server_role_argv(sys.argv[1:]):
+        _clear_delegated_marker()
+except Exception:
+    pass  # best-effort — a missing agent package must not break the CLI
+
 # Initialize centralized file logging early — all `hermes` subcommands
 # (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
 # Dashboard entrypoints bootstrap with GUI mode so gui.log is always present

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -32,6 +32,8 @@ Examples:
     hermes debug share --no-redact  Disable upload-time secret redaction
     hermes debug share --nous       Upload to Nous-internal storage (private)
     hermes debug delete <url>       Delete a previously uploaded paste
+    hermes debug diagnose           Snapshot the Hermes process tree (local only)
+    hermes debug diagnose --wpr     Also record a bounded WPR trace (UNSANITIZED)
 """,
     )
     debug_sub = debug_parser.add_subparsers(dest="debug_command")
@@ -96,5 +98,51 @@ Examples:
         nargs="*",
         default=[],
         help="One or more paste URLs to delete (e.g. https://paste.rs/abc123)",
+    )
+    diagnose_parser = debug_sub.add_parser(
+        "diagnose",
+        help="Snapshot the Hermes process tree, optionally with a bounded WPR trace",
+        description=(
+            "Host-side companion to the desktop app's diagnostics capture "
+            "(Settings -> Diagnostics). Writes a local report: the Hermes "
+            "process tree (pid, parent pid and executable basename only -- "
+            "never command lines) and, with --wpr, a time-bounded Windows "
+            "Performance Recorder trace. Nothing is uploaded. The WPR ETL is a "
+            "SYSTEM-WIDE kernel capture that is NOT sanitized and must not be "
+            "attached to a bug report; it is written to an 'unsafe-to-share' "
+            "subdirectory with a README explaining why."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    diagnose_parser.add_argument(
+        "--out",
+        default=None,
+        help="Output directory (default: $HERMES_HOME/diagnostics/diagnose-<timestamp>)",
+    )
+    diagnose_parser.add_argument(
+        "--wpr",
+        action="store_true",
+        help=(
+            "Also record a Windows Performance Recorder trace. Requires an "
+            "elevated shell and wpr.exe; skipped with a note when unavailable. "
+            "Produces an UNSANITIZED, unsafe-to-share ETL (see the description)."
+        ),
+    )
+    diagnose_parser.add_argument(
+        "--wpr-profile",
+        default="GeneralProfile",
+        help="WPR profile to record (default: GeneralProfile)",
+    )
+    diagnose_parser.add_argument(
+        "--wpr-seconds",
+        type=int,
+        default=30,
+        help="How long to record, in seconds (default: 30)",
+    )
+    diagnose_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Hard timeout for any single wpr invocation, in seconds (default: 300)",
     )
     debug_parser.set_defaults(func=cmd_debug)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -57,6 +57,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
+from hermes_cli import diagnostics_ring
 from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
@@ -12620,6 +12621,60 @@ async def stop_gateway(profile: Optional[str] = None):
 
 
 # ---------------------------------------------------------------------------
+# Hitch-capture diagnostics ring (U3 / KTD2 / KTD4).
+#
+# These three routes are the gateway's half of a desktop hitch capture. They
+# ride the SAME authenticated channel the desktop's ``hermes:api`` calls
+# already use: no listener, port, or credential is introduced here — the
+# ``/api/`` prefix alone puts them behind ``auth_middleware`` (session token on
+# loopback) and the OAuth gate on public binds, since they are deliberately not
+# in ``PUBLIC_API_PATHS``. The same three operations are also reachable as
+# JSON-RPC methods over ``/api/ws`` (see
+# ``hermes_cli.diagnostics_ring.install_rpc_methods``).
+#
+# Everything the ring holds is counts, durations, and HMAC'd identifiers —
+# see the module docstring for the sanitization contract.
+# ---------------------------------------------------------------------------
+
+
+async def _diagnostics_body(request: Request) -> dict:
+    """Params for a diagnostics route; a missing/!dict body means no params."""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    return body if isinstance(body, dict) else {}
+
+
+@app.post("/api/diagnostics/arm")
+async def diagnostics_arm(request: Request):
+    body = await _diagnostics_body(request)
+    try:
+        return diagnostics_ring.arm(
+            body.get("capture_id"), body.get("wall_clock_anchor_ms")
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.post("/api/diagnostics/disarm")
+async def diagnostics_disarm(request: Request):
+    return diagnostics_ring.disarm()
+
+
+@app.post("/api/diagnostics/collect")
+async def diagnostics_collect(request: Request):
+    body = await _diagnostics_body(request)
+    try:
+        return diagnostics_ring.collect(body.get("capture_id"))
+    except LookupError as exc:
+        # 409, not 404: the route exists, the capture does not. The desktop
+        # client reads 404/405/501 as "this gateway predates diagnostics" and
+        # would mislabel a mis-sequenced pull as an unsupported backend.
+        raise HTTPException(status_code=409, detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
 # Credential pool endpoints — list / add / remove rotation keys.
 #
 # The credential pool (auth.json -> credential_pool.<provider>[]) holds the
@@ -17383,6 +17438,44 @@ app.include_router(_dashboard_auth_router)
 mount_spa(app)
 
 
+# ── Loop heartbeat watchdog (CF-1) ───────────────────────────────────
+# Confirm the GIL-pressure hypothesis in production. Re-arm a 2s tick and
+# measure the drift between when it *should* fire and when it actually does: a
+# healthy loop drifts ~0, but a turn that holds the GIL blocks the loop and the
+# next tick fires late by the stall duration. We log that so a stalled-loop WS
+# drop is diagnosable from the gateway log. Uses loop.time() (monotonic) for
+# drift, and call_later (not a task) so it dies with the loop — nothing to
+# cancel on shutdown.
+_HB_INTERVAL = 2.0
+_HB_STALL_THRESHOLD = 5.0
+
+
+def _install_loop_heartbeat(loop) -> None:
+    """Arm the self-re-arming heartbeat tick on *loop*."""
+
+    def _loop_heartbeat(expected: float) -> None:
+        now = loop.time()
+        drift = now - expected
+        if drift > _HB_STALL_THRESHOLD:
+            _log.warning(
+                "event loop stalled %.1fs (GIL pressure suspected)",
+                drift,
+            )
+        interval = _HB_INTERVAL
+        # While a diagnostics capture is armed this same tick doubles as the
+        # gateway's stall sampler (U3/KTD4): it runs fast enough to resolve a
+        # sub-second block, and every drift above the ring floor becomes a
+        # structured event. The warning threshold above is deliberately
+        # untouched — the ring is an additional sink, not a louder log.
+        if diagnostics_ring.ARMED:
+            interval = diagnostics_ring.armed_heartbeat_interval()
+            diagnostics_ring.note_loop_tick()
+            diagnostics_ring.record_loop_drift(drift)
+        loop.call_later(interval, _loop_heartbeat, now + interval)
+
+    loop.call_later(_HB_INTERVAL, _loop_heartbeat, loop.time() + _HB_INTERVAL)
+
+
 def _read_bound_port(server: "uvicorn.Server", fallback: int) -> int:
     """Read the OS-assigned port from a live uvicorn server socket.
 
@@ -17713,34 +17806,8 @@ def start_server(
             except Exception as exc:  # pragma: no cover - best-effort
                 _log.debug("loop noise filter install skipped: %s", exc)
 
-            # ── Loop heartbeat watchdog (CF-1) ───────────────────────────
-            # Confirm the GIL-pressure hypothesis in production. Re-arm a 2s
-            # tick and measure the drift between when it *should* fire and
-            # when it actually does: a healthy loop drifts ~0, but a turn that
-            # holds the GIL blocks the loop and the next tick fires late by the
-            # stall duration. We log that so a stalled-loop WS drop is
-            # diagnosable from the gateway log. Uses loop.time() (monotonic)
-            # for drift, and call_later (not a task) so it dies with the loop —
-            # nothing to cancel on shutdown.
-            _hb_interval = 2.0
-            _hb_stall_threshold = 5.0
-            _hb_loop = asyncio.get_running_loop()
-
-            def _loop_heartbeat(expected: float) -> None:
-                now = _hb_loop.time()
-                drift = now - expected
-                if drift > _hb_stall_threshold:
-                    _log.warning(
-                        "event loop stalled %.1fs (GIL pressure suspected)",
-                        drift,
-                    )
-                _hb_loop.call_later(
-                    _hb_interval, _loop_heartbeat, now + _hb_interval
-                )
-
-            _hb_loop.call_later(
-                _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
-            )
+            # Loop heartbeat watchdog (CF-1) — see _install_loop_heartbeat.
+            _install_loop_heartbeat(asyncio.get_running_loop())
 
             await server.main_loop()
             if server.started:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12674,6 +12674,13 @@ async def diagnostics_collect(request: Request):
         raise HTTPException(status_code=409, detail=str(exc))
 
 
+# The U5 proof harness has to cause a real gateway stall to prove the capture
+# attributes one to the gateway. Its hook is mounted here and ONLY when the
+# process was started with HERMES_DIAGNOSTICS_TEST_HOOKS=1 — a normally started
+# gateway never registers the route, so it answers 404.
+diagnostics_ring.install_test_routes(app)
+
+
 # ---------------------------------------------------------------------------
 # Credential pool endpoints — list / add / remove rotation keys.
 #

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -675,6 +675,16 @@
                 "WebSocket auth failed — reload the page to refresh the session token."));
               return;
             }
+            // WS_KANBAN_UNAVAILABLE (plugin_api.py): the server cannot open the
+            // Kanban database and the condition is permanent for its process,
+            // so reconnecting just re-triggers it every backoff tick — that
+            // loop is what filled errors.log. Terminal, and deliberately NOT
+            // the auth message: nothing is wrong with the session token.
+            if (ev && ev.code === 4004) {
+              setError(tx(t, "wsKanbanUnavailable",
+                "Kanban live updates stopped — the Hermes server cannot open the Kanban database. Restart Hermes to recover."));
+              return;
+            }
             const delay = Math.min(wsBackoffRef.current, 30000);
             wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
             setTimeout(openWs, delay);

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -57,6 +57,39 @@ router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
+# Permanent (process-level) Kanban failures
+# ---------------------------------------------------------------------------
+
+# A ``PermissionError`` out of ``kanban_db`` comes from the delegate_task
+# delegated-child guard, which reads process-level state: it will fail
+# identically for every request until the process is restarted. Retrying is
+# pointless, so the WS closes with a terminal code and the client stops
+# reconnecting. 4004 is in the WebSocket private-use range (4000-4999) and is
+# deliberately NOT 1008 — the dashboard renders 1008 as "auth failed", which is
+# the wrong message and sends users hunting for a session-token problem.
+WS_KANBAN_UNAVAILABLE = 4004
+WS_KANBAN_UNAVAILABLE_REASON = "kanban-unavailable"
+
+# One warning per process, not one per reconnect: the storm this replaces put a
+# line in errors.log every few seconds for as long as a dashboard tab was open.
+_permanent_error_logged = False
+
+
+def _log_permanent_kanban_error(context: str, exc: BaseException) -> None:
+    """Log a permanent process-level Kanban failure exactly once per process."""
+    global _permanent_error_logged
+    if _permanent_error_logged:
+        return
+    _permanent_error_logged = True
+    log.warning(
+        "%s — permanent for this process, not retrying (restart Hermes to "
+        "recover): %s",
+        context,
+        exc,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Auth helper — WebSocket only (HTTP routes live behind the dashboard's
 # existing plugin-bypass; this is documented above).
 # ---------------------------------------------------------------------------
@@ -130,6 +163,10 @@ def _conn(board: Optional[str] = None):
     """
     try:
         kanban_db.init_db(board=board)
+    except PermissionError as exc:
+        # Delegated-child guard: permanent for this process. Logging it per
+        # request produced the same storm as the event stream did.
+        _log_permanent_kanban_error("kanban init_db unavailable", exc)
     except Exception as exc:
         log.warning("kanban init_db failed: %s", exc)
     return kanban_db.connect(board=board)
@@ -2853,6 +2890,22 @@ async def stream_events(ws: WebSocket):
         # CancelledError is a BaseException in 3.8+ so the bare Exception
         # handler below would not catch it; without this clause Uvicorn
         # surfaces the cancellation as an application traceback. Quiet it.
+        return
+    except PermissionError as exc:
+        # Same shape as the CancelledError clause above — a specific exception
+        # class the generic handler would otherwise mistreat. This one is the
+        # delegate_task delegated-child guard: process-level and permanent, so
+        # the catch-all's plain close() (which the client retries with a
+        # backoff its own onopen resets) turned one failure into a reconnect
+        # storm. Log once, close terminally, let the client stop.
+        _log_permanent_kanban_error("Kanban event stream unavailable", exc)
+        try:
+            await ws.close(
+                code=WS_KANBAN_UNAVAILABLE,
+                reason=WS_KANBAN_UNAVAILABLE_REASON,
+            )
+        except Exception:
+            pass
         return
     except Exception as exc:  # defensive: never crash the dashboard worker
         log.warning("Kanban event stream error: %s", exc)

--- a/tests/hermes_cli/test_diagnostics_diagnose.py
+++ b/tests/hermes_cli/test_diagnostics_diagnose.py
@@ -1,0 +1,330 @@
+"""Tests for ``hermes debug diagnose`` (U4 / KTD6).
+
+Covers the three failure modes the plan names for the WPR helper (absent,
+stuck, failing), plus the sanitization rule the process tree shares with the
+desktop bundle manifest: basename only, never a command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+import pytest
+
+from hermes_cli.diagnostics_diagnose import (
+    CommandResult,
+    basename_only,
+    collect_process_tree,
+    find_wpr,
+    run_bounded,
+    run_diagnose,
+    run_wpr_trace,
+)
+
+MARKER = "HERMES-DIAGNOSE-CANARY-4b21"
+
+
+# ── fakes ────────────────────────────────────────────────────────────
+
+
+class FakeProc:
+    """A child process whose behaviour each test dictates."""
+
+    def __init__(self, *, output="", returncode=0, hang=False):
+        self._output = output
+        self.returncode = returncode
+        self._hang = hang
+        self.killed = False
+        self.communicate_calls = 0
+
+    def communicate(self, timeout=None):
+        self.communicate_calls += 1
+        # A hung child stays hung until it is killed; after the kill it drains.
+        if self._hang and not self.killed:
+            raise subprocess.TimeoutExpired(cmd="wpr", timeout=timeout or 0)
+        return self._output, ""
+
+    def kill(self):
+        self.killed = True
+
+
+def make_popen(procs):
+    """Return a Popen stand-in handing out *procs* in order, recording argv."""
+    calls: list[list[str]] = []
+    remaining = list(procs)
+
+    def popen(cmd, **_kwargs):
+        calls.append(list(cmd))
+        return remaining.pop(0) if remaining else FakeProc()
+
+    popen.calls = calls  # type: ignore[attr-defined]
+    return popen
+
+
+def ns(**kwargs):
+    return argparse.Namespace(**kwargs)
+
+
+# ── basename / sanitization ──────────────────────────────────────────
+
+
+def test_basename_only_strips_paths_and_argv():
+    assert basename_only(r"C:\Program Files\Hermes\Hermes.exe") == "Hermes.exe"
+    assert basename_only("/opt/hermes/bin/hermes") == "hermes"
+    assert basename_only(f"/opt/hermes/bin/hermes --token={MARKER}") == "hermes"
+    assert basename_only("") == "unknown"
+    assert basename_only(None) == "unknown"
+
+
+def test_process_tree_keeps_only_pid_ppid_basename():
+    def source():
+        return [
+            {
+                "pid": 100,
+                "ppid": 1,
+                "name": "hermes.exe",
+                "exe": r"C:\hermes\hermes.exe",
+                # Fields psutil could return that must never survive.
+                "cmdline": ["hermes", f"--api-key={MARKER}"],
+                "environ": {"HERMES_TOKEN": MARKER},
+            },
+            {"pid": 101, "ppid": 100, "name": "python.exe", "exe": r"C:\py\python.exe"},
+            {"pid": 1, "ppid": 0, "name": "explorer.exe", "exe": r"C:\Windows\explorer.exe"},
+            {"pid": 900, "ppid": 1, "name": "chrome.exe", "exe": r"C:\chrome\chrome.exe"},
+        ]
+
+    tree = collect_process_tree(iter_processes=source)
+
+    # The hermes process, its parent (ancestor) and its child; not chrome.
+    assert tree == [
+        {"pid": 1, "ppid": 0, "name": "explorer.exe"},
+        {"pid": 100, "ppid": 1, "name": "hermes.exe"},
+        {"pid": 101, "ppid": 100, "name": "python.exe"},
+    ]
+    assert MARKER not in json.dumps(tree)
+    for entry in tree:
+        assert sorted(entry) == ["name", "pid", "ppid"]
+
+
+def test_process_tree_survives_a_cyclic_parent_map():
+    def source():
+        return [
+            {"pid": 5, "ppid": 6, "name": "hermes"},
+            {"pid": 6, "ppid": 5, "name": "shell"},
+        ]
+
+    assert [entry["pid"] for entry in collect_process_tree(iter_processes=source)] == [5, 6]
+
+
+def test_process_tree_is_empty_when_the_source_explodes():
+    def source():
+        raise RuntimeError("psutil unavailable")
+
+    assert collect_process_tree(iter_processes=source) == []
+
+
+# ── wpr availability ─────────────────────────────────────────────────
+
+
+def test_find_wpr_returns_none_when_absent(monkeypatch):
+    monkeypatch.delenv("SystemRoot", raising=False)
+    monkeypatch.delenv("SYSTEMROOT", raising=False)
+    assert find_wpr(which=lambda _name: None) is None
+
+
+def test_find_wpr_prefers_path():
+    assert find_wpr(which=lambda _name: "/usr/bin/wpr") == "/usr/bin/wpr"
+
+
+def test_wpr_absent_is_skipped_not_failed(tmp_path, monkeypatch):
+    monkeypatch.delenv("SystemRoot", raising=False)
+    monkeypatch.delenv("SYSTEMROOT", raising=False)
+    monkeypatch.setattr("hermes_cli.diagnostics_diagnose.shutil.which", lambda _n: None)
+
+    result = run_wpr_trace(tmp_path / "unsafe-to-share", seconds=0)
+
+    assert result["status"] == "skipped"
+    assert "wpr.exe" in result["reason"]
+    # Nothing was created for a trace that never ran.
+    assert not (tmp_path / "unsafe-to-share").exists()
+
+
+# ── wpr happy path + hard timeout ────────────────────────────────────
+
+
+def test_wpr_records_and_stops(tmp_path):
+    popen = make_popen([FakeProc(), FakeProc()])
+    slept: list[float] = []
+
+    result = run_wpr_trace(
+        tmp_path / "unsafe",
+        profile="GeneralProfile",
+        seconds=7,
+        wpr_path="wpr.exe",
+        popen=popen,
+        sleep=slept.append,
+    )
+
+    assert result["status"] == "recorded"
+    assert result["seconds"] == 7
+    assert result["file"] == "trace.etl"
+    assert slept == [7]
+    assert popen.calls[0][:3] == ["wpr.exe", "-start", "GeneralProfile"]
+    assert popen.calls[1][:2] == ["wpr.exe", "-stop"]
+    assert popen.calls[1][2].endswith("trace.etl")
+
+
+def test_stuck_wpr_start_is_killed_at_the_hard_timeout(tmp_path):
+    stuck = FakeProc(hang=True)
+    popen = make_popen([stuck])
+
+    result = run_wpr_trace(
+        tmp_path / "unsafe",
+        seconds=0,
+        timeout_s=0.01,
+        wpr_path="wpr.exe",
+        popen=popen,
+        sleep=lambda _s: None,
+    )
+
+    assert stuck.killed is True
+    assert result["status"] == "timeout"
+    assert result["phase"] == "start"
+    # A start that never returned must not be followed by a stop.
+    assert len(popen.calls) == 1
+
+
+def test_stuck_wpr_stop_is_killed_and_the_session_cancelled(tmp_path):
+    stuck_stop = FakeProc(hang=True)
+    popen = make_popen([FakeProc(), stuck_stop, FakeProc()])
+
+    result = run_wpr_trace(
+        tmp_path / "unsafe",
+        seconds=0,
+        timeout_s=0.01,
+        wpr_path="wpr.exe",
+        popen=popen,
+        sleep=lambda _s: None,
+    )
+
+    assert stuck_stop.killed is True
+    assert result["status"] == "timeout"
+    assert result["phase"] == "stop"
+    # A killed -stop leaves a live system-wide session; it must be cancelled.
+    assert popen.calls[-1] == ["wpr.exe", "-cancel"]
+
+
+def test_wpr_start_failure_reports_the_first_output_line(tmp_path):
+    popen = make_popen([FakeProc(returncode=5, output="Error: elevated privileges required.\nmore\n")])
+
+    result = run_wpr_trace(
+        tmp_path / "unsafe", seconds=0, wpr_path="wpr.exe", popen=popen, sleep=lambda _s: None
+    )
+
+    assert result["status"] == "failed"
+    assert result["phase"] == "start"
+    assert result["reason"] == "Error: elevated privileges required."
+
+
+def test_run_bounded_reports_a_clean_exit():
+    popen = make_popen([FakeProc(output="fine", returncode=0)])
+    result = run_bounded(["wpr", "-status"], 5, popen=popen)
+
+    assert isinstance(result, CommandResult)
+    assert result.ok is True
+    assert result.timed_out is False
+    assert result.output == "fine"
+
+
+# ── command ──────────────────────────────────────────────────────────
+
+
+def test_diagnose_writes_a_report_without_wpr(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.diagnostics_diagnose.collect_process_tree",
+        lambda **_k: [{"pid": 100, "ppid": 1, "name": "hermes.exe"}],
+    )
+
+    out = tmp_path / "report"
+    code = run_diagnose(ns(out=str(out), wpr=False))
+
+    assert code == 0
+    report = json.loads((out / "diagnose.json").read_text(encoding="utf-8"))
+    assert report["process_tree"] == [{"pid": 100, "ppid": 1, "name": "hermes.exe"}]
+    assert report["wpr"]["status"] == "skipped"
+    # No opt-in means no unsafe directory at all.
+    assert not (out / "unsafe-to-share").exists()
+    assert "hermes.exe" in capsys.readouterr().out
+
+
+def test_diagnose_labels_the_wpr_output_unsafe_to_share(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.diagnostics_diagnose.collect_process_tree", lambda **_k: [])
+    monkeypatch.setattr(
+        "hermes_cli.diagnostics_diagnose.run_wpr_trace",
+        lambda _dir, **_k: {"status": "recorded", "profile": "GeneralProfile", "seconds": 30, "file": "trace.etl"},
+    )
+
+    out = tmp_path / "report"
+    run_diagnose(ns(out=str(out), wpr=True, wpr_profile="GeneralProfile", wpr_seconds=30, timeout=300))
+
+    readme = (out / "unsafe-to-share" / "README.txt").read_text(encoding="utf-8")
+    assert "DO NOT SHARE" in readme
+    assert "COMMAND LINES" in readme
+
+    printed = capsys.readouterr().out
+    assert "UNSANITIZED" in printed
+
+
+def test_diagnose_succeeds_when_wpr_is_unavailable(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.diagnostics_diagnose.collect_process_tree", lambda **_k: [])
+    monkeypatch.setattr(
+        "hermes_cli.diagnostics_diagnose.run_wpr_trace",
+        lambda _dir, **_k: {"status": "skipped", "reason": "wpr.exe not found"},
+    )
+
+    out = tmp_path / "report"
+    code = run_diagnose(ns(out=str(out), wpr=True, wpr_profile=None, wpr_seconds=None, timeout=None))
+
+    assert code == 0
+    report = json.loads((out / "diagnose.json").read_text(encoding="utf-8"))
+    assert report["wpr"]["status"] == "skipped"
+    assert "skipped" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("status,phase", [("failed", "start"), ("timeout", "stop")])
+def test_diagnose_still_writes_the_report_when_wpr_fails(tmp_path, monkeypatch, status, phase):
+    monkeypatch.setattr(
+        "hermes_cli.diagnostics_diagnose.collect_process_tree",
+        lambda **_k: [{"pid": 7, "ppid": 1, "name": "hermes"}],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.diagnostics_diagnose.run_wpr_trace",
+        lambda _dir, **_k: {"status": status, "phase": phase, "reason": "boom"},
+    )
+
+    out = tmp_path / "report"
+    assert run_diagnose(ns(out=str(out), wpr=True, wpr_profile=None, wpr_seconds=None, timeout=None)) == 0
+
+    report = json.loads((out / "diagnose.json").read_text(encoding="utf-8"))
+    assert report["wpr"]["status"] == status
+    assert report["process_tree"]
+
+
+def test_debug_diagnose_parser_is_registered():
+    from hermes_cli.subcommands.debug import build_debug_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    handler = object()
+    build_debug_parser(subparsers, cmd_debug=handler)
+
+    parsed = parser.parse_args(["debug", "diagnose", "--wpr", "--wpr-seconds", "5"])
+
+    assert parsed.func is handler
+    assert parsed.debug_command == "diagnose"
+    assert parsed.wpr is True
+    assert parsed.wpr_seconds == 5
+    # Default is opt-OUT: a bare diagnose records no ETL.
+    assert parser.parse_args(["debug", "diagnose"]).wpr is False

--- a/tests/hermes_cli/test_diagnostics_ring.py
+++ b/tests/hermes_cli/test_diagnostics_ring.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from types import SimpleNamespace
 
@@ -337,7 +338,15 @@ class TestAuthenticatedSurfaceOnly:
         from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
 
         paths = [getattr(r, "path", "") for r in web_server.app.routes]
-        mounted = [p for p in paths if "/diagnostics/" in p and "plugins" not in p]
+        mounted = [
+            p
+            for p in paths
+            if "/diagnostics/" in p
+            and "plugins" not in p
+            # The U5 test hook mounts only under an env opt-in and has its own
+            # coverage in TestLoopBlockHookIsGuarded.
+            and p != diagnostics_ring._TEST_BLOCK_PATH
+        ]
         assert sorted(mounted) == [
             "/api/diagnostics/arm",
             "/api/diagnostics/collect",
@@ -437,3 +446,91 @@ class TestAuthenticatedSurfaceOnly:
         assert got["result"]["dropped"] == 0
         assert got["result"]["events"][0]["kind"] == "loop_drift"
         assert server._methods["diagnostics/disarm"]("r3", {})["result"]["armed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test-only loop-block hook (U5)
+# ---------------------------------------------------------------------------
+
+
+class TestLoopBlockHookIsGuarded:
+    """The hook that lets the U5 harness stall the gateway on purpose.
+
+    The whole safety property is *registration-time*: without the opt-in env
+    var the route does not exist, so there is no handler to reach, no flag to
+    misread, and no refusal path to get wrong.
+    """
+
+    @staticmethod
+    def _fresh_app():
+        from fastapi import FastAPI
+
+        return FastAPI()
+
+    def test_not_mounted_without_the_env_var(self, monkeypatch):
+        monkeypatch.delenv(diagnostics_ring._TEST_HOOKS_ENV, raising=False)
+        app = self._fresh_app()
+
+        assert diagnostics_ring.install_test_routes(app) is False
+        assert [getattr(r, "path", "") for r in app.routes if "block-loop" in getattr(r, "path", "")] == []
+
+    def test_a_normally_started_gateway_has_no_such_route(self):
+        """The real app, imported without the env var, never mounted it."""
+        if os.environ.get(diagnostics_ring._TEST_HOOKS_ENV) == "1":
+            pytest.skip("this test process itself opted into the hooks")
+        assert diagnostics_ring.test_hooks_enabled() is False
+        paths = [getattr(r, "path", "") for r in web_server.app.routes]
+        assert diagnostics_ring._TEST_BLOCK_PATH not in paths
+
+    def test_mounted_only_with_the_env_var_and_stays_behind_the_api_gate(self, monkeypatch):
+        from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+        monkeypatch.setenv(diagnostics_ring._TEST_HOOKS_ENV, "1")
+        app = self._fresh_app()
+
+        assert diagnostics_ring.install_test_routes(app) is True
+        paths = [getattr(r, "path", "") for r in app.routes]
+        assert diagnostics_ring._TEST_BLOCK_PATH in paths
+        # Same gate as the rest of the ring: under /api/ and not public.
+        assert diagnostics_ring._TEST_BLOCK_PATH.startswith("/api/")
+        assert diagnostics_ring._TEST_BLOCK_PATH not in PUBLIC_API_PATHS
+
+    def test_the_hook_blocks_for_the_requested_duration(self, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setenv(diagnostics_ring._TEST_HOOKS_ENV, "1")
+        app = self._fresh_app()
+        diagnostics_ring.install_test_routes(app)
+
+        started = time.monotonic()
+        with TestClient(app) as client:
+            resp = client.post(diagnostics_ring._TEST_BLOCK_PATH, json={"seconds": 0.4})
+        elapsed = time.monotonic() - started
+
+        assert resp.status_code == 200
+        assert resp.json()["blocked_s"] >= 0.4
+        assert elapsed >= 0.4
+
+    def test_a_block_lands_in_an_armed_ring_as_loop_drift(self, monkeypatch):
+        """What the harness asserts on: the block is what the ring records.
+
+        The heartbeat itself is the recorder, so this drives its two calls the
+        way ``_install_loop_heartbeat`` does — the block happens *between* two
+        ticks and the drift it caused is the event.
+        """
+        monkeypatch.setenv(diagnostics_ring._TEST_HOOKS_ENV, "1")
+        diagnostics_ring.arm("cap-block")
+
+        started = time.monotonic()
+        diagnostics_ring.block_event_loop(0.4)
+        drift = time.monotonic() - started
+        diagnostics_ring.record_loop_drift(drift)
+
+        events = diagnostics_ring.collect("cap-block")["events"]
+        assert [e["kind"] for e in events] == ["loop_drift"]
+        assert events[0]["drift_s"] >= 0.4
+
+    @pytest.mark.parametrize("seconds", [None, "soon", 0, -1, 31.0])
+    def test_a_nonsense_duration_is_refused(self, seconds):
+        with pytest.raises(ValueError):
+            diagnostics_ring.block_event_loop(seconds)

--- a/tests/hermes_cli/test_diagnostics_ring.py
+++ b/tests/hermes_cli/test_diagnostics_ring.py
@@ -1,0 +1,439 @@
+"""Tests for the gateway diagnostics ring (U3 / KTD2 / KTD4).
+
+Covers the four things the capture bundle depends on:
+
+* a **sub-second** loop block lands in the ring even though it never reaches
+  the 5s "event loop stalled" log threshold, and carries a sanitized frame
+  summary naming the blocking call site;
+* disarmed is genuinely inert — no ring, no thread, and the production 2.0s
+  heartbeat interval is untouched;
+* ``collect`` returns events + a dropped count and is reachable only through
+  the authenticated ``/api/ws`` surface;
+* peer identifiers are HMAC'd per capture, so the same peer tokenizes
+  differently in two captures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import diagnostics_ring
+from hermes_cli import web_server
+
+
+@pytest.fixture(autouse=True)
+def _disarmed_between_tests():
+    """Never leave a capture (or its watchdog thread) armed across tests."""
+    diagnostics_ring.disarm()
+    yield
+    diagnostics_ring.disarm()
+
+
+@pytest.fixture
+def loopback_client():
+    """``web_server.app`` in loopback (session-token) mode, as the desktop sees it."""
+    from fastapi.testclient import TestClient
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 8080
+    web_server.app.state.auth_required = False
+    with TestClient(web_server.app, base_url="http://127.0.0.1:8080") as client:
+        yield client
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeLoop:
+    """Enough of an event loop to drive ``_install_loop_heartbeat`` by hand."""
+
+    def __init__(self) -> None:
+        self.now = 100.0
+        self.scheduled: list[tuple[float, object, tuple]] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def call_later(self, delay, fn, *args):
+        self.scheduled.append((delay, fn, args))
+        return SimpleNamespace(cancel=lambda: None)
+
+    def tick(self):
+        """Fire the most recently scheduled heartbeat callback."""
+        delay, fn, args = self.scheduled.pop()
+        fn(*args)
+        return delay
+
+
+def _blocking_call_site(seconds: float) -> None:
+    """Stand-in for the GIL-heavy work that stalls the loop in production."""
+    time.sleep(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Arm / disarm / collect
+# ---------------------------------------------------------------------------
+
+
+class TestArmDisarmCollect:
+    def test_arm_is_idempotent_per_capture_id(self):
+        first = diagnostics_ring.arm("cap-1", wall_clock_anchor_ms=1234.0)
+        again = diagnostics_ring.arm("cap-1", wall_clock_anchor_ms=9999.0)
+        assert again["monotonic_anchor_ms"] == first["monotonic_anchor_ms"]
+        assert diagnostics_ring.collect("cap-1")["wall_clock_anchor_ms"] == 1234.0
+
+    def test_arm_new_capture_id_replaces_the_window(self):
+        diagnostics_ring.arm("cap-1")
+        diagnostics_ring.record_loop_drift(1.0)
+        diagnostics_ring.arm("cap-2")
+        with pytest.raises(LookupError):
+            diagnostics_ring.collect("cap-1")
+        assert diagnostics_ring.collect("cap-2")["events"] == []
+
+    def test_disarm_is_idempotent_and_clears_the_flag(self):
+        diagnostics_ring.arm("cap-1")
+        assert diagnostics_ring.ARMED is True
+        assert diagnostics_ring.disarm()["armed"] is False
+        assert diagnostics_ring.disarm()["armed"] is False
+        assert diagnostics_ring.ARMED is False
+
+    def test_collect_reports_events_and_dropped(self, monkeypatch):
+        monkeypatch.setattr(diagnostics_ring, "_MAX_EVENTS", 3)
+        diagnostics_ring.arm("cap-1")
+        for _ in range(5):
+            diagnostics_ring.record_loop_drift(0.5)
+        out = diagnostics_ring.collect("cap-1")
+        assert out["capture_id"] == "cap-1"
+        assert len(out["events"]) == 3
+        assert out["dropped"] == 2
+        assert out["monotonic_anchor_ms"] > 0
+
+    def test_collect_on_unknown_capture_id_raises(self):
+        diagnostics_ring.arm("cap-1")
+        with pytest.raises(LookupError):
+            diagnostics_ring.collect("cap-other")
+
+    def test_drift_below_the_floor_is_not_recorded(self):
+        diagnostics_ring.arm("cap-1")
+        assert diagnostics_ring.record_loop_drift(0.1) is None
+        assert diagnostics_ring.collect("cap-1")["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# Disarmed = inert
+# ---------------------------------------------------------------------------
+
+
+class TestDisarmedIsInert:
+    def test_no_ring_and_no_recording_when_disarmed(self):
+        assert diagnostics_ring.ARMED is False
+        assert diagnostics_ring.record_loop_drift(9.0) is None
+        diagnostics_ring.record_ws_write_slow("1.2.3.4:5", 10.0)
+        diagnostics_ring.note_loop_tick()
+        with pytest.raises(LookupError):
+            diagnostics_ring.collect("cap-1")
+
+    def test_watchdog_thread_only_exists_while_armed(self):
+        import threading
+
+        def _watchdogs():
+            return [t for t in threading.enumerate()
+                    if t.name.startswith("hermes-diag-watchdog")]
+
+        assert _watchdogs() == []
+        diagnostics_ring.arm("cap-1")
+        assert len(_watchdogs()) == 1
+        diagnostics_ring.disarm()
+        for _ in range(50):
+            if not _watchdogs():
+                break
+            time.sleep(0.02)
+        assert _watchdogs() == []
+
+    def test_heartbeat_keeps_the_2s_interval_when_disarmed(self):
+        assert web_server._HB_INTERVAL == 2.0
+        loop = _FakeLoop()
+        web_server._install_loop_heartbeat(loop)
+        assert loop.scheduled[0][0] == 2.0
+        loop.now += 2.0
+        assert loop.tick() == 2.0
+        assert loop.scheduled[-1][0] == 2.0
+
+    def test_heartbeat_tightens_only_while_armed(self):
+        loop = _FakeLoop()
+        web_server._install_loop_heartbeat(loop)
+        diagnostics_ring.arm("cap-1")
+        loop.now += 2.0
+        loop.tick()
+        assert loop.scheduled[-1][0] == diagnostics_ring.armed_heartbeat_interval()
+        diagnostics_ring.disarm()
+        loop.now += 0.05
+        loop.tick()
+        assert loop.scheduled[-1][0] == 2.0
+
+    def test_log_threshold_is_unchanged_while_armed(self, caplog):
+        """Armed capture adds a sink; it must not lower the 5s warning."""
+        loop = _FakeLoop()
+        web_server._install_loop_heartbeat(loop)
+        diagnostics_ring.arm("cap-1")
+        with caplog.at_level(logging.WARNING, logger=web_server._log.name):
+            # 3.0s of drift: above the ring floor, below the log threshold.
+            loop.now += 5.0
+            loop.tick()
+        assert "event loop stalled" not in caplog.text
+        events = diagnostics_ring.collect("cap-1")["events"]
+        assert [e["kind"] for e in events] == ["loop_drift"]
+        assert events[0]["drift_s"] == pytest.approx(3.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Sub-second stall + attribution
+# ---------------------------------------------------------------------------
+
+
+class TestSubSecondStallAttribution:
+    def test_400ms_block_lands_in_the_ring_with_a_frame_summary(self, monkeypatch):
+        # Production ticks every 2s, which cannot resolve a 400ms block at all.
+        # Shorten only the *disarmed* interval so the heartbeat starts promptly
+        # inside the test; the armed interval is the module's own value.
+        monkeypatch.setattr(web_server, "_HB_INTERVAL", 0.05)
+
+        async def _main():
+            loop = asyncio.get_running_loop()
+            diagnostics_ring.arm("cap-block")
+            web_server._install_loop_heartbeat(loop)
+            # Let a few ticks establish loop liveness for the watchdog.
+            await asyncio.sleep(0.25)
+            _blocking_call_site(0.4)
+            # Let the post-stall tick record the drift.
+            await asyncio.sleep(0.25)
+
+        asyncio.run(_main())
+
+        out = diagnostics_ring.collect("cap-block")
+        stalls = [e for e in out["events"] if e["drift_s"] >= 0.25]
+        assert stalls, f"no sub-second stall recorded: {out['events']}"
+        worst = max(stalls, key=lambda e: e["drift_s"])
+        assert worst["kind"] == "loop_drift"
+        assert 0.3 <= worst["drift_s"] < 1.0
+        assert worst["t_monotonic"] > 0
+
+        attributed = [e for e in stalls if e.get("frames")]
+        assert attributed, f"no stall carried a frame summary: {stalls}"
+        frames = attributed[0]["frames"]
+        assert any(f["function"] == "_blocking_call_site" for f in frames)
+        for f in frames:
+            assert set(f) == {"module", "function", "line"}
+            assert ":" not in f["module"] and "/" not in f["module"]
+            assert "\\" not in f["module"]
+        blocking = next(f for f in frames if f["function"] == "_blocking_call_site")
+        assert blocking["module"].endswith("test_diagnostics_ring")
+        assert isinstance(blocking["line"], int)
+
+
+# ---------------------------------------------------------------------------
+# WS write-slow events + per-capture HMAC
+# ---------------------------------------------------------------------------
+
+
+class TestWsWriteSlowEvents:
+    def test_peer_is_tokenized_and_correlates_within_a_capture(self):
+        diagnostics_ring.arm("cap-1")
+        diagnostics_ring.record_ws_write_slow("127.0.0.1:51544", 10.0)
+        diagnostics_ring.record_ws_write_slow("127.0.0.1:51544", 10.0)
+        diagnostics_ring.record_ws_write_slow("127.0.0.1:60001", 10.0)
+        events = diagnostics_ring.collect("cap-1")["events"]
+        assert [e["kind"] for e in events] == ["ws_write_slow"] * 3
+        assert events[0]["peer"] == events[1]["peer"]
+        assert events[0]["peer"] != events[2]["peer"]
+        # Non-reversible: the raw identifier appears nowhere in the ring.
+        assert "127.0.0.1" not in repr(events)
+        assert events[0]["timeout_s"] == 10.0
+
+    def test_same_peer_tokenizes_differently_across_captures(self):
+        peer = "127.0.0.1:51544"
+        diagnostics_ring.arm("cap-1")
+        diagnostics_ring.record_ws_write_slow(peer, 10.0)
+        one = diagnostics_ring.collect("cap-1")["events"][0]["peer"]
+        diagnostics_ring.arm("cap-2")
+        diagnostics_ring.record_ws_write_slow(peer, 10.0)
+        two = diagnostics_ring.collect("cap-2")["events"][0]["peer"]
+        assert one != two
+
+    def test_per_capture_key_is_never_exposed(self):
+        diagnostics_ring.arm("cap-1")
+        diagnostics_ring.record_ws_write_slow("peer-a", 10.0)
+        out = diagnostics_ring.collect("cap-1")
+        assert "key" not in out
+        assert set(out) == {
+            "capture_id", "monotonic_anchor_ms", "wall_clock_anchor_ms",
+            "events", "dropped",
+        }
+
+    def test_ws_transport_records_on_the_write_timeout_path(self, monkeypatch):
+        """The real ``ws write slow`` branch feeds the ring while armed."""
+        import concurrent.futures
+
+        from tui_gateway import ws as ws_mod
+
+        class _StalledFuture:
+            """A send scheduled onto a loop that never breathes."""
+
+            def result(self, timeout=None):
+                raise concurrent.futures.TimeoutError()
+
+        def _stalled(coro, loop):
+            coro.close()  # never awaited; keep the test warning-free
+            return _StalledFuture()
+
+        monkeypatch.setattr(
+            "agent.async_utils.safe_schedule_threadsafe", _stalled
+        )
+        transport = ws_mod.WSTransport(
+            ws=SimpleNamespace(), loop=_FakeLoop(), peer="127.0.0.1:51544"
+        )
+
+        diagnostics_ring.arm("cap-ws")
+        assert transport.write({"jsonrpc": "2.0", "id": "1", "result": {}}) is True
+        events = diagnostics_ring.collect("cap-ws")["events"]
+        assert [e["kind"] for e in events] == ["ws_write_slow"]
+        assert "127.0.0.1" not in repr(events)
+
+
+# ---------------------------------------------------------------------------
+# Auth surface
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedSurfaceOnly:
+    def test_methods_are_registered_on_the_gateway_rpc_table(self):
+        from tui_gateway import server, ws as _ws  # noqa: F401 - installs methods
+
+        for name in (
+            "diagnostics.arm", "diagnostics.disarm", "diagnostics.collect",
+            "diagnostics/arm", "diagnostics/disarm", "diagnostics/collect",
+        ):
+            assert name in server._methods
+
+    def test_routes_live_on_the_gated_api_prefix_only(self):
+        """The ring rides the existing gate — it must not become public.
+
+        ``/api/`` + absence from ``PUBLIC_API_PATHS`` *is* the auth: any other
+        prefix would slip past ``auth_middleware`` entirely.
+        """
+        from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+        paths = [getattr(r, "path", "") for r in web_server.app.routes]
+        mounted = [p for p in paths if "/diagnostics/" in p and "plugins" not in p]
+        assert sorted(mounted) == [
+            "/api/diagnostics/arm",
+            "/api/diagnostics/collect",
+            "/api/diagnostics/disarm",
+        ]
+        for path in mounted:
+            assert path not in PUBLIC_API_PATHS
+
+    def test_unauthenticated_http_pull_is_refused(self, loopback_client):
+        """An unauthenticated local caller cannot pull an armed ring."""
+        diagnostics_ring.arm("cap-http")
+        diagnostics_ring.record_loop_drift(0.4)
+
+        for path, body in (
+            ("/api/diagnostics/arm", {"capture_id": "cap-evil"}),
+            ("/api/diagnostics/collect", {"capture_id": "cap-http"}),
+            ("/api/diagnostics/disarm", {}),
+        ):
+            resp = loopback_client.post(path, json=body)
+            assert resp.status_code == 401, path
+        # Still armed, still ours: the refused calls changed nothing.
+        assert diagnostics_ring.collect("cap-http")["capture_id"] == "cap-http"
+
+    def test_authenticated_http_round_trip(self, loopback_client):
+        headers = {"Authorization": f"Bearer {web_server._SESSION_TOKEN}"}
+
+        armed = loopback_client.post(
+            "/api/diagnostics/arm",
+            json={"capture_id": "cap-http", "wall_clock_anchor_ms": 17.0},
+            headers=headers,
+        )
+        assert armed.status_code == 200
+        assert armed.json()["monotonic_anchor_ms"] > 0
+
+        diagnostics_ring.record_loop_drift(0.4)
+        got = loopback_client.post(
+            "/api/diagnostics/collect",
+            json={"capture_id": "cap-http"},
+            headers=headers,
+        )
+        assert got.status_code == 200
+        payload = got.json()
+        assert payload["capture_id"] == "cap-http"
+        assert payload["dropped"] == 0
+        assert payload["events"][0]["kind"] == "loop_drift"
+
+        # 409, not 404 — the desktop client reads 404 as "gateway too old".
+        missing = loopback_client.post(
+            "/api/diagnostics/collect", json={"capture_id": "other"}, headers=headers
+        )
+        assert missing.status_code == 409
+
+        assert loopback_client.post(
+            "/api/diagnostics/disarm", json={}, headers=headers
+        ).json()["armed"] is False
+        assert diagnostics_ring.ARMED is False
+
+    def test_unauthenticated_ws_upgrade_is_refused(self, monkeypatch):
+        """The ring is only reachable behind ``/api/ws``'s existing gate."""
+        monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+        monkeypatch.setattr(web_server.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(web_server.app.state, "bound_port", 8080, raising=False)
+
+        class _QP:
+            def __init__(self, q):
+                self._q = q
+
+            def get(self, k, default=""):
+                return self._q.get(k, default)
+
+        def _ws(query):
+            return SimpleNamespace(
+                query_params=_QP(query),
+                client=SimpleNamespace(host="127.0.0.1"),
+                url=SimpleNamespace(path="/api/ws"),
+            )
+
+        assert web_server._ws_auth_ok(_ws({})) is False
+        assert web_server._ws_auth_ok(_ws({"token": "not-the-token"})) is False
+        assert web_server._ws_auth_ok(_ws({"token": web_server._SESSION_TOKEN})) is True
+
+    def test_collect_handler_refuses_an_unarmed_capture(self):
+        from tui_gateway import server, ws as _ws  # noqa: F401
+
+        resp = server._methods["diagnostics.collect"]("r1", {"capture_id": "nope"})
+        assert resp["error"]["code"] == diagnostics_ring._ERR_NO_CAPTURE
+
+    def test_arm_collect_disarm_round_trip_through_the_rpc_table(self):
+        from tui_gateway import server, ws as _ws  # noqa: F401
+
+        armed = server._methods["diagnostics/arm"](
+            "r1", {"capture_id": "cap-rpc", "wall_clock_anchor_ms": 42.0}
+        )
+        assert armed["result"]["monotonic_anchor_ms"] > 0
+        diagnostics_ring.record_loop_drift(0.4)
+        got = server._methods["diagnostics/collect"]("r2", {"capture_id": "cap-rpc"})
+        assert got["result"]["dropped"] == 0
+        assert got["result"]["events"][0]["kind"] == "loop_drift"
+        assert server._methods["diagnostics/disarm"]("r3", {})["result"]["armed"] is False

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -26,8 +26,12 @@ from hermes_cli import kanban_db as kb
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py as a fresh module.
+
+    Fresh per call so process-scoped state in the plugin (the once-per-process
+    permanent-error latch) starts clean in each test.
+    """
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
@@ -39,7 +43,12 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    return _load_plugin_module().router
 
 
 @pytest.fixture
@@ -388,6 +397,132 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
         "/api/plugins/kanban/events?token=secret-xyz"
     ) as ws:
         assert ws is not None  # handshake succeeded
+
+
+# ---------------------------------------------------------------------------
+# Permanent (process-level) Kanban failure — no reconnect storm
+# ---------------------------------------------------------------------------
+
+
+def _permissive_ws_auth(monkeypatch):
+    """Stub hermes_cli.web_server so every WS upgrade is authorized."""
+    import hermes_cli
+    import types
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="",
+        _ws_auth_ok=lambda ws: True,
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+
+def test_ws_events_delegated_child_closes_terminally_and_logs_once(
+    tmp_path, monkeypatch, caplog,
+):
+    """A delegated-child PermissionError is permanent — close terminally, log once.
+
+    The guard is process-level, so every reconnect hits it again. Before the
+    fix the catch-all closed with no code, the dashboard's backoff treated that
+    as transient, and errors.log grew a line every few seconds for as long as a
+    tab was open. Now: a distinct terminal close code (not 1008, which the
+    dashboard renders as an auth failure) and exactly one warning per process.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    _permissive_ws_auth(monkeypatch)
+
+    mod = _load_plugin_module()
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api/plugins/kanban")
+    c = TestClient(app)
+
+    # Genuinely delegated-child context: the real guard fires inside
+    # connect()'s first-open migration pass (write_txn), so clear the
+    # per-process init cache to force that pass to run again.
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    kb._INITIALIZED_PATHS.clear()
+
+    from starlette.websockets import WebSocketDisconnect
+
+    caplog.clear()
+    codes = []
+    # Two connections back to back — the second stands in for the client's
+    # immediate reconnect attempt.
+    for _ in range(2):
+        with caplog.at_level("WARNING"):
+            with pytest.raises(WebSocketDisconnect) as exc:
+                with c.websocket_connect("/api/plugins/kanban/events") as ws:
+                    ws.receive_json()
+        codes.append(exc.value.code)
+
+    assert codes == [mod.WS_KANBAN_UNAVAILABLE, mod.WS_KANBAN_UNAVAILABLE]
+    assert mod.WS_KANBAN_UNAVAILABLE != 1008  # 1008 renders as "auth failed"
+
+    stream_warnings = [
+        r for r in caplog.records
+        if "Kanban event stream" in r.getMessage()
+    ]
+    assert len(stream_warnings) == 1, [r.getMessage() for r in stream_warnings]
+    assert "not retrying" in stream_warnings[0].getMessage()
+    # And the old per-attempt line is gone entirely.
+    assert not [
+        r for r in caplog.records
+        if "Kanban event stream error:" in r.getMessage()
+    ]
+
+
+def test_init_db_permission_error_logs_once_per_process(tmp_path, monkeypatch, caplog):
+    """``_conn``'s init_db failure is the same permanent condition — log once."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    mod = _load_plugin_module()
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    kb._INITIALIZED_PATHS.clear()
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            with pytest.raises(PermissionError):
+                mod._conn()
+
+    init_warnings = [
+        r for r in caplog.records if "init_db" in r.getMessage()
+    ]
+    assert len(init_warnings) == 1, [r.getMessage() for r in init_warnings]
+    assert "not retrying" in init_warnings[0].getMessage()
+
+
+def test_dashboard_bundle_stops_reconnecting_on_kanban_unavailable_close():
+    """Client terminal branch: new close code ends the loop with a non-auth message.
+
+    Ordinary transient closes must keep the existing backoff/reopen behavior.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text(encoding="utf-8")
+
+    mod = _load_plugin_module()
+    close_branch = f"if (ev && ev.code === {mod.WS_KANBAN_UNAVAILABLE})"
+    assert close_branch in js, f"missing terminal branch for {close_branch}"
+
+    onclose = js.split("ws.onclose = function (ev) {", 1)[1].split("};", 1)[0]
+    assert close_branch in onclose
+    # Terminal: the branch returns before reaching the backoff/reopen tail.
+    terminal, _, transient = onclose.partition(close_branch)
+    assert "setTimeout(openWs" not in terminal + close_branch
+    assert "wsKanbanUnavailable" in transient
+    assert "auth" not in transient.split("return;", 1)[0].lower()
+    # Transient closes still reopen with the unchanged backoff.
+    assert "setTimeout(openWs, delay)" in transient
+    assert "wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000)" in transient
 
 
     # The bug symptom was a traceback; we don't assert on stderr because

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -296,3 +296,157 @@ def test_child_attempting_default_complete_does_not_finish_parent_or_delete_work
     assert task.status == "running"
     assert run.status == "running"
     assert workspace.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Server-role entrypoints must not inherit the lineage marker
+# ---------------------------------------------------------------------------
+
+
+def _run_child_python(code: str, env_overrides: dict[str, str], tmp_path):
+    """Run *code* in a real subprocess with the repo under test importable."""
+    import subprocess
+
+    env = dict(os.environ)
+    env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    env["HERMES_HOME"] = str(tmp_path / ".hermes")
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        (["serve", "--host", "127.0.0.1"], True),
+        (["dashboard"], True),
+        (["gui"], True),
+        (["desktop"], True),
+        (["gateway", "run"], True),
+        # Short-lived CLI calls are NOT a server role — a delegated child that
+        # shells out to any of these must keep its lineage.
+        (["gateway", "restart"], False),
+        (["gateway"], False),
+        (["kanban", "boards", "rm", "victim", "--delete"], False),
+        (["chat"], False),
+        ([], False),
+        (["--version"], False),
+    ],
+)
+def test_is_server_role_argv(argv, expected):
+    from agent.delegation_context import is_server_role_argv
+
+    assert is_server_role_argv(argv) is expected
+
+
+def test_serve_entrypoint_drops_inherited_marker_and_kanban_works(tmp_path):
+    """The gateway/dashboard process must pass the guard, guard unchanged.
+
+    Reproduces the live defect: the desktop app (and the ``hermes serve`` it
+    spawns) was launched from a delegated child, inherited
+    HERMES_DELEGATED_CHILD_CONTEXT=1, and then failed every Kanban open for the
+    life of the process — connect()'s first-open migration pass goes through
+    write_txn, so the guard killed the read path too.
+    """
+    code = (
+        "import sys; sys.argv = ['hermes', 'serve', '--host', '127.0.0.1', '--port', '0']\n"
+        "import os\n"
+        "import hermes_cli.main  # noqa: F401 — module-level startup is the fix\n"
+        "assert 'HERMES_DELEGATED_CHILD_CONTEXT' not in os.environ, 'marker not cleared'\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "kb.init_db()\n"
+        "conn = kb.connect()\n"
+        "try:\n"
+        "    tid = kb.create_task(conn, title='from-server')\n"
+        "finally:\n"
+        "    conn.close()\n"
+        "assert tid\n"
+        "print('SERVER_OK')\n"
+    )
+    proc = _run_child_python(
+        code, {"HERMES_DELEGATED_CHILD_CONTEXT": "1"}, tmp_path,
+    )
+    assert "SERVER_OK" in proc.stdout, (proc.returncode, proc.stdout, proc.stderr)
+
+
+def test_agent_cli_entrypoint_keeps_inherited_marker(tmp_path):
+    """The reset is server-role only: a delegated `hermes kanban` stays rejected."""
+    code = (
+        "import sys; sys.argv = ['hermes', 'kanban', 'list']\n"
+        "import os\n"
+        "import hermes_cli.main  # noqa: F401\n"
+        "assert os.environ.get('HERMES_DELEGATED_CHILD_CONTEXT') == '1', 'marker cleared'\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "try:\n"
+        "    kb.init_db()\n"
+        "except PermissionError as exc:\n"
+        "    assert 'delegate_task child contexts' in str(exc)\n"
+        "    print('CLI_REJECTED')\n"
+        "else:\n"
+        "    print('CLI_ALLOWED')\n"
+    )
+    proc = _run_child_python(
+        code, {"HERMES_DELEGATED_CHILD_CONTEXT": "1"}, tmp_path,
+    )
+    assert "CLI_REJECTED" in proc.stdout, (proc.returncode, proc.stdout, proc.stderr)
+
+
+def test_real_lineage_child_and_grandchild_still_rejected(tmp_path, monkeypatch):
+    """Real delegate_task subprocess-env path: child AND grandchild stay rejected.
+
+    Also pins that the fix does not clear or narrow the marker anywhere on that
+    lineage — the grandchild inherits it through a plain ``env=None`` spawn.
+    """
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.delegation_context import (
+        delegated_child_context,
+        delegated_child_subprocess_env,
+    )
+
+    grandchild = (
+        "import os\n"
+        "assert os.environ.get('HERMES_DELEGATED_CHILD_CONTEXT') == '1'\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "try:\n"
+        "    kb.init_db()\n"
+        "except PermissionError:\n"
+        "    print('GRANDCHILD_REJECTED')\n"
+        "else:\n"
+        "    print('GRANDCHILD_ALLOWED')\n"
+    )
+    child = (
+        "import os, subprocess, sys\n"
+        "assert os.environ.get('HERMES_DELEGATED_CHILD_CONTEXT') == '1'\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "try:\n"
+        "    kb.init_db()\n"
+        "except PermissionError:\n"
+        "    print('CHILD_REJECTED')\n"
+        "else:\n"
+        "    print('CHILD_ALLOWED')\n"
+        # env=None → the grandchild inherits this process's env, marker included.
+        f"g = subprocess.run([sys.executable, '-c', {grandchild!r}],\n"
+        "                   capture_output=True, text=True, timeout=120)\n"
+        "print(g.stdout.strip())\n"
+        "print(g.stderr[-500:], file=sys.stderr)\n"
+    )
+
+    # Build the child env exactly the way delegate_task's subprocess call sites
+    # do, from inside a real delegated-child ContextVar scope.
+    with delegated_child_context():
+        child_env = delegated_child_subprocess_env(os.environ)
+    assert child_env is not None
+    assert child_env["HERMES_DELEGATED_CHILD_CONTEXT"] == "1"
+
+    proc = _run_child_python(child, child_env, tmp_path)
+    assert "CHILD_REJECTED" in proc.stdout, (proc.returncode, proc.stdout, proc.stderr)
+    assert "GRANDCHILD_REJECTED" in proc.stdout, (proc.returncode, proc.stdout, proc.stderr)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -31,9 +31,16 @@ import socket
 import threading
 from typing import Any
 
+from hermes_cli import diagnostics_ring
 from tui_gateway import server
 
 _log = logging.getLogger(__name__)
+
+# Diagnostics capture RPCs (U3) ride this transport's own dispatch surface, so
+# they are installed when the WS transport module loads — that is exactly the
+# set of processes that can serve them, and it keeps the auth boundary at
+# ``/api/ws`` where it already is.
+diagnostics_ring.install_rpc_methods(server)
 
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
@@ -177,6 +184,14 @@ class WSTransport:
                 "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
                 _WS_WRITE_TIMEOUT_S, self._peer,
             )
+            # Same signal, machine-readable, only while a capture is armed
+            # (U3/KTD4). The peer is HMAC'd under a per-capture key inside the
+            # ring, so the exported bundle correlates one connection's stalls
+            # without naming the address.
+            if diagnostics_ring.ARMED:
+                diagnostics_ring.record_ws_write_slow(
+                    self._peer, _WS_WRITE_TIMEOUT_S
+                )
             return not self._closed
         except Exception as exc:
             self._closed = True


### PR DESCRIPTION
> **Stacked on #80866 and #80870** — review the last commit only (`fix(desktop): bound the in-flight turn journal ...`).

## What

The crash-recovery in-flight turn journal (`inflight-turn-journal.ts`) was the dominant source of desktop UI hitching under streaming, especially with concurrent threads. While any session is busy, every 400ms per busy session it synchronously, on the renderer main thread:

1. `getItem` + `JSON.parse` of the **entire** single-key store (all sessions' journaled turns, up to 24 entries kept 7 days),
2. deep-cloned the unbounded turn tail via `JSON.parse(JSON.stringify(...))` — full tool-call bodies included,
3. re-`JSON.stringify`ed everything and `setItem`ed the whole blob back.

On a real profile the blob had grown to **~12MB** (agentic turns journal full tool results; old sessions ride along for a week). A DevTools Performance trace of live hitching showed ~2s of a 10s window inside this timer: repeating ~260–310ms tasks ending in `setItem`, ~1.9s of JSON serialization self-time. Cost multiplies per concurrent busy session — which is why multi-thread streaming felt so much worse. A 12MB value also exceeds typical localStorage quota, so writes were likely failing *silently* (errors are swallowed) after paying full serialization cost: all the jank, possibly no actual recovery.

The rewrite (recovery/merge semantics preserved verbatim, all pre-existing tests unchanged and passing):

- **Bounded schema-aware projection built before any clone**: user prompt kept in full (recovery matching normalizes and compares it) + attachment refs; assistant text ≤64KB/part; reasoning ≤16KB/part; tool calls reduced to id/name/error + 2KB arg/result previews. 256KB hard entry budget enforced structurally (never byte-slicing JSON), single stringify.
- **Write-only hot path to per-session keys** (`…journal.v2.<sessionId>`): no read-before-write, no aggregate in-memory cache (multi-window coherence — secondary/peer windows share the storage partition). Reads happen only during recovery and the boot sweep.
- **One-shot boot migration**: v1 entries are projected onto bounded v2 keys (new-key-wins), then the v1 blob is deleted unconditionally — including on parse failure.
- **Boot sweep** enforces the 7-day / 24-entry global bound, replacing the per-write filter/sort/slice.
- Quota failures now warn once per session and are recorded; kill switch (`…inflightTurnJournal.disabled = '1'`) for A/B diagnosis; new `journal_write` diagnostics ring event (`durationMs`/`bytes`/`outcome`/`busySessions`).

## Result

Verified before/after on the same machine and workload (two threads streaming):

| Metric (DevTools trace) | Before | After |
|---|---|---|
| `localStorage.setItem` self-time | 394ms / 10s | **1ms / 34.5s** |
| ~277ms journal timer tasks | 7 in 10s | **0** |
| Renderer long-task time share | ~38% | ~7% |

The design was cross-checked by two independent external model reviews before implementation (both confirmed the mechanism; the write-only no-cache design and the explicit legacy-blob policy come out of that review).

## Related issues

- Likely fixes #63047 (total freeze incl. Settings after ~5 messages — a few tool-heavy turns produce exactly this blob growth; needs reporter confirmation).
- Likely fixes/improves #52950 (Send clicks swallowed in long sessions — input events dropped during the 250–400ms main-thread stalls).
- Substantial progress on #56267 (general desktop perf degradation).
- Related, NOT addressed here: #69638 is a sibling localStorage-bloat bug on the composer-queue path; the bounded-projection approach here is a template for it.

## Testing

vitest 24 journal tests (all pre-existing recovery-semantics tests unchanged) + new: 5MB tool-result fixture bounds under budget with tool identity and recovery merge intact; 100KB user prompt kept whole; migration (normal/oversized/expired/garbage v1 blobs, new-key-wins, unconditional v1 deletion); quota-throw resilience (streaming unaffected, warn once, later writes recover). Full session-hooks suite: 442 tests passing. `tsc` and eslint clean.