### PR TITLE
chore: map contributor cwt@users.noreply.github.com → Wintle

### DIFF
--- a/contributors/emails/cwt@users.noreply.github.com
+++ b/contributors/emails/cwt@users.noreply.github.com
@@ -1,0 +1,2 @@
+Wintle
+# PR #80293 salvage


### PR DESCRIPTION
## Summary
Maps contributor email `cwt@users.noreply.github.com` to GitHub login `Wintle` for the attribution check.

Required by salvage PR #80924 (author of the cherry-picked commit from PR #80293).

Must merge BEFORE #80924 so the attribution check passes.