### PR TITLE
fix(cron): persist multiplexed sessions in the owning profile

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3001,8 +3001,13 @@ def run_job(
 
         if _session_db_timeout > 0:
             _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            # SessionDB resolves profile-sensitive paths during construction.
+            # Preserve this cron job's profile scope across the timeout worker.
+            _session_db_context = contextvars.copy_context()
             try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
+                _session_db = _session_db_pool.submit(
+                    _session_db_context.run, SessionDB
+                ).result(timeout=_session_db_timeout)
             finally:
                 # Don't wait for a wedged connect() to unwind — abandon the
                 # worker thread (same pattern as the agent inactivity timeout

--- a/tests/cron/test_cron_profile_isolation.py
+++ b/tests/cron/test_cron_profile_isolation.py
@@ -17,6 +17,7 @@ was filed for. These tests pin per-profile isolation so a stale-branch merge or
 a re-anchor "fix" can't silently flip it back.
 """
 import importlib
+import threading
 from pathlib import Path
 
 
@@ -67,3 +68,201 @@ def test_cron_storage_anchors_at_profile_home(tmp_path, monkeypatch):
         importlib.reload(jobs)
 
 
+def test_cron_session_persists_only_to_active_profile_home(tmp_path, monkeypatch):
+    """The multiplex ticker persists a cron session in its owning profile."""
+    import cron.scheduler as scheduler
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+    import hermes_constants
+    import hermes_state
+
+    SessionDB = hermes_state.SessionDB
+
+    user_home = tmp_path / "user"
+    default_home = tmp_path / "default"
+    secondary_home = tmp_path / "profiles" / "secondary"
+    default_home.mkdir(parents=True)
+    secondary_home.mkdir(parents=True)
+
+    # Match the multiplex gateway: the process belongs to the default profile,
+    # while the ticker scopes each dispatched run to the profile owning it.
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("HERMES_CRON_SESSION_DB_TIMEOUT", "10")
+    monkeypatch.setattr(scheduler, "_hermes_home", None)
+    # The autouse test fixture deliberately pins DEFAULT_DB_PATH to its own
+    # sandbox when hermes_state was imported during collection. Neutralize that
+    # test-only escape hatch so this test exercises production's dynamic,
+    # ContextVar-aware default resolution.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache", lambda: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test-key",
+            "base_url": None,
+            "provider": "",
+            "requested_provider": "",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        scheduler, "_guard_job_credential_exfil", lambda _job: None
+    )
+    monkeypatch.setattr(
+        jobs, "_compute_provider_model_snapshots", lambda **_kwargs: (None, None)
+    )
+
+    # Create the job in the secondary profile's real cron store, then make it
+    # due so the provider's normal multiplex tick discovers and dispatches it.
+    home_token = hermes_constants.set_hermes_home_override(secondary_home)
+    try:
+        with jobs.use_cron_store(secondary_home):
+            job = jobs.create_job(
+                prompt="Reply only: OK.",
+                schedule="every 1h",
+                name="Profile Session",
+                model="test-model",
+                deliver="local",
+                enabled_toolsets=["no_mcp"],
+            )
+            stored_jobs = jobs.load_jobs()
+            stored_jobs[0]["next_run_at"] = "2000-01-01T00:00:00+00:00"
+            jobs.save_jobs(stored_jobs)
+    finally:
+        hermes_constants.reset_hermes_home_override(home_token)
+
+    class _ObservableStop:
+        """Expose when one complete multiplex tick reaches its wait point."""
+
+        def __init__(self):
+            self._stop = threading.Event()
+            self.after_cycle = threading.Event()
+
+        def is_set(self):
+            return self._stop.is_set()
+
+        def wait(self, timeout):
+            # start() reaches this only after tick(sync=False) returns and every
+            # temporary profile override for the cycle has been reset.
+            self.after_cycle.set()
+            return self._stop.wait(timeout)
+
+        def set(self):
+            self._stop.set()
+
+    stop = _ObservableStop()
+    agent_done = threading.Event()
+
+    # Keep the real SessionDB implementation, but delay its construction until
+    # the provider has returned from the fire-and-forget tick and reset the
+    # calling thread's profile scope. The only remaining profile state is what
+    # the executor chain propagated into the job worker.
+    RealSessionDB = hermes_state.SessionDB
+
+    def _session_db_after_multiplex_cycle(*args, **kwargs):
+        assert stop.after_cycle.wait(10), "multiplex tick did not finish its cycle"
+        return RealSessionDB(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _session_db_after_multiplex_cycle)
+
+    created_session_ids: list[str] = []
+
+    class _PersistingCronAgent:
+        def __init__(self, *args, session_db, session_id, **kwargs):
+            assert session_db is not None
+            self.session_db = session_db
+            self.session_id = session_id
+
+        def run_conversation(self, _prompt):
+            try:
+                self.session_db.create_session(self.session_id, "cron")
+                self.session_db.append_message(
+                    self.session_id, "assistant", "profile isolation sentinel"
+                )
+                created_session_ids.append(self.session_id)
+                return {
+                    "completed": True,
+                    "failed": False,
+                    "final_response": "ok",
+                    "turn_exit_reason": "",
+                }
+            finally:
+                agent_done.set()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _PersistingCronAgent)
+
+    provider = InProcessCronScheduler()
+    monkeypatch.setattr(provider, "recover_interrupted", lambda: 0)
+    monkeypatch.setattr(
+        jobs, "record_ticker_heartbeat", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(jobs, "clear_ticker_error", lambda: None)
+    monkeypatch.setattr(
+        jobs, "record_ticker_error", lambda *_args, **_kwargs: None
+    )
+
+    # The cron pools are process-global. Start clean, and join the dispatched
+    # fire-and-forget future before querying either database or leaving the test.
+    scheduler._shutdown_parallel_pool()
+    ticker = threading.Thread(
+        target=provider.start,
+        args=(stop,),
+        kwargs={
+            "interval": 60,
+            "profile_homes": [
+                ("default", default_home),
+                ("secondary", secondary_home),
+            ],
+        },
+        daemon=True,
+    )
+    ticker.start()
+    try:
+        assert stop.after_cycle.wait(10), "multiplex ticker did not finish a cycle"
+        assert agent_done.wait(20), "dispatched cron job did not persist its session"
+    finally:
+        stop.set()
+        ticker.join(timeout=10)
+        scheduler._shutdown_parallel_pool()
+        scheduler.release_running_job(job["id"])
+
+    assert not ticker.is_alive(), "multiplex ticker did not stop"
+    assert len(created_session_ids) == 1
+    session_id = created_session_ids[0]
+
+    def _contains_session(home: Path) -> bool:
+        db_path = home / "state.db"
+        if not db_path.exists():
+            return False
+        # Some cron setup paths may create an empty state.db placeholder. Open
+        # normally so the public SessionDB interface initializes its schema
+        # before we ask whether the cron session is retrievable there.
+        db = SessionDB(db_path)
+        try:
+            return db.get_session(session_id) is not None
+        finally:
+            db.close()
+
+    assert {
+        "default": _contains_session(default_home),
+        "secondary": _contains_session(secondary_home),
+    } == {"default": False, "secondary": True}


### PR DESCRIPTION
## What does this PR do?

Gateway cron multiplexing correctly executes a secondary profile's job under
that profile, but the resulting session is currently persisted to the default
profile's `state.db`.

This change preserves the active cron job's context while constructing
`SessionDB` inside the timeout executor, so profile-sensitive paths resolve to
the store that owns the job.

## Related Issue

Fixes #80635

Follow-up to #70646, which made the gateway tick every served profile's cron
store. This fixes the remaining persistence hop after dispatch.

## Root Cause

The multiplex scheduler establishes the profile with a `ContextVar`. Agent
dispatch preserves that context, but `run_job()` constructs `SessionDB` on a
second plain `ThreadPoolExecutor` worker to bound initialization time. Plain
executor submission does not propagate context variables, so the constructor
falls back to the process-default `HERMES_HOME` and opens the default
profile's database.

## Changes Made

- Capture the current context immediately before the bounded `SessionDB`
  executor hop and run construction inside it.
- Add an end-to-end regression through the real multiplex scheduler, cron
  store, executor hops, profile-home resolution, and SQLite persistence.
- Delay `SessionDB` construction until the outer multiplex profile scope has
  reset, proving the nested worker carries the owning profile explicitly.
- Assert the resulting cron session exists only in the secondary profile's
  database.

## Validation

- Mutation check on upstream `main`: regression fails with the session in the
  default database and absent from the secondary database.
- Patched regression: passes with the inverse ownership invariant.
- `pytest tests/cron -q`: 417 passed.
- `git diff --check`: clean.

Tested on Linux. The implementation uses platform-neutral Python context and
executor primitives; the original report reproduces on Windows 11.

## Adjacent Work

#72822 touches the same `SessionDB` timeout-executor area to clean up handles
that finish after a timeout. It does not propagate profile context and is not a
duplicate; if it lands first, the two independent behaviors should both be
preserved during rebase.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)
- [ ] New feature
- [ ] Breaking change

