### PR TITLE
fix(compress): preserve in-flight tool chain across context compression (salvage #79293)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4687,8 +4687,34 @@ This compaction should PRIORITISE preserving all information related to the focu
         #    when call_id != id (Codex Responses API format), re-exposing orphans.
         missing_results = surviving_call_ids - result_call_ids
         if missing_results:
+            # --- In-flight tool chain protection (issue #79278) -------------
+            # A strip here must distinguish a *pending* tool_call (the model's
+            # live request whose result the executor has not yet appended) from
+            # an *orphaned* call (one whose result was summarized/truncated away
+            # and can never come back).  Compression can fire mid-chain: the
+            # model emits `assistant(tool_calls)`, and tool_executor.py only
+            # appends the matching `role="tool"` result AFTER it runs the call.
+            # In that window `messages[-1]` is an assistant tool_call whose id
+            # is (not yet) in result_call_ids.  Any tool result would be
+            # appended *after* this message (tool_executor.py), so if it is the
+            # final message its calls are, by construction, all still pending.
+            # Stripping it as an orphan would delete the live request; when the
+            # executor later appends the real result, repair_message_sequence
+            # would drop it as an unmatched orphan and the completed side
+            # effect — and the model's final synthesis built on it — would be
+            # lost.  We therefore preserve the trailing in-flight call verbatim;
+            # only genuinely orphaned calls in the *discarded* region are
+            # stripped.
+            trailing_inflight: Optional[Dict[str, Any]] = None
+            if messages and messages[-1].get("role") == "assistant":
+                trailing_inflight = messages[-1]
+            # -----------------------------------------------------------------
             for msg in messages:
                 if msg.get("role") != "assistant":
+                    continue
+                if msg is trailing_inflight:
+                    # Live request, not an orphan — the executor appends its
+                    # result(s) after compress() returns.
                     continue
                 tcs = msg.get("tool_calls")
                 if not tcs:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4697,7 +4697,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             # In that window `messages[-1]` is an assistant tool_call whose id
             # is (not yet) in result_call_ids.  Any tool result would be
             # appended *after* this message (tool_executor.py), so if it is the
-            # final message its calls are, by construction, all still pending.
+            # last non-tool message its calls are presumed still pending.
             # Stripping it as an orphan would delete the live request; when the
             # executor later appends the real result, repair_message_sequence
             # would drop it as an unmatched orphan and the completed side
@@ -4711,7 +4711,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             # a snapshot taken between appends looks like
             # ``[..., assistant(c1,c2,c3), tool(c1)]`` — the chain is still
             # in flight even though the last message is a tool result. The
-            # last NON-tool message is the live request in both shapes.
+            # last NON-tool message is presumed the live request in both
+            # shapes; a genuinely unanswered call preserved here is stubbed
+            # pre-API by sanitize_api_messages step 2, so preserving is safe
+            # while stripping a live call silently loses its late result.
             idx = len(messages) - 1
             while idx >= 0 and messages[idx].get("role") == "tool":
                 idx -= 1

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4706,8 +4706,17 @@ This compaction should PRIORITISE preserving all information related to the focu
             # only genuinely orphaned calls in the *discarded* region are
             # stripped.
             trailing_inflight: Optional[Dict[str, Any]] = None
-            if messages and messages[-1].get("role") == "assistant":
-                trailing_inflight = messages[-1]
+            # Walk back over any trailing tool results first: with a
+            # multi-call batch the executor appends results one at a time, so
+            # a snapshot taken between appends looks like
+            # ``[..., assistant(c1,c2,c3), tool(c1)]`` — the chain is still
+            # in flight even though the last message is a tool result. The
+            # last NON-tool message is the live request in both shapes.
+            idx = len(messages) - 1
+            while idx >= 0 and messages[idx].get("role") == "tool":
+                idx -= 1
+            if idx >= 0 and messages[idx].get("role") == "assistant":
+                trailing_inflight = messages[idx]
             # -----------------------------------------------------------------
             for msg in messages:
                 if msg.get("role") != "assistant":

--- a/contributors/emails/craig@shotflame.local
+++ b/contributors/emails/craig@shotflame.local
@@ -1,0 +1,1 @@
+Shotflame

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2223,6 +2223,180 @@ class TestSanitizerStripsOrphanedToolCalls:
         # No stub tool messages (which would have call_id != id mismatch)
 
 
+class TestSanitizerPreservesInFlightToolChain:
+    """Issue #79278: an in-flight tool call chain must survive compression.
+
+    When compression fires mid-chain — after the model emitted
+    ``assistant(tool_calls)`` but before tool_executor.py appended the matching
+    ``role="tool"`` result — the final message is a *pending* tool call, not an
+    orphan.  Stripping it (or replacing content with ``(tool call removed)``)
+    destroys the chain: when the executor later appends the real result,
+    repair_message_sequence drops it as an unmatched orphan and the completed
+    side effect and final synthesis are lost.  _sanitize_tool_pairs must exempt
+    the trailing in-flight call.
+    """
+
+    def test_trailing_inflight_tool_call_preserved(self, compressor):
+        """A trailing assistant tool_call with no result yet is pending, not
+        orphaned — preserve it verbatim.  #79278"""
+        msgs = [
+            {"role": "user", "content": "summarize"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "summarize", "arguments": "{}"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_2", "function": {"name": "finalize", "arguments": "{}"}},
+                ],
+            },
+            # in-flight: call_2 has been emitted but its tool result is not
+            # yet appended by tool_executor.py
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        # The trailing in-flight call must survive intact.
+        assert sanitized[-1]["role"] == "assistant"
+        assert len(sanitized[-1]["tool_calls"]) == 1
+        assert sanitized[-1]["tool_calls"][0]["id"] == "call_2"
+        assert sanitized[-1]["content"] != "(tool call removed)"
+
+    def test_inflight_result_arrives_after_compress(self, compressor):
+        """After compress() preserves the pending call, appending its tool
+        result leaves a well-formed chain — the side effect's result reaches
+        the model.  #79278"""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_2", "function": {"name": "finalize", "arguments": "{}"}},
+                ],
+            },
+        ]
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+        assert sanitized[-1]["tool_calls"][0]["id"] == "call_2"
+
+        # The executor appends the result after compress() returns.
+        sanitized.append(
+            {"role": "tool", "tool_call_id": "call_2", "content": "side effect done"}
+        )
+
+        # Chain now settled: the assistant call is matched, result survives.
+        surviving = {tc["id"] for m in sanitized if m["role"] == "assistant"
+                     for tc in (m.get("tool_calls") or [])}
+        assert "call_2" in surviving
+        results = [m for m in sanitized if m["role"] == "tool"]
+        assert len(results) == 1 and results[0]["tool_call_id"] == "call_2"
+
+    def test_inflight_preserved_while_true_orphan_still_stripped(self, compressor):
+        """Preserving the trailing in-flight call must not weaken the existing
+        orphan-stripping behavior for genuinely orphaned calls in the discarded
+        region.  #79278"""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_orphan", "function": {"name": "search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "user", "content": "interim"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_pending", "function": {"name": "write", "arguments": "{}"}},
+                ],
+            },
+            # trailing in-flight call_pending
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        middle = [m for m in sanitized if m["role"] == "assistant" and m.get("tool_calls")]
+        # Only the trailing in-flight call survives.
+        assert len(middle) == 1
+        assert middle[0]["tool_calls"][0]["id"] == "call_pending"
+        # The genuine orphan at the head was still stripped.
+        assert not any(m.get("tool_calls") and m["tool_calls"][0]["id"] == "call_orphan"
+                       for m in sanitized)
+
+    def test_side_effect_final_result_returned_end_to_end(self, compressor):
+        """Issue #79278 end-to-end: an in-flight tool chain that triggers
+        compression must still deliver the completed side effect's result.
+
+        Reproduces the full executor flow:
+          1. the model emits ``assistant(tool_calls=call_2)`` while call_2 is
+             still IN-FLIGHT — tool_executor.py has not yet appended its
+             ``role="tool"`` result;
+          2. context compression fires and ``_sanitize_tool_pairs()`` runs on
+             a history whose tail is that pending call;
+          3. the side effect completes and the executor appends the ``tool``
+             result for call_2;
+          4. the next pre-call pass, ``repair_message_sequence()``, runs and
+             must NOT drop the completed result as an unmatched orphan.
+
+        On the old code, compression stripped the pending call_2 as an
+        "orphan"; when the result then arrived, repair_message_sequence
+        dropped it as unmatched — so the completed side effect's result and
+        the final synthesis built on it were both lost.  The fix preserves the
+        trailing in-flight call, so the chain closes and the result survives.
+        """
+        from agent.agent_runtime_helpers import repair_message_sequence
+
+        history = [
+            {"role": "user", "content": "Do the work and use the tools."},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "run_side_effect", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1",
+             "content": "side effect completed"},
+            # in-flight: call_2 emitted, its result not yet appended
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_2", "type": "function",
+                 "function": {"name": "gather_final_result", "arguments": "{}"}}]},
+        ]
+
+        # Step 1: compression fires mid-chain.
+        compressed = compressor._sanitize_tool_pairs([dict(m) for m in history])
+
+        # The in-flight call must survive the compression pass (fix), not be
+        # stripped as an orphan (bug) — otherwise the chain is already broken.
+        assert compressed[-1]["role"] == "assistant"
+        assert [tc["id"] for tc in compressed[-1].get("tool_calls", [])] == ["call_2"]
+        assert compressed[-1].get("content") != "(tool call removed)"
+
+        # Step 2: the side effect completes; the executor appends its result.
+        messages = [dict(m) for m in compressed] + [
+            {"role": "tool", "tool_call_id": "call_2",
+             "content": "final computed result: 42"}
+        ]
+
+        # Step 3: the next pre-call sanitizer runs on the settled chain.
+        repair_message_sequence(None, messages)
+
+        # Step 4: the final result must still be returned — the assistant call
+        # and its completed tool result both survive, still paired.
+        assistant_ids = {
+            tc["id"]
+            for m in messages if m["role"] == "assistant"
+            for tc in (m.get("tool_calls") or [])
+        }
+        assert "call_2" in assistant_ids
+
+        results = [m for m in messages
+                   if m["role"] == "tool" and m.get("tool_call_id") == "call_2"]
+        assert len(results) == 1
+        assert "42" in results[0]["content"]
+
+
 class TestCooldownReentryAbort:
     """Regression: a second compress() call during the failure cooldown must
     still abort when the original failure was a network/auth error.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2150,8 +2150,16 @@ class TestSanitizerStripsOrphanedToolCalls:
         assert asst.get("content") == "(tool call removed)"
 
     def test_sanitizer_strips_orphaned_keeps_valid(self, compressor):
-        """When an assistant has both valid and orphaned tool_calls, only
-        the orphans are stripped.  #51218"""
+        """When a MID-LIST assistant has both valid and orphaned tool_calls,
+        only the orphans are stripped.  #51218
+
+        The shape must sit mid-list: the same shape at the TAIL is
+        indistinguishable from a partial multi-call batch whose remaining
+        results are still in flight, and the sanitizer now presumes in-flight
+        there (#79278) — preserving is safe because the pre-API chokepoint
+        injects stub results for genuinely unanswered calls, while stripping
+        a live call silently loses its late result.
+        """
         msgs = [
             {
                 "role": "assistant",
@@ -2162,6 +2170,8 @@ class TestSanitizerStripsOrphanedToolCalls:
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_valid", "content": "file content"},
+            # Later turn: the chain above is settled history, not in flight.
+            {"role": "assistant", "content": "done"},
         ]
 
         sanitized = compressor._sanitize_tool_pairs(msgs)
@@ -2395,6 +2405,34 @@ class TestSanitizerPreservesInFlightToolChain:
                    if m["role"] == "tool" and m.get("tool_call_id") == "call_2"]
         assert len(results) == 1
         assert "42" in results[0]["content"]
