### PR TITLE
fix: preserve DeepSeek thinking blocks on relay/gateway endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2515,8 +2515,15 @@ def _manage_thinking_signatures(
             # Kimi does not enforce thinking signatures — replay as-is
             # (shared cleanup below still strips cache markers + the internal flag).
             pass
-        elif _is_deepseek_anthropic_endpoint(base_url):
+        elif _is_deepseek_anthropic_endpoint(base_url) or (
+            isinstance(model, str) and "deepseek" in model.lower()
+        ):
             # DeepSeek: strip signed, preserve unsigned.
+            # Model-name fallback mirrors the Kimi family check above:
+            # gateways/relays (e.g. ReachAPI) fronting DeepSeek enforce the
+            # same thinking round-trip contract regardless of hostname —
+            # stripping here causes HTTP 400 "The content[].thinking in the
+            # thinking mode must be passed back to the API."
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:


### PR DESCRIPTION
## Problem

A DeepSeek model (e.g. `deepseek-v4-flash`) configured on an `anthropic_messages` custom provider that fronts a relay/aggregator (e.g. ReachAPI `direct.reachapi.ai/v1`) hard-aborts every turn with HTTP 400:

```
The content[].thinking in the thinking mode must be passed back to the API.
```

Non-retryable once any history turn carries a thinking block.

## Root cause

In `agent/anthropic_adapter.py`, `_manage_thinking_signatures` matched DeepSeek endpoints **only by hostname** (`_is_deepseek_anthropic_endpoint` = `api.deepseek.com` + `/anthropic` path). Any relay/gateway hostname falls through to the generic third-party branch, which strips **all** thinking blocks on replay — so the upstream DeepSeek thinking mode receives no echo → 400.

The error wording also isn't mapped in `error_classifier.py` (`thinking_signature` matching covers "signature"/"cannot be modified" only), so the strip-and-retry self-heal never fires — hard abort instead of recovery.

Kimi already solves exactly this with a model-name fallback (`_is_kimi_family_endpoint` checks the model name precisely because "the upstream enforces Kimi's thinking semantics regardless of the gateway's hostname"). DeepSeek lacked the equivalent.

## Fix

Extend the DeepSeek branch with the same model-name fallback:

```python
elif _is_deepseek_anthropic_endpoint(base_url) or (
    isinstance(model, str) and "deepseek" in model.lower()
):
```

Behaviour unchanged for direct `api.deepseek.com` connections; for relay-hosted DeepSeek models, unsigned thinking blocks (synthesised from `reasoning_content`) now round-trip, while signed/redacted blocks are still stripped (a relay cannot validate Anthropic signatures).

## Verification

- Functional simulation: `_manage_thinking_signatures(messages, "https://direct.reachapi.ai/v1", "deepseek-v4-flash")` — unsigned `thinking` preserved, signed stripped, `tool_use` untouched.
- `tests/agent/test_deepseek_anthropic_thinking.py` + `tests/agent/test_anthropic_kimi_signed_thinking_replay.py`: 5 passed.
- `tests/agent/test_anthropic_adapter.py`: 94 passed.
- Live: the patched code has been running as the primary model path (DeepSeek via relay) without the 400 since the patch landed.

Same direction as the existing Kimi handling — worth considering upstreaming the error-wording mapping (`content[].thinking ... must be passed back`) to `error_classifier.py` in a follow-up so the self-heal path covers it too.