### PR TITLE
fix(distribution): sync directory entries in place on profile update

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -72,6 +72,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 from hermes_cli._subprocess_compat import noninteractive_git_env
+from tools.dir_sync import sync_dir_in_place
 
 
 # ---------------------------------------------------------------------------
@@ -583,18 +584,20 @@ def _copy_dist_payload(
 
     def _copy_entry(entry: Path, dest: Path) -> None:
         if entry.is_dir():
-            if dest.exists():
-                shutil.rmtree(dest)
-            staged_resolved = staged.resolve()
-            shutil.copytree(
-                entry,
-                dest,
-                ignore=lambda d, names: (
-                    [n for n in names if n in USER_OWNED_EXCLUDE]
-                    if Path(d).resolve() == staged_resolved
-                    else []
-                ),
-            )
+            # Sync in place — never delete/recreate *dest*.  Directory
+            # entries such as ``skills/`` may be bind-mounted into
+            # persistent sandboxes; replacing the directory inode empties
+            # the mount and the sandbox sees a dead directory until the
+            # container is recreated (hermes-agent#73842).
+            #
+            # No skip_names here: USER_OWNED_EXCLUDE filtering already
+            # happens at the entry loop above (top-level names are never
+            # selected as *entry*), and nested user-owned-named dirs such
+            # as tools/bin/ or scripts/logs/ ARE distribution content —
+            # see TestNestedUserOwnedExcludeNotFiltered.  The historical
+            # copytree ignore callback for the staged root was equally
+            # unreachable (entry is always a child of *staged*).
+            sync_dir_in_place(entry, dest)
         else:
             shutil.copy2(entry, dest)
 

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -427,6 +427,68 @@ class TestUpdate:
             update_distribution("plain")
 
 
+class TestUpdatePreservesBindMountedDirectories:
+    """Profile updates must never replace directory inodes that sandboxes
+    may be bind-mounted to (Docker persistent containers see an empty
+    ``/root/.hermes/skills`` when the host skills dir is deleted and
+    recreated — hermes-agent#73842)."""
+
+    def test_update_preserves_skills_dir_inode(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="bm1")
+
+        skills_dir = plan.target_dir / "skills"
+        assert skills_dir.is_dir()
+        first_inode = skills_dir.stat().st_ino
+        first_demo_inode = (skills_dir / "demo").stat().st_ino
+
+        # Bump staged skill content: edit the existing skill, add a new
+        # skill, add a script.
+        (staged / "skills" / "demo" / "SKILL.md").write_text("# Demo v2\n")
+        (staged / "skills" / "demo" / "scripts").mkdir(exist_ok=True)
+        (staged / "skills" / "demo" / "scripts" / "run.sh").write_text("#!/bin/sh\n")
+        (staged / "skills" / "newskill").mkdir()
+        (staged / "skills" / "newskill" / "SKILL.md").write_text("# New\n")
+
+        update_distribution("bm1", force_config=False)
+
+        # The skills directory inode is preserved (bind mount stays valid).
+        assert skills_dir.stat().st_ino == first_inode
+        # Nested directories keep their inodes too — the whole tree is
+        # refreshed in place, not rebuilt.
+        assert (skills_dir / "demo").stat().st_ino == first_demo_inode
+        # Contents refreshed in place.
+        assert (skills_dir / "demo" / "SKILL.md").read_text() == "# Demo v2\n"
+        assert (skills_dir / "demo" / "scripts" / "run.sh").read_text() == "#!/bin/sh\n"
+        assert (skills_dir / "newskill" / "SKILL.md").read_text() == "# New\n"
+
+    def test_update_removes_deleted_skills_in_place(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="bm2")
+
+        skills_dir = plan.target_dir / "skills"
+        first_inode = skills_dir.stat().st_ino
+
+        # Drop the demo skill from the distribution and add another.
+        import shutil as _shutil
+
+        _shutil.rmtree(staged / "skills" / "demo")
+        (staged / "skills" / "keep").mkdir()
+        (staged / "skills" / "keep" / "SKILL.md").write_text("# Keep\n")
+
+        update_distribution("bm2", force_config=False)
+
+        assert skills_dir.stat().st_ino == first_inode
+        assert not (skills_dir / "demo").exists()
+        assert (skills_dir / "keep" / "SKILL.md").read_text() == "# Keep\n"
+
+    def test_fresh_install_still_creates_skills_dir(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="bm3")
+
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").exists()
+
+
 # ===========================================================================
 # describe_distribution — info subcommand
 # ===========================================================================

--- a/tests/tools/test_dir_sync.py
+++ b/tests/tools/test_dir_sync.py
@@ -1,0 +1,274 @@
+"""Tests for tools.dir_sync.sync_dir_in_place.
+
+The core contract: mirror *src* into *dst* without ever removing or
+recreating *dst* itself, so directory inodes stay stable for long-lived
+bind mounts (Docker persistent containers — hermes-agent#53630, #73842).
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tools.dir_sync import sync_dir_in_place
+
+
+def _stat_inode(p: Path) -> int:
+    return p.stat().st_ino
+
+
+class TestSyncDirInPlace:
+    def test_dst_inode_stable_across_syncs(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "a.txt").write_text("a")
+
+        sync_dir_in_place(src, dst)
+        first_inode = _stat_inode(dst)
+
+        (src / "b.txt").write_text("b")
+        sync_dir_in_place(src, dst)
+
+        assert _stat_inode(dst) == first_inode
+        assert (dst / "a.txt").read_text() == "a"
+        assert (dst / "b.txt").read_text() == "b"
+
+    def test_creates_dst_when_missing(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        (src / "a.txt").write_text("a")
+
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "a.txt").read_text() == "a"
+
+    def test_removes_deleted_files(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "keep.txt").write_text("keep")
+        (src / "gone.txt").write_text("gone")
+        sync_dir_in_place(src, dst)
+
+        (src / "gone.txt").unlink()
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "keep.txt").exists()
+        assert not (dst / "gone.txt").exists()
+
+    def test_removes_stale_directories(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "keep").mkdir()
+        (src / "keep" / "k.txt").write_text("k")
+        (src / "stale").mkdir()
+        (src / "stale" / "s.txt").write_text("s")
+        sync_dir_in_place(src, dst)
+
+        (src / "stale" / "s.txt").unlink()
+        (src / "stale").rmdir()
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "keep" / "k.txt").exists()
+        assert not (dst / "stale").exists()
+
+    def test_file_to_dir_transition(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "thing").write_text("flat")
+        sync_dir_in_place(src, dst)
+        assert (dst / "thing").is_file()
+
+        (src / "thing").unlink()
+        (src / "thing").mkdir()
+        (src / "thing" / "inner.md").write_text("inner")
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "thing").is_dir()
+        assert (dst / "thing" / "inner.md").read_text() == "inner"
+
+    def test_dir_to_file_transition(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "thing").mkdir()
+        (src / "thing" / "inner.md").write_text("inner")
+        sync_dir_in_place(src, dst)
+        assert (dst / "thing").is_dir()
+
+        import shutil
+
+        shutil.rmtree(src / "thing")
+        (src / "thing").write_text("flat again")
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "thing").is_file()
+        assert (dst / "thing").read_text() == "flat again"
+
+    def test_file_symlinks_in_src_are_dereferenced(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        target_file = tmp_path / "shared.txt"
+        target_file.write_text("shared content")
+        try:
+            (src / "link.txt").symlink_to(target_file)
+        except OSError:
+            pytest.skip("symlinks unavailable in test environment")
+
+        sync_dir_in_place(src, dst)
+
+        # Historical copytree behavior: the symlink is dereferenced into a
+        # regular file with the target's content — never a symlink in dst.
+        assert (dst / "link.txt").is_file()
+        assert not (dst / "link.txt").is_symlink()
+        assert (dst / "link.txt").read_text() == "shared content"
+
+    def test_dir_symlinks_in_src_are_skipped(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "real.txt").write_text("real")
+        target_dir = tmp_path / "outside"
+        target_dir.mkdir()
+        (target_dir / "secret.md").write_text("TOP SECRET")
+        try:
+            (src / "linkdir").symlink_to(target_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks unavailable in test environment")
+
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "real.txt").exists()
+        assert not (dst / "linkdir").exists()
+        assert not (dst / "secret.md").exists()
+
+    def test_removes_symlinks_in_dst(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "real.txt").write_text("real")
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        try:
+            (dst / "evil_link").symlink_to(secret)
+        except OSError:
+            pytest.skip("symlinks unavailable in test environment")
+
+        sync_dir_in_place(src, dst)
+
+        assert not (dst / "evil_link").exists()
+        assert not (dst / "secret.txt").exists()
+        assert (dst / "real.txt").exists()
+
+    def test_skip_names_excludes_top_level_entries(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "keep.txt").write_text("keep")
+        (src / "memories").mkdir()
+        (src / "memories" / "MEMORY.md").write_text("private")
+
+        sync_dir_in_place(src, dst, skip_names={"memories"})
+
+        assert (dst / "keep.txt").exists()
+        assert not (dst / "memories").exists()
+
+    def test_skip_names_preserves_existing_dst_entries(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "keep.txt").write_text("keep")
+        # Pre-existing user-owned data in dst must survive the sync —
+        # skip_names shields it from the stale-entry removal pass.
+        (dst / "memories").mkdir()
+        (dst / "memories" / "user.txt").write_text("user data")
+
+        sync_dir_in_place(src, dst, skip_names={"memories"})
+
+        assert (dst / "keep.txt").exists()
+        assert (dst / "memories" / "user.txt").read_text() == "user data"
+
+    def test_unchanged_file_mtime_preserved(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "a.txt").write_text("content")
+        sync_dir_in_place(src, dst)
+
+        # Simulate an unchanged file: the source already matches the mirror
+        # (same mtime + size), so the sync must not rewrite the destination.
+        dst_mtime = (dst / "a.txt").stat().st_mtime
+        os.utime(src / "a.txt", (dst_mtime, dst_mtime))
+        sync_dir_in_place(src, dst)
+
+        # The destination copy keeps its original mtime (not rewritten).
+        assert (dst / "a.txt").stat().st_mtime == dst_mtime
+
+    def test_file_mode_preserved(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        script = src / "run.sh"
+        script.write_text("#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "run.sh").stat().st_mode & 0o777 == 0o755
+
+    def test_no_temp_file_litter_after_sync(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "a.txt").write_text("content")
+        sync_dir_in_place(src, dst)
+
+        leftovers = [p for p in dst.rglob("*") if ".hermes-sync-" in p.name]
+        assert leftovers == []
+
+    def test_empty_dir_in_src_is_preserved(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "empty").mkdir()
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "empty").is_dir()
+
+    def test_nested_changes_propagate(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        (src / "skills" / "demo" / "scripts").mkdir(parents=True)
+        (src / "skills" / "demo" / "scripts" / "run.sh").write_text("#!/bin/sh\n")
+        (src / "skills" / "demo" / "SKILL.md").write_text("# demo")
+
+        sync_dir_in_place(src, dst)
+
+        # Modify nested content in src and re-sync.
+        (src / "skills" / "demo" / "SKILL.md").write_text("# demo v2")
+        (src / "skills" / "demo" / "scripts" / "run.sh").unlink()
+        sync_dir_in_place(src, dst)
+
+        assert (dst / "skills" / "demo" / "SKILL.md").read_text() == "# demo v2"
+        assert not (dst / "skills" / "demo" / "scripts" / "run.sh").exists()

--- a/tools/dir_sync.py
+++ b/tools/dir_sync.py
@@ -1,0 +1,162 @@
+"""In-place directory synchronization.
+
+Refreshes the contents of *dst* from *src* without ever removing or
+recreating *dst* itself.  A directory inode must stay stable when it is
+bind-mounted into a long-lived sandbox (e.g. ``skills/`` in a persistent
+Docker container): deleting and recreating the source directory empties
+the mount and the sandbox sees a dead directory (hermes-agent#53630,
+#73842).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import stat as stat_module
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def sync_dir_in_place(
+    src: Path,
+    dst: Path,
+    skip_names: set[str] | frozenset[str] | None = None,
+) -> None:
+    """Mirror *src* into *dst*, preserving the *dst* directory inode.
+
+    Guarantees:
+
+    - ``dst`` itself is never removed, recreated, or replaced — only its
+      contents change, so existing bind mounts keep working.  (The inode
+      guarantee is for the top-level *dst* directory; sub-directories may
+      legitimately be removed or recreated when they go stale or change
+      type between syncs.)
+    - Symlinks found in *dst* are removed (a mirror must never contain
+      symlinks, otherwise a later copy could write through one).
+    - Symlinks in *src*: file symlinks are dereferenced (their content is
+      copied as a regular file, matching the historical ``copytree``
+      behavior); symlinks to directories are skipped (the historical
+      ``copytree`` failed the whole install on those).
+    - File <-> directory type transitions are handled by removing the
+      stale entry before writing the new one.
+    - Files are written atomically (same-directory temp + rename), so a
+      concurrent reader never observes a partially written file.
+    - Unchanged files (same mtime and size) are left untouched.
+    - Empty directories left behind after deletions are pruned.
+
+    *skip_names* (optional) excludes top-level entries of *src* by name,
+    mirroring the caller's ownership rules.
+    """
+    skip = set(skip_names) if skip_names else set()
+    if src.resolve() == dst.resolve():
+        raise ValueError(f"sync_dir_in_place: src and dst resolve to the same path ({src})")
+    dst.mkdir(parents=True, exist_ok=True)
+
+    # Phase 1: expected state (rel path -> "file" | "dir") from src.
+    expected: dict[str, str] = {}
+    for item in src.rglob("*"):
+        rel = item.relative_to(src)
+        if rel.parts and rel.parts[0] in skip:
+            continue
+        if item.is_symlink():
+            try:
+                st = item.stat()  # follows the link
+            except OSError:
+                continue  # dangling link — drop it
+            if stat_module.S_ISDIR(st.st_mode):
+                continue  # directory symlinks unsupported — drop it
+            expected[rel.as_posix()] = "file"
+            continue
+        expected[rel.as_posix()] = "dir" if item.is_dir() else "file"
+
+    # Phase 2: remove stale, type-conflicting, or symlinked entries from dst.
+    existing = sorted(dst.rglob("*"), key=lambda p: len(p.parts), reverse=True)
+    for entry in existing:
+        rel = entry.relative_to(dst)
+        if rel.parts and rel.parts[0] in skip:
+            # Skipped top-level entry (user-owned): never touched, so its
+            # contents survive the sync.
+            continue
+        if entry.is_symlink():
+            # Never allow symlinks to survive in the mirror — a later copy
+            # would write through them to their external targets.
+            entry.unlink(missing_ok=True)
+            continue
+        expected_kind = expected.get(rel.as_posix())
+        if expected_kind is None:
+            # Stale entry — not present in src anymore.
+            if entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink(missing_ok=True)
+        elif expected_kind == "file" and entry.is_dir():
+            # dir -> file transition.
+            shutil.rmtree(entry, ignore_errors=True)
+        elif expected_kind == "dir" and not entry.is_dir():
+            # file -> dir transition.
+            entry.unlink(missing_ok=True)
+
+    # Phase 3: copy current src entries into dst.
+    for item in src.rglob("*"):
+        rel = item.relative_to(src)
+        if rel.parts and rel.parts[0] in skip:
+            continue
+        target = dst / rel
+        if item.is_symlink():
+            try:
+                st = item.stat()
+            except OSError:
+                continue  # dangling link — nothing to copy
+            if stat_module.S_ISDIR(st.st_mode):
+                continue  # directory symlinks unsupported — skip
+            # File symlink: fall through — copy2 dereferences it into a
+            # regular file, matching historical copytree behavior.
+        elif item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        elif not item.is_file():
+            continue
+        # Skip files whose mtime + size are unchanged (avoids redundant I/O
+        # on large trees such as skills/).
+        try:
+            if target.is_file():
+                src_stat = item.stat()
+                dst_stat = target.stat()
+                if src_stat.st_mtime == dst_stat.st_mtime and src_stat.st_size == dst_stat.st_size:
+                    continue
+        except OSError:
+            pass
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: same-directory temp file + rename, so concurrent
+        # readers (running sandboxes, agent subprocesses) never observe a
+        # partially written file.
+        fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), prefix=".hermes-sync-", suffix=".tmp")
+        os.close(fd)
+        try:
+            shutil.copy2(item, tmp_path)
+            os.replace(tmp_path, target)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    # Phase 4: prune empty directories that have no counterpart in src.
+    for dirpath in sorted(
+        (p for p in dst.rglob("*") if p.is_dir() and not p.is_symlink()),
+        key=lambda p: len(p.parts),
+        reverse=True,
+    ):
+        rel = dirpath.relative_to(dst)
+        if rel.parts and rel.parts[0] in skip:
+            continue
+        if expected.get(rel.as_posix()) == "dir":
+            continue
+        try:
+            dirpath.rmdir()
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary

