### PR TITLE
fix(desktop): prevent duplicate in-app Browser panes

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/model.ts
@@ -128,61 +128,85 @@ export function allPaneIds(node: LayoutNode): string[] {
  * editor-applied tree keeps them until the first structural op.
  */
 export function normalize(node: LayoutNode): LayoutNode | null {
-  if (node.type === 'group') {
-    if (node.panes.length === 0) {
+  // Pane ids are contribution keys, not instance ids: one pane can only be
+  // mounted once in the layout tree. Keep the first occurrence in tree order
+  // so a stale persisted duplicate cannot render the same Browser twice.
+  const seenPanes = new Set<string>()
+
+  const walk = (current: LayoutNode): LayoutNode | null => {
+    if (current.type === 'group') {
+      const panes: string[] = []
+      let deduped = false
+
+      for (const paneId of current.panes) {
+        if (seenPanes.has(paneId)) {
+          deduped = true
+
+          continue
+        }
+
+        seenPanes.add(paneId)
+
+        panes.push(paneId)
+      }
+
+      if (panes.length === 0) {
+        return null
+      }
+
+      const active = panes.includes(current.active) ? current.active : panes[0]
+
+      // NOTE: `headerHidden` is deliberately untouched here. A zone down to one
+      // pane is headerless by default anyway, so a stored `true` is visually
+      // redundant *while it's alone* — but normalize used to DROP it, which threw
+      // away the user's standing choice: the bar came back the moment a pane
+      // rejoined (close a stacked tool panel, toggle it back on). `false` is
+      // sticky for the mirror reason — once a zone has had a tab bar, it keeps it.
+      if (!deduped && active === current.active) {
+        return current
+      }
+
+      return { ...current, panes, active }
+    }
+
+    const children: LayoutNode[] = []
+    const weights: number[] = []
+
+    current.children.forEach((child, i) => {
+      const kept = walk(child)
+
+      if (!kept) {
+        return
+      }
+
+      if (kept.type === 'split' && kept.orientation === current.orientation) {
+        // Flatten: distribute this slot's weight across the flattened children
+        // proportionally to their internal weights.
+        const total = kept.weights.reduce((a, b) => a + b, 0) || 1
+        kept.children.forEach((grandchild, j) => {
+          children.push(grandchild)
+          weights.push((current.weights[i] ?? 1) * ((kept.weights[j] ?? 1) / total))
+        })
+
+        return
+      }
+
+      children.push(kept)
+      weights.push(current.weights[i] ?? 1)
+    })
+
+    if (children.length === 0) {
       return null
     }
 
-    const active = node.panes.includes(node.active) ? node.active : node.panes[0]
-
-    // NOTE: `headerHidden` is deliberately untouched here. A zone down to one
-    // pane is headerless by default anyway, so a stored `true` is visually
-    // redundant *while it's alone* — but normalize used to DROP it, which threw
-    // away the user's standing choice: the bar came back the moment a pane
-    // rejoined (close a stacked tool panel, toggle it back on). `false` is
-    // sticky for the mirror reason — once a zone has had a tab bar, it keeps it.
-    if (active === node.active) {
-      return node
+    if (children.length === 1) {
+      return children[0]
     }
 
-    return { ...node, active }
+    return { ...current, children, weights }
   }
 
-  const children: LayoutNode[] = []
-  const weights: number[] = []
-
-  node.children.forEach((child, i) => {
-    const kept = normalize(child)
-
-    if (!kept) {
-      return
-    }
-
-    if (kept.type === 'split' && kept.orientation === node.orientation) {
-      // Flatten: distribute this slot's weight across the flattened children
-      // proportionally to their internal weights.
-      const total = kept.weights.reduce((a, b) => a + b, 0) || 1
-      kept.children.forEach((grandchild, j) => {
-        children.push(grandchild)
-        weights.push((node.weights[i] ?? 1) * ((kept.weights[j] ?? 1) / total))
-      })
-
-      return
-    }
-
-    children.push(kept)
-    weights.push(node.weights[i] ?? 1)
-  })
-
-  if (children.length === 0) {
-    return null
-  }
-
-  if (children.length === 1) {
-    return children[0]
-  }
-
-  return { ...node, children, weights }
+  return walk(node)
 }
 
 /** Remove a pane wherever it lives. Closing the ACTIVE tab leaves selection on

--- a/apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { findGroup, group, removePane, split } from './model'
+import { allPaneIds, findGroup, group, normalize, removePane, split } from './model'
 
 describe('removePane close-neighbor selection', () => {
   it('closing a middle active tab keeps you on the tab that slides into its slot', () => {
@@ -38,5 +38,17 @@ describe('removePane close-neighbor selection', () => {
     const stack = next ? findGroup(next, 'stack') : null
 
     expect(stack).toMatchObject({ panes: ['tile:1', 'tile:3'], active: 'tile:3' })
+  })
+
+  it('keeps a pane id in only one group when normalizing a persisted tree', () => {
+    const next = normalize(
+      split('row', [
+        group(['workspace', 'preview-tile:url:browser'], { id: 'main' }),
+        group(['preview-tile:url:browser'], { id: 'duplicate-browser' })
+      ])
+    )
+
+    expect(allPaneIds(next!)).toEqual(['workspace', 'preview-tile:url:browser'])
+    expect(findGroup(next!, 'duplicate-browser')).toBeNull()
   })
 })

--- a/apps/desktop/src/store/preview-persistence.test.ts
+++ b/apps/desktop/src/store/preview-persistence.test.ts
@@ -94,4 +94,35 @@ describe('persisted preview migration', () => {
 
     expect(restored?.target.previewKind).toBe('text')
   })
+
+  it('restores URL tabs as one Browser tab, keeping the latest URL', () => {
+    const restored = decodePreviewTabs(
+      JSON.stringify([
+        {
+          id: 'url:https://old.example',
+          target: {
+            kind: 'url',
+            label: 'old',
+            source: 'https://old.example',
+            url: 'https://old.example'
+          }
+        },
+        {
+          id: 'url:https://new.example',
+          target: {
+            kind: 'url',
+            label: 'new',
+            source: 'https://new.example',
+            url: 'https://new.example'
+          }
+        }
+      ])
+    )
+
+    expect(restored).toHaveLength(1)
+    expect(restored[0]).toMatchObject({
+      id: 'url:browser',
+      target: { url: 'https://new.example' }
+    })
+  })
 })

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -60,6 +60,13 @@ export interface PreviewTab {
   target: PreviewTarget
 }
 
+/** The one Browser tab's id. URL targets all share it: the tab names the
+ *  SURFACE (Browser), not the page, so opening a second URL navigates the
+ *  browser it already has — re-front the tab, swap its target, and the pane
+ *  rebuilds its webview against the new url. Files and artifacts stay keyed
+ *  by identity; only the web surface is a singleton. */
+const BROWSER_TAB_ID: RightRailTabId = 'url:browser'
+
 const TABS_STORAGE_KEY = 'hermes.desktop.previewTabs.v2'
 /** Superseded by the tab list above; cleared so it can't leak forever. */
 const LEGACY_SESSION_REGISTRY_KEY = 'hermes.desktop.sessionPreviews.v1'
@@ -186,13 +193,6 @@ export const $previewTabSources = computed($previewTabs, tabs => tabs.map(tab =>
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)
 export const $previewServerRestartStatus = computed($previewServerRestart, restart => restart?.status ?? 'idle')
-
-/** The one Browser tab's id. URL targets all share it: the tab names the
- *  SURFACE (Browser), not the page, so opening a second URL navigates the
- *  browser it already has — re-front the tab, swap its target, and the pane
- *  rebuilds its webview against the new url. Files and artifacts stay keyed
- *  by identity; only the web surface is a singleton. */
-const BROWSER_TAB_ID: RightRailTabId = 'url:browser'
 
 export function previewTabId(target: PreviewTarget): RightRailTabId {
   return target.kind === 'url' ? BROWSER_TAB_ID : `${target.kind}:${target.url}`

--- a/docs/rca-desktop-browser-pane-duplicates.md
+++ b/docs/rca-desktop-browser-pane-duplicates.md
@@ -1,0 +1,48 @@
+# Desktop in-app Browser pane duplication
+
+Status: fixed locally; draft PR [#80929](https://github.com/NousResearch/hermes-agent/pull/80929) is awaiting contributor review.
+
+Date investigated: 2026-08-07
+
+## User-visible symptoms
+
+- Hermes Desktop could show two in-app `BROWSER` panes for one Browser surface.
+- Right-clicking one Browser pane and choosing Remove could remove both panes.
+- The layout could look correct after restart, then gain a second Browser pane when an agent opened another URL.
+
+## Root causes
+
+There were two related persistence problems:
+
+1. The persisted layout tree could contain the same pane contribution ID in more than one group. The Browser pane uses a shared contribution ID, so closing that ID affected every persisted occurrence.
+2. The persisted preview decoder called `previewTabId()` while the `BROWSER_TAB_ID` constant was still in the module's temporal dead zone. `persistentAtom()` caught the initialization error and fell back to an empty preview-tab list. The next agent-driven URL open then added a new Browser pane beside the stale layout entry.
+
+## Fix
+
+- Normalize pane IDs globally across the whole layout tree, keeping the first occurrence in tree order.
+- Initialize `BROWSER_TAB_ID` before persisted preview state is decoded.
+- Keep all restored URL previews on the singleton `url:browser` ID and retain the latest URL.
+- Add regression tests for duplicate layout entries and multiple persisted URL tabs.
+
+Changed files:
+
+- `apps/desktop/src/components/pane-shell/tree/model.ts`
+- `apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts`
+- `apps/desktop/src/store/preview.ts`
+- `apps/desktop/src/store/preview-persistence.test.ts`
+
+## Local verification
+
+Completed before updating PR #80929:
+
+- UI tests: 59 suites / 450 tests passed.
+- Desktop typecheck passed.
+- ESLint passed for all changed Desktop files.
+- `git diff --check` passed.
+- Rebuilt and launched the local macOS `Hermes.app`.
+- Confirmed one Browser after restart.
+- Confirmed one Browser after the agent opened one URL and then a different URL.
+
+## Update warning
+
+Until PR #80929 is merged and included in an official release, installing an older official Hermes build can overwrite the local packaged app and reintroduce this bug. Use the locally built app for verification until the fixed release is available.


### PR DESCRIPTION
## Summary

- Deduplicate persisted pane IDs during layout normalization
- Restore saved URL previews onto the singleton Browser tab without creating another pane
- Add regression tests and an RCA document

## Validation

- 450 UI tests passed
- Typecheck and changed-file lint passed
- Verified one Browser pane after restart and multiple agent-opened URLs in a packaged macOS app