### PR TITLE
fix(desktop): reap backend on quit — escalate SIGTERM to SIGKILL

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7269,6 +7269,8 @@ const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PA
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
 let sshQuitTeardownDone = false
+let backendQuitTeardownDone = false
+let backendQuitTeardownPromise = null
 
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
@@ -8320,6 +8322,27 @@ function stopAllPoolBackends() {
   for (const profile of [...backendPool.keys()]) {
     stopPoolBackend(profile)
   }
+}
+
+// Escalating variant of stopAllPoolBackends() for teardown paths that must
+// not orphan a backend: SIGTERM each pool backend, then waitForBackendExit()
+// SIGKILLs any that swallow SIGTERM after the 5s grace. Mirrors
+// teardownPoolBackendAndWait() applied to every pool entry.
+async function teardownAllPoolBackendsAndWait() {
+  const processes = [...backendPool.keys()].map(profile => {
+    const entry = backendPool.get(profile)
+
+    if (!entry) {
+      return null
+    }
+
+    backendPool.delete(profile)
+    stopBackendChild(entry.process)
+
+    return entry.process
+  }).filter(Boolean)
+
+  await Promise.all(processes.map(entry => waitForBackendExit(entry)))
 }
 
 // Returns the profile name whose backend was torn down, or null when the
@@ -12021,8 +12044,37 @@ app.on('before-quit', event => {
     disposeTerminalSession(id)
   }
 
-  stopBackendChild(backendConnectionState.getProcess())
-  stopAllPoolBackends()
+  // The backend (`hermes serve` → uvicorn) swallows SIGTERM: its graceful
+  // shutdown handler is installed (SigCgt) but the process never exits, so
+  // a fire-and-forget SIGTERM orphans the gateway. The KDE-launched
+  // transient unit (ExitType=cgroup) then stays "active" with MainPID=0 as
+  // long as the cgroup holds the leaked process — every Desktop launch
+  // leaks a ~364 MB `hermes serve` until SIGKILL'd. Escalate the same way
+  // teardownPrimaryBackendAndWait() does: SIGTERM now, then
+  // waitForBackendExit() SIGKILLs after the 5s grace. Mirror the SSH
+  // teardown guard so the re-entrant app.quit() below doesn't loop.
+  if (!backendQuitTeardownDone) {
+    const quittingBackend = backendConnectionState.getProcess()
+    backendQuitTeardownDone = true
+    event.preventDefault()
+
+    // SIGTERM every backend (graceful attempt), then escalate survivors.
+    stopBackendChild(quittingBackend)
+    backendQuitTeardownPromise = Promise.all([
+      waitForBackendExit(quittingBackend),
+      teardownAllPoolBackendsAndWait()
+    ]).then(() => {
+      backendQuitTeardownPromise = null
+      app.quit()
+    })
+  } else if (backendQuitTeardownPromise) {
+    // Re-entrant pass triggered by a CONCURRENT teardown path (e.g. the SSH
+    // block above finished first) while our escalation is still pending:
+    // hold the quit — the promise's app.quit() fires once backends are
+    // reaped, so a fast ssh path can't let the app exit mid-escalation and
+    // re-orphan the gateway.
+    event.preventDefault()
+  }
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Problem

Every Hermes Desktop launch on Linux leaks a ~364 MB `hermes serve` gateway process. Closing the app does not kill it.

### Root cause chain

1. **The backend swallows SIGTERM.** `hermes serve` (uvicorn's graceful shutdown) installs a SIGTERM handler (`SigCgt` bit 15 set) but the process never exits — verified live: sent SIGTERM, waited 5+ minutes, process still alive at 4h12m uptime; SIGKILL reaps it in <1s.
2. **before-quit is fire-and-forget.** `stopBackendChild()` sends a single SIGTERM and returns immediately (`backend-child.ts`). If the process ignores it, nothing else happens.
3. **systemd never reaps it.** KDE Plasma 6 scopes `.desktop` launches into transient units (`app-Hermes@<uuid>.service`, `KDE_APPLICATIONS_AS_SCOPE=1`, `ExitType=cgroup`). The unit only counts as "exited" when the cgroup is EMPTY, so the orphaned gateway keeps it `active` with `MainPID=0` forever. Every launch = one more permanent orphan.

The codebase already contains the correct escalation pattern — `teardownPrimaryBackendAndWait()` + `waitForBackendExit()` (SIGTERM, 5s grace, SIGKILL) used for profile switches, and `_kill_stale_dashboard_processes` (SIGTERM, 3s grace, SIGKILL) used by `hermes update` / `hermes dashboard --stop`. The desktop quit path just never used it. Additionally `hermes update` excludes the desktop's live backend via `HERMES_DESKTOP_CHILD_PID`, so updates don't clean these up either.

## Fix

Wire the existing escalation into `before-quit`:

- SIGTERM the primary backend + all pool backends (graceful attempt)
- `waitForBackendExit()` on each — SIGKILL after 5s grace
- Guard with `backendQuitTeardownDone` + a pending-promise check mirroring the existing SSH teardown guard, so a concurrent SSH teardown finishing first cannot let the app exit mid-escalation and re-orphan the gateway

New helper `teardownAllPoolBackendsAndWait()` applies the existing `teardownPoolBackendAndWait()` pattern to every pool entry (same bug class as the primary).

## Verification

- Live reproduction: orphaned `hermes serve --host 127.0.0.1 --port 0` survived SIGTERM (5+ min) but died in <1s on SIGKILL
- Orphaned unit reaped via `systemctl --user stop 'app-Hermes@*'` (the documented cleanup)
- `esbuild` compile passes on `electron/main.ts`
- Before-quit re-entrancy traced: first pass escalates, re-entrant pass from a concurrent SSH teardown holds the quit until the escalation promise resolves

Note: the desktop app's own `hermes serve` backend SIGTERM swallow is a separate upstream issue worth fixing in uvicorn shutdown handling — this PR makes the desktop robust regardless.