### PR TITLE
fix(cli): delete git-installed plugins on Windows despite read-only .git objects

### DIFF
--- a/hermes_cli/fs_remove.py
+++ b/hermes_cli/fs_remove.py
@@ -1,0 +1,109 @@
+"""Recursive directory removal that survives read-only files.
+
+``shutil.rmtree`` deletes a file with ``os.unlink``, and on Windows
+``os.unlink`` refuses a file carrying the read-only attribute with
+``PermissionError: [WinError 5] Access is denied``. On POSIX the parent
+directory's write bit governs the unlink, so a read-only *file* deletes
+fine and this whole class of failure is invisible there.
+
+Git is the common source of such files: objects under ``.git/objects/``
+(loose objects, ``pack-*.pack``, ``pack-*.idx``) are written read-only on
+purpose, since they're content-addressed and must never be edited in
+place. So *any* code path that removes a git checkout (an installed
+plugin, a cloned skill, a staged update) fails on Windows unless it
+clears the read-only bit first.
+
+Use :func:`rmtree_force` anywhere a tree that might contain a checkout
+gets removed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+import time
+from pathlib import Path
+from typing import Union
+
+__all__ = ["rmtree_force"]
+
+_StrPath = Union[str, "os.PathLike[str]"]
+
+# ``onerror`` was removed in 3.12 and ``onexc`` added in the same release.
+# Hermes supports >=3.11,<3.14, so both are live.
+_USE_ONEXC = sys.version_info >= (3, 12)
+
+
+def _make_writable(func, path: str, exc) -> None:
+    """rmtree error callback: clear the read-only bit, then retry.
+
+    Compatible with both callback APIs:
+      ``onexc(func, path, exc_instance)``     on 3.12+
+      ``onerror(func, path, exc_info_tuple)`` on 3.11
+    """
+    if isinstance(exc, tuple):  # exc_info tuple → the exception itself
+        exc = exc[1]
+
+    if not isinstance(exc, PermissionError):
+        raise exc
+
+    # The path itself may be read-only (mode 0444, or the Windows
+    # read-only attribute), and so may its parent. A directory has to be
+    # writable for unlink/rmdir of a child to succeed.
+    #
+    # OR the write bit into the existing mode rather than assigning one:
+    # replacing the mode outright strips group and other bits, which breaks
+    # group-shared installs (see #67496). On Windows os.chmod only honours
+    # the owner-write bit, and clearing it is what drops the read-only
+    # attribute that blocks os.unlink in the first place.
+    for target in (path, os.path.dirname(path)):
+        if not target:
+            continue
+        try:
+            os.chmod(target, os.stat(target).st_mode | stat.S_IWUSR)
+        except OSError:
+            pass
+
+    func(path)
+
+
+def rmtree_force(path: _StrPath, ignore_errors: bool = False, attempts: int = 3) -> None:
+    """``shutil.rmtree`` that clears read-only files and retries transients.
+
+    Two failure modes are handled:
+
+    * **Read-only files** (the git-objects case above). The error callback
+      chmods the path and its parent writable and retries the operation.
+    * **Transient locks**. On Windows a file another process just closed,
+      or one an antivirus scanner is holding, raises ``PermissionError``
+      that a moment later would not. Also ``ENOTEMPTY`` on POSIX when a
+      writer lands a file after rmtree walked past its directory. A few
+      spaced retries win those races instead of failing the whole delete.
+
+    With ``ignore_errors=True`` this never raises, matching ``shutil``.
+    """
+    p = Path(path)
+    last_exc: OSError | None = None
+
+    for attempt in range(max(1, attempts)):
+        try:
+            if _USE_ONEXC:
+                shutil.rmtree(p, onexc=_make_writable)
+            else:
+                shutil.rmtree(p, onerror=_make_writable)
+            return
+        except FileNotFoundError:
+            return
+        except OSError as e:
+            last_exc = e
+            if not p.exists():
+                return
+            if attempt < attempts - 1:
+                time.sleep(0.3 * (attempt + 1))
+
+    if ignore_errors:
+        return
+    if last_exc is not None:
+        raise last_exc

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -23,6 +23,7 @@ from typing import Any, Optional
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.config import cfg_get
+from hermes_cli.fs_remove import rmtree_force
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
@@ -531,7 +532,8 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
                     f"Plugin '{plugin_name}' already exists. Use force reinstall "
                     f"or run `hermes plugins update {plugin_name}`.",
                 )
-            shutil.rmtree(target)
+            # Force reinstall wipes the previous checkout, .git and all.
+            rmtree_force(target)
 
         shutil.move(str(tmp_target), str(target))
 
@@ -694,7 +696,9 @@ def cmd_remove(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    shutil.rmtree(target)
+    # Plugins are git checkouts, and git writes .git/objects/** read-only.
+    # Plain rmtree fails on Windows there; rmtree_force clears the bit.
+    rmtree_force(target)
     _display_removed(name, plugins_dir)
 
 
@@ -2036,7 +2040,8 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' was not found under {plugins_dir}.",
         }
 
-    shutil.rmtree(target)
+    # Same read-only .git/objects problem as the CLI ``plugins remove`` path.
+    rmtree_force(target)
     return {"ok": True, "name": name}
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -33,6 +33,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_cli.fs_remove import rmtree_force
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -1438,36 +1439,6 @@ def _stop_profile_backends(canon: str, profile_dir: Path) -> None:
     print(f"✓ Stopped {len(pids)} profile backend process(es)")
 
 
-def _rmtree_with_retry(profile_dir: Path, onexc_handler) -> None:
-    """``shutil.rmtree`` with a short retry loop for transient races.
-
-    Even after stopping the gateway and profile backends, a just-terminated
-    process can leave in-flight writes (SQLite ``-wal``/``-shm`` checkpoints,
-    sandbox temp files) that land after ``rmtree`` has walked past a directory,
-    surfacing as ``ENOTEMPTY`` (POSIX) or a transient ``PermissionError``
-    (Windows file lock still releasing).  A few spaced retries let those settle
-    instead of failing the whole delete on a race the next attempt would win.
-    """
-    attempts = 3
-    last_exc: OSError | None = None
-    for attempt in range(attempts):
-        try:
-            # ``onexc`` was added in 3.12; fall back to ``onerror`` on 3.11.
-            try:
-                shutil.rmtree(profile_dir, onexc=onexc_handler)
-            except TypeError:
-                shutil.rmtree(profile_dir, onerror=onexc_handler)
-            return
-        except OSError as e:
-            last_exc = e
-            if not profile_dir.exists():
-                return
-            if attempt < attempts - 1:
-                time.sleep(0.3 * (attempt + 1))
-    if last_exc is not None:
-        raise last_exc
-
-
 def delete_profile(name: str, yes: bool = False) -> Path:
     """Delete a profile, its wrapper script, and its gateway service.
 
