### PR TITLE
feat: list every installed skin in desktop Appearance settings

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -69,7 +69,7 @@ import { reportInstallMethodWarning } from '@/store/updates'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
-import { ingestBackendSkin } from '@/themes/backend-sync'
+import { ingestBackendSkin, ingestBackendSkins } from '@/themes/backend-sync'
 import type { RpcEvent } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
@@ -289,6 +289,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // Seed the active skin into the desktop theme registry without applying,
         // so a fresh connect never overrides the user's persisted desktop theme.
         ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, { apply: false })
+        // Register every installed skin so the built-in Appearance settings
+        // lists them all natively (not just the active one). Never touches the
+        // apply baseline — ingestBackendSkin owns that for the active skin.
+        ingestBackendSkins((payload as { skins?: HermesSkin[] } | undefined)?.skins)
         // Backends with the change watcher broadcast pet/cron/sessions change
         // events; consumers demote their legacy polls to slow backstops.
         setChangeEventsAvailable(Boolean((payload as { change_events?: boolean } | undefined)?.change_events))

--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin, ingestBackendSkins } from './backend-sync'
 
 const skin = (name: string) => ({
   name,
@@ -104,6 +104,52 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin(undefined, { apply: true })
     ingestBackendSkin({ name: '' }, { apply: true })
 
+    expect($pendingSkinApply.get()).toBeNull()
+  })
+})
+
+describe('ingestBackendSkins', () => {
+  beforeEach(() => __resetBackendSkinSync())
+
+  it('registers every user skin in the payload', () => {
+    ingestBackendSkins([skin('neon'), skin('forest'), skin('ocean')])
+
+    expect($backendThemes.get().neon?.name).toBe('neon')
+    expect($backendThemes.get().forest?.name).toBe('forest')
+    expect($backendThemes.get().ocean?.name).toBe('ocean')
+  })
+
+  it('never registers default or built-in names', () => {
+    ingestBackendSkins([skin('default'), skin('mono'), skin('slate'), skin('neon')])
+
+    expect($backendThemes.get().default).toBeUndefined()
+    expect($backendThemes.get().mono).toBeUndefined()
+    expect($backendThemes.get().slate).toBeUndefined()
+    expect($backendThemes.get().neon?.name).toBe('neon')
+  })
+
+  it('never sets the apply baseline (bulk list is seed-only)', () => {
+    ingestBackendSkins([skin('neon'), skin('forest')])
+
+    expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('a bulk list cannot snap back a manual desktop switch', () => {
+    // User manually switched the desktop theme, then a reconnect re-seeds the
+    // full skin list. The bulk list must not repaint or override the switch.
+    $pendingSkinApply.set(null)
+    ingestBackendSkins([skin('neon'), skin('forest')])
+
+    expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('is a no-op for empty / malformed payloads', () => {
+    ingestBackendSkins(undefined)
+    ingestBackendSkins(null)
+    ingestBackendSkins([])
+    ingestBackendSkins([undefined, { name: '' }, {}])
+
+    expect(Object.keys($backendThemes.get())).toHaveLength(0)
     expect($pendingSkinApply.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -37,6 +37,47 @@ export const $pendingSkinApply = atom<string | null>(null)
 // restart / disconnected), an explicit re-affirm must repaint, not no-op.
 let lastSynced: { applied: boolean; name: string } | null = null
 
+/**
+ * Fold every installed skin into the desktop registry at connect time.
+ *
+ * The `gateway.ready` payload now carries `skins` (all installed skins, built-in
+ * + user) alongside the active `skin`. This registers each one into
+ * `$backendThemes` so the built-in Appearance settings list every skin natively
+ * — not just the active one. It deliberately does NOT touch `lastSynced` or
+ * `$pendingSkinApply`: only the active skin (via `ingestBackendSkin`) owns the
+ * apply baseline, so a bulk list can never repaint or snap back a manual switch.
+ */
+export function ingestBackendSkins(skins: Array<HermesSkin | undefined | null> | undefined | null): void {
+  if (!Array.isArray(skins)) {
+    return
+  }
+
+  for (const skin of skins) {
+    const name = (skin && typeof skin === 'object' ? (skin.name ?? '') : '').trim()
+
+    // `default` is "no opinion" on the PALETTE and built-in names keep the
+    // desktop's own hand-tuned palette — same rules as ingestBackendSkin.
+    if (!name || name === 'default' || BUILTIN_THEMES[name]) {
+      continue
+    }
+
+    const theme = skinToDesktopTheme(skin as HermesSkin)
+
+    if (!theme) {
+      continue
+    }
+
+    const current = $backendThemes.get()
+
+    // Only write on a real change — the store stays referentially stable
+    // across a connect that didn't add anything, so the Appearance grid
+    // doesn't re-render pointlessly.
+    if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
+      $backendThemes.set({ ...current, [name]: theme })
+    }
+  }
+}
+
 /** Test-only: reset the module's apply guard + registry between cases. */
 export function __resetBackendSkinSync(): void {
   lastSynced = null

--- a/tests/tui_gateway/test_cold_start_gil_stall.py
+++ b/tests/tui_gateway/test_cold_start_gil_stall.py
@@ -161,6 +161,56 @@ def test_handle_ws_ready_payload_wires_skin_through_to_thread():
 # ─── Fix 3: _warm_gateway_module pre-imports heavy chains ──────────────
 
 
+def test_ready_payload_carries_all_skins_beside_the_active_skin():
+    """gateway.ready must include the full skin list (built-in + user) so the
+    desktop Appearance settings lists every skin natively, not just the
+    active one (#desktop-theme-pack appearance integration)."""
+    import asyncio as _asyncio
+    import threading
+
+    import tui_gateway.server as server_mod
+    import tui_gateway.ws as ws_mod
+
+    idents = {}
+    frames = []
+
+    def _fake_resolve_all_skins():
+        idents["skins_thread"] = threading.get_ident()
+        return [{"name": "neon", "colors": {}}, {"name": "forest", "colors": {}}]
+
+    async def _scenario():
+        idents["loop_thread"] = threading.get_ident()
+        with patch.object(server_mod, "resolve_all_skins", _fake_resolve_all_skins):
+            # Reproduce handle_ws's ready-frame construction verbatim — the
+            # same to_thread pattern for the bulk list as for the active skin.
+            skins_payload = await _asyncio.to_thread(server_mod.resolve_all_skins)
+            frames.append(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "event",
+                    "params": {
+                        "type": "gateway.ready",
+                        "payload": {"skin": {"name": "neon"}, "skins": skins_payload, "change_events": True},
+                    },
+                }
+            )
+
+    _asyncio.run(_scenario())
+
+    assert frames[0]["params"]["payload"]["skins"] == [
+        {"name": "neon", "colors": {}},
+        {"name": "forest", "colors": {}},
+    ]
+    assert frames[0]["params"]["payload"]["skin"] == {"name": "neon"}
+    assert frames[0]["params"]["payload"]["change_events"] is True
+    assert idents["skins_thread"] != idents["loop_thread"]
+    # Belt and braces: the production site must route the bulk list through
+    # to_thread too — assert against the live source so a revert to inline
+    # resolve_all_skins() cannot slip past the behavioral stub above.
+    source = inspect.getsource(ws_mod.handle_ws)
+    assert "to_thread(server.resolve_all_skins)" in source
+
+
 def test_warm_gateway_module_imports_cold_start_chains():
     """_warm_gateway_module must pre-import the module chains that the
     first WS connection + RPC burst would otherwise import on the loop

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -20,7 +20,7 @@ import traceback
 from tui_gateway._stdin_recovery import handle_spurious_eof
 
 from tui_gateway import server
-from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
+from tui_gateway.server import _CRASH_LOG, dispatch, resolve_all_skins, resolve_skin, write_json
 from tui_gateway.transport import TeeTransport
 
 logger = logging.getLogger(__name__)
@@ -446,7 +446,13 @@ def main():
         "params": {
             "type": "gateway.ready",
             # change_events: see tui_gateway/ws.py — clients demote legacy polls.
-            "payload": {"skin": resolve_skin(), "change_events": True},
+            # skins: every installed skin, so the desktop Appearance settings
+            # lists them natively (see ws.py for the same payload shape).
+            "payload": {
+                "skin": resolve_skin(),
+                "skins": resolve_all_skins(),
+                "change_events": True,
+            },
         },
     }):
         _log_exit("startup write failed (broken stdout pipe before first event)")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3211,27 +3211,55 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
+def _skin_payload(skin) -> dict:
+    """One skin → the JSON-RPC payload shape (`HermesSkin` on the desktop)."""
+    return {
+        "name": skin.name,
+        "colors": skin.colors,
+        # Paired palettes: the TUI detects the terminal's polarity and
+        # prefers the matching hand-tuned block over adapting `colors`.
+        "light_colors": skin.light_colors,
+        "dark_colors": skin.dark_colors,
+        "branding": skin.branding,
+        "banner_logo": skin.banner_logo,
+        "banner_hero": skin.banner_hero,
+        "tool_prefix": skin.tool_prefix,
+        "help_header": (skin.branding or {}).get("help_header", ""),
+    }
+
+
 def resolve_skin() -> dict:
     try:
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
 
         init_skin_from_config(_load_cfg())
-        skin = get_active_skin()
-        return {
-            "name": skin.name,
-            "colors": skin.colors,
-            # Paired palettes: the TUI detects the terminal's polarity and
-            # prefers the matching hand-tuned block over adapting `colors`.
-            "light_colors": skin.light_colors,
-            "dark_colors": skin.dark_colors,
-            "branding": skin.branding,
-            "banner_logo": skin.banner_logo,
-            "banner_hero": skin.banner_hero,
-            "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
-        }
+        return _skin_payload(get_active_skin())
     except Exception:
         return {}
+
+
+def resolve_all_skins() -> list:
+    """Every available skin (built-in + user) as a full payload.
+
+    The desktop Appearance settings merge this list (via the gateway.ready
+    payload) so every installed skin shows up natively — not just the active
+    one, which is all `resolve_skin` carries. Skins that fail to load are
+    skipped, mirroring `resolve_skin`'s fail-open behavior.
+    """
+    try:
+        from hermes_cli.skin_engine import list_skins, load_skin
+    except Exception:
+        return []
+    out = []
+    for entry in list_skins():
+        try:
+            payload = _skin_payload(load_skin(entry["name"]))
+        except Exception:
+            continue
+        payload["description"] = entry.get("description", "")
+        payload["source"] = entry.get("source", "user")
+        out.append(payload)
+    return out
 
 
 # Signature of the last skin broadcast: (name, active user-file mtime). Lets the

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -311,6 +311,7 @@ async def handle_ws(ws: Any) -> None:
         # (#60800). The skin payload is small (a dict of strings/arrays),
         # so the to_thread overhead is negligible.
         skin_payload = await asyncio.to_thread(server.resolve_skin)
+        skins_payload = await asyncio.to_thread(server.resolve_all_skins)
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
@@ -320,7 +321,14 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    # skins: every installed skin (built-in + user) with full
+                    # palettes, so the desktop Appearance settings can list
+                    # them natively — not just the active skin.
+                    "payload": {
+                        "skin": skin_payload,
+                        "skins": skins_payload,
+                        "change_events": True,
+                    },
                 },
             }
         )


### PR DESCRIPTION
## What

The desktop's built-in Appearance settings only listed the **active** skin, because the `gateway.ready` payload carried a single resolved skin. With a theme pack installed (34+ skins in `~/.hermes/skins/`), users had to install a separate plugin to browse and apply them from the desktop.

This makes every installed skin (built-in + user) appear **natively** in the built-in Appearance grid, the Cmd-K palette, and `/skin` — no plugin needed. A skin dropped into `~/.hermes/skins/` now behaves like the theme analogue of a plugin, which is how the theming system is documented to work.

## Changes

**Backend**
- `tui_gateway/server.py`: refactored `resolve_skin()` to share a `_skin_payload()` builder; added `resolve_all_skins()` which returns every skin with full palettes, failing open per-skin exactly like `resolve_skin` does.
- `tui_gateway/ws.py` + `tui_gateway/entry.py`: the `gateway.ready` payload now carries `skins` (all installed skins) alongside `skin` (the active one). Both are routed through `asyncio.to_thread` so the bulk list never blocks the cold-start event loop (same pattern as #60800).

**Desktop**
- `apps/desktop/src/themes/backend-sync.ts`: new `ingestBackendSkins()` folds the bulk list into `$backendThemes` **without touching `lastSynced` or `$pendingSkinApply`**, so a reconnect re-seed can never repaint or snap back a manual desktop theme switch. Only the active skin (via `ingestBackendSkin`) owns the apply baseline.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`: calls `ingestBackendSkins()` on `gateway.ready` after seeding the active skin.

**Tests**
- 6 new `ingestBackendSkins` cases: registers all user skins, skips `default`/built-ins, never sets the apply baseline, cannot snap back a manual switch, no-op for empty/malformed payloads.
- 1 new backend test asserting the ready frame carries `skins` through `to_thread`.

## Why the payload, not a new RPC

The desktop's `gateway.ready` handler is an event consumer with no `requestGateway` handle; adding a `skins.list` RPC would require threading a new transport through the event pipeline. Extending the ready payload is one emission site (kept in sync in `ws.py`/`entry.py`), one handler, and the list only changes when skins are installed/removed — exactly the connect-time moment.

## Safety

- `ingestBackendSkins` is seed-only: it registers palettes, never applies. A manual desktop theme switch is never overridden on reconnect (covered by test).
- Built-in names and `default` are skipped, so the desktop's own hand-tuned palettes are never shadowed (same rule as `ingestBackendSkin`).
- Store writes are guarded by JSON equality, so a connect that added nothing keeps the `$backendThemes` reference stable and the Appearance grid doesn't re-render pointlessly.
- Skins that fail to load are skipped, mirroring `resolve_skin`'s fail-open behavior.

## Verification

- `scripts/run_tests.sh tests/tui_gateway/test_cold_start_gil_stall.py` — 7 passed, 0 failed
- `vitest run src/themes/backend-sync.test.ts` — 16 passed (10 existing + 6 new)
- `vitest run src/app/session/hooks/use-message-stream/` — 79 passed
- `tsc --noEmit` — clean
