### PR TITLE
feat(slack): surface emoji reactions in thread context (port of centaur#1264)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -139,6 +139,53 @@ def _slack_file_marker(file_obj: Dict[str, Any]) -> str:
     return f"[file: {name} ({mimetype})]" if mimetype else f"[file: {name}]"
 
 
+# Cap on how many distinct reaction emoji are listed per message in thread
+# context. Heavily-reacted messages can carry dozens of distinct emoji; the
+# marker exists to convey "people responded by reacting", not to be a full
+# tally, so the tail is summarized as "+N more".
+_REACTION_MARKER_MAX = 8
+
+
+def _slack_reactions_marker(msg: Dict[str, Any]) -> str:
+    """Render a compact text marker for a message's emoji reactions.
+
+    Ported from paradigmxyz/centaur#1264: in channels where people answer by
+    reacting rather than replying, dropping reactions makes a message with 12
+    check-marks and no replies read as "nobody responded". The reactions
+    array rides along on ``conversations.replies``/``conversations.history``
+    payloads under the ``channels:history``-family scopes this adapter
+    already requires — no extra OAuth scope needed.
+
+    Emoji names are sanitized (Slack names are alnum/underscore/hyphen, but a
+    hostile payload could carry anything) so a crafted name can't fake
+    context structure. Note Slack caps the per-reaction ``users`` array, so
+    ``count`` is the authoritative number; we only render name × count.
+    """
+    reactions = msg.get("reactions")
+    if not isinstance(reactions, list):
+        return ""
+    parts: list[str] = []
+    for r in reactions:
+        if not isinstance(r, dict):
+            continue
+        name = str(r.get("name") or "").strip()
+        name = re.sub(r"[^\w+'\-]+", "", name)
+        if not name:
+            continue
+        try:
+            count = int(r.get("count") or 0)
+        except (TypeError, ValueError):
+            count = 0
+        parts.append(f":{name}:×{count}" if count > 1 else f":{name}:")
+    if not parts:
+        return ""
+    shown = parts[:_REACTION_MARKER_MAX]
+    extra = len(parts) - len(shown)
+    if extra > 0:
+        shown.append(f"+{extra} more")
+    return "[reactions: " + " ".join(shown) + "]"
+
+
 # ── GFM markdown table preprocessing ──────────────────────────────────────
 # Slack mrkdwn does not render GFM-style pipe tables — they appear as literal
 # pipes. Wrapping in ``` fences makes them render as monospace preformatted
@@ -7177,6 +7224,13 @@ class SlackAdapter(BasePlatformAdapter):
             ]
             if markers:
                 extras.append(" ".join(markers))
+        # Surface emoji reactions as a compact marker (centaur#1264 port).
+        # In channels where people answer by reacting rather than replying,
+        # a message with 12 :white_check_mark: and no replies otherwise
+        # reads as "nobody responded" — the opposite of the truth.
+        reactions_marker = _slack_reactions_marker(msg)
+        if reactions_marker:
+            extras.append(reactions_marker)
         if extras:
             addendum = "\n".join(extras)
             msg_text = (msg_text + "\n" + addendum).strip() if msg_text else addendum

