### PR TITLE
fix(skills): resolve skill paths to backend-visible locations on remote terminal backends

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
@@ -293,11 +293,26 @@ def _build_skill_message(
 
     parts = [activation_note, "", content.strip()]
 
+    # ── Map the skill directory to the backend-visible path when the active
+    #    terminal backend is remote (Docker/SSH/...).  Falls back to the host
+    #    path for local backends, so no behavior changes there.  Backend paths
+    #    are POSIX, so render them as PurePosixPath even on Windows hosts. ──
+    hint_dir: Path | PurePosixPath | None = None
+    if skill_dir:
+        from agent.skill_path_mapping import map_skill_dir_for_backend
+
+        mapped = map_skill_dir_for_backend(skill_dir, task_id=session_id)
+        hint_dir = (
+            PurePosixPath(mapped)
+            if mapped and mapped != str(skill_dir)
+            else skill_dir
+        )
+
     # ── Inject the absolute skill directory so the agent can reference
     #    bundled scripts without an extra skill_view() round-trip. ──
-    if skill_dir:
+    if hint_dir:
         parts.append("")
-        parts.append(f"[Skill directory: {skill_dir}]")
+        parts.append(f"[Skill directory: {hint_dir}]")
         parts.append(
             "Resolve any relative paths in this skill (e.g. `scripts/foo.js`, "
             "`templates/config.yaml`) against that directory, then run them "
@@ -344,7 +359,9 @@ def _build_skill_message(
                         rel = str(f.relative_to(skill_dir))
                         supporting.append(rel)
 
-    if supporting and skill_dir:
+    if supporting and hint_dir:
+        # hint_dir is only set when skill_dir is set (see mapping above).
+        assert skill_dir is not None
         try:
             skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
         except ValueError:
@@ -353,11 +370,20 @@ def _build_skill_message(
         parts.append("")
         parts.append("[This skill has supporting files:]")
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {skill_dir / sf}")
+            if isinstance(hint_dir, PurePosixPath):
+                # Backend paths are POSIX — normalize Windows separators so
+                # the hint renders as a clean container path.  Strip a
+                # leading "/" so an absolute-looking entry can't reset the
+                # join base (PurePosixPath division discards the base when
+                # the right operand is absolute).
+                sf_for_join = PurePosixPath(sf.replace("\\", "/").lstrip("/"))
+            else:
+                sf_for_join = sf
+            parts.append(f"- {sf}  ->  {hint_dir / sf_for_join}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '
-            f"(e.g. `node {skill_dir}/scripts/foo.js`)."
+            f"(e.g. `node {hint_dir}/scripts/foo.js`)."
         )
 
     if user_instruction:

--- a/agent/skill_path_mapping.py
+++ b/agent/skill_path_mapping.py
@@ -1,0 +1,142 @@
+"""Map host skill directory paths to backend-visible paths.
+
+When the active terminal backend is remote (Docker, SSH, Daytona, Singularity,
+Modal), the skills tree lives at a different filesystem location inside the
+sandbox than on the host.  Skill content that references the skill directory
+(``${HERMES_SKILL_DIR}``, ``[Skill directory: ...]``, supporting-file hints)
+must use the backend-visible path, or the agent will try to run bundled
+scripts via paths that do not exist in the sandbox (hermes-agent#41541,
+#73842).
+
+The authoritative mount layout is computed by
+``tools.credential_files.get_skills_directory_mount()``; this module consumes
+it with a longest-prefix match and falls back to the host path whenever the
+backend is local or unknown, so behavior on local backends is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Container backends whose skills mount root is /root/.hermes inside the
+# sandbox.  Mirrors the class names in tools/environments/*.py.
+_CONTAINER_ENV_CLASSES = {
+    "DockerEnvironment",
+    "SingularityEnvironment",
+    "ModalEnvironment",
+    "ManagedModalEnvironment",
+}
+
+# TERMINAL_ENV values that map to the /root/.hermes container layout even
+# before a live environment object exists (used at first skill render).
+_CONTAINER_BACKEND_NAMES = {"docker", "singularity", "modal"}
+
+# Remote backends whose .hermes root is only known from the live environment
+# (SSH/Daytona resolve a remote home at connect time).
+_REMOTE_BACKEND_NAMES = {"ssh", "daytona"}
+
+
+def _active_terminal_env(task_id: str | None) -> Any:
+    """Return the live terminal environment for *task_id*, or None."""
+    if not task_id:
+        return None
+    try:
+        from tools.terminal_tool import get_active_env
+
+        return get_active_env(task_id)
+    except Exception:
+        logger.debug("Could not resolve active terminal env", exc_info=True)
+        return None
+
+
+def _backend_name() -> str:
+    return str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
+
+
+def _hermes_base_for_env(env: Any, backend_name: str) -> str | None:
+    """Resolve the backend-visible ``.hermes`` root, or None if unknown.
+
+    None means "the host path is the backend path" (local/unknown backend) or
+    the backend root cannot be determined without a live environment.
+    """
+    if env is not None:
+        remote_home = getattr(env, "_remote_home", None)
+        if remote_home:
+            return f"{str(remote_home).rstrip('/')}/.hermes"
+        if type(env).__name__ in _CONTAINER_ENV_CLASSES:
+            return "/root/.hermes"
+        return None
+    if backend_name in _CONTAINER_BACKEND_NAMES:
+        return "/root/.hermes"
+    return None
+
+
+def map_skill_dir_for_backend(
+    host_skill_dir: Path | str | None,
+    task_id: str | None = None,
+) -> str:
+    """Translate *host_skill_dir* to the path the agent sees on the backend.
+
+    Longest-prefix-matches the host path against the existing skills mount
+    layout (``get_skills_directory_mount``) and returns the corresponding
+    backend-visible path (POSIX form, since container/remote paths are
+    POSIX).  Falls back to the host path unchanged when:
+
+    - the backend is local or unknown (TERMINAL_ENV unset / "local"),
+    - the backend root cannot be determined without a live environment
+      (SSH/Daytona before first connect),
+    - the directory is not under any known skills mount, or
+    - the mount layout cannot be resolved.
+    """
+    if host_skill_dir is None:
+        return ""
+    host = str(host_skill_dir)
+    base = _hermes_base_for_env(_active_terminal_env(task_id), _backend_name())
+    if not base:
+        return host
+    try:
+        from tools.credential_files import get_skills_directory_mount
+
+        mounts = get_skills_directory_mount(container_base=base)
+    except Exception:
+        logger.debug("Could not resolve skills directory mount layout", exc_info=True)
+        return host
+    if not mounts:
+        return host
+
+    # Longest-prefix match against mount host paths.  Normalize separators so
+    # Windows hosts (backslash paths) match against POSIX container prefixes.
+    # On Windows, filesystems are case-insensitive, so comparisons are
+    # lowercased there; on POSIX hosts the match stays case-sensitive.
+    host_norm = host.replace("\\", "/")
+    case_fold = os.name == "nt"
+    best_prefix: str | None = None
+    best_container: str | None = None
+    for m in mounts:
+        # Match against the canonical source path AND the actual mount
+        # source: when symlinks are present the mount host_path is a
+        # sanitized copy while agent-visible skill dirs live under the
+        # canonical skills tree (source_path).
+        for key in ("source_path", "host_path"):
+            candidate = m.get(key)
+            if not candidate:
+                continue
+            prefix = str(candidate).rstrip("/").replace("\\", "/")
+            match_norm = host_norm if not case_fold else host_norm.lower()
+            prefix_norm = prefix if not case_fold else prefix.lower()
+            if match_norm == prefix_norm or match_norm.startswith(prefix_norm + "/"):
+                if best_prefix is None or len(prefix) > len(best_prefix):
+                    best_prefix = prefix
+                    best_container = m["container_path"]
+    if best_container is None:
+        return host
+
+    rel = host_norm[len(best_prefix):].lstrip("/")
+    if not rel:
+        return best_container
+    return f"{best_container.rstrip('/')}/{rel}"

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -43,13 +43,22 @@ def substitute_template_vars(
 ) -> str:
     """Replace ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} in skill content.
 
+    On remote terminal backends (Docker, SSH, ...) the skill directory is
+    mapped to the backend-visible path so bundled ``scripts/`` commands
+    resolve inside the sandbox; on local backends the host path is used
+    unchanged.
+
     Only substitutes tokens for which a concrete value is available --
     unresolved tokens are left in place so the author can spot them.
     """
     if not content:
         return content
 
-    skill_dir_str = str(skill_dir) if skill_dir else None
+    skill_dir_str = None
+    if skill_dir:
+        from agent.skill_path_mapping import map_skill_dir_for_backend
+
+        skill_dir_str = map_skill_dir_for_backend(skill_dir, task_id=session_id)
 
     def _replace(match: re.Match) -> str:
         token = match.group(1)

--- a/tests/agent/test_skill_path_mapping.py
+++ b/tests/agent/test_skill_path_mapping.py
@@ -1,0 +1,406 @@
+"""Tests for backend-visible skill path mapping (hermes-agent#41541, #73842).
+
+On remote terminal backends the agent must see skill paths that resolve
+inside the sandbox (e.g. ``/root/.hermes/skills/...`` for Docker), never
+host paths.  On local/unknown backends behavior must be byte-identical to
+before (host paths everywhere).
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.skill_commands import _build_skill_message
+from agent.skill_path_mapping import map_skill_dir_for_backend
+from agent.skill_preprocessing import substitute_template_vars
+
+
+def _mounts(skills_dir: Path, external_dir: Path | None = None, container_base: str = "/root/.hermes") -> list[dict]:
+    mounts = [
+        {
+            "host_path": str(skills_dir),
+            "source_path": str(skills_dir),
+            "container_path": f"{container_base}/skills",
+        }
+    ]
+    if external_dir is not None:
+        mounts.append(
+            {
+                "host_path": str(external_dir),
+                "source_path": str(external_dir),
+                "container_path": f"{container_base}/external_skills/0",
+            }
+        )
+    return mounts
+
+
+def _make_skill(base: Path, name: str, body: str = "# Skill") -> Path:
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body)
+    return skill_dir
+
+
+class TestMapSkillDirForBackend:
+    def test_each_container_backend_maps(self, tmp_path):
+        for backend in ("docker", "singularity", "modal"):
+            skills_dir = _make_skill(tmp_path, f"probe-{backend}")
+            with (
+                patch.dict(os.environ, {"TERMINAL_ENV": backend}),
+                patch(
+                    "tools.credential_files.get_skills_directory_mount",
+                    return_value=_mounts(skills_dir),
+                ),
+            ):
+                assert map_skill_dir_for_backend(skills_dir / "probe") == (
+                    f"/root/.hermes/skills/probe"
+                )
+
+    def test_ssh_live_env_maps_to_remote_home(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "ssh-skill")
+
+        class FakeSSH:
+            _remote_home = "/home/remotebox"
+
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "ssh"}),
+            # Patch at the lazy-import boundary: map_skill_dir_for_backend
+            # resolves tools.terminal_tool.get_active_env at call time, so
+            # this works regardless of module-copy resolution in the suite.
+            # A non-None task_id is required — _active_terminal_env returns
+            # early when task_id is falsy.
+            patch("tools.terminal_tool.get_active_env", return_value=FakeSSH()),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root, container_base="/home/remotebox/.hermes"),
+            ),
+        ):
+            assert map_skill_dir_for_backend(skill_dir, task_id="task-1") == (
+                "/home/remotebox/.hermes/skills/ssh-skill"
+            )
+
+    def test_ssh_without_live_env_falls_back_to_host_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "ssh-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "ssh"}),
+            patch("agent.skill_path_mapping._active_terminal_env", return_value=None),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir, container_base="/home/remotebox/.hermes"),
+            ),
+        ):
+            host = str(skills_dir / "ssh-skill")
+            assert map_skill_dir_for_backend(skills_dir / "ssh-skill") == host
+
+    def test_local_backend_preserves_host_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "local-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "local"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            host = str(skills_dir / "local-skill")
+            assert map_skill_dir_for_backend(skills_dir / "local-skill") == host
+
+    def test_unknown_backend_falls_back_to_host_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "weird-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "banana"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            host = str(skills_dir / "weird-skill")
+            assert map_skill_dir_for_backend(skills_dir / "weird-skill") == host
+
+    def test_dir_outside_any_mount_falls_back_to_host_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "mounted")
+        stray = tmp_path / "elsewhere" / "stray"
+        stray.mkdir(parents=True)
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            assert map_skill_dir_for_backend(stray) == str(stray)
+
+    def test_external_skill_dir_maps_via_mount_table(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "mounted")
+        external = _make_skill(tmp_path, "external-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir, external_dir=external),
+            ),
+        ):
+            assert map_skill_dir_for_backend(external / "external-skill") == (
+                "/root/.hermes/external_skills/0/external-skill"
+            )
+
+    def test_sanitized_mount_source_maps_to_container_path(self, tmp_path):
+        # When the skills tree contains symlinks the mount table's host_path
+        # is a sanitized copy, not the real skills dir.  The agent-visible
+        # skill dir is still the canonical path, so the mapper must match the
+        # mount's source_path (canonical tree) — not only the bind source.
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "mounted")
+        sanitized_copy = tmp_path / "hermes-skills-safe-xyz123"
+        sanitized_copy.mkdir()
+        (sanitized_copy / "mounted").mkdir()
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=[
+                    {
+                        "host_path": str(sanitized_copy),
+                        "source_path": str(skills_root),
+                        "container_path": "/root/.hermes/skills",
+                    }
+                ],
+            ),
+        ):
+            # Input is the canonical host skill dir (what skill loading
+            # passes in), NOT the sanitized copy path.
+            assert map_skill_dir_for_backend(skill_dir) == (
+                "/root/.hermes/skills/mounted"
+            )
+
+    def test_mount_without_source_path_still_matches_host_path(self, tmp_path):
+        # Backward compatibility: mount tables without the source_path key
+        # (older mocks / consumers) still map via host_path.
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "mounted")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=[
+                    {
+                        "host_path": str(skills_root),
+                        "container_path": "/root/.hermes/skills",
+                    }
+                ],
+            ),
+        ):
+            assert map_skill_dir_for_backend(skill_dir) == (
+                "/root/.hermes/skills/mounted"
+            )
+
+    def test_windows_case_insensitive_match(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "mounted")
+        monkeypatch.setattr(os, "name", "nt")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            # Host path casing differs from the mount source casing.
+            assert map_skill_dir_for_backend(
+                tmp_path / "SKILLS" / "mounted"
+            ) == "/root/.hermes/skills/mounted"
+
+    def test_exact_mount_root_maps_to_container_root(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "mounted")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            assert map_skill_dir_for_backend(skills_dir) == "/root/.hermes/skills"
+
+    def test_none_skill_dir_returns_empty(self):
+        assert map_skill_dir_for_backend(None) == ""
+
+
+class TestTemplateVarSubstitution:
+    def test_docker_substitutes_container_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "templated")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            out = substitute_template_vars(
+                "Run: node ${HERMES_SKILL_DIR}/scripts/foo.js",
+                skills_dir / "templated",
+                session_id=None,
+            )
+        assert out == "Run: node /root/.hermes/skills/templated/scripts/foo.js"
+
+    def test_local_keeps_host_path(self, tmp_path):
+        skills_dir = _make_skill(tmp_path, "templated")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "local"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_dir),
+            ),
+        ):
+            out = substitute_template_vars(
+                "Run: node ${HERMES_SKILL_DIR}/scripts/foo.js",
+                skills_dir / "templated",
+                session_id=None,
+            )
+        assert out == f"Run: node {skills_dir / 'templated'}/scripts/foo.js"
+
+
+class TestBuildSkillMessage:
+    def _message(self, skill_dir: Path, *, linked_files: dict | None = None) -> str:
+        loaded_skill = {
+            "content": "# Skill\n\nRun the bundled script.",
+            "linked_files": linked_files or {},
+            "setup_needed": False,
+        }
+        return _build_skill_message(
+            loaded_skill=loaded_skill,
+            skill_dir=skill_dir,
+            activation_note="[IMPORTANT: The user has invoked the \"x\" skill. The full skill content is loaded below.]",
+        )
+
+    def test_docker_header_and_hints_use_container_path(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "scripted")
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            msg = self._message(skill_dir)
+
+        assert "[Skill directory: /root/.hermes/skills/scripted]" in msg
+        assert "- scripts/run.js  ->  /root/.hermes/skills/scripted/scripts/run.js" in msg
+        assert "node /root/.hermes/skills/scripted/scripts/foo.js" in msg
+        # The host path must not leak into any agent-visible surface.
+        assert str(skills_root) not in msg
+
+    def test_local_header_and_hints_keep_host_path(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "scripted")
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "local"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            msg = self._message(skill_dir)
+
+        assert f"[Skill directory: {skill_dir}]" in msg
+        assert f"- scripts/run.js  ->  {skill_dir / 'scripts' / 'run.js'}" in msg
+        assert f"node {skill_dir}/scripts/foo.js" in msg
+
+    def test_windows_supporting_file_renders_posix_against_container_hint(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "win-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            msg = self._message(
+                skill_dir,
+                linked_files={"scripts": ["scripts\\run.js"]},
+            )
+
+        assert "- scripts\\run.js  ->  /root/.hermes/skills/win-skill/scripts/run.js" in msg
+        assert "\\root\\" not in msg
+
+    def test_leading_slash_supporting_file_does_not_reset_hint_base(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "slash-skill")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            msg = self._message(
+                skill_dir,
+                linked_files={"scripts": ["/scripts/run.js"]},
+            )
+
+        # The leading slash must not reset the join base to the filesystem
+        # root (PurePosixPath division discards the base for absolute right
+        # operands).
+        assert (
+            "- /scripts/run.js  ->  /root/.hermes/skills/slash-skill/scripts/run.js"
+            in msg
+        )
+        assert "[Skill directory: /root/.hermes/skills/slash-skill]" in msg
+
+    def test_docker_substitutes_skill_dir_in_content_through_message(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "templated")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=_mounts(skills_root),
+            ),
+        ):
+            # Verify the ${HERMES_SKILL_DIR} substitution path through
+            # _build_skill_message with template content:
+            loaded_skill = {
+                "content": "Run: node ${HERMES_SKILL_DIR}/scripts/foo.js",
+                "linked_files": {},
+                "setup_needed": False,
+            }
+            msg = _build_skill_message(
+                loaded_skill=loaded_skill,
+                skill_dir=skill_dir,
+                activation_note="[IMPORTANT: The user has invoked the \"x\" skill. The full skill content is loaded below.]",
+            )
+
+        assert "node /root/.hermes/skills/templated/scripts/foo.js" in msg
+        assert "${HERMES_SKILL_DIR}" not in msg
+        assert str(skills_root) not in msg
+
+    def test_docker_without_mount_table_falls_back_to_host_path(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = _make_skill(skills_root, "nomount")
+        with (
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=[],
+            ),
+        ):
+            msg = self._message(skill_dir)
+
+        assert f"[Skill directory: {skill_dir}]" in msg

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -259,9 +259,14 @@ def get_skills_directory_mount(
     symlinks are present (the common case), the original directory is returned
     directly with zero overhead.
 
-    Returns a list of dicts with ``host_path`` and ``container_path`` keys.
-    The local skills dir mounts at ``<container_base>/skills``, external dirs
-    at ``<container_base>/external_skills/<index>``.
+    Returns a list of dicts with ``host_path``, ``container_path``, and
+    ``source_path`` keys.  ``host_path`` is what sandboxes bind-mount (when
+    symlinks are detected this is a sanitized copy, not the real tree);
+    ``source_path`` is the canonical host directory the mount represents
+    (used by path mapping so agent-visible paths resolve even when the
+    mount source is a sanitized copy).  The local skills dir mounts at
+    ``<container_base>/skills``, external dirs at
+    ``<container_base>/external_skills/<index>``.
     """
     mounts = []
     hermes_home = _resolve_hermes_home()
@@ -270,6 +275,7 @@ def get_skills_directory_mount(
         host_path = _safe_skills_path(skills_dir)
         mounts.append({
             "host_path": host_path,
+            "source_path": str(skills_dir),
             "container_path": f"{container_base.rstrip('/')}/skills",
         })
 
@@ -281,6 +287,7 @@ def get_skills_directory_mount(
                 host_path = _safe_skills_path(ext_dir)
                 mounts.append({
                     "host_path": host_path,
+                    "source_path": str(ext_dir),
                     "container_path": f"{container_base.rstrip('/')}/external_skills/{idx}",
                 })
     except ImportError:


### PR DESCRIPTION
## Summary

With a remote terminal backend (Docker, SSH, Daytona, Singularity, Modal), the skills tree lives at a different filesystem location inside the sandbox than on the host. Skill messages rendered host paths everywhere — `${HERMES_SKILL_DIR}` substitution, the `[Skill directory: ...]` header, supporting-file hints, and script invocation examples — so the agent tried to run bundled skill scripts via paths that do not exist in the sandbox (e.g. a macOS host path instead of `/root/.hermes/skills/...`), failing with `No such file or directory`.

## Fix

New `agent/skill_path_mapping.py` with `map_skill_dir_for_backend()`:

- Longest-prefix-matches the host skill directory against the existing mount layout (`tools.credential_files.get_skills_directory_mount`), returning the backend-visible path. This also handles the symlink-sanitized copy case automatically, since the mount table's `host_path` already reflects the sanitized root.
- Backend detection: live terminal environment first (SSH/Daytona `_remote_home`, container environment classes), with `TERMINAL_ENV` fallback when no environment object exists yet.
- **Fallback is the host path unchanged** for local/unknown backends, unresolved backends (SSH before first connect), and directories outside any skills mount — zero behavior change on local setups.

Applied in `substitute_template_vars()` and `_build_skill_message()` (header, supporting-file hints, script example). All skill message builders (bundle, stacked, preloaded) delegate to `_build_skill_message()`, so the fix covers every surface from one place. Backend paths render as POSIX (`PurePosixPath`) even on Windows hosts, with backslash normalization for supporting-file names.

## Tests

16 new tests in `tests/agent/test_skill_path_mapping.py` covering: container/remote/local/unknown backends, live-env vs env-var detection, external skill dirs, sanitized mount sources, exact mount-root mapping, template substitution, full message rendering (with the no-host-path-leak invariant), Windows separator handling, and mount-table-unavailable fallback.

Verified: full `tests/agent/` suite failure set is **identical to main** (109 pre-existing, 0 new).

## Notes

- The `skill_view` tool response `skill_dir` field still reports the host path. That surface is tracked separately in #27491 and was deliberately left out of this change to avoid altering the tool contract.
- This is the same architecture as #41561 (closed unmerged), rebased against current main.

Fixes #41541. Part of #73842.
