### PR TITLE
i18n(desktop): localize right-click context menu labels to Chinese

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5658,7 +5658,7 @@ function installContextMenu(window) {
     if (hasImage) {
       template.push(
         {
-          label: 'Open Image',
+          label: '打开图片',
           click: () => {
             if (params.srcURL && !params.srcURL.startsWith('data:')) {
               openExternalUrl(params.srcURL)
@@ -5667,17 +5667,17 @@ function installContextMenu(window) {
           enabled: !params.srcURL.startsWith('data:')
         },
         {
-          label: 'Copy Image',
+          label: '复制图片',
           click: () => {
             void copyImageFromUrl(params.srcURL).catch(error => rememberLog(`Copy image failed: ${error.message}`))
           }
         },
         {
-          label: 'Copy Image Address',
+          label: '复制图片地址',
           click: () => clipboard.writeText(params.srcURL)
         },
         {
-          label: 'Save Image As...',
+          label: '图片另存为...',
           click: () => {
             void saveImageFromUrl(params.srcURL).catch(error => rememberLog(`Save image failed: ${error.message}`))
           }
@@ -5692,11 +5692,11 @@ function installContextMenu(window) {
 
       template.push(
         {
-          label: 'Open Link',
+          label: '打开链接',
           click: () => openExternalUrl(params.linkURL)
         },
         {
-          label: 'Copy Link',
+          label: '复制链接',
           click: () => clipboard.writeText(params.linkURL)
         }
       )
@@ -5721,7 +5721,7 @@ function installContextMenu(window) {
 
       template.push({ type: 'separator' })
       template.push({
-        label: 'Add to dictionary',
+        label: '添加到词典',
         click: () => window.webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord)
       })
     }
@@ -5733,14 +5733,14 @@ function installContextMenu(window) {
 
       if (isEditable) {
         template.push(
-          { role: 'cut', enabled: params.editFlags.canCut },
-          { role: 'copy', enabled: params.editFlags.canCopy },
-          { role: 'paste', enabled: params.editFlags.canPaste },
+          { role: 'cut', label: '剪切', enabled: params.editFlags.canCut },
+          { role: 'copy', label: '复制', enabled: params.editFlags.canCopy },
+          { role: 'paste', label: '粘贴', enabled: params.editFlags.canPaste },
           { type: 'separator' },
-          { role: 'selectAll', enabled: params.editFlags.canSelectAll }
+          { role: 'selectAll', label: '全选', enabled: params.editFlags.canSelectAll }
         )
       } else {
-        template.push({ role: 'copy', enabled: params.editFlags.canCopy })
+        template.push({ role: 'copy', label: '复制', enabled: params.editFlags.canCopy })
       }
     }
 


### PR DESCRIPTION
Localize the Electron main-process right-click context menu to Chinese. Previously all labels were hardcoded English (Open Image, Copy Link, Cut/Copy/Paste/Select All, Add to dictionary), which shows English even on zh-CN Windows systems. Tested: npm run typecheck passes; verified on Windows 10 zh-CN.