### PR TITLE
Port from block/buzz#4959: classify transport timeouts distinctly in API error summaries

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4195,7 +4195,11 @@ def run_conversation(
                 
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
-                _error_summary = agent._summarize_api_error(api_error)
+                _error_summary = agent._summarize_api_error(
+                    api_error,
+                    provider=getattr(agent, "provider", None),
+                    model=getattr(agent, "model", None),
+                )
                 logger.warning(
                     "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
                     retry_count,
@@ -5143,7 +5147,11 @@ def run_conversation(
                     # returned ``error`` field and downstream consumers deliver
                     # it verbatim (e.g. a cron failure notification dumped a
                     # ~60KB Cloudflare challenge page as 31 Discord messages).
-                    _nonretryable_summary = agent._summarize_api_error(api_error)
+                    _nonretryable_summary = agent._summarize_api_error(
+                        api_error,
+                        provider=getattr(agent, "provider", None),
+                        model=getattr(agent, "model", None),
+                    )
                     if classified.reason == FailoverReason.content_policy_blocked:
                         agent._emit_status(
                             f"❌ Provider safety filter blocked this request: "
@@ -5355,7 +5363,11 @@ def run_conversation(
                         continue
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
-                    _final_summary = agent._summarize_api_error(api_error)
+                    _final_summary = agent._summarize_api_error(
+                        api_error,
+                        provider=getattr(agent, "provider", None),
+                        model=getattr(agent, "model", None),
+                    )
                     _billing_guidance = ""
                     if classified.reason == FailoverReason.billing:
                         agent._emit_status(f"❌ Billing or credits exhausted — {_final_summary}")

--- a/agent/timeout_error_summary.py
+++ b/agent/timeout_error_summary.py
@@ -1,0 +1,129 @@
+"""Factual summaries for transport-timeout errors with empty messages.
+
+httpx timeout exceptions (``ReadTimeout``, ``ConnectTimeout``, ``PoolTimeout``,
+``WriteTimeout``) stringify to an EMPTY string, and the OpenAI SDK's
+``APITimeoutError`` stringifies to the generic "Request timed out.".  When one
+of these survives the retry loop, ``AIAgent._summarize_api_error`` fell through
+to its ``raw[:500]`` fallback and produced a blank (or near-blank) summary —
+the user saw ``"API call failed after 6 retries: "`` with nothing after the
+colon, and an operator could not tell a TLS abort from a reset connection from
+a deterministic self-inflicted timeout fire.
+
+This module is a pure classifier (no network, no agent instance) that turns
+the exception *type* into a factual, phase-specific message with the
+configured timeout value embedded and the exact config knob to raise:
+
+=====================  =====================================================
+Case                   Message
+=====================  =====================================================
+Connect-phase timeout  ``connect timeout: no connection established with the
+                       provider``
+Read/pool timeout      ``read timeout: no response received within <N>s —
+                       consider raising providers.<provider>.
+                       request_timeout_seconds in ~/.hermes/config.yaml``
+Non-timeout            ``None`` (caller falls through to existing handling)
+=====================  =====================================================
+
+Ported from block/buzz#4959 (``timeout_message`` pure fn over
+``{is_connect, llm_timeout, phase}`` in ``crates/buzz-agent/src/llm.rs``),
+adapted to hermes-agent's exception-type landscape and per-provider
+``request_timeout_seconds`` config.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# Exception type names that indicate the CONNECT phase timed out: no TCP/TLS
+# connection was ever established.  Raising the read timeout will not help;
+# the endpoint is unreachable or the connect window is too small.
+_CONNECT_TIMEOUT_TYPES = frozenset({
+    "ConnectTimeout",           # httpx
+    "ConnectTimeoutError",      # urllib3
+})
+
+# Exception type names that indicate the connection was established but no
+# (or no further) response bytes arrived within the read window.  This is the
+# deterministic self-inflicted case: a slow model generation legitimately
+# exceeding the configured timeout looks identical to a network fault unless
+# we say which timer fired.
+_READ_TIMEOUT_TYPES = frozenset({
+    "ReadTimeout",              # httpx
+    "WriteTimeout",             # httpx
+    "PoolTimeout",              # httpx
+    "TimeoutException",         # httpx base class
+    "ReadTimeoutError",         # urllib3
+    "APITimeoutError",          # openai SDK ("Request timed out.")
+})
+
+
+def _resolve_configured_timeout(
+    provider: Optional[str], model: Optional[str]
+) -> Optional[float]:
+    """Best-effort lookup of the request timeout that governed the call.
+
+    Mirrors the resolution order in ``agent/chat_completion_helpers.py``:
+    per-model / per-provider ``request_timeout_seconds`` from config.yaml
+    wins; otherwise the ``HERMES_API_TIMEOUT`` env default (1800s).  Returns
+    ``None`` when nothing can be resolved (e.g. config unreadable in tests).
+    """
+    if provider:
+        try:
+            from hermes_cli.timeouts import get_provider_request_timeout
+            cfg = get_provider_request_timeout(provider, model)
+            if cfg is not None:
+                return float(cfg)
+        except Exception:
+            pass
+    raw = os.environ.get("HERMES_API_TIMEOUT")
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def summarize_timeout_error(
+    error: BaseException,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Optional[str]:
+    """Return a factual timeout summary, or ``None`` for non-timeout errors.
+
+    Pure over the exception's type name (the exceptions themselves carry no
+    useful message — that is the bug).  ``provider``/``model`` are optional
+    context used to embed the configured timeout value and name the exact
+    config knob; when absent the message still names the knob generically.
+    """
+    name = type(error).__name__
+
+    if name in _CONNECT_TIMEOUT_TYPES:
+        return (
+            "connect timeout: no connection established with the provider "
+            "(endpoint unreachable or connect window too small — check the "
+            "base_url and network path)"
+        )
+
+    if name not in _READ_TIMEOUT_TYPES:
+        return None
+
+    timeout_s = _resolve_configured_timeout(provider, model)
+    if timeout_s is not None:
+        within = f"within {timeout_s:g}s"
+    else:
+        within = "within the configured request timeout"
+
+    if provider:
+        knob = f"`providers.{provider}.request_timeout_seconds`"
+    else:
+        knob = "`providers.<provider>.request_timeout_seconds`"
+
+    return (
+        f"read timeout: no response received {within} — the generation may "
+        f"legitimately need longer; consider raising {knob} in "
+        "`~/.hermes/config.yaml`"
+    )

--- a/run_agent.py
+++ b/run_agent.py
@@ -2495,14 +2495,35 @@ class AIAgent:
         return str(value)
 
     @staticmethod
-    def _summarize_api_error(error: Exception) -> str:
+    def _summarize_api_error(
+        error: Exception,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
         """Extract a human-readable one-liner from an API error.
 
         Handles Cloudflare HTML error pages (502, 503, etc.) by pulling the
         <title> tag instead of dumping raw HTML.  Falls back to a truncated
         str(error) for everything else.
+
+        ``provider``/``model`` are optional context: when supplied, transport
+        timeouts (which stringify to an EMPTY string in httpx) are summarized
+        with the configured timeout value and the exact config knob to raise
+        instead of producing a blank summary.  Ported from block/buzz#4959.
         """
         raw = str(error)
+
+        # Transport timeouts first: httpx's ReadTimeout/ConnectTimeout carry
+        # no message at all, so every later branch would yield a blank
+        # summary ("API call failed after 6 retries: ").  Classify the phase
+        # (connect vs read) from the exception type and say which timer
+        # fired.  Non-timeout errors return None and fall through unchanged.
+        from agent.timeout_error_summary import summarize_timeout_error
+        _timeout_summary = summarize_timeout_error(
+            error, provider=provider, model=model,
+        )
+        if _timeout_summary is not None:
+            return _timeout_summary
 
         if (
             isinstance(error, ValueError)

--- a/tests/agent/test_timeout_error_summary.py
+++ b/tests/agent/test_timeout_error_summary.py
@@ -1,0 +1,118 @@
+"""Tests for agent/timeout_error_summary.py — factual transport-timeout summaries.
+
+httpx timeout exceptions stringify to an EMPTY string; before this module,
+``_summarize_api_error`` produced a blank summary for them ("API call failed
+after 6 retries: " with nothing after the colon).  Ported from
+block/buzz#4959.
+"""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from agent.timeout_error_summary import (
+    _resolve_configured_timeout,
+    summarize_timeout_error,
+)
+from run_agent import AIAgent
+
+
+# ── Pure classifier ─────────────────────────────────────────────────
+
+
+def test_httpx_read_timeout_empty_str_precondition():
+    """The bug's precondition: httpx timeouts stringify to nothing."""
+    assert str(httpx.ReadTimeout("")) == ""
+    assert str(httpx.ConnectTimeout("")) == ""
+
+
+def test_read_timeout_names_read_phase_and_config_knob():
+    summary = summarize_timeout_error(
+        httpx.ReadTimeout(""), provider="openrouter", model="some/model"
+    )
+    assert summary is not None
+    assert summary.startswith("read timeout")
+    assert "providers.openrouter.request_timeout_seconds" in summary
+    assert "config.yaml" in summary
+
+
+def test_connect_timeout_names_connect_phase_not_config_knob():
+    """Connect-phase failures must NOT advise raising the read timeout —
+    the endpoint never answered at all."""
+    summary = summarize_timeout_error(httpx.ConnectTimeout(""))
+    assert summary is not None
+    assert summary.startswith("connect timeout")
+    assert "request_timeout_seconds" not in summary
+
+
+def test_pool_and_write_timeouts_classify_as_read_phase():
+    for exc in (httpx.PoolTimeout(""), httpx.WriteTimeout("")):
+        summary = summarize_timeout_error(exc)
+        assert summary is not None
+        assert summary.startswith("read timeout")
+
+
+def test_openai_sdk_api_timeout_error_classifies():
+    openai = pytest.importorskip("openai")
+    err = openai.APITimeoutError(request=httpx.Request("POST", "http://x"))
+    summary = summarize_timeout_error(err, provider="nous")
+    assert summary is not None
+    assert summary.startswith("read timeout")
+    assert "providers.nous.request_timeout_seconds" in summary
+
+
+def test_non_timeout_errors_return_none():
+    for exc in (ValueError("boom"), ConnectionResetError("reset"), Exception("")):
+        assert summarize_timeout_error(exc) is None
+
+
+def test_missing_provider_uses_generic_knob():
+    summary = summarize_timeout_error(httpx.ReadTimeout(""))
+    assert summary is not None
+    assert "providers.<provider>.request_timeout_seconds" in summary
+
+
+def test_configured_timeout_value_embedded(monkeypatch):
+    monkeypatch.setenv("HERMES_API_TIMEOUT", "240")
+    summary = summarize_timeout_error(httpx.ReadTimeout(""))
+    assert summary is not None
+    assert "within 240s" in summary
+
+
+def test_env_timeout_invalid_values_ignored(monkeypatch):
+    for bad in ("abc", "-5", "0"):
+        monkeypatch.setenv("HERMES_API_TIMEOUT", bad)
+        assert _resolve_configured_timeout(None, None) is None
+
+
+# ── Integration with AIAgent._summarize_api_error ───────────────────
+
+
+def test_summarize_api_error_read_timeout_not_blank():
+    """The user-visible regression: summary must never be empty for a
+    transport timeout."""
+    summary = AIAgent._summarize_api_error(
+        httpx.ReadTimeout(""), provider="openrouter", model="m"
+    )
+    assert summary.strip()
+    assert "read timeout" in summary
+
+
+def test_summarize_api_error_backward_compatible_single_arg():
+    """Existing single-arg call sites keep working and still get a
+    non-blank summary."""
+    summary = AIAgent._summarize_api_error(httpx.ReadTimeout(""))
+    assert summary.strip()
+    assert "read timeout" in summary
+
+
+def test_summarize_api_error_non_timeout_path_unchanged():
+    err = Exception("")
+    err.status_code = 400
+    err.body = {}
+    err.response = SimpleNamespace(
+        text='{"error": {"message": "model `foo` does not exist"}}'
+    )
+    summary = AIAgent._summarize_api_error(err, provider="openrouter")
+    assert "model `foo` does not exist" in summary


### PR DESCRIPTION
## Summary

Transport timeouts now produce factual, phase-specific error summaries instead of nothing — httpx's `ReadTimeout`/`ConnectTimeout` stringify to an EMPTY string, so a timeout that survived the retry loop surfaced as `API call failed after 6 retries: ` with nothing after the colon.

Port of [block/buzz#4959](https://github.com/block/buzz/pull/4959) (`timeout_message` pure classifier in `crates/buzz-agent/src/llm.rs`).

## Ours vs theirs

| | Buzz | Hermes (this PR) |
|---|---|---|
| Trigger | reqwest generic pre-response string identical for TLS abort / reset / read_timeout | httpx timeout exceptions with **empty** `str()` → blank summary |
| Classification | pure fn over `{is_connect, phase}` flags | pure fn over exception type name (`ConnectTimeout` vs `ReadTimeout`/`PoolTimeout`/`WriteTimeout`/`APITimeoutError`) |
| Embedded value | `BUZZ_AGENT_LLM_TIMEOUT_SECS` env knob | per-model/per-provider `request_timeout_seconds` from config.yaml, `HERMES_API_TIMEOUT` fallback |
| Guidance | "consider raising BUZZ_AGENT_LLM_TIMEOUT_SECS" | exact knob: `providers.<provider>.request_timeout_seconds` in `~/.hermes/config.yaml` |

Connect-phase timeouts deliberately do NOT advise raising the read timeout — no connection was ever established, so the advice points at base_url/network instead.

## Changes

- `agent/timeout_error_summary.py` (new): pure classifier, no network/agent dependency. Returns `None` for non-timeout errors so every existing summary branch is untouched.
- `run_agent.py`: `_summarize_api_error()` consults the classifier first (all later branches yield blank output for message-less exceptions); gains optional `provider`/`model` kwargs — fully backward compatible, single-arg call sites still get a non-blank summary with a generic knob name.
- `agent/conversation_loop.py`: the three retry-loop summary sites (`_error_summary`, `_nonretryable_summary`, `_final_summary`) pass provider/model context.
- `tests/agent/test_timeout_error_summary.py`: 12 tests — pins the empty-`str()` precondition, phase classification, config-knob naming, env-value embedding, invalid-env handling, AIAgent integration, and the unchanged non-timeout fall-through.

## Validation

| | Before | After |
|---|---|---|
| `ReadTimeout` after retries | `API call failed after 6 retries: ` (blank) | `read timeout: no response received within 240s — consider raising \`providers.openrouter.request_timeout_seconds\` in \`~/.hermes/config.yaml\`` |
| `ConnectTimeout` | blank | `connect timeout: no connection established with the provider (…check the base_url and network path)` |
| Non-timeout errors | unchanged | unchanged (classifier returns `None`) |

Targeted tests: 12/12 new + 17/17 adjacent (`test_summarize_api_error`, `test_nonretryable_error_html_summary`, `test_32646_fallback_429_after_timeout`, `test_gemini_standard_key_guidance`). Sabotage-verified: disabling the classifier fails the regression tests with the historical `assert ''`. E2E: real `AIAgent._summarize_api_error` exercised with real httpx/openai exceptions in the repo venv.

## Infographic

![Timeout errors, named — ukiyo-e infographic](https://v3b.fal.media/files/b/0aa559d6/YiKLCRZedltIZ46NAZlnX_LyRg1Lzr.png)