+
+    def test_partial_batch_inflight_calls_preserved(self, compressor):
+        """Multi-call batch snapshotted BETWEEN result appends: the executor
+        has appended tool(c1) but not yet tool(c2)/tool(c3), so the last
+        message is a tool result while c2/c3 are still pending.  The walk-back
+        must find the assistant behind the trailing results and preserve the
+        whole batch — stripping c2/c3 there loses their late results exactly
+        like the tail-is-assistant shape.  #79278 follow-up."""
+        msgs = [
+            {"role": "user", "content": "run the batch"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "c1", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "b", "arguments": "{}"}},
+                {"id": "c3", "function": {"name": "c", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "done 1"},
+            # snapshot taken here: c2/c3 results not yet appended
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        batch = [m for m in sanitized if m.get("role") == "assistant"][-1]
+        assert [tc["id"] for tc in batch["tool_calls"]] == ["c1", "c2", "c3"]
+        # And the already-arrived result survives too.
+        assert any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "c1"
+            for m in sanitized
+        )
 
 
 class TestCooldownReentryAbort:


### PR DESCRIPTION
## Summary

Context compression no longer destroys an in-flight tool chain: a trailing pending `assistant(tool_calls)` — the model's live request whose result the executor hasn't appended yet — is preserved through `_sanitize_tool_pairs` instead of being stripped as an "orphan," so the completed side effect's result reaches the agent instead of being dropped by `repair_message_sequence` and silently replayed.

