### PR TITLE
fix(gateway): preserve archived compaction history on /retry and yuanbao recall

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1150,7 +1150,7 @@ class RecallGuardMiddleware(InboundMiddleware):
                     if entry.get("role") == "user" and entry.get("content") == recalled_text:
                         entry["content"] = cls._REDACTED
                         try:
-                            store.rewrite_transcript(sid, transcript)
+                            store.rewrite_transcript(sid, transcript, active_only=True)
                             logger.info("[%s] Recall redact: session %s", adapter.name, session_key[:30])
                         except Exception as exc:
                             logger.warning("[%s] Recall redact failed: %s", adapter.name, exc)
@@ -1210,7 +1210,7 @@ class RecallGuardMiddleware(InboundMiddleware):
         if target is not None:
             target["content"] = cls._REDACTED
             try:
-                store.rewrite_transcript(sid, transcript)
+                store.rewrite_transcript(sid, transcript, active_only=True)
                 logger.info("[%s] Recall: redacted msg_id=%s (%s)", adapter.name, recalled_id, branch_label)
             except Exception as exc:
                 logger.warning("[%s] Recall: rewrite_transcript failed: %s", adapter.name, exc)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3379,8 +3379,7 @@ class SessionStore:
         compaction history that archive_and_compact() keeps on disk
         (#38763). Callers rewriting the live transcript of a session that
         may carry archived rows must pass ``active_only=True`` so only the
-        live rows are replaced; callers that mean to purge (e.g. yuanbao
-        recall redaction) keep the default.
+        live rows are replaced.
 
         Returns ``True`` when the write lands (or there is no DB to write to)
         and ``False`` when the canonical write fails. Most callers can ignore

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3362,11 +3362,41 @@ class SessionStore:
             logger.debug("has_platform_message_id lookup failed", exc_info=True)
             return False
 
-    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> bool:
+    def has_archived_messages(self, session_id: str) -> bool:
+        """Check if a session has any soft-archived (``active = 0``) rows.
+
+        Thin wrapper over SessionDB.has_archived_messages(). Returns False
+        when no DB is available (in-memory sessions). Used by transcript
+        rewrite callers (e.g. /retry) to decide whether the rewrite must
+        pass ``active_only=True`` so archived compaction history survives.
+        """
+        if not self._db:
+            return False
+        try:
+            return self._db.has_archived_messages(session_id)
+        except Exception:
+            logger.debug("has_archived_messages lookup failed", exc_info=True)
+            return False
+
+    def rewrite_transcript(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        active_only: bool = False,
+    ) -> bool:
         """Replace the entire transcript for a session with new messages.
 
-        Used by /retry, /undo, and /compress to persist modified conversation
-        history. state.db is the canonical store.
+        Used by /retry and /compress to persist modified conversation
+        history. state.db is the canonical store. (/undo is not a caller:
+        it soft-archives rows via rewind_session / rewind_to_message.)
+
+        DESTRUCTIVE by default: ``replace_messages(active_only=False)``
+        DELETEs every row for the session, including the soft-archived
+        compaction history that archive_and_compact() keeps on disk
+        (#38763). Callers rewriting the live transcript of a session that
+        may carry archived rows must pass ``active_only=True`` so only the
+        live rows are replaced; callers that mean to purge (e.g. yuanbao
+        recall redaction) keep the default.
 
         Returns ``True`` when the write lands (or there is no DB to write to)
         and ``False`` when the canonical write fails. Most callers can ignore
@@ -3379,7 +3409,7 @@ class SessionStore:
             return True
         self._clear_dirty_transcript(session_id)
         try:
-            self._db.replace_messages(session_id, messages)
+            self._db.replace_messages(session_id, messages, active_only=active_only)
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3362,22 +3362,6 @@ class SessionStore:
             logger.debug("has_platform_message_id lookup failed", exc_info=True)
             return False
 
-    def has_archived_messages(self, session_id: str) -> bool:
-        """Check if a session has any soft-archived (``active = 0``) rows.
-
-        Thin wrapper over SessionDB.has_archived_messages(). Returns False
-        when no DB is available (in-memory sessions). Used by transcript
-        rewrite callers (e.g. /retry) to decide whether the rewrite must
-        pass ``active_only=True`` so archived compaction history survives.
-        """
-        if not self._db:
-            return False
-        try:
-            return self._db.has_archived_messages(session_id)
-        except Exception:
-            logger.debug("has_archived_messages lookup failed", exc_info=True)
-            return False
-
     def rewrite_transcript(
         self,
         session_id: str,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2582,9 +2582,19 @@ class GatewaySlashCommandsMixin:
         if not last_user_msg:
             return t("gateway.retry.no_previous")
         
-        # Truncate history to before the last user message and persist
+        # Truncate history to before the last user message and persist. Probe
+        # for soft-archived rows first: after an in-place compaction the
+        # pre-compaction transcript lives on as active=0/compacted=1 rows
+        # under this same session id, and a bare rewrite (active_only=False)
+        # would DELETE them (same class as #61145; ACP _persist and TUI
+        # prompt.submit already guard their rewrite paths).
         truncated = history[:last_user_idx]
-        await self.async_session_store.rewrite_transcript(session_entry.session_id, truncated)
+        has_archived = await self.async_session_store.has_archived_messages(
+            session_entry.session_id
+        )
+        await self.async_session_store.rewrite_transcript(
+            session_entry.session_id, truncated, active_only=has_archived
+        )
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2582,18 +2582,15 @@ class GatewaySlashCommandsMixin:
         if not last_user_msg:
             return t("gateway.retry.no_previous")
         
-        # Truncate history to before the last user message and persist. Probe
-        # for soft-archived rows first: after an in-place compaction the
-        # pre-compaction transcript lives on as active=0/compacted=1 rows
-        # under this same session id, and a bare rewrite (active_only=False)
-        # would DELETE them (same class as #61145; ACP _persist and TUI
-        # prompt.submit already guard their rewrite paths).
+        # Truncate history to before the last user message and persist only the
+        # live view. After in-place compaction the pre-compaction transcript
+        # lives on as active=0/compacted=1 rows under this same session id, and
+        # a bare rewrite (active_only=False) would DELETE them (same class as
+        # #61145). /retry never intends to purge archived history, so avoid a
+        # separate existence probe: it could fail open or race with the write.
         truncated = history[:last_user_idx]
-        has_archived = await self.async_session_store.has_archived_messages(
-            session_entry.session_id
-        )
         await self.async_session_store.rewrite_transcript(
-            session_entry.session_id, truncated, active_only=has_archived
+            session_entry.session_id, truncated, active_only=True
         )
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -67,3 +67,79 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
     ]
 
 
+@pytest.mark.asyncio
+async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkeypatch):
+    """/retry must not DELETE soft-archived compaction history.
+
+    With compression.in_place (the default, #38763) archive_and_compact()
+    keeps the pre-compaction transcript on disk as active=0/compacted=1 rows
+    under the same session id. /retry used to persist its truncation via a
+    bare rewrite_transcript(), whose replace_messages(active_only=False)
+    DELETEs every row for the session and reinserts only the truncated live
+    tail, wiping the archived history permanently (same class as #61145;
+    #57803 named this call site as a residual gap). The handler must probe
+    has_archived_messages() and pass active_only=True so only the live rows
+    are replaced.
+    """
+    import hermes_state
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+
+    session_id = "retry_archived_session"
+    store._db.create_session(session_id=session_id, source="test")
+    store._db.append_message(session_id=session_id, role="user", content="old question")
+    store._db.append_message(session_id=session_id, role="assistant", content="old answer")
+    # In-place compaction: the two rows above are soft-archived and the
+    # compacted transcript becomes the live set under the same id.
+    store._db.archive_and_compact(
+        session_id,
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "retry me"},
+            {"role": "assistant", "content": "old answer"},
+        ],
+    )
+    assert store._db.has_archived_messages(session_id) is True
+
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = store
+
+    session_entry = MagicMock(session_id=session_id)
+    session_entry.last_prompt_tokens = 111
+    gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
+
+    async def fake_handle_message(event):
+        assert event.text == "retry me"
+        store.append_to_transcript(session_id, {"role": "user", "content": event.text})
+        store.append_to_transcript(session_id, {"role": "assistant", "content": "new answer"})
+        return "new answer"
+
+    gw._handle_message = AsyncMock(side_effect=fake_handle_message)
+
+    result = await gw._handle_retry_command(
+        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    )
+
+    assert result == "new answer"
+    # The archived pre-compaction rows survive the rewrite untouched.
+    archived = [
+        m for m in store._db.get_messages(session_id, include_inactive=True)
+        if not m["active"]
+    ]
+    assert [(m["role"], m["content"]) for m in archived] == [
+        ("user", "old question"),
+        ("assistant", "old answer"),
+    ]
+    assert all(m["compacted"] == 1 for m in archived)
+    # The live set reflects the truncation plus the retried exchange.
+    transcript_after = store.load_transcript(session_id)
+    assert [m.get("content") for m in transcript_after if m.get("role") == "user"] == [
+        "first question",
+        "retry me",
+    ]
+
+

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -68,8 +68,10 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
 
 
 @pytest.mark.asyncio
-async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkeypatch):
-    """/retry must not DELETE soft-archived compaction history.
+async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails(
+    tmp_path, monkeypatch
+):
+    """/retry must not DELETE archives when an existence probe would fail.
 
     With compression.in_place (the default, #38763) archive_and_compact()
     keeps the pre-compaction transcript on disk as active=0/compacted=1 rows
@@ -77,9 +79,9 @@ async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkey
     bare rewrite_transcript(), whose replace_messages(active_only=False)
     DELETEs every row for the session and reinserts only the truncated live
     tail, wiping the archived history permanently (same class as #61145;
-    #57803 named this call site as a residual gap). The handler must probe
-    has_archived_messages() and pass active_only=True so only the live rows
-    are replaced.
+    #57803 named this call site as a residual gap). /retry never intends to
+    purge archived history, so it must pass active_only=True unconditionally:
+    a separate existence probe can fail open or race with the rewrite.
     """
     import hermes_state
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
@@ -104,6 +106,11 @@ async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkey
     )
     assert store._db.has_archived_messages(session_id) is True
 
+    # A failed preflight lookup must not turn this data-preservation path back
+    # into a destructive full-history rewrite. The write itself still works.
+    archived_probe = MagicMock(side_effect=OSError("transient archive lookup failure"))
+    monkeypatch.setattr(store._db, "has_archived_messages", archived_probe)
+
     gw = GatewayRunner.__new__(GatewayRunner)
     gw.config = config
     gw.session_store = store
@@ -125,6 +132,7 @@ async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkey
     )
 
     assert result == "new answer"
+    archived_probe.assert_not_called()
     # The archived pre-compaction rows survive the rewrite untouched.
     archived = [
         m for m in store._db.get_messages(session_id, include_inactive=True)
@@ -141,5 +149,3 @@ async def test_gateway_retry_preserves_archived_compaction_rows(tmp_path, monkey
         "first question",
         "retry me",
     ]
-
-


### PR DESCRIPTION
## Summary
After in-place compaction, `rewrite_transcript()` called `replace_messages()` with the default `active_only=False`, DELETEing every row for the session — including soft-archived (`active=0`) pre-compaction history that `archive_and_compact()` deliberately keeps on disk (#38763). After any `/retry` or yuanbao recall redaction on a compacted session, the archived history was gone permanently.

## Root cause
`gateway/session.py` `rewrite_transcript` called `replace_messages(session_id, messages)` with `active_only` defaulting to `False`. The DELETE had no `AND active = 1` clause, so it took the archived rows too. Same data-loss class as #61145; #57803 named this call site as a residual gap after rejecting the auto-detect-inside-rewrite_transcript approach in favor of per-caller guards.

## Changes
- `gateway/session.py`: `rewrite_transcript` gains an `active_only` parameter (default `False`, forwarded to `replace_messages`). Docstring updated to remove stale `/undo` reference and document the `active_only` contract.
- `gateway/slash_commands.py`: `/retry` passes `active_only=True` unconditionally — no probe needed (when no archived rows exist, `AND active = 1` matches the same rows as no clause). Avoids TOCTOU race and fail-open exception path that a probe would introduce.
- `gateway/platforms/yuanbao.py`: both yuanbao recall redaction call sites now pass `active_only=True`. `load_transcript` only returns active rows, so the redacted content is in the active set and archived pre-compaction history should survive the rewrite.
- `tests/gateway/test_retry_replacement.py`: new regression test seeds archived compaction rows, simulates a probe failure, and asserts archives survive `/retry` and the live set reflects the truncation + retried exchange.

## Attribution
Cherry-picked from PR #80218 by @Adolanium (original fix + regression test) and @poisdahl (fail-safe follow-up). Sibling-site fix (yuanbao callers + docstring cleanup) added on top.

Closes #80216. Closes #80218. Supersedes #80695.

## Test plan
- `tests/gateway/test_retry_replacement.py tests/gateway/test_retry_response.py tests/gateway/test_session.py tests/gateway/test_compress_command.py tests/gateway/test_session_hygiene.py` — 87 passed, 0 failed
- `tests/gateway/ -k 'yuanbao'` — 16 passed, 1 skipped
- E2E: real SessionDB + SessionStore, seeded with compaction-archived rows → `rewrite_transcript(active_only=True)` preserves all 4 archived rows; `active_only=False` destroys them (confirms the bug)
- ruff: all checks passed
- py_compile: all files compile
