### PR TITLE
fix(terminal): report the dropped PTY instead of hanging on a pipe

### DIFF
--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -5,9 +5,9 @@ import tools.terminal_tool as terminal_tool_module
 from tools import process_registry as process_registry_module
 
 
-def _base_config(tmp_path):
+def _base_config(tmp_path, env_type="local"):
     return {
-        "env_type": "local",
+        "env_type": env_type,
         "docker_image": "",
         "singularity_image": "",
         "modal_image": "",
@@ -15,6 +15,16 @@ def _base_config(tmp_path):
         "cwd": str(tmp_path),
         "timeout": 30,
     }
+
+
+def _patch_common(monkeypatch, config, dummy_env):
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module, "_check_all_guards", lambda *_a, **_kw: {"approved": True}
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
 
 
 def test_command_requires_pipe_stdin_detects_gh_with_token():
@@ -35,12 +45,8 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
         captured.update(kwargs)
         return SimpleNamespace(id="proc_test", pid=1234, notify_on_complete=False)
 
-    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
-    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
-    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_args, **_kwargs: {"approved": True})
+    _patch_common(monkeypatch, config, dummy_env)
     monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
-    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
-    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
 
     try:
         result = json.loads(
@@ -56,3 +62,101 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
 
     assert captured["use_pty"] is True
     assert "pty_note" not in result
+
+
+def test_foreground_pty_still_runs_but_reports_the_dropped_pty(monkeypatch, tmp_path):
+    """Foreground has no PTY path, so pty=true is dropped — say so.
+
+    The command must still run (skills pass pty=true to one-shot commands like
+    `codex exec` and consume the inline output), but the result has to carry the
+    remedy instead of letting the agent rediscover it after a hang.
+    """
+    config = _base_config(tmp_path)
+    executed = []
+    dummy_env = SimpleNamespace(
+        env={},
+        cwd=str(tmp_path),
+        execute=lambda command, **kwargs: (
+            executed.append(command) or {"output": "done", "returncode": 0}
+        ),
+    )
+
+    _patch_common(monkeypatch, config, dummy_env)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(command="codex exec 'ship it'", pty=True)
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert executed == ["codex exec 'ship it'"]
+    assert result["output"] == "done"
+    assert result["exit_code"] == 0
+    assert "background=true" in result["pty_note"]
+
+
+def test_foreground_pty_timeout_carries_the_pty_note(monkeypatch, tmp_path):
+    """A terminal-hungry command on a pipe expires — the timeout must explain why."""
+    config = _base_config(tmp_path)
+
+    def _timeout(command, **kwargs):
+        raise RuntimeError("command timeout exceeded")
+
+    dummy_env = SimpleNamespace(env={}, cwd=str(tmp_path), execute=_timeout)
+    _patch_common(monkeypatch, config, dummy_env)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(command="htop", pty=True)
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert result["exit_code"] == 124
+    assert "background=true" in result["pty_note"]
+
+
+def test_foreground_without_pty_has_no_pty_note(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(
+        env={},
+        cwd=str(tmp_path),
+        execute=lambda command, **kwargs: {"output": "hi", "returncode": 0},
+    )
+
+    _patch_common(monkeypatch, config, dummy_env)
+
+    try:
+        result = json.loads(terminal_tool_module.terminal_tool(command="echo hi"))
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert "pty_note" not in result
+
+
+def test_pty_on_non_local_backend_reports_the_downgrade(monkeypatch, tmp_path):
+    """spawn_via_env() has no PTY, so the request is dropped — but not silently."""
+    config = _base_config(tmp_path, env_type="docker")
+    dummy_env = SimpleNamespace(
+        env={},
+        cwd=str(tmp_path),
+        execute=lambda command, **kwargs: {"output": "ok", "returncode": 0},
+    )
+
+    _patch_common(monkeypatch, config, dummy_env)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="python3", pty=True, background=True
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert "docker" in result["pty_note"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1074,7 +1074,7 @@ Environment state persists: activate a virtualenv or export variables once per s
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
 Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
 Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
-PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
+PTY: interactive CLIs and full-screen TUIs need a real terminal, which only background sessions get — launch them with background=true AND pty=true, then drive them with process(action="poll"/"submit"). Local backend only; foreground runs on a plain pipe no matter what pty says. Pipe git output to cat if it might page.
 """
 
 # Global state for environment lifecycle management
@@ -2256,7 +2256,9 @@ def terminal_tool(
         session_id: Conversation/session identifier for durable observability
         force: If True, skip dangerous command check (use after user confirms)
         workdir: Working directory for this command (optional, uses session cwd if not set)
-        pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
+        pty: If True, use pseudo-terminal for interactive CLI tools. Only honoured
+            for background=True on the local backend; elsewhere the command runs
+            on a plain pipe and the result carries a pty_note
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
 
@@ -2674,6 +2676,32 @@ def terminal_tool(
                 "processes, call process(action='close') after writing so it receives "
                 "EOF."
             )
+        # A PTY is only ever attached by process_registry.spawn_local(): the
+        # foreground path goes through env.execute(), which always hands the
+        # child a plain pipe, and spawn_via_env() has no PTY support at all.
+        # Both cases used to drop pty=true without a word, so a REPL or TUI
+        # launched exactly as the schema advises sat on a dead pipe until the
+        # timeout with nothing in the result explaining why. The command still
+        # runs — skills legitimately pass pty=true to one-shot commands like
+        # `codex exec` and rely on the inline output — but the dropped PTY is
+        # now reported so the next attempt is correct instead of a re-diagnosis.
+        elif pty and env_type != "local":
+            effective_pty = False
+            pty_disabled_reason = (
+                f"PTY is not supported on the {env_type} terminal backend, so this "
+                "command ran on a plain pipe. Interactive CLIs and full-screen TUIs "
+                "hang or render nothing here — run them on the local backend."
+            )
+        elif pty and not background:
+            effective_pty = False
+            pty_disabled_reason = (
+                "PTY was NOT applied: foreground commands always run on a plain "
+                "pipe. Fine for a command that prints and exits, but anything that "
+                "needs a real terminal (REPLs, full-screen TUIs, redrawing prompts) "
+                "hangs until the timeout. Re-run it with background=true and "
+                "pty=true, then read it with process(action='poll') and type into "
+                "it with process(action='submit')."
+            )
 
         # The session key is already computed above the gateway guard.
         if background:
@@ -2961,11 +2989,18 @@ def terminal_tool(
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
-                        return json.dumps({
+                        timeout_result = {
                             "output": "",
                             "exit_code": 124,
-                            "error": f"Command timed out after {effective_timeout} seconds"
-                        }, ensure_ascii=False)
+                            "error": f"Command timed out after {effective_timeout} seconds",
+                        }
+                        # The dropped-PTY timeout is the whole point of the note:
+                        # a terminal-hungry command sitting on a pipe is exactly
+                        # what expires here, and the timeout is the only result
+                        # the agent ever sees.
+                        if pty_disabled_reason:
+                            timeout_result["pty_note"] = pty_disabled_reason
+                        return json.dumps(timeout_result, ensure_ascii=False)
                     
                     # Retry on transient errors
                     if retry_count < max_retries:
@@ -3174,6 +3209,8 @@ def terminal_tool(
                     result_dict["approval"] = approval_note
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
+            if pty_disabled_reason:
+                result_dict["pty_note"] = pty_disabled_reason
             if failure_hint:
                 result_dict["hint"] = failure_hint
             if sudo_auth_failed:
@@ -3388,7 +3425,7 @@ TERMINAL_SCHEMA = {
             },
             "pty": {
                 "type": "boolean",
-                "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
+                "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or a Python REPL, and for full-screen TUIs. Requires background=true and the local backend — a foreground call, or any non-local backend, runs on a plain pipe and returns a pty_note saying the PTY was dropped. Default: false.",
                 "default": False
             },
             "notify_on_complete": {


### PR DESCRIPTION
## Summary

`pty=true` is silently ignored unless the call is `background=true` on the local backend. A PTY is only ever attached by `process_registry.spawn_local()`; the foreground path runs `env.execute()`, which always hands the child a plain pipe, and `spawn_via_env()` has no PTY support at all. Both accepted `pty=true` and ran anyway without a word.

That matters because the terminal schema tells the agent the opposite:

> PTY: set pty=true for interactive CLIs (they hang without it).

So the agent launches a REPL or a full-screen TUI exactly as advised, the process sits on a dead pipe until the timeout, and the `exit_code: 124` result says nothing about the dropped PTY. Next turn it tries the same thing again. Users see this as the agent "trying to render a TUI the built-in shell doesn't support" and doing the work twice.

The command still runs — bundled skills pass `pty=true` to one-shot commands like `codex exec` and consume the inline output, so rejecting or auto-promoting to background would break them. What changes is that the dropped PTY is now reported:

- foreground `pty=true` → runs as before, result carries a `pty_note` saying PTY needs `background=true` and pointing at `process(action='poll'/'submit')`
- non-local backend (docker/ssh/modal/daytona) → `pty_note` names the backend and says to use the local one
- the note is also attached to the `124` timeout return, since a terminal-hungry command on a pipe expires there and the timeout is the only result the agent ever sees
- the `pty` schema description and the `terminal_tool` docstring now describe the real constraint instead of "Only works with local and SSH backends"

The existing `gh auth login --with-token` PTY-disable branch is untouched and still wins.

## Test plan

`tests/tools/test_terminal_tool_pty_fallback.py`:

- foreground `pty=true` still executes and returns inline output, plus the note
- the note survives onto the `exit_code: 124` timeout result
- a non-local backend names itself in the note
- a plain foreground call has no `pty_note`
- the pre-existing background-PTY test still asserts `use_pty=True` with no note

All four new assertions fail on `main` (the first one fails as `assert ['codex exec ...'] == []` against the old auto-promotion attempt, then as a missing `pty_note`) and pass here.

```
scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_pty_fallback.py \
  tests/tools/test_process_registry.py tests/tools/test_terminal_foreground_timeout_cap.py \
  tests/tools/test_terminal_hints.py tests/tools/test_terminal_compound_background.py \
  tests/tools/test_terminal_exit_semantics.py tests/tools/test_terminal_timeout_output.py \
  tests/tools/test_terminal_truncation_spill.py tests/tools/test_approved_command_clean_slate.py \
  tests/tools/test_subprocess_stdin_guard.py tests/tools/test_terminal_task_cwd.py \
  tests/tools/test_terminal_cwd_echo.py
```

→ 13 files, 151 tests passed, 0 failed.