### PR TITLE
feat(cli): speed improvements (50-70%) to STT during voice input

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1226,8 +1226,26 @@ stt:
   #   model: "whisper-large-v3-turbo"
   #   language: ""             # blank = stt.language > HERMES_LOCAL_STT_LANGUAGE > auto-detect
   openai:
+    base_url: ""               # optional OpenAI-compatible API base; Realtime support is required for streaming
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
+    streaming: true             # automatic when this is the selected provider; set false to force batch
+    streaming_model_id: "gpt-4o-mini-transcribe"  # Realtime transcription with semantic VAD
     language: ""               # auto-detect; set to "en", "es", "fr", etc. to force
+  # elevenlabs:
+  #   base_url: ""             # optional HTTP API base
+  #   wss_url: ""              # optional WebSocket API base; defaults to base_url with ws(s) scheme
+  #   model_id: "scribe_v2"
+  #   streaming: true           # automatic when this is the selected provider; set false to force batch
+  #   streaming_model_id: "scribe_v2_realtime"
+  #   # Optional Realtime VAD tuning; omitted values use ElevenLabs defaults:
+  #   # vad_threshold: 0.4
+  #   # vad_silence_threshold_secs: 1.5
+  #   # min_speech_duration_ms: 100
+  #   # min_silence_duration_ms: 100
+  # xai:
+  #   base_url: ""             # optional API base for API-key auth; OAuth stays on its validated origin
+  #   language: ""
+  #   diarize: false
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
   # deepinfra:

--- a/cli.py
+++ b/cli.py
@@ -47,6 +47,8 @@ from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
+_STREAMING_STT_ENDPOINT_GRACE_SECONDS = 0.5
+
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
@@ -4777,7 +4779,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_mode = False
         self._voice_tts = False
         self._voice_recorder = None
+        self._voice_stt_stream = None
         self._voice_recording = False
+        self._voice_recording_generation = 0
+        self._voice_capture_started_generation = 0
         self._voice_processing = False
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
@@ -4786,6 +4791,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
         self._voice_last_tts_text = ""  # most recently spoken TTS text (echo guard, #75780)
         self._voice_barge_phase = None  # "generation" or "playback" phase of the last barge trip
+        self._voice_stream_barge_release = threading.Event()
+        self._voice_stream_audio_sink = None
+        self._voice_stream_pending_finals = []
+        self._voice_stream_final_sequence = 0
+        self._voice_stream_drain_after = None
+        self._voice_stream_barge_candidate_after = None
+        self._voice_stream_seen_final_ids = set()
+        self._voice_stream_endpoint_timer = None
+        self._voice_stream_endpoint_token = 0
+        self._voice_stream_endpoint_segment_id = None
+        self._voice_stream_last_submitted_segment_id = None
+        self._voice_stream_partial_barge_segment_id = None
+        self._voice_stream_manual_commit = False
+        self._voice_stream_dispatch_pending = False
+        self._voice_stream_dispatch_barge = False
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
@@ -12400,6 +12420,39 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self._voice_recording:
                 return
             self._voice_recording = True
+            self._voice_recording_generation += 1
+            recording_generation = self._voice_recording_generation
+            # Finals collected while no local barge was confirmed belong to
+            # the preceding idle/agent/TTS phase, not this new capture.
+            self._voice_stream_pending_finals = []
+            self._voice_stream_drain_after = None
+            self._voice_stream_barge_candidate_after = None
+            endpoint_timer = getattr(
+                self,
+                "_voice_stream_endpoint_timer",
+                None,
+            )
+            self._voice_stream_endpoint_timer = None
+            self._voice_stream_endpoint_token = (
+                getattr(self, "_voice_stream_endpoint_token", 0) + 1
+            )
+            self._voice_stream_endpoint_segment_id = None
+            self._voice_stream_partial_barge_segment_id = None
+            self._voice_stream_manual_commit = False
+            logger.debug(
+                "Voice capture armed: generation=%d stream_sequence=%d",
+                recording_generation,
+                self._voice_stream_final_sequence,
+            )
+        if endpoint_timer is not None:
+            endpoint_timer.cancel()
+
+        def _recording_attempt_active() -> bool:
+            with self._voice_lock:
+                return (
+                    self._voice_recording
+                    and recording_generation == self._voice_recording_generation
+                )
 
         # Load silence detection params from config. Shape-safe: a
         # hand-edited ``voice: true`` / ``voice: cmd+b`` leaves
@@ -12455,6 +12508,47 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             else 120.0
         )
 
+        # Streaming is selected only when the configured provider has a
+        # transcription-only realtime implementation and the recorder can
+        # expose callback frames. A failed handshake falls through to the
+        # existing local-endpoint/WAV path for this utterance.
+        stream_coordinator = None
+        try:
+            stream_coordinator = self._voice_get_streaming_stt()
+            if (
+                stream_coordinator is not None
+                and not stream_coordinator.start_utterance()
+            ):
+                stream_coordinator = None
+        except Exception:
+            logger.warning(
+                "Streaming STT setup failed; using batch transcription",
+                exc_info=True,
+            )
+            stream_coordinator = None
+
+        if not _recording_attempt_active():
+            if stream_coordinator is not None:
+                stream_coordinator.pause()
+            return
+
+        if stream_coordinator is not None:
+            self._voice_attach_stream_sink(stream_coordinator)
+
+        # The first PortAudio input open can take several seconds. Complete
+        # that work before the start cue so the cue still precedes capture,
+        # but capture can arm immediately afterward.
+        prepare_recorder = getattr(self._voice_recorder, "prepare", None)
+        if callable(prepare_recorder):
+            try:
+                prepare_recorder()
+            except Exception:
+                if stream_coordinator is not None:
+                    stream_coordinator.pause()
+                with self._voice_lock:
+                    self._voice_recording = False
+                raise
+
         def _on_silence():
             """Called by AudioRecorder when silence is detected after speech."""
             with self._voice_lock:
@@ -12473,14 +12567,41 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
+        if not _recording_attempt_active():
+            if stream_coordinator is not None:
+                stream_coordinator.pause()
+            return
+
         try:
-            self._voice_recorder.start(on_silence_stop=_on_silence)
+            if stream_coordinator is not None:
+                started = self._voice_recorder.start(
+                    on_silence_stop=None,
+                    on_no_speech=self._voice_streaming_no_speech,
+                    on_max_duration=self._voice_streaming_commit,
+                    start_guard=_recording_attempt_active,
+                )
+            else:
+                started = self._voice_recorder.start(on_silence_stop=_on_silence)
         except Exception:
+            if stream_coordinator is not None:
+                stream_coordinator.pause()
             with self._voice_lock:
                 self._voice_recording = False
             raise
+        if started is False or not _recording_attempt_active():
+            if stream_coordinator is not None:
+                stream_coordinator.pause()
+            return
+        with self._voice_lock:
+            if (
+                self._voice_recording
+                and recording_generation == self._voice_recording_generation
+            ):
+                self._voice_capture_started_generation = recording_generation
         _label = self._voice_record_key_label()
-        if getattr(self._voice_recorder, "supports_silence_autostop", True):
+        if stream_coordinator is not None:
+            _recording_hint = f"provider endpointing | {_label} to stop & exit continuous"
+        elif getattr(self._voice_recorder, "supports_silence_autostop", True):
             _recording_hint = f"auto-stops on silence | {_label} to stop & exit continuous"
         elif _is_termux_environment():
             _recording_hint = f"Termux:API capture | {_label} to stop"
@@ -12532,6 +12653,497 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             return ""
 
+    def _voice_get_streaming_stt(self):
+        """Return the persistent streamer for the selected STT provider."""
+        recorder = self._voice_recorder
+        if not getattr(recorder, "supports_streaming_frames", False):
+            return None
+        try:
+            from hermes_cli.config import load_config
+            from tools.stt_streaming import (
+                StreamingSTTTurnController,
+                resolve_streaming_stt_provider,
+            )
+
+            raw = load_config().get("stt", {})
+            stt_config = raw if isinstance(raw, dict) else {}
+            provider = resolve_streaming_stt_provider(stt_config)
+        except Exception:
+            logger.debug("Streaming STT resolution failed", exc_info=True)
+            return None
+        coordinator = getattr(self, "_voice_stt_stream", None)
+        if provider is None:
+            if coordinator is not None:
+                self._voice_detach_stream_sink()
+                self._voice_stt_stream = None
+                threading.Thread(target=coordinator.close, daemon=True).start()
+            return None
+
+        if (
+            coordinator is not None
+            and coordinator.provider_configuration_key == provider.configuration_key
+        ):
+            return coordinator
+        if coordinator is not None:
+            self._voice_detach_stream_sink()
+            threading.Thread(target=coordinator.close, daemon=True).start()
+        coordinator = StreamingSTTTurnController(
+            provider,
+            self._voice_streaming_event,
+            self._voice_streaming_error,
+            continuous=True,
+        )
+        self._voice_stt_stream = coordinator
+        return coordinator
+
+    def _voice_attach_stream_sink(self, coordinator) -> None:
+        recorder = self._voice_recorder
+        if recorder is None or not hasattr(recorder, "add_continuous_frame_sink"):
+            return
+        sink = getattr(self, "_voice_stream_audio_sink", None)
+        if sink is not None:
+            recorder.remove_continuous_frame_sink(sink)
+        sink = coordinator.enqueue_audio
+        self._voice_stream_audio_sink = sink
+        recorder.add_continuous_frame_sink(sink)
+
+    def _voice_detach_stream_sink(self) -> None:
+        recorder = self._voice_recorder
+        sink = getattr(self, "_voice_stream_audio_sink", None)
+        self._voice_stream_audio_sink = None
+        if (
+            recorder is not None
+            and sink is not None
+            and hasattr(recorder, "remove_continuous_frame_sink")
+        ):
+            recorder.remove_continuous_frame_sink(sink)
+
+    def _voice_streaming_commit(self) -> None:
+        """Commit a streaming utterance while retaining batch fallback audio."""
+        with self._voice_lock:
+            if not self._voice_recording or self._voice_processing:
+                return
+            self._voice_recording = False
+            self._voice_processing = True
+            self._voice_stream_drain_after = self._voice_stream_final_sequence
+            self._voice_stream_manual_commit = True
+            logger.debug(
+                "Streaming STT commit requested: drain_after=%d",
+                self._voice_stream_drain_after,
+            )
+        recorder = self._voice_recorder
+        if recorder is not None:
+            recorder.finish_capture()
+        if hasattr(self, '_app') and self._app:
+            self._app.invalidate()
+        coordinator = self._voice_stt_stream
+        if coordinator is None or not coordinator.commit():
+            # The provider may have committed automatically just before the
+            # keypress. Its callback owns the turn now; do not race that final
+            # into the retained-audio batch path.
+            if coordinator is not None and (
+                coordinator.delivering is True
+                or coordinator.commit_pending is True
+            ):
+                return
+            self._voice_streaming_error(
+                RuntimeError("Streaming STT commit was not accepted")
+            )
+
+    def _voice_streaming_event(self, event) -> None:
+        """Route provider events without stopping the continuous audio feed."""
+        if event.is_final:
+            self._voice_streaming_final(event)
+        else:
+            self._voice_streaming_partial(event)
+
+    def _voice_streaming_partial(self, event) -> None:
+        """Use a new partial to extend an endpoint or confirm a barge-in."""
+        transcript = str(event.text or "").strip()
+        if not transcript:
+            return
+        segment_id = str(getattr(event, "segment_id", None) or "").strip()
+        cancel_timer = None
+        confirm_barge = False
+        with self._voice_lock:
+            relevant = bool(
+                self._voice_mode
+                or self._voice_recording
+                or self._voice_processing
+                or self._voice_barge_capture.is_set()
+            )
+            if not relevant:
+                return
+            endpoint_timer = getattr(
+                self,
+                "_voice_stream_endpoint_timer",
+                None,
+            )
+            endpoint_segment_id = getattr(
+                self,
+                "_voice_stream_endpoint_segment_id",
+                None,
+            )
+            continues_after_endpoint = bool(
+                endpoint_timer is not None
+                and (
+                    not segment_id
+                    or not endpoint_segment_id
+                    or segment_id != endpoint_segment_id
+                )
+            )
+            if continues_after_endpoint:
+                cancel_timer = endpoint_timer
+                self._voice_stream_endpoint_timer = None
+                self._voice_stream_endpoint_token = (
+                    getattr(self, "_voice_stream_endpoint_token", 0) + 1
+                )
+                self._voice_stream_endpoint_segment_id = None
+                logger.debug(
+                    "Streaming STT endpoint extended by partial: "
+                    "segment_id=%s",
+                    segment_id or "-",
+                )
+                last_submitted = getattr(
+                    self,
+                    "_voice_stream_last_submitted_segment_id",
+                    None,
+                )
+                prior_barge = getattr(
+                    self,
+                    "_voice_stream_partial_barge_segment_id",
+                    None,
+                )
+                confirm_barge = bool(
+                    not self._voice_recording
+                    and segment_id
+                    and segment_id != last_submitted
+                    and segment_id != prior_barge
+                    and self._voice_continuous
+                )
+                if confirm_barge:
+                    self._voice_stream_partial_barge_segment_id = segment_id
+            elif not self._voice_recording:
+                last_submitted = getattr(
+                    self,
+                    "_voice_stream_last_submitted_segment_id",
+                    None,
+                )
+                prior_barge = getattr(
+                    self,
+                    "_voice_stream_partial_barge_segment_id",
+                    None,
+                )
+                confirm_barge = bool(
+                    segment_id
+                    and segment_id != last_submitted
+                    and segment_id != prior_barge
+                    and self._voice_continuous
+                )
+                if confirm_barge:
+                    self._voice_stream_partial_barge_segment_id = segment_id
+            if confirm_barge and getattr(
+                self,
+                "_voice_stream_dispatch_pending",
+                False,
+            ):
+                self._voice_stream_dispatch_barge = True
+        if cancel_timer is not None:
+            cancel_timer.cancel()
+        if confirm_barge:
+            logger.debug(
+                "Streaming STT partial confirmed barge: segment_id=%s",
+                segment_id,
+            )
+            self._voice_handle_barge_trigger()
+
+    def _voice_streaming_barge_confirmed(self) -> None:
+        """Drain buffered provider finals through the barge's next boundary."""
+        self._voice_barge_capture.set()
+        self._voice_stream_barge_release.set()
+        with self._voice_lock:
+            boundary = self._voice_stream_barge_candidate_after
+            if boundary is None:
+                boundary = self._voice_stream_final_sequence
+            self._voice_stream_drain_after = boundary
+            self._voice_stream_barge_candidate_after = None
+            self._voice_processing = True
+            logger.debug(
+                "Streaming STT barge confirmed: drain_after=%d sequence=%d",
+                boundary,
+                self._voice_stream_final_sequence,
+            )
+        recorder = self._voice_recorder
+        if recorder is not None and hasattr(
+            recorder,
+            "begin_continuous_fallback_capture",
+        ):
+            try:
+                recorder.begin_continuous_fallback_capture()
+            except Exception:
+                logger.debug(
+                    "Unable to retain continuous barge audio for fallback",
+                    exc_info=True,
+                )
+        self._voice_drain_streaming_finals(allow_recording=False)
+
+    def _voice_streaming_barge_candidate(self) -> None:
+        """Remember which provider finals predate a possible interruption."""
+        with self._voice_lock:
+            self._voice_stream_barge_candidate_after = (
+                self._voice_stream_final_sequence
+            )
+            logger.debug(
+                "Streaming STT barge candidate: sequence=%d",
+                self._voice_stream_final_sequence,
+            )
+
+    def _voice_take_streaming_pending_finals(self) -> list[str]:
+        with self._voice_lock:
+            endpoint_timer = getattr(
+                self,
+                "_voice_stream_endpoint_timer",
+                None,
+            )
+            self._voice_stream_endpoint_timer = None
+            self._voice_stream_endpoint_token = (
+                getattr(self, "_voice_stream_endpoint_token", 0) + 1
+            )
+            self._voice_stream_endpoint_segment_id = None
+            pending = self._voice_stream_pending_finals
+            self._voice_stream_pending_finals = []
+            self._voice_stream_drain_after = None
+            self._voice_stream_barge_candidate_after = None
+            self._voice_stream_manual_commit = False
+        if endpoint_timer is not None:
+            endpoint_timer.cancel()
+        return pending
+
+    def _voice_arm_streaming_endpoint(self, segment_id: str) -> None:
+        """Wait briefly for evidence that an automatic endpoint was early."""
+        with self._voice_lock:
+            old_timer = getattr(self, "_voice_stream_endpoint_timer", None)
+            token = getattr(self, "_voice_stream_endpoint_token", 0) + 1
+            self._voice_stream_endpoint_token = token
+            self._voice_stream_endpoint_segment_id = segment_id or None
+            timer = threading.Timer(
+                _STREAMING_STT_ENDPOINT_GRACE_SECONDS,
+                lambda: self._voice_drain_streaming_finals(
+                    allow_recording=True,
+                    endpoint_token=token,
+                ),
+            )
+            timer.daemon = True
+            self._voice_stream_endpoint_timer = timer
+        if old_timer is not None:
+            old_timer.cancel()
+        timer.start()
+
+    def _voice_streaming_final(self, event) -> None:
+        """Buffer provider finals and drain the current logical voice turn."""
+        transcript = str(event.text or "").strip()
+        event_id = str(event.event_id or "").strip()
+        segment_id = str(getattr(event, "segment_id", None) or "").strip()
+        recorder = self._voice_recorder
+        recorder_has_spoken = bool(getattr(recorder, "has_spoken", True))
+        with self._voice_lock:
+            capture_has_speech = bool(
+                recorder_has_spoken
+                and self._voice_capture_started_generation
+                == self._voice_recording_generation
+            )
+            relevant = bool(
+                self._voice_mode
+                or self._voice_recording
+                or self._voice_processing
+                or self._voice_barge_capture.is_set()
+            )
+            if not relevant:
+                return
+            if event_id:
+                if event_id in self._voice_stream_seen_final_ids:
+                    return
+                self._voice_stream_seen_final_ids.add(event_id)
+            # The provider connection also hears the idle/agent/TTS phase. A
+            # late final from that phase can cross the instant Ctrl+B arms a
+            # new capture. Do not let it close a capture that has not observed
+            # any new microphone speech. Manual commit and confirmed barge-in
+            # set a drain boundary and intentionally bypass this guard.
+            stale_for_new_capture = bool(
+                self._voice_recording
+                and self._voice_stream_drain_after is None
+                and not capture_has_speech
+            )
+            if transcript and not stale_for_new_capture:
+                self._voice_stream_pending_finals.append(transcript)
+            self._voice_stream_final_sequence += 1
+            self._voice_stream_partial_barge_segment_id = None
+            logger.debug(
+                "Streaming STT final routed: sequence=%d event_id=%s "
+                "segment_id=%s text_chars=%d recording=%s processing=%s speech=%s "
+                "drain_after=%s action=%s",
+                self._voice_stream_final_sequence,
+                event_id or "-",
+                segment_id or "-",
+                len(transcript),
+                self._voice_recording,
+                self._voice_processing,
+                capture_has_speech,
+                self._voice_stream_drain_after,
+                "discard-pre-capture" if stale_for_new_capture else "buffer",
+            )
+            if stale_for_new_capture:
+                return
+            drain_after = self._voice_stream_drain_after
+            crossed_boundary = bool(
+                drain_after is not None
+                and self._voice_stream_final_sequence > drain_after
+            )
+            manual_commit = bool(
+                crossed_boundary
+                and getattr(self, "_voice_stream_manual_commit", False)
+            )
+        if manual_commit:
+            self._voice_drain_streaming_finals(allow_recording=False)
+        else:
+            self._voice_arm_streaming_endpoint(segment_id)
+
+    def _voice_drain_streaming_finals(
+        self,
+        *,
+        allow_recording: bool,
+        endpoint_token: Optional[int] = None,
+    ) -> bool:
+        """Claim and submit buffered finals once the requested boundary lands."""
+        streaming_barge = False
+        barge_phase = None
+        with self._voice_lock:
+            endpoint_timer = getattr(
+                self,
+                "_voice_stream_endpoint_timer",
+                None,
+            )
+            if endpoint_token is not None and (
+                endpoint_timer is None
+                or endpoint_token
+                != getattr(self, "_voice_stream_endpoint_token", 0)
+            ):
+                return False
+            drain_after = self._voice_stream_drain_after
+            crossed_boundary = bool(
+                drain_after is not None
+                and self._voice_stream_final_sequence > drain_after
+            )
+            if not crossed_boundary and not (
+                allow_recording and self._voice_recording
+            ):
+                if endpoint_token is not None:
+                    self._voice_stream_endpoint_timer = None
+                    self._voice_stream_endpoint_token = (
+                        getattr(self, "_voice_stream_endpoint_token", 0) + 1
+                    )
+                    self._voice_stream_endpoint_segment_id = None
+                return False
+            endpoint_segment_id = getattr(
+                self,
+                "_voice_stream_endpoint_segment_id",
+                None,
+            )
+            self._voice_stream_endpoint_timer = None
+            self._voice_stream_endpoint_token = (
+                getattr(self, "_voice_stream_endpoint_token", 0) + 1
+            )
+            self._voice_stream_endpoint_segment_id = None
+            self._voice_stream_last_submitted_segment_id = (
+                endpoint_segment_id
+            )
+            self._voice_stream_partial_barge_segment_id = None
+            self._voice_stream_manual_commit = False
+            self._voice_recording = False
+            self._voice_processing = True
+            pending = self._voice_stream_pending_finals
+            self._voice_stream_dispatch_pending = any(
+                str(segment).strip() for segment in pending
+            )
+            self._voice_stream_dispatch_barge = False
+            self._voice_stream_pending_finals = []
+            self._voice_stream_drain_after = None
+            self._voice_stream_barge_candidate_after = None
+            if self._voice_barge_capture.is_set():
+                streaming_barge = True
+                barge_phase = getattr(self, "_voice_barge_phase", None)
+            logger.debug(
+                "Streaming STT finals drained: reason=%s count=%d sequence=%d",
+                "boundary" if crossed_boundary else "normal-recording",
+                len(pending),
+                self._voice_stream_final_sequence,
+            )
+
+        if endpoint_timer is not None:
+            endpoint_timer.cancel()
+
+        if self._voice_recorder is not None:
+            self._voice_recorder.cancel()
+            if hasattr(
+                self._voice_recorder,
+                "clear_continuous_fallback_buffer",
+            ):
+                self._voice_recorder.clear_continuous_fallback_buffer()
+        self._voice_barge_capture.clear()
+
+        if self._voice_beeps_enabled():
+            try:
+                from tools.voice_mode import play_beep
+                play_beep(frequency=660, count=2)
+            except Exception:
+                pass
+
+        submitted = False
+        try:
+            combined = ""
+            for segment in pending:
+                segment = segment.strip()
+                if not segment:
+                    continue
+                if not combined:
+                    combined = segment
+                else:
+                    combined += f" {segment}"
+            if not combined:
+                _cprint(f"{_DIM}No speech detected.{_RST}")
+            else:
+                submitted = self._voice_submit_transcript(
+                    combined,
+                    barge_phase=barge_phase,
+                )
+        except Exception as e:
+            _cprint(f"\n{_DIM}Voice processing error: {e}{_RST}")
+        finally:
+            if streaming_barge:
+                self._voice_barge_phase = None
+            self._voice_finish_processing(submitted)
+        return submitted
+
+    def _voice_streaming_error(self, error: Exception) -> None:
+        """Recover an interrupted streaming turn through WAV transcription."""
+        with self._voice_lock:
+            if not self._voice_recording and not self._voice_processing:
+                return
+        logger.warning("Streaming STT failed; falling back to batch: %s", error)
+        self._voice_stop_and_transcribe(_stream_fallback=True)
+
+    def _voice_streaming_no_speech(self) -> None:
+        """End an empty streaming turn using the recorder's safety guard."""
+        with self._voice_lock:
+            if not self._voice_recording or self._voice_processing:
+                return
+            self._voice_recording = False
+            self._voice_processing = True
+        if self._voice_recorder is not None:
+            self._voice_recorder.cancel()
+        _cprint(f"{_DIM}No speech detected.{_RST}")
+        self._voice_finish_processing(False)
+
     def _voice_restart_recording_async(self) -> None:
         """Restart continuous-mode recording off-thread (start() can block)."""
         def _restart_recording():
@@ -12543,13 +13155,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
         threading.Thread(target=_restart_recording, daemon=True).start()
 
-    def _voice_stop_and_transcribe(self):
+    def _voice_stop_and_transcribe(self, _stream_fallback: bool = False):
         """Stop recording, transcribe via STT, and queue the transcript as input."""
+        if not _stream_fallback:
+            stream = getattr(self, "_voice_stt_stream", None)
+            if stream is not None and (stream.active or stream.delivering):
+                self._voice_streaming_commit()
+                return
+
         # Atomic guard: only one thread can enter stop-and-transcribe.
         # Set _voice_processing immediately so concurrent Ctrl+B presses
         # don't race into the START path while recorder.stop() holds its lock.
+        fallback_wav_covers_pending = False
+        fallback_is_barge = False
+        fallback_barge_phase = None
         with self._voice_lock:
-            if not self._voice_recording:
+            if _stream_fallback:
+                if not self._voice_recording and not self._voice_processing:
+                    return
+                # A normal-turn recording retains audio from its beginning.
+                # A barge fallback starts from a short rolling pre-buffer, so
+                # earlier provider finals may contain speech outside its WAV.
+                fallback_wav_covers_pending = not self._voice_barge_capture.is_set()
+                if not fallback_wav_covers_pending:
+                    fallback_is_barge = True
+                    fallback_barge_phase = getattr(
+                        self,
+                        "_voice_barge_phase",
+                        None,
+                    )
+            elif not self._voice_recording:
                 return
             self._voice_recording = False
             self._voice_processing = True
@@ -12562,6 +13197,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return
 
             wav_path = self._voice_recorder.stop()
+            if _stream_fallback and hasattr(
+                self._voice_recorder,
+                "clear_continuous_fallback_buffer",
+            ):
+                self._voice_recorder.clear_continuous_fallback_buffer()
 
             # Audio cue: double beep after stream stopped (no CoreAudio conflict)
             if self._voice_beeps_enabled():
@@ -12572,7 +13212,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
 
             if wav_path is None:
-                _cprint(f"{_DIM}No speech detected.{_RST}")
+                pending = (
+                    self._voice_take_streaming_pending_finals()
+                    if _stream_fallback
+                    else []
+                )
+                if pending:
+                    submitted = self._voice_submit_transcript(
+                        " ".join(pending).strip(),
+                        barge_phase=fallback_barge_phase,
+                    )
+                else:
+                    _cprint(f"{_DIM}No speech detected.{_RST}")
                 return
 
             # _voice_processing is already True (set atomically above)
@@ -12592,21 +13243,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             result = transcribe_recording(wav_path, model=stt_model)
 
             if result.get("success") and result.get("transcript", "").strip():
-                transcript = result["transcript"].strip()
-                from tools.voice_mode import is_voice_stop_phrase
-                if is_voice_stop_phrase(transcript):
-                    # Bare "stop" (or configured phrase) ends the voice chat
-                    # instead of being sent to the agent.
-                    _cprint(f"{_DIM}Stop phrase detected — ending voice chat.{_RST}")
-                    self._disable_voice_mode()
-                    return
-                self._attached_images.clear()
-                if hasattr(self, '_app') and self._app:
-                    self._app.invalidate()
-                self._pending_input.put(_VoiceInputMessage(transcript))
-                submitted = True
+                pending = (
+                    self._voice_take_streaming_pending_finals()
+                    if _stream_fallback
+                    else []
+                )
+                transcript_parts = (
+                    [] if fallback_wav_covers_pending else pending
+                )
+                transcript_parts.append(result["transcript"].strip())
+                submitted = self._voice_submit_transcript(
+                    " ".join(transcript_parts).strip(),
+                    barge_phase=fallback_barge_phase,
+                )
             elif result.get("success"):
