### PR TITLE
fix: replace assert with runtime guard in tts_tool streaming playback

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3594,7 +3594,8 @@ def stream_tts_to_speaker(
 
         def _playback_worker() -> None:
             """Single consumer: play audio segments from the queue in order."""
-            assert streamer is not None
+            if streamer is None:
+                return
             if output_stream is not None:
                 import numpy as _np
 
@@ -3701,7 +3702,8 @@ def stream_tts_to_speaker(
 
         def _enqueue_audio(text_to_speak: str) -> None:
             """Synthesize *text_to_speak* and start prefetching immediately."""
-            assert streamer is not None
+            if streamer is None:
+                return
             try:
                 audio_iter = streamer.stream(text_to_speak)
             except Exception as exc:


### PR DESCRIPTION
## Summary

Two `assert` statements in `stream_tts_to_speaker()` inner functions (`_playback_worker` and `_enqueue_audio`) would be stripped by `python -O`, silently removing invariant checks.

## Changes

- `tools/tts_tool.py:3597` — `_playback_worker()`: `assert streamer is not None` → `if streamer is None: return`
- `tools/tts_tool.py:3704` — `_enqueue_audio()`: `assert streamer is not None` → `if streamer is None: return`

## Why

`assert` is stripped by `python -O`. If a future refactor breaks the invariant that `streamer` is non-None when these functions run, the code would crash with a confusing `AttributeError` instead of a clear guard. The early-return pattern is consistent with the rest of the codebase.