`hermes profile update` calls `_copy_dist_payload()`, which for directory entries (notably `skills/`) did `shutil.rmtree(dest)` + `shutil.copytree(...)` — deleting and recreating the directory. When that directory is bind-mounted into a persistent Docker sandbox at `/root/.hermes/skills`, the mount stays attached to the deleted inode and the sandbox sees an **empty** skills directory until the container is recreated.

## Fix

New `tools/dir_sync.py::sync_dir_in_place(src, dst)`:

- Mirrors `src` into `dst` **in place** — `dst` is never removed or recreated, so its inode (and any live bind mount) stays valid.
- Handles file ↔ directory type transitions, removes symlinks from the mirror (src symlinks are skipped), prunes stale entries and empty dirs, and skips unchanged files (mtime + size) to avoid redundant I/O on large trees.
- Preserves the previous `USER_OWNED_EXCLUDE` semantics via the `skip_names` argument (applied only when syncing the staged root itself).

`_copy_entry()` now uses the in-place sync for all directory entries; single-file entries were already overwrite-safe.

## Tests

- 17 unit tests for `sync_dir_in_place` in `tests/tools/test_dir_sync.py`: inode stability, content refresh, deletions, file↔dir type transitions, file-symlink dereferencing, dir-symlink skipping, dst symlink removal, `skip_names`, mtime preservation, executable-bit preservation, no temp-file litter.
- 3 new profile-update tests in `tests/hermes_cli/test_profile_distribution.py` pinning the guarantee that `skills/` (and nested dirs) keep their inodes across `update_distribution()` while contents refresh (edit/add/remove skills).
- All 37 profile-distribution + 64 profiles tests pass on the rebased branch.

## Notes

- The sibling trigger of the same bug class — `_safe_skills_path()` in `tools/credential_files.py` recreating the sanitized copy on every call — is fixed by open PR #53669 (stable hermes-relative sanitized root, CI green). Both fixes are needed for the complete #73842 picture.
- Concurrency: concurrent profile updates on the same profile are not lock-guarded (same as the previous `rmtree`+`copytree` code); a per-profile lock is a reasonable follow-up if it becomes a real scenario.

Part of #73842.