-                _cprint(f"{_DIM}No speech detected.{_RST}")
+                pending = (
+                    self._voice_take_streaming_pending_finals()
+                    if _stream_fallback
+                    else []
+                )
+                if pending:
+                    submitted = self._voice_submit_transcript(
+                        " ".join(pending).strip(),
+                        barge_phase=fallback_barge_phase,
+                    )
+                else:
+                    _cprint(f"{_DIM}No speech detected.{_RST}")
             else:
                 error = result.get("error", "Unknown error")
                 _cprint(f"\n{_DIM}Transcription failed: {error}{_RST}")
@@ -12616,10 +13278,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"\n{_DIM}Voice processing error: {e}{_RST}")
             transcription_failed = wav_path is not None
         finally:
-            with self._voice_lock:
-                self._voice_processing = False
-            if hasattr(self, '_app') and self._app:
-                self._app.invalidate()
             # Clean up temp file unless transcription failed. On failure, keep
             # the source recording so long dictation is not lost.
             try:
@@ -12631,42 +13289,85 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
-            # Track consecutive no-speech cycles to avoid infinite restart loops.
-            # While the agent is mid-turn or TTS is speaking, the user is
-            # CORRECTLY silent (waiting/listening) — those cycles must not
-            # count, or a multi-minute tool run ends the voice chat under
-            # the user. The stop phrase and barge-in still work during the
-            # hold (they run on their own paths above).
-            stop_continuous_restart = False
-            _tts_done = getattr(self, "_voice_tts_done", None)
-            _activity_hold = bool(
-                getattr(self, "_agent_running", False)
-                or (_tts_done is not None and not _tts_done.is_set())
-            )
-            if not submitted:
-                if _activity_hold:
-                    pass  # held: keep listening without counting the cycle
-                else:
-                    self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
-                    if self._no_speech_count >= 3:
-                        self._voice_continuous = False
-                        self._no_speech_count = 0
-                        _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                        stop_continuous_restart = True
-            else:
-                self._no_speech_count = 0
+            if fallback_is_barge:
+                self._voice_barge_capture.clear()
+                self._voice_barge_phase = None
+            self._voice_finish_processing(submitted)
 
-            # If no transcript was submitted but continuous mode is active,
-            # restart recording so the user can keep talking.
-            # (When transcript IS submitted, process_loop handles restart
-            # after chat() completes.)
-            if (
-                self._voice_continuous
-                and not submitted
-                and not self._voice_recording
-                and not stop_continuous_restart
+    def _voice_submit_transcript(
+        self,
+        transcript: str,
+        *,
+        barge_phase: Optional[str] = None,
+    ) -> bool:
+        """Queue one final STT transcript, or consume a voice stop phrase."""
+        from tools.voice_mode import is_voice_stop_phrase
+        if is_voice_stop_phrase(transcript):
+            _cprint(f"{_DIM}Stop phrase detected — ending voice chat.{_RST}")
+            self._disable_voice_mode()
+            return False
+        if barge_phase == "playback":
+            from tools.voice_mode import is_tts_echo
+            if is_tts_echo(
+                transcript,
+                getattr(self, "_voice_last_tts_text", ""),
             ):
-                self._voice_restart_recording_async()
+                logger.debug(
+                    "Dropping playback-phase barge transcript as TTS echo: %r",
+                    transcript,
+                )
+                _cprint(f"\n{_DIM}Ignored likely TTS echo (not queued).{_RST}")
+                return False
+        self._attached_images.clear()
+        if hasattr(self, '_app') and self._app:
+            self._app.invalidate()
+        self._pending_input.put(_VoiceInputMessage(transcript))
+        return True
+
+    def _voice_finish_processing(self, submitted: bool) -> None:
+        """Apply shared post-transcription counters and restart behavior."""
+        with self._voice_lock:
+            self._voice_processing = False
+            if not submitted:
+                self._voice_stream_dispatch_pending = False
+                self._voice_stream_dispatch_barge = False
+        if hasattr(self, '_app') and self._app:
+            self._app.invalidate()
+
+        # Track consecutive no-speech cycles to avoid infinite restart loops.
+        # While the agent is mid-turn or TTS is speaking, the user is
+        # correctly silent (waiting/listening) — those cycles must not count,
+        # or a multi-minute tool run ends the voice chat under the user. The
+        # stop phrase and barge-in still work during the hold.
+        stop_continuous_restart = False
+        _tts_done = getattr(self, "_voice_tts_done", None)
+        _activity_hold = bool(
+            getattr(self, "_agent_running", False)
+            or (_tts_done is not None and not _tts_done.is_set())
+        )
+        if not submitted:
+            if _activity_hold:
+                pass  # held: keep listening without counting the cycle
+            else:
+                self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
+                if self._no_speech_count >= 3:
+                    self._voice_continuous = False
+                    self._no_speech_count = 0
+                    _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
+                    stop_continuous_restart = True
+        else:
+            self._no_speech_count = 0
+
+        # If no transcript was submitted but continuous mode is active,
+        # restart recording so the user can keep talking. When a transcript
+        # is submitted, process_loop restarts after chat() completes.
+        if (
+            self._voice_continuous
+            and not submitted
+            and not self._voice_recording
+            and not stop_continuous_restart
+        ):
+            self._voice_restart_recording_async()
 
     def _voice_speak_response_async(self, text: str) -> None:
         """Schedule TTS and mark it pending before continuous recording can restart."""
@@ -12688,6 +13389,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 target=self._voice_full_duplex_listener,
                 daemon=True,
             ).start()
+
+    def _voice_wait_for_streaming_tts(self, thread, timeout: float) -> bool:
+        """Wait for spoken output unless streaming STT confirmed a barge."""
+        deadline = time.monotonic() + timeout
+        while thread.is_alive():
+            release = getattr(self, "_voice_stream_barge_release", None)
+            if release is not None and release.is_set():
+                logger.debug(
+                    "Streaming TTS wait released by streaming STT barge"
+                )
+                return False
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            thread.join(timeout=min(0.1, remaining))
+        return True
 
     def _voice_speak_response(self, text: str):
         """Speak the agent's response aloud using TTS (runs in background thread)."""
@@ -12758,6 +13475,81 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         finally:
             self._voice_tts_done.set()
 
+    def _voice_tts_is_playing(self) -> bool:
+        """Return whether enabled voice TTS is currently producing audio."""
+        if not self._voice_tts or self._voice_tts_done.is_set():
+            return False
+        try:
+            from tools.voice_mode import is_audio_output_active
+
+            return is_audio_output_active()
+        except Exception:
+            return False
+
+    def _voice_apply_pending_streaming_barge(
+        self,
+        agent,
+        *,
+        voice_input: bool,
+    ) -> None:
+        """Carry a confirmed continuation into its queued streaming turn."""
+        if not voice_input:
+            return
+        with self._voice_lock:
+            interrupt = bool(
+                getattr(self, "_voice_stream_dispatch_pending", False)
+                and getattr(self, "_voice_stream_dispatch_barge", False)
+            )
+            self._voice_stream_dispatch_pending = False
+            self._voice_stream_dispatch_barge = False
+        if interrupt:
+            logger.debug(
+                "Applying streaming STT barge at voice turn dispatch"
+            )
+            agent.interrupt()
+
+    def _voice_handle_barge_trigger(self, phase: Optional[str] = None) -> None:
+        """Apply one confirmed barge from either audio or transcript activity."""
+        already_confirmed = self._voice_barge_capture.is_set()
+        self._voice_barge_capture.set()
+        if already_confirmed:
+            return
+        stream = getattr(self, "_voice_stt_stream", None)
+        if stream is not None and stream.active:
+            self._voice_streaming_barge_confirmed()
+
+        if phase is None:
+            phase = (
+                "playback"
+                if self._voice_tts_is_playing()
+                else "generation"
+            )
+        self._voice_barge_phase = phase
+
+        if phase == "playback":
+            logger.debug("TTS CUT: voice barge confirmed during playback")
+            from tools.tts_streaming import mark_speech_interrupted
+            from tools.voice_mode import stop_playback
+
+            mark_speech_interrupted()
+            pipeline_stop = getattr(self, "_voice_tts_stop", None)
+            if pipeline_stop is not None:
+                pipeline_stop.set()
+            stop_playback()
+            return
+
+        logger.debug(
+            "Voice barge confirmed during generation — interrupting agent turn"
+        )
+        pipeline_stop = getattr(self, "_voice_tts_stop", None)
+        if pipeline_stop is not None:
+            pipeline_stop.set()
+        try:
+            if self.agent is not None and getattr(self, "_agent_running", False):
+                _cprint(f"\n{_DIM}🎤 Voice interjection — interrupting…{_RST}")
+                self.agent.interrupt()
+        except Exception as e:
+            logger.debug("voice interjection interrupt failed: %s", e)
 
     def _voice_full_duplex_listener(self) -> None:
         """Full-duplex agent-turn listener: mic live for the WHOLE turn.
@@ -12774,15 +13566,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         * generation (no TTS audio yet): speech interrupts the in-flight
           agent turn via ``self.agent.interrupt()`` — the same seam the
-          typed/Ctrl+C interrupt uses — and the captured utterance is
-          submitted as the next message.
+          typed/Ctrl+C interrupt uses.
         * playback: speech cuts TTS (pipeline stop event + stop_playback)
-          and the interruption is captured with pre-roll and submitted.
+          while microphone capture continues.
+
+        Streaming STT already has the interruption audio, so its buffered
+        finals are drained through the next provider endpoint. Batch-only
+        providers retain the existing pre-roll WAV transcription path.
 
         The stop phrase ends the voice chat in BOTH phases (a stop during
-        generation means "stop everything": the turn is already interrupted
-        at trip time, then ``_voice_submit_barge_utterance`` disables voice
-        mode).
+        generation means "stop everything": the turn is interrupted at trip
+        time and the committed transcript disables voice mode).
         """
         fd_active = getattr(self, "_voice_fd_active", None)
         if fd_active is None:
@@ -12791,16 +13585,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if fd_active.is_set():
             return  # one listener owns the mic for this turn
         fd_active.set()
+        frame_queue = None
+        frame_sink = None
         try:
             from hermes_cli.config import load_config
             voice_cfg = load_config().get("voice") or {}
             if not (isinstance(voice_cfg, dict) and voice_cfg.get("barge_in", True)):
                 return
             from tools.voice_mode import (
+                ContinuousAudioFrameQueue,
                 full_duplex_listen,
                 is_audio_output_active,
-                stop_playback,
             )
+
+            stream = getattr(self, "_voice_stt_stream", None)
+            recorder = self._voice_recorder
+            # AudioRecorder keeps its input stream open across turns for both
+            # batch and streaming STT. Reuse it so the barge listener never
+            # opens a competing microphone stream.
+            shared_stream = bool(
+                recorder is not None
+                and hasattr(recorder, "add_continuous_frame_sink")
+            )
+            if shared_stream:
+                frame_queue = ContinuousAudioFrameQueue()
+                frame_sink = frame_queue.enqueue
+                recorder.add_continuous_frame_sink(frame_sink)
 
             try:
                 _mult = float(voice_cfg.get("barge_in_threshold_multiplier", 0) or 0)
@@ -12826,34 +13636,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             def _on_trigger(phase: str) -> None:
                 # Latch BEFORE cutting anything: suppresses process_loop's
                 # auto-restart until the capture is submitted.
-                self._voice_barge_capture.set()
-                self._voice_barge_phase = phase
-                if phase == "playback":
-                    logger.debug(
-                        "TTS CUT: full-duplex listener tripped during playback"
-                    )
-                    from tools.tts_streaming import mark_speech_interrupted
-                    mark_speech_interrupted()
-                    _pipe_stop = getattr(self, "_voice_tts_stop", None)
-                    if _pipe_stop is not None:
-                        _pipe_stop.set()
-                    stop_playback()
-                else:
-                    # Generation phase: no audio to cut — interrupt the
-                    # in-flight agent turn (same seam as typed interrupt).
-                    logger.debug(
-                        "full-duplex listener tripped during generation — "
-                        "interrupting agent turn"
-                    )
-                    _pipe_stop = getattr(self, "_voice_tts_stop", None)
-                    if _pipe_stop is not None:
-                        _pipe_stop.set()  # never let the stale reply speak
-                    try:
-                        if self.agent is not None and getattr(self, "_agent_running", False):
-                            _cprint(f"\n{_DIM}🎤 Voice interjection — interrupting…{_RST}")
-                            self.agent.interrupt()
-                    except Exception as e:
-                        logger.debug("voice interjection interrupt failed: %s", e)
+                self._voice_handle_barge_trigger(phase)
 
             wav_path = full_duplex_listen(
                 _should_stop,
@@ -12861,15 +13644,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 on_trigger=_on_trigger,
                 multiplier=_mult or None,
                 grace_ms=max(0, _grace_ms),
+                frame_queue=frame_queue,
+                capture=lambda: not (stream is not None and stream.active),
+                on_candidate=(
+                    self._voice_streaming_barge_candidate
+                    if stream is not None and stream.active
+                    else None
+                ),
             )
             if wav_path and self._voice_barge_capture.is_set():
                 self._voice_submit_barge_utterance(wav_path)
+            elif (
+                stream is not None
+                and stream.active
+                and self._voice_barge_capture.is_set()
+            ):
+                # The provider already has the entire interruption. Its next
+                # final drains this barge together with earlier unsent finals.
+                pass
             else:
                 self._voice_barge_capture.clear()
         except Exception as e:
             self._voice_barge_capture.clear()
             logger.debug("Voice full-duplex listener failed: %s", e)
         finally:
+            if frame_queue is not None:
+                frame_queue.close()
+            if frame_sink is not None and self._voice_recorder is not None:
+                self._voice_recorder.remove_continuous_frame_sink(frame_sink)
             fd_active.clear()
 
     def _voice_submit_barge_utterance(self, wav_path: str) -> None:
@@ -12880,27 +13682,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             result = transcribe_recording(wav_path, model=self._voice_stt_model())
             transcript = (result.get("transcript") or "").strip() if result.get("success") else ""
             if transcript:
-                from tools.voice_mode import is_voice_stop_phrase
-                if is_voice_stop_phrase(transcript):
-                    _cprint(f"\n{_DIM}Stop phrase detected — ending voice chat.{_RST}")
-                    self._disable_voice_mode()
-                    return
-                # Fail-closed echo guard (#75780): a playback-phase capture
-                # has no acoustic echo cancellation, so speaker bleed alone
-                # can trip the barge trigger. If the transcript is a close
-                # match for what Hermes just spoke, treat it as self-capture
-                # instead of queuing it as a user turn.
-                if getattr(self, "_voice_barge_phase", None) == "playback":
-                    from tools.voice_mode import is_tts_echo
-                    if is_tts_echo(transcript, getattr(self, "_voice_last_tts_text", "")):
-                        logger.debug(
-                            "Dropping playback-phase barge transcript as TTS echo: %r",
-                            transcript,
-                        )
-                        _cprint(f"\n{_DIM}Ignored likely TTS echo (not queued).{_RST}")
-                        return
-                self._pending_input.put(_VoiceInputMessage(transcript))
-                submitted = True
+                submitted = self._voice_submit_transcript(
+                    transcript,
+                    barge_phase=getattr(self, "_voice_barge_phase", None),
+                )
             elif not result.get("success"):
                 _cprint(f"\n{_DIM}Transcription failed: {result.get('error', 'Unknown error')}{_RST}")
         except Exception as e:
@@ -13030,14 +13815,42 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _disable_voice_mode(self):
         """Disable voice mode, cancel any active recording, and stop TTS."""
         recorder = None
+        stt_stream = None
         with self._voice_lock:
-            if self._voice_recording and self._voice_recorder:
-                self._voice_recorder.cancel()
+            if self._voice_recording:
                 self._voice_recording = False
             recorder = self._voice_recorder
+            stt_stream = getattr(self, "_voice_stt_stream", None)
+            self._voice_stt_stream = None
             self._voice_mode = False
             self._voice_tts = False
             self._voice_continuous = False
+            self._voice_processing = False
+            self._voice_stream_pending_finals = []
+            self._voice_stream_drain_after = None
+            self._voice_stream_barge_candidate_after = None
+            self._voice_stream_seen_final_ids.clear()
+            endpoint_timer = getattr(
+                self,
+                "_voice_stream_endpoint_timer",
+                None,
+            )
+            self._voice_stream_endpoint_timer = None
+            self._voice_stream_endpoint_token = (
+                getattr(self, "_voice_stream_endpoint_token", 0) + 1
+            )
+            self._voice_stream_endpoint_segment_id = None
+            self._voice_stream_last_submitted_segment_id = None
+            self._voice_stream_partial_barge_segment_id = None
+            self._voice_stream_manual_commit = False
+            self._voice_stream_dispatch_pending = False
+            self._voice_stream_dispatch_barge = False
+
+        if endpoint_timer is not None:
+            endpoint_timer.cancel()
+        self._voice_detach_stream_sink()
+        if recorder is not None:
+            recorder.cancel()
 
         # Shut down the persistent audio stream in background
         if recorder is not None:
@@ -13048,6 +13861,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
             threading.Thread(target=_bg_shutdown, daemon=True).start()
             self._voice_recorder = None
+
+        if stt_stream is not None:
+            threading.Thread(target=stt_stream.close, daemon=True).start()
 
         # Stop any active TTS playback (file player + streaming pipeline)
         try:
@@ -13923,6 +14739,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         agent = self.agent
         if agent is None:
             return None
+        self._voice_apply_pending_streaming_barge(
+            agent,
+            voice_input=voice_input,
+        )
 
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters
@@ -14052,6 +14872,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # across intermediate turn boundaries (tool-calling loops) — only
             # reset at the start of each user turn.
             self._reasoning_shown_this_turn = False
+            release = getattr(self, "_voice_stream_barge_release", None)
+            if release is not None:
+                release.clear()
 
             # Full-duplex agent-turn listener (continuous voice mode): arm
             # the mic NOW — at utterance-submit — not when TTS playback
@@ -14410,7 +15233,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if use_streaming_tts and text_queue is not None:
                 text_queue.put(None)  # sentinel
                 if tts_thread is not None:
-                    tts_thread.join(timeout=120)
+                    self._voice_wait_for_streaming_tts(tts_thread, timeout=120)
                 # Mark normal completion only if the thread actually
                 # finished.  If join() timed out and the thread is still
                 # alive, leave _tts_normal_exit False so the finally block
@@ -14501,6 +15324,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         self.agent.clear_interrupt()
                 except Exception:
                     pass
+
+            # Recover prompt_toolkit before rendering the interrupted turn's
+            # response. ChatConsole routes background-thread output through
+            # run_in_terminal, so recovering afterward can replay the panel
+            # while its original print is still queued and show it twice.
+            if self._last_turn_interrupted:
+                self._recover_terminal_after_interrupt()
 
             response_previewed = result.get("response_previewed", False) if result else False
 
@@ -14700,7 +15530,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 logger.info("TTS CUT: exception finally block setting stop_event")
                 stop_event.set()
             if tts_thread is not None and tts_thread.is_alive():
-                tts_thread.join(timeout=5)
+                release = getattr(self, "_voice_stream_barge_release", None)
+                timeout = (
+                    0.2
+                    if release is not None and release.is_set()
+                    else 5
+                )
+                tts_thread.join(timeout=timeout)
+            release = getattr(self, "_voice_stream_barge_release", None)
+            if release is not None:
+                release.clear()
     
     def _clear_terminal_on_exit(self):
         """Clear screen + scrollback so nothing is stranded above the exit summary.
@@ -14984,7 +15823,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if self._agent_running:
             return _state_fragment("class:prompt-working", "⚕")
         if self._voice_mode:
-            return _state_fragment("class:voice-prompt", "🎤")
+            # Keep the editable prompt prefix single-cell. Emoji microphone
+            # width differs between prompt_toolkit's wcwidth table and some
+            # terminals, which shifts the physical cursor into the placeholder.
+            return _state_fragment("class:voice-prompt", "♪")
         return [("class:prompt", symbol)]
 
     def _get_tui_prompt_text(self) -> str:
@@ -15365,7 +16207,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_mode = False        # Whether voice mode is enabled
         self._voice_tts = False         # Whether TTS output is enabled
         self._voice_recorder = None     # AudioRecorder instance (lazy init)
+        self._voice_stt_stream = None   # Persistent streaming STT voice controller
         self._voice_recording = False   # Whether currently recording
+        self._voice_recording_generation = 0  # Revokes a blocked recording start
+        self._voice_capture_started_generation = 0
         self._voice_processing = False  # Whether STT is in progress
         self._voice_continuous = False  # Whether to auto-restart after agent responds
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
@@ -15374,6 +16219,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
         self._voice_last_tts_text = ""  # most recently spoken TTS text (echo guard, #75780)
         self._voice_barge_phase = None  # "generation" or "playback" phase of the last barge trip
+        self._voice_stream_barge_release = threading.Event()
+        self._voice_stream_audio_sink = None
+        self._voice_stream_pending_finals = []
+        self._voice_stream_final_sequence = 0
+        self._voice_stream_drain_after = None
+        self._voice_stream_barge_candidate_after = None
+        self._voice_stream_seen_final_ids = set()
+        self._voice_stream_endpoint_timer = None
+        self._voice_stream_endpoint_token = 0
+        self._voice_stream_endpoint_segment_id = None
+        self._voice_stream_last_submitted_segment_id = None
+        self._voice_stream_partial_barge_segment_id = None
+        self._voice_stream_manual_commit = False
+        self._voice_stream_dispatch_pending = False
+        self._voice_stream_dispatch_barge = False
 
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") != "1":
             self._install_tool_callbacks()
@@ -17673,17 +18533,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                         app.invalidate()  # Refresh status line
 
-                        # Post-turn terminal recovery (#33271): after an
-                        # interrupt the prompt_toolkit renderer may have
-                        # drifted from the physical terminal state — CSI 6n
-                        # cursor position reports can leak as literal text
-                        # (^[[19;1R), and the VT100 input parser can stall in
-                        # a partial-escape state, accepting no further
-                        # keystrokes.  Drain stray escape bytes from the OS
-                        # input buffer and force a clean renderer redraw.
-                        if self._last_turn_interrupted:
-                            self._recover_terminal_after_interrupt()
-
                         # Re-queue any messages that arrived in _interrupt_queue
                         # while the agent was running and were never claimed by
                         # the explicit interrupt path. See
@@ -17991,6 +18840,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     request_hard_interrupt(self.agent)
                 except Exception:
                     pass
+            # Stop provider forwarding before closing either side of the
+            # persistent microphone-to-STT pipeline.
+            self._voice_detach_stream_sink()
+            stt_stream = getattr(self, "_voice_stt_stream", None)
+            if stt_stream is not None:
+                try:
+                    stt_stream.close()
+                except Exception:
+                    pass
+                self._voice_stt_stream = None
             # Shut down voice recorder (release persistent audio stream)
             if hasattr(self, '_voice_recorder') and self._voice_recorder:
                 try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1583,7 +1583,10 @@ DEFAULT_CONFIG = {
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
+            "base_url": "",
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
+            "streaming": True,
+            "streaming_model_id": "gpt-4o-mini-transcribe",
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "mistral": {
@@ -1591,10 +1594,16 @@ DEFAULT_CONFIG = {
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "xai": {
+            "base_url": "",
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+            "diarize": False,
         },
         "elevenlabs": {
+            "base_url": "",
+            "wss_url": "",
             "model_id": "scribe_v2",  # scribe_v2, scribe_v1
+            "streaming": True,
+            "streaming_model_id": "scribe_v2_realtime",
             "language_code": "",  # auto-detect by default; set to "eng", "spa", "fra", etc. to force
             "tag_audio_events": False,
             "diarize": False,

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -57,6 +57,18 @@ class TestCliSkinPromptIntegration:
         assert frags[0][1].startswith("●")
         assert "❯" not in frags[0][1]
 
+    def test_idle_voice_prompt_uses_a_single_cell_icon(self):
+        from prompt_toolkit.formatted_text.utils import fragment_list_width
+
+        cli = _make_cli_stub()
+        cli._voice_mode = True
+
+        with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=80):
+            frags = cli._get_tui_prompt_fragments()
+
+        assert frags[0][0] == "class:voice-prompt"
+        assert fragment_list_width(frags) == len(frags[0][1])
+
 
 
     def test_apply_tui_skin_style_updates_running_app(self):

--- a/tests/cli/test_terminal_interrupt_recovery.py
+++ b/tests/cli/test_terminal_interrupt_recovery.py
@@ -7,8 +7,8 @@ down. The reply then leaks as literal text (``^[[19;1R``) and the VT100 parser
 can stall, accepting no further keystrokes — the terminal appears frozen.
 
 The recovery path lives in ``HermesCLI._recover_terminal_after_interrupt()``,
-which is invoked from ``process_loop``'s ``finally`` block only when
-``self._last_turn_interrupted`` is set. It must:
+which is invoked from ``chat()`` only when ``self._last_turn_interrupted`` is
+set. It must:
   1. Drain stray escape bytes from the OS input buffer (``flush_stdin``).
   2. Force a clean prompt_toolkit renderer redraw (``_force_full_redraw``).
 
@@ -84,16 +84,16 @@ class TestRecoverTerminalAfterInterrupt:
         flush_stdin()  # must not raise in a non-TTY test environment
 
 
-class TestFinallyBlockWiring:
-    """The recovery helper is only useful if process_loop actually calls it.
+class TestChatWiring:
+    """The recovery helper is only useful if chat actually calls it.
 
-    These guard against the helper silently becoming dead code (the fix being
-    present but never invoked), which a unit test of the helper alone can't
-    catch.
+    Recovery must run before the final response panel is queued. Otherwise
+    ``_replay_output_history`` can paint the interruption panel while its
+    original cross-thread ``run_in_terminal`` print is still pending.
     """
 
-    def test_recovery_is_invoked_behind_interrupt_guard(self):
-        src = inspect.getsource(HermesCLI.run)
+    def test_recovery_is_invoked_before_response_display(self):
+        src = inspect.getsource(HermesCLI.chat)
         # The recovery call must be gated on _last_turn_interrupted so it only
         # fires after an actual interrupt, not on every normal turn.
         guard = re.search(
@@ -102,10 +102,13 @@ class TestFinallyBlockWiring:
             src,
         )
         assert guard, (
-            "process_loop's finally block must call "
+            "chat() must call "
             "_recover_terminal_after_interrupt() guarded by "
             "self._last_turn_interrupted"
         )
+        assert src.index("self._recover_terminal_after_interrupt()") < src.index(
+            "if response and not response_previewed:"
+        ), "terminal recovery must precede final response rendering"
 
     def test_recovery_helper_exists(self):
         assert hasattr(HermesCLI, "_recover_terminal_after_interrupt")

