### PR TITLE
fix(tests): read and write test files as UTF-8 so the suite runs on Windows

### DIFF
--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -189,14 +189,14 @@ class TestReadManifest:
         assert result == {}
 
     def test_invalid_yaml_returns_empty_and_logs(self, tmp_path, caplog):
-        (tmp_path / "plugin.yaml").write_text(": : : bad yaml [[[")
+        (tmp_path / "plugin.yaml").write_text(": : : bad yaml [[[", encoding="utf-8")
         with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
             result = _read_manifest(tmp_path)
         assert result == {}
         assert any("Failed to read plugin.yaml" in r.message for r in caplog.records)
 
     def test_empty_file_returns_empty(self, tmp_path):
-        (tmp_path / "plugin.yaml").write_text("")
+        (tmp_path / "plugin.yaml").write_text("", encoding="utf-8")
         result = _read_manifest(tmp_path)
         assert result == {}
 
@@ -388,7 +388,7 @@ class TestCopyExampleFiles:
 
         # Create example file
         example_file = tmp_path / "config.yaml.example"
-        example_file.write_text("key: value")
+        example_file.write_text("key: value", encoding="utf-8")
 
         _copy_example_files(tmp_path, console)
 
@@ -404,7 +404,7 @@ class TestCopyExampleFiles:
 
         # Create example file
         example_file = tmp_path / "config.yaml.example"
