### PR TITLE
fix(agent): trigger gc.collect() after retiring shared OpenAI clients (#80792)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4863,6 +4863,14 @@ class AIAgent:
                 self._client_log_context(),
                 exc,
             )
+        # #79244 / #80792: force_close_tcp_sockets() deliberately does NOT
+        # call close() to avoid the FD-recycling race with SSL BIO (#29507).
+        # FD release is deferred to GC.  In long sessions with repeated
+        # provider fallbacks, retired clients accumulate and their FDs are
+        # only reclaimed when the GC actually runs — which may be too late,
+        # causing EMFILE.  Trigger a collection here to release promptly.
+        import gc
+        gc.collect()
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
         with self._openai_client_lock():


### PR DESCRIPTION
Fixes #80792

## Root cause

`_retire_shared_openai_client` calls `force_close_tcp_sockets()` which only does `sock.shutdown(SHUT_RDWR)` — it deliberately does NOT call `sock.close()` to avoid the FD-recycling race with SSL BIO discussed in #29507/#70773. FD release is deferred to Python garbage collection.

In the common case (no borrower), the refcount hits zero immediately and FDs are released. But in long sessions with repeated provider fallbacks, retired clients accumulate and their FDs are only reclaimed when the GC actually runs — which on CPython can be deferred significantly, causing EMFILE (Errno 24).

## Fix

Add `gc.collect()` after each shared client retirement to trigger prompt FD release. This is safe because:
- `gc.collect()` does NOT call `close()` on the sockets — it only decrements refcounts
- The FD-recycling race requires explicit `close()` to release the FD, not GC
- The SSL BIO unwinding has already completed by the time the retired client's refcount hits zero

## Impact

- Prevents EMFILE in long-running gateway/CLI sessions with multiple provider fallbacks
- No change to the FD-recycling safety guarantees from #29507