--- a/tests/tools/test_stt_streaming.py
+++ b/tests/tools/test_stt_streaming.py
@@ -1,0 +1,992 @@
+"""Contract tests for provider-neutral streaming speech-to-text."""
+
+import asyncio
+import base64
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from tools.transcription_tools import (
+    _resolve_openai_audio_client_config,
+    resolve_stt_provider_config,
+)
+from tools.stt_streaming import (
+    ElevenLabsStreamingSTTProvider,
+    ElevenLabsStreamingSTTSession,
+    OpenAIStreamingSTTProvider,
+    OpenAIStreamingSTTSession,
+    StreamingSTTCoordinator,
+    StreamingSTTProvider,
+    StreamingSTTSession,
+    StreamingSTTTurnController,
+    StreamingTranscriptEvent,
+    _PCM16StreamResampler,
+    resolve_streaming_stt_provider,
+)
+
+
+class _FakeWebSocket:
+    def __init__(self, incoming=None):
+        self.incoming = asyncio.Queue()
+        for message in incoming or []:
+            self.incoming.put_nowait(json.dumps(message))
+        self.sent = []
+        self.closed = False
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def recv(self):
+        return await self.incoming.get()
+
+    async def close(self):
+        self.closed = True
+
+
+def _event(value):
+    if isinstance(value, dict):
+        return SimpleNamespace(**{key: _event(item) for key, item in value.items()})
+    return value
+
+
+class _FakeOpenAIConnection:
+    def __init__(self, incoming=None):
+        self.incoming = asyncio.Queue()
+        for event in incoming or []:
+            self.incoming.put_nowait(_event(event))
+        self.input_audio_buffer = SimpleNamespace(
+            append=AsyncMock(),
+            commit=AsyncMock(),
+        )
+        self.session = SimpleNamespace(update=AsyncMock())
+        self.close = AsyncMock()
+
+    async def recv(self):
+        return await self.incoming.get()
+
+
+class _FakeOpenAIClient:
+    def __init__(self, connection):
+        manager = SimpleNamespace(enter=AsyncMock(return_value=connection))
+        self.realtime = SimpleNamespace(connect=MagicMock(return_value=manager))
+        self.close = AsyncMock()
+
+
+@pytest.fixture
+def provider_wire_events():
+    """Sanitized provider events validated against the live APIs."""
+    return {
+        "openai": [
+            {"type": "session.updated"},
+            {
+                "type": "conversation.item.input_audio_transcription.delta",
+                "delta": "Hermes streaming",
+                "event_id": "evt-openai-delta",
+                "item_id": "item-openai",
+            },
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "transcript": "Hermes streaming speech test alpha seven.",
+                "event_id": "evt-openai-completed",
+                "item_id": "item-openai",
+            },
+        ],
+        "elevenlabs": [
+            {"message_type": "session_started", "session_id": "session-elevenlabs"},
+            {"message_type": "partial_transcript", "text": "Hermes streaming"},
+            {
+                "message_type": "committed_transcript",
+                "text": "Hermes streaming speech test alpha seven.",
+            },
+        ],
+    }
+
+
+class TestProviderResolution:
+    @pytest.mark.parametrize(
+        "provider_name",
+        ["local", "groq", "mistral", "xai", "plugin-provider"],
+    )
+    def test_unsupported_providers_stay_batch(self, provider_name):
+        assert (
+            resolve_streaming_stt_provider({
+                "provider": provider_name,
+            })
+            is None
+        )
+
+    def test_xai_stays_batch_when_credentialed(self):
+        assert (
+            resolve_streaming_stt_provider({
+                "provider": "xai",
+                "xai": {"api_key": "configured-xai-key"},
+            })
+            is None
+        )
+
+    def test_disabled_streaming_stays_batch(self):
+        assert (
+            resolve_streaming_stt_provider({
+                "provider": "openai",
+                "openai": {"streaming": False},
+            })
+            is None
+        )
+
+    def test_master_stt_switch_disables_streaming(self):
+        assert (
+            resolve_streaming_stt_provider({
+                "enabled": False,
+                "provider": "openai",
+                "openai": {
+                    "api_key": "key",
+                    "streaming_model_id": "configured-model",
+                },
+            })
+            is None
+        )
+
+    def test_switching_to_unsupported_provider_disables_streaming(self):
+        openai_config = {
+            "provider": "openai",
+            "openai": {
+                "api_key": "key",
+                "streaming_model_id": "configured-model",
+            },
+        }
+        local_config = {**openai_config, "provider": "local"}
+
+        assert isinstance(
+            resolve_streaming_stt_provider(openai_config),
+            OpenAIStreamingSTTProvider,
+        )
+        assert resolve_streaming_stt_provider(local_config) is None
+
+    def test_openai_batch_and_streaming_share_resolved_connection(self):
+        config = {
+            "provider": "openai",
+            "openai": {
+                "api_key": "shared-key",
+                "base_url": "https://compatible.example/v1",
+                "model": "batch-model",
+                "streaming_model_id": "streaming-model",
+            },
+        }
+
+        resolved = resolve_stt_provider_config("openai", config)
+        streaming = resolve_streaming_stt_provider(config)
+        with patch("tools.transcription_tools._load_stt_config", return_value=config):
+            batch_key, batch_url = _resolve_openai_audio_client_config()
+
+        assert resolved is not None
+        assert isinstance(streaming, OpenAIStreamingSTTProvider)
+        assert (batch_key, batch_url) == (resolved.api_key, resolved.base_url)
+        assert (streaming.api_key, streaming.base_url) == (
+            resolved.api_key,
+            resolved.base_url,
+        )
+
+    def test_openai_requires_direct_profile_scoped_key(self):
+        config = {
+            "provider": "openai",
+            "openai": {"streaming_model_id": "gpt-4o-mini-transcribe"},
+        }
+        with patch("tools.transcription_tools.resolve_openai_audio_api_key", return_value=""):
+            assert resolve_streaming_stt_provider(config) is None
+        with patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value="profile-key",
+        ):
+            provider = resolve_streaming_stt_provider(config)
+        assert isinstance(provider, OpenAIStreamingSTTProvider)
+        assert provider.api_key == "profile-key"
+
+    @pytest.mark.parametrize(
+        "config, env_url",
+        [
+            (
+                {
+                    "provider": "openai",
+                    "openai": {"base_url": "https://compatible.example/v1"},
+                },
+                "",
+            ),
+            (
+                {"provider": "openai"},
+                "https://compatible.example/v1",
+            ),
+        ],
+    )
+    def test_custom_openai_endpoint_is_passed_to_realtime_client(self, config, env_url):
+        config.setdefault("openai", {})["streaming_model_id"] = "configured-model"
+        with (
+            patch(
+                "tools.transcription_tools.get_env_value",
+                return_value=env_url,
+            ),
+            patch(
+                "tools.transcription_tools.resolve_openai_audio_api_key",
+                return_value="key",
+            ),
+        ):
+            provider = resolve_streaming_stt_provider(config)
+        assert isinstance(provider, OpenAIStreamingSTTProvider)
+        assert provider.base_url == "https://compatible.example/v1"
+        assert provider.model == "configured-model"
+
+    def test_openai_accepts_profile_config_key_for_official_realtime(self):
+        with patch("tools.transcription_tools.get_env_value", return_value=""):
+            provider = resolve_streaming_stt_provider({
+                "provider": "openai",
+                "openai": {
+                    "api_key": "profile-config-key",
+                    "streaming_model_id": "configured-model",
+                },
+            })
+        assert isinstance(provider, OpenAIStreamingSTTProvider)
+        assert provider.api_key == "profile-config-key"
+
+    def test_elevenlabs_uses_config_key_and_custom_endpoint(self):
+        config = {
+            "provider": "elevenlabs",
+            "elevenlabs": {
+                "api_key": "config-key",
+                "base_url": "https://compatible.example/v1",
+                "streaming_model_id": "configured-model",
+            },
+        }
+        provider = resolve_streaming_stt_provider(config)
+        assert isinstance(provider, ElevenLabsStreamingSTTProvider)
+        assert provider.api_key == "config-key"
+        assert provider.base_url == "https://compatible.example/v1"
+
+    def test_provider_language_uses_shared_stt_precedence(self):
+        openai_config = {
+            "provider": "openai",
+            "language": "fr",
+            "openai": {
+                "language": "",
+                "streaming_model_id": "configured-model",
+            },
+        }
+        with patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key", return_value="key"
+        ):
+            openai = resolve_streaming_stt_provider(openai_config)
+
+        elevenlabs_config = {
+            "provider": "elevenlabs",
+            "language": "fr",
+            "elevenlabs": {
+                "language_code": "eng",
+                "streaming_model_id": "configured-model",
+            },
+        }
+        with patch(
+            "tools.transcription_tools._resolve_provider_key", return_value="key"
+        ):
+            elevenlabs = resolve_streaming_stt_provider(elevenlabs_config)
+
+        assert openai.language == "fr"
+        assert elevenlabs.language == "eng"
+
+    def test_real_profile_config_selects_streaming_provider(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "profile"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "stt:\n"
+            "  provider: openai\n"
+            "  openai:\n"
+            "    streaming_model_id: gpt-4o-mini-transcribe\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        with patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value="profile-key",
+        ):
+            provider = resolve_streaming_stt_provider()
+        assert isinstance(provider, OpenAIStreamingSTTProvider)
+
+    @pytest.mark.parametrize(
+        "provider_name,key_name,key_value,provider_type",
+        [
+            (
+                "openai",
+                "VOICE_TOOLS_OPENAI_KEY",
+                "profile-openai-key",
+                OpenAIStreamingSTTProvider,
+            ),
+            (
+                "elevenlabs",
+                "ELEVENLABS_API_KEY",
+                "profile-elevenlabs-key",
+                ElevenLabsStreamingSTTProvider,
+            ),
+        ],
+    )
+    def test_profile_dotenv_selects_each_supported_provider(
+        self,
+        tmp_path,
+        monkeypatch,
+        provider_name,
+        key_name,
+        key_value,
+        provider_type,
+    ):
+        hermes_home = tmp_path / provider_name
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            f"stt:\n  provider: {provider_name}\n",
+            encoding="utf-8",
+        )
+        (hermes_home / ".env").write_text(
+            f"{key_name}={key_value}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        provider = resolve_streaming_stt_provider()
+
+        assert isinstance(provider, provider_type)
+        assert provider.api_key == key_value
+
+
+class TestProviderProtocols:
+    def test_openai_configures_transcription_only_semantic_vad(
+        self, provider_wire_events
+    ):
+        async def _test():
+            connection = _FakeOpenAIConnection(provider_wire_events["openai"][:1])
+            client = _FakeOpenAIClient(connection)
+            provider = OpenAIStreamingSTTProvider(
+                "key",
+                "https://openai-compatible.example/v1",
+                "configured-model",
+                "en",
+            )
+            with patch("openai.AsyncOpenAI", return_value=client) as openai_client:
+                session = await provider.open_session()
+            openai_client.assert_called_once_with(
+                api_key="key",
+                base_url="https://openai-compatible.example/v1",
+            )
+            client.realtime.connect.assert_called_once_with(
+                extra_query={"intent": "transcription"},
+            )
+            update = connection.session.update.await_args.kwargs["session"]
+            assert update["type"] == "transcription"
+            audio = update["audio"]["input"]
+            assert audio["format"] == {"type": "audio/pcm", "rate": 24000}
+            assert audio["turn_detection"] == {
+                "type": "semantic_vad",
+                "eagerness": "auto",
+            }
+            assert audio["transcription"]["model"] == "configured-model"
+            assert audio["transcription"]["language"] == "en"
+            assert isinstance(session, OpenAIStreamingSTTSession)
+
+        asyncio.run(_test())
+
+    def test_openai_normalizes_delta_and_completed_events(self, provider_wire_events):
+        async def _test():
+            connection = _FakeOpenAIConnection(provider_wire_events["openai"][1:])
+            client = _FakeOpenAIClient(connection)
+            session = OpenAIStreamingSTTSession(client, connection)
+            partial = await session.receive_event()
+            final = await session.receive_event()
+            assert partial == StreamingTranscriptEvent(
+                "Hermes streaming",
+                False,
+                "evt-openai-delta",
+                "item-openai",
+            )
+            assert final == StreamingTranscriptEvent(
+                "Hermes streaming speech test alpha seven.",
+                True,
+                "evt-openai-completed",
+                "item-openai",
+            )
+
+        asyncio.run(_test())
+
+    def test_openai_transcription_failure_is_terminal(self):
+        async def _test():
+            connection = _FakeOpenAIConnection([
+                {
+                    "type": "conversation.item.input_audio_transcription.failed",
+                    "event_id": "evt-failed",
+                    "item_id": "item-failed",
+                    "error": {"message": "audio could not be transcribed"},
+                }
+            ])
+            session = OpenAIStreamingSTTSession(
+                _FakeOpenAIClient(connection),
+                connection,
+            )
+            with pytest.raises(RuntimeError, match="could not be transcribed"):
+                await session.receive_event()
+
+        asyncio.run(_test())
+
+    def test_openai_empty_manual_commit_error_keeps_final_in_flight(self):
+        async def _test():
+            connection = _FakeOpenAIConnection([
+                {
+                    "type": "error",
+                    "error": {
+                        "message": (
+                            "Error committing input audio buffer: buffer too small. "
+                            "Expected at least 100ms of audio, but buffer only has "
+                            "0.00ms of audio."
+                        )
+                    },
+                },
+                {
+                    "type": (
+                        "conversation.item.input_audio_transcription.completed"
+                    ),
+                    "event_id": "evt-final",
+                    "item_id": "item-final",
+                    "transcript": "already committed by semantic VAD",
+                },
+            ])
+            session = OpenAIStreamingSTTSession(
+                _FakeOpenAIClient(connection),
+                connection,
+            )
+
+            assert await session.receive_event() is None
+            assert await session.receive_event() == StreamingTranscriptEvent(
+                "already committed by semantic VAD",
+                True,
+                "evt-final",
+                "item-final",
+            )
+
+        asyncio.run(_test())
+
+    def test_openai_uses_sdk_audio_buffer_and_closes_client(self):
+        async def _test():
+            connection = _FakeOpenAIConnection()
+            client = _FakeOpenAIClient(connection)
+            session = OpenAIStreamingSTTSession(client, connection)
+            await session.send_audio(b"\x01\x02\x03\x04")
+            await session.commit()
+            await session.close()
+            connection.input_audio_buffer.append.assert_awaited_once_with(
+                audio=base64.b64encode(b"\x01\x02\x03\x04").decode("ascii")
+            )
+            connection.input_audio_buffer.commit.assert_awaited_once_with()
+            connection.close.assert_awaited_once_with()
+            client.close.assert_awaited_once_with()
+
+        asyncio.run(_test())
+
+    def test_elevenlabs_marks_commits_for_vad_silence_confirmation(
+        self, provider_wire_events
+    ):
+        async def _test():
+            websocket = _FakeWebSocket(provider_wire_events["elevenlabs"])
+            provider = ElevenLabsStreamingSTTProvider(
+                "key",
+                "https://elevenlabs-compatible.example/v1",
+                {
+                    "streaming_model_id": "configured-model",
+                    "vad_threshold": 0.4,
+                    "vad_silence_threshold_secs": 1.5,
+                },
+                "eng",
+            )
+            with patch(
+                "tools.stt_streaming._connect", AsyncMock(return_value=websocket)
+            ) as connect:
+                session = await provider.open_session()
+            url = urlsplit(connect.await_args.args[0])
+            assert url.scheme == "wss"
+            assert url.netloc == "elevenlabs-compatible.example"
+            assert url.path == "/v1/speech-to-text/realtime"
+            assert parse_qs(url.query) == {
+                "model_id": ["configured-model"],
+                "audio_format": ["pcm_16000"],
+                "commit_strategy": ["vad"],
+                "language_code": ["eng"],
+                "vad_threshold": ["0.4"],
+                "vad_silence_threshold_secs": ["1.5"],
+            }
+            assert connect.await_args.args[1] == {"xi-api-key": "key"}
+            assert await session.receive_event() == StreamingTranscriptEvent(
+                "Hermes streaming", False, None, "elevenlabs-0"
+            )
+            assert await session.receive_event() == StreamingTranscriptEvent(
+                "Hermes streaming speech test alpha seven.",
+                True,
+                "elevenlabs-0",
+                "elevenlabs-0",
+            )
+
+        asyncio.run(_test())
+
+    @pytest.mark.parametrize(
+        "message_type",
+        [
+            "auth_error",
+            "chunk_size_exceeded",
+            "commit_throttled",
+            "input_error",
+            "insufficient_audio_activity",
+            "resource_exhausted",
+            "session_time_limit_exceeded",
+            "transcriber_error",
+            "unaccepted_terms",
+        ],
+    )
+    def test_elevenlabs_documented_terminal_events_raise(self, message_type):
+        async def _test():
+            session = ElevenLabsStreamingSTTSession(
+                _FakeWebSocket([
+                    {"message_type": message_type, "error": "terminal failure"}
+                ])
+            )
+            with pytest.raises(RuntimeError, match="terminal failure"):
+                await session.receive_event()
+
+        asyncio.run(_test())
+
+    @pytest.mark.parametrize(
+        "session_type,sample_rate",
+        [
+            (ElevenLabsStreamingSTTSession, 16000),
+        ],
+    )
+    def test_json_audio_sessions_send_base64_pcm(self, session_type, sample_rate):
+        async def _test():
+            websocket = _FakeWebSocket()
+            session = session_type(websocket)
+            assert session.sample_rate == sample_rate
+            await session.send_audio(b"\x01\x02\x03\x04")
+            message = json.loads(websocket.sent[0])
+            assert (
+                base64.b64decode(message.get("audio") or message.get("audio_base_64"))
+                == b"\x01\x02\x03\x04"
+            )
+
+        asyncio.run(_test())
+
+    def test_manual_commits_do_not_close_persistent_sessions(self):
+        async def _test():
+            openai_connection = _FakeOpenAIConnection()
+            openai_client = _FakeOpenAIClient(openai_connection)
+            elevenlabs_socket = _FakeWebSocket()
+            await OpenAIStreamingSTTSession(openai_client, openai_connection).commit()
+            await ElevenLabsStreamingSTTSession(elevenlabs_socket).commit()
+            openai_connection.input_audio_buffer.commit.assert_awaited_once_with()
+            elevenlabs_commit = json.loads(elevenlabs_socket.sent[0])
+            assert elevenlabs_commit["message_type"] == "input_audio_chunk"
+            assert elevenlabs_commit["commit"] is True
+            assert base64.b64decode(elevenlabs_commit["audio_base_64"]) == b"\0" * 640
+            openai_connection.close.assert_not_awaited()
+            openai_client.close.assert_not_awaited()
+            assert not elevenlabs_socket.closed
+
+        asyncio.run(_test())
+
+class _CoordinatorSession(StreamingSTTSession):
+    sample_rate = 16000
+
+    def __init__(self):
+        self.events = asyncio.Queue()
+        self.audio = []
+        self.operations = []
+        self.commits = 0
+        self.closes = 0
+
+    async def send_audio(self, pcm16):
+        self.audio.append(pcm16)
+        self.operations.append("audio")
+
+    async def commit(self):
+        self.commits += 1
+        self.operations.append("commit")
+
+    async def receive_event(self):
+        event = await self.events.get()
+        if isinstance(event, Exception):
+            raise event
+        return event
+
+    async def close(self):
+        self.closes += 1
+
+
+class _CoordinatorProvider(StreamingSTTProvider):
+    name = "fake"
+
+    def __init__(self):
+        self.sessions = []
+
+    async def open_session(self):
+        session = _CoordinatorSession()
+        self.sessions.append(session)
+        return session
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class TestStreamingSTTCoordinator:
+    def test_one_session_serves_two_turns_and_delivers_partials(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        finals = []
+        errors = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: finals.append((generation, event.text)),
+            lambda generation, error: errors.append((generation, error)),
+        )
+        assert coordinator.start_utterance(1)
+        session = provider.sessions[0]
+        coordinator.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: bool(session.audio))
+        session.events.put_nowait(StreamingTranscriptEvent("hel", False))
+        assert _wait_until(lambda: finals == [(1, "hel")])
+        session.events.put_nowait(StreamingTranscriptEvent("hello", True))
+        assert _wait_until(lambda: finals[-1] == (1, "hello"))
+
+        assert coordinator.start_utterance(2)
+        assert len(provider.sessions) == 1
+        session.events.put_nowait(StreamingTranscriptEvent("stale", True))
+        time.sleep(0.05)
+        assert finals == [(1, "hel"), (1, "hello")]
+        coordinator.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: len(session.audio) >= 2)
+        session.events.put_nowait(StreamingTranscriptEvent("again", True))
+        assert _wait_until(lambda: finals[-1] == (2, "again"))
+        coordinator.close()
+        assert session.closes == 1
+        assert errors == []
+
+    def test_empty_committed_final_ends_turn(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        finals = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: finals.append((generation, event.text)),
+            lambda generation, error: None,
+        )
+        assert coordinator.start_utterance(3)
+        session = provider.sessions[0]
+        assert coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        )
+        assert _wait_until(lambda: bool(session.audio))
+        session.events.put_nowait(StreamingTranscriptEvent("", True))
+        assert _wait_until(lambda: finals == [(3, "")])
+        coordinator.close()
+
+    def test_abandoned_turn_resets_session_before_next_turn(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        finals = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: finals.append((generation, event.text)),
+            lambda generation, error: None,
+        )
+        assert coordinator.start_utterance(4)
+        first_session = provider.sessions[0]
+        assert coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        )
+        assert _wait_until(lambda: bool(first_session.audio))
+
+        coordinator.pause(4)
+        assert coordinator.start_utterance(5)
+        assert len(provider.sessions) == 2
+        second_session = provider.sessions[1]
+        first_session.events.put_nowait(StreamingTranscriptEvent("late", True))
+        assert coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        )
+        assert _wait_until(lambda: bool(second_session.audio))
+        second_session.events.put_nowait(StreamingTranscriptEvent("current", True))
+        assert _wait_until(lambda: finals == [(5, "current")])
+        coordinator.close()
+
+    def test_audio_buffer_overflow_reports_once_without_blocking(self):
+        provider = _CoordinatorProvider()
+        errors = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: None,
+            lambda generation, error: errors.append((generation, str(error))),
+        )
+        assert coordinator.start_utterance(7)
+        oversized_frame = [0] * (16000 * 2 + 1)
+        started = time.monotonic()
+        assert coordinator.enqueue_audio(oversized_frame, 16000) is False
+        assert time.monotonic() - started < 0.1
+        assert _wait_until(lambda: len(errors) == 1)
+        assert "overflow" in errors[0][1]
+        assert coordinator.start_utterance(8)
+        assert len(provider.sessions) == 2
+        coordinator.close()
+
+    def test_commit_flushes_already_queued_audio_first(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: None,
+            lambda generation, error: None,
+        )
+        assert coordinator.start_utterance(9)
+        session = provider.sessions[0]
+        coordinator.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert coordinator.commit(9)
+        assert coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        ) is False
+        assert _wait_until(lambda: session.commits == 1)
+        assert session.operations[-1] == "commit"
+        assert "audio" in session.operations[:-1]
+        coordinator.close()
+
+    def test_disconnect_falls_back_current_turn_and_reconnects_next_turn(self):
+        provider = _CoordinatorProvider()
+        errors = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: None,
+            lambda generation, error: errors.append(generation),
+        )
+        assert coordinator.start_utterance(11)
+        provider.sessions[0].events.put_nowait(RuntimeError("expired"))
+        assert _wait_until(lambda: errors == [11])
+        assert coordinator.start_utterance(12)
+        assert len(provider.sessions) == 2
+        coordinator.close()
+
+    def test_aged_session_recycles_between_turns(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        provider.session_recycle_seconds = 0.01
+        finals = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: finals.append((generation, event.text)),
+            lambda generation, error: None,
+        )
+        assert coordinator.start_utterance(13)
+        first_session = provider.sessions[0]
+        coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        )
+        assert _wait_until(lambda: bool(first_session.audio))
+        first_session.events.put_nowait(StreamingTranscriptEvent("first", True))
+        assert _wait_until(lambda: finals == [(13, "first")])
+
+        with coordinator._lock:
+            coordinator._session_opened_at = time.monotonic() - 1.0
+        assert coordinator.start_utterance(14)
+        assert len(provider.sessions) == 2
+        coordinator.close()
+
+    def test_queued_final_wins_when_provider_closes_after_commit(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        finals = []
+        errors = []
+        coordinator = StreamingSTTCoordinator(
+            provider,
+            lambda generation, event: finals.append((generation, event.text)),
+            lambda generation, error: errors.append(generation),
+        )
+        assert coordinator.start_utterance(15)
+        session = provider.sessions[0]
+        coordinator.enqueue_audio(
+            np.ones((480, 1), dtype=np.int16),
+            48000,
+        )
+        assert _wait_until(lambda: bool(session.audio))
+        session.events.put_nowait(StreamingTranscriptEvent("complete", True))
+        session.events.put_nowait(RuntimeError("closed after final"))
+
+        assert _wait_until(lambda: finals == [(15, "complete")])
+        assert errors == []
+        coordinator.close()
+
+    def test_stateful_resampler_preserves_duration_across_chunks(self):
+        np = pytest.importorskip("numpy")
+        resampler = _PCM16StreamResampler(48000, 16000)
+        first = resampler.convert(np.arange(480, dtype=np.int16))
+        second = resampler.convert(np.arange(480, 960, dtype=np.int16))
+        samples = len(first + second) // 2
+        assert 318 <= samples <= 321
+
+
+class TestStreamingSTTTurnController:
+    def test_two_turns_reuse_session_without_exposing_generation(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        finals = []
+        errors = []
+        controller = StreamingSTTTurnController(
+            provider,
+            lambda event: finals.append(event.text),
+            lambda error: errors.append(str(error)),
+        )
+
+        assert controller.provider_name == "fake"
+        assert controller.start_utterance()
+        session = provider.sessions[0]
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: bool(session.audio))
+        session.events.put_nowait(StreamingTranscriptEvent("first", True))
+        assert _wait_until(lambda: finals == ["first"])
+        assert controller.active is False
+
+        assert controller.start_utterance()
+        assert len(provider.sessions) == 1
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: len(session.audio) == 2)
+        session.events.put_nowait(StreamingTranscriptEvent("second", True))
+        assert _wait_until(lambda: finals == ["first", "second"])
+        controller.close()
+
+        assert errors == []
+        assert session.closes == 1
+
+    def test_commit_timeout_fails_active_turn_once(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        errors = []
+        controller = StreamingSTTTurnController(
+            provider,
+            lambda event: None,
+            lambda error: errors.append(str(error)),
+            commit_timeout=0.02,
+        )
+
+        assert controller.start_utterance()
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert controller.commit()
+        assert _wait_until(lambda: len(errors) == 1)
+        assert "timed out" in errors[0]
+        assert controller.active is False
+        controller.close()
+
+    def test_pause_revokes_a_blocked_session_start(self):
+        provider = _CoordinatorProvider()
+        entered = threading.Event()
+        release = threading.Event()
+        original_open = provider.open_session
+
+        async def _blocked_open():
+            entered.set()
+            await asyncio.get_running_loop().run_in_executor(None, release.wait)
+            return await original_open()
+
+        provider.open_session = _blocked_open
+        controller = StreamingSTTTurnController(
+            provider,
+            lambda event: None,
+            lambda error: None,
+        )
+        result = []
+        starter = threading.Thread(
+            target=lambda: result.append(controller.start_utterance(timeout=1.0))
+        )
+        starter.start()
+        assert entered.wait(1.0)
+        controller.pause()
+        release.set()
+        starter.join(1.0)
+
+        assert result == [False]
+        assert controller.active is False
+        controller.close()
+
+
+class TestContinuousStreamingSTTTurnController:
+    def test_audio_and_events_continue_across_provider_finals(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        events = []
+        errors = []
+        controller = StreamingSTTTurnController(
+            provider,
+            lambda event: events.append((event.text, event.is_final)),
+            lambda error: errors.append(str(error)),
+            continuous=True,
+        )
+
+        assert controller.start_utterance()
+        session = provider.sessions[0]
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: len(session.audio) == 1)
+        session.events.put_nowait(StreamingTranscriptEvent("first par", False))
+        session.events.put_nowait(StreamingTranscriptEvent("first", True))
+        assert _wait_until(
+            lambda: events == [("first par", False), ("first", True)]
+        )
+
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert _wait_until(lambda: len(session.audio) == 2)
+        session.events.put_nowait(StreamingTranscriptEvent("second", True))
+        assert _wait_until(lambda: events[-1] == ("second", True))
+
+        assert controller.active is True
+        assert len(provider.sessions) == 1
+        controller.close()
+        assert errors == []
+        assert session.closes == 1
+
+    def test_manual_commit_preserves_continuous_audio_order(self):
+        np = pytest.importorskip("numpy")
+        provider = _CoordinatorProvider()
+        events = []
+        controller = StreamingSTTTurnController(
+            provider,
+            events.append,
+            lambda error: None,
+            continuous=True,
+        )
+
+        assert controller.start_utterance()
+        session = provider.sessions[0]
+        controller.enqueue_audio(np.ones((480, 1), dtype=np.int16), 48000)
+        assert controller.commit()
+        controller.enqueue_audio(np.full((480, 1), 2, dtype=np.int16), 48000)
+
+        assert _wait_until(lambda: len(session.operations) >= 3)
+        assert session.operations[:3] == ["audio", "commit", "audio"]
+        session.events.put_nowait(
+            StreamingTranscriptEvent("still speaking", False, None, "segment-1")
+        )
+        assert _wait_until(lambda: len(events) == 1)
+        assert controller.commit_pending
+        session.events.put_nowait(StreamingTranscriptEvent("done", True))
+        assert _wait_until(lambda: len(events) == 2)
+        assert not controller.commit_pending
+        controller.close()

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -230,12 +230,61 @@ def test_stream_cap_truncates_runaway_upstream(monkeypatch):
 # ── Dispatch: chunked streamer path (regression tests) ───────────────────
 
 
-# The 12 speaker-path tests below assert on the sounddevice OutputStream
+# The 13 speaker-path tests below assert on the sounddevice OutputStream
 # branch, which stream_tts_to_speaker takes on every host EXCEPT macOS —
 # Darwin routes to the tempfile/afplay path by design. They used to fake
 # platform.system() == "Linux" (a no-op on the Linux CI lane) purely to
 # shield macOS dev machines; an honest exclusion skipif says the same
 # thing without lying to the interpreter.
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS deliberately skips the sounddevice OutputStream path (PR #62601)",
+)
+def test_streamer_waiting_for_first_chunk_is_not_reported_as_playback(monkeypatch):
+    """A ready output worker is not playback until PCM actually arrives."""
+    from tools import tts_tool
+    from tools import voice_mode
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _BlockingProvider(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            entered.set()
+            assert release.wait(2.0)
+            yield b"\x01\x00" * 50
+
+    sd, _out = _sd_mock()
+    stop, done = threading.Event(), threading.Event()
+    worker = threading.Thread(
+        target=tts_tool.stream_tts_to_speaker,
+        args=(_drain_queue(["A delayed sentence for testing."]), stop, done),
+    )
+
+    with (
+        patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=_BlockingProvider({}, {}),
+        ),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+    ):
+        worker.start()
+        assert entered.wait(2.0)
+        assert voice_mode.is_audio_output_active() is False
+        release.set()
+        worker.join(3.0)
+
+    assert not worker.is_alive()
+    assert done.is_set()
+    assert voice_mode.is_audio_output_active() is False
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="macOS deliberately skips the sounddevice OutputStream path (PR #62601)",

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -24,7 +24,10 @@ def _make_voice_cli(**overrides):
     cli._voice_mode = False
     cli._voice_tts = False
     cli._voice_recorder = None
+    cli._voice_stt_stream = None
     cli._voice_recording = False
+    cli._voice_recording_generation = 0
+    cli._voice_capture_started_generation = 0
     cli._voice_processing = False
     cli._voice_continuous = False
     cli._voice_tts_done = threading.Event()
@@ -33,6 +36,21 @@ def _make_voice_cli(**overrides):
     cli._voice_barge_capture = threading.Event()
     cli._voice_last_tts_text = ""
     cli._voice_barge_phase = None
+    cli._voice_stream_barge_release = threading.Event()
+    cli._voice_stream_audio_sink = None
+    cli._voice_stream_pending_finals = []
+    cli._voice_stream_final_sequence = 0
+    cli._voice_stream_drain_after = None
+    cli._voice_stream_barge_candidate_after = None
+    cli._voice_stream_seen_final_ids = set()
+    cli._voice_stream_endpoint_timer = None
+    cli._voice_stream_endpoint_token = 0
+    cli._voice_stream_endpoint_segment_id = None
+    cli._voice_stream_last_submitted_segment_id = None
+    cli._voice_stream_partial_barge_segment_id = None
+    cli._voice_stream_manual_commit = False
+    cli._voice_stream_dispatch_pending = False
+    cli._voice_stream_dispatch_barge = False
     cli._pending_input = queue.Queue()
     cli._app = None
     cli._attached_images = []
@@ -40,6 +58,13 @@ def _make_voice_cli(**overrides):
     for k, v in overrides.items():
         setattr(cli, k, v)
     return cli
+
+
+def _expire_streaming_endpoint(cli):
+    timer = cli._voice_stream_endpoint_timer
+    assert timer is not None
+    timer.cancel()
+    timer.function()
 
 
 # ============================================================================
@@ -182,6 +207,43 @@ class TestVoiceBeepConfigReal:
 
         recorder.start.assert_called_once()
         mock_beep.assert_not_called()
+
+    def test_start_cue_follows_input_preparation(self):
+        order = []
+        recorder = MagicMock()
+        recorder.supports_silence_autostop = True
+        recorder.prepare.side_effect = lambda: order.append("prepare")
+        recorder.start.side_effect = lambda **_kwargs: (
+            order.append("start") or True
+        )
+
+        cli = _make_voice_cli(_voice_recorder=recorder)
+        cli._voice_get_streaming_stt = MagicMock(return_value=None)
+
+        with (
+            patch("cli._cprint"),
+            patch(
+                "tools.voice_mode.check_voice_requirements",
+                return_value={
+                    "available": True,
+                    "audio_available": True,
+                    "stt_available": True,
+                    "details": "OK",
+                    "missing_packages": [],
+                },
+            ),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"voice": {"beep_enabled": True}},
+            ),
+            patch(
+                "tools.voice_mode.play_beep",
+                side_effect=lambda **_kwargs: order.append("beep"),
+            ),
+        ):
+            cli._voice_start_recording()
+
+        assert order == ["prepare", "beep", "start"]
 
 
 class TestMaxRecordingSecondsConfigReal:
@@ -373,6 +435,987 @@ class TestVoiceStopAndTranscribeReal:
         assert any("Transcribing..." in message for message in messages)
         assert all("Hugging Face" not in message for message in messages)
         mock_transcribe.assert_called_once_with("/tmp/test.wav", model="whisper-1")
+
+
+class TestStreamingVoiceInputReal:
+    """Classic CLI streaming STT reuses the established voice lifecycle."""
+
+    def test_streaming_start_disables_local_silence_endpointing(self):
+        recorder = MagicMock()
+        recorder.supports_streaming_frames = True
+        recorder._max_recording_seconds = 0
+        coordinator = MagicMock()
+        coordinator.start_utterance.return_value = True
+        cli = _make_voice_cli(
+            _voice_recorder=recorder,
+            _voice_stream_pending_finals=["stale TTS transcript"],
+            _voice_stream_drain_after=2,
+            _voice_stream_barge_candidate_after=1,
+        )
+        cli._voice_get_streaming_stt = MagicMock(return_value=coordinator)
+
+        class _Timer:
+            daemon = True
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+        with patch("cli._cprint"), \
+             patch("cli.threading.Timer", _Timer), \
+             patch("cli.threading.Thread", return_value=MagicMock(start=MagicMock())), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "tools.voice_mode.check_voice_requirements",
+                 return_value={"audio_available": True, "stt_available": True},
+             ), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"voice": {"beep_enabled": False}},
+             ):
+            cli._voice_start_recording()
+
+        coordinator.start_utterance.assert_called_once_with()
+        start_kwargs = recorder.start.call_args.kwargs
+        assert start_kwargs["on_silence_stop"] is None
+        assert "frame_sink" not in start_kwargs
+        recorder.add_continuous_frame_sink.assert_called_once()
+        assert start_kwargs["on_no_speech"] == cli._voice_streaming_no_speech
+        assert start_kwargs["on_max_duration"] == cli._voice_streaming_commit
+        assert callable(start_kwargs["start_guard"])
+        assert "on_frame_sink_error" not in start_kwargs
+        assert cli._voice_stream_pending_finals == []
+        assert cli._voice_stream_drain_after is None
+        assert cli._voice_stream_barge_candidate_after is None
+        assert cli._voice_capture_started_generation == 1
+
+    def test_initial_stream_connection_failure_uses_local_endpointing(self):
+        recorder = MagicMock()
+        recorder.supports_streaming_frames = True
+        coordinator = MagicMock()
+        coordinator.start_utterance.return_value = False
+        cli = _make_voice_cli(_voice_recorder=recorder)
+        cli._voice_get_streaming_stt = MagicMock(return_value=coordinator)
+
+        with patch("cli._cprint"), \
+             patch("cli.threading.Thread", return_value=MagicMock(start=MagicMock())), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "tools.voice_mode.check_voice_requirements",
+                 return_value={"audio_available": True, "stt_available": True},
+             ), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"voice": {"beep_enabled": False}},
+             ):
+            cli._voice_start_recording()
+
+        start_kwargs = recorder.start.call_args.kwargs
+        assert callable(start_kwargs["on_silence_stop"])
+        assert "frame_sink" not in start_kwargs
+
+    def test_cancel_during_stream_handshake_never_starts_recorder(self):
+        recorder = MagicMock(supports_streaming_frames=True)
+        coordinator = MagicMock()
+        cli = _make_voice_cli(_voice_recorder=recorder)
+
+        def _finish_after_cancel():
+            with cli._voice_lock:
+                cli._voice_recording = False
+            return True
+
+        coordinator.start_utterance.side_effect = _finish_after_cancel
+        cli._voice_get_streaming_stt = MagicMock(return_value=coordinator)
+
+        with patch("cli._cprint"), patch(
+            "tools.voice_mode.check_voice_requirements",
+            return_value={"audio_available": True, "stt_available": True},
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"beep_enabled": False}},
+        ):
+            cli._voice_start_recording()
+
+        recorder.start.assert_not_called()
+        coordinator.pause.assert_called_once_with()
+
+    def test_real_turn_controller_is_reused_across_two_cli_turns(self):
+        provider = MagicMock()
+        provider.name = "openai"
+        recorder = MagicMock(supports_streaming_frames=True)
+        cli = _make_voice_cli(_voice_recorder=recorder)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"stt": {"provider": "openai"}},
+        ), patch(
+            "tools.stt_streaming.resolve_streaming_stt_provider",
+            return_value=provider,
+        ):
+            first = cli._voice_get_streaming_stt()
+            first._coordinator.start_utterance = MagicMock(return_value=True)
+            first._coordinator.pause = MagicMock()
+            assert first.start_utterance() is True
+            first.pause()
+
+            second = cli._voice_get_streaming_stt()
+
+        assert second is first
+        assert second.provider_name == "openai"
+
+    def test_same_provider_with_changed_config_rebuilds_controller(self):
+        recorder = MagicMock(supports_streaming_frames=True)
+        cli = _make_voice_cli(_voice_recorder=recorder)
+        first_provider = SimpleNamespace(
+            name="openai",
+            configuration_key=("openai", "key", "https://one.example/v1"),
+        )
+        second_provider = SimpleNamespace(
+            name="openai",
+            configuration_key=("openai", "key", "https://two.example/v1"),
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"stt": {"provider": "openai"}},
+        ), patch(
+            "tools.stt_streaming.resolve_streaming_stt_provider",
+            side_effect=[first_provider, second_provider],
+        ):
+            first = cli._voice_get_streaming_stt()
+            second = cli._voice_get_streaming_stt()
+
+        assert second is not first
+        assert second.provider_configuration_key == second_provider.configuration_key
+
+    def test_committed_final_bypasses_wav_and_batch_transcription(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("cli._cprint"), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.transcribe_recording") as transcribe:
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent(
+                    "hello from stream", True, "final-1", "segment-1"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == "hello from stream"
+        recorder.cancel.assert_called_once()
+        recorder.stop.assert_not_called()
+        transcribe.assert_not_called()
+
+    def test_late_tts_final_cannot_end_new_recording_before_speech(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        recorder.has_spoken = False
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(),
+        )
+
+        cli._voice_streaming_final(
+            StreamingTranscriptEvent("late text from TTS", True, "tts-final")
+        )
+
+        assert cli._voice_recording is True
+        assert cli._voice_processing is False
+        assert cli._voice_stream_pending_finals == []
+        assert cli._pending_input.empty()
+        recorder.cancel.assert_not_called()
+
+        recorder.has_spoken = True
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent(
+                    "actual user request",
+                    True,
+                    "user-final",
+                    "user-segment",
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == "actual user request"
+        recorder.cancel.assert_called_once_with()
+
+    def test_late_final_cannot_claim_capture_before_recorder_starts(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        recorder.has_spoken = True
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=True,
+            _voice_recording_generation=2,
+            _voice_capture_started_generation=1,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(),
+        )
+
+        cli._voice_streaming_final(
+            StreamingTranscriptEvent("late prior turn", True, "late-final")
+        )
+
+        assert cli._voice_recording is True
+        assert cli._voice_processing is False
+        assert cli._voice_stream_pending_finals == []
+        assert cli._pending_input.empty()
+        recorder.cancel.assert_not_called()
+
+    def test_manual_commit_finishes_capture_immediately_and_only_once(self):
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        coordinator.commit.return_value = True
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        cli._voice_streaming_commit()
+        cli._voice_streaming_commit()
+
+        assert cli._voice_recording is False
+        assert cli._voice_processing is True
+        recorder.finish_capture.assert_called_once_with()
+        coordinator.commit.assert_called_once_with()
+
+    def test_manual_stop_reuses_pending_boundary_flush(self):
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        coordinator.commit.return_value = False
+        coordinator.delivering = False
+        coordinator.commit_pending = True
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+        cli._voice_streaming_error = MagicMock()
+
+        cli._voice_streaming_commit()
+
+        assert cli._voice_recording is False
+        assert cli._voice_processing is True
+        assert cli._voice_stream_drain_after == 0
+        recorder.finish_capture.assert_called_once_with()
+        cli._voice_streaming_error.assert_not_called()
+
+    def test_manual_commit_final_discards_retained_fallback_audio(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        coordinator.commit.return_value = True
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_commit()
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent("manual transcript", True)
+            )
+
+        assert str(cli._pending_input.get_nowait()) == "manual transcript"
+        recorder.finish_capture.assert_called_once_with()
+        recorder.cancel.assert_called_once_with()
+        recorder.stop.assert_not_called()
+        assert cli._voice_processing is False
+
+    def test_manual_commit_timeout_falls_back_with_retained_audio(self):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/retained.wav"
+        coordinator = MagicMock()
+        coordinator.commit.return_value = True
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("cli._cprint"), \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai"}},
+             ), \
+             patch(
+                 "tools.voice_mode.transcribe_recording",
+                 return_value={"success": True, "transcript": "recovered"},
+             ) as transcribe:
+            cli._voice_streaming_commit()
+            cli._voice_streaming_error(
+                RuntimeError("Streaming STT commit timed out")
+            )
+
+        recorder.finish_capture.assert_called_once_with()
+        recorder.stop.assert_called_once_with()
+        transcribe.assert_called_once_with("/tmp/retained.wav", model=None)
+        assert str(cli._pending_input.get_nowait()) == "recovered"
+
+    def test_provider_final_delivery_cannot_race_into_batch_path(self):
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        coordinator.active = False
+        coordinator.delivering = True
+        coordinator.commit.return_value = False
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("tools.voice_mode.transcribe_recording") as transcribe:
+            cli._voice_stop_and_transcribe()
+
+        recorder.finish_capture.assert_called_once_with()
+        recorder.stop.assert_not_called()
+        transcribe.assert_not_called()
+        assert cli._voice_processing is True
+
+    def test_empty_committed_final_finishes_as_no_speech(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(),
+        )
+
+        with patch("cli._cprint") as output, patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent("", True, "empty", "empty-segment")
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert cli._pending_input.empty()
+        assert cli._voice_processing is False
+        assert any("No speech detected" in call.args[0] for call in output.call_args_list)
+
+    def test_stream_error_uses_retained_audio_batch_fallback(self):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/retained.wav"
+        coordinator = MagicMock()
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("cli._cprint"), \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai"}},
+             ), \
+             patch(
+                 "tools.voice_mode.transcribe_recording",
+                 return_value={"success": True, "transcript": "recovered"},
+             ) as transcribe:
+            cli._voice_streaming_error(RuntimeError("socket closed"))
+
+        transcribe.assert_called_once_with("/tmp/retained.wav", model=None)
+        assert str(cli._pending_input.get_nowait()) == "recovered"
+
+    def test_full_turn_fallback_does_not_duplicate_buffered_final(self):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/retained.wav"
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(),
+            _voice_stream_pending_finals=["already transcribed"],
+        )
+
+        with patch("cli._cprint"), \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai"}},
+             ), \
+             patch(
+                 "tools.voice_mode.transcribe_recording",
+                 return_value={
+                     "success": True,
+                     "transcript": "already transcribed and continued",
+                 },
+             ):
+            cli._voice_streaming_error(RuntimeError("socket closed"))
+
+        assert str(cli._pending_input.get_nowait()) == (
+            "already transcribed and continued"
+        )
+        assert cli._voice_stream_pending_finals == []
+
+    def test_no_speech_guard_keeps_stream_and_discards_empty_capture(self):
+        recorder = MagicMock()
+        coordinator = MagicMock()
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=coordinator,
+        )
+
+        with patch("cli._cprint"):
+            cli._voice_streaming_no_speech()
+
+        coordinator.pause.assert_not_called()
+        recorder.cancel.assert_called_once_with()
+        assert cli._voice_recording is False
+        assert cli._voice_processing is False
+
+    def test_stale_and_duplicate_finals_are_ignored(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(),
+        )
+        event = StreamingTranscriptEvent(
+            "one transcript", True, "one-final", "one-segment"
+        )
+
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_final(event)
+            cli._voice_streaming_final(event)
+            _expire_streaming_endpoint(cli)
+
+        assert cli._pending_input.qsize() == 1
+        recorder.cancel.assert_called_once()
+
+    def test_provider_final_is_authoritative_over_local_silence_state(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = SimpleNamespace(
+            has_spoken=True,
+            speech_silence_seconds=0.1,
+            cancel=MagicMock(),
+            clear_continuous_fallback_buffer=MagicMock(),
+        )
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+        )
+
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent(
+                    "provider committed transcript",
+                    True,
+                    "provider-final",
+                    "provider-segment",
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert cli._voice_recording is False
+        assert str(cli._pending_input.get_nowait()) == "provider committed transcript"
+        assert cli._pending_input.empty()
+        recorder.cancel.assert_called_once_with()
+
+    def test_partial_during_endpoint_grace_keeps_logical_turn_open(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+        )
+
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "first clause", True, "final-1", "segment-1"
+                )
+            )
+            first_timer = cli._voice_stream_endpoint_timer
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "continuing", False, "partial-2", "segment-2"
+                )
+            )
+
+            assert cli._voice_stream_endpoint_timer is None
+            assert cli._voice_recording is True
+            assert cli._voice_stream_pending_finals == ["first clause"]
+            assert cli._pending_input.empty()
+
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "second clause", True, "final-2", "segment-2"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        first_timer.cancel()
+        assert str(cli._pending_input.get_nowait()) == (
+            "first clause second clause"
+        )
+        recorder.cancel.assert_called_once_with()
+
+    def test_partial_after_endpoint_grace_confirms_and_submits_barge(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        agent = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=False,
+            agent=agent,
+        )
+
+        with (
+            patch("cli._cprint"),
+            patch("tools.voice_mode.play_beep"),
+            patch("tools.voice_mode.is_audio_output_active", return_value=False),
+        ):
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "initial request", True, "final-1", "segment-1"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+            assert str(cli._pending_input.get_nowait()) == "initial request"
+
+            cli._agent_running = True
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "interrupting", False, "partial-2", "segment-2"
+                )
+            )
+            assert cli._voice_barge_capture.is_set()
+            assert cli._voice_stream_drain_after == 1
+            agent.interrupt.assert_called_once_with()
+
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "interrupting now", True, "final-2", "segment-2"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == "interrupting now"
+        assert cli._pending_input.empty()
+
+    def test_partial_inside_grace_confirms_barge_once_during_agent_turn(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        agent = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recording=False,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+            agent=agent,
+        )
+
+        with patch("cli._cprint"):
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "earlier words", True, "final-1", "segment-1"
+                )
+            )
+            endpoint_timer = cli._voice_stream_endpoint_timer
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "more words", False, "partial-2", "segment-2"
+                )
+            )
+            cli._voice_handle_barge_trigger("generation")
+
+        endpoint_timer.cancel()
+        assert cli._voice_stream_endpoint_timer is None
+        assert cli._voice_stream_pending_finals == ["earlier words"]
+        assert cli._voice_stream_drain_after == 1
+        agent.interrupt.assert_called_once_with()
+
+    def test_streaming_partial_preserves_playback_only_barge_semantics(self):
+        agent = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_tts=True,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+            agent=agent,
+        )
+        cli._voice_tts_done.clear()
+
+        with (
+            patch("cli._cprint"),
+            patch("tools.voice_mode.is_audio_output_active", return_value=True),
+            patch("tools.voice_mode.stop_playback") as stop_playback,
+            patch("tools.tts_streaming.mark_speech_interrupted"),
+        ):
+            cli._voice_handle_barge_trigger()
+            cli._voice_handle_barge_trigger("generation")
+
+        stop_playback.assert_called_once_with()
+        agent.interrupt.assert_not_called()
+
+    def test_endpoint_beep_continuation_interrupts_queued_voice_turn(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        agent = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=False,
+            agent=agent,
+        )
+
+        with (
+            patch("cli._cprint"),
+            patch("tools.voice_mode.play_beep"),
+            patch(
+                "tools.voice_mode.is_audio_output_active",
+                return_value=True,
+            ),
+            patch("tools.voice_mode.stop_playback") as stop_playback,
+        ):
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "first part", True, "final-1", "segment-1"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "still talking", False, "partial-2", "segment-2"
+                )
+            )
+
+        assert cli._voice_stream_dispatch_barge is True
+        agent.interrupt.assert_not_called()
+        stop_playback.assert_not_called()
+
+        cli._voice_apply_pending_streaming_barge(
+            agent,
+            voice_input=True,
+        )
+
+        agent.interrupt.assert_called_once_with()
+        assert cli._voice_stream_dispatch_pending is False
+        assert cli._voice_stream_dispatch_barge is False
+
+    def test_barge_drains_prior_finals_and_the_next_final_once(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=False,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+        )
+
+        with patch("cli._cprint"), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.transcribe_recording") as transcribe:
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "first interruption", True, "final-1", "segment-1"
+                )
+            )
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "first interruption", True, "final-1", "segment-1"
+                )
+            )
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "second thought", True, "final-2", "segment-2"
+                )
+            )
+            assert cli._pending_input.empty()
+
+            cli._voice_streaming_barge_confirmed()
+            assert cli._voice_stream_barge_release.is_set()
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "finish this request", True, "final-3", "segment-3"
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == (
+            "first interruption second thought finish this request"
+        )
+        assert cli._pending_input.empty()
+        assert not cli._voice_barge_capture.is_set()
+        recorder.cancel.assert_called_once_with()
+        transcribe.assert_not_called()
+
+    def test_streaming_playback_barge_drops_tts_echo(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recording=False,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+            _voice_last_tts_text=(
+                "The streaming transcript should not repeat my spoken reply."
+            ),
+        )
+        cli._voice_restart_recording_async = MagicMock()
+
+        with (
+            patch("cli._cprint"),
+            patch("tools.voice_mode.play_beep"),
+            patch("tools.voice_mode.stop_playback"),
+            patch("tools.tts_streaming.mark_speech_interrupted"),
+        ):
+            cli._voice_handle_barge_trigger("playback")
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "The streaming transcript should not repeat my spoken reply.",
+                    True,
+                    "echo-final",
+                    "echo-segment",
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert cli._pending_input.empty()
+        assert not cli._voice_barge_capture.is_set()
+        assert cli._voice_barge_phase is None
+        cli._voice_restart_recording_async.assert_called_once_with()
+
+    def test_streaming_playback_barge_keeps_genuine_interjection(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recording=False,
+            _voice_recorder=MagicMock(),
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+            _voice_last_tts_text="The weather today is sunny with a light breeze.",
+        )
+
+        with (
+            patch("cli._cprint"),
+            patch("tools.voice_mode.play_beep"),
+            patch("tools.voice_mode.stop_playback"),
+            patch("tools.tts_streaming.mark_speech_interrupted"),
+        ):
+            cli._voice_handle_barge_trigger("playback")
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "Actually, check my calendar for tomorrow.",
+                    True,
+                    "user-final",
+                    "user-segment",
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == (
+            "Actually, check my calendar for tomorrow."
+        )
+        assert cli._voice_barge_phase is None
+
+    def test_confirmed_streaming_barge_releases_tts_wait(self):
+        class StuckThread:
+            def __init__(self):
+                self.join_calls = []
+
+            def is_alive(self):
+                return True
+
+            def join(self, timeout=None):
+                self.join_calls.append(timeout)
+
+        cli = _make_voice_cli()
+        thread = StuckThread()
+        cli._voice_stream_barge_release.set()
+
+        assert cli._voice_wait_for_streaming_tts(thread, timeout=120) is False
+        assert thread.join_calls == []
+
+    def test_uninterrupted_streaming_tts_waits_for_worker(self):
+        class FinishingThread:
+            def __init__(self):
+                self.alive = True
+                self.join_calls = []
+
+            def is_alive(self):
+                return self.alive
+
+            def join(self, timeout=None):
+                self.join_calls.append(timeout)
+                self.alive = False
+
+        cli = _make_voice_cli()
+        thread = FinishingThread()
+
+        assert cli._voice_wait_for_streaming_tts(thread, timeout=120) is True
+        assert thread.join_calls == [0.1]
+
+    def test_barge_stream_failure_preserves_prior_finals_in_batch_fallback(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/barge-retained.wav"
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=False,
+            _voice_recorder=recorder,
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+        )
+
+        with patch("cli._cprint"), \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("tools.voice_mode.play_beep"), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai"}},
+             ), \
+             patch(
+                 "tools.voice_mode.transcribe_recording",
+                 return_value={"success": True, "transcript": "current words"},
+             ):
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent("earlier words", True)
+            )
+            cli._voice_streaming_barge_confirmed()
+            cli._voice_streaming_error(RuntimeError("socket closed"))
+
+        recorder.begin_continuous_fallback_capture.assert_called_once_with()
+        assert str(cli._pending_input.get_nowait()) == (
+            "earlier words current words"
+        )
+
+    def test_new_barge_candidate_replaces_a_decayed_noise_candidate(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_recording=False,
+            _voice_recorder=MagicMock(),
+            _voice_stt_stream=MagicMock(active=True),
+            _agent_running=True,
+        )
+
+        with patch("cli._cprint"), patch("tools.voice_mode.play_beep"):
+            cli._voice_streaming_barge_candidate()
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent("earlier unsent words", True)
+            )
+            cli._voice_streaming_barge_candidate()
+            cli._voice_streaming_barge_confirmed()
+            assert cli._pending_input.empty()
+
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent(
+                    "actual interruption",
+                    True,
+                    "actual-final",
+                    "actual-segment",
+                )
+            )
+            _expire_streaming_endpoint(cli)
+
+        assert str(cli._pending_input.get_nowait()) == (
+            "earlier unsent words actual interruption"
+        )
+
+    def test_streaming_stop_phrase_uses_existing_voice_shutdown(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=MagicMock(),
+            _voice_stt_stream=MagicMock(),
+        )
+        cli._disable_voice_mode = MagicMock()
+
+        with patch("cli._cprint"), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.is_voice_stop_phrase", return_value=True):
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent("stop", True, "stop-final", "stop-segment")
+            )
+            _expire_streaming_endpoint(cli)
+
+        cli._disable_voice_mode.assert_called_once()
+        assert cli._pending_input.empty()
+
+    def test_disable_invalidates_turn_and_closes_persistent_session(self):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        coordinator = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_processing=True,
+            _voice_stt_stream=coordinator,
+        )
+
+        class _Thread:
+            def __init__(self, target=None, **kwargs):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        with patch("cli._cprint"), \
+             patch("cli.threading.Thread", _Thread), \
+             patch("tools.voice_mode.stop_playback"):
+            cli._disable_voice_mode()
+            cli._voice_streaming_final(
+                StreamingTranscriptEvent("late transcript", True)
+            )
+
+        coordinator.close.assert_called_once()
+        assert cli._voice_stt_stream is None
+        assert cli._voice_processing is False
+        assert cli._pending_input.empty()
 
 
 # ---------------------------------------------------------------------------