@@ -1560,44 +1531,9 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # 4. Remove profile directory
     remove_error: Exception | None = None
     try:
-        def _make_writable(func, path, exc):
-            """onexc/onerror handler: add +w on PermissionError so rmtree can proceed.
-
-            Handles two cases on NixOS (and other systems with read-only
-            copies from immutable stores):
-            1. The path itself isn't writable (e.g. a file with mode 0444)
-            2. The *parent* directory isn't writable (e.g. mode 0555)
-
-            Compatible with both the ``onexc`` API (3.12+, receives an
-            exception instance) and the ``onerror`` API (3.11-, receives
-            ``sys.exc_info()`` tuple).
-            """
-            import stat as _stat
-
-            # Normalise the two callback signatures:
-            #   onexc(func, path, exc_instance)   — 3.12+
-            #   onerror(func, path, exc_info_tuple) — 3.11
-            if isinstance(exc, tuple):
-                exc = exc[1]  # exc_info → actual exception object
-
-            if isinstance(exc, PermissionError):
-                # Make the path writable
-                try:
-                    os.chmod(path, os.stat(path).st_mode | _stat.S_IWUSR)
-                except OSError:
-                    pass
-                # Also make the parent writable (needed for unlink/rmdir)
-                parent = os.path.dirname(path)
-                if parent:
-                    try:
-                        os.chmod(parent, os.stat(parent).st_mode | _stat.S_IWUSR)
-                    except OSError:
-                        pass
-                func(path)
-            else:
-                raise
-
-        _rmtree_with_retry(profile_dir, _make_writable)
+        # Clears read-only files (NixOS store copies, git objects under any
+        # plugin/MCP checkout in the profile) and retries transient locks.
+        rmtree_force(profile_dir)
         print(f"✓ Removed {profile_dir}")
     except Exception as e:
         print(f"⚠ Could not remove {profile_dir}: {e}")

