### PR TITLE
fix(desktop): start Nous OAuth from billing

### DIFF
--- a/apps/desktop/src/app/settings/billing/index.test.tsx
+++ b/apps/desktop/src/app/settings/billing/index.test.tsx
@@ -31,6 +31,11 @@ const apiMocks = vi.hoisted(() => ({
   updateAutoReload: vi.fn()
 }))
 
+const oauthMocks = vi.hoisted(() => ({
+  signInToNousPortal: vi.fn(),
+  signingIn: false
+}))
+
 vi.mock('./api', () => ({
   // Pass-through provider — the mocked useBillingApi ignores any override anyway.
   BillingApiProvider: ({ children }: { children: ReactNode }) => children,
@@ -45,6 +50,10 @@ vi.mock('./api', () => ({
     stepUp: apiMocks.stepUp,
     updateAutoReload: apiMocks.updateAutoReload
   })
+}))
+
+vi.mock('@/hooks/use-nous-portal-login', () => ({
+  useNousPortalLogin: () => oauthMocks
 }))
 
 function renderBilling(initialEntries: string[] = ['/settings?tab=billing']) {
@@ -595,14 +604,17 @@ describe('BillingSettings', () => {
     await waitFor(() => expect(screen.getByText('$25 added. Balance is refreshing.')).toBeTruthy())
   })
 
-  it('renders logged-out as a connect card without normal account rows', async () => {
+  it('starts Nous OAuth from the logged-out connect card without normal account rows', async () => {
     apiMocks.fetchBillingState.mockResolvedValue(okBilling(loggedOutBillingState))
     apiMocks.fetchSubscriptionState.mockResolvedValue(okSubscription(loggedOutSubscriptionState))
 
     renderBilling()
 
     expect(await screen.findByText('Connect your Nous account')).toBeTruthy()
-    expect(screen.getByText('Run /portal in the TUI or open the Nous portal to connect your account.')).toBeTruthy()
+    expect(screen.getByText('Sign in to your Nous Portal account to manage your plan and usage.')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in to Nous Portal' }))
+    expect(oauthMocks.signInToNousPortal).toHaveBeenCalledTimes(1)
+    expect(apiMocks.openExternal).not.toHaveBeenCalled()
     expect(screen.queryByText('Payment method')).toBeNull()
     expect(screen.queryByText('Usage')).toBeNull()
   })

--- a/apps/desktop/src/app/settings/billing/index.tsx
+++ b/apps/desktop/src/app/settings/billing/index.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { BarChart3, CreditCard, ExternalLink, Package, Wrench } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
+import { useNousPortalLogin } from '../../../hooks/use-nous-portal-login'
 import { useRouteEnumParam } from '../../hooks/use-route-enum-param'
 import {
   ListRow,
@@ -71,8 +72,19 @@ function SummaryCard({ label, value, tone }: { label: string; tone?: 'muted' | '
   )
 }
 
-function NoticeCard({ notice }: { notice: BillingNoticeView }) {
+function NoticeCard({
+  notice,
+  onNousPortalSignIn,
+  signingIn
+}: {
+  notice: BillingNoticeView
+  onNousPortalSignIn: () => void
+  signingIn: boolean
+}) {
   const warn = notice.tone === 'warn'
+  const action = notice.action
+  const usesNousOAuth = action?.kind === 'nous_oauth'
+  const onAction = usesNousOAuth ? onNousPortalSignIn : action ? () => openExternal(action.url) : undefined
 
   return (
     <div className={cn('mb-6 rounded-xl p-4', warn ? 'bg-(--ui-yellow)/10' : 'bg-(--ui-bg-quaternary)')}>
@@ -87,16 +99,17 @@ function NoticeCard({ notice }: { notice: BillingNoticeView }) {
       <div className="mt-1 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
         {notice.message}
       </div>
-      {notice.action && (
+      {action && (
         <Button
           className="mt-3"
-          onClick={() => openExternal(notice.action?.url)}
+          disabled={usesNousOAuth && signingIn}
+          onClick={onAction}
           size="sm"
           type="button"
           variant="outline"
         >
-          {notice.action.label}
-          <ExternalLink className="size-3.5" />
+          {usesNousOAuth && signingIn ? 'Opening sign-in…' : action.label}
+          {!usesNousOAuth && <ExternalLink className="size-3.5" />}
         </Button>
       )}
     </div>
@@ -456,6 +469,16 @@ function BillingSettingsContent({
   onFixtureChange?: (value: BillingFixtureSelection) => void
 }) {
   const [subView, setSubView] = useRouteEnumParam<BillingSubView>('bview', BILLING_VIEWS, 'overview')
+  const queryClient = useQueryClient()
+
+  const { signInToNousPortal, signingIn } = useNousPortalLogin({
+    failureMessage: 'Could not sign in to Nous Portal.',
+    onApproved: () => {
+      void queryClient.invalidateQueries({ queryKey: ['billing'] })
+    },
+    successMessage: 'Your Nous Portal account is connected.',
+    successTitle: 'Nous Portal connected'
+  })
 
   // Fixture mode flows through the SAME query path — the simulated api (supplied by
   // BillingApiProvider in the DEV wrapper) backs these fetches — so there is no
@@ -504,7 +527,13 @@ function BillingSettingsContent({
     <SettingsContent>
       <BillingHeader fixtureName={fixtureName} onFixtureChange={onFixtureChange} />
 
-      {view.notice && <NoticeCard notice={view.notice} />}
+      {view.notice && (
+        <NoticeCard
+          notice={view.notice}
+          onNousPortalSignIn={() => void signInToNousPortal()}
+          signingIn={signingIn}
+        />
+      )}
 
       <div className="@container mb-6">
         <div className="grid gap-3 @2xl:grid-cols-3">

--- a/apps/desktop/src/app/settings/billing/use-billing-state.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.ts
@@ -9,7 +9,6 @@ import type { BillingStateResponse, SubscriptionStateResponse, SubscriptionTierO
 
 export const EMPTY_BILLING_VALUE = '—'
 export const FALLBACK_PORTAL_BILLING_URL = 'https://portal.nousresearch.com/billing'
-export const FALLBACK_PORTAL_URL = 'https://portal.nousresearch.com'
 
 // The billing endpoint is the authoritative source of truth for balance / cap /
 // plan — the inference `x-nous-credits-*` headers are best-effort and can drift
@@ -36,10 +35,9 @@ export interface BillingSummaryItemView {
 }
 
 export interface BillingNoticeView {
-  action?: {
-    label: string
-    url: string
-  }
+  action?:
+    | { kind: 'external'; label: string; url: string }
+    | { kind: 'nous_oauth'; label: string }
   message: string
   title: string
   /** `warn` = an actionable blocker (e.g. no card); `info` = neutral guidance. */
@@ -199,8 +197,8 @@ export function deriveBillingView(
   if (!billing.logged_in || subscription?.logged_in === false) {
     return {
       notice: {
-        action: { label: 'Open portal ↗', url: billing.portal_url ?? subscription?.portal_url ?? FALLBACK_PORTAL_URL },
-        message: 'Run /portal in the TUI or open the Nous portal to connect your account.',
+        action: { kind: 'nous_oauth', label: 'Sign in to Nous Portal' },
+        message: 'Sign in to your Nous Portal account to manage your plan and usage.',
         title: 'Connect your Nous account'
       },
       status: 'logged_out',
@@ -302,7 +300,7 @@ function refusalNotice(refusal: BillingRefusal): BillingNoticeView {
   const portalUrl = resolved.action.type === 'portal' ? resolved.action.url : undefined
 
   return {
-    action: portalUrl ? { label: 'Open portal ↗', url: portalUrl } : undefined,
+    action: portalUrl ? { kind: 'external', label: 'Open portal ↗', url: portalUrl } : undefined,
     message: resolved.message,
     title: resolved.title,
     tone: 'warn'
@@ -318,7 +316,7 @@ function noCardNotice(billing: BillingStateResponse): BillingNoticeView | undefi
   }
 
   return {
-    action: { label: 'Add card ↗', url: billing.portal_url ?? FALLBACK_PORTAL_BILLING_URL },
+    action: { kind: 'external', label: 'Add card ↗', url: billing.portal_url ?? FALLBACK_PORTAL_BILLING_URL },
     message: 'Buying top-up credits and auto-refill stay disabled until a card is on file. Add one on the portal.',
     title: 'No payment method on file',
     tone: 'warn'

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -9,14 +9,13 @@ import {
   getActionStatus,
   getToolsetConfig,
   getToolsetModels,
-  pollOAuthSession,
   revealEnvVar,
   runToolsetPostSetup,
   selectToolsetModel,
   selectToolsetProvider,
-  setEnvVar,
-  startOAuthLogin
+  setEnvVar
 } from '@/hermes'
+import { useNousPortalLogin } from '@/hooks/use-nous-portal-login'
 import { useI18n } from '@/i18n'
 import { Check, Loader2, Save, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -500,17 +499,6 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
   // Default-provider selection and a user click race just after config arrives:
   // a stale initialization effect must never replace an explicit choice.
   const providerChoiceClaimedRef = useRef(false)
-  // Guard the Nous Portal sign-in poll loop against unmount/state updates.
-  const mountedRef = useRef(true)
-
-  // eslint-disable-next-line no-restricted-syntax -- mount flag guarding an async poll loop, not an atom mirror
-  useEffect(() => {
-    mountedRef.current = true
-
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -533,6 +521,15 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
       setLoading(false)
     }
   }, [copy.failedLoad, toolset])
+
+  const { signInToNousPortal } = useNousPortalLogin({
+    failureMessage: copy.nousAuthFailed,
+    onApproved: () => {
+      void refresh().then(() => onConfiguredChange?.())
+    },
+    successMessage: copy.nousAuthDoneMessage,
+    successTitle: copy.nousAuthDoneTitle
+  })
 
   useEffect(() => {
     void refresh()
@@ -611,61 +608,6 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     }
   }
 
-  // Drive the existing Nous Portal OAuth device-code flow (the same session
-  // machinery onboarding uses: start → open verification URL → poll), then
-  // refetch the toolset config so is_active / status flip once entitled.
-  async function signInToNousPortal() {
-    try {
-      const start = await startOAuthLogin('nous')
-
-      if (start.flow !== 'device_code') {
-        notifyError(new Error(`unexpected flow: ${start.flow}`), copy.nousAuthFailed)
-
-        return
-      }
-
-      const url = start.verification_url
-
-      if (window.hermesDesktop?.openExternal) {
-        try {
-          await window.hermesDesktop.openExternal(url)
-        } catch {
-          window.open(url, '_blank', 'noopener,noreferrer')
-        }
-      } else {
-        window.open(url, '_blank', 'noopener,noreferrer')
-      }
-
-      // Poll until the device-code session resolves (~5s cadence, bounded).
-      for (let attempt = 0; attempt < 120 && mountedRef.current; attempt += 1) {
-        await new Promise(resolve => window.setTimeout(resolve, 5000))
-
-        if (!mountedRef.current) {
-          return
-        }
-
-        const polled = await pollOAuthSession('nous', start.session_id)
-
-        if (polled.status === 'approved') {
-          notify({ kind: 'success', title: copy.nousAuthDoneTitle, message: copy.nousAuthDoneMessage })
-          await refresh()
-          onConfiguredChange?.()
-
-          return
-        }
-
-        if (polled.status !== 'pending') {
-          notifyError(new Error(polled.error_message || `Sign-in ${polled.status}`), copy.nousAuthFailed)
-
-          return
-        }
-      }
-    } catch (err) {
-      if (mountedRef.current) {
-        notifyError(err, copy.nousAuthFailed)
-      }
-    }
-  }
 
   function patchEnv(key: string, isSet: boolean) {
     setEnvState(c => ({ ...c, [key]: isSet }))

--- a/apps/desktop/src/hooks/use-nous-portal-login.ts
+++ b/apps/desktop/src/hooks/use-nous-portal-login.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { pollOAuthSession, startOAuthLogin } from '@/hermes'
+import { notify, notifyError } from '@/store/notifications'
+
+interface UseNousPortalLoginOptions {
+  failureMessage: string
+  onApproved?: () => void
+  successMessage: string
+  successTitle: string
+}
+
+async function openSignInUrl(url: string) {
+  if (window.hermesDesktop?.openExternal) {
+    try {
+      await window.hermesDesktop.openExternal(url)
+
+      return
+    } catch {
+      // Keep a broken native bridge from stranding an otherwise valid OAuth session.
+    }
+  }
+
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+/**
+ * Starts and observes the shared Nous Portal device-code flow for settings
+ * surfaces. The backend owns the credential; callers only refresh their own
+ * cached view after approval.
+ */
+export function useNousPortalLogin({
+  failureMessage,
+  onApproved,
+  successMessage,
+  successTitle
+}: UseNousPortalLoginOptions) {
+  const mountedRef = useRef(true)
+  const inFlightRef = useRef(false)
+  const [signingIn, setSigningIn] = useState(false)
+
+  // eslint-disable-next-line no-restricted-syntax -- mount flag guards an async poll loop, not an atom mirror.
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const signInToNousPortal = useCallback(async () => {
+    if (inFlightRef.current) {
+      return
+    }
+
+    inFlightRef.current = true
+    setSigningIn(true)
+
+    try {
+      const start = await startOAuthLogin('nous')
+
+      if (start.flow !== 'device_code') {
+        notifyError(new Error(`unexpected flow: ${start.flow}`), failureMessage)
+
+        return
+      }
+
+      await openSignInUrl(start.verification_url)
+
+      for (let attempt = 0; attempt < 120 && mountedRef.current; attempt += 1) {
+        await new Promise(resolve => window.setTimeout(resolve, 5000))
+
+        if (!mountedRef.current) {
+          return
+        }
+
+        const polled = await pollOAuthSession('nous', start.session_id)
+
+        if (polled.status === 'approved') {
+          notify({ kind: 'success', title: successTitle, message: successMessage })
+          onApproved?.()
+
+          return
+        }
+
+        if (polled.status !== 'pending') {
+          notifyError(new Error(polled.error_message || `Sign-in ${polled.status}`), failureMessage)
+
+          return
+        }
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        notifyError(err, failureMessage)
+      }
+    } finally {
+      inFlightRef.current = false
+
+      if (mountedRef.current) {
+        setSigningIn(false)
+      }
+    }
+  }, [failureMessage, onApproved, successMessage, successTitle])
+
+  return { signInToNousPortal, signingIn }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the logged-out Desktop Billing path for Nous Portal. The prior action opened the generic Portal URL and told Desktop users to run `/portal` in the TUI, although that is not a valid in-session command and does not initiate Hermes OAuth.

The Billing notice now starts the existing Nous OAuth device-code flow, opens its returned verification URL, polls for approval, and refreshes Billing data on success. The flow is extracted into a shared Desktop hook so Billing and the existing Toolset configuration path use one implementation.

## Related Issue

No existing issue or PR matching the obsolete `/portal` Desktop guidance was found before submitting this focused bug fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Replaced the logged-out Billing "Open portal" action with "Sign in to Nous Portal."
- Removed the invalid `/portal` TUI instruction from the Billing screen.
- Added a typed distinction between external Portal links and the in-app Nous OAuth action.
- Extracted the existing Toolset device-code OAuth sequence into `useNousPortalLogin` and reused it from Billing.
- Added a Billing regression test that verifies the logged-out call-to-action invokes OAuth rather than opening the generic Portal URL.

## How to Test

1. Open Desktop Settings > Billing while signed out of Nous Portal.
2. Confirm the notice reads "Connect your Nous account" and offers "Sign in to Nous Portal," without `/portal` guidance.
3. Select the sign-in action, complete the browser device-code login, and return to Desktop.
4. Confirm Billing refreshes into the authenticated state.

Automated on Windows 10:

```text
npm run lint
npm run typecheck
npm exec -- vitest run --project ui src/app/settings/billing/index.test.tsx src/app/settings/toolset-config-panel.test.tsx
```

The focused UI suite passed 57 tests. The repository-wide lint command exited successfully with 88 pre-existing warnings outside this change.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and issues to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've added regression coverage for the Billing entry point.
- [x] I've tested on Windows 10 through the Desktop UI test suite.

### Documentation & Housekeeping

- [x] Relevant documentation changes are N/A: this corrects an in-app action and copy.
- [x] Config, architecture, tool-schema, and cross-platform process changes are N/A.
