### PR TITLE
fix: attribute session_model_usage to resolved model for router/aggregator main-loop calls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3344,7 +3344,7 @@ def run_conversation(
                     # aggregator does the full acting loop). Price the aggregator
                     # turn at its REAL model/provider, read from the MoA client's
                     # resolved aggregator slot.
-                    _agg_cost_model = agent.model
+                    _agg_cost_model = getattr(response, "model", None) or agent.model
                     _agg_cost_provider = agent.provider
                     _agg_cost_base_url = agent.base_url
                     _agg_slot = getattr(_moa_client, "last_aggregator_slot", None) if _moa_client is not None else None
@@ -3420,6 +3420,13 @@ def run_conversation(
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
+                                # Resolved upstream model (for routers like
+                                # openrouter/auto-beta, response.model carries
+                                # the selected upstream model, distinct from the
+                                # configured slug) — used for per-model usage
+                                # attribution only.
+                                resolved_model=getattr(response, "model", None)
+                                or agent.model,
                                 api_call_count=1,
                             )
                         except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4808,7 +4808,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     )
     _TOKEN_DELTA_COST_FIELDS = ("estimated_cost_usd", "actual_cost_usd")
     _TOKEN_DELTA_ROUTE_FIELDS = (
-        "model", "cost_status", "cost_source", "pricing_version",
+        "model", "resolved_model", "cost_status", "cost_source", "pricing_version",
         "billing_provider", "billing_base_url", "billing_mode",
     )
 
@@ -5048,6 +5048,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         input_tokens: int = 0,
         output_tokens: int = 0,
         model: str = None,
+        resolved_model: Optional[str] = None,
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         reasoning_tokens: int = 0,
@@ -5191,10 +5192,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             conn.execute(sql, params)
             if record_model_usage:
+                # ``resolved_model`` is the model that actually served this
+                # request (for routers/aggregators like openrouter/auto-beta,
+                # this is the selected upstream model, distinct from the
+                # configured ``model`` slug). Attribution to the per-model usage
+                # table must use the resolved model so distribution/spend is
+                # accurate; the ``sessions`` summary row keeps the configured
+                # route.
+                _attr_model = resolved_model or model
                 self._record_model_usage(
                     conn,
                     session_id,
-                    model=model,
+                    model=_attr_model,
                     billing_provider=billing_provider,
                     billing_base_url=billing_base_url,
                     billing_mode=billing_mode,

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -506,3 +506,60 @@ class TestCoalesceFieldContract:
             f"coalescing field lists reference kwargs update_token_counts "
             f"no longer accepts: {sorted(phantom)}"
         )
+
+
+class TestResolvedModel:
+    def test_resolved_model_attributions_for_router(self, db):
+        """Router/aggregator calls attribute session_model_usage to the
+        RESOLVED upstream model, not the configured slug.
+
+        The sessions summary row keeps the configured route; the per-model
+        table gets the resolved model so distribution/spend is accurate.
+        """
+        db.create_session("s-r", "test", model="openrouter/auto-beta")
+        db.update_token_counts(
+            "s-r", input_tokens=200, output_tokens=100,
+            model="openrouter/auto-beta", resolved_model="anthropic/claude-sonnet-5",
+            billing_provider="openrouter", api_call_count=1,
+        )
+        usage = _model_usage(db, "s-r")
+        assert len(usage) == 1
+        assert usage[0]["model"] == "anthropic/claude-sonnet-5"
+        assert usage[0]["api_call_count"] == 1
+        assert usage[0]["input_tokens"] == 200
+        assert usage[0]["output_tokens"] == 100
+        # Summary row keeps the configured router route.
+        assert _totals(db, "s-r")["model"] == "openrouter/auto-beta"
+
+    def test_resolved_model_falls_back_to_configured(self, db):
+        """Without resolved_model, behavior is unchanged (attributes to the
+        configured model) — preserves all existing callers."""
+        db.create_session("s-f", "test", model="openrouter/auto-beta")
+        db.update_token_counts(
+            "s-f", input_tokens=10, output_tokens=5,
+            model="openrouter/auto-beta", billing_provider="openrouter",
+            api_call_count=1,
+        )
+        usage = _model_usage(db, "s-f")
+        assert usage[0]["model"] == "openrouter/auto-beta"
+
+    def test_resolved_model_breaks_coalescing_across_route_change(self, db):
+        """Two adjacent deltas with different resolved models must not merge —
+        resolved_model is a route field."""
+        db.create_session("s-c2", "test")
+        db.queue_token_counts(
+            "s-c2", input_tokens=10, output_tokens=1,
+            model="openrouter/auto-beta", resolved_model="anthropic/claude-sonnet-5",
+            billing_provider="openrouter", api_call_count=1,
+        )
+        db.queue_token_counts(
+            "s-c2", input_tokens=10, output_tokens=1,
+            model="openrouter/auto-beta", resolved_model="anthropic/claude-opus-5",
+            billing_provider="openrouter", api_call_count=1,
+        )
+        assert db.flush_token_counts()
+        usage = _model_usage(db, "s-c2")
+        assert {r["model"] for r in usage} == {
+            "anthropic/claude-sonnet-5", "anthropic/claude-opus-5",
+        }
+        assert len(usage) == 2


### PR DESCRIPTION
## Problem

`update_token_counts` recorded the **configured** model slug (e.g. `openrouter/auto-beta`) for main-loop API calls in `session_model_usage`. With a router/aggregator as the main model, every call was attributed to the router slug — so:

- per-model usage analytics could not see which upstream model the router actually selected (e.g. 50% Opus, 30% Sonnet, 20% other),
- cost was estimated against an un-priced router slug, under-reporting real spend.

The auxiliary path (`agent/aux_accounting.py`) already reads `response.model` (the resolved upstream model); the main loop did not.

## Change

- `hermes_state.py` — `update_token_counts()` gains a `resolved_model` kwarg, used **only** for the `session_model_usage` per-model attribution row. The `sessions` summary row keeps the configured route. `resolved_model` is classified as a route field (`_TOKEN_DELTA_ROUTE_FIELDS`) so coalescing does not merge deltas across different resolved models.
- `agent/conversation_loop.py` — the main-loop accounting call passes `resolved_model=getattr(response, "model", None) or agent.model` (works through `queue_token_counts` → writer → `update_token_counts`), and cost estimation prices against the resolved model.

Backwards compatible: callers that don't pass `resolved_model` fall back to `model` (byte-identical behavior).

## Tests

Added `TestResolvedModel` (3 tests) to `tests/agent/test_async_token_accounting.py`:
- attribution goes to resolved model, summary keeps configured route
- fallback when `resolved_model` omitted
- coalescing breaks across different resolved models

Local run: 16/16 async-accounting tests, 128/128 accounting+insights+state tests pass.

## Why it matters

Routers (OpenRouter auto/auto-beta, fusion, MoA) are increasingly common as the main model. Without this, usage dashboards can't answer "what's the actual model distribution/spend" — the question that motivated this change.

cc @NousResearch