-        example_file.write_text("key: value")
+        example_file.write_text("key: value", encoding="utf-8")
 
         # Mock shutil.copy2 to raise an error
         with patch(
@@ -497,10 +497,10 @@ class TestProviderDiscovery:
         """Saving a context engine persists to config.yaml."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("context:\n  engine: compressor\n")
+        config_file.write_text("context:\n  engine: compressor\n", encoding="utf-8")
         from hermes_cli.plugins_cmd import _save_context_engine
         _save_context_engine("lcm")
-        content = yaml.safe_load(config_file.read_text())
+        content = yaml.safe_load(config_file.read_text(encoding="utf-8"))
         assert content["context"]["engine"] == "lcm"
 
 
@@ -525,7 +525,7 @@ class TestNoAutoActivation:
         # This tests the run_agent.py logic indirectly by checking that the
         # code path for default config doesn't call get_plugin_context_engine.
         import run_agent as ra_module
-        source = open(ra_module.__file__).read()
+        source = Path(ra_module.__file__).read_text(encoding="utf-8")
         # The old code had: "Even with default config, check if a plugin registered one"
         # The fix removes this. Verify it's gone.
         assert "Even with default config, check if a plugin registered one" not in source
@@ -545,16 +545,19 @@ class TestSubdirInstallE2E:
 
         repo_root.mkdir(parents=True, exist_ok=True)
         # Root-level noise: docs + tests that should NOT be installed.
-        (repo_root / "README.md").write_text("# Monorepo docs\n")
+        (repo_root / "README.md").write_text("# Monorepo docs\n", encoding="utf-8")
         (repo_root / "tests").mkdir()
-        (repo_root / "tests" / "test_x.py").write_text("def test_x():\n    pass\n")
+        (repo_root / "tests" / "test_x.py").write_text(
+            "def test_x():\n    pass\n", encoding="utf-8"
+        )
         # The actual plugin in a subdirectory.
         plugin_dir = repo_root / "my-plugin"
         plugin_dir.mkdir()
         (plugin_dir / "plugin.yaml").write_text(
-            "name: my-plugin\nmanifest_version: 1\ndescription: A subdir plugin\n"
+            "name: my-plugin\nmanifest_version: 1\ndescription: A subdir plugin\n",
+            encoding="utf-8",
         )
-        (plugin_dir / "__init__.py").write_text("# plugin entry\n")
+        (plugin_dir / "__init__.py").write_text("# plugin entry\n", encoding="utf-8")
 
         env = {
             **os.environ,

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -705,7 +705,7 @@ def _idempotency_race_worker(hermes_home: str, key: str, result_file: str,
         )
     finally:
         conn.close()
-    with open(result_file, "w") as f:
+    with open(result_file, "w", encoding="utf-8") as f:
         f.write(tid)
 
 
@@ -731,12 +731,16 @@ def _(home, kb):
         p.start()
     time.sleep(0.1)  # let them hit the spin
     # Fire the gun
-    with open(barrier, "w") as f:
+    with open(barrier, "w", encoding="utf-8") as f:
         f.write("go")
     for p in procs:
         p.join(timeout=10)
 
-    tids = [open(r).read().strip() for r in results if os.path.exists(r)]
+    tids = [
+        Path(r).read_text(encoding="utf-8").strip()
+        for r in results
+        if os.path.exists(r)
+    ]
     assert len(tids) == 2, f"only {len(tids)} workers finished"
     assert tids[0] == tids[1], (
         f"idempotency key race produced two different tasks: {tids}"

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -6,6 +6,7 @@ _get_extract_char_limit, and the end-to-end web_extract_tool truncation behavior
 import asyncio
 import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -49,7 +50,7 @@ class TestTruncation:
         path_line = next(ln for ln in out.splitlines() if "Full text saved to:" in ln)
         stored_path = path_line.split("Full text saved to:", 1)[1].strip()
         assert os.path.exists(stored_path)
-        full = open(stored_path).read()
+        full = Path(stored_path).read_text(encoding="utf-8")
         assert "UNIQUE_MIDDLE_MARKER" in full
         assert "row 2500" in full  # the omitted-middle row is in the stored file
 


### PR DESCRIPTION
## What does this PR do?

`tests/hermes_cli/test_plugins_cmd.py::TestNoAutoActivation::test_compressor_default_ignores_plugin` fails on every native Windows machine:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 47744: character maps to <undefined>
```

The test reads `run_agent.py` back as text to assert a removed comment is gone, but calls `open()` with no `encoding=`. Python falls back to `locale.getpreferredencoding(False)`, which is UTF-8 on Linux and macOS but cp1252 on a default US Windows install. `run_agent.py` is UTF-8 and contains nine bytes cp1252 leaves undefined, so the decode raises before the assertion is ever reached. It passes everywhere else, which is why CI stayed green.

That one line is the only active failure, and fixing it takes `test_plugins_cmd.py` from 38 passed with 1 failure to 39 passing on Windows.

**Why the rest of the diff.** `scripts/check-windows-footguns.py` flags eleven more bare encoding sites across the same three files, and the #71014 read_text campaign has been closing this class elsewhere in the tree. Two of them matter beyond tidiness: `tests/tools/test_web_tools_truncate.py:52` reads stored extracted web text, which is arbitrary content from the internet and therefore one non-ASCII page away from the same crash, and `tests/stress/test_atypical_scenarios.py:708` is the *write* that pairs with the read at 739, so fixing only the read would leave an asymmetric round trip. All three files are clean under `check-windows-footguns.py` after this change.

Reads go through `Path.read_text(encoding="utf-8")` rather than `open(...).read()`, which also closes the handle instead of leaving it to the garbage collector. A live handle blocks tmpdir cleanup on Windows, so that part is not cosmetic either.

Prior art: #37423 covered the `gateway/run.py` instances of this and is closed, #71014 carried the campaign forward, and #79490 is the same fix applied to `tests/scripts/test_contributor_map.py`. This is the `tests/hermes_cli`, `tests/tools` and `tests/stress` corner of it.

## Related Issue

Fixes #80894

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_plugins_cmd.py`: the failing read now uses `Path.read_text(encoding="utf-8")`. Nine bare `write_text` calls writing YAML manifests, config and plugin sources get an explicit `encoding="utf-8"`.
- `tests/tools/test_web_tools_truncate.py`: read the stored full text with an explicit encoding.
- `tests/stress/test_atypical_scenarios.py`: explicit encoding on the two barrier and result writes and the matching read.

## How to Test

On Windows, before this change:

```
pytest tests/hermes_cli/test_plugins_cmd.py -q
38 passed, 1 failed
```

After:

```
pytest tests/hermes_cli/test_plugins_cmd.py -q
39 passed
```

Full set touched by this PR:

```bash
pytest tests/hermes_cli/test_plugins_cmd.py tests/tools/test_web_tools_truncate.py -q
python scripts/check-windows-footguns.py --diff main
```

The footgun check reports no findings on all three files after the change.

To see the underlying cause on any platform:

```python
import locale
print(locale.getpreferredencoding(False))
data = open("run_agent.py", "rb").read()
print([(i, b) for i, b in enumerate(data) if b in (0x8f, 0x90, 0x9d, 0x81)][:3])
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 10.0.26200, Python 3.13.13

On the tests checkbox, to be straight about it: no new test was added, because the thing being fixed is a test. It fails on Windows before this change and passes after, so it is its own regression coverage. `scripts/check-windows-footguns.py` is the mechanical guard against the pattern coming back, and it is clean on these files now.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```
tests\hermes_cli\test_plugins_cmd.py:532: in test_compressor_default_ignores_plugin
    source = open(ra_module.__file__).read()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Lib\encodings\cp1252.py:23: in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 47744: character maps to <undefined>
=========================== short test summary info ===========================
FAILED tests/hermes_cli/test_plugins_cmd.py::TestNoAutoActivation::test_compressor_default_ignores_plugin
1 failed
```
