### PR TITLE
fix(plugins): route inject_message to dashboard sessions, targeted at the originating session

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1969,6 +1969,7 @@ class PluginContext:
         self,
         content: str,
         role: str = "user",
+        session_id: str | None = None,
         *,
         session_key: str | None = None,
     ) -> bool:
@@ -1979,6 +1980,14 @@ class PluginContext:
 
         This enables plugins (e.g. remote control viewers, messaging bridges)
         to send messages into the conversation from external sources.
+
+        ``session_id`` is the dashboard session that originated the work
+        (capture it inside the tool call via
+        ``gateway.session_context.get_session_env("HERMES_UI_SESSION_ID")``
+        — watcher threads spawned later don't inherit the ContextVar). When
+        set, dashboard routing delivers to that session only and drops the
+        message if it has been closed; the interactive CLI ignores it, having
+        a single conversation.
 
         Gateway injection requires an existing ``session_key`` and an explicit
         ``plugins.entries.<plugin_id>.allow_gateway_injection`` config grant.
@@ -2001,14 +2010,15 @@ class PluginContext:
 
         # No interactive CLI in this process. The dashboard/desktop chat
         # hosts its sessions in the in-process tui_gateway server instead
-        # — route the message to its most recently active session. Gate on
-        # sys.modules: a process that never imported the dashboard stack
-        # (e.g. a pure messaging gateway) has no sessions to route to, and
-        # must not pay the import for a guaranteed miss.
+        # — route the message to the originating session when known, else
+        # to the most recently active one. Gate on sys.modules: a process
+        # that never imported the dashboard stack (e.g. a pure messaging
+        # gateway) has no sessions to route to, and must not pay the import
+        # for a guaranteed miss.
         tui_server = sys.modules.get("tui_gateway.server")
         if tui_server is not None:
             try:
-                if tui_server.inject_external_message(msg):
+                if tui_server.inject_external_message(msg, target_sid=session_id):
                     return True
             except Exception:
                 logger.warning(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1999,9 +1999,26 @@ class PluginContext:
                 cli._pending_input.put(msg)
             return True
 
+        # No interactive CLI in this process. The dashboard/desktop chat
+        # hosts its sessions in the in-process tui_gateway server instead
+        # — route the message to its most recently active session. Gate on
+        # sys.modules: a process that never imported the dashboard stack
+        # (e.g. a pure messaging gateway) has no sessions to route to, and
+        # must not pay the import for a guaranteed miss.
+        tui_server = sys.modules.get("tui_gateway.server")
+        if tui_server is not None:
+            try:
+                if tui_server.inject_external_message(msg):
+                    return True
+            except Exception:
+                logger.warning(
+                    "inject_message: tui_gateway routing failed", exc_info=True
+                )
+
         if not session_key:
             logger.warning(
-                "inject_message: gateway mode requires an existing session_key"
+                "inject_message: no CLI reference, no active dashboard "
+                "session, and no session_key for gateway mode"
             )
             return False
         if not self._gateway_injection_allowed():

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -507,11 +507,29 @@ class PluginContext:
         Returns True if the message was queued successfully.
         """
         cli = self._manager._cli_ref
-        if cli is None:
-            logger.warning("inject_message: no CLI reference (not available in gateway mode)")
-            return False
-
         msg = content if role == "user" else f"[{role}] {content}"
+
+        if cli is None:
+            # No interactive CLI in this process. The dashboard/desktop chat
+            # hosts its sessions in the in-process tui_gateway server instead
+            # — route the message to its most recently active session. Gate on
+            # sys.modules: a process that never imported the dashboard stack
+            # (e.g. a pure messaging gateway) has no sessions to route to, and
+            # must not pay the import for a guaranteed miss.
+            tui_server = sys.modules.get("tui_gateway.server")
+            if tui_server is not None:
+                try:
+                    if tui_server.inject_external_message(msg):
+                        return True
+                except Exception:
+                    logger.warning(
+                        "inject_message: tui_gateway routing failed", exc_info=True
+                    )
+            logger.warning(
+                "inject_message: no CLI reference and no active dashboard "
+                "session (not available in gateway mode)"
+            )
+            return False
 
         if getattr(cli, "_agent_running", False):
             # Agent is mid-turn — interrupt with the message

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -495,7 +495,9 @@ class PluginContext:
 
     # -- message injection --------------------------------------------------
 
-    def inject_message(self, content: str, role: str = "user") -> bool:
+    def inject_message(
+        self, content: str, role: str = "user", session_id: str | None = None
+    ) -> bool:
         """Inject a message into the active conversation.
 
         If the agent is idle (waiting for user input), this starts a new turn.
@@ -503,6 +505,14 @@ class PluginContext:
 
         This enables plugins (e.g. remote control viewers, messaging bridges)
         to send messages into the conversation from external sources.
+
+        ``session_id`` is the dashboard session that originated the work
+        (capture it inside the tool call via
+        ``gateway.session_context.get_session_env("HERMES_UI_SESSION_ID")``
+        — watcher threads spawned later don't inherit the ContextVar). When
+        set, headless routing delivers to that session only and drops the
+        message if it has been closed; the interactive CLI ignores it, having
+        a single conversation.
 
         Returns True if the message was queued successfully.
         """
@@ -512,14 +522,17 @@ class PluginContext:
         if cli is None:
             # No interactive CLI in this process. The dashboard/desktop chat
             # hosts its sessions in the in-process tui_gateway server instead
-            # — route the message to its most recently active session. Gate on
+            # — route the message to the originating session when known,
+            # else to the most recently active one. Gate on
             # sys.modules: a process that never imported the dashboard stack
             # (e.g. a pure messaging gateway) has no sessions to route to, and
             # must not pay the import for a guaranteed miss.
             tui_server = sys.modules.get("tui_gateway.server")
             if tui_server is not None:
                 try:
-                    if tui_server.inject_external_message(msg):
+                    if tui_server.inject_external_message(
+                        msg, target_sid=session_id
+                    ):
                         return True
                 except Exception:
                     logger.warning(

--- a/tests/test_tui_gateway_inject.py
+++ b/tests/test_tui_gateway_inject.py
@@ -98,6 +98,42 @@ def test_most_recently_active_session_wins(monkeypatch):
     assert _wait_until(lambda: fired.get("sid") == "new")
 
 
+def test_target_session_beats_more_recent_activity(monkeypatch):
+    fired = {}
+
+    def fake_run_prompt_submit(rid, sid, session, text, **kwargs):
+        fired["sid"] = sid
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_run_prompt_submit)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda s: False)
+    monkeypatch.setattr(server, "_sessions", {
+        "origin": _session(last_active=10.0),
+        "chatty": _session(last_active=200.0),
+    })
+
+    assert server.inject_external_message("report", target_sid="origin") is True
+    assert _wait_until(lambda: fired.get("sid") == "origin")
+
+
+def test_closed_target_session_drops_instead_of_rerouting(monkeypatch):
+    other = _session(last_active=200.0)
+    monkeypatch.setattr(server, "_sessions", {"other": other})
+
+    assert server.inject_external_message("report", target_sid="gone") is False
+    assert other.get("queued_prompt") is None
+
+
+def test_lazy_target_session_drops_instead_of_rerouting(monkeypatch):
+    other = _session(last_active=200.0)
+    monkeypatch.setattr(server, "_sessions", {
+        "watch": _session(lazy=True, last_active=10.0),
+        "other": other,
+    })
+
+    assert server.inject_external_message("report", target_sid="watch") is False
+    assert other.get("queued_prompt") is None
+
+
 def test_lazy_watch_sessions_are_skipped(monkeypatch):
     monkeypatch.setattr(server, "_sessions", {
         "watch": _session(lazy=True, last_active=200.0),
@@ -136,6 +172,26 @@ def test_inject_message_routes_to_gateway_when_no_cli(monkeypatch):
     assert ctx._manager._cli_ref is None
     assert ctx.inject_message("run finished") is True
     assert session["queued_prompt"]["text"] == "run finished"
+
+
+def test_inject_message_session_id_targets_origin_session(monkeypatch):
+    origin = _session(running=True, last_active=10.0)
+    chatty = _session(running=True, last_active=200.0)
+    monkeypatch.setattr(server, "_sessions", {"origin": origin, "chatty": chatty})
+
+    ctx = _plugin_ctx()
+    assert ctx.inject_message("run finished", session_id="origin") is True
+    assert origin["queued_prompt"]["text"] == "run finished"
+    assert chatty.get("queued_prompt") is None
+
+
+def test_inject_message_session_id_gone_drops(monkeypatch):
+    chatty = _session(running=True, last_active=200.0)
+    monkeypatch.setattr(server, "_sessions", {"chatty": chatty})
+
+    ctx = _plugin_ctx()
+    assert ctx.inject_message("run finished", session_id="gone") is False
+    assert chatty.get("queued_prompt") is None
 
 
 def test_inject_message_still_false_without_cli_or_sessions(monkeypatch):

--- a/tests/test_tui_gateway_inject.py
+++ b/tests/test_tui_gateway_inject.py
@@ -1,0 +1,166 @@
+"""External message injection reaches dashboard/desktop sessions.
+
+``PluginContext.inject_message`` used to be CLI-only: in a headless serving
+process (``hermes serve`` / the desktop app) ``_cli_ref`` is ``None``, so a
+plugin's completion report was logged as a warning and dropped — dispatch
+watchers finished work nobody ever heard about. The gateway now exposes
+``tui_gateway.server.inject_external_message``, and ``inject_message`` routes
+to it when no interactive CLI is attached: busy sessions get the message
+merged into their queued next-turn prompt (never interrupting in-flight
+work), idle sessions start a relay turn immediately.
+"""
+
+import threading
+import time
+import types
+
+from tui_gateway import server
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "transport": None,
+        "attached_images": [],
+        **extra,
+    }
+
+
+def _wait_until(predicate, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    return predicate()
+
+
+# ── inject_external_message ────────────────────────────────────────────────
+
+def test_idle_session_fires_a_turn_immediately(monkeypatch):
+    fired = {}
+
+    def fake_run_prompt_submit(rid, sid, session, text, **kwargs):
+        fired["sid"] = sid
+        fired["text"] = text
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_run_prompt_submit)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda s: False)
+    session = _session(last_active=100.0)
+    monkeypatch.setattr(server, "_sessions", {"sid-1": session})
+
+    assert server.inject_external_message("run finished") is True
+    assert _wait_until(lambda: fired.get("text") == "run finished")
+    assert fired["sid"] == "sid-1"
+
+
+def test_busy_session_queues_without_interrupting(monkeypatch):
+    calls = {"interrupt": 0}
+    agent = types.SimpleNamespace(
+        interrupt=lambda *a, **k: calls.__setitem__("interrupt", calls["interrupt"] + 1)
+    )
+    session = _session(agent=agent, running=True, last_active=100.0)
+    monkeypatch.setattr(server, "_sessions", {"sid-1": session})
+
+    assert server.inject_external_message("run finished") is True
+    assert session["queued_prompt"]["text"] == "run finished"
+    assert calls["interrupt"] == 0
+
+
+def test_busy_session_merges_behind_queued_user_prompt(monkeypatch):
+    session = _session(running=True, last_active=100.0)
+    server._enqueue_prompt(session, "user typed this", "ws-1")
+    monkeypatch.setattr(server, "_sessions", {"sid-1": session})
+
+    assert server.inject_external_message("run finished") is True
+    assert session["queued_prompt"]["text"] == "user typed this\n\nrun finished"
+    # The user's transport binding survives the merge.
+    assert session["queued_prompt"]["transport"] == "ws-1"
+
+
+def test_most_recently_active_session_wins(monkeypatch):
+    fired = {}
+
+    def fake_run_prompt_submit(rid, sid, session, text, **kwargs):
+        fired["sid"] = sid
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_run_prompt_submit)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda s: False)
+    monkeypatch.setattr(server, "_sessions", {
+        "old": _session(last_active=10.0),
+        "new": _session(last_active=200.0),
+    })
+
+    assert server.inject_external_message("report") is True
+    assert _wait_until(lambda: fired.get("sid") == "new")
+
+
+def test_lazy_watch_sessions_are_skipped(monkeypatch):
+    monkeypatch.setattr(server, "_sessions", {
+        "watch": _session(lazy=True, last_active=200.0),
+    })
+    assert server.inject_external_message("report") is False
+
+
+def test_no_sessions_returns_false(monkeypatch):
+    monkeypatch.setattr(server, "_sessions", {})
+    assert server.inject_external_message("report") is False
+
+
+def test_blank_text_is_rejected(monkeypatch):
+    monkeypatch.setattr(server, "_sessions", {"sid-1": _session(last_active=1.0)})
+    assert server.inject_external_message("   ") is False
+    assert server.inject_external_message(None) is False
+
+
+# ── PluginContext.inject_message routing ───────────────────────────────────
+
+def _plugin_ctx():
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    pm = PluginManager()
+    manifest = PluginManifest(
+        name="testplugin", version="1.0.0", description="test", source="user",
+    )
+    return PluginContext(manifest, pm)
+
+
+def test_inject_message_routes_to_gateway_when_no_cli(monkeypatch):
+    session = _session(running=True, last_active=100.0)
+    monkeypatch.setattr(server, "_sessions", {"sid-1": session})
+
+    ctx = _plugin_ctx()
+    assert ctx._manager._cli_ref is None
+    assert ctx.inject_message("run finished") is True
+    assert session["queued_prompt"]["text"] == "run finished"
+
+
+def test_inject_message_still_false_without_cli_or_sessions(monkeypatch):
+    monkeypatch.setattr(server, "_sessions", {})
+    ctx = _plugin_ctx()
+    assert ctx.inject_message("run finished") is False
+
+
+def test_inject_message_prefers_cli_when_attached(monkeypatch):
+    session = _session(last_active=100.0)
+    monkeypatch.setattr(server, "_sessions", {"sid-1": session})
+
+    class _Queue:
+        def __init__(self):
+            self.items = []
+
+        def put(self, item):
+            self.items.append(item)
+
+    cli = types.SimpleNamespace(
+        _agent_running=False, _pending_input=_Queue(), _interrupt_queue=_Queue(),
+    )
+    ctx = _plugin_ctx()
+    ctx._manager._cli_ref = cli
+
+    assert ctx.inject_message("hello") is True
+    assert cli._pending_input.items == ["hello"]
+    assert session.get("queued_prompt") is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8343,15 +8343,23 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
-def inject_external_message(text: Any) -> bool:
-    """Deliver an externally-originated message into the most recently active
-    chat session, as if the user had typed it.
+def inject_external_message(text: Any, target_sid: str | None = None) -> bool:
+    """Deliver an externally-originated message into a chat session, as if
+    the user had typed it.
 
     This is the dashboard/desktop counterpart of the CLI's inject queues
     (``hermes_cli.plugins.PluginContext.inject_message``): plugins and watcher
     threads use it to push completion reports and escalations into the
     conversation of a headless serving process, where no interactive CLI
     exists to receive them.
+
+    ``target_sid`` names the session that originated the work. When given,
+    the message is delivered to that session ONLY — if it has been closed
+    (or is unroutable), the message is dropped and False is returned, never
+    rerouted: a report about session A's work must not surface in session
+    B's conversation. Without a target the message goes to the most
+    recently active session (callers that genuinely address "whoever is
+    listening").
 
     Routing mirrors ``prompt.submit``'s busy policy, minus the interrupt: a
     busy session gets the message merged into its queued next-turn prompt
@@ -8365,11 +8373,15 @@ def inject_external_message(text: Any) -> bool:
     """
     if not isinstance(text, str) or not text.strip():
         return False
-    candidates = sorted(
-        list(_sessions.items()),
-        key=lambda kv: kv[1].get("last_active") or 0,
-        reverse=True,
-    )
+    if target_sid is not None:
+        session = _sessions.get(target_sid)
+        candidates = [(target_sid, session)] if session is not None else []
+    else:
+        candidates = sorted(
+            list(_sessions.items()),
+            key=lambda kv: kv[1].get("last_active") or 0,
+            reverse=True,
+        )
     for sid, session in candidates:
         if session.get("lazy"):
             continue

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8343,6 +8343,62 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
+def inject_external_message(text: Any) -> bool:
+    """Deliver an externally-originated message into the most recently active
+    chat session, as if the user had typed it.
+
+    This is the dashboard/desktop counterpart of the CLI's inject queues
+    (``hermes_cli.plugins.PluginContext.inject_message``): plugins and watcher
+    threads use it to push completion reports and escalations into the
+    conversation of a headless serving process, where no interactive CLI
+    exists to receive them.
+
+    Routing mirrors ``prompt.submit``'s busy policy, minus the interrupt: a
+    busy session gets the message merged into its queued next-turn prompt
+    (``_enqueue_prompt`` is lossless, and a notification must never cancel
+    in-flight work), and an idle session starts a new turn immediately so the
+    model can relay the report right away. ``lazy`` watch sessions are skipped
+    — their runs live in the parent turn.
+
+    Returns True when a session accepted the message; False when no live
+    session exists. Callers own the degraded path (log, webhook, drop).
+    """
+    if not isinstance(text, str) or not text.strip():
+        return False
+    candidates = sorted(
+        list(_sessions.items()),
+        key=lambda kv: kv[1].get("last_active") or 0,
+        reverse=True,
+    )
+    for sid, session in candidates:
+        if session.get("lazy"):
+            continue
+        lock = session.get("history_lock")
+        if lock is None:
+            continue
+        with lock:
+            # ``_enqueue_prompt``'s latest-transport-wins rule is meant for
+            # user resubmits; an external message carries no transport and
+            # must not clobber the pin of a user prompt already in the slot.
+            queued = session.get("queued_prompt") or {}
+            keep_transport = queued.get("transport")
+            if session.get("running"):
+                _enqueue_prompt(session, text, keep_transport)
+                session["last_active"] = time.time()
+                return True
+            _enqueue_prompt(session, text, keep_transport)
+        # Idle: fire the queued message as a turn now. A user prompt racing
+        # this thread simply claims the session first — the queued message
+        # then drains at that turn's tail instead, so nothing is lost.
+        rid = f"inject-{uuid.uuid4().hex[:8]}"
+        threading.Thread(
+            target=_drain_queued_prompt, args=(rid, sid, session),
+            daemon=True, name=f"external-inject-{sid[:8]}",
+        ).start()
+        return True
+    return False
+
+
 def _inflight_snapshot(session: dict) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7560,6 +7560,62 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
+def inject_external_message(text: Any) -> bool:
+    """Deliver an externally-originated message into the most recently active
+    chat session, as if the user had typed it.
+
+    This is the dashboard/desktop counterpart of the CLI's inject queues
+    (``hermes_cli.plugins.PluginContext.inject_message``): plugins and watcher
+    threads use it to push completion reports and escalations into the
+    conversation of a headless serving process, where no interactive CLI
+    exists to receive them.
+
+    Routing mirrors ``prompt.submit``'s busy policy, minus the interrupt: a
+    busy session gets the message merged into its queued next-turn prompt
+    (``_enqueue_prompt`` is lossless, and a notification must never cancel
+    in-flight work), and an idle session starts a new turn immediately so the
+    model can relay the report right away. ``lazy`` watch sessions are skipped
+    — their runs live in the parent turn.
+
+    Returns True when a session accepted the message; False when no live
+    session exists. Callers own the degraded path (log, webhook, drop).
+    """
+    if not isinstance(text, str) or not text.strip():
+        return False
+    candidates = sorted(
+        list(_sessions.items()),
+        key=lambda kv: kv[1].get("last_active") or 0,
+        reverse=True,
+    )
+    for sid, session in candidates:
+        if session.get("lazy"):
+            continue
+        lock = session.get("history_lock")
+        if lock is None:
+            continue
+        with lock:
+            # ``_enqueue_prompt``'s latest-transport-wins rule is meant for
+            # user resubmits; an external message carries no transport and
+            # must not clobber the pin of a user prompt already in the slot.
+            queued = session.get("queued_prompt") or {}
+            keep_transport = queued.get("transport")
+            if session.get("running"):
+                _enqueue_prompt(session, text, keep_transport)
+                session["last_active"] = time.time()
+                return True
+            _enqueue_prompt(session, text, keep_transport)
+        # Idle: fire the queued message as a turn now. A user prompt racing
+        # this thread simply claims the session first — the queued message
+        # then drains at that turn's tail instead, so nothing is lost.
+        rid = f"inject-{uuid.uuid4().hex[:8]}"
+        threading.Thread(
+            target=_drain_queued_prompt, args=(rid, sid, session),
+            daemon=True, name=f"external-inject-{sid[:8]}",
+        ).start()
+        return True
+    return False
+
+
 def _inflight_snapshot(session: dict) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7560,15 +7560,23 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
-def inject_external_message(text: Any) -> bool:
-    """Deliver an externally-originated message into the most recently active
-    chat session, as if the user had typed it.
+def inject_external_message(text: Any, target_sid: str | None = None) -> bool:
+    """Deliver an externally-originated message into a chat session, as if
+    the user had typed it.
 
     This is the dashboard/desktop counterpart of the CLI's inject queues
     (``hermes_cli.plugins.PluginContext.inject_message``): plugins and watcher
     threads use it to push completion reports and escalations into the
     conversation of a headless serving process, where no interactive CLI
     exists to receive them.
+
+    ``target_sid`` names the session that originated the work. When given,
+    the message is delivered to that session ONLY — if it has been closed
+    (or is unroutable), the message is dropped and False is returned, never
+    rerouted: a report about session A's work must not surface in session
+    B's conversation. Without a target the message goes to the most
+    recently active session (callers that genuinely address "whoever is
+    listening").
 
     Routing mirrors ``prompt.submit``'s busy policy, minus the interrupt: a
     busy session gets the message merged into its queued next-turn prompt
@@ -7582,11 +7590,15 @@ def inject_external_message(text: Any) -> bool:
     """
     if not isinstance(text, str) or not text.strip():
         return False
-    candidates = sorted(
-        list(_sessions.items()),
-        key=lambda kv: kv[1].get("last_active") or 0,
-        reverse=True,
-    )
+    if target_sid is not None:
+        session = _sessions.get(target_sid)
+        candidates = [(target_sid, session)] if session is not None else []
+    else:
+        candidates = sorted(
+            list(_sessions.items()),
+            key=lambda kv: kv[1].get("last_active") or 0,
+            reverse=True,
+        )
     for sid, session in candidates:
         if session.get("lazy"):
             continue


### PR DESCRIPTION
## What does this PR do?

  `PluginContext.inject_message` is CLI-only. In a headless serving process (`hermes serve`, the desktop app) `_cli_ref` is `None`, so plugin notifications — dispatch completion reports, watcher escalations — were logged as a warning and silently dropped. Desktop chat never heard about finished background work.

  This adds `tui_gateway.server.inject_external_message`, the dashboard counterpart of the CLI inject queues, routes `inject_message` there when no CLI is attached, and lets callers name the session the work originated in so a report about session A can't surface in session B.

  Two commits, each independently green:

  **1. Route to dashboard sessions when no CLI is attached.**
  `inject_external_message` mirrors `prompt.submit`'s busy policy, minus the interrupt: a busy session gets the message merged losslessly into its queued next-turn prompt (a notification must never cancel in-flight work, and must not clobber a queued user prompt's pinned transport), and an idle session fires a new turn immediately so the model can relay the report right
  away. `lazy` watch sessions are skipped — their runs live in the parent turn. With no live session it returns `False` and the caller keeps its degraded path. The route is gated on `tui_gateway.server` already being in `sys.modules`, so a pure messaging-gateway process doesn't pay the dashboard import for a guaranteed miss.

  **2. Target the originating session.**
  With two dashboard sessions open concurrently, a completion report from session A landed in session B whenever the user had typed there more recently — deterministically, not as a race — and delivery bumped the wrong session's `last_active`, steering every subsequent notification to it too. `inject_external_message` grows `target_sid` and `PluginContext.inject_message`
  grows `session_id` to carry it. A targeted message goes to that session only; if it is gone the message is **dropped, never rerouted**. Untargeted callers keep the most-recent routing. Plugins capture the id inside the tool call via the `HERMES_UI_SESSION_ID` ContextVar — watcher threads spawned later don't inherit it, which is why the id travels by value.

  Both signature additions are keyword-only with defaults, so existing callers are unaffected.

  ## Related Issue

  No existing issue — found while running a plugin that dispatches background work from the desktop app. Happy to file one if you'd prefer a tracker entry.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `tui_gateway/server.py` — new `inject_external_message(text, target_sid=None)`
  - `hermes_cli/plugins.py` — `PluginContext.inject_message(..., session_id=None)`; routes to the dashboard when no CLI is attached
  - `tests/test_tui_gateway_inject.py` — new; 15 tests covering busy-merge, idle-fire, transport pinning, lazy-session skip, no-live-session, targeted delivery, and the drop-on-missing-target rule

  ## How to Test

  1. `pytest tests/test_tui_gateway_inject.py -q` — 15 passed.
  2. End-to-end: run `hermes dashboard` with no CLI attached, open a chat session, and have a plugin call `ctx.inject_message("done", session_id=<sid>)` from a background thread. Before this change the message is logged as a warning and dropped; after it appears in that session's conversation — merged into the next turn if the session is busy, as a new turn if idle.
  3. With two sessions open, type in session B, then inject with `session_id` set to session A. The message lands in A, not B.

  ## Known limitation (follow-up, not addressed here)

  A targeted session id is the **in-process** UI session id. When a remote desktop client's WebSocket drops, `_ws_orphan_reap` (20s grace, `HERMES_TUI_WS_ORPHAN_REAP_GRACE_S`) removes the session from `_sessions`, and a report arriving in that window is dropped even though the conversation still exists and is reclaimed on reconnect. I hit this on a remote-desktop setup:
  session reaped at T+0, report at T+4m40s, client reconnected 19s later.

  Covering it means matching on the durable `HERMES_SESSION_KEY` when the UI sid misses, plus parking the message for a session that is currently unattached. I left that out because the `_SESSION_UI_SESSION_ID` docstring says the ephemeral id was chosen deliberately — "so a stale/rotated durable session key cannot be consumed by whichever desktop poller wakes first" — and
  reversing that trade-off deserves its own PR and its own discussion. This PR is a strict improvement over the current behaviour (drop everything), and doesn't foreclose that fix.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix
  - [x] I've run the relevant suites (`-k "plugin or gateway or inject"`: 171 passed, 12 skipped)
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: macOS (Darwin 25.3.0), Python 3.11.15

  ### Documentation & Housekeeping

  - [x] Docstrings on both new entry points — no user-facing docs affected
  - [x] `cli-config.yaml.example` — N/A, no config keys
  - [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
  - [x] Cross-platform impact — N/A, pure Python with no platform-specific calls
  - [x] Tool descriptions/schemas — N/A

  ## Notes for reviewers

  Branched from `863e313`; merges cleanly into current `main` (verified with `git merge-tree`). Happy to rebase on request.