Salvage of #79293 by @Shotflame (cherry-picked, authorship preserved) + a follow-up widening the guard to the partial multi-call batch shape.

## Root cause

`tool_executor.py` appends `role=tool` results only AFTER running each call. When compression fires mid-chain, the trailing `assistant(tool_calls)` has no result yet — by construction pending, not orphaned. `_sanitize_tool_pairs` stripped it anyway; when the executor later appended the real result, `repair_message_sequence` Pass 1 dropped it as an unmatched stray. Side effect already happened server-side → the agent sees nothing → concludes failure → **replays the step** (unsafe for non-idempotent ops). The existing `_align_boundary_backward` protection only covers *completed* call/result groups — an in-flight chain has no result to align to.

## Changes

- `agent/context_compressor.py`: `_sanitize_tool_pairs` exempts the trailing in-flight request from orphan-stripping. The follow-up widens the guard from "last message is assistant" to "last **non-tool** message is assistant" — a multi-call batch snapshotted between per-result appends (`[..., assistant(c1,c2,c3), tool(c1)]`, reachable via concurrent `/compress` or the gateway hygiene pass) is equally in flight. Preserving is safe in both shapes: the pre-API chokepoint (`sanitize_api_messages` step 2) injects stub results for any call that genuinely never gets an answer, so a wrongly-preserved dangling call can't 400 the API — while stripping a live call silently loses its result.
- `tests/agent/test_context_compressor.py`: @Shotflame's 4 regression tests (3 unit + 1 end-to-end through `repair_message_sequence`) + a partial-batch regression test; `test_sanitizer_strips_orphaned_keeps_valid`'s mixed shape moves mid-list (at the tail it's byte-identical to a live partial batch, where in-flight is now correctly presumed).

## Validation

| Scenario (E2E: real `compress()` with stubbed summarizer, 103-msg history, then `repair_message_sequence`) | upstream/main | this branch |
|---|---|---|
| Compression fires with trailing pending call | in-flight call stripped, chain lost | call survives, late result kept, 0 repairs |
| Partial batch `assistant(c1,c2,c3), tool(c1)` at snapshot | c2/c3 stripped | whole batch + arrived result preserved |

113/113 in `test_context_compressor.py` (mutation-verified: contributor's 4 tests fail on pre-fix main; the partial-batch test fails without the walk-back); 462 passed across all compression-related `tests/agent/` suites; ruff clean.

## Issue #79278 stays open

This closes the compression-strip mechanism, but the persistent-mute variant reported in the issue's comments (12 side effects → 0 results for 5+ hours across session rotations) is not explained by a per-event strip — that needs separate investigation (rotation reconciliation or delivery-side). Deliberately using "Addresses" rather than "Fixes."

Addresses #79278 (compression-strip mechanism)

## Credit

@Shotflame (#79293) — root cause, fix, and tests, cherry-picked with authorship preserved. @zakhounet (#79278) — the reproduction with telemetry, and @ferhimedamine (#7255) — the original mechanism framing.

## Infographic

_Image generation is unavailable in this environment (no FAL key / Codex token) — will be attached via `gh pr edit` once a backend is available._