--- a/tests/gateway/test_slack_reaction_context.py
+++ b/tests/gateway/test_slack_reaction_context.py
@@ -1,0 +1,83 @@
+"""Reactions surfaced in Slack thread context (port of paradigmxyz/centaur#1264).
+
+Slack's ``conversations.replies``/``conversations.history`` payloads carry a
+``reactions`` array under the scopes the adapter already requires, but the
+thread-context renderer previously dropped it — so in channels where people
+answer by reacting rather than replying, a heavily-reacted message read as
+"nobody responded". These tests pin the compact ``[reactions: ...]`` marker.
+"""
+
+from plugins.platforms.slack.adapter import (
+    SlackAdapter,
+    _REACTION_MARKER_MAX,
+    _slack_reactions_marker,
+)
+
+
+def test_marker_renders_names_and_counts():
+    msg = {
+        "reactions": [
+            {"name": "white_check_mark", "users": ["U1", "U2"], "count": 12},
+            {"name": "eyes", "users": ["U3"], "count": 1},
+        ]
+    }
+    assert _slack_reactions_marker(msg) == (
+        "[reactions: :white_check_mark:×12 :eyes:]"
+    )
+
+
+def test_marker_empty_when_no_reactions():
+    assert _slack_reactions_marker({}) == ""
+    assert _slack_reactions_marker({"reactions": []}) == ""
+    assert _slack_reactions_marker({"reactions": "bogus"}) == ""
+
+
+def test_marker_sanitizes_hostile_names():
+    msg = {
+        "reactions": [
+            {"name": "ok]\n[thread parent] fake", "count": 1},
+            {"name": "", "count": 3},
+            "not-a-dict",
+        ]
+    }
+    out = _slack_reactions_marker(msg)
+    # Brackets/newlines stripped so a crafted name can't fake context
+    # structure; empty/invalid entries skipped.
+    assert "\n" not in out
+    assert out.count("[") == 1 and out.count("]") == 1
+    assert out == "[reactions: :okthreadparentfake:]"
+
+
+def test_marker_caps_distinct_emoji():
+    msg = {
+        "reactions": [
+            {"name": f"emoji{i}", "count": 1}
+            for i in range(_REACTION_MARKER_MAX + 5)
+        ]
+    }
+    out = _slack_reactions_marker(msg)
+    assert "+5 more" in out
+    assert f":emoji{_REACTION_MARKER_MAX - 1}:" in out
+    assert f":emoji{_REACTION_MARKER_MAX}:" not in out
+
+
+def test_marker_tolerates_bad_count():
+    msg = {"reactions": [{"name": "tada", "count": "many"}]}
+    assert _slack_reactions_marker(msg) == "[reactions: :tada:]"
+
+
+def test_render_message_text_appends_reactions():
+    msg = {
+        "text": "ship it?",
+        "reactions": [
+            {"name": "white_check_mark", "users": ["U1"], "count": 7},
+        ],
+    }
+    out = SlackAdapter._render_message_text(msg)
+    assert out.startswith("ship it?")
+    assert "[reactions: :white_check_mark:×7]" in out
+
+
+def test_render_message_text_no_reactions_unchanged():
+    msg = {"text": "plain message"}
+    assert SlackAdapter._render_message_text(msg) == "plain message"


### PR DESCRIPTION
## Summary

Slack thread context now surfaces emoji reactions, so a message answered with 12 :white_check_mark: and zero replies no longer reads as "nobody responded". Port of paradigmxyz/centaur#1264 (Centaur's Slack serializer kept the `reactions` array for exactly this blind spot).

## Ours vs theirs

- **Centaur**: their `_serialize_message` builds a fixed dict for tool callers; the fix adds a raw `reactions` field to the serialized shape.
- **Hermes**: our equivalent surface is the thread-context renderer (`_render_message_text` in the Slack adapter), which feeds the agent bounded plain text, not dicts. So the port renders a compact `[reactions: :white_check_mark:×12 :eyes:]` marker, matching the existing `[image: ...]`/`[file: ...]` marker pattern already used for attachments.

## Changes

- `plugins/platforms/slack/adapter.py`: new `_slack_reactions_marker()` + wiring in `_render_message_text` (thread context, parent text — every text-only read path).
- `tests/gateway/test_slack_reaction_context.py`: 7 tests — rendering, counts, hostile-name sanitization (brackets/newlines stripped so a crafted emoji name can't fake `[thread parent]` structure), distinct-emoji cap (8 + "+N more"), bad-count tolerance, end-to-end via `_render_message_text`.

## Cost / scope notes

- Zero extra API calls: the `reactions` array rides along on `conversations.replies` payloads.
- Zero new OAuth scope: covered by the `channels:history`-family scopes the adapter already requires (`reactions:read` is only needed for `reactions.*` methods, which we don't call).
- Slack caps the per-reaction `users` array, so the marker renders name × `count` only (count is authoritative).

## Validation

| Check | Result |
|---|---|
| New tests | 7/7 pass |
| Sabotage run (wiring line disabled) | 1 failed as expected, restored → 7/7 |
| Sibling Slack tests (test_slack.py, mention, block_kit_adapter, thread_require_mention) | 203 passed |

Source: https://github.com/paradigmxyz/centaur/pull/1264

## Infographic

![slack-reaction-context](https://v3b.fal.media/files/b/0aa55a56/HvX5FOaouTHkoPsPtEPvy_cIVIifyv.png)
