### PR TITLE
fix(api-server): allow extension routing CORS headers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -987,7 +987,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    # Browser Extension requests can include profile/session routing headers.
+    # Keep this list explicit (not '*') so CORS remains narrow while allowing
+    # the extension's authenticated local API probes and chat requests.
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Profile, X-Hermes-Session-Id, X-Hermes-Session-Key",
 }
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2192,7 +2192,8 @@ class TestCORS:
 
 
     @pytest.mark.asyncio
-    async def test_cors_allows_idempotency_key_header(self):
+    async def test_cors_allows_extension_routing_headers(self):
+        """Configured origins can preflight browser-extension routing headers."""
         adapter = _make_adapter(cors_origins=["http://localhost:3000"])
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -2201,11 +2202,21 @@ class TestCORS:
                 headers={
                     "Origin": "http://localhost:3000",
                     "Access-Control-Request-Method": "POST",
-                    "Access-Control-Request-Headers": "Idempotency-Key",
+                    "Access-Control-Request-Headers": (
+                        "Idempotency-Key, X-Hermes-Profile, X-Hermes-Session-Id, "
+                        "X-Hermes-Session-Key"
+                    ),
                 },
             )
             assert resp.status == 200
-            assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
+            allowed_headers = resp.headers.get("Access-Control-Allow-Headers", "")
+            for header in (
+                "Idempotency-Key",
+                "X-Hermes-Profile",
+                "X-Hermes-Session-Id",
+                "X-Hermes-Session-Key",
+            ):
+                assert header in allowed_headers
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allow configured browser origins to preflight `X-Hermes-Profile`, `X-Hermes-Session-Id`, and `X-Hermes-Session-Key`.
- Retain an explicit CORS allowlist rather than permitting arbitrary request headers.
- Cover the extension routing-header preflight behavior with an aiohttp integration test.

## Validation
- `./scripts/run_tests.sh tests/gateway/test_api_server.py -q --disable-warnings --tb=short` (99 passed)
- `.venv/Scripts/python.exe -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- Candidate-only Gitleaks scan (`fork/main..HEAD`) — no leaks found