### PR TITLE
docs(skills): PR作業の最小diff確認を追加

### DIFF
--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -59,6 +59,21 @@ echo "Owner: $OWNER, Repo: $REPO"
 
 This part is pure `git` — identical either way:
 
+### Minimum-diff gate
+
+Unless the user explicitly requests another base or broader scope, start from the current remote `main` and keep the branch limited to the stated deliverable.
+
+Before implementation:
+
+1. Fetch and verify `origin/main`.
+2. Create the worktree/branch from `origin/main`, not from an existing feature branch, backup branch, or worktree with unrelated changes.
+3. Write down the requested outcome and the files/features that are actually required.
+4. Check `git diff --stat origin/main...HEAD` and inspect any pre-existing commits before editing.
+5. Treat related functionality as out of scope unless the task has a concrete dependency: an import, route, schema, runtime call, or failing verification that proves it is required.
+6. If a broader change appears necessary, stop and report the evidence before adding it.
+
+After implementation, review the final diff against `origin/main` and remove unrelated routes, fixtures, snapshots, generated artifacts, and feature code. A previous branch or backup containing related work is context, not an implicit dependency.
+
 ```bash
 # Make sure you're up to date
 git fetch origin


### PR DESCRIPTION
## 概要

`github-pr-workflow` skillに、PR作業を開始・完了する際の最小diff確認を追加します。

## 変更内容

- 明示的な指定がない場合は、最新の`origin/main`から作業を開始する
- 既存のfeature branchや未整理worktreeを暗黙の土台にしない
- 実装前に目的・必要ファイル・既存差分を確認する
- import、route、schema、runtime call、再現可能な失敗ログなどの具体的依存がない関連機能をスコープ外とする
- 実装後に`origin/main`との差分を確認し、無関係な変更を除去する

## 背景

E2E作業で、別作業に含まれていた関連機能を技術的依存と誤認し、目的外の変更を一時的に含めてしまう事象がありました。PR workflow自体に開始時の最小diffゲートを明記し、同種の混入を防ぎます。

## 検証

- `git diff --check`
- 対象skillの差分確認
- 変更対象: `skills/github/github-pr-workflow/SKILL.md`
