### PR TITLE
fix(web): consult pluginTabs before the hardcoded root title in resolvePageTitle

### DIFF
--- a/web/src/lib/resolve-page-title.test.ts
+++ b/web/src/lib/resolve-page-title.test.ts
@@ -53,4 +53,22 @@ describe("resolvePageTitle", () => {
     expect(resolvePageTitle("/", t, [])).toBe("Sessions");
     expect(resolvePageTitle("/mcp/", t, [])).toBe("MCP");
   });
+
+  it("prefers a plugin's own label when it overrides the root path (#80891)", () => {
+    // A plugin with tab: { path: "/example", override: "/" } is registered
+    // in pluginTabs under the "/" key (its own path, not the override
+    // target's) -- resolvePageTitle must consult pluginTabs before
+    // special-casing "/" to the hardcoded "Sessions" title.
+    expect(
+      resolvePageTitle("/", t, [{ path: "/", label: "Example Plugin" }]),
+    ).toBe("Example Plugin");
+  });
+
+  it("still falls back to Sessions at root when no plugin overrides it", () => {
+    // Sanity: a plugin registered at a DIFFERENT path must not affect the
+    // root title -- behavior for everyone else is unchanged.
+    expect(
+      resolvePageTitle("/", t, [{ path: "/kanban", label: "Kanban" }]),
+    ).toBe("Sessions");
+  });
 });

--- a/web/src/lib/resolve-page-title.test.ts
+++ b/web/src/lib/resolve-page-title.test.ts
@@ -56,9 +56,9 @@ describe("resolvePageTitle", () => {
 
   it("prefers a plugin's own label when it overrides the root path (#80891)", () => {
     // A plugin with tab: { path: "/example", override: "/" } is registered
-    // in pluginTabs under the "/" key (its own path, not the override
-    // target's) -- resolvePageTitle must consult pluginTabs before
-    // special-casing "/" to the hardcoded "Sessions" title.
+    // in pluginTabs under the "/" key (the override target's path, not
+    // the plugin's own) -- resolvePageTitle must consult pluginTabs
+    // before special-casing "/" to the hardcoded "Sessions" title.
     expect(
       resolvePageTitle("/", t, [{ path: "/", label: "Example Plugin" }]),
     ).toBe("Example Plugin");

--- a/web/src/lib/resolve-page-title.ts
+++ b/web/src/lib/resolve-page-title.ts
@@ -33,12 +33,12 @@ export function resolvePageTitle(
   pluginTabs: { path: string; label: string }[],
 ): string {
   const normalized = pathname.replace(/\/$/, "") || "/";
-  if (normalized === "/") {
-    return t.app.nav.sessions;
-  }
   const plugin = pluginTabs.find((p) => p.path === normalized);
   if (plugin) {
     return plugin.label;
+  }
+  if (normalized === "/") {
+    return t.app.nav.sessions;
   }
   const key = BUILTIN[normalized];
   if (key) {


### PR DESCRIPTION
Fixes #80891.

## Problem

`resolvePageTitle()` special-cased the root path (`"/"`) and returned the hardcoded `"Sessions"` title before it ever consulted `pluginTabs`. A dashboard plugin declaring `tab: { path: "/example", override: "/" }` correctly renders at the root once manifests load, but the shell's page header still showed "Sessions" instead of the plugin's own label.

## Fix

Swapped the two blocks: check `pluginTabs` first, fall back to the hardcoded "Sessions" title only when nothing overrides `"/"`. Behavior for everyone else is unchanged.

## Verification

Added the requested regression test plus a sanity test. Verified as a genuine regression by reverting the fix and confirming the new test fails with "Sessions" instead of the plugin's label.

7/7 pass in `resolve-page-title.test.ts`; 167/167 across the broader `web/src/lib` test suite (no regression).