### PR TITLE
fix(skills): require --force to replace an untracked skill on install

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -22,7 +22,7 @@ from rich.table import Table
 
 # Lazy imports to avoid circular dependencies and slow startup.
 # tools.skills_hub and tools.skills_guard are imported inside functions.
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 
 _console = Console()
 
@@ -677,10 +677,19 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     if not existing and not force:
         untracked = _untracked_skill_dir(bundle.name, category)
         if untracked is not None:
-            shown = (
-                f"{display_hermes_home()}/skills/"
-                f"{category + '/' if category else ''}{bundle.name}"
-            )
+            # Name the directory that would actually be rmtree'd. Rebuilding
+            # the path from the raw ``category`` would drift from it: the
+            # resolution in _untracked_skill_dir() runs the category through
+            # _validate_install_parent_path(), which strips empty and "."
+            # segments and rewrites "\" to "/". A consent prompt whose whole
+            # job is to name a deletion target must not name a different one.
+            try:
+                relative = untracked.relative_to(get_hermes_home().resolve())
+                shown = f"{display_hermes_home()}/{relative.as_posix()}"
+            except ValueError:
+                # SKILLS_DIR overridden outside HERMES_HOME -- no ~-shorthand
+                # to apply, so show the resolved path as-is.
+                shown = str(untracked)
             c.print(
                 f"[yellow]Warning:[/] '{bundle.name}' already exists at {shown} "
                 "and is not tracked by the skills hub (a local or user-edited skill)."

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -176,6 +176,42 @@ def _is_valid_installed_skill_name(name: str) -> bool:
     return bool(_VALID_NAME_RE.match(candidate))
 
 
+def _untracked_skill_dir(name: str, category: str) -> Optional[Path]:
+    """Return the install directory when it already holds an untracked skill.
+
+    ``do_install``'s collision check reads the hub lock file, which only knows
+    about hub-installed skills. ``install_from_quarantine`` nonetheless calls
+    ``shutil.rmtree`` on whatever sits at the install path, and its own comment
+    justifies that by pointing at "the lock-file check in ``do_install()``" --
+    a guarantee that does not hold for a skill with no lock entry. Locally
+    authored skills and bundled skills the user has edited are exactly that
+    population.
+
+    Resolve the directory ``install_from_quarantine`` would delete, using that
+    function's own validators so the two agree on the target, and report it
+    when it is an existing skill directory (one that directly contains
+    ``SKILL.md``). Return ``None`` when nothing is there, when it is a category
+    bucket, or when the name/category is malformed -- those cases are already
+    refused downstream with actionable errors, and pre-empting them here would
+    only change the message the user sees.
+    """
+    from tools.skills_hub import (
+        _resolve_lock_install_path,
+        _validate_install_parent_path,
+        _validate_skill_name,
+    )
+
+    try:
+        safe_name = _validate_skill_name(name)
+        safe_category = _validate_install_parent_path(category) if category else ""
+        install_rel_path = f"{safe_category}/{safe_name}" if safe_category else safe_name
+        install_dir = _resolve_lock_install_path(install_rel_path, safe_name)
+    except ValueError:
+        return None
+
+    return install_dir if (install_dir / "SKILL.md").is_file() else None
+
+
 def _existing_categories() -> List[str]:
     """Return sorted subdirectory names under ``~/.hermes/skills/`` that look
     like category buckets (contain at least one ``SKILL.md`` somewhere below).
@@ -631,6 +667,25 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
+            return
+
+    # The lock file only tracks hub-installed skills, so the check above cannot
+    # see a locally authored or user-edited skill sitting at the install path --
+    # yet install_from_quarantine() rmtrees it all the same. Consult the
+    # filesystem too, so an untracked skill gets the same "use --force" consent
+    # gate a hub-installed one already gets.
+    if not existing and not force:
+        untracked = _untracked_skill_dir(bundle.name, category)
+        if untracked is not None:
+            shown = (
+                f"{display_hermes_home()}/skills/"
+                f"{category + '/' if category else ''}{bundle.name}"
+            )
+            c.print(
+                f"[yellow]Warning:[/] '{bundle.name}' already exists at {shown} "
+                "and is not tracked by the skills hub (a local or user-edited skill)."
+            )
+            c.print("Installing would replace it. Use --force to overwrite.\n")
             return
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -255,6 +255,137 @@ def _install_mocks(monkeypatch, tmp_path, source_factory, category_hint=""):
     return install_calls
 
 
+# ---------------------------------------------------------------------------
+# Untracked skills (no hub lock entry) must not be silently destroyed.
+#
+# install_from_quarantine() rmtree's whatever sits at the install path and
+# justifies it by deferring to "the lock-file check in do_install()". That
+# check reads the hub lock file, so it is blind to locally authored skills
+# (source_type="local") and to bundled skills the user has edited -- both of
+# which live under skills/ with no lock entry.
+#
+# These tests drive the REAL quarantine/install/lock code so the destructive
+# rmtree actually runs; only the remote source and the scanner are faked.
+# ---------------------------------------------------------------------------
+
+_LOCAL_SKILL_BODY = "---\nname: note-taker\ndescription: hand written\n---\n# my own notes\n"
+_UPSTREAM_SKILL_BODY = "---\nname: note-taker\ndescription: upstream\n---\n# upstream body\n"
+
+
+def _untracked_source(name, identifier):
+    class _Source:
+        def inspect(self, _identifier):
+            return type("Meta", (), {
+                "extra": {}, "identifier": identifier, "name": name, "path": name,
+            })()
+
+        def fetch(self, _identifier):
+            return type("Bundle", (), {
+                "name": name,
+                "files": {"SKILL.md": _UPSTREAM_SKILL_BODY},
+                "source": "github",
+                "identifier": identifier,
+                "trust_level": "community",
+                "metadata": {},
+            })()
+
+    return _Source()
+
+
+def _real_install_env(monkeypatch, name, identifier):
+    """Fake only the remote source and the scanner; keep the disk path real."""
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: None)
+    monkeypatch.setattr(
+        hub, "create_source_router",
+        lambda auth: [_untracked_source(name, identifier)],
+    )
+    monkeypatch.setattr(
+        guard, "scan_skill_cached",
+        lambda skill_path, source="community", source_url="", cache_dir=None: (
+            guard.ScanResult(
+                skill_name=name, source=source,
+                trust_level="community", verdict="safe",
+            ),
+            {
+                "fresh": True, "scanner_version": "test", "bundle_hash": "sha256:t",
+                "source_url": source_url, "scanned_at": "now", "rules": [],
+            },
+        ),
+    )
+    monkeypatch.setattr(guard, "format_scan_report", lambda _result: "scan ok")
+    monkeypatch.setattr(
+        guard, "should_allow_install", lambda _result, force=False: (True, "ok"),
+    )
+
+
+def _seed_untracked_skill(tmp_path, name):
+    """A skill directory on disk with NO entry in the hub lock file."""
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_LOCAL_SKILL_BODY, encoding="utf-8")
+    return skill_dir
+
+
+def _run_install(monkeypatch, name, identifier, **kwargs):
+    _real_install_env(monkeypatch, name, identifier)
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    do_install(identifier, console=console, skip_confirm=True,
+               invalidate_cache=False, **kwargs)
+    # Rich hard-wraps at the console width; collapse it so assertions can match
+    # message text without depending on where the wrap lands.
+    return " ".join(sink.getvalue().split())
+
+
+def test_install_refuses_to_replace_untracked_local_skill(hub_env, monkeypatch, tmp_path):
+    """A local/user-edited skill has no lock entry, so the lock-file check
+    cannot see it -- but install_from_quarantine() would still rmtree it.
+    Without --force the install must refuse and leave the file untouched."""
+    skill_dir = _seed_untracked_skill(tmp_path, "note-taker")
+
+    out = _run_install(monkeypatch, "note-taker", "acme/note-taker")
+
+    # The user's own file survives, byte for byte.
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _LOCAL_SKILL_BODY
+    assert "not tracked by the skills hub" in out
+    assert "Use --force to overwrite." in out
+    # And the install did not report success.
+    assert "Installed:" not in out
+
+
+def test_install_force_still_replaces_untracked_local_skill(hub_env, monkeypatch, tmp_path):
+    """--force remains the escape hatch: the guard warns but does not block."""
+    skill_dir = _seed_untracked_skill(tmp_path, "note-taker")
+
+    out = _run_install(monkeypatch, "note-taker", "acme/note-taker", force=True)
+
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _UPSTREAM_SKILL_BODY
+    assert "Installed:" in out
+
+
+def test_install_untracked_guard_leaves_lockfile_branch_alone(hub_env, monkeypatch, tmp_path):
+    """A hub-installed skill (lock entry present) keeps the existing message
+    and the existing behaviour -- the new filesystem check must not fire."""
+    from tools.skills_hub import HubLockFile
+
+    skill_dir = _seed_untracked_skill(tmp_path, "note-taker")
+    HubLockFile().record_install(
+        name="note-taker", source="github", identifier="acme/note-taker",
+        trust_level="community", scan_verdict="safe", skill_hash="sha256:old",
+        install_path="note-taker", files=["SKILL.md"],
+    )
+
+    out = _run_install(monkeypatch, "note-taker", "acme/note-taker")
+
+    assert "is already installed at" in out
+    assert "Use --force to reinstall." in out
+    assert "not tracked by the skills hub" not in out
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _LOCAL_SKILL_BODY
+
+
 
 
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -329,10 +329,10 @@ def _seed_untracked_skill(tmp_path, name):
     return skill_dir
 
 
-def _run_install(monkeypatch, name, identifier, **kwargs):
+def _run_install(monkeypatch, name, identifier, console_width=200, **kwargs):
     _real_install_env(monkeypatch, name, identifier)
     sink = StringIO()
-    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    console = Console(file=sink, force_terminal=False, color_system=None, width=console_width)
     do_install(identifier, console=console, skip_confirm=True,
                invalidate_cache=False, **kwargs)
     # Rich hard-wraps at the console width; collapse it so assertions can match
@@ -364,6 +364,42 @@ def test_install_force_still_replaces_untracked_local_skill(hub_env, monkeypatch
 
     assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _UPSTREAM_SKILL_BODY
     assert "Installed:" in out
+
+
+def test_untracked_warning_names_the_resolved_deletion_target(hub_env, monkeypatch, tmp_path):
+    """The refusal message must name the directory that would actually be
+    rmtree'd.
+
+    The install target is resolved through _validate_install_parent_path(),
+    which drops empty and "." segments (and rewrites "\\" to "/"), so a message
+    rebuilt from the raw category can name a path that does not even exist
+    while a *different* directory is the one at risk. The whole purpose of
+    this prompt is to name the deletion target, so the two must agree.
+    """
+    from hermes_cli.skills_hub import _untracked_skill_dir
+    from hermes_constants import display_hermes_home
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw_category = "personal//./notes"
+    skill_dir = _seed_untracked_skill(tmp_path, "personal/notes/note-taker")
+
+    # Sanity: this really is the directory install_from_quarantine() would
+    # delete, and the raw category does not spell it.
+    target = _untracked_skill_dir("note-taker", raw_category)
+    assert target == skill_dir.resolve()
+
+    out = _run_install(
+        monkeypatch, "note-taker", "acme/note-taker",
+        category=raw_category, console_width=400,
+    )
+
+    expected = (
+        f"{display_hermes_home()}/"
+        f"{target.relative_to(tmp_path.resolve()).as_posix()}"
+    )
+    assert f"already exists at {expected} " in out
+    assert raw_category not in out
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _LOCAL_SKILL_BODY
 
 
 def test_install_untracked_guard_leaves_lockfile_branch_alone(hub_env, monkeypatch, tmp_path):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -560,6 +560,97 @@ def test_skills_manage_search_uses_tools_hub_sources(server):
     search.assert_called_once_with("showroom", ["source"], source_filter="all", limit=20)
 
 
+def _seed_untracked_skill(monkeypatch, tmp_path, name="note-taker"):
+    """Put an untracked skill (no hub lock entry) at the install path.
+
+    Returns (skill_dir, do_install_calls); ``do_install`` is stubbed so the
+    test asserts on whether it is *reached*, never on a real network install.
+    """
+    import hermes_cli.skills_hub as cli_hub
+    import tools.skills_hub as tools_hub
+
+    monkeypatch.setattr(tools_hub, "SKILLS_DIR", tmp_path / "skills")
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: note-taker\ndescription: hand written\n---\n# my own notes\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+    monkeypatch.setattr(cli_hub, "do_install", lambda *a, **kw: calls.append((a, kw)))
+    return skill_dir, calls
+
+
+def test_skills_manage_install_reports_untracked_refusal(server, monkeypatch, tmp_path):
+    """A refused install must not be reported as ``installed: True``.
+
+    ``do_install()`` refuses to replace a skill that has no hub lock entry with
+    a bare ``return``, and this handler hands it a console whose ``print`` is a
+    no-op — so the refusal and its "use --force" hint are both invisible here.
+    Before this was fixed the handler returned ``{"installed": True}`` for an
+    install that never happened.
+    """
+    skill_dir, calls = _seed_untracked_skill(monkeypatch, tmp_path)
+
+    resp = server.handle_request({
+        "id": "skills-install",
+        "method": "skills.manage",
+        "params": {"action": "install", "query": "note-taker"},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["installed"] is False
+    assert result["reason"] == "untracked_skill_exists"
+    assert result["path"] == str(skill_dir.resolve())
+    assert "force: true" in result["message"]
+    # The guard runs before do_install(), so the rmtree inside
+    # install_from_quarantine() is never reached either.
+    assert calls == []
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8").endswith("# my own notes\n")
+
+
+def test_skills_manage_install_forwards_force_override(server, monkeypatch, tmp_path):
+    """``force`` is the override on this surface, and it reaches ``do_install``.
+
+    Without it the handler has no way to consent past the guard at all.
+    """
+    _skill_dir, calls = _seed_untracked_skill(monkeypatch, tmp_path)
+
+    resp = server.handle_request({
+        "id": "skills-install-force",
+        "method": "skills.manage",
+        "params": {"action": "install", "query": "note-taker", "force": True},
+    })
+
+    assert "error" not in resp
+    assert resp["result"] == {"installed": True, "name": "note-taker"}
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args == ("note-taker",)
+    assert kwargs["force"] is True
+    assert kwargs["skip_confirm"] is True
+
+
+def test_skills_manage_install_force_is_not_bare_truthiness(server, monkeypatch, tmp_path):
+    """``"false"`` over JSON-RPC must not consent to a destructive overwrite.
+
+    ``bool("false")`` is ``True``; this gate decides whether a user's own skill
+    directory gets rmtree'd, so it goes through the project's shared coercion.
+    """
+    _skill_dir, calls = _seed_untracked_skill(monkeypatch, tmp_path)
+
+    resp = server.handle_request({
+        "id": "skills-install-strforce",
+        "method": "skills.manage",
+        "params": {"action": "install", "query": "note-taker", "force": "false"},
+    })
+
+    assert resp["result"]["installed"] is False
+    assert calls == []
+
+
 # ── dispatch(): pool routing for long handlers (#12546) ──────────────
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1734,13 +1734,38 @@ def _(rid, params: dict) -> dict:
                 },
             )
         if action == "install":
-            from hermes_cli.skills_hub import do_install
+            from hermes_cli.skills_hub import _untracked_skill_dir, do_install
+            from utils import is_truthy_value
 
             class _Q:
                 def print(self, *a, **k):
                     pass
 
-            do_install(query, skip_confirm=True, console=_Q())
+            # do_install()'s untracked-skill guard refuses with a bare return
+            # and reports through the console above, whose print() discards
+            # everything -- so a refusal is indistinguishable from success on
+            # this surface. Consult the guard's own helper before calling, and
+            # forward force so the refusal is overridable here as it is on the
+            # CLI. This call site passes no category, so neither does the
+            # pre-check; resolving the directory is left to the helper rather
+            # than rebuilt here, so the two surfaces name the same target.
+            force = is_truthy_value(params.get("force", False))
+            if not force:
+                untracked = _untracked_skill_dir(query, "")
+                if untracked is not None:
+                    return _ok(rid, {
+                        "installed": False,
+                        "name": query,
+                        "reason": "untracked_skill_exists",
+                        "path": str(untracked),
+                        "message": (
+                            f"'{query}' already exists at {untracked} and is not "
+                            "tracked by the skills hub (a local or user-edited "
+                            "skill). Installing would replace it. Retry with "
+                            "force: true to overwrite."
+                        ),
+                    })
+            do_install(query, force=force, skip_confirm=True, console=_Q())
             return _ok(rid, {"installed": True, "name": query})
         if action == "browse":
             from hermes_cli.skills_hub import browse_skills


### PR DESCRIPTION
## This is a sibling follow-up to #80848

- **What #80848 covers:** `do_update()` → `do_install(force=True)` replacing a hub skill the user has edited. It compares `content_hash(skill_dir)` against the **lockfile's** `content_hash` and skips unless `--force`.
- **What #80848 does not touch:** a skill with **no lock entry at all**. A lockfile-hash comparison structurally cannot cover a skill that has no lockfile row to compare against, and its hunks are in `do_check` / `do_update` / `skills_command` / `handle_skills_slash` (`@@1052`, `@@1063`, `@@1082`, `@@1745`, `@@1929`) — the `do_install` collision block is untouched.
- **What this adds:** the same consent gate on the *install* caller, keyed on the **filesystem** instead of the lockfile, so a locally authored or user-edited skill with no lock entry also requires `--force`. Disjoint hunks (`@@179`, `@@636`); the two changes compose.

## What does this PR do?

`install_from_quarantine()` calls `shutil.rmtree(install_dir)` on whatever sits at a skill's install path. Its own comment justifies that by deferring the consent question upstream — `tools/skills_hub.py`, above the `rmtree`:

> A directory that directly contains SKILL.md is an existing skill installation and stays overwritable (**hub-installed skills are additionally guarded by the lock-file check in `do_install()`**).

**That parenthetical does not hold for a skill with no lock entry.** `do_install()`'s only pre-install collision check is:

```python
# Check if already installed
lock = HubLockFile()
existing = lock.get_installed(bundle.name)
if existing:
    c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
    if not force:
        c.print("Use --force to reinstall.\n")
        return
```

`HubLockFile` only tracks hub installs, so `existing is None` for two first-class populations that live under `skills/` without a lock row:

1. **Locally authored skills** — `source_type = "local"` / `trust = "local"`.
2. **Bundled skills the user has edited** — the repo ships `skills list --modified`, `skills diff` and `skills reset --restore` specifically for this population.

For either, installing a same-named skill takes no `--force`, prints no warning, and deletes the directory. This PR makes that comment true by consulting the filesystem alongside the lock file.

This is the sibling of the data-loss report in #75983 (*"silently deletes an entire existing category directory … unconditional rmtree, data loss"*). The fix for that one — `75e85ef` (`refuse to overwrite category bucket during skill install`), widened a day later by `881ac52` (`hybrid skill-dir nesting and file collisions`) — guards the *category-bucket* branch and explicitly leaves the `SKILL.md`-bearing branch overwritable, on the strength of the lock-file claim quoted above. This closes that remaining branch.

### Coverage: one guard covers every install surface

`do_install()` is the **single production caller** of `install_from_quarantine()`:

```
$ git grep -n "install_from_quarantine" -- '*.py' | grep -v tests/
hermes_cli/skills_hub.py:513:        quarantine_bundle, install_from_quarantine, HubLockFile,
hermes_cli/skills_hub.py:731:        install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
tools/skills_hub.py:3711:def install_from_quarantine(
```

So the one guard covers all of these, and no other site shares the root cause:

| Surface | Call site | Consent available today |
|---|---|---|
| `hermes skills install` | `skills_command`, `hermes_cli/skills_hub.py` | confirm panel, but it only says *"Files will be at: …"* — it never says an existing directory is deleted |
| `/skills install` | `handle_skills_slash` | **none** — `skip_confirm = True` is hardcoded |
| tui_gateway skills tool | `skills.manage`, `tui_gateway/methods_tools.py` | **none as originally filed** — `skip_confirm=True` and a console whose `print` discards output. Fixed by the follow-up commit below |
| `hermes skills snapshot import` | `do_snapshot_import` | passes `force` through; defaults to `False` |
| `hermes skills update` | `do_update` | passes `force=True` — **unaffected by this change**; that path is #80848's |

## Follow-up commit `0398a15` — make the refusal observable on `skills.manage`

Thanks @spfcraze — this was a real hole and it was one this PR opened. The table row above understated it, so it is corrected there too.

**The problem.** The refusal *behaviour* reached the tui_gateway surface (no `rmtree`), but the *report* did not. As filed, the handler was:

```python
class _Q:
    def print(self, *a, **k):
        pass

do_install(query, skip_confirm=True, console=_Q())
return _ok(rid, {"installed": True, "name": query})
```

`do_install()` is `-> None` and refuses with a bare `return`, and `_Q.print` is a literal `pass`. So on the one surface this PR newly refuses on, a refusal was reported as `installed: True`, the `Use --force to overwrite.` hint went nowhere, and there was no `force` argument to override it with. That is strictly worse than the pre-PR state, where the same unconditional `installed: True` at least happened to be true.

**The fix.** Consult the guard's own helper before calling, and forward `force`:

- `installed: false` with `reason: "untracked_skill_exists"`, `path` (the directory that would have been replaced), and a `message` carrying the actionable hint. **The success shape is byte-identical** to today's `{"installed": True, "name": query}`, so no consumer breaks.
- The directory is resolved by `_untracked_skill_dir()` — the same helper the CLI guard uses — rather than rebuilt here, so the two surfaces cannot name different deletion targets. This is the same reasoning as the Copilot thread on the CLI message, applied to the second surface.
- `force` is forwarded to `do_install()`, giving this surface the CLI's escape hatch. It is coerced through the project's shared `is_truthy_value()` (as `methods_session.py` / `methods_prompt.py` do) rather than `bool()`, because `bool("false")` is `True` and this gate decides whether a user's own skill directory is `rmtree`'d.

**No client change is needed for `/skills install`.** `ui-tui/src/app/slash/commands/ops.ts:612` already branches on the flag:

```ts
sys(r.installed ? `installed ${r.name ?? query}` : 'install failed')
```

so an honest `installed: false` renders as `install failed` today, with no `ui-tui/` edit. Separately, `ui-tui/src/components/skillsHub.tsx:83` discards the payload (`.then(() => onClose())`) — a pre-existing gap in the overlay that predates this PR and is not touched here; #38688 already proposes changes to that file (see Positioning).

**Deliberately out of scope: `do_install()`'s `-> None` contract is unchanged.** It has 11 bare `return`s; the other ten (unknown source adapter, fetch failure / rate limit, missing-name on a URL install, blocked scan verdict, cancelled confirm, invalid install path) *also* misreport as `installed: True` on this surface. But those predate this PR, sit on different code paths, and fixing them means changing the return type of a function with five call sites — a general outcome-reporting refactor bundled into a consent-gate fix. Happy to file it as a follow-up, or to fold it in here if you would rather have it in one go.

## Related Issue

No auto-close keyword — this PR does not fully resolve an open issue on its own.

Related: #75983 (CLOSED, the category-bucket case whose fix introduced the comment quoted above) and #80848 (the update-caller half of the same hazard).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/skills_hub.py`** — new `_untracked_skill_dir(name, category)` helper. It resolves the install directory using `install_from_quarantine()`'s *own* validators (`_validate_skill_name`, `_validate_install_parent_path`, `_resolve_lock_install_path`) so both functions agree on which directory is at stake, and returns it only when that directory directly contains `SKILL.md`.
- **`hermes_cli/skills_hub.py`** — in `do_install()`, after the existing lock-file block, refuse when `not existing and not force` and the helper reports an untracked skill. Message follows the surrounding console idiom and the path is rendered via `display_hermes_home()`, matching the confirm panel.
- **`tests/hermes_cli/test_skills_hub.py`** — three regression tests.
- **`tui_gateway/methods_tools.py`** (follow-up `0398a15`) — the `skills.manage` `install` action pre-checks with `_untracked_skill_dir()`, reports `installed: false` + `reason` + `path` + `message` on refusal, and forwards `force` (coerced with `is_truthy_value`) to `do_install()`. +29/-2.
- **`tests/tui_gateway/test_protocol.py`** (follow-up `0398a15`) — three regression tests on that handler. +91.

Deliberately unchanged, to keep the diff to one idea:

- The existing lock-file branch is **byte-identical** — the new check is a separate statement after it, so the `already installed` path keeps its exact message and behavior.
- `--force` remains a full escape hatch.
- The category-bucket guard and the malformed-name/symlink `ValueError`s in `install_from_quarantine()` are untouched; `_untracked_skill_dir` returns `None` on those so the existing, more actionable downstream error is still what the user sees.
- **`tools/skills_hub.py` is not edited.** The point is to make its existing comment true, not to move the guard.

## How to Test

```bash
# Seed a locally authored skill with no hub lock entry
mkdir -p "$HERMES_HOME/skills/note-taker"
printf -- '---\nname: note-taker\ndescription: hand written\n---\n# my own notes\n' \
  > "$HERMES_HOME/skills/note-taker/SKILL.md"

# Install a same-named skill from the hub
hermes skills install <some-source>/note-taker
```

- **Before:** installs successfully; `SKILL.md` now contains the upstream body. The hand-written file is gone.
- **After:** `Warning: 'note-taker' already exists at <hermes-home>/skills/note-taker and is not tracked by the skills hub (a local or user-edited skill).` / `Installing would replace it. Use --force to overwrite.` — and the file is untouched.
- `--force` still overwrites.

### Regression test, verified in both directions

The tests drive the **real** `quarantine_bundle` / `install_from_quarantine` / `HubLockFile` inside `tmp_path` (only the remote source and the scanner are faked), so the destructive `rmtree` genuinely runs and the red is real data loss rather than a mock assertion.

**RED — production hunk reverted (`git stash push -- hermes_cli/skills_hub.py`), tests untouched:**

```
FAILED tests/hermes_cli/test_skills_hub.py::test_install_refuses_to_replace_untracked_local_skill
>       assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == _LOCAL_SKILL_BODY
E       AssertionError: assert '---\nname: n...stream body\n' == '---\nname: n...y own notes\n'
E           ---
E           name: note-taker
E         - description: hand written
E         + description: upstream
E           ---
E         - # my own notes
E         + # upstream body
========================= 1 failed, 5 passed in 0.26s ==========================
```

It fails on the *data-survival* assertion, not on a message string.

**GREEN — fix restored:**

```
tests/hermes_cli/test_skills_hub.py::test_install_refuses_to_replace_untracked_local_skill PASSED
tests/hermes_cli/test_skills_hub.py::test_install_force_still_replaces_untracked_local_skill PASSED
tests/hermes_cli/test_skills_hub.py::test_install_untracked_guard_leaves_lockfile_branch_alone PASSED
============================== 6 passed in 0.21s ===============================
```

The other two tests hold in both directions by design — they are non-regression assertions, pinning that `--force` still overwrites and that the lock-file branch keeps its existing message.

### Follow-up commit `0398a15`, also verified in both directions

Three tests in `tests/tui_gateway/test_protocol.py`, driven through `server.handle_request()` so they exercise the real registered handler. They seed a real untracked skill directory under `tmp_path` and stub only `do_install`, so "was the refusal reported?" and "was `do_install` reached at all?" are both real assertions.

**RED — follow-up production hunk reverted (`git checkout HEAD~1 -- tui_gateway/methods_tools.py`), tests untouched:**

```
FAILED test_skills_manage_install_reports_untracked_refusal
>       assert result["installed"] is False
E       assert True is False

FAILED test_skills_manage_install_forwards_force_override
>       assert kwargs["force"] is True
E       KeyError: 'force'

FAILED test_skills_manage_install_force_is_not_bare_truthiness
>       assert resp["result"]["installed"] is False
E       assert True is False
```

The first failure is the reported bug exactly: the surface says `installed: True` for an install it refused.

**GREEN — fix restored:** `43 passed` (`tests/tui_gateway/test_protocol.py`).

**Suites run for the follow-up commit** (green on `0398a15`):

```
tests/hermes_cli/test_skills_hub.py + tests/tools/test_skills_hub.py         67 passed
tests/tui_gateway/test_protocol.py                                           43 passed
ruff check tui_gateway/methods_tools.py tests/tui_gateway/test_protocol.py   clean
```

**Suites run for the first two commits** (green on `faec6d6`):

```
tests/hermes_cli/test_skills_hub.py
tests/tools/test_skills_hub.py + tests/tools/test_skills_guard.py   91 passed
tests/hermes_cli/test_skills_skip_confirm.py
tests/hermes_cli/test_skills_install_flags.py
tests/hermes_cli/test_managed_installs.py
tests/hermes_cli/test_web_server_skills_profiles.py
tests/tools/test_blueprints.py
tests/tools/test_skill_bundle_provenance.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *ran the targeted suites listed under "How to Test" instead of the full tree; leaving this unchecked rather than claiming a run I didn't do*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — *N/A: no user-facing flag or config changed; `--force` already documented. Behavior is covered by the new docstring.*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — *N/A*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — *N/A*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — *pathlib only, no separators or platform branches; path resolution is delegated to the existing `_resolve_lock_install_path`, so it inherits whatever junction/symlink handling that helper has (including any hardening from #76885 / #64954).*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — *The `skills.manage` `install` action changes in `0398a15`: it accepts a new optional `force` param and, on refusal, returns `installed: false` with `reason` / `path` / `message` instead of `installed: true`. The success shape is byte-identical. `skills.manage` has no declared JSON schema — its params are read from the `params` dict — so there is no schema file to update; the two typed TS consumers are `SkillsInstallResponse` (`ui-tui/src/app/slash/commands/ops.ts:41`, whose fields are all optional and which already branches on `r.installed`) and the inline type at `ui-tui/src/components/skillsHub.tsx:83`. Neither needs a change to keep compiling or behaving.*

  *(This line previously read "N/A: no tool schema change; the tui_gateway skills tool gains the same refusal as the CLI." That overstated: the refusal behaviour reached that surface, but the report and the override did not — which is exactly what the table above records as consent "none", so the body contradicted itself. Corrected here and in that table.)*

## Related / Positioning

Dedup performed before opening, recorded so it can be checked rather than taken on trust:

- **By changed path** (`gh pr list --state open --limit 300 --json number,author,files`, snapshot spanning PRs #80454–#80897): the only other open PR touching `hermes_cli/skills_hub.py` or `tests/hermes_cli/test_skills_hub.py` in that window is #80848.
- **By symbol, corpus-wide** (`gh search prs --state open`): `do_install`, `install_from_quarantine`, `skills_hub`, `HubLockFile`, `_resolve_lock_install_path`, `untracked skill`, `local skill overwrite`, `skill install rmtree`, `user-edited skill`. Every `_resolve_lock_install_path` / `install_from_quarantine` hit is about *resolving* the path correctly under symlinks, junctions or CRLF (#49885, #53493, #64954, #65050, #76885, #53409, #53541, #78082, #58827, #41199), not about consent to overwrite. The `HubLockFile` hits are all atomic-write PRs (#16440, #29699, #29019, #30139, #64244).
- **Hunk-checked the open PRs nearest by topic** — #71723, #72920, #73102, #74828, #75434, #76885, #76449, #74519, #50261, #76021, #64996, #50045, #38688. None lands on the `existing is None` case:
  - **#64996** — its nearby hunks are `except ValueError` → `except (ValueError, PermissionError)` on the quarantine/install calls, plus a read-only gate at the top of `do_install`.
  - **#76021** — dependency resolution, inserted after the security verdict.
  - **#75434** — a `skill_lock` concurrency lock; orthogonal mechanism.
  - **#38043** is the closest: it edits the *same block*, changing `if not force:` to `if not (force or reinstall_existing):` **inside** the `if existing:` branch so update flows can reinstall without also forcing past a blocked scan. That only has an effect when `existing` is truthy, so it leaves the no-lock-entry case exactly as it is today. The two changes are complementary; this PR leaves that line untouched, so they should not conflict textually either.
- `git log --since=30d -- hermes_cli/skills_hub.py` shows 5 commits, none in `do_install`.

**Re-run for the follow-up commit's file, `tui_gateway/methods_tools.py`** (snapshot spanning PRs #80579–#81135):

- **⚠️ There is a competing design on this exact block — #38688 (@coygeek, `fix(tui-gateway): preserve skill install review`), and I would rather flag it than have you find it.** It removes the `do_install` call from this handler outright and returns `{"installed": False, "status": "review_required"}`, i.e. it takes install *off* this surface rather than making it report honestly, and it carries matching `ui-tui/` changes (`ops.ts`, `skillsHub.tsx`). It is not a duplicate of this change, and as written it does not apply to the current tree: it targets `tui_gateway/server.py@15761`, and the mechanical split `f67ca22` (*"split @method handlers into methods_\* modules"*) moved that handler into `tui_gateway/methods_tools.py`. Last updated 2026-07-21; `mergeStateStatus: UNKNOWN`. **If you prefer that direction, say so and I will close this half** — the two are alternatives on the same 14 lines, not complements.
- **By changed path:** the only other open PR touching `tui_gateway/methods_tools.py` in that window is #80692 (@pedro-dalben, skill provider/model routing), whose hunks are at `@545`/`@554` — disjoint from the `install` action.
- **By symbol, corpus-wide:** `_untracked_skill_dir` returns this PR only. `methods_tools` returns #78036 (`shell.exec` env builder, `@1886`/`@1893` — disjoint) and my own #76131 (`@391`/`@1408`/`@1886` — disjoint; the install block sits between its two nearest hunks). `skills.manage` returns #51946, #64963, #19168, #57990 — none on the install action.
- **Self-overlap:** my other open PRs on this file are #76366 (`@842`), #76131 (above) and #75385 (`@635`). All hunk-disjoint from `@1736`.

Happy to rebase behind #80848, fold this into it, or adjust the wording of the warning if you'd prefer it phrased differently.