@@ -610,6 +1653,91 @@ class TestVoiceFullDuplexListener:
         assert disabled == [True]     # chat ended by the stop phrase
         assert cli._pending_input.empty()  # stop phrase never reaches the agent
 
+    def test_streaming_barge_reuses_recorder_and_drains_provider_final(
+        self, monkeypatch
+    ):
+        from tools.stt_streaming import StreamingTranscriptEvent
+
+        observed = {}
+        interrupted = threading.Event()
+        recorder = MagicMock()
+        stream = MagicMock(active=True)
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=stream,
+            _agent_running=True,
+        )
+        cli.agent = SimpleNamespace(interrupt=lambda: interrupted.set())
+
+        def fake_listen(should_stop, is_playing=None, on_trigger=None, **kwargs):
+            observed.update(kwargs)
+            kwargs["on_candidate"]()
+            cli._voice_streaming_event(
+                StreamingTranscriptEvent("streamed interruption", True)
+            )
+            assert cli._pending_input.empty()
+            on_trigger("generation")
+            return None
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"barge_in": True}},
+        )
+        monkeypatch.setattr("tools.voice_mode.full_duplex_listen", fake_listen)
+        monkeypatch.setattr("tools.voice_mode.is_audio_output_active", lambda: False)
+        monkeypatch.setattr("tools.voice_mode.stop_playback", lambda: None)
+
+        with patch("cli._cprint"), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.transcribe_recording") as transcribe:
+            cli._voice_full_duplex_listener()
+
+        assert interrupted.is_set()
+        assert observed["frame_queue"] is not None
+        assert observed["capture"]() is False
+        recorder.add_continuous_frame_sink.assert_called_once_with(
+            observed["frame_queue"].enqueue
+        )
+        recorder.remove_continuous_frame_sink.assert_called_once()
+        assert str(cli._pending_input.get_nowait()) == "streamed interruption"
+        transcribe.assert_not_called()
+
+    def test_batch_barge_reuses_persistent_recorder(self, monkeypatch):
+        """Batch STT must not open a second mic while the recorder stays open."""
+        observed = {}
+        recorder = MagicMock()
+        cli = _make_voice_cli(
+            _voice_mode=True,
+            _voice_continuous=True,
+            _voice_recorder=recorder,
+            _voice_stt_stream=None,
+            _agent_running=True,
+        )
+        cli.agent = SimpleNamespace(interrupt=lambda: None)
+
+        def fake_listen(should_stop, is_playing=None, on_trigger=None, **kwargs):
+            observed.update(kwargs)
+            return None
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"barge_in": True}},
+        )
+        monkeypatch.setattr("tools.voice_mode.full_duplex_listen", fake_listen)
+        monkeypatch.setattr("tools.voice_mode.is_audio_output_active", lambda: False)
+        monkeypatch.setattr("tools.voice_mode.stop_playback", lambda: None)
+
+        cli._voice_full_duplex_listener()
+
+        assert observed["frame_queue"] is not None
+        assert observed["capture"]() is True
+        recorder.add_continuous_frame_sink.assert_called_once_with(
+            observed["frame_queue"].enqueue
+        )
+        recorder.remove_continuous_frame_sink.assert_called_once()
+
 
 # ============================================================================
 # Typed stop phrase — typing "stop" during a voice chat ends it
@@ -680,4 +1808,3 @@ class TestFallbackSpeakArmsBargeMonitor:
         # speak thread came and went without arming the mic.
         assert not cli._monitor_armed.wait(0.05)
         assert cli._monitor_calls == []
-

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -2,6 +2,7 @@
 
 import os
 import struct
+import threading
 import time
 import wave
 from pathlib import Path
@@ -209,7 +210,9 @@ class TestDetectAudioEnvironment:
                             lambda: (MagicMock(), MagicMock()))
 
         proc_version = tmp_path / "proc_version"
-        proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")
+        proc_version.write_text(
+            "Linux 5.15.0-microsoft-standard-WSL2", encoding="utf-8"
+        )
 
         _real_open = open
         def _fake_open(f, *a, **kw):
@@ -381,6 +384,24 @@ class TestTermuxAudioRecorder:
 
 
 class TestAudioRecorder:
+    def test_prepare_opens_stream_before_capture_is_armed(self, mock_sd):
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.prepare()
+
+        assert recorder.is_recording is False
+        mock_sd.InputStream.assert_called_once()
+        mock_stream.start.assert_called_once_with()
+
+        recorder.start()
+
+        assert recorder.is_recording is True
+        mock_sd.InputStream.assert_called_once()
+
     def test_start_raises_without_audio_libs(self, monkeypatch):
         def _fail_import():
             raise ImportError("no sounddevice")
@@ -423,6 +444,134 @@ class TestAudioRecorder:
         assert recorder.is_recording is True
         mock_sd.InputStream.assert_called_once()
         mock_stream.start.assert_called_once()
