### PR TITLE
fix(agent): ignore remote-backend TERMINAL_CWD during local prompt construction

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
-from agent.runtime_cwd import resolve_agent_cwd
+from agent.runtime_cwd import _REMOTE_TERMINAL_BACKENDS, resolve_agent_cwd
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
@@ -1007,10 +1007,7 @@ WSL_ENVIRONMENT_HINT = (
 # container / remote host rather than on the machine where Hermes itself
 # runs. For these backends, host info (Windows/Linux/macOS, $HOME, cwd) is
 # misleading — the agent should only see the machine it can actually touch.
-_REMOTE_TERMINAL_BACKENDS = frozenset({
-    "docker", "singularity", "modal", "daytona", "ssh",
-    "vercel_sandbox", "managed_modal",
-})
+# Defined once in agent.runtime_cwd and imported here (see that module).
 
 
 # Per-backend fallback descriptions — used when the live probe fails.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -87,8 +87,14 @@ def _find_git_root(start: Path) -> Optional[Path]:
     """
     current = start.resolve()
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
+        try:
+            if (parent / ".git").exists():
+                return parent
+        except OSError:
+            # Unreadable directory (e.g. /root owned by another user) — skip
+            # and keep walking up; prompt construction must never crash on a
+            # permission error.
+            continue
     return None
 
 
@@ -112,8 +118,12 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     for directory in search_dirs:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError:
+                # Unreadable directory — keep searching elsewhere.
+                continue
         if stop_at and directory == stop_at:
             break
     return None

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -22,6 +22,21 @@ _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 
+# Terminal backends whose TERMINAL_CWD refers to a path on a REMOTE machine /
+# container (ssh, docker, ...), NOT on the host where Hermes runs. For these,
+# TERMINAL_CWD must never be stat'd from the host process: e.g. a root@ssh
+# profile sets TERMINAL_CWD=/root, and an unprivileged local user cannot even
+# stat /root/.git — prompting a PermissionError that aborts system-prompt
+# construction. Keep this in sync with prompt_builder._REMOTE_TERMINAL_BACKENDS.
+_REMOTE_TERMINAL_BACKENDS = frozenset({
+    "docker", "singularity", "modal", "daytona", "ssh",
+    "vercel_sandbox", "managed_modal",
+})
+
+
+def _terminal_env_is_remote() -> bool:
+    return (os.getenv("TERMINAL_ENV") or "local").strip().lower() in _REMOTE_TERMINAL_BACKENDS
+
 # The Python package/source root (this file lives at <root>/agent/runtime_cwd.py).
 # When a backend is launched from, or self-spawns into, this tree (the desktop
 # app default), an os.getcwd() fallback would inject this repo's contributor
@@ -65,7 +80,10 @@ def resolve_agent_cwd() -> Path:
             return p
         logger.warning("configured working directory does not exist: %s", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
+    # For remote terminal backends TERMINAL_CWD is a path on the remote
+    # machine/container — never stat it from the host process (it may be
+    # unreadable, e.g. root@ssh → /root). Fall back to the launch dir.
+    if raw and not _terminal_env_is_remote():
         p = Path(raw).expanduser()
         if p.is_dir():
             return p
@@ -91,7 +109,10 @@ def resolve_context_cwd() -> Path | None:
             return p
         return None
     raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
+    # Remote backends: TERMINAL_CWD is a remote path; do not validate/return
+    # it from the host process. None lets build_context_files_prompt fall back
+    # to the launch dir.
+    if raw and not _terminal_env_is_remote():
         p = Path(raw).expanduser()
         if not p.is_dir():
             logger.warning("TERMINAL_CWD does not exist: %s", raw)

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -27,7 +27,9 @@ _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 # TERMINAL_CWD must never be stat'd from the host process: e.g. a root@ssh
 # profile sets TERMINAL_CWD=/root, and an unprivileged local user cannot even
 # stat /root/.git — prompting a PermissionError that aborts system-prompt
-# construction. Keep this in sync with prompt_builder._REMOTE_TERMINAL_BACKENDS.
+# construction. Single source of truth: prompt_builder and env_probe import
+# this set instead of redefining it, so a backend added here is automatically
+# honored by all three consumers.
 _REMOTE_TERMINAL_BACKENDS = frozenset({
     "docker", "singularity", "modal", "daytona", "ssh",
     "vercel_sandbox", "managed_modal",

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -488,10 +488,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
-        context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
-            context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+        try:
+            context_files_prompt = _r.build_context_files_prompt(
+                cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+                context_length=_ctx_len,
+                allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+        except Exception as e:
+            # Context-file discovery must never abort prompt construction —
+            # an unreadable cwd (e.g. remote TERMINAL_CWD=/root on a local
+            # host) or a malformed file is a soft failure, not a crash.
+            logger.warning("context-file discovery failed; skipping: %s", e)
+            context_files_prompt = ""
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -51,6 +51,36 @@ class TestResolveContextCwd:
         assert resolve_context_cwd() == Path(os.path.expanduser("~"))
 
 
+class TestRemoteBackendIgnoresTerminalCwd:
+    """TERMINAL_CWD on a remote backend (ssh/docker/...) is a path on the
+    REMOTE machine — it must never be stat'd or returned from the host
+    process (root@ssh profiles set TERMINAL_CWD=/root, unreadable locally;
+    that used to abort system-prompt construction with PermissionError)."""
+
+    @pytest.mark.parametrize("backend", ["ssh", "docker", "modal"])
+    def test_context_cwd_ignored_for_remote_backend(self, monkeypatch, tmp_path, backend):
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert resolve_context_cwd() is None
+
+    @pytest.mark.parametrize("backend", ["ssh", "docker"])
+    def test_agent_cwd_falls_back_to_getcwd_for_remote_backend(self, monkeypatch, tmp_path, backend):
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        assert resolve_agent_cwd() == tmp_path
+
+    def test_local_backend_still_uses_terminal_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert resolve_context_cwd() == tmp_path
+
+    def test_unset_env_is_local(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert resolve_context_cwd() == tmp_path
+
+
 
 class TestSessionCwdOverride:
     """The #29531 per-session arm: a contextvar cwd wins over TERMINAL_CWD so a

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -69,13 +69,10 @@ _PROBE_WAIT_TIMEOUT = 10.0
 # ever finishes, the published line resumes appearing in new prompts.
 _WAIT_ALREADY_TIMED_OUT = False
 
-# Remote backends — keep in sync with agent/prompt_builder.py:_REMOTE_TERMINAL_BACKENDS.
-# Duplicated rather than imported to avoid a circular import (prompt_builder
-# imports nothing from tools).
-_REMOTE_BACKENDS = frozenset({
-    "docker", "singularity", "modal", "daytona", "ssh", "managed_modal",
-    "vercel_sandbox",
-})
+# Remote backends — single source of truth lives in agent/runtime_cwd
+# (agent.runtime_cwd is stdlib-only, so importing it here cannot create a
+# circular import).
+from agent.runtime_cwd import _REMOTE_TERMINAL_BACKENDS
 
 
 def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
@@ -195,7 +192,7 @@ def _build_probe_line() -> str:
     # Bail out if a remote terminal backend is configured; the host's
     # Python state isn't where the agent's tools run.
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
-    if backend in _REMOTE_BACKENDS:
+    if backend in _REMOTE_TERMINAL_BACKENDS:
         return ""
 
     py3_ver = _python_version_of("python3")


### PR DESCRIPTION
## Summary

When a profile uses an SSH terminal backend (`TERMINAL_ENV=ssh`), its `.env` sets `TERMINAL_CWD` to a **path on the remote machine** (e.g. `root@ssh` → `TERMINAL_CWD=/root`). When the same profile is launched as a **local CLI** process (uid ≠ 0), that remote path leaks into local system-prompt construction:

```
resolve_context_cwd() → _find_git_root() → (Path('/root') / '.git').exists()
→ PermissionError: [Errno 13] Permission denied: '/root/.git'
```

`Path.exists()` on an unreadable parent directory raises instead of returning `False`, and the call site in `build_system_prompt_parts` had no guard — so the whole CLI aborted with `Error: [Errno 13] Permission denied: '/root/.git'` right after "Initializing agent...".

## Root cause

`TERMINAL_CWD` is consumed by two different layers with different semantics:

1. `terminal_tool` (the SSH backend) — needs the **remote** cwd to launch commands there.
2. System-prompt / context-file discovery — `resolve_context_cwd()` (agent/runtime_cwd.py) stats it **on the local host**.

For local backends the two meanings coincide; for remote backends they don't — the host process must never stat a remote path.

## Fix

- **agent/runtime_cwd.py** — `resolve_context_cwd()` / `resolve_agent_cwd()` now skip `TERMINAL_CWD` when `TERMINAL_ENV` is a remote backend (`ssh`, `docker`, `singularity`, `modal`, `daytona`, `vercel_sandbox`, `managed_modal`), falling back to the launch dir. The remote path is left untouched for `terminal_tool` to consume.
- **agent/prompt_builder.py** — `_find_git_root()` / `_find_hermes_md()` tolerate `OSError` on unreadable directories (skip and continue walking) instead of crashing.
- **agent/system_prompt.py** — `build_context_files_prompt` call site wrapped so context-file discovery is a soft failure, never an abort of prompt construction.
- **tests/agent/test_runtime_cwd.py** — new `TestRemoteBackendIgnoresTerminalCwd` regression suite (7 parametrized cases: ssh/docker/modal ignore TERMINAL_CWD; local/unset still honor it).

## Test Plan

- `venv/bin/python3 -m pytest tests/agent/test_runtime_cwd.py tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py -o 'addopts=' -q` → **82 passed**
- Manual repro of the original failure: with `TERMINAL_ENV=ssh` + `TERMINAL_CWD=/root` as an unprivileged user, `resolve_context_cwd()` returns `None`, `_find_git_root(Path('/root'))` returns `None`, and `build_context_files_prompt(cwd=None)` completes without raising (previously: `PermissionError`).

## Notes

A previous attempt at this guard lived at the `build_system_prompt_parts` call site (`agent.platform != "cli"` check) but was lost when context-file cwd routing was refactored into `resolve_context_cwd()` (f90777a6b). Placing the check at the resolver — the single source of truth for the agent working directory — makes it survive future refactors.