--- a/tests/hermes_cli/test_fs_remove.py
+++ b/tests/hermes_cli/test_fs_remove.py
@@ -1,0 +1,200 @@
+"""Tests for hermes_cli.fs_remove, rmtree that survives read-only files.
+
+The bug these guard: git writes ``.git/objects/**`` read-only, and on
+Windows ``os.unlink`` refuses a read-only file with ``PermissionError:
+[WinError 5]``. Any path that removes a git checkout hits it, which is
+why ``hermes plugins remove`` fails outright on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.fs_remove import rmtree_force
+
+
+def _make_git_like_tree(root: Path) -> Path:
+    """Build a directory whose layout mirrors a real plugin checkout.
+
+    The read-only ``pack-*.idx`` under ``.git/objects/pack/`` is exactly
+    what git produces and exactly what plain rmtree chokes on.
+    """
+    pack = root / ".git" / "objects" / "pack"
+    pack.mkdir(parents=True)
+    idx = pack / "pack-0123456789abcdef.idx"
+    idx.write_bytes(b"idx")
+    (pack / "pack-0123456789abcdef.pack").write_bytes(b"pack")
+    (root / "plugin.yaml").write_text("name: demo\n", encoding="utf-8")
+
+    for f in pack.iterdir():
+        os.chmod(f, stat.S_IREAD)
+    return idx
+
+
+def _restore(root: Path) -> None:
+    """Best-effort chmod +w sweep so a failed test can still clean up."""
+    for p in root.rglob("*"):
+        try:
+            os.chmod(p, stat.S_IWRITE | stat.S_IREAD)
+        except OSError:
+            pass
+
+
+class TestRmtreeForce:
+    def test_removes_tree_with_readonly_file(self, tmp_path):
+        root = tmp_path / "demo-plugin"
+        _make_git_like_tree(root)
+
+        rmtree_force(root)
+
+        assert not root.exists()
+
+    def test_plain_rmtree_fails_on_windows(self, tmp_path):
+        """Pin the underlying platform behaviour this module exists for.
+
+        On POSIX the parent directory's write bit governs the unlink, so
+        plain rmtree succeeds there and there is nothing to assert.
+        """
+        root = tmp_path / "demo-plugin"
+        _make_git_like_tree(root)
+
+        if sys.platform == "win32":
+            with pytest.raises(PermissionError):
+                shutil.rmtree(root)
+            _restore(root)
+            rmtree_force(root)
+            assert not root.exists()
+        else:
+            shutil.rmtree(root)
+            assert not root.exists()
+
+    def test_readonly_directory(self, tmp_path):
+        """A read-only *directory*, not just a read-only file."""
+        root = tmp_path / "tree"
+        inner = root / "inner"
+        inner.mkdir(parents=True)
+        (inner / "file.txt").write_text("x", encoding="utf-8")
+        os.chmod(inner, stat.S_IREAD | stat.S_IEXEC)
+
+        try:
+            rmtree_force(root)
+        finally:
+            if root.exists():
+                _restore(root)
+                shutil.rmtree(root, ignore_errors=True)
+
+        assert not root.exists()
+
+    def test_missing_path_is_a_noop(self, tmp_path):
+        rmtree_force(tmp_path / "does-not-exist")
+
+    def test_missing_path_with_ignore_errors(self, tmp_path):
+        rmtree_force(tmp_path / "does-not-exist", ignore_errors=True)
+
+    def test_accepts_str_path(self, tmp_path):
+        root = tmp_path / "demo-plugin"
+        _make_git_like_tree(root)
+
+        rmtree_force(str(root))
+
+        assert not root.exists()
+
+    def test_ignore_errors_swallows_failure(self, tmp_path, monkeypatch):
+        root = tmp_path / "tree"
+        root.mkdir()
+        (root / "f.txt").write_text("x", encoding="utf-8")
+
+        def boom(*a, **kw):
+            raise OSError("device busy")
+
+        monkeypatch.setattr(shutil, "rmtree", boom)
+
+        # Without ignore_errors the error propagates...
+        with pytest.raises(OSError):
+            rmtree_force(root, attempts=1)
+
+        # ...with it, the call is quiet.
+        rmtree_force(root, attempts=1, ignore_errors=True)
+
+    def test_non_permission_errors_are_re_raised(self):
+        """The handler only rescues PermissionError.
+
+        Anything else means a real problem (a busy device, a bad path) and
+        must surface rather than be chmod-and-retried into silence.
+        """
+        from hermes_cli.fs_remove import _make_writable
+
+        def should_not_run(_path):
+            raise AssertionError("retry attempted for a non-permission error")
+
+        with pytest.raises(IsADirectoryError):
+            _make_writable(should_not_run, "/some/path", IsADirectoryError("nope"))
+
+    def test_handler_accepts_the_311_exc_info_tuple(self):
+        """3.11 passes onerror a sys.exc_info() tuple, 3.12+ passes onexc an
+        exception instance. Both have to reach the same code path."""
+        from hermes_cli.fs_remove import _make_writable
+
+        with pytest.raises(IsADirectoryError):
+            _make_writable(
+                lambda _p: None,
+                "/some/path",
+                (IsADirectoryError, IsADirectoryError("nope"), None),
+            )
+
+
+class TestPluginRemoval:
+    """The reported symptom: ``hermes plugins remove <name>`` on Windows."""
+
+    def test_cmd_remove_deletes_git_checkout(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd
+
+        plugins_dir = tmp_path / "plugins"
+        target = plugins_dir / "demo-plugin"
+        target.mkdir(parents=True)
+        _make_git_like_tree(target)
+
+        monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: plugins_dir)
+        monkeypatch.setattr(
+            plugins_cmd, "_require_installed_plugin", lambda *a, **kw: target
+        )
+        monkeypatch.setattr(plugins_cmd, "_display_removed", lambda *a, **kw: None)
+
+        try:
+            plugins_cmd.cmd_remove("demo-plugin")
+        finally:
+            if target.exists():
+                _restore(target)
+                shutil.rmtree(target, ignore_errors=True)
+
+        assert not target.exists()
+
+    def test_dashboard_remove_deletes_git_checkout(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd
+
+        plugins_dir = tmp_path / "plugins"
+        target = plugins_dir / "demo-plugin"
+        target.mkdir(parents=True)
+        _make_git_like_tree(target)
+
+        monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: plugins_dir)
+        monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: [])
+        monkeypatch.setattr(
+            plugins_cmd, "_user_installed_plugin_dir", lambda name: target
+        )
+
+        try:
+            result = plugins_cmd.dashboard_remove_user_plugin("demo-plugin")
+        finally:
+            if target.exists():
+                _restore(target)
+                shutil.rmtree(target, ignore_errors=True)
+
+        assert result == {"ok": True, "name": "demo-plugin"}
+        assert not target.exists()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -307,9 +307,13 @@ class TestCmdUpdate:
 class TestCmdRemove:
     """Test the remove command."""
 
+    # Removal goes through rmtree_force, not plain shutil.rmtree: plugins are
+    # git checkouts and git writes .git/objects/** read-only, which plain
+    # rmtree cannot delete on Windows. See tests/hermes_cli/test_fs_remove.py
+    # for the behaviour test on a real read-only tree.
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.shutil.rmtree")
+    @patch("hermes_cli.plugins_cmd.rmtree_force")
     def test_remove_deletes_plugin(self, mock_rmtree, mock_plugins_dir, mock_sanitize):
         from hermes_cli.plugins_cmd import cmd_remove
 


### PR DESCRIPTION
Share read-only checkout cleanup between plugin removal, install rollback, and profile deletion. Preserve current metadata staging and rollback. Permission repair stays inside the deletion tree, and existing retry behavior remains. Successful force-reinstall cleanup continues through TemporaryDirectory.

Fixes #80886

Validation: Four real Git checkout removal cases reproduced on main and passed after the fix, covering CLI/dashboard and recorded/unrecorded installs after forced reinstalls. 137 related tests passed. Five unrelated Windows failures in profile setup/aliases and Git autostash were reproduced on main; one fixture now uses the shared helper for intentional manual checkout removal.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