+
+    def test_frame_sink_receives_copied_frame_and_native_rate(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+        received = []
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start(frame_sink=lambda frame, rate: received.append((frame, rate)))
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        source = np.full((480, 1), 1000, dtype=np.int16)
+        callback(source, 480, None, None)
+        source[:] = 0
+
+        assert len(received) == 1
+        assert received[0][1] == recorder._sample_rate
+        assert received[0][0][0, 0] == 1000
+        assert recorder._frames[0][0, 0] == 1000
+
+    def test_frame_sink_exception_does_not_escape_audio_callback(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start(frame_sink=MagicMock(side_effect=RuntimeError("boom")))
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        callback(np.ones((480, 1), dtype=np.int16), 480, None, None)
+        callback(np.ones((480, 1), dtype=np.int16), 480, None, None)
+
+        assert len(recorder._frames) == 2
+        assert recorder._frame_sink is None
+
+    def test_frame_sink_exception_reports_away_from_audio_callback(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+        reported = []
+        delivered = threading.Event()
+        callback_thread = threading.current_thread()
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start(
+            frame_sink=MagicMock(side_effect=RuntimeError("boom")),
+            on_frame_sink_error=lambda error: (
+                reported.append((str(error), threading.current_thread())),
+                delivered.set(),
+            ),
+        )
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        callback(np.ones((480, 1), dtype=np.int16), 480, None, None)
+
+        assert delivered.wait(1.0)
+        assert reported[0][0] == "boom"
+        assert reported[0][1] is not callback_thread
+        recorder.cancel()
+
+    def test_clear_frame_sink_retains_batch_fallback_frames(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start(frame_sink=MagicMock())
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        callback(np.ones((480, 1), dtype=np.int16), 480, None, None)
+        recorder.clear_frame_sink()
+
+        assert recorder.is_recording is True
+        assert len(recorder._frames) == 1
+
+    def test_continuous_sink_receives_frames_between_logical_recordings(
+        self, mock_sd
+    ):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+        received = []
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.add_continuous_frame_sink(
+            lambda frame, rate: received.append((frame.copy(), rate))
+        )
+        recorder.start()
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        callback(np.full((480, 1), 1000, dtype=np.int16), 480, None, None)
+        recorder.cancel()
+        callback(np.full((480, 1), 2000, dtype=np.int16), 480, None, None)
+        recorder.start()
+
+        assert [int(frame[0, 0]) for frame, _ in received] == [1000, 2000]
+        assert mock_sd.InputStream.call_count == 1
+
+    def test_continuous_sink_failure_does_not_race_control_path_lock(
+        self, mock_sd
+    ):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        failed_sink = MagicMock(side_effect=RuntimeError("boom"))
+        healthy_sink = MagicMock()
+        recorder.add_continuous_frame_sink(failed_sink)
+        recorder.add_continuous_frame_sink(healthy_sink)
+        recorder.start()
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        frame = np.ones((480, 1), dtype=np.int16)
+
+        with recorder._lock:
+            callback(frame, 480, None, None)
+        assert failed_sink in recorder._continuous_frame_sinks
+
+        callback(frame, 480, None, None)
+        assert failed_sink not in recorder._continuous_frame_sinks
+        assert healthy_sink in recorder._continuous_frame_sinks
 
 class TestAudioRecorderStop:
     def test_stop_writes_wav_file(self, mock_sd, temp_voice_dir):
@@ -472,6 +621,70 @@ class TestAudioRecorderStop:
 
         wav_path = recorder.stop()
         assert wav_path is None
+
+    def test_finish_capture_retains_only_pre_commit_audio(
+        self, mock_sd, temp_voice_dir
+    ):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+        sink = MagicMock()
+
+        from tools.voice_mode import AudioRecorder, SAMPLE_RATE
+
+        recorder = AudioRecorder()
+        recorder.start(frame_sink=sink)
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        frame = np.full((SAMPLE_RATE, 1), 1000, dtype="int16")
+        callback(frame, SAMPLE_RATE, None, None)
+
+        assert recorder.finish_capture() is True
+        callback(frame, SAMPLE_RATE, None, None)
+        wav_path = recorder.stop()
+
+        assert recorder.is_recording is False
+        assert sink.call_count == 1
+        assert wav_path is not None
+        with wave.open(wav_path, "rb") as wf:
+            assert wf.getnframes() == SAMPLE_RATE
+
+    def test_continuous_barge_buffer_is_available_for_batch_fallback(
+        self, mock_sd, temp_voice_dir
+    ):
+        np = pytest.importorskip("numpy")
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.add_continuous_frame_sink(lambda frame, rate: None)
+        recorder.start()
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        recorder.cancel()
+        recorder.clear_continuous_fallback_buffer()
+        samples = int(recorder._sample_rate * 0.2)
+        callback(
+            np.full((samples, 1), 1000, dtype=np.int16),
+            samples,
+            None,
+            None,
+        )
+
+        assert recorder.begin_continuous_fallback_capture()
+        callback(
+            np.full((samples, 1), 2000, dtype=np.int16),
+            samples,
+            None,
+            None,
+        )
+        wav_path = recorder.stop()
+
+        assert wav_path is not None
+        with wave.open(wav_path, "rb") as wf:
+            audio = np.frombuffer(wf.readframes(wf.getnframes()), dtype="<i2")
+        assert int(audio[0]) == 1000
+        assert int(audio[-1]) == 2000
 
 
 class TestAudioRecorderCancel:
@@ -719,6 +932,62 @@ class TestPlayBeep:
 # ============================================================================
 
 class TestSilenceDetection:
+    def test_streaming_mode_keeps_no_speech_guard_without_local_endpointing(
+        self, mock_sd, fake_clock
+    ):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_wait = 0.05
+        no_speech = threading.Event()
+
+        recorder.start(
+            on_silence_stop=None,
+            on_no_speech=no_speech.set,
+            frame_sink=MagicMock(),
+        )
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        silent_frame = np.zeros((1600, 1), dtype="int16")
+        callback(silent_frame, 1600, None, None)
+        fake_clock.advance(0.06)
+        callback(silent_frame, 1600, None, None)
+
+        assert no_speech.wait(timeout=5.0) is True
+        assert recorder._on_silence_stop is None
+        recorder.cancel()
+
+    def test_streaming_mode_keeps_max_duration_guard_without_local_endpointing(
+        self, mock_sd, fake_clock
+    ):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_recording_seconds = 0.05
+        max_duration = threading.Event()
+
+        recorder.start(
+            on_silence_stop=None,
+            on_max_duration=max_duration.set,
+            frame_sink=MagicMock(),
+        )
+        callback = mock_sd.InputStream.call_args.kwargs["callback"]
+        loud_frame = np.full((1600, 1), 5000, dtype="int16")
+        callback(loud_frame, 1600, None, None)
+        fake_clock.advance(0.06)
+        callback(loud_frame, 1600, None, None)
+
+        assert max_duration.wait(timeout=5.0) is True
+        assert recorder._on_silence_stop is None
+        recorder.cancel()
+
     def test_silence_callback_fires_after_speech_then_silence(self, mock_sd, fake_clock):
         np = pytest.importorskip("numpy")
         import threading
@@ -917,6 +1186,40 @@ class TestPlaybackInterrupt:
         with _playback_lock:
             assert vm._active_playback is None
 
+    def test_interrupted_system_player_does_not_try_next_player(
+        self,
+        sample_wav,
+    ):
+        """An intentional stop is not a player failure requiring fallback."""
+        from tools import voice_mode as vm
+
+        class InterruptedProcess:
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = -15
+
+            def wait(self, timeout=None):
+                if self.returncode is None:
+                    vm.stop_playback()
+                return self.returncode
+
+        process = InterruptedProcess()
+        with patch("tools.voice_mode.platform.system", return_value="Darwin"), \
+             patch("tools.voice_mode.shutil.which", return_value="/usr/bin/player"), \
+             patch(
+                 "tools.voice_mode.subprocess.Popen",
+                 return_value=process,
+             ) as popen:
+            result = vm.play_audio_file(sample_wav)
+
+        assert result is True
+        popen.assert_called_once()
+        assert process._hermes_interrupted is True
+
 # ============================================================================
 # Continuous mode flow
 # ============================================================================
@@ -1034,6 +1337,7 @@ class TestConfigurableSilenceParams:
             fake_clock.advance(0.02)
 
         assert recorder._has_spoken is False
+        assert recorder.has_spoken is False
         assert fired.wait(timeout=0.2) is False
 
         # Now send really loud audio (above 5000 threshold)
@@ -1042,6 +1346,7 @@ class TestConfigurableSilenceParams:
         fake_clock.advance(0.06)
         callback(very_loud, 1600, None, None)
         assert recorder._has_spoken is True
+        assert recorder.has_spoken is True
 
         recorder.cancel()
 
@@ -1221,7 +1526,11 @@ class TestFullDuplexListen:
         written = {}
         monkeypatch.setattr(
             "tools.voice_mode.AudioRecorder._write_wav",
-            staticmethod(lambda audio: written.update(audio=audio) or "/tmp/fd.wav"),
+            staticmethod(
+                lambda audio, **kwargs: (
+                    written.update(audio=audio, **kwargs) or "/tmp/fd.wav"
+                )
+            ),
         )
         from tools.voice_mode import full_duplex_listen
 
@@ -1255,6 +1564,90 @@ class TestFullDuplexListen:
         assert path == "/tmp/fd.wav"
         assert phases == ["generation"]
         assert int((audio == 5000).sum()) > 0  # speech onset in the capture
+
+    def test_callback_frames_use_same_detector_without_opening_input_stream(
+        self, mock_sd
+    ):
+        np = pytest.importorskip("numpy")
+        from tools.voice_mode import ContinuousAudioFrameQueue, full_duplex_listen
+
+        frame_queue = ContinuousAudioFrameQueue(max_seconds=10.0)
+        for level in [100] * self.CALIB + [5000] * 30:
+            frame_queue.enqueue(
+                np.full((self.BLOCK, 1), level, dtype=np.int16),
+                16000,
+            )
+        events = []
+
+        assert full_duplex_listen(
+            lambda: False,
+            is_playing=lambda: False,
+            on_trigger=events.append,
+            frame_queue=frame_queue,
+            capture=False,
+            on_candidate=lambda: events.append("candidate"),
+        ) is None
+        assert events == ["candidate", "generation"]
+        mock_sd.InputStream.assert_not_called()
+
+    def test_callback_capture_writes_native_sample_rate(
+        self, mock_sd, monkeypatch
+    ):
+        np = pytest.importorskip("numpy")
+        from tools.voice_mode import ContinuousAudioFrameQueue, full_duplex_listen
+
+        native_rate = 48000
+        native_block = int(native_rate * 0.03)
+        frame_queue = ContinuousAudioFrameQueue(max_seconds=10.0)
+        levels = [100] * self.CALIB + [5000] * 30 + [0] * 50
+        for level in levels:
+            frame_queue.enqueue(
+                np.full((native_block, 1), level, dtype=np.int16),
+                native_rate,
+            )
+        written = {}
+        monkeypatch.setattr(
+            "tools.voice_mode.AudioRecorder._write_wav",
+            staticmethod(
+                lambda audio, *, sample_rate: (
+                    written.update(audio=audio, sample_rate=sample_rate)
+                    or "/tmp/native-rate-barge.wav"
+                )
+            ),
+        )
+
+        assert full_duplex_listen(
+            lambda: False,
+            is_playing=lambda: False,
+            frame_queue=frame_queue,
+        ) == "/tmp/native-rate-barge.wav"
+        assert written["sample_rate"] == native_rate
+        mock_sd.InputStream.assert_not_called()
+
+    def test_candidate_restarts_after_unconfirmed_window_decays(
+        self, mock_sd, monkeypatch
+    ):
+        candidates = []
+        phases = []
+        levels = (
+            [100] * self.CALIB
+            + [5000]
+            + [100] * self.TRIP
+            + [5000] * 30
+        )
+
+        path, _, _ = self._run(
+            mock_sd,
+            monkeypatch,
+            levels,
+            capture=False,
+            on_candidate=lambda: candidates.append(True),
+            on_trigger=phases.append,
+        )
+
+        assert path is None
+        assert candidates == [True, True]
+        assert phases == ["generation"]
 
     def test_playback_bleed_alone_does_not_trip(self, mock_sd, monkeypatch):
         """Speaker bleed (~1000 RMS) during playback stays below the playback

--- a/tools/stt_streaming.py
+++ b/tools/stt_streaming.py
@@ -1,0 +1,1282 @@
+"""Provider-neutral streaming speech-to-text sessions and coordination.
+
+Capture surfaces may enqueue copied audio frames through the coordinator's
+non-blocking frame sink. WebSocket I/O and sample-rate conversion run on the
+coordinator's daemon thread.
+
+Streaming is deliberately transcription-only.  Hermes continues to own turn
+submission, agent execution, TTS, and barge-in handling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import logging
+import queue
+import threading
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+logger = logging.getLogger(__name__)
+
+# Two seconds absorbs ordinary scheduling and network jitter while failing over
+# before a live transcript falls noticeably behind the speaker. This is an
+# internal backpressure policy, not a user-facing quality or endpointing knob.
+_MAX_BUFFERED_AUDIO_SECONDS = 2.0
+_AUDIO_SEND_BATCH_SIZE = 16
+# ElevenLabs enforces an account-dependent Realtime STT session lifetime but
+# does not include that limit in session_started metadata. A 60-second ceiling
+# leaves room for the next utterance below the shortest observed limit while
+# still reusing each physical connection across several turns.
+_ELEVENLABS_SESSION_RECYCLE_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class StreamingTranscriptEvent:
+    """Normalized transcript event emitted by a provider session."""
+
+    text: str
+    is_final: bool
+    event_id: Optional[str] = None
+    segment_id: Optional[str] = None
+
+
+@dataclass
+class _UtteranceState:
+    generation: int = 0
+    active: bool = False
+    accepting_audio: bool = False
+    has_sent_audio: bool = False
+    has_activity: bool = False
+    failure_pending: bool = False
+    error_reported: bool = False
+    resampler: Optional["_PCM16StreamResampler"] = None
+
+
+class StreamingSTTSession(ABC):
+    """One persistent transcription-only provider connection."""
+
+    sample_rate: int
+
+    @abstractmethod
+    async def send_audio(self, pcm16: bytes) -> None:
+        """Send mono, little-endian PCM16 at ``sample_rate``."""
+
+    @abstractmethod
+    async def commit(self) -> None:
+        """Force the current utterance to commit without closing the session."""
+
+    @abstractmethod
+    async def receive_event(self) -> Optional[StreamingTranscriptEvent]:
+        """Wait for and normalize the next provider event."""
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the physical provider connection."""
+
+
+class StreamingSTTProvider(ABC):
+    """Factory for one provider's persistent streaming STT session."""
+
+    name: str
+    session_recycle_seconds: Optional[float] = None
+
+    @property
+    def configuration_key(self) -> tuple[Any, ...]:
+        """Return the connection settings that determine session reuse."""
+        return (self.name,)
+
+    @abstractmethod
+    async def open_session(self) -> StreamingSTTSession:
+        """Open and configure a transcription-only session."""
+
+
+async def _connect(url: str, headers: Dict[str, str]):
+    import websockets
+
+    return await websockets.connect(
+        url,
+        additional_headers=headers,
+        open_timeout=10,
+        close_timeout=3,
+        max_size=2 * 1024 * 1024,
+    )
+
+
+def _websocket_endpoint(base_url: str, endpoint: str) -> str:
+    parsed = urlsplit(base_url.rstrip("/"))
+    scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme)
+    path = parsed.path.rstrip("/")
+    endpoint_path = f"/{endpoint.strip('/')}"
+    if not path.endswith(endpoint_path):
+        path = f"{path}{endpoint_path}"
+    return urlunsplit((scheme, parsed.netloc, path, parsed.query, ""))
+
+
+def _with_query(url: str, params: Dict[str, Any]) -> str:
+    parsed = urlsplit(url)
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    query.extend(params.items())
+    return urlunsplit((
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+        urlencode(query, doseq=True),
+        "",
+    ))
+
+
+class _JSONWebSocketSession(StreamingSTTSession):
+    """Shared JSON send/receive and close handling for provider adapters."""
+
+    def __init__(self, websocket: Any):
+        self.websocket = websocket
+
+    async def _receive_json(self) -> Dict[str, Any]:
+        raw = await self.websocket.recv()
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        message = json.loads(raw)
+        if not isinstance(message, dict):
+            raise RuntimeError("Streaming STT provider returned a non-object event")
+        return message
+
+    async def _send_json(self, message: Dict[str, Any]) -> None:
+        await self.websocket.send(json.dumps(message))
+
+    async def close(self) -> None:
+        await self.websocket.close()
+
+
+class OpenAIStreamingSTTSession(StreamingSTTSession):
+    sample_rate = 24000
+
+    def __init__(self, client: Any, connection: Any):
+        self.client = client
+        self.connection = connection
+
+    async def send_audio(self, pcm16: bytes) -> None:
+        await self.connection.input_audio_buffer.append(
+            audio=base64.b64encode(pcm16).decode("ascii"),
+        )
+
+    async def commit(self) -> None:
+        await self.connection.input_audio_buffer.commit()
+
+    async def receive_event(self) -> Optional[StreamingTranscriptEvent]:
+        event = await self.connection.recv()
+        event_type = event.type
+        if event_type == "conversation.item.input_audio_transcription.delta":
+            return StreamingTranscriptEvent(
+                text=str(event.delta or ""),
+                is_final=False,
+                event_id=getattr(event, "event_id", None),
+                segment_id=getattr(event, "item_id", None),
+            )
+        if event_type == "conversation.item.input_audio_transcription.completed":
+            return StreamingTranscriptEvent(
+                text=str(event.transcript or ""),
+                is_final=True,
+                event_id=getattr(event, "event_id", None),
+                segment_id=getattr(event, "item_id", None),
+            )
+        if event_type == "conversation.item.input_audio_transcription.failed":
+            error = getattr(event, "error", None)
+            raise RuntimeError(
+                str(
+                    getattr(error, "message", None)
+                    or "OpenAI Realtime transcription failed"
+                )
+            )
+        if event_type == "error":
+            message = str(
+                event.error.message or "OpenAI Realtime transcription failed"
+            )
+            if (
+                "input audio buffer" in message.lower()
+                and "buffer too small" in message.lower()
+            ):
+                # Semantic VAD may commit immediately before a manual commit
+                # reaches the server. Keep receiving: the matching final can
+                # still be in flight, and the controller timeout remains the
+                # bounded fallback when it is not.
+                return None
+            raise RuntimeError(message)
+        return None
+
+    async def close(self) -> None:
+        try:
+            await self.connection.close()
+        finally:
+            await self.client.close()
+
+
+class OpenAIStreamingSTTProvider(StreamingSTTProvider):
+    name = "openai"
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        model: str,
+        language: str,
+    ):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model
+        self.language = language
+
+    @property
+    def configuration_key(self) -> tuple[Any, ...]:
+        return (
+            self.name,
+            self.api_key,
+            self.base_url,
+            self.model,
+            self.language,
+        )
+
+    async def open_session(self) -> StreamingSTTSession:
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url or None,
+        )
+        try:
+            connection = await client.realtime.connect(
+                extra_query={"intent": "transcription"},
+            ).enter()
+        except Exception:
+            await client.close()
+            raise
+
+        session = OpenAIStreamingSTTSession(client, connection)
+        transcription: Dict[str, Any] = {"model": self.model}
+        if self.language:
+            transcription["language"] = self.language
+        try:
+            await connection.session.update(
+                session={
+                    "type": "transcription",
+                    "audio": {
+                        "input": {
+                            "format": {"type": "audio/pcm", "rate": 24000},
+                            "transcription": transcription,
+                            "turn_detection": {
+                                "type": "semantic_vad",
+                                "eagerness": "auto",
+                            },
+                        },
+                    },
+                }
+            )
+            while True:
+                event = await asyncio.wait_for(connection.recv(), timeout=10)
+                event_type = event.type
+                if event_type == "session.updated":
+                    return session
+                if event_type == "error":
+                    raise RuntimeError(
+                        str(
+                            event.error.message
+                            or "OpenAI Realtime session setup failed"
+                        )
+                    )
+        except Exception:
+            await session.close()
+            raise
+
+
+class ElevenLabsStreamingSTTSession(_JSONWebSocketSession):
+    sample_rate = 16000
+
+    def __init__(self, websocket: Any):
+        super().__init__(websocket)
+        self._segment_index = 0
+
+    async def send_audio(self, pcm16: bytes) -> None:
+        await self._send_json(
+            {
+                "message_type": "input_audio_chunk",
+                "audio_base_64": base64.b64encode(pcm16).decode("ascii"),
+            }
+        )
+
+    async def commit(self) -> None:
+        # ElevenLabs attaches the commit flag to an audio chunk rather than a
+        # standalone message. A short silence chunk gives manual PTT a valid
+        # commit payload without replaying or omitting captured speech.
+        await self._send_json(
+            {
+                "message_type": "input_audio_chunk",
+                "audio_base_64": base64.b64encode(b"\0" * 640).decode("ascii"),
+                "commit": True,
+            }
+        )
+
+    async def receive_event(self) -> Optional[StreamingTranscriptEvent]:
+        message = await self._receive_json()
+        message_type = message.get("message_type")
+        segment_id = f"elevenlabs-{self._segment_index}"
+        if message_type in {"partial_transcript", "final_transcript"}:
+            return StreamingTranscriptEvent(
+                text=str(message.get("text") or ""),
+                is_final=False,
+                event_id=message.get("event_id"),
+                segment_id=segment_id,
+            )
+        if message_type == "committed_transcript":
+            event = StreamingTranscriptEvent(
+                text=str(message.get("text") or ""),
+                is_final=True,
+                event_id=message.get("event_id") or segment_id,
+                segment_id=segment_id,
+            )
+            self._segment_index += 1
+            return event
+        if message_type in {
+            "auth_error",
+            "chunk_size_exceeded",
+            "commit_throttled",
+            "error",
+            "input_error",
+            "insufficient_audio_activity",
+            "queue_overflow",
+            "quota_exceeded",
+            "rate_limited",
+            "resource_exhausted",
+            "session_time_limit_exceeded",
+            "transcriber_error",
+            "unaccepted_terms",
+        }:
+            raise RuntimeError(str(message.get("error") or message_type))
+        return None
+
+
+class ElevenLabsStreamingSTTProvider(StreamingSTTProvider):
+    name = "elevenlabs"
+    session_recycle_seconds = _ELEVENLABS_SESSION_RECYCLE_SECONDS
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        section: Dict[str, Any],
+        language: str,
+    ):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.section = section
+        self.language = language
+
+    @property
+    def configuration_key(self) -> tuple[Any, ...]:
+        return (
+            self.name,
+            self.api_key,
+            self.base_url,
+            self.language,
+            json.dumps(self.section, sort_keys=True, default=str),
+        )
+
+    async def open_session(self) -> StreamingSTTSession:
+        params = {
+            "model_id": str(self.section["streaming_model_id"]),
+            "audio_format": "pcm_16000",
+            "commit_strategy": "vad",
+        }
+        if self.language:
+            params["language_code"] = self.language
+        for key in (
+            "vad_threshold",
+            "vad_silence_threshold_secs",
+            "min_speech_duration_ms",
+            "min_silence_duration_ms",
+        ):
+            if self.section.get(key) is not None:
+                params[key] = self.section[key]
+        websocket_base_url = (
+            str(self.section.get("wss_url") or self.base_url).strip().rstrip("/")
+        )
+        websocket = await _connect(
+            _with_query(
+                _websocket_endpoint(websocket_base_url, "speech-to-text/realtime"),
+                params,
+            ),
+            {"xi-api-key": self.api_key},
+        )
+        session = ElevenLabsStreamingSTTSession(websocket)
+        try:
+            while True:
+                message = await asyncio.wait_for(session._receive_json(), timeout=10)
+                message_type = message.get("message_type")
+                if message_type == "session_started":
+                    return session
+                if message_type and message_type != "partial_transcript":
+                    raise RuntimeError(str(message.get("error") or message_type))
+        except Exception:
+            await websocket.close()
+            raise
+
+
+def resolve_streaming_stt_provider(
+    stt_config: Optional[Dict[str, Any]] = None,
+) -> Optional[StreamingSTTProvider]:
+    """Resolve the explicitly selected streaming provider, or ``None``.
+
+    A different cloud provider is never selected merely because it supports
+    streaming.
+    """
+    if stt_config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            raw = load_config().get("stt", {})
+            stt_config = raw if isinstance(raw, dict) else {}
+        except Exception:
+            return None
+    if not isinstance(stt_config, dict):
+        return None
+
+    provider_name = str(stt_config.get("provider") or "").strip().lower()
+    from tools.transcription_tools import resolve_stt_provider_config
+
+    resolved = resolve_stt_provider_config(provider_name, stt_config)
+    if resolved is None or not resolved.streaming_enabled or not resolved.api_key:
+        return None
+
+    if provider_name == "openai":
+        return OpenAIStreamingSTTProvider(
+            resolved.api_key,
+            resolved.base_url,
+            resolved.streaming_model_id,
+            resolved.language,
+        )
+
+    if provider_name == "elevenlabs":
+        return ElevenLabsStreamingSTTProvider(
+            resolved.api_key,
+            resolved.base_url,
+            resolved.section,
+            resolved.language,
+        )
+
+    return None
+
+
+class _PCM16StreamResampler:
+    """Stateful chunk resampler for live mono PCM16 provider input."""
+
+    def __init__(self, source_rate: int, target_rate: int):
+        self.source_rate = source_rate
+        self.target_rate = target_rate
+        self._tail = None
+        self._next_position = 0.0
+
+    def convert(self, frame: Any) -> bytes:
+        np = __import__("numpy")
+        samples = np.asarray(frame, dtype=np.int16).reshape(-1)
+        if not len(samples):
+            return b""
+        if self.source_rate == self.target_rate:
+            return samples.astype("<i2", copy=False).tobytes()
+
+        if self._tail is not None:
+            samples = np.concatenate((self._tail, samples))
+        ratio = self.source_rate / self.target_rate
+        if len(samples) < 2:
+            self._tail = samples[-1:].copy()
+            return b""
+        positions = np.arange(self._next_position, len(samples) - 1, ratio)
+        output = np.interp(positions, np.arange(len(samples)), samples)
+        next_absolute = (
+            (positions[-1] + ratio) if len(positions) else self._next_position
+        )
+        self._next_position = next_absolute - (len(samples) - 1)
+        self._tail = samples[-1:].copy()
+        return np.rint(output).astype("<i2").tobytes()
+
+
+class StreamingSTTCoordinator:
+    """Own provider I/O, ordered callbacks, and capture backpressure."""
+
+    def __init__(
+        self,
+        provider: StreamingSTTProvider,
+        on_event: Callable[[int, StreamingTranscriptEvent], None],
+        on_error: Callable[[int, Exception], None],
+        *,
+        continuous: bool = False,
+    ):
+        self._provider = provider
+        self._on_event = on_event
+        self._on_error = on_error
+        self._continuous = continuous
+        self._audio_queue: queue.Queue = queue.Queue()
+        self._command_queue: queue.Queue = queue.Queue()
+        self._callback_queue: queue.Queue = queue.Queue()
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._callback_thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._reconnect = threading.Event()
+        self._reset_session = threading.Event()
+        self._closing = threading.Event()
+        self._session: Optional[StreamingSTTSession] = None
+        self._session_opened_at = 0.0
+        self._connected = False
+        self._queued_audio_seconds = 0.0
+        self._audio_sequence = 0
+        self._deferred_audio: Optional[tuple[int, int, Any, int]] = None
+        self._revoked_generation = 0
+        self._utterance = _UtteranceState()
+
+    @property
+    def connected(self) -> bool:
+        with self._lock:
+            return self._connected
+
+    @property
+    def provider_name(self) -> str:
+        return self._provider.name
+
+    @property
+    def provider_configuration_key(self) -> tuple[Any, ...]:
+        return self._provider.configuration_key
+
+    def start_utterance(self, generation: int, timeout: float = 10.0) -> bool:
+        """Ensure a session exists and arm one capture turn."""
+        self._ensure_thread()
+        with self._lock:
+            if self._closing.is_set() or generation <= self._revoked_generation:
+                return False
+            recycle_seconds = self._provider.session_recycle_seconds
+            recycle_session = bool(
+                self._connected
+                and recycle_seconds
+                and self._session_opened_at
+                and time.monotonic() - self._session_opened_at
+                >= recycle_seconds
+            )
+            if recycle_session:
+                self._connected = False
+                self._ready.clear()
+                self._reset_session.set()
+                self._reconnect.set()
+            elif not self._connected:
+                self._ready.clear()
+                self._reconnect.set()
+        if not self._ready.wait(timeout):
+            return False
+
+        # Nothing can legitimately carry across utterance boundaries. Drain
+        # before arming so a newly attached capture sink cannot race cleanup.
+        self._drain_audio_queue()
+        self._drain_command_queue()
+        with self._lock:
+            if (
+                not self._connected
+                or self._closing.is_set()
+                or generation <= self._revoked_generation
+            ):
+                return False
+            self._utterance = _UtteranceState(
+                generation=generation,
+                active=True,
+                accepting_audio=True,
+            )
+        return True
+
+    def enqueue_audio(self, frame: Any, sample_rate: int) -> bool:
+        """Accept a copied PCM frame without blocking the capture callback."""
+        try:
+            source_rate = int(sample_rate)
+            frame_count = len(frame)
+        except (TypeError, ValueError):
+            return False
+        if source_rate <= 0 or frame_count <= 0:
+            return False
+        frame_seconds = frame_count / source_rate
+
+        with self._lock:
+            utterance = self._utterance
+            if (
+                not utterance.active
+                or not utterance.accepting_audio
+                or utterance.failure_pending
+                or not self._connected
+            ):
+                return False
+            generation = utterance.generation
+            if (
+                self._queued_audio_seconds + frame_seconds
+                > _MAX_BUFFERED_AUDIO_SECONDS
+            ):
+                overflow = True
+            else:
+                overflow = False
+                self._queued_audio_seconds += frame_seconds
+                self._audio_sequence += 1
+                self._audio_queue.put_nowait(
+                    (
+                        generation,
+                        self._audio_sequence,
+                        frame,
+                        source_rate,
+                        frame_seconds,
+                    )
+                )
+        if overflow:
+            with self._lock:
+                utterance = self._utterance
+                if (
+                    utterance.active
+                    and generation == utterance.generation
+                    and not utterance.failure_pending
+                ):
+                    utterance.failure_pending = True
+                    self._command_queue.put_nowait(
+                        (
+                            "fail",
+                            generation,
+                            RuntimeError("Streaming STT audio queue overflow"),
+                        )
+                    )
+            return False
+        return True
+
+    def commit(self, generation: int) -> bool:
+        with self._lock:
+            utterance = self._utterance
+            if (
+                not utterance.active
+                or not utterance.accepting_audio
+                or generation != utterance.generation
+            ):
+                return False
+            # This lock is also used by enqueue_audio(). Once accepting_audio
+            # is cleared, every frame already accepted is ahead of this commit.
+            if not self._continuous:
+                utterance.accepting_audio = False
+            self._command_queue.put_nowait(
+                ("commit", generation, self._audio_sequence)
+            )
+        return True
+
+    def pause(self, generation: Optional[int] = None) -> None:
+        reset_session = False
+        with self._lock:
+            if generation is not None:
+                self._revoked_generation = max(
+                    self._revoked_generation,
+                    generation,
+                )
+            if (
+                generation is not None
+                and generation != self._utterance.generation
+            ):
+                return
+            reset_session = self._utterance.active
+            self._utterance.active = False
+            self._utterance.accepting_audio = False
+            self._utterance.resampler = None
+            if reset_session:
+                self._connected = False
+                self._ready.clear()
+                self._reset_session.set()
+        self._drain_audio_queue()
+
+    def has_activity(self, generation: int) -> bool:
+        with self._lock:
+            return (
+                generation == self._utterance.generation
+                and self._utterance.has_activity
+            )
+
+    def close(self, timeout: float = 3.0) -> None:
+        with self._lock:
+            self._utterance.active = False
+            self._utterance.accepting_audio = False
+            self._connected = False
+            self._session_opened_at = 0.0
+        self._closing.set()
+        self._reconnect.set()
+        self._command_queue.put(("close", 0, None))
+        self._drain_audio_queue()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+        self._callback_queue.put_nowait(None)
+        callback_thread = self._callback_thread
+        if (
+            callback_thread is not None
+            and callback_thread is not threading.current_thread()
+        ):
+            callback_thread.join(timeout=timeout)
+
+    def _ensure_thread(self) -> None:
+        with self._lock:
+            if (
+                self._callback_thread is None
+                or not self._callback_thread.is_alive()
+            ):
+                self._callback_thread = threading.Thread(
+                    target=self._run_callbacks,
+                    name=f"stt-callback-{self._provider.name}",
+                    daemon=True,
+                )
+                self._callback_thread.start()
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._closing.clear()
+            self._thread = threading.Thread(
+                target=self._run,
+                name=f"stt-stream-{self._provider.name}",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            asyncio.run(self._worker())
+        except Exception:
+            logger.debug("Streaming STT worker exited unexpectedly", exc_info=True)
+        finally:
+            with self._lock:
+                self._connected = False
+                self._session = None
+                self._session_opened_at = 0.0
+            self._ready.set()
+
+    async def _worker(self) -> None:
+        event_queue: Optional[asyncio.Queue] = None
+        reader_task: Optional[asyncio.Task] = None
+        while not self._closing.is_set():
+            if self._reset_session.is_set():
+                self._reset_session.clear()
+                await self._cancel_reader(reader_task)
+                reader_task = None
+                event_queue = None
+                session = self._session
+                self._session = None
+                if session is not None:
+                    await self._close_session(session)
+                with self._lock:
+                    self._connected = False
+                    self._session_opened_at = 0.0
+            if self._session is None:
+                if not self._reconnect.is_set():
+                    await asyncio.sleep(0.02)
+                    continue
+                self._reconnect.clear()
+                try:
+                    session = await self._provider.open_session()
+                except Exception as exc:
+                    with self._lock:
+                        self._connected = False
+                    logger.warning(
+                        "Streaming STT connection to %s failed: %s",
+                        self._provider.name,
+                        exc,
+                    )
+                    self._ready.set()
+                    continue
+                event_queue = asyncio.Queue()
+                reader_task = asyncio.create_task(
+                    self._read_events(session, event_queue)
+                )
+                self._reconnect.clear()
+                with self._lock:
+                    self._session = session
+                    self._session_opened_at = time.monotonic()
+                    self._connected = True
+                logger.debug(
+                    "Streaming STT session opened: provider=%s",
+                    self._provider.name,
+                )
+                self._ready.set()
+
+            try:
+                if event_queue is not None:
+                    while True:
+                        try:
+                            event = event_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                        self._handle_event(event)
+                if reader_task is not None and reader_task.done():
+                    error = reader_task.exception()
+                    if error is None:
+                        error = RuntimeError(
+                            "Streaming STT provider event stream ended"
+                        )
+                    reader_task = None
+                    event_queue = None
+                    await self._drop_session(error)
+                    continue
+                await self._send_pending()
+            except Exception as exc:
+                await self._cancel_reader(reader_task)
+                reader_task = None
+                event_queue = None
+                await self._drop_session(exc)
+                continue
+            await asyncio.sleep(0.01)
+
+        await self._cancel_reader(reader_task)
+        session = self._session
+        self._session = None
+        if session is not None:
+            await self._close_session(session)
+
+    @staticmethod
+    async def _read_events(
+        session: StreamingSTTSession,
+        event_queue: asyncio.Queue,
+    ) -> None:
+        while True:
+            event = await session.receive_event()
+            if event is not None:
+                await event_queue.put(event)
+
+    @staticmethod
+    async def _cancel_reader(reader_task: Optional[asyncio.Task]) -> None:
+        if reader_task is None:
+            return
+        if reader_task.done():
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                reader_task.exception()
+            return
+        reader_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reader_task
+
+    async def _send_pending(self) -> None:
+        pending_commit = None
+        pending_failure = None
+        while True:
+            try:
+                command, generation, value = self._command_queue.get_nowait()
+            except queue.Empty:
+                break
+            if command == "close":
+                return
+            with self._lock:
+                valid = (
+                    self._utterance.active
+                    and generation == self._utterance.generation
+                )
+            if command == "commit" and valid:
+                pending_commit = (generation, value)
+            elif command == "fail" and valid:
+                pending_failure = (generation, value)
+
+        if pending_failure is not None:
+            generation, error = pending_failure
+            self._fail_turn(generation, error, reset_session=True)
+            return
+
+        # A manual/max-duration commit must not overtake frames accepted before
+        # the request. Continuous capture may enqueue later frames, so the
+        # sequence fence establishes the provider-side audio boundary.
+        send_limit = (
+            self._audio_queue.qsize()
+            if pending_commit is not None
+            else _AUDIO_SEND_BATCH_SIZE
+        )
+        if self._deferred_audio is not None:
+            send_limit += 1
+        for _ in range(send_limit):
+            queued = self._dequeue_audio()
+            if queued is None:
+                break
+            generation, sequence, frame, source_rate = queued
+            if pending_commit is not None and sequence > pending_commit[1]:
+                self._deferred_audio = queued
+                break
+            with self._lock:
+                utterance = self._utterance
+                valid = utterance.active and generation == utterance.generation
+                session = self._session
+                if session is None:
+                    return
+                target_rate = session.sample_rate
+                if valid and (
+                    utterance.resampler is None
+                    or utterance.resampler.source_rate != source_rate
+                    or utterance.resampler.target_rate != target_rate
+                ):
+                    utterance.resampler = _PCM16StreamResampler(
+                        source_rate,
+                        target_rate,
+                    )
+                resampler = utterance.resampler
+            if not valid or resampler is None:
+                continue
+            pcm16 = resampler.convert(frame)
+            if pcm16:
+                await session.send_audio(pcm16)
+                with self._lock:
+                    if (
+                        self._utterance.active
+                        and generation == self._utterance.generation
+                    ):
+                        self._utterance.has_sent_audio = True
+
+        if pending_commit is not None:
+            commit_generation = pending_commit[0]
+            with self._lock:
+                valid = (
+                    self._utterance.active
+                    and commit_generation == self._utterance.generation
+                )
+                session = self._session
+            if valid and session is not None:
+                await session.commit()
+
+    def _handle_event(self, event: StreamingTranscriptEvent) -> None:
+        with self._lock:
+            utterance = self._utterance
+            if not utterance.active or not utterance.has_sent_audio:
+                logger.debug(
+                    "Streaming STT event ignored: provider=%s active=%s "
+                    "audio_sent=%s final=%s text_chars=%d",
+                    self._provider.name,
+                    utterance.active,
+                    utterance.has_sent_audio,
+                    event.is_final,
+                    len(event.text.strip()),
+                )
+                return
+            generation = utterance.generation
+            text = event.text.strip()
+            logger.debug(
+                "Streaming STT event: provider=%s generation=%d final=%s "
+                "text_chars=%d event_id=%s segment_id=%s",
+                self._provider.name,
+                generation,
+                event.is_final,
+                len(text),
+                event.event_id or "-",
+                event.segment_id or "-",
+            )
+            if text:
+                utterance.has_activity = True
+            if event.is_final and not self._continuous:
+                utterance.active = False
+                utterance.accepting_audio = False
+        if event.is_final and not self._continuous:
+            self._drain_audio_queue()
+        self._dispatch_callback(
+            self._on_event,
+            generation,
+            event,
+            failure_message="Streaming STT event callback failed",
+        )
+
+    async def _drop_session(self, exc: Exception) -> None:
+        session = self._session
+        if session is not None:
+            await self._close_session(session)
+        with self._lock:
+            self._session = None
+            self._connected = False
+            self._session_opened_at = 0.0
+            generation = self._utterance.generation
+            active = self._utterance.active
+        if active:
+            self._fail_turn(generation, exc)
+
+    @staticmethod
+    async def _close_session(session: StreamingSTTSession) -> None:
+        try:
+            await session.close()
+        except Exception:
+            logger.debug("Streaming STT session close failed", exc_info=True)
+
+    def _fail_turn(
+        self,
+        generation: int,
+        exc: Exception,
+        *,
+        reset_session: bool = False,
+    ) -> None:
+        with self._lock:
+            utterance = self._utterance
+            if (
+                utterance.error_reported
+                or not utterance.active
+                or generation != utterance.generation
+            ):
+                return
+            utterance.error_reported = True
+            utterance.active = False
+            utterance.accepting_audio = False
+            utterance.resampler = None
+            if reset_session:
+                self._connected = False
+                self._reset_session.set()
+        self._drain_audio_queue()
+        self._dispatch_callback(
+            self._on_error,
+            generation,
+            exc,
+            failure_message="Streaming STT error callback failed",
+        )
+
+    def _dispatch_callback(
+        self,
+        callback: Callable[[int, Any], None],
+        generation: int,
+        value: Any,
+        *,
+        failure_message: str,
+    ) -> None:
+        self._callback_queue.put_nowait(
+            (callback, generation, value, failure_message)
+        )
+
+    def _run_callbacks(self) -> None:
+        while True:
+            item = self._callback_queue.get()
+            if item is None:
+                return
+            callback, generation, value, failure_message = item
+            try:
+                callback(generation, value)
+            except Exception:
+                logger.error(failure_message, exc_info=True)
+
+    def _dequeue_audio(self) -> Optional[tuple[int, int, Any, int]]:
+        if self._deferred_audio is not None:
+            queued = self._deferred_audio
+            self._deferred_audio = None
+            return queued
+        try:
+            generation, sequence, frame, source_rate, frame_seconds = (
+                self._audio_queue.get_nowait()
+            )
+        except queue.Empty:
+            return None
+        with self._lock:
+            self._queued_audio_seconds = max(
+                0.0,
+                self._queued_audio_seconds - frame_seconds,
+            )
+        return generation, sequence, frame, source_rate
+
+    def _drain_audio_queue(self) -> None:
+        self._deferred_audio = None
+        while self._dequeue_audio() is not None:
+            pass
+
+    def _drain_command_queue(self) -> None:
+        while True:
+            try:
+                self._command_queue.get_nowait()
+            except queue.Empty:
+                return
+
+
+class StreamingSTTTurnController:
+    """Present streaming capture without exposing coordinator generations."""
+
+    def __init__(
+        self,
+        provider: StreamingSTTProvider,
+        on_event: Callable[[StreamingTranscriptEvent], None],
+        on_error: Callable[[Exception], None],
+        *,
+        commit_timeout: float = 8.0,
+        continuous: bool = False,
+    ):
+        self._on_event = on_event
+        self._on_error = on_error
+        self._commit_timeout = commit_timeout
+        self._continuous = continuous
+        self._lock = threading.Lock()
+        self._generation = 0
+        self._active = False
+        self._delivering = False
+        self._closed = False
+        self._commit_requested = False
+        self._commit_timer: Optional[threading.Timer] = None
+        self._coordinator = StreamingSTTCoordinator(
+            provider,
+            self._handle_event,
+            self._handle_error,
+            continuous=continuous,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return self._coordinator.provider_name
+
+    @property
+    def provider_configuration_key(self) -> tuple[Any, ...]:
+        return self._coordinator.provider_configuration_key
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return self._active
+
+    @property
+    def delivering(self) -> bool:
+        """Whether a provider result is currently entering its callback."""
+        with self._lock:
+            return self._delivering
+
+    @property
+    def commit_pending(self) -> bool:
+        """Whether a provider commit response is already outstanding."""
+        with self._lock:
+            return self._commit_requested
+
+    def start_utterance(self, timeout: float = 10.0) -> bool:
+        with self._lock:
+            if self._closed or self._delivering:
+                return False
+            if self._active:
+                return self._continuous
+            self._generation += 1
+            generation = self._generation
+            self._active = True
+            self._commit_requested = False
+        started = self._coordinator.start_utterance(generation, timeout=timeout)
+        with self._lock:
+            still_active = (
+                self._active
+                and generation == self._generation
+                and not self._closed
+            )
+            if not started and generation == self._generation:
+                self._active = False
+        if started and still_active:
+            return True
+        if started:
+            self._coordinator.pause(generation)
+        return False
+
+    def enqueue_audio(self, frame: Any, sample_rate: int) -> bool:
+        return self._coordinator.enqueue_audio(frame, sample_rate)
+
+    def commit(self) -> bool:
+        with self._lock:
+            if not self._active or self._commit_requested:
+                return False
+            generation = self._generation
+            self._commit_requested = True
+        if not self._coordinator.commit(generation):
+            self._fail_turn(
+                generation,
+                RuntimeError("Streaming STT commit was not accepted"),
+            )
+            return False
+
+        timer = threading.Timer(
+            self._commit_timeout,
+            lambda: self._fail_turn(
+                generation,
+                RuntimeError("Streaming STT commit timed out"),
+            ),
+        )
+        timer.daemon = True
+        with self._lock:
+            if not self._active or generation != self._generation:
+                return True
+            self._commit_timer = timer
+        timer.start()
+        return True
+
+    def pause(self) -> None:
+        with self._lock:
+            if not self._active:
+                return
+            generation = self._generation
+            self._active = False
+            self._commit_requested = False
+            timer = self._take_commit_timer_locked()
+        if timer is not None:
+            timer.cancel()
+        self._coordinator.pause(generation)
+
+    def close(self, timeout: float = 3.0) -> None:
+        with self._lock:
+            self._closed = True
+            self._active = False
+            self._commit_requested = False
+            timer = self._take_commit_timer_locked()
+        if timer is not None:
+            timer.cancel()
+        self._coordinator.close(timeout=timeout)
+
+    def _handle_event(
+        self,
+        generation: int,
+        event: StreamingTranscriptEvent,
+    ) -> None:
+        self._deliver(
+            generation,
+            self._on_event,
+            event,
+            keep_active=self._continuous or not event.is_final,
+            completes_commit=event.is_final,
+        )
+
+    def _handle_error(self, generation: int, error: Exception) -> None:
+        self._deliver(
+            generation,
+            self._on_error,
+            error,
+            keep_active=False,
+            completes_commit=True,
+        )
+
+    def _fail_turn(self, generation: int, error: Exception) -> None:
+        self._coordinator.pause(generation)
+        self._handle_error(generation, error)
+
+    def _deliver(
+        self,
+        generation: int,
+        callback: Callable[[Any], None],
+        value: Any,
+        *,
+        keep_active: bool,
+        completes_commit: bool,
+    ) -> None:
+        with self._lock:
+            if (
+                not self._active
+                or generation != self._generation
+                or self._delivering
+            ):
+                return
+            if not keep_active:
+                self._active = False
+            self._delivering = True
+            if completes_commit:
+                self._commit_requested = False
+                timer = self._take_commit_timer_locked()
+            else:
+                timer = None
+        if timer is not None:
+            timer.cancel()
+        try:
+            callback(value)
+        finally:
+            with self._lock:
+                self._delivering = False
+
+    def _take_commit_timer_locked(self) -> Optional[threading.Timer]:
+        timer = self._commit_timer
+        self._commit_timer = None
+        return timer

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -38,6 +38,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
@@ -68,7 +69,11 @@ def get_env_value(name, default=None):
     return default if value is None else value
 
 
-def _resolve_provider_key(env_var: str, provider_id: str) -> str:
+def _resolve_provider_key(
+    env_var: str,
+    provider_id: str,
+    config_value: str = "",
+) -> str:
     """Resolve an STT provider API key via the shared voice-key resolver.
 
     Delegates to ``tools.tool_backend_helpers.resolve_provider_secret`` —
@@ -81,7 +86,12 @@ def _resolve_provider_key(env_var: str, provider_id: str) -> str:
         from tools.tool_backend_helpers import resolve_provider_secret
     except ImportError:  # pragma: no cover — helpers are in-repo
         return str(get_env_value(env_var) or "").strip()
-    return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
+    return resolve_provider_secret(
+        env_var,
+        provider_id,
+        config_value=config_value,
+        env_getter=get_env_value,
+    )
 
 # ---------------------------------------------------------------------------
 # Optional imports — graceful degradation
@@ -420,6 +430,160 @@ def _get_stt_section(stt_config: Dict[str, Any], name: str) -> Dict[str, Any]:
         return {}
     section = stt_config.get(name)
     return section if isinstance(section, dict) else {}
+
+
+@dataclass(frozen=True)
+class ResolvedSTTProviderConfig:
+    """Connection and model settings shared by one STT provider's transports."""
+
+    name: str
+    section: Dict[str, Any]
+    api_key: str = ""
+    base_url: str = ""
+    language: str = ""
+    model: str = ""
+    streaming_model_id: str = ""
+    supports_streaming: bool = False
+    direct_access: bool = True
+    credential_source: str = "direct"
+
+    @property
+    def streaming_enabled(self) -> bool:
+        """Whether the selected provider should use its streaming transport."""
+        return (
+            self.supports_streaming
+            and self.direct_access
+            and is_truthy_value(self.section.get("streaming", True), default=True)
+            and bool(self.streaming_model_id)
+        )
+
+
+def resolve_stt_provider_config(
+    provider_name: Optional[str] = None,
+    stt_config: Optional[Dict[str, Any]] = None,
+) -> Optional[ResolvedSTTProviderConfig]:
+    """Resolve one selected provider for both batch and streaming STT.
+
+    Provider credentials, base URL, language, and model settings are resolved
+    once here. Transports may differ, but they must not choose a different
+    account or endpoint for the same provider.
+    """
+    if stt_config is None:
+        stt_config = _load_stt_config()
+    if not isinstance(stt_config, dict) or not is_stt_enabled(stt_config):
+        return None
+
+    name = str(provider_name or stt_config.get("provider") or "").strip().lower()
+    if not name:
+        return None
+    section = _get_stt_section(stt_config, name)
+    language = _resolve_stt_language(
+        name,
+        stt_config,
+        extra_keys=("language_code",) if name == "elevenlabs" else (),
+    ) or ""
+
+    if name == "openai":
+        configured_base_url = str(
+            section.get("base_url")
+            or get_env_value("STT_OPENAI_BASE_URL")
+            or OPENAI_BASE_URL
+        ).strip().rstrip("/")
+        configured_key = str(section.get("api_key") or "").strip()
+        api_key = configured_key or resolve_openai_audio_api_key()
+        direct_access = True
+        if not api_key and configured_base_url and _is_local_or_private_url(configured_base_url):
+            api_key = "not-needed"
+        if not api_key:
+            managed_gateway = resolve_managed_tool_gateway("openai-audio")
+            if managed_gateway is not None:
+                api_key = managed_gateway.nous_user_token
+                configured_base_url = urljoin(
+                    f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"
+                )
+                direct_access = False
+        return ResolvedSTTProviderConfig(
+            name=name,
+            section=section,
+            api_key=api_key,
+            base_url=configured_base_url,
+            language=language,
+            model=str(section.get("model") or DEFAULT_STT_MODEL).strip(),
+            streaming_model_id=str(section.get("streaming_model_id") or "").strip(),
+            supports_streaming=True,
+            direct_access=direct_access,
+        )
+
+    if name == "elevenlabs":
+        return ResolvedSTTProviderConfig(
+            name=name,
+            section=section,
+            api_key=_resolve_provider_key(
+                "ELEVENLABS_API_KEY",
+                "elevenlabs",
+                config_value=section.get("api_key") or "",
+            ),
+            base_url=str(
+                section.get("base_url")
+                or get_env_value("ELEVENLABS_STT_BASE_URL")
+                or ELEVENLABS_STT_BASE_URL
+            ).strip().rstrip("/"),
+            language=language,
+            model=str(section.get("model_id") or DEFAULT_ELEVENLABS_STT_MODEL).strip(),
+            streaming_model_id=str(section.get("streaming_model_id") or "").strip(),
+            supports_streaming=True,
+        )
+
+    if name == "xai":
+        from tools.tool_backend_helpers import resolve_provider_secret
+        from tools.xai_http import resolve_xai_http_credentials
+
+        direct_api_key = resolve_provider_secret(
+            "XAI_API_KEY",
+            "",
+            config_value=section.get("api_key") or "",
+            env_getter=get_env_value,
+        )
+        if direct_api_key:
+            api_key = direct_api_key
+            base_url = str(
+                section.get("base_url")
+                or get_env_value("XAI_STT_BASE_URL")
+                or get_env_value("XAI_BASE_URL")
+                or XAI_STT_BASE_URL
+            ).strip().rstrip("/")
+        else:
+            credentials = resolve_xai_http_credentials()
+            api_key = str(credentials.get("api_key") or "").strip()
+            credential_source = str(credentials.get("provider") or "xai")
+            if credentials.get("provider") == "xai-oauth":
+                base_url = str(
+                    credentials.get("base_url") or XAI_STT_BASE_URL
+                ).strip().rstrip("/")
+            else:
+                base_url = str(
+                    section.get("base_url")
+                    or get_env_value("XAI_STT_BASE_URL")
+                    or credentials.get("base_url")
+                    or XAI_STT_BASE_URL
+                ).strip().rstrip("/")
+        if direct_api_key:
+            credential_source = "xai"
+        return ResolvedSTTProviderConfig(
+            name=name,
+            section=section,
+            api_key=api_key,
+            base_url=base_url,
+            language=language,
+            model="grok-stt",
+            credential_source=credential_source,
+        )
+
+    return ResolvedSTTProviderConfig(
+        name=name,
+        section=section,
+        language=language,
+    )
 
 
 def _get_named_stt_provider_config(
@@ -1070,9 +1234,8 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "xai":
-            from tools.xai_http import resolve_xai_http_credentials
-
-            if resolve_xai_http_credentials().get("api_key"):
+            resolved = resolve_stt_provider_config("xai", stt_config)
+            if resolved is not None and resolved.api_key:
                 return "xai"
             logger.warning(
                 "STT provider 'xai' configured but no xAI credentials are available"
@@ -1080,7 +1243,8 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "elevenlabs":
-            if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
+            resolved = resolve_stt_provider_config("elevenlabs", stt_config)
+            if resolved is not None and resolved.api_key:
                 return "elevenlabs"
             logger.warning(
                 "STT provider 'elevenlabs' configured but ELEVENLABS_API_KEY not set"
@@ -1126,14 +1290,14 @@ def _get_provider(stt_config: dict) -> str:
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
     try:
-        from tools.xai_http import resolve_xai_http_credentials
-
-        if resolve_xai_http_credentials().get("api_key"):
+        resolved_xai = resolve_stt_provider_config("xai", stt_config)
+        if resolved_xai is not None and resolved_xai.api_key:
             logger.info("No local STT available, using xAI Grok STT API")
             return "xai"
     except Exception:
         pass
-    if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
+    resolved_elevenlabs = resolve_stt_provider_config("elevenlabs", stt_config)
+    if resolved_elevenlabs is not None and resolved_elevenlabs.api_key:
         logger.info("No local STT available, using ElevenLabs Scribe STT API")
         return "elevenlabs"
     if _HAS_OPENAI and _resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"):
@@ -2190,30 +2354,29 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_xai_stt_credentials(
+    stt_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Return the shared xAI provider configuration in the legacy dict shape."""
+    resolved = resolve_stt_provider_config("xai", stt_config)
+    if resolved is None:
+        return {}
+    return {
+        "provider": resolved.credential_source,
+        "api_key": resolved.api_key,
+        "base_url": resolved.base_url,
+    }
+
+
 def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using xAI Grok STT API.
 
     Uses the ``POST /v1/stt`` REST endpoint with multipart/form-data.
     Supports Inverse Text Normalization, diarization, and word-level timestamps.
-    Requires ``XAI_API_KEY`` environment variable.
+    Supports a configured/direct API key or Hermes-managed xAI OAuth.
     """
-    from tools.xai_http import resolve_xai_http_credentials
-
-    # STT is an API-billed endpoint. Prefer the explicit XAI_API_KEY over the
-    # general xAI OAuth/Grok-subscription credential; subscription OAuth may be
-    # valid for Grok while returning personal-team spending-limit errors for
-    # /v1/stt. Other xAI integrations keep their existing resolver precedence.
-    direct_api_key = str(get_env_value("XAI_API_KEY") or "").strip()
-    if direct_api_key:
-        creds = {
-            "provider": "xai",
-            "api_key": direct_api_key,
-            "base_url": str(
-                get_env_value("XAI_BASE_URL") or "https://api.x.ai/v1"
-            ).strip().rstrip("/"),
-        }
-    else:
-        creds = resolve_xai_http_credentials()
+    stt_config = _load_stt_config()
+    creds = _resolve_xai_stt_credentials(stt_config)
     api_key = str(creds.get("api_key") or "").strip()
     if not api_key:
         return {
@@ -2222,21 +2385,11 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
             "error": "No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY",
         }
 
-    stt_config = _load_stt_config()
     xai_config = stt_config.get("xai") or {}
 
     def _resolve_base_url(resolved_creds: Dict[str, str]) -> str:
-        # OAuth bearers are pinned to the resolver-validated xAI origin;
-        # config/env base URL overrides only apply to API-key credentials.
-        if resolved_creds.get("provider") == "xai-oauth":
-            return str(
-                resolved_creds.get("base_url") or XAI_STT_BASE_URL
-            ).strip().rstrip("/")
         return str(
-            xai_config.get("base_url")
-            or get_env_value("XAI_STT_BASE_URL")
-            or resolved_creds.get("base_url")
-            or XAI_STT_BASE_URL
+            resolved_creds.get("base_url") or XAI_STT_BASE_URL
         ).strip().rstrip("/")
 
     base_url = _resolve_base_url(creds)
@@ -2284,6 +2437,8 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
                 response.status_code,
             )
             try:
+                from tools.xai_http import resolve_xai_http_credentials
+
                 refreshed_creds = resolve_xai_http_credentials(
                     force_refresh=True,
                     api_key_hint=api_key,
@@ -2349,20 +2504,15 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using ElevenLabs Scribe STT API."""
-    api_key = _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs")
-    if not api_key:
+    stt_config = _load_stt_config()
+    resolved = resolve_stt_provider_config("elevenlabs", stt_config)
+    if resolved is None or not resolved.api_key:
         return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
 
-    stt_config = _load_stt_config()
-    elevenlabs_config = stt_config.get("elevenlabs") or {}
-    base_url = str(
-        elevenlabs_config.get("base_url")
-        or get_env_value("ELEVENLABS_STT_BASE_URL")
-        or ELEVENLABS_STT_BASE_URL
-    ).strip().rstrip("/")
-    language_code = _resolve_stt_language(
-        "elevenlabs", stt_config, extra_keys=("language_code",)
-    ) or ""
+    elevenlabs_config = resolved.section
+    api_key = resolved.api_key
+    base_url = resolved.base_url
+    language_code = resolved.language
     tag_audio_events = is_truthy_value(elevenlabs_config.get("tag_audio_events", False))
     diarize = is_truthy_value(elevenlabs_config.get("diarize", False))
 
@@ -2952,24 +3102,8 @@ def transcribe_audio_local_fallback(
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
     """Return direct OpenAI audio config or a managed gateway fallback."""
-    stt_config = _load_stt_config()
-    openai_cfg = stt_config.get("openai") or {}
-    cfg_api_key = openai_cfg.get("api_key", "")
-    cfg_base_url = openai_cfg.get("base_url", "")
-    if cfg_api_key:
-        return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
-
-    # A local OpenAI-compatible server needs no key — send a placeholder so
-    # the SDK doesn't refuse to construct a client (#25193, credit @nnnet).
-    if cfg_base_url and _is_local_or_private_url(cfg_base_url):
-        return "not-needed", cfg_base_url
-
-    direct_api_key = resolve_openai_audio_api_key()
-    if direct_api_key:
-        return direct_api_key, OPENAI_BASE_URL
-
-    managed_gateway = resolve_managed_tool_gateway("openai-audio")
-    if managed_gateway is None:
+    resolved = resolve_stt_provider_config("openai")
+    if resolved is None or not resolved.api_key:
         message = "Neither stt.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         if managed_nous_tools_enabled():
             message += (
@@ -2979,10 +3113,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
                 )
             )
         raise ValueError(message)
-
-    return managed_gateway.nous_user_token, urljoin(
-        f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"
-    )
+    return resolved.api_key, resolved.base_url
 
 
 def _extract_transcript_text(transcription: Any) -> str:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -4145,35 +4145,38 @@ def stream_tts_to_speaker(
                     def mark_audio_output_active(_active):
                         return None
 
-                mark_audio_output_active(True)
-                try:
-                    _max_reinit = 3
-                    _reinit_count = 0
-                    _current_stream = output_stream
-                    while True:
-                        chunk_queue = _audio_queue.get()
-                        if chunk_queue is None:
-                            break
-                        if stop_event.is_set():
-                            continue
-                        if _current_stream is None:
-                            _chunks = []
-                            while True:
-                                chunk = chunk_queue.get()
-                                if chunk is None:
-                                    break
-                                _chunks.append(chunk)
-                            _play_via_tempfile(
-                                iter(_chunks), stop_event, streamer.sample_rate
-                            )
-                            continue
-                        _pcm_leftover = b""
+                _max_reinit = 3
+                _reinit_count = 0
+                _current_stream = output_stream
+                while True:
+                    chunk_queue = _audio_queue.get()
+                    if chunk_queue is None:
+                        break
+                    if stop_event.is_set():
+                        continue
+                    if _current_stream is None:
+                        _chunks = []
+                        while True:
+                            chunk = chunk_queue.get()
+                            if chunk is None:
+                                break
+                            _chunks.append(chunk)
+                        _play_via_tempfile(
+                            iter(_chunks), stop_event, streamer.sample_rate
+                        )
+                        continue
+                    _pcm_leftover = b""
+                    output_active = False
+                    try:
                         while True:
                             chunk = chunk_queue.get()
                             if chunk is None:
                                 break
                             if stop_event.is_set():
                                 break
+                            if not output_active:
+                                mark_audio_output_active(True)
+                                output_active = True
                             _buf = _pcm_leftover + chunk
                             _aligned_len = len(_buf) - (len(_buf) % 2)
                             if _aligned_len >= 2:
@@ -4221,8 +4224,9 @@ def stream_tts_to_speaker(
                             _pcm_leftover = (
                                 _buf[_aligned_len:] if _aligned_len < len(_buf) else b""
                             )
-                finally:
-                    mark_audio_output_active(False)
+                    finally:
+                        if output_active:
+                            mark_audio_output_active(False)
             else:
                 while True:
                     chunk_queue = _audio_queue.get()

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -28,6 +28,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+_CONTINUOUS_FALLBACK_BUFFER_SECONDS = 2.0
+
 # ---------------------------------------------------------------------------
 # Lazy audio imports -- never imported at module level to avoid crashing
 # in headless environments (SSH, Docker, WSL, no PortAudio).
@@ -826,8 +828,11 @@ class AudioRecorder:
     """
 
     supports_silence_autostop = True
+    supports_streaming_frames = True
 
     def __init__(self) -> None:
+        from collections import deque
+
         self._lock = threading.Lock()
         self._stream: Any = None
         self._frames: List[Any] = []
@@ -844,6 +849,15 @@ class AudioRecorder:
         self._resume_start: float = 0.0  # Tracks sustained speech after silence starts
         self._resume_dip_start: float = 0.0  # Dip tolerance tracker for resume detection
         self._on_silence_stop = None
+        self._on_no_speech = None
+        self._on_max_duration = None
+        self._frame_sink = None
+        self._frame_sink_failed = False
+        self._frame_sink_error_event = None
+        self._frame_sink_error_holder = None
+        self._continuous_frame_sinks: tuple[Callable[[Any, int], Any], ...] = ()
+        self._continuous_frames = deque()
+        self._continuous_frame_seconds = 0.0
         self._silence_threshold: int = SILENCE_RMS_THRESHOLD
         self._silence_duration: float = SILENCE_DURATION_SECONDS
         self._max_wait: float = 15.0  # Max seconds to wait for speech before auto-stop
@@ -880,11 +894,42 @@ class AudioRecorder:
         return self._current_rms
 
     @property
+    def has_spoken(self) -> bool:
+        """Whether the current capture has confirmed microphone speech."""
+        return self._has_spoken
+
+    @property
     def is_recording(self) -> bool:
         """Whether audio recording is currently active."""
         return self._recording
 
     # -- public methods ------------------------------------------------------
+
+    def prepare(self) -> None:
+        """Open the persistent input stream without arming frame capture."""
+        try:
+            sd, _ = _import_audio()
+        except OSError as e:
+            if _is_termux_environment():
+                portaudio_hint = "  Termux: pkg install portaudio"
+            else:
+                portaudio_hint = (
+                    "  Linux:  sudo apt-get install libportaudio2\n"
+                    "  macOS:  brew install portaudio"
+                )
+            raise RuntimeError(
+                "PortAudio system library not found -- install it first:\n"
+                f"{portaudio_hint}\n"
+                "Then retry /voice on."
+            ) from e
+        except ImportError as e:
+            raise RuntimeError(
+                "Voice mode requires sounddevice and numpy.\n"
+                f"Install with: {sys.executable} -m pip install sounddevice numpy"
+            ) from e
+
+        self._sample_rate = _default_input_samplerate(sd)
+        self._ensure_stream()
 
     def _ensure_stream(self) -> None:
         """Create the audio InputStream once and keep it alive.
@@ -902,18 +947,92 @@ class AudioRecorder:
         def _callback(indata, frames, time_info, status):  # noqa: ARG001
             if status:
                 logger.debug("sounddevice status: %s", status)
-            # When not recording the stream is idle — discard audio.
-            if not self._recording:
+            recording = self._recording
+            continuous_sinks = self._continuous_frame_sinks
+            if not recording and not continuous_sinks:
                 return
-            self._frames.append(indata.copy())
+            frame = indata.copy()
+
+            if continuous_sinks:
+                # The callback must never wait for control-path operations.
+                # Missing one ring-buffer frame is preferable to blocking
+                # PortAudio; the provider sinks still receive every frame.
+                if self._lock.acquire(blocking=False):
+                    try:
+                        frame_seconds = len(frame) / self._sample_rate
+                        self._continuous_frames.append((frame, frame_seconds))
+                        self._continuous_frame_seconds += frame_seconds
+                        while (
+                            self._continuous_frames
+                            and self._continuous_frame_seconds
+                            > _CONTINUOUS_FALLBACK_BUFFER_SECONDS
+                        ):
+                            _, dropped_seconds = self._continuous_frames.popleft()
+                            self._continuous_frame_seconds = max(
+                                0.0,
+                                self._continuous_frame_seconds - dropped_seconds,
+                            )
+                    finally:
+                        self._lock.release()
+
+            for sink in continuous_sinks:
+                try:
+                    sink(frame, self._sample_rate)
+                except Exception as e:
+                    logger.error(
+                        "Continuous audio frame sink failed: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    # Do not race control-path sink additions, and never wait
+                    # for their lock from the PortAudio callback.  If the lock
+                    # is busy, the next frame gets another removal attempt.
+                    if self._lock.acquire(blocking=False):
+                        try:
+                            self._continuous_frame_sinks = tuple(
+                                current
+                                for current in self._continuous_frame_sinks
+                                if current is not sink
+                            )
+                        finally:
+                            self._lock.release()
+
+            if not recording:
+                return
+            self._frames.append(frame)
+
+            # Streaming STT receives the same copied frame retained for batch
+            # fallback.  The sink contract is intentionally synchronous and
+            # non-blocking: it may enqueue only; network I/O and resampling
+            # belong to the streaming coordinator's worker thread.
+            frame_sink = self._frame_sink
+            if frame_sink is not None:
+                try:
+                    frame_sink(frame, self._sample_rate)
+                except Exception as e:
+                    if not self._frame_sink_failed:
+                        self._frame_sink_failed = True
+                        logger.error("Audio frame sink failed: %s", e, exc_info=True)
+                    self._frame_sink = None
+                    error_holder = self._frame_sink_error_holder
+                    error_event = self._frame_sink_error_event
+                    if error_holder is not None and error_event is not None:
+                        error_holder.append(e)
+                        error_event.set()
 
             # Compute RMS for level display and silence detection
             rms = int(np.sqrt(np.mean(indata.astype(np.float64) ** 2)))
             self._current_rms = rms
             self._peak_rms = max(self._peak_rms, rms)
 
-            # Silence detection
-            if self._on_silence_stop is not None:
+            # Speech-state tracking supports three independent outcomes. A
+            # streaming consumer can disable only local end-of-turn detection
+            # while retaining the recorder's no-speech and hard-cap guards.
+            if any((
+                self._on_silence_stop,
+                self._on_no_speech,
+                self._on_max_duration,
+            )):
                 now = time.monotonic()
                 elapsed = now - self._start_time
 
@@ -968,32 +1087,57 @@ class AudioRecorder:
                 # Fire silence callback when:
                 # 1. User spoke then went silent for silence_duration, OR
                 # 2. No speech detected at all for max_wait seconds
-                should_fire = False
-                if self._has_spoken and rms <= self._silence_threshold:
+                callback_kind = None
+                if (
+                    self._on_silence_stop is not None
+                    and self._has_spoken
+                    and rms <= self._silence_threshold
+                ):
                     # User was speaking and now is silent
                     if self._silence_start == 0.0:
                         self._silence_start = now
                     elif now - self._silence_start >= self._silence_duration:
                         logger.info("Silence detected (%.1fs), auto-stopping",
                                     self._silence_duration)
-                        should_fire = True
-                elif not self._has_spoken and elapsed >= self._max_wait:
+                        callback_kind = "silence"
+                elif (
+                    self._on_no_speech is not None
+                    and not self._has_spoken
+                    and elapsed >= self._max_wait
+                ):
                     logger.info("No speech within %.0fs, auto-stopping",
                                 self._max_wait)
-                    should_fire = True
+                    callback_kind = "no_speech"
 
                 # 3. Hard cap on total recording length (voice.max_recording_seconds).
                 #    Independent of speech/silence so a continuous speaker past the
                 #    configured limit still auto-stops instead of recording forever.
-                if not should_fire and self._max_duration_reached(elapsed):
+                if (
+                    callback_kind is None
+                    and self._on_max_duration is not None
+                    and self._max_duration_reached(elapsed)
+                ):
                     logger.info("Max recording length reached (%.0fs), auto-stopping",
                                 self._max_recording_seconds)
-                    should_fire = True
+                    callback_kind = "max_duration"
 
-                if should_fire:
+                if callback_kind is not None:
                     with self._lock:
-                        cb = self._on_silence_stop
-                        self._on_silence_stop = None  # fire only once
+                        if callback_kind == "silence":
+                            cb = self._on_silence_stop
+                        elif callback_kind == "no_speech":
+                            cb = self._on_no_speech
+                        else:
+                            cb = self._on_max_duration
+                        if (
+                            callback_kind == "max_duration"
+                            and cb is not self._on_silence_stop
+                        ):
+                            self._on_max_duration = None
+                        else:
+                            self._on_silence_stop = None
+                            self._on_no_speech = None
+                            self._on_max_duration = None
                     if cb:
                         def _safe_cb():
                             try:
@@ -1024,7 +1168,15 @@ class AudioRecorder:
             ) from e
         self._stream = stream
 
-    def start(self, on_silence_stop=None) -> None:
+    def start(
+        self,
+        on_silence_stop=None,
+        frame_sink=None,
+        on_no_speech=None,
+        on_max_duration=None,
+        start_guard=None,
+        on_frame_sink_error=None,
+    ) -> bool:
         """Start capturing audio from the default input device.
 
         The underlying InputStream is created once and kept alive across
@@ -1035,37 +1187,30 @@ class AudioRecorder:
             on_silence_stop: Optional callback invoked (in a daemon thread) when
                 silence is detected after speech. The callback receives no arguments.
                 Use this to auto-stop recording and trigger transcription.
+            frame_sink: Optional non-blocking callback receiving ``(frame,
+                sample_rate)`` for streaming consumers. The copied frame remains
+                buffered locally until ``stop()`` or ``cancel()``.
+            on_no_speech: Optional callback for the initial no-speech timeout.
+                Defaults to ``on_silence_stop`` for backward compatibility.
+            on_max_duration: Optional callback for the recording hard cap.
+                Defaults to ``on_silence_stop`` for backward compatibility.
+            start_guard: Optional callback checked before capture is armed.
+                Returning false revokes a start that blocked while its input
+                stream or streaming STT session was being prepared.
+            on_frame_sink_error: Optional callback receiving an exception if
+                the sink fails. Delivery occurs away from the audio callback.
 
         Raises ``RuntimeError`` if sounddevice/numpy are not installed
         or if a recording is already in progress.
         """
-        try:
-            sd, _ = _import_audio()
-        except OSError as e:
-            # sounddevice imports but PortAudio's shared library is missing —
-            # a pip install can't fix that; point at the system package
-            # instead of misreporting missing Python packages (#18432).
-            if _is_termux_environment():
-                portaudio_hint = "  Termux: pkg install portaudio"
-            else:
-                portaudio_hint = (
-                    "  Linux:  sudo apt-get install libportaudio2\n"
-                    "  macOS:  brew install portaudio"
-                )
-            raise RuntimeError(
-                "PortAudio system library not found -- install it first:\n"
-                f"{portaudio_hint}\n"
-                "Then retry /voice on."
-            ) from e
-        except ImportError as e:
-            raise RuntimeError(
-                "Voice mode requires sounddevice and numpy.\n"
-                f"Install with: {sys.executable} -m pip install sounddevice numpy"
-            ) from e
+        self.prepare()
 
         with self._lock:
             if self._recording:
-                return  # already recording
+                return True  # already recording
+
+            if start_guard is not None and not start_guard():
+                return False
 
             self._frames = []
             self._start_time = time.monotonic()
@@ -1078,13 +1223,49 @@ class AudioRecorder:
             self._peak_rms = 0
             self._current_rms = 0
             self._on_silence_stop = on_silence_stop
-        # Ensure the persistent stream is alive (no-op after first call).
-        self._sample_rate = _default_input_samplerate(sd)
-        self._ensure_stream()
+            self._on_no_speech = (
+                on_no_speech if on_no_speech is not None else on_silence_stop
+            )
+            self._on_max_duration = (
+                on_max_duration
+                if on_max_duration is not None
+                else on_silence_stop
+            )
+            self._frame_sink = frame_sink
+            self._frame_sink_failed = False
+            error_event = threading.Event()
+            error_holder: List[Exception] = []
+            self._frame_sink_error_event = error_event
+            self._frame_sink_error_holder = error_holder
 
+        if on_frame_sink_error is not None:
+            def _report_frame_sink_error() -> None:
+                error_event.wait()
+                if error_holder:
+                    try:
+                        on_frame_sink_error(error_holder[0])
+                    except Exception:
+                        logger.error(
+                            "Audio frame sink error callback failed",
+                            exc_info=True,
+                        )
+
+            threading.Thread(
+                target=_report_frame_sink_error,
+                name="audio-frame-sink-error",
+                daemon=True,
+            ).start()
         with self._lock:
+            if start_guard is not None and not start_guard():
+                self._on_silence_stop = None
+                self._on_no_speech = None
+                self._on_max_duration = None
+                self._frame_sink = None
+                error_event.set()
+                return False
             self._recording = True
         logger.info("Voice recording started (rate=%d, channels=%d)", self._sample_rate, CHANNELS)
+        return True
 
     def _close_stream_with_timeout(self, timeout: float = 3.0) -> None:
         """Close the audio stream with a timeout to prevent CoreAudio hangs."""
@@ -1120,10 +1301,16 @@ class AudioRecorder:
             Path to the WAV file, or ``None`` if no audio was captured.
         """
         with self._lock:
-            if not self._recording:
+            if not self._recording and not self._frames:
                 return None
 
             self._recording = False
+            self._on_silence_stop = None
+            self._on_no_speech = None
+            self._on_max_duration = None
+            self._frame_sink = None
+            if self._frame_sink_error_event is not None:
+                self._frame_sink_error_event.set()
             self._current_rms = 0
             # Stream stays alive — no close needed.
 
@@ -1135,8 +1322,12 @@ class AudioRecorder:
             audio_data = np.concatenate(self._frames, axis=0)
             self._frames = []
 
-            elapsed = time.monotonic() - self._start_time
-            logger.info("Voice recording stopped (%.1fs, %d samples)", elapsed, len(audio_data))
+            captured_seconds = len(audio_data) / self._sample_rate
+            logger.info(
+                "Voice recording stopped (%.1fs, %d samples)",
+                captured_seconds,
+                len(audio_data),
+            )
 
             # Skip very short recordings (< 0.3s of audio)
             min_samples = int(self._sample_rate * 0.3)
@@ -1153,6 +1344,27 @@ class AudioRecorder:
 
             return self._write_wav(audio_data, sample_rate=self._sample_rate)
 
+    def finish_capture(self) -> bool:
+        """Stop accepting frames while retaining audio for fallback.
+
+        Streaming callers use this at a manual commit boundary. A later final
+        can discard the retained frames with ``cancel()``, while a provider
+        failure can still write exactly the pre-commit audio with ``stop()``.
+        """
+        with self._lock:
+            if not self._recording:
+                return False
+            self._recording = False
+            self._on_silence_stop = None
+            self._on_no_speech = None
+            self._on_max_duration = None
+            self._frame_sink = None
+            if self._frame_sink_error_event is not None:
+                self._frame_sink_error_event.set()
+            self._current_rms = 0
+        logger.info("Voice capture finished; retaining frames for STT fallback")
+        return True
+
     def cancel(self) -> None:
         """Stop recording and discard all captured audio.
 
@@ -1162,8 +1374,71 @@ class AudioRecorder:
             self._recording = False
             self._frames = []
             self._on_silence_stop = None
+            self._on_no_speech = None
+            self._on_max_duration = None
+            self._frame_sink = None
+            if self._frame_sink_error_event is not None:
+                self._frame_sink_error_event.set()
             self._current_rms = 0
         logger.info("Voice recording cancelled")
+
+    def clear_frame_sink(self) -> None:
+        """Stop forwarding frames while retaining buffered fallback audio."""
+        with self._lock:
+            self._frame_sink = None
+            if self._frame_sink_error_event is not None:
+                self._frame_sink_error_event.set()
+
+    def add_continuous_frame_sink(
+        self,
+        sink: Callable[[Any, int], Any],
+    ) -> None:
+        """Forward every input frame until the sink is explicitly removed."""
+        with self._lock:
+            if not any(current is sink for current in self._continuous_frame_sinks):
+                self._continuous_frame_sinks = (*self._continuous_frame_sinks, sink)
+
+    def remove_continuous_frame_sink(
+        self,
+        sink: Callable[[Any, int], Any],
+    ) -> None:
+        with self._lock:
+            self._continuous_frame_sinks = tuple(
+                current
+                for current in self._continuous_frame_sinks
+                if current is not sink
+            )
+
+    def begin_continuous_fallback_capture(self) -> bool:
+        """Retain recent continuous audio if the provider fails mid-barge."""
+        np = _import_numpy()
+        with self._lock:
+            if self._recording:
+                return True
+            buffered = [frame for frame, _ in self._continuous_frames]
+            self._frames = buffered
+            self._start_time = time.monotonic()
+            self._has_spoken = bool(buffered)
+            self._speech_start = 0.0
+            self._silence_start = 0.0
+            self._on_silence_stop = None
+            self._on_no_speech = None
+            self._on_max_duration = None
+            self._frame_sink = None
+            self._peak_rms = max(
+                (
+                    int(np.sqrt(np.mean(frame.astype(np.float64) ** 2)))
+                    for frame in buffered
+                ),
+                default=0,
+            )
+            self._recording = True
+        return True
+
+    def clear_continuous_fallback_buffer(self) -> None:
+        with self._lock:
+            self._continuous_frames.clear()
+            self._continuous_frame_seconds = 0.0
 
     def shutdown(self) -> None:
         """Release the audio stream.  Call when voice mode is disabled."""
@@ -1171,6 +1446,13 @@ class AudioRecorder:
             self._recording = False
             self._frames = []
             self._on_silence_stop = None
+            self._on_no_speech = None
+            self._on_max_duration = None
+            self._continuous_frame_sinks = ()
+            self._continuous_frames.clear()
+            self._continuous_frame_seconds = 0.0
+            if self._frame_sink_error_event is not None:
+                self._frame_sink_error_event.set()
         # Close stream OUTSIDE the lock to avoid deadlock with audio callback
         self._close_stream_with_timeout()
         logger.info("AudioRecorder shut down")
@@ -1566,6 +1848,8 @@ def stop_playback() -> None:
     global _active_playback
     with _playback_lock:
         proc = _active_playback
+        if proc is not None and proc.poll() is None:
+            proc._hermes_interrupted = True
         _active_playback = None
     if proc and proc.poll() is None:
         try:
@@ -1779,7 +2063,17 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 proc.wait(timeout=300)
                 rc = proc.returncode
                 with _playback_lock:
-                    _active_playback = None
+                    interrupted = (
+                        getattr(proc, "_hermes_interrupted", False) is True
+                    )
+                    if _active_playback is proc:
+                        _active_playback = None
+                if interrupted:
+                    logger.debug(
+                        "System player %s was intentionally interrupted",
+                        cmd[0],
+                    )
+                    return True
                 if rc == 0:
                     return True
                 # Non-zero exit: player failed (e.g. WSL ffplay/aplay with no
@@ -1791,11 +2085,13 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 proc.kill()
                 proc.wait()
                 with _playback_lock:
-                    _active_playback = None
+                    if _active_playback is proc:
+                        _active_playback = None
             except Exception as e:
                 logger.debug("System player %s failed: %s", cmd[0], e)
                 with _playback_lock:
-                    _active_playback = None
+                    if _active_playback is proc:
+                        _active_playback = None
 
     logger.warning("No audio player available for %s", file_path)
     return False
@@ -2002,6 +2298,106 @@ TRIGGER_CEILING = 4000.0
 # staying reachable (300 RMS floor * 3 = 900 trigger vs 3000+ RMS speech).
 DEFAULT_BARGE_MULTIPLIER = 3.0
 
+# Barge monitoring may briefly fall behind the PortAudio callback while the
+# agent interrupt is dispatched. Retain only a short duration and drop oldest
+# frames instead of ever blocking microphone capture.
+_BARGE_MONITOR_BUFFER_SECONDS = 2.0
+
+
+class ContinuousAudioFrameQueue:
+    """Duration-bounded frame handoff that never blocks the audio callback."""
+
+    def __init__(self, max_seconds: float = _BARGE_MONITOR_BUFFER_SECONDS):
+        from collections import deque
+
+        self._max_seconds = max_seconds
+        self._frames = deque()
+        self._queued_seconds = 0.0
+        self._lock = threading.Lock()
+        self._ready = threading.Event()
+        self._closed = False
+
+    def enqueue(self, frame: Any, sample_rate: int) -> bool:
+        try:
+            duration = len(frame) / int(sample_rate)
+        except (TypeError, ValueError, ZeroDivisionError):
+            return False
+        if duration <= 0 or not self._lock.acquire(blocking=False):
+            return False
+        try:
+            if self._closed:
+                return False
+            self._frames.append((frame, int(sample_rate), duration))
+            self._queued_seconds += duration
+            while self._frames and self._queued_seconds > self._max_seconds:
+                _, _, dropped = self._frames.popleft()
+                self._queued_seconds = max(0.0, self._queued_seconds - dropped)
+            self._ready.set()
+            return True
+        finally:
+            self._lock.release()
+
+    def get(self, timeout: float = 0.1) -> Optional[tuple[Any, int]]:
+        if not self._ready.wait(timeout):
+            return None
+        with self._lock:
+            if not self._frames:
+                self._ready.clear()
+                return None
+            frame, sample_rate, duration = self._frames.popleft()
+            self._queued_seconds = max(0.0, self._queued_seconds - duration)
+            if not self._frames:
+                self._ready.clear()
+            return frame, sample_rate
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            self._frames.clear()
+            self._queued_seconds = 0.0
+            self._ready.set()
+
+
+class _QueuedAudioBlockStream:
+    """Present native-rate callback frames as approximately 30 ms blocks."""
+
+    def __init__(self, source: ContinuousAudioFrameQueue, np: Any):
+        self._source = source
+        self._np = np
+        self._pending = None
+        self._sample_rate = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    def read(self, _block: int):
+        while True:
+            if self._pending is not None and self._sample_rate > 0:
+                block_size = max(1, int(self._sample_rate * 0.03))
+                if len(self._pending) >= block_size:
+                    data = self._pending[:block_size]
+                    self._pending = self._pending[block_size:]
+                    return data, False
+            item = self._source.get()
+            if item is None:
+                return None, False
+            frame, sample_rate = item
+            samples = self._np.asarray(frame, dtype=self._np.int16).reshape(-1, 1)
+            if sample_rate != self._sample_rate:
+                self._sample_rate = sample_rate
+                self._pending = None
+            if self._pending is None:
+                self._pending = samples
+            else:
+                self._pending = self._np.concatenate((self._pending, samples))
+
 
 def _voice_debug_enabled() -> bool:
     return os.environ.get("HERMES_VOICE_DEBUG", "").strip() == "1"
@@ -2029,6 +2425,9 @@ def full_duplex_listen(
     pre_roll_ms: int = 1200,
     endpoint_silence_ms: int = 1250,
     max_utterance_ms: int = 30_000,
+    frame_queue: Optional[ContinuousAudioFrameQueue] = None,
+    capture: bool | Callable[[], bool] = True,
+    on_candidate: Optional[Callable[[], None]] = None,
 ) -> Optional[str]:
     """Listen across an ENTIRE agent turn; return the captured interruption.
 
@@ -2052,8 +2451,11 @@ def full_duplex_listen(
 
     On detection ``on_trigger(phase)`` fires (cut TTS / interrupt the turn),
     then capture continues from the rolling *pre_roll_ms* buffer until
-    *endpoint_silence_ms* of quiet, and the WAV path is returned. Returns
-    ``None`` when *should_stop* ends the turn without speech.
+    *endpoint_silence_ms* of quiet, and the WAV path is returned. A callable
+    *capture* chooses at trigger time, allowing provider failure to fall back
+    without opening another input stream. ``on_candidate`` fires once on the
+    first above-threshold block; it does not alter the detector decision.
+    Returns ``None`` when *should_stop* ends the turn without speech.
     """
     try:
         sd, np = _import_audio()
@@ -2081,15 +2483,27 @@ def full_duplex_listen(
     grace_remaining = 0
     blocks_since_playback = 10_000
     block_idx = 0
+    candidate_active = False
 
     try:
-        with sd.InputStream(
-            samplerate=SAMPLE_RATE, channels=1, dtype="int16", blocksize=block
-        ) as stream:
+        stream_context = (
+            _QueuedAudioBlockStream(frame_queue, np)
+            if frame_queue is not None
+            else sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=1,
+                dtype="int16",
+                blocksize=block,
+            )
+        )
+        with stream_context as stream:
             while not should_stop():
                 data, _ = stream.read(block)
+                if data is None:
+                    continue
                 rms = float(np.sqrt(np.mean(data.astype(np.float64) ** 2)))
-                pre_roll.append(data.copy())
+                if capture:
+                    pre_roll.append(data.copy())
                 block_idx += 1
 
                 playing = bool(is_playing()) if is_playing is not None else False
@@ -2161,6 +2575,18 @@ def full_duplex_listen(
                     grace_remaining -= 1
 
                 recent_above.append(above)
+                if above and not candidate_active:
+                    candidate_active = True
+                    if on_candidate:
+                        try:
+                            on_candidate()
+                        except Exception as e:
+                            logger.debug(
+                                "full-duplex candidate callback failed: %s",
+                                e,
+                            )
+                elif not any(recent_above):
+                    candidate_active = False
                 if rms >= trigger * 0.5:
                     _vad_log(
                         f"block={block_idx} rms={rms:.0f} floor={quiet_floor:.0f} "
@@ -2184,6 +2610,10 @@ def full_duplex_listen(
                     except Exception as e:
                         logger.debug("full-duplex trigger callback failed: %s", e)
 
+                should_capture = capture() if callable(capture) else capture
+                if not should_capture:
+                    return None
+
                 # Capture until the user goes quiet. Playback was cut by
                 # on_trigger, so plain silence endpointing works.
                 frames: List[Any] = list(pre_roll)
@@ -2195,7 +2625,15 @@ def full_duplex_listen(
                     quiet = quiet + 1 if rms < SILENCE_RMS_THRESHOLD else 0
                     if quiet >= endpoint_blocks:
                         break
-                return AudioRecorder._write_wav(np.concatenate(frames, axis=0))
+                sample_rate = (
+                    stream.sample_rate
+                    if isinstance(stream, _QueuedAudioBlockStream)
+                    else SAMPLE_RATE
+                )
+                return AudioRecorder._write_wav(
+                    np.concatenate(frames, axis=0),
+                    sample_rate=sample_rate,
+                )
     except Exception as e:
         logger.debug("Full-duplex listener failed: %s", e)
     return None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1902,14 +1902,34 @@ stt:
   groq:
     language: ""               # per-provider override of stt.language
   openai:
+    base_url: ""               # optional OpenAI-compatible API base; Realtime support is required for streaming
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
+    streaming: true            # automatic when selected; false forces batch
+    streaming_model_id: "gpt-4o-mini-transcribe"  # semantic-VAD capable Realtime model
     language: ""               # per-provider override of stt.language
+  elevenlabs:
+    base_url: ""               # optional HTTP API base
+    wss_url: ""                # optional WebSocket API base
+    model_id: "scribe_v2"
+    streaming: true            # automatic when selected; false forces batch
+    streaming_model_id: "scribe_v2_realtime"
+    # Optional Realtime VAD tuning; omitted values use provider defaults:
+    # vad_threshold: 0.4
+    # vad_silence_threshold_secs: 1.5
+    # min_speech_duration_ms: 100
+    # min_silence_duration_ms: 100
+  xai:
+    base_url: ""               # API-key auth only; OAuth stays on its validated origin
+    language: ""
+    diarize: false
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
 Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
+
+In classic CLI voice mode, explicitly selected OpenAI and ElevenLabs providers stream normal microphone turns automatically. Provider endpointing supplies the committed final transcript; partials are not displayed or submitted. Set `stt.<provider>.streaming: false` to force that provider onto batch transcription. Provider credentials and `base_url` are resolved once and shared by the streaming and batch transports. OpenAI delegates endpoint construction to its SDK, while ElevenLabs derives its WebSocket endpoint from the configured API base. A custom endpoint must implement that provider's Realtime transcription protocol. Unsupported providers, Termux, and other voice surfaces continue to use local endpointing followed by file transcription. Streaming failures recover through the locally retained WAV. Barge-in detection remains local, with provider partials as an additional confirmation signal.
 
 Provider behavior:
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -111,7 +111,7 @@ If `faster-whisper` is installed, voice mode works with **zero API keys** for ST
 
 ## CLI Voice Mode
 
-Voice mode is available in both the **classic CLI** (`hermes chat`) and the **TUI** (`hermes --tui`). Behavior is identical across both — same slash commands, same VAD silence detection, same streaming TTS, same hallucination filter. The TUI additionally forwards crash-forensic logs to `~/.hermes/logs/` so push-to-talk failures on exotic audio backends can be reported with a full stack trace rather than disappearing silently.
+Voice mode is available in both the **classic CLI** (`hermes chat`) and the **TUI** (`hermes --tui`). They share slash commands, streaming TTS, and transcript filtering. In the classic CLI, OpenAI and ElevenLabs can additionally stream microphone audio to the selected STT provider and use its end-of-turn detection. Other providers and surfaces keep the WAV-based transcription path.
 
 ### Quick Start
 
@@ -136,9 +136,9 @@ Then use these commands inside the CLI:
 1. Start the CLI with `hermes` and enable voice mode with `/voice on`
 2. **Press Ctrl+B** — a beep plays (880Hz), recording starts
 3. **Speak** — a live audio level bar shows your input: `● [▁▂▃▅▇▇▅▂] ❯`
-4. **Stop speaking** — after 3 seconds of silence, recording auto-stops
+4. **Stop speaking** — the selected streaming provider detects the end of the turn, or the local recorder detects 3 seconds of silence on the batch path
 5. **Two beeps** play (660Hz) confirming the recording ended
-6. Audio is transcribed via Whisper and sent to the agent
+6. The final transcript is sent to the agent
 7. If TTS is enabled, the agent's reply is spoken aloud
 8. Recording **automatically restarts** — speak again without pressing any key
 
@@ -148,7 +148,13 @@ This loop continues until you press **Ctrl+B** during recording (exits continuou
 The record key is configurable via `voice.record_key` in `~/.hermes/config.yaml` (default: `ctrl+b`).
 :::
 
-### Silence Detection
+### End-of-turn detection
+
+The classic CLI automatically streams normal-turn microphone frames when the explicitly selected provider is `openai` or `elevenlabs` and its credential is available. OpenAI uses semantic VAD and ElevenLabs uses its VAD commit strategy. Partial transcripts stay internal; only committed text is submitted. A short grace window after each automatic endpoint lets a new partial keep the same user turn open and also gives streaming STT a second way to confirm barge-in.
+
+The microphone and provider connection remain open between turns so interruption audio reaches streaming STT immediately. The existing local barge-in detector remains active; provider partials can confirm the same barge-in path, while batch-only providers continue to capture interruptions to WAV. If the streaming connection fails before recording, Hermes uses the batch path; if it fails during an utterance, Hermes transcribes the locally retained recording instead.
+
+For local STT, unsupported providers, Termux, TUI, and Desktop, the existing two-stage local detector remains in use:
 
 Two-stage algorithm detects when you've finished speaking:
 
@@ -157,7 +163,7 @@ Two-stage algorithm detects when you've finished speaking:
 
 If no speech is detected at all for 15 seconds, recording stops automatically.
 
-Both `silence_threshold` and `silence_duration` are configurable in `config.yaml`. You can also disable the record start/stop beeps with `voice.beep_enabled: false`.
+Both `silence_threshold` and `silence_duration` are configurable in `config.yaml` and apply to the local batch path. You can force a supported provider onto its batch path with `stt.<provider>.streaming: false`, or disable the record start/stop beeps with `voice.beep_enabled: false`.
 
 ### Ending a voice chat by voice
 
@@ -430,6 +436,23 @@ stt:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   groq:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  openai:
+    base_url: ""                     # optional OpenAI-compatible API base; Realtime support is required for streaming
+    model: "whisper-1"               # batch/file model
+    streaming: true                  # automatic when selected; false forces batch
+    streaming_model_id: "gpt-4o-mini-transcribe"  # semantic-VAD capable Realtime model
+  elevenlabs:
+    base_url: ""                     # optional HTTP API base
+    wss_url: ""                      # optional WebSocket API base
+    model_id: "scribe_v2"            # batch/file model
+    streaming: true                  # automatic when selected; false forces batch
+    streaming_model_id: "scribe_v2_realtime"
+    # vad_threshold: 0.4              # optional Realtime VAD tuning
+    # vad_silence_threshold_secs: 1.5
+  xai:
+    base_url: ""                     # API-key auth only; OAuth uses its validated origin
+    language: ""
+    diarize: false
   # model: "whisper-1"              # Legacy: used when provider is not set
 
 # Text-to-Speech


### PR DESCRIPTION
## What does this PR do?

This PR reduces latency of STT significantly in voice mode. It does so by
using streaming STT if one is configured. Initial results are:

| Provider | Legacy p50 | Streaming p50 | Reduction | Legacy p95 | Streaming p95 | Reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| OpenAI | 3,917 ms | 1,098 ms | 72.0% | 5,055 ms | 3,053 ms | 39.6% |
| ElevenLabs | 3,784 ms | 1,893 ms | 50.0% | 4,148 ms | 2,002 ms | 51.7% |

I'm aware that there is a lot of PR chatter about voice. I reviewed the work and
have made this PR as a targeted step to make things better as we wait for an 
overall design choice on how speech-to-speech will be handled.

Classic CLI voice mode currently waits for local silence, encodes the complete
recording as a WAV, uploads that file to a batch transcription endpoint, and
then waits for the full response. This adds a provider-neutral streaming STT
path for providers that support both realtime transcription and provider-owned
end-of-turn detection.

When OpenAI or ElevenLabs is the explicitly selected and credentialed STT
provider, Hermes now sends microphone frames through a persistent transcription
session. Provider partials remain internal, while committed finals enter the
existing transcript-submission path. Unsupported providers and configurations
continue to use the existing WAV/batch path.

The change is deliberately limited to classic CLI voice mode. It does not add
the broad duplex abstraction discussed in #77111, and it does not change
Discord, TUI, Desktop, Termux, voice notes, the agent loop, or tool ownership.
I have PRS ready for those surfaces can adopt the provider-neutral streaming 
module separately if this input contract is accepted.

I also have PRs ready for some other STT providers if we think this PR is the 
direction the project is going to go.

### Latency results

The benchmark replayed the same 20 utterances as realtime PCM through each
provider's legacy and streaming paths. Legacy timing includes local silence
endpointing, WAV creation, upload, and the batch response. Streaming timing
ends when the provider commits its final transcript. This measures latency,
not transcription quality.

## Related Issue

Related to #77111.

Related prior work reviewed before implementing this narrower change:

- #62500
- #27650
- #21504
- #75325

This PR does not close or supersede those broader proposals.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools/stt_streaming.py`, containing provider/session contracts and a
  coordinator that owns the worker thread, private asyncio loop, bounded audio
  queue, resampling, reconnects, commits, and normalized transcript events.
- Added OpenAI Realtime transcription through the installed OpenAI client,
  respecting the configured API key, base URL, model ID, and semantic-VAD
  settings.
- Added ElevenLabs Realtime STT with its VAD commit strategy. The repository is
  pinned to `elevenlabs==1.59.0`, which does not expose this realtime STT API,
  so this provider uses a lazily imported WebSocket connection while still
  respecting the existing API key, `base_url`, optional `wss_url`, model ID,
  and VAD configuration.
- Unified batch and streaming provider resolution in
  `tools/transcription_tools.py`, so streaming uses the selected provider's
  existing credentials and endpoint rather than a second STT configuration.
- Extended `tools/voice_mode.py` so the existing persistent microphone stream
  can forward copied native-rate frames without blocking or performing network
  I/O in the PortAudio callback. Audio remains buffered for batch fallback.
- Integrated streaming turn handling into classic CLI voice mode in `cli.py`.
  Provider endpoints submit finals, Ctrl+B requests a provider commit, stale
  events are fenced by turn state, and setup or mid-turn failures return to the
  retained-WAV batch path.
- Kept the existing local barge-in detector. Streaming partials provide an
  additional speech signal and feed the same established interruption path;
  normal provider-owned endpointing does not depend on local silence.
- Kept one physical STT session across turns and kept microphone audio flowing
  during generation and TTS so interruption audio reaches the provider without
  reconnect delay.
- Added provider configuration examples and user documentation in
  `cli-config.yaml.example` and `website/docs/user-guide/features/voice-mode.md`.
- Added focused coverage for provider resolution, protocol events, session
  reuse and reconnects, callback-thread constraints, batch fallback, Ctrl+B,
  stale and duplicate finals, endpoint grace, interruptions, and shutdown.
- Fixed voice-path regressions found during manual testing, including replay of
  an interrupted TTS sentence, duplicate interruption notices, prompt cursor
  recovery, native-rate barge-in WAV headers, and duplicate text during a
  full-turn streaming fallback.

### Compatibility and fallback behavior

- Streaming is selected only for a supported, explicitly selected provider
  whose credential resolves successfully.
- `stt.openai.streaming: false` or `stt.elevenlabs.streaming: false` forces the
  existing batch path.
- A non-realtime `streaming_model_id` fails connection setup and falls back to
  batch transcription rather than breaking voice input.
- Custom OpenAI-compatible endpoints remain batch-only unless they implement
  the required Realtime protocol.
- Local Whisper, Groq, Mistral, xAI, plugins, Termux, TUI, Desktop, Discord, and
  voice notes retain their existing transcription behavior.

### Known limitation

The existing barge-in detector can miss speech that begins almost immediately
after a previous endpoint. This behavior was reproduced on `main`, including
with local Whisper, and is not introduced by streaming STT. It remains outside
this targeted provider-owned endpointing change.

For some reason the elevenlabs version is pinned to a very old version that does
not support streaming. As a result I had to implement it myself. We shoul dupdate
the elevenlabs library in this project, or, drop the current one; it is too old.

## How to Test

1. Configure either `stt.provider: openai` with an OpenAI audio credential or
   `stt.provider: elevenlabs` with `ELEVENLABS_API_KEY`.
2. Start `hermes`, enable `/voice on`, and complete multiple consecutive turns.
   Confirm that the final transcript arrives after the provider endpoint and
   that normal turns do not upload a WAV to the batch endpoint.
3. Press Ctrl+B during recording. Confirm that it requests a provider commit,
   submits one transcript, and returns terminal input control without hanging.
4. Enable voice TTS, interrupt both model generation and active playback, and
   confirm the interruption becomes the next user message without replaying the
   interrupted TTS sentence.
5. Force a streaming connection failure. Confirm the current retained audio is
   batch-transcribed and that the following turn attempts streaming again.
6. Set the provider's `streaming: false`, then test local Whisper and another
   batch provider. Confirm local silence endpointing and WAV transcription are
   unchanged.
7. Run the focused regression suites:

   ```bash
   pytest -q \
     tests/tools/test_stt_streaming.py \
     tests/tools/test_voice_cli_integration.py \
     tests/tools/test_voice_mode.py \
     tests/tools/test_tts_streaming.py \
     tests/cli/test_cli_skin_integration.py \
     tests/cli/test_terminal_interrupt_recovery.py
   ```

8. Run Ruff on the touched Python files, `git diff --check`, the Windows
   footgun check, the complete Python test suite, and the documentation build.

Manual testing completed on macOS Apple Silicon with:

- OpenAI streaming STT
- ElevenLabs streaming STT
- Local Whisper batch STT
- Continuous sessions longer than three minutes
- Ctrl+B commits
- Interruptions during model generation and TTS playback
- Multiple consecutive turns and forced provider failures

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
Native-overlay slices:
  Slice 1: 3,156 passed, 0 failed
  Slice 2: 3,499 passed, 0 failed
  Slice 3: 2,627 passed, 0 failed
  Slice 4: 2,932 passed, 0 failed
  Slice 5: 4,466 passed, 0 failed
  Slice 6: 3,054 passed, 0 failed
  Slice 7: 3,111 passed, 0 failed
  Slice 8: 3,020 passed, 0 failed
  ```