### PR TITLE
fix(todo): parse Python-repr string in todos guard

### DIFF
--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -14,6 +14,7 @@ Design:
 - Behavioral guidance lives entirely in the tool schema description
 """
 
+import ast
 import json
 from typing import Dict, Any, List, Optional
 
@@ -221,12 +222,17 @@ def todo_tool(
         return tool_error("TodoStore not initialized")
 
     if todos is not None:
-        # Guard: LLM sometimes sends todos as a JSON string instead of a list
+        # Guard: LLM sometimes sends todos as a JSON string instead of a list.
+        # Open-weight providers (DeepSeek/Qwen via agent-loop) emit Python repr
+        # (single-quoted) rather than JSON — parse that too.
         if isinstance(todos, str):
             try:
                 todos = json.loads(todos)
             except (json.JSONDecodeError, TypeError):
-                return tool_error("todos must be a list of objects, got unparseable string")
+                try:
+                    todos = ast.literal_eval(todos)
+                except (ValueError, SyntaxError):
+                    return tool_error("todos must be a list of objects, got unparseable string")
         if not isinstance(todos, list):
             return tool_error(
                 f"todos must be a list, got {type(todos).__name__}"


### PR DESCRIPTION
## Summary

Upstream #52618 added defensive `json.loads` coercion for `todos` sent as a JSON-encoded string (Pattern A: double-quoted JSON). That covers Claude/GPT behavior, but **open-weight providers (DeepSeek/Qwen via the agent-loop path) emit Python repr (single-quoted) instead of JSON**:

```python
{"todos": "[{'id': 't1', 'content': 'x', 'status': 'pending'}]"}
```

`json.loads` fails on single quotes → `todo_tool` returns `"todos must be a list of objects, got unparseable string"` even for well-formed input.

## Fix

Add `ast.literal_eval` fallback after `json.loads` fails in the `todo_tool` guard:

- `json.loads` still handles standard JSON (double-quoted)
- `ast.literal_eval` covers the Python-repr shape (single-quoted) emitted by open-weight models
- Fails closed: garbage input still returns the structured error, never raises

## Testing

Verified with unit-style tests against `todo_tool`:
- standard list (dict items) ✓
- JSON string (double-quoted) ✓
- Python repr string (single-quoted) ✓ — the previously failing case
- garbage string → structured error, no crash ✓

`python -m py_compile` clean.

## Notes

Same single-quote drift exists in `memory_tool`'s `operations` guard, but that guard is a separate local/unmerged change (PR #79421) — out of scope here.
