### PR TITLE
Fix dashboard skill lookup by display name

### DIFF
--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -25,10 +25,12 @@ Do the thing.
 """
 
 
-def _write_skill(skills_dir, name):
+def _write_skill(skills_dir, name, display_name=None):
     d = skills_dir / name
     d.mkdir(parents=True, exist_ok=True)
-    (d / "SKILL.md").write_text(SKILL_MD.format(name=name), encoding="utf-8")
+    (d / "SKILL.md").write_text(
+        SKILL_MD.format(name=display_name or name), encoding="utf-8"
+    )
 
 
 @pytest.fixture
@@ -77,6 +79,28 @@ class TestSkillContent:
         assert data["name"] == "dashboard-skill"
         assert data["content"].startswith("---")
         assert "Do the thing." in data["content"]
+
+    def test_get_and_update_by_frontmatter_display_name(
+        self, client, isolated_profiles
+    ):
+        skills_dir = isolated_profiles["default"] / "skills"
+        _write_skill(skills_dir, "agong-deep-search-trace", "AGong Deep Search Trace")
+
+        resp = client.get(
+            "/api/skills/content", params={"name": "AGong Deep Search Trace"}
+        )
+        assert resp.status_code == 200
+
+        new_content = resp.json()["content"].replace(
+            "Do the thing.", "Do the NEW thing."
+        )
+        resp = client.put(
+            "/api/skills/content",
+            json={"name": "AGong Deep Search Trace", "content": new_content},
+        )
+        assert resp.status_code == 200
+        skill_md = skills_dir / "agong-deep-search-trace" / "SKILL.md"
+        assert "Do the NEW thing." in skill_md.read_text(encoding="utf-8")
 
     def test_get_content_scopes_to_profile(self, client, isolated_profiles):
         resp = client.get(

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -644,13 +644,15 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
-    Find a skill by name across all skill directories.
+    Find a skill by directory name or frontmatter display name.
 
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    frontmatter_match = None
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
@@ -659,7 +661,16 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
                 continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
-    return None
+            if frontmatter_match is None:
+                try:
+                    frontmatter, _ = _parse_frontmatter(
+                        skill_md.read_text(encoding="utf-8")
+                    )
+                except (OSError, UnicodeError):
+                    continue
+                if frontmatter.get("name") == name:
+                    frontmatter_match = {"path": skill_md.parent}
+    return frontmatter_match
 
 
 def _maybe_auto_propose_org_edit(name: str, skill_path: Path) -> Optional[str]:


### PR DESCRIPTION
Summary
- preserve exact directory-name lookup precedence
- fall back to the SKILL.md frontmatter display name used by the dashboard
- cover read and update through the Skill Editor API

Tests
- HERMES_PYTHON=/tmp/hermes-core-test-venv-20260807/bin/python scripts/run_tests.sh tests/hermes_cli/test_web_server_skill_editor.py -q
- 13 passed