### PR TITLE
fix(signal): add notifySelf for Note to Self replies (#80845)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1077,6 +1077,11 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            # #80845: When replying to Note to Self (chat_id matches our own
+            # account), include notifySelf so the primary device renders the
+            # reply as an incoming message instead of self-authored sync.
+            if self._account_normalized and chat_id == self._account_normalized:
+                params["notifySelf"] = True
 
         logger.info("[Signal] Sending response (%d chars) to %s", len(plain_text), chat_id)
         result = await self._rpc("send", params)
@@ -1251,6 +1256,8 @@ class SignalAdapter(BasePlatformAdapter):
             base_params["groupId"] = chat_id[6:]
         else:
             base_params["recipient"] = [await self._resolve_recipient(chat_id)]
+            if self._account_normalized and chat_id == self._account_normalized:
+                base_params["notifySelf"] = True
 
         att_batches = [
             attachments[i:i + SIGNAL_MAX_ATTACHMENTS_PER_MSG]
@@ -1403,6 +1410,8 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            if self._account_normalized and chat_id == self._account_normalized:
+                params["notifySelf"] = True
 
         result = await self._rpc("send", params)
         if result is not None:
@@ -1445,6 +1454,8 @@ class SignalAdapter(BasePlatformAdapter):
             params["groupId"] = chat_id[6:]
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
+            if self._account_normalized and chat_id == self._account_normalized:
+                params["notifySelf"] = True
 
         result = await self._rpc("send", params)
         if result is not None:


### PR DESCRIPTION
Fixes #80845

## Root cause

When Hermes replies to a Signal Note to Self conversation, `signal-cli` syncs the reply as self-authored activity because the `notifySelf` parameter is missing. The primary device shows the assistant reply as if the user sent it.

## Fix

Add `notifySelf: true` to all outbound Signal RPC `send` calls when the destination `chat_id` matches the configured Signal account (`self._account_normalized`). This tells `signal-cli` to render the reply as an incoming Note to Self message on the primary device.

## Coverage

Applied to all send paths:
- `send()` — text messages
- `send_image()` — single image with caption
- `send_multiple_images()` — batched image sends
- `_send_attachment()` — shared by `send_document`, `send_image_file`, `send_voice`, `send_video`

Group chats and messages to other recipients are unaffected (the `notifySelf` flag is only added in the `else` / non-group branch when `chat_id == self._account_normalized`).
