### PR TITLE
fix(kanban): strip gateway approval env from dispatcher-spawned workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8996,6 +8996,18 @@ def _default_spawn(
     for key in _VAR_MAP:
         env.pop(key, None)
 
+    # A dispatcher-owned worker is headless — it must NEVER be classified as a
+    # gateway/ask approval session. Gateways carry HERMES_GATEWAY_SESSION (and
+    # optionally HERMES_EXEC_ASK) in process env; when inherited, the worker's
+    # execute_code / dangerous-command checks take the gateway branch and go to
+    # a human-approval prompt that nobody can answer in headless dispatch →
+    # every gated action times out and the task blocks (kanban smoke test
+    # t_0c500861, 2026-08-06). Stripping restores the documented
+    # non-interactive non-gateway auto-approve contract
+    # (tools/approval.py check_execute_code_guard / _run_approval_gate).
+    env.pop("HERMES_GATEWAY_SESSION", None)
+    env.pop("HERMES_EXEC_ASK", None)
+
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
     # config.  Without this, `env = dict(os.environ)` copies only the parent's

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -89,6 +89,55 @@ agent:
         assert required in pinned
 
 
+def test_default_spawn_strips_gateway_approval_env(monkeypatch, tmp_path):
+    """Headless workers must not inherit the gateway-approval classification.
+
+    Regression guard for blocked kanban tasks (t_0c500861, 2026-08-06): a
+    worker spawned from a gateway process inherits HERMES_GATEWAY_SESSION=1
+    (and HERMES_EXEC_ASK when set), which classifies it as a gateway approval
+    context. execute_code and dangerous terminal commands then go to a
+    human-approval prompt nobody can answer in headless dispatch — every gated
+    action times out and the task blocks. The spawn must strip both vars so
+    the worker lands in the documented non-interactive non-gateway
+    auto-approve branch (tools/approval.py check_execute_code_guard).
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli: [terminal, file, code_execution]\n",
+        encoding="utf-8",
+    )
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4245
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+
+    assert "HERMES_GATEWAY_SESSION" not in captured["env"]
+    assert "HERMES_EXEC_ASK" not in captured["env"]
+    # Sanity: the worker still gets its task-scoped env.
+    assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
+    assert captured["env"]["HERMES_HOME"] == str(profile)
+
+
 def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_path):
     """The dispatcher's pre-``chat`` model flag must reach ``args.model``.
 


### PR DESCRIPTION
## Problem

Dispatcher-spawned kanban workers get classified as **gateway-approval contexts** and every gated action blocks.

Observed symptom (real board, 2026-08-06): a kanban smoke-test worker found `execute_code` approval-blocked with *"Asking the user for approval"*, and the task blocked with `kind=capability` after every gated action timed out. Same failure class hit a second task 20 minutes later. Headless workers have no human to answer an approval prompt — the prompt just times out and the task wedges.

## Root cause

1. `tui_gateway/server.py` sets `HERMES_GATEWAY_SESSION=1` in the process environment.
2. Gateway processes inherit it; `_default_spawn` (`hermes_cli/kanban_db.py`) builds the worker env with `env = dict(os.environ)` and strips only `_VAR_MAP` keys (`gateway/session_context.py`) — which does **not** include `HERMES_GATEWAY_SESSION` or `HERMES_EXEC_ASK`.
3. In the worker process, `tools/approval.py:_is_gateway_approval_context()` therefore returns `True`.
4. `check_execute_code_guard` and `check_all_command_guards` take the gateway branch → `prompt_dangerous_approval()` with no listener → timeout → `{"approved": False}`.

The documented contract (`check_execute_code_guard` docstring, #30882) is that a local non-interactive non-gateway session auto-approves — "trusted-by-config". The spawn accidentally turned every worker into a gateway session, defeating that contract regardless of the profile's `approvals` settings.

## Fix

`_default_spawn` now pops `HERMES_GATEWAY_SESSION` and `HERMES_EXEC_ASK` from the worker env, so the child lands in the non-interactive non-gateway auto-approve branch. Minimal change; sibling spawn paths (cron) already scope their own approval policy via `_cron_session_var`.

## Test

New regression test `test_default_spawn_strips_gateway_approval_env` in `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`: spawns with `HERMES_GATEWAY_SESSION=1` + `HERMES_EXEC_ASK=1` in the parent env and asserts the child env is clean while task-scoped vars (`HERMES_KANBAN_TASK`, `HERMES_HOME`) survive. Full file passes: 4/4.

## E2E verification

Production board, after gateways were restarted onto this code: the previously-blocked smoke-test task re-dispatched and **passed** — `execute_code` ran unprompted (exit 0, no approval prompt), `terminal('echo ok')` via `hermes_tools` returned exit 0, file reads worked. Downstream tasks (which had been blocking on this) completed.
