### PR TITLE
fix(desktop): remote-mode Update now updates the local app too, and stop false backend-update failures

### DIFF
--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -7,11 +7,16 @@ import { Codicon } from '@/components/ui/codicon'
 import { type Translations, useI18n } from '@/i18n'
 import { CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $connection } from '@/store/session'
 import {
+  $backendUpdateApply,
+  $backendUpdateChecking,
+  $backendUpdateStatus,
   $desktopVersion,
   $updateApply,
   $updateChecking,
   $updateStatus,
+  checkBackendUpdates,
   checkUpdates,
   openUpdatesWindow,
   refreshDesktopVersion,
@@ -51,8 +56,17 @@ export function AboutSettings() {
   const version = useStore($desktopVersion)
   const status = useStore($updateStatus)
   const apply = useStore($updateApply)
-  const checking = useStore($updateChecking)
+  const clientChecking = useStore($updateChecking)
+  const connection = useStore($connection)
+  const backendStatus = useStore($backendUpdateStatus)
+  const backendApply = useStore($backendUpdateApply)
+  const backendChecking = useStore($backendUpdateChecking)
   const [justChecked, setJustChecked] = useState(false)
+
+  // Remote gateway: the desktop shell drives a remote backend, but this app is
+  // still built from the LOCAL checkout. Both are updatable — show both, and
+  // "Update now" (startActiveUpdate) chains backend-then-client.
+  const isRemote = connection?.mode === 'remote'
 
   // The version atom is loaded once at app boot, which makes About show a
   // stale number after a self-update (the running binary is current, the
@@ -64,30 +78,39 @@ export function AboutSettings() {
 
   const behind = status?.behind ?? 0
   const supported = status?.supported !== false
-  const applying = apply.applying || apply.stage === 'restart'
+  const backendBehind = isRemote && backendStatus?.supported !== false && !backendStatus?.error ? (backendStatus?.behind ?? 0) : 0
+  const checking = clientChecking || backendChecking
+  const applying = apply.applying || apply.stage === 'restart' || backendApply.applying || backendApply.stage === 'restart'
+  const updateReady = (behind > 0 && supported) || backendBehind > 0
 
   const handleCheck = async () => {
     setJustChecked(false)
-    const next = await checkUpdates()
+    const [next] = await Promise.all([checkUpdates(), isRemote ? checkBackendUpdates() : Promise.resolve(null)])
     setJustChecked(Boolean(next))
   }
 
   let statusLine: string
   let statusTone: 'idle' | 'available' | 'error' = 'idle'
 
-  if (!supported) {
+  if (!supported && backendBehind <= 0) {
     statusLine = status?.message ?? a.cantUpdate
     statusTone = 'error'
-  } else if (status?.error) {
+  } else if (status?.error && backendBehind <= 0) {
     statusLine = a.cantReach
     statusTone = 'error'
   } else if (applying) {
     statusLine = a.installing
     statusTone = 'available'
+  } else if (behind > 0 && supported && backendBehind > 0) {
+    statusLine = a.updateReadyBoth(backendBehind, behind)
+    statusTone = 'available'
+  } else if (backendBehind > 0) {
+    statusLine = a.backendUpdateReady(backendBehind)
+    statusTone = 'available'
   } else if (behind > 0) {
     statusLine = a.updateReady(behind)
     statusTone = 'available'
-  } else if (status) {
+  } else if (status || (isRemote && backendStatus)) {
     statusLine = a.onLatest
   } else {
     statusLine = a.tapCheck
@@ -133,7 +156,7 @@ export function AboutSettings() {
 
           <div className="mt-3 flex flex-wrap items-center gap-4">
             <Button
-              disabled={checking || applying || !supported}
+              disabled={checking || applying || (!supported && !isRemote)}
               onClick={() => void handleCheck()}
               size="sm"
               variant="textStrong"
@@ -142,7 +165,7 @@ export function AboutSettings() {
               {checking ? a.checking : a.checkNow}
             </Button>
 
-            {behind > 0 && supported && !applying && (
+            {updateReady && !applying && (
               <>
                 <Button onClick={() => startActiveUpdate()} size="sm">
                   {a.updateNow}
@@ -172,7 +195,10 @@ export function AboutSettings() {
 
         <ListRow
           description={a.automaticUpdatesDesc}
-          hint={a.branchCommit(status?.branch ?? 'unknown', status?.currentSha?.slice(0, 7) ?? 'unknown')}
+          hint={
+            a.branchCommit(status?.branch ?? 'unknown', status?.currentSha?.slice(0, 7) ?? 'unknown') +
+            (isRemote && backendStatus?.currentVersion ? ` · ${a.backendVersion(backendStatus.currentVersion)}` : '')
+          }
           title={a.automaticUpdates}
         />
 

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -29,7 +29,7 @@ import {
   $updateOverlayOpen,
   $updateOverlayTarget,
   $updateStatus,
-  applyBackendUpdate,
+  applyRemoteUpdates,
   applyUpdates,
   checkBackendUpdates,
   checkUpdates,
@@ -58,7 +58,10 @@ export function UpdatesOverlay() {
   const checking = isBackend ? backendChecking : clientChecking
   const apply = isBackend ? backendApply : clientApply
   const check = isBackend ? checkBackendUpdates : checkUpdates
-  const install = isBackend ? applyBackendUpdate : applyUpdates
+  // The backend target only appears in remote mode, where an update means BOTH
+  // sides: the remote backend and then the local client (which is still built
+  // from the local checkout). applyRemoteUpdates chains the two.
+  const install = isBackend ? applyRemoteUpdates : applyUpdates
 
   useEffect(() => {
     if (open && !status && !checking) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -537,6 +537,10 @@ export const en: Translations = {
       cantReach: "We couldn't reach the update server.",
       tapCheck: 'Tap "Check now" to look for updates.',
       updateReady: count => `A new update is ready (${count} change${count === 1 ? '' : 's'} included).`,
+      backendUpdateReady: count => `A backend update is ready (${count} change${count === 1 ? '' : 's'} included).`,
+      updateReadyBoth: (backendCount, appCount) =>
+        `Updates ready: backend (${backendCount} change${backendCount === 1 ? '' : 's'}) and this app (${appCount} change${appCount === 1 ? '' : 's'}).`,
+      backendVersion: value => `Connected backend · ${value}`,
       lastChecked: age => `Last checked ${age}`,
       justNowSuffix: ' · just now',
       automaticUpdates: 'Automatic updates',
@@ -2225,6 +2229,7 @@ export const en: Translations = {
       preparing: 'Updating backend…',
       pulling: 'Backend updating…',
       restarting: 'Backend restarting to load the update…',
+      verifying: 'Confirming the update finished…',
       notAvailable: 'Update not available for this backend.',
       failed: 'Backend update failed.',
       noReturn: 'Backend didn’t come back online. The update may not have completed — check the backend host.'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -437,6 +437,9 @@ export interface Translations {
       cantReach: string
       tapCheck: string
       updateReady: (count: number) => string
+      backendUpdateReady: (count: number) => string
+      updateReadyBoth: (backendCount: number, appCount: number) => string
+      backendVersion: (value: string) => string
       lastChecked: (age: string) => string
       justNowSuffix: string
       automaticUpdates: string
@@ -1856,6 +1859,7 @@ export interface Translations {
       preparing: string
       pulling: string
       restarting: string
+      verifying: string
       notAvailable: string
       failed: string
       noReturn: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -748,6 +748,9 @@ export const zh: Translations = {
       cantReach: '无法连接更新服务器。',
       tapCheck: '点击"立即检查"以查找更新。',
       updateReady: count => `已准备好新更新 (包含 ${count} 项更改)。`,
+      backendUpdateReady: count => `已准备好后端更新 (包含 ${count} 项更改)。`,
+      updateReadyBoth: (backendCount, appCount) => `更新已就绪:后端 (${backendCount} 项更改) 和本应用 (${appCount} 项更改)。`,
+      backendVersion: value => `已连接的后端 · ${value}`,
       lastChecked: age => `上次检查:${age}`,
       justNowSuffix: ' · 刚刚',
       automaticUpdates: '自动更新',
@@ -2416,6 +2419,7 @@ export const zh: Translations = {
       preparing: '正在更新后端…',
       pulling: '后端更新中…',
       restarting: '后端正在重启以加载更新…',
+      verifying: '正在确认更新已完成…',
       notAvailable: '此后端无法更新。',
       failed: '后端更新失败。',
       noReturn: '后端未恢复在线。更新可能未完成——请检查后端主机。'

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -46,6 +46,7 @@ const {
   checkBackendUpdates,
   $backendUpdateStatus,
   applyBackendUpdate,
+  applyRemoteUpdates,
   $backendUpdateApply,
   reportBackendContract,
   applyUpdates,
@@ -857,6 +858,199 @@ describe('applyBackendUpdate recovery', () => {
 
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
+  }, 10000)
+
+  // The observed real-world failure: `hermes update` restarts the gateway that
+  // spawned it, so the new gateway reports running=false with no exit code and
+  // the completion receipt is never written. The update actually succeeded —
+  // /update/check?force=true is the surviving proof.
+  it('proves success via update/check when the restart loses the exit code and receipt', async () => {
+    const actionId = 'g'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValue({
+      exit_code: null,
+      lines: ['→ Pulling updates...', '✓ Code updated!'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      behind: 0,
+      can_apply: true,
+      commits: [],
+      current_version: '0.20.1',
+      install_method: 'git',
+      message: null,
+      update_available: false,
+      update_command: 'hermes update'
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(20000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledWith(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+    expect($backendUpdateApply.get().applying).toBe(false)
+  })
+
+  it('asks the backend one last time before failing when the poll window expires', async () => {
+    updateHermesSpy.mockResolvedValue({ action_id: 'h'.repeat(32), ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
+    checkHermesUpdateSpy.mockResolvedValue({
+      behind: 0,
+      can_apply: true,
+      commits: [],
+      current_version: '0.20.1',
+      install_method: 'git',
+      message: null,
+      update_available: false,
+      update_command: 'hermes update'
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(250000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledWith(true)
+  }, 10000)
+
+  it('still fails when the verification says the backend stayed behind', async () => {
+    updateHermesSpy.mockResolvedValue({ action_id: 'i'.repeat(32), ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: null,
+      lines: ['some output'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      behind: 2,
+      can_apply: true,
+      commits: [],
+      current_version: '0.20.0',
+      install_method: 'git',
+      message: null,
+      update_available: true,
+      update_command: 'hermes update'
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 1500)
+
+    await expect(promise).resolves.toMatchObject({ ok: false, error: 'apply-failed' })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledWith(true)
+    expect($backendUpdateApply.get().stage).toBe('error')
+  }, 10000)
+})
+
+// Remote mode has two independent update targets: the remote backend and the
+// local checkout this GUI is built from. applyRemoteUpdates() chains them —
+// backend first, then the client — so the app side no longer silently stays
+// behind after a remote update.
+describe('applyRemoteUpdates chain', () => {
+  const applyClientMock = vi.fn()
+  const checkClientMock = vi.fn()
+
+  const backendCurrent = {
+    behind: 0,
+    can_apply: true,
+    commits: [],
+    current_version: '0.20.1',
+    install_method: 'git',
+    message: null,
+    update_available: false,
+    update_command: 'hermes update'
+  }
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    applyClientMock.mockReset().mockResolvedValue({ ok: true, handedOff: true })
+    checkClientMock.mockReset().mockResolvedValue(status({ behind: 0 }))
+    updateHermesSpy.mockReset().mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockReset().mockResolvedValue({ exit_code: 0, lines: [], name: 'hermes-update', pid: 1, running: false })
+    checkHermesUpdateSpy.mockReset().mockResolvedValue(backendCurrent)
+    resetUpdateApplyState()
+    $updateStatus.set(null)
+    $backendUpdateStatus.set(null)
+    $updateOverlayOpen.set(false)
+    setRemote(true)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyClientMock, check: checkClientMock } }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    setRemote(false)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('updates the backend, then chains the local client update', async () => {
+    $backendUpdateStatus.set(status({ behind: 2 }))
+    $updateStatus.set(status({ behind: 1 }))
+
+    const result = await applyRemoteUpdates()
+
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(result.ok).toBe(true)
+    // The client handed off to the relauncher: hold the overlay open on the
+    // restarting view, exactly like a local-mode update.
+    expect($updateOverlayOpen.get()).toBe(true)
+  }, 10000)
+
+  it('closes the overlay after a backend-only success when the client is already current', async () => {
+    $backendUpdateStatus.set(status({ behind: 2 }))
+    $updateStatus.set(status({ behind: 0, updateAvailable: false }))
+
+    const result = await applyRemoteUpdates()
+
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).not.toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+    expect($updateOverlayOpen.get()).toBe(false)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  }, 10000)
+
+  it('skips the backend phase and updates only the client when the backend is current', async () => {
+    $backendUpdateStatus.set(status({ behind: 0, updateAvailable: false }))
+    $updateStatus.set(status({ behind: 3 }))
+
+    const result = await applyRemoteUpdates()
+
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(result.ok).toBe(true)
+  })
+
+  it('stops with the error view up on a genuine backend failure, never touching the client', async () => {
+    $backendUpdateStatus.set(status({ behind: 2 }))
+    $updateStatus.set(status({ behind: 1 }))
+    getActionStatusSpy.mockResolvedValue({ exit_code: 1, lines: ['update failed'], name: 'hermes-update', pid: 1, running: false })
+
+    const result = await applyRemoteUpdates()
+
+    expect(result.ok).toBe(false)
+    expect(applyClientMock).not.toHaveBeenCalled()
+    expect($backendUpdateApply.get().stage).toBe('error')
+    expect($updateOverlayOpen.get()).toBe(true)
+  }, 10000)
+
+  it('shares one in-flight chain between concurrent requests', async () => {
+    $backendUpdateStatus.set(status({ behind: 2 }))
+    $updateStatus.set(status({ behind: 0, updateAvailable: false }))
+
+    const first = applyRemoteUpdates()
+    const second = applyRemoteUpdates()
+
+    expect(second).toBe(first)
+    await Promise.all([first, second])
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
   }, 10000)
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -248,29 +248,106 @@ export function openUpdatesWindow(): void {
  * only be able to open the changelog overlay.
  */
 export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
-  $updateOverlayTarget.set(target)
+  if (isRemoteMode()) {
+    void applyRemoteUpdates()
+
+    return
+  }
+
+  $updateOverlayTarget.set('client')
   $updateOverlayOpen.set(true)
-  void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
+  void applyUpdates()
+}
+
+function statusHasUpdate(status: DesktopUpdateStatus | null): boolean {
+  return !!status && status.supported !== false && !status.error && ((status.behind ?? 0) > 0 || !!status.updateAvailable)
 }
 
 /**
  * Command-palette entry point. The About panel's "Update now" only renders once
  * we know an update is waiting; this row is always listed, so it also has to
  * handle "already current" — open the overlay for the active target and let its
- * check answer, and only apply when there's something to install.
+ * check answer, and only apply when there's something to install. In remote
+ * mode both the backend AND the local client are updatable, so either being
+ * behind counts as "update waiting".
  */
 export function requestActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
-  const status = target === 'backend' ? $backendUpdateStatus.get() : $updateStatus.get()
+  const remote = isRemoteMode()
 
-  if ((status?.behind ?? 0) > 0 || status?.updateAvailable) {
+  const ready = remote
+    ? statusHasUpdate($backendUpdateStatus.get()) || statusHasUpdate($updateStatus.get())
+    : statusHasUpdate($updateStatus.get())
+
+  if (ready) {
     startActiveUpdate()
 
     return
   }
 
-  openUpdateOverlayFor(target)
+  openUpdateOverlayFor(remote ? 'backend' : 'client')
+}
+
+let remoteUpdateChain: Promise<DesktopUpdateApplyResult> | null = null
+
+/**
+ * Remote-mode update: the desktop shell drives a remote backend, but the GUI
+ * itself is still built from the LOCAL checkout — so "Update now" has two
+ * independent targets. Update the backend first, then chain the local client
+ * update (git pull → rebuild → relaunch) so the app side doesn't silently stay
+ * behind. On genuine backend failure the chain stops with the error view up:
+ * advancing the GUI past a backend that stayed old would manufacture exactly
+ * the contract skew reportBackendContract() warns about.
+ */
+export function applyRemoteUpdates(): Promise<DesktopUpdateApplyResult> {
+  if (remoteUpdateChain) {
+    return remoteUpdateChain
+  }
+
+  remoteUpdateChain = runRemoteUpdateChain()
+    // Both phases resolve their own failures into state; anything escaping here
+    // is unexpected. Resolve it (callers `void` this promise) instead of
+    // leaking an unhandled rejection.
+    .catch(error => ({
+      ok: false as const,
+      error: 'apply-failed',
+      message: error instanceof Error ? error.message : String(error)
+    }))
+    .finally(() => {
+      remoteUpdateChain = null
+    })
+
+  return remoteUpdateChain
+}
+
+async function runRemoteUpdateChain(): Promise<DesktopUpdateApplyResult> {
+  const backend = $backendUpdateStatus.get() ?? (await checkBackendUpdates())
+  let result: DesktopUpdateApplyResult = { ok: true }
+
+  if (statusHasUpdate(backend)) {
+    $updateOverlayTarget.set('backend')
+    $updateOverlayOpen.set(true)
+    result = await applyBackendUpdate({ holdOverlay: true })
+
+    if (!result.ok) {
+      return result
+    }
+  }
+
+  const client = $updateStatus.get() ?? (await checkUpdates())
+  const clientReady = !!client && client.supported !== false && !client.error && (client.behind ?? 0) > 0
+
+  if (!clientReady || $updateApply.get().applying) {
+    // Nothing local to install — land where a backend-only success would have.
+    setUpdateOverlayOpen(false)
+    resetUpdateApplyState()
+
+    return result
+  }
+
+  $updateOverlayTarget.set('client')
+  $updateOverlayOpen.set(true)
+
+  return applyUpdates()
 }
 
 /** Re-read the running app's version from the Electron main process and
@@ -490,11 +567,28 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 const BACKEND_ACTION_POLL_MS = 1500
 const BACKEND_ACTION_MAX_MS = 6 * 60 * 1000
 const BACKEND_RETURN_MAX_MS = 4 * 60 * 1000
+// The completion receipt is written by the gateway process that spawned the
+// action; when the update restarts that gateway, the receipt is never written
+// and polling sees a terminal-but-unproven state (running=false, exit_code
+// null). Give the receipt a few polls to show up, then fall back to asking the
+// backend itself — rate-limited so we don't hammer /update/check.
+const BACKEND_VERIFY_GRACE_POLLS = 4
+const BACKEND_VERIFY_MIN_INTERVAL_MS = 10_000
 
-function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
+interface BackendApplyOptions {
+  /** Keep the overlay open on success so a chained client update can take it
+   *  over without flashing the idle changelog in between. */
+  holdOverlay?: boolean
+}
+
+function finishBackendApply(returned: boolean, opts: BackendApplyOptions = {}): DesktopUpdateApplyResult {
   if (returned) {
     $backendUpdateApply.set(IDLE)
-    setUpdateOverlayOpen(false)
+
+    if (!opts.holdOverlay) {
+      setUpdateOverlayOpen(false)
+    }
+
     void checkBackendUpdates()
 
     return { ok: true, message: 'Backend update applied.' }
@@ -539,7 +633,7 @@ function completedAfterRestart(
   return !!actionId && status.lines.some(line => line === `=== hermes-update completed ${actionId} ===`)
 }
 
-function legacyBackendReachedTarget(
+function backendReachedTarget(
   status: BackendUpdateCheckResponse,
   targetSha: string | undefined,
   previousVersion: string | undefined
@@ -555,9 +649,23 @@ function legacyBackendReachedTarget(
   return !!targetSha && !!status.commits?.length && !status.commits.some(commit => commit.sha === targetSha)
 }
 
+/** Ask the backend itself whether the update landed (`/update/check?force=true`
+ *  busts the server-side cache). The recovery proof when the action's exit code
+ *  and completion receipt were lost to the gateway restart. */
+async function verifyBackendUpdated(
+  targetSha: string | undefined,
+  previousVersion: string | undefined
+): Promise<boolean> {
+  try {
+    return backendReachedTarget(await checkHermesUpdate(true), targetSha, previousVersion)
+  } catch {
+    return false
+  }
+}
+
 let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
 
-async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+async function runBackendUpdate(opts: BackendApplyOptions = {}): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
     ...IDLE,
@@ -597,6 +705,8 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     const actionDeadline = Date.now() + BACKEND_ACTION_MAX_MS
     let deadline = actionDeadline
     let reconnecting = false
+    let ambiguousPolls = 0
+    let lastVerifyAt = 0
 
     while (Date.now() < deadline) {
       await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_ACTION_POLL_MS))
@@ -620,6 +730,8 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
       }
 
       if (last.running) {
+        ambiguousPolls = 0
+
         if (reconnecting) {
           reconnecting = false
           deadline = actionDeadline
@@ -635,23 +747,46 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
       }
 
       if (last.exit_code === 0 || (last.exit_code === null && completedAfterRestart(last, started.action_id))) {
-        return finishBackendApply(true)
-      }
-
-      if (!started.action_id && last.exit_code === null) {
-        try {
-          const status = await checkHermesUpdate(true)
-
-          if (legacyBackendReachedTarget(status, requestedTargetSha, previousVersion)) {
-            return finishBackendApply(true)
-          }
-        } catch {
-          continue
-        }
+        return finishBackendApply(true, opts)
       }
 
       if (last.exit_code !== null) {
         break
+      }
+
+      // Terminal-but-unproven: not running, no exit code, no receipt — the
+      // gateway that owned the action restarted and lost both. Legacy backends
+      // (no action_id) can't ever produce a receipt, so verify immediately;
+      // otherwise give the receipt a short grace, then ask the backend itself.
+      ambiguousPolls += 1
+
+      const graceElapsed =
+        ambiguousPolls >= BACKEND_VERIFY_GRACE_POLLS && Date.now() - lastVerifyAt >= BACKEND_VERIFY_MIN_INTERVAL_MS
+
+      if (!started.action_id || graceElapsed) {
+        lastVerifyAt = Date.now()
+        $backendUpdateApply.set({
+          ...$backendUpdateApply.get(),
+          message: translateNow('updates.applyStatus.verifying')
+        })
+
+        if (await verifyBackendUpdated(requestedTargetSha, previousVersion)) {
+          return finishBackendApply(true, opts)
+        }
+      }
+    }
+
+    // Last chance before declaring failure: a genuine non-zero exit lands here
+    // via the break above and must stay a hard failure, but a timeout or a
+    // receipt lost to the restart deserves one final answer from the backend.
+    if (!last || (last.exit_code === null && !last.running)) {
+      $backendUpdateApply.set({
+        ...$backendUpdateApply.get(),
+        message: translateNow('updates.applyStatus.verifying')
+      })
+
+      if (await verifyBackendUpdated(requestedTargetSha, previousVersion)) {
+        return finishBackendApply(true, opts)
       }
     }
 
@@ -678,12 +813,12 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   }
 }
 
-export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+export function applyBackendUpdate(opts: BackendApplyOptions = {}): Promise<DesktopUpdateApplyResult> {
   if (backendUpdateInFlight) {
     return backendUpdateInFlight
   }
 
-  backendUpdateInFlight = runBackendUpdate().finally(() => {
+  backendUpdateInFlight = runBackendUpdate(opts).finally(() => {
     backendUpdateInFlight = null
   })
 


### PR DESCRIPTION
## Problem

Two related issues with the desktop app's update flow in **Remote gateway** mode:

1. **"Update now" never updates the local app.** `startActiveUpdate()` picks a single target — in remote mode that's `applyBackendUpdate()`, which only POSTs `/api/hermes/update` to the remote host. But the desktop shell is still built from the *local* checkout, which is never pulled or rebuilt. The GUI silently falls behind with no way to update it from inside the app (the About pane even shows the local checkout's behind-count while the button updates the remote).

2. **Successful remote updates report "Backend update failed."** `hermes update` restarts the gateway that spawned it, wiping the in-memory `_ACTION_PROCS`/`_ACTION_RESULTS` — so polling sees `running: false, exit_code: null` — and the completion receipt (`=== hermes-update completed <id> ===`) is written by the dead parent, so it never lands in the log. The existing `/update/check?force=true` fallback is gated on `!started.action_id`, i.e. it only runs for pre-action-ID backends. Result: the poll loop times out after the 4-minute reconnect window and reports failure for an update that succeeded. (Reproduced against a real remote over SSH tunnel; the remote's `update.log` showed a clean update + full gateway fleet restart.)

## Fix

- **`applyRemoteUpdates()` chain** (`store/updates.ts`): in remote mode, "Update now" updates the backend first, then chains the existing client flow (`applyUpdates()`: git pull → rebuild → relaunch) when the local checkout is supported and behind. A new `holdOverlay` option on `applyBackendUpdate` hands the overlay from the backend phase to the client phase without flashing the idle changelog. On genuine backend failure the chain stops with the error view up — advancing the GUI past a backend that stayed old would manufacture exactly the contract skew `reportBackendContract()` warns about. Guarded by a module-level in-flight promise (plus the existing `backendUpdateInFlight` and main-process `updateInFlight` guards).
- **Terminal-but-unproven verification**: when polling lands on `running: false, exit_code: null` with no receipt, verify via `/update/check?force=true` regardless of `action_id` — after a short receipt grace (4 polls, then at most every 10 s), and once more before declaring failure on deadline expiry. Non-zero exits still fail hard, and legacy (no-`action_id`) behavior is unchanged.
- **About pane**: in remote mode, "Check now" checks both targets, the status line distinguishes backend-only / app-only / both updates, and the branch·commit hint gains the connected backend's version.

## Testing

- 8 new tests in `store/updates.test.ts` (51 total, all passing): the restart-ambiguity repro (in-loop and post-deadline verification), verification-still-behind → hard failure, and the remote chain (backend→client, client-current, backend-current, hard-failure stop, in-flight dedupe).
- `npm run typecheck` and eslint clean.
- The underlying failure was diagnosed against a real remote gateway (macOS desktop ↔ SSH tunnel ↔ Linux backend); the fixed flow is covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
