### PR TITLE
fix(runtime): propagate and enforce session write policy

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -530,6 +530,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    session_write_policy=None,
 ):
     """
     Initialize the AI Agent.
@@ -1567,6 +1568,11 @@ def init_agent(
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
+    # Session write policy (parent -> child inheritance carrier).
+    # C19 contract: bound here so a delegated child receives the parent's
+    # policy by identity (or by derived instance when the parent's is
+    # invalid).  Default None preserves the prior uninitialized state.
+    agent.session_write_policy = session_write_policy
     # A close flush and the worker's turn-start flush can overlap. The durable
     # marker is attached to each in-memory message dict, so its test-and-append
     # sequence must be serialized per agent rather than relying on SQLite alone.

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -507,6 +507,60 @@ class CopilotACPClient:
             # (#56747). Hide-only — stdio pipes stay intact for the ACP wire.
             from hermes_cli._subprocess_compat import windows_hide_flags
 
+            # ── C23 pre-spawn policy consultation ────────────────────────────
+            # Consult the active session write policy BEFORE
+            # _build_subprocess_env() and BEFORE subprocess.Popen so that:
+            #   * DENY decision     -> RuntimeError, no env build, no spawn.
+            #   * PolicyDenied exc  -> RuntimeError, no env build, no spawn.
+            #   * other exceptions  -> RuntimeError with class-name suffix
+            #                          (no original message echoed).
+            #   * ALLOW decision    -> proceed normally (env_build -> Popen).
+            # Ordering invariant: events = ["policy_consult", "env_build",
+            # "popen"] on ALLOW; ["policy_consult"] only on deny/error.
+            try:
+                from agent.session_write_policy import (
+                    CallerType as _CallerType,
+                    PolicyDenied as _PolicyDenied,
+                    SessionWritePolicyDecisionResult as _DecisionResult,
+                    pre_spawn_consult as _pre_spawn_consult,
+                )
+                _decision = _pre_spawn_consult(
+                    caller_type=_CallerType.DELEGATION,
+                    operation_kind="terminal_exec",
+                    argv=[self._acp_command] + list(self._acp_args),
+                    raw_command=None,
+                    cwd=self._acp_cwd,
+                    env_subset=None,
+                    target_path=None,
+                )
+                if _decision.result is _DecisionResult.DENY:
+                    raise RuntimeError(
+                        f"acp_subprocess_blocked_by_session_write_policy "
+                        f"disposition=DENY_POLICY reason={_decision.reason}"
+                    )
+            except _PolicyDenied as _pd:
+                raise RuntimeError(
+                    f"acp_subprocess_blocked_by_session_write_policy "
+                    f"disposition=DENY_POLICY reason={_pd.reason}"
+                ) from None
+            except RuntimeError as _re:
+                # Re-raise RuntimeErrors that already carry the canonical
+                # diagnostic prefix; translate every other RuntimeError to
+                # the fail-closed form WITHOUT echoing its message.
+                if "acp_subprocess_blocked_by_session_write_policy" in str(_re):
+                    raise
+                raise RuntimeError(
+                    f"acp_subprocess_blocked_by_session_write_policy "
+                    f"acp_pre_spawn_policy_evaluation_failed:{type(_re).__name__}"
+                ) from None
+            except BaseException as _be:
+                # Fail closed on any other exception.  Scrub the original
+                # message; only the class name is surfaced.
+                raise RuntimeError(
+                    f"acp_subprocess_blocked_by_session_write_policy "
+                    f"acp_pre_spawn_policy_evaluation_failed:{type(_be).__name__}"
+                ) from None
+
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
                 stdin=subprocess.PIPE,

--- a/agent/session_write_policy.py
+++ b/agent/session_write_policy.py
@@ -1,0 +1,384 @@
+"""Session write policy for Hermes Agent.
+
+This module defines the ``SessionWritePolicy`` dataclass and supporting
+helpers used to gate write-style operations performed by delegated
+subagents and ACP subprocesses.
+
+It is the contract-forward current-native implementation required by the
+sealed C19 / C23 design.  It is intentionally stdlib-only and has no
+dependency on ``agent.self_improvement_policy``,
+``agent.git_mutation_classifier``, or ``agent.git_target_resolver`` —
+those surfaces are out of scope.
+
+Public surface (required by the C19 / C23 contract):
+
+* :class:`SessionWritePolicyMode` — mode enum (NORMAL / DENY_ALL / ALLOWLIST)
+* :class:`SessionWritePolicyDecisionResult` — decision enum (ALLOW / DENY)
+* :class:`CallerType` — caller enum (DELEGATION + future expansion room)
+* :class:`CapabilityGrant` — capability description (kind / operation / roots)
+* :class:`SessionWritePolicy` — immutable policy record with factories
+  ``normal`` and ``deny_all`` plus a ``derive_child`` method
+* :class:`SessionWritePolicyDecision` — structured decision returned by
+  :func:`evaluate` and :func:`pre_spawn_consult`
+* :class:`PolicyDenied` — typed exception raised by ``pre_spawn_consult``
+* :func:`evaluate` — pure decision helper
+* :func:`pre_spawn_consult` — resolves the active policy and returns a
+  decision (or raises ``PolicyDenied``)
+* :func:`get_current_session_write_policy` — returns the active policy
+  for a session identifier, defaulting to a normal policy for unknown
+  sessions
+* :func:`session_write_policy_scope` — context manager that binds a
+  policy as the current one for the duration of the ``with`` block
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterator, Optional, Sequence, Tuple
+
+
+class SessionWritePolicyMode(str, Enum):
+    """Top-level policy mode for a session."""
+
+    NORMAL = "normal"
+    DENY_ALL = "deny_all"
+    ALLOWLIST = "allowlist"
+
+
+class SessionWritePolicyDecisionResult(str, Enum):
+    """Outcome of a policy evaluation."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+class CallerType(str, Enum):
+    """Caller classification passed to the policy.
+
+    Currently only ``DELEGATION`` is exercised by the C19 / C23 contract;
+    additional values are reserved for future expansion.
+    """
+
+    DELEGATION = "DELEGATION"
+    TOOL = "TOOL"
+    USER = "USER"
+    CRON = "CRON"
+
+
+@dataclass(frozen=True)
+class CapabilityGrant:
+    """A single capability grant attached to an :class:`SessionWritePolicy`.
+
+    Attributes
+    ----------
+    kind:
+        The category of capability.  Examples: ``"filesystem"``,
+        ``"terminal_exec"``.
+    operation:
+        The operation the capability covers.  Examples: ``"read"``,
+        ``"write"``, ``"execute"``.
+    roots:
+        The optional set of roots the capability is scoped to (e.g.
+        filesystem paths the grant applies to).  Empty tuple means
+        "anywhere" (subject to the policy mode).
+    """
+
+    kind: str
+    operation: str
+    roots: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SessionWritePolicy:
+    """Immutable description of a session's write policy.
+
+    Attributes
+    ----------
+    session_id:
+        Identifier of the session the policy belongs to.
+    mode:
+        The top-level mode (``NORMAL`` / ``DENY_ALL`` / ``ALLOWLIST``).
+    allowed_roots:
+        Filesystem roots the policy considers in scope.  Only consulted
+        in ``ALLOWLIST`` mode.
+    capability_grants:
+        Tuple of :class:`CapabilityGrant` records describing granted
+        capabilities.  Only consulted in ``ALLOWLIST`` mode.
+    protected:
+        ``True`` if the policy is locked from modification.  C19 / C23
+        only read this attribute; mutation is the parent's responsibility.
+    """
+
+    session_id: str
+    mode: SessionWritePolicyMode
+    allowed_roots: Tuple[str, ...] = ()
+    capability_grants: Tuple[CapabilityGrant, ...] = ()
+    protected: bool = False
+
+    # ------------------------------------------------------------------
+    # Factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def normal(cls, session_id: str) -> "SessionWritePolicy":
+        """Build a permissive ``NORMAL`` policy for ``session_id``."""
+
+        return cls(session_id=session_id, mode=SessionWritePolicyMode.NORMAL)
+
+    @classmethod
+    def deny_all(cls, session_id: str) -> "SessionWritePolicy":
+        """Build a strict ``DENY_ALL`` policy for ``session_id``."""
+
+        return cls(session_id=session_id, mode=SessionWritePolicyMode.DENY_ALL)
+
+    # ------------------------------------------------------------------
+    # Inheritance
+    # ------------------------------------------------------------------
+
+    def derive_child(self, requested: Optional[object] = None) -> "SessionWritePolicy":
+        """Return the policy a child session should inherit.
+
+        C19 R01 asserts this is called exactly once with ``requested=None``
+        and that the returned policy is identity-equal to the parent's
+        policy when the parent has a real :class:`SessionWritePolicy`.
+
+        The ``requested`` parameter is reserved for future use (a child
+        may request a stricter subset); the current contract ignores it
+        and returns ``self`` unchanged so children receive the parent's
+        policy by identity.
+        """
+
+        return self
+
+
+@dataclass(frozen=True)
+class SessionWritePolicyDecision:
+    """Structured decision returned by :func:`evaluate` and
+    :func:`pre_spawn_consult`.
+
+    Attributes
+    ----------
+    result:
+        :class:`SessionWritePolicyDecisionResult.ALLOW` or ``DENY``.
+    reason:
+        Short machine-readable reason for the decision (e.g.
+        ``"policy_allow"`` or ``"terminal_exec_denied_protected_mode"``).
+    operation_kind:
+        The operation kind that was evaluated (e.g. ``"terminal_exec"``).
+    origin:
+        The caller class that originated the request (typically the
+        stringified value of a :class:`CallerType`).
+    """
+
+    result: SessionWritePolicyDecisionResult
+    reason: str
+    operation_kind: str
+    origin: str
+
+
+class PolicyDenied(Exception):
+    """Raised by :func:`pre_spawn_consult` for structured denials.
+
+    The ``detail`` field carries sensitive information that MUST NOT be
+    echoed to the user by callers — see C23 R04.
+    """
+
+    DISPOSITION_POLICY_DENY = "DENY_POLICY"
+
+    def __init__(
+        self,
+        *,
+        disposition: str = DISPOSITION_POLICY_DENY,
+        caller_type: CallerType,
+        operation_kind: str,
+        reason: str,
+        detail: Optional[object] = None,
+    ) -> None:
+        super().__init__(reason)
+        self.disposition = disposition
+        self.caller_type = caller_type
+        self.operation_kind = operation_kind
+        self.reason = reason
+        self.detail = detail
+
+    def __str__(self) -> str:  # pragma: no cover - explicit repr contract
+        return self.reason
+
+
+# ----------------------------------------------------------------------
+# Active-policy context variable
+# ----------------------------------------------------------------------
+
+_active_policy_var: contextvars.ContextVar[Optional[SessionWritePolicy]] = contextvars.ContextVar(
+    "hermes_active_session_write_policy",
+    default=None,
+)
+
+
+@contextlib.contextmanager
+def session_write_policy_scope(policy: SessionWritePolicy) -> Iterator[SessionWritePolicy]:
+    """Bind ``policy`` as the active session write policy for the scope.
+
+    Inside the ``with`` block, :func:`pre_spawn_consult` and
+    :func:`get_current_session_write_policy` resolve the active policy
+    from this binding.
+    """
+
+    token = _active_policy_var.set(policy)
+    try:
+        yield policy
+    finally:
+        _active_policy_var.reset(token)
+
+
+def get_current_session_write_policy(
+    *,
+    session_id: str,
+    protected: bool = False,
+) -> SessionWritePolicy:
+    """Return the active session write policy for ``session_id``.
+
+    Resolution order:
+
+    1. If a policy has been bound via :func:`session_write_policy_scope`,
+       return that policy (with ``protected`` updated to the requested
+       value when the binding was unset).
+    2. Otherwise, return :meth:`SessionWritePolicy.normal` for ``session_id``.
+
+    The ``protected`` parameter is forwarded to the returned policy so
+    callers can request a locked view; the C19 contract passes
+    ``protected=False`` for fallback chains.
+    """
+
+    active = _active_policy_var.get()
+    if active is not None:
+        return SessionWritePolicy(
+            session_id=active.session_id,
+            mode=active.mode,
+            allowed_roots=active.allowed_roots,
+            capability_grants=active.capability_grants,
+            protected=protected,
+        )
+    return SessionWritePolicy.normal(session_id)
+
+
+def _has_capability(
+    policy: SessionWritePolicy, kind: str, operation: str
+) -> bool:
+    for grant in policy.capability_grants:
+        if grant.kind == kind and grant.operation == operation:
+            return True
+    return False
+
+
+def evaluate(
+    policy: SessionWritePolicy,
+    *,
+    caller_type: CallerType,
+    operation_kind: str,
+    argv: Optional[Sequence[str]] = None,
+    raw_command: Optional[str] = None,
+    cwd: Optional[str] = None,
+    env_subset: Optional[object] = None,
+    target_path: Optional[str] = None,
+) -> SessionWritePolicyDecision:
+    """Decide whether ``policy`` allows the described operation.
+
+    The decision is structured (a :class:`SessionWritePolicyDecision`)
+    so callers can surface a consistent diagnostic without inspecting
+    string contents.
+
+    Resolution rules:
+
+    * ``DENY_ALL`` always denies with reason
+      ``"terminal_exec_denied_protected_mode"`` (or
+      ``"<operation_kind>_denied_protected_mode"``).
+    * ``ALLOWLIST`` denies when the operation_kind is not granted by
+      any :class:`CapabilityGrant` on the policy.
+    * ``NORMAL`` allows everything.
+    """
+
+    origin = getattr(caller_type, "value", str(caller_type))
+
+    if policy.mode is SessionWritePolicyMode.DENY_ALL:
+        reason = f"{operation_kind}_denied_protected_mode"
+        return SessionWritePolicyDecision(
+            result=SessionWritePolicyDecisionResult.DENY,
+            reason=reason,
+            operation_kind=operation_kind,
+            origin=origin,
+        )
+
+    if policy.mode is SessionWritePolicyMode.ALLOWLIST:
+        kind = "terminal_exec" if operation_kind == "terminal_exec" else operation_kind
+        granted = _has_capability(policy, kind, "execute")
+        if not granted:
+            reason = f"{operation_kind}_denied_no_capability_grant"
+            return SessionWritePolicyDecision(
+                result=SessionWritePolicyDecisionResult.DENY,
+                reason=reason,
+                operation_kind=operation_kind,
+                origin=origin,
+            )
+
+    return SessionWritePolicyDecision(
+        result=SessionWritePolicyDecisionResult.ALLOW,
+        reason="policy_allow",
+        operation_kind=operation_kind,
+        origin=origin,
+    )
+
+
+def pre_spawn_consult(
+    *,
+    caller_type: CallerType,
+    operation_kind: str,
+    argv: Optional[Sequence[str]] = None,
+    raw_command: Optional[str] = None,
+    cwd: Optional[str] = None,
+    env_subset: Optional[object] = None,
+    target_path: Optional[str] = None,
+) -> SessionWritePolicyDecision:
+    """Consult the active session write policy before a subprocess spawn.
+
+    Resolves the active policy via
+    :func:`get_current_session_write_policy` and returns an
+    :func:`evaluate` decision.  This function never raises — denial is
+    conveyed through the returned decision's ``result`` field.
+
+    Raises
+    ------
+    PolicyDenied
+        Reserved for future structured-denial paths; the current
+        contract only returns a ``DENY`` decision.
+    """
+
+    policy = get_current_session_write_policy(session_id="active")
+    return evaluate(
+        policy,
+        caller_type=caller_type,
+        operation_kind=operation_kind,
+        argv=argv,
+        raw_command=raw_command,
+        cwd=cwd,
+        env_subset=env_subset,
+        target_path=target_path,
+    )
+
+
+__all__ = [
+    "CallerType",
+    "CapabilityGrant",
+    "PolicyDenied",
+    "SessionWritePolicy",
+    "SessionWritePolicyDecision",
+    "SessionWritePolicyDecisionResult",
+    "SessionWritePolicyMode",
+    "evaluate",
+    "get_current_session_write_policy",
+    "pre_spawn_consult",
+    "session_write_policy_scope",
+]

--- a/run_agent.py
+++ b/run_agent.py
@@ -507,6 +507,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        session_write_policy=None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -591,6 +592,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            session_write_policy=session_write_policy,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/test_copilot_acp_session_write_policy.py
+++ b/tests/agent/test_copilot_acp_session_write_policy.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.copilot_acp_client import CopilotACPClient
+from agent.session_write_policy import (
+    CallerType,
+    PolicyDenied,
+    SessionWritePolicy,
+    SessionWritePolicyDecision,
+    SessionWritePolicyDecisionResult,
+    SessionWritePolicyMode,
+    session_write_policy_scope,
+)
+
+
+class _FakeReadable:
+    def __init__(self, lines: list[str] | None = None) -> None:
+        self._lines = list(lines or [])
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class _FakePopenProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = _FakeReadable(
+            [
+                json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+                json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"sessionId": "fake-session"}}) + "\n",
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": {"text": "fake-acp-response"},
+                            }
+                        },
+                    }
+                )
+                + "\n",
+                json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}) + "\n",
+            ]
+        )
+        self.stderr = _FakeReadable([])
+        self.killed = False
+        self.terminated = False
+
+    def poll(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+@pytest.fixture
+def client(tmp_path):
+    return CopilotACPClient(
+        acp_command="fake-acp",
+        acp_args=["--acp", "--stdio", "--flag=value"],
+        acp_cwd=str(tmp_path),
+    )
+
+
+def _allow_decision() -> SessionWritePolicyDecision:
+    return SessionWritePolicyDecision(
+        result=SessionWritePolicyDecisionResult.ALLOW,
+        reason="policy_allow",
+        operation_kind="terminal_exec",
+        origin="DELEGATION",
+    )
+
+
+def _deny_decision(reason: str = "terminal_exec_denied_protected_mode") -> SessionWritePolicyDecision:
+    return SessionWritePolicyDecision(
+        result=SessionWritePolicyDecisionResult.DENY,
+        reason=reason,
+        operation_kind="terminal_exec",
+        origin="DELEGATION",
+    )
+
+
+def _run_with_fakes(monkeypatch, client, events: list[str], *, decision: Any = None):
+    policy_calls: list[dict[str, Any]] = []
+    popen_calls: list[dict[str, Any]] = []
+    env = {"SAFE_ENV": "1"}
+
+    def fake_pre_spawn_consult(**kwargs):
+        events.append("policy_consult")
+        policy_calls.append(kwargs)
+        if isinstance(decision, BaseException):
+            raise decision
+        return decision if decision is not None else _allow_decision()
+
+    def fake_build_env():
+        events.append("env_build")
+        return env
+
+    def fake_popen(argv, **kwargs):
+        events.append("popen")
+        popen_calls.append({"argv": argv, "kwargs": kwargs})
+        return _FakePopenProcess()
+
+    monkeypatch.setattr("agent.session_write_policy.pre_spawn_consult", fake_pre_spawn_consult)
+    monkeypatch.setattr("agent.copilot_acp_client._build_subprocess_env", fake_build_env)
+    monkeypatch.setattr("agent.copilot_acp_client.subprocess.Popen", fake_popen)
+
+    result = client._run_prompt("hello", timeout_seconds=1)
+    return result, policy_calls, popen_calls, env
+
+
+def test_consult_arguments_are_exact(monkeypatch, client):
+    events: list[str] = []
+    result, policy_calls, _popen_calls, _env = _run_with_fakes(monkeypatch, client, events)
+
+    assert result == ("fake-acp-response", "")
+    assert len(policy_calls) == 1
+    call = policy_calls[0]
+    assert call["caller_type"] is CallerType.DELEGATION
+    assert call["operation_kind"] == "terminal_exec"
+    assert call["argv"] == [client._acp_command, *client._acp_args]
+    assert call["raw_command"] is None
+    assert call["cwd"] == client._acp_cwd
+    assert call["env_subset"] is None
+    assert call["target_path"] is None
+
+
+def test_allow_builds_env_after_policy_and_reaches_popen(monkeypatch, client):
+    events: list[str] = []
+    result, policy_calls, popen_calls, env = _run_with_fakes(monkeypatch, client, events)
+
+    assert result == ("fake-acp-response", "")
+    assert events == ["policy_consult", "env_build", "popen"]
+    assert len(policy_calls) == 1
+    assert len(popen_calls) == 1
+    popen_call = popen_calls[0]
+    assert popen_call["argv"] == [client._acp_command, *client._acp_args]
+    assert popen_call["kwargs"]["cwd"] == client._acp_cwd
+    assert popen_call["kwargs"]["env"] is env
+    assert popen_call["kwargs"]["stdin"] is not None
+    assert popen_call["kwargs"]["stdout"] is not None
+    assert popen_call["kwargs"]["stderr"] is not None
+
+
+def test_returned_deny_blocks_before_env_and_popen(monkeypatch, client):
+    events: list[str] = []
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_with_fakes(monkeypatch, client, events, decision=_deny_decision("deny-reason"))
+
+    message = str(excinfo.value)
+    assert events == ["policy_consult"]
+    assert "acp_subprocess_blocked_by_session_write_policy" in message
+    assert "disposition=DENY_POLICY" in message
+    assert "reason=deny-reason" in message
+
+
+def test_policy_denied_blocks_before_env_and_popen(monkeypatch, client):
+    events: list[str] = []
+    denied = PolicyDenied(
+        disposition=PolicyDenied.DISPOSITION_POLICY_DENY,
+        caller_type=CallerType.DELEGATION,
+        operation_kind="terminal_exec",
+        reason="policy-denied-reason",
+        detail={"unsafe": "not-rendered"},
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_with_fakes(monkeypatch, client, events, decision=denied)
+
+    message = str(excinfo.value)
+    assert events == ["policy_consult"]
+    assert "acp_subprocess_blocked_by_session_write_policy" in message
+    assert "disposition=DENY_POLICY" in message
+    assert "reason=policy-denied-reason" in message
+    assert "not-rendered" not in message
+
+
+def test_unexpected_policy_error_fails_closed_without_sensitive_text(monkeypatch, client):
+    events: list[str] = []
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_with_fakes(
+            monkeypatch,
+            client,
+            events,
+            decision=RuntimeError("SECRET_TOKEN=do-not-render"),
+        )
+
+    message = str(excinfo.value)
+    assert events == ["policy_consult"]
+    assert "acp_subprocess_blocked_by_session_write_policy" in message
+    assert "acp_pre_spawn_policy_evaluation_failed:RuntimeError" in message
+    assert "SECRET_TOKEN" not in message
+    assert "do-not-render" not in message
+
+
+def _run_real_policy_context(monkeypatch, tmp_path, policy: SessionWritePolicy) -> tuple[tuple[str, str] | None, list[str]]:
+    events: list[str] = []
+    client = CopilotACPClient(acp_command="python", acp_args=["--version"], acp_cwd=str(tmp_path))
+
+    def fake_build_env():
+        events.append("env_build")
+        return {"SAFE_ENV": "1"}
+
+    def fake_popen(argv, **kwargs):
+        events.append("popen")
+        return _FakePopenProcess()
+
+    monkeypatch.setattr("agent.copilot_acp_client._build_subprocess_env", fake_build_env)
+    monkeypatch.setattr("agent.copilot_acp_client.subprocess.Popen", fake_popen)
+
+    with session_write_policy_scope(policy):
+        try:
+            return client._run_prompt("hello", timeout_seconds=1), events
+        except RuntimeError:
+            return None, events
+
+
+def test_real_normal_context_allows_simple_non_git_acp(monkeypatch, tmp_path):
+    result, events = _run_real_policy_context(
+        monkeypatch,
+        tmp_path,
+        SessionWritePolicy.normal("normal-session"),
+    )
+
+    assert result == ("fake-acp-response", "")
+    assert events == ["env_build", "popen"]
+
+
+def test_real_deny_all_context_blocks_before_popen(monkeypatch, tmp_path):
+    result, events = _run_real_policy_context(
+        monkeypatch,
+        tmp_path,
+        SessionWritePolicy.deny_all("deny-session"),
+    )
+
+    assert result is None
+    assert events == []
+
+
+def test_real_allowlist_context_denies_terminal_exec(monkeypatch, tmp_path):
+    result, events = _run_real_policy_context(
+        monkeypatch,
+        tmp_path,
+        SessionWritePolicy(
+            session_id="allowlist-session",
+            mode=SessionWritePolicyMode.ALLOWLIST,
+            allowed_roots=(str(tmp_path),),
+            protected=True,
+        ),
+    )
+
+    assert result is None
+    assert events == []
+
+
+def test_no_delegate_or_terminal_tool_used_and_no_duplicate_env_or_popen(monkeypatch, client):
+    events: list[str] = []
+
+    def fail_terminal_tool(*args, **kwargs):
+        raise AssertionError("terminal_tool must not be called")
+
+    def fail_delegate_tool(*args, **kwargs):
+        raise AssertionError("delegate_tool must not be called")
+
+    monkeypatch.setattr("tools.terminal_tool.terminal", fail_terminal_tool, raising=False)
+    monkeypatch.setattr("tools.delegate_tool.delegate_task", fail_delegate_tool)
+
+    result, policy_calls, popen_calls, _env = _run_with_fakes(monkeypatch, client, events)
+
+    assert result == ("fake-acp-response", "")
+    assert events == ["policy_consult", "env_build", "popen"]
+    assert len(policy_calls) == 1
+    assert len(popen_calls) == 1
+    assert len([event for event in events if event == "env_build"]) == 1
+    assert len([event for event in events if event == "popen"]) == 1
+
+
+def test_policy_receives_no_full_env_and_no_forced_target_path(monkeypatch, client):
+    events: list[str] = []
+    _result, policy_calls, _popen_calls, _env = _run_with_fakes(monkeypatch, client, events)
+
+    assert len(policy_calls) == 1
+    assert policy_calls[0]["env_subset"] is None
+    assert policy_calls[0]["target_path"] is None

--- a/tests/tools/test_delegate_session_write_policy.py
+++ b/tests/tools/test_delegate_session_write_policy.py
@@ -1,3 +1,4 @@
+import io
 import json
 import subprocess
 import threading
@@ -5,12 +6,67 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.copilot_acp_client import CopilotACPClient
 from agent.session_write_policy import (
     CapabilityGrant,
     SessionWritePolicy,
     SessionWritePolicyMode,
+    get_current_session_write_policy,
 )
 from tools import delegate_tool
+
+
+class _FakeReadable:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = list(lines)
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class _FakeACPProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = _FakeReadable(
+            [
+                json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {"sessionId": "fake-session"},
+                    }
+                )
+                + "\n",
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": {"text": "fake-acp-response"},
+                            }
+                        },
+                    }
+                )
+                + "\n",
+                json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}) + "\n",
+            ]
+        )
+        self.stderr = _FakeReadable([])
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        return None
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        return None
 
 
 class FakeAgent:
@@ -21,6 +77,7 @@ class FakeAgent:
         self.kwargs = kwargs
         FakeAgent.constructed.append(kwargs)
         self.session_id = "child-session"
+        self.session_write_policy = kwargs.get("session_write_policy")
         self.model = kwargs.get("model")
         self.provider = kwargs.get("provider")
         self.base_url = kwargs.get("base_url")
@@ -33,6 +90,12 @@ class FakeAgent:
         self.session_reasoning_tokens = 0
         self.session_estimated_cost_usd = 0.0
         self.closed = False
+        self._acp_client = None
+        if kwargs.get("acp_command"):
+            self._acp_client = CopilotACPClient(
+                acp_command=kwargs["acp_command"],
+                acp_args=list(kwargs.get("acp_args") or []),
+            )
 
     def run_conversation(self, user_message, task_id=None, stream_callback=None):
         FakeAgent.run_calls.append(
@@ -42,6 +105,26 @@ class FakeAgent:
                 "stream_callback": stream_callback,
             }
         )
+        if self._acp_client is not None:
+            try:
+                response, _reasoning = self._acp_client._run_prompt(
+                    user_message,
+                    timeout_seconds=1,
+                )
+            except Exception as exc:
+                return {
+                    "final_response": "",
+                    "completed": False,
+                    "api_calls": 0,
+                    "messages": [],
+                    "error": str(exc),
+                }
+            return {
+                "final_response": response,
+                "completed": bool(response),
+                "api_calls": 1,
+                "messages": [],
+            }
         return {
             "final_response": "child done",
             "completed": True,
@@ -53,6 +136,8 @@ class FakeAgent:
         return {"api_call_count": 1, "max_iterations": 1, "current_tool": None}
 
     def close(self):
+        if self._acp_client is not None:
+            self._acp_client.close()
         self.closed = True
 
 
@@ -61,7 +146,7 @@ def _reset_fake_agent():
     FakeAgent.run_calls = []
 
 
-def _parent(policy, *, session_policy_attr=True):
+def _parent(policy, *, session_policy_attr=True, acp_command=None):
     parent = SimpleNamespace(
         session_id="parent-session",
         enabled_toolsets=["file", "terminal", "delegation"],
@@ -72,6 +157,8 @@ def _parent(policy, *, session_policy_attr=True):
         api_mode="chat_completions",
         api_key="parent-key",
         _client_kwargs={"api_key": "parent-key"},
+        acp_command=acp_command,
+        acp_args=["--acp", "--stdio"] if acp_command else [],
         providers_allowed=["ProviderA"],
         providers_ignored=["ProviderB"],
         providers_order=["ProviderA"],
@@ -241,6 +328,106 @@ def test_acp_command_and_args_forward_without_execution_or_pre_spawn(monkeypatch
     assert constructed["provider"] == "copilot-acp"
     assert constructed["acp_command"] == "copilot"
     assert constructed["acp_args"] == ["--acp", "--stdio"]
+
+
+def test_child_execution_binds_policy_through_real_acp_path(monkeypatch, tmp_path):
+    env_builds: list[str] = []
+    popen_calls: list[dict] = []
+
+    monkeypatch.setattr(
+        "agent.copilot_acp_client._build_subprocess_env",
+        lambda: env_builds.append("env") or {"SAFE_ENV": "1"},
+    )
+    monkeypatch.setattr(
+        "agent.copilot_acp_client.subprocess.Popen",
+        lambda argv, **kwargs: popen_calls.append({"argv": argv, "kwargs": kwargs})
+        or _FakeACPProcess(),
+    )
+    parent = _parent(
+        SessionWritePolicy.deny_all("parent-deny"),
+        acp_command="fake-copilot",
+    )
+
+    child = _build(
+        parent,
+        override_acp_command="fake-copilot",
+        override_acp_args=["--acp", "--stdio"],
+    )
+    assert child.session_write_policy is parent.session_write_policy
+
+    result = delegate_tool._run_single_child(
+        0,
+        "deny child",
+        child,
+        parent,
+    )
+
+    assert result["status"] == "failed"
+    assert "acp_subprocess_blocked_by_session_write_policy" in result["error"]
+    assert env_builds == []
+    assert popen_calls == []
+    assert get_current_session_write_policy(session_id="after-child").mode is SessionWritePolicyMode.NORMAL
+
+
+def test_child_execution_binds_normal_policy_and_restores_external_context(monkeypatch, tmp_path):
+    env_builds: list[str] = []
+    popen_calls: list[dict] = []
+
+    monkeypatch.setattr(
+        "agent.copilot_acp_client._build_subprocess_env",
+        lambda: env_builds.append("env") or {"SAFE_ENV": "1"},
+    )
+    monkeypatch.setattr(
+        "agent.copilot_acp_client.subprocess.Popen",
+        lambda argv, **kwargs: popen_calls.append({"argv": argv, "kwargs": kwargs})
+        or _FakeACPProcess(),
+    )
+    parent = _parent(
+        SessionWritePolicy.normal("parent-normal"),
+        acp_command="fake-copilot",
+    )
+    child = _build(
+        parent,
+        override_acp_command="fake-copilot",
+        override_acp_args=["--acp", "--stdio"],
+    )
+    sentinel = SessionWritePolicy.deny_all("external-sentinel")
+
+    from agent.session_write_policy import session_write_policy_scope
+
+    with session_write_policy_scope(sentinel):
+        result = delegate_tool._run_single_child(
+            0,
+            "normal child",
+            child,
+            parent,
+        )
+        assert get_current_session_write_policy(session_id="inside-parent").mode is SessionWritePolicyMode.DENY_ALL
+
+    assert result["status"] == "completed"
+    assert env_builds == ["env"]
+    assert len(popen_calls) == 1
+    assert get_current_session_write_policy(session_id="after-child").mode is SessionWritePolicyMode.NORMAL
+
+
+def test_child_policy_context_restores_after_child_exception(monkeypatch):
+    parent = _parent(SessionWritePolicy.deny_all("parent-deny"))
+    child = _build(parent)
+    sentinel = SessionWritePolicy.normal("external-sentinel")
+
+    def boom(**_kwargs):
+        assert get_current_session_write_policy(session_id="child").mode is SessionWritePolicyMode.DENY_ALL
+        raise RuntimeError("child failure")
+
+    child.run_conversation = boom
+    from agent.session_write_policy import session_write_policy_scope
+
+    with session_write_policy_scope(sentinel):
+        result = delegate_tool._run_single_child(0, "raises", child=child, parent_agent=parent)
+        assert get_current_session_write_policy(session_id="restored").mode is SessionWritePolicyMode.NORMAL
+
+    assert result["status"] == "error"
+    assert get_current_session_write_policy(session_id="after-exception").mode is SessionWritePolicyMode.NORMAL
 
 
 def test_dead_policy_helpers_are_not_exposed():

--- a/tests/tools/test_delegate_session_write_policy.py
+++ b/tests/tools/test_delegate_session_write_policy.py
@@ -1,0 +1,265 @@
+import json
+import subprocess
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent.session_write_policy import (
+    CapabilityGrant,
+    SessionWritePolicy,
+    SessionWritePolicyMode,
+)
+from tools import delegate_tool
+
+
+class FakeAgent:
+    constructed = []
+    run_calls = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        FakeAgent.constructed.append(kwargs)
+        self.session_id = "child-session"
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        self.api_mode = kwargs.get("api_mode")
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self._session_init_model_config = {}
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.closed = False
+
+    def run_conversation(self, user_message, task_id=None, stream_callback=None):
+        FakeAgent.run_calls.append(
+            {
+                "user_message": user_message,
+                "task_id": task_id,
+                "stream_callback": stream_callback,
+            }
+        )
+        return {
+            "final_response": "child done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1, "max_iterations": 1, "current_tool": None}
+
+    def close(self):
+        self.closed = True
+
+
+def _reset_fake_agent():
+    FakeAgent.constructed = []
+    FakeAgent.run_calls = []
+
+
+def _parent(policy, *, session_policy_attr=True):
+    parent = SimpleNamespace(
+        session_id="parent-session",
+        enabled_toolsets=["file", "terminal", "delegation"],
+        valid_tool_names=[],
+        model="parent-model",
+        provider="parent-provider",
+        base_url="https://parent.example/v1",
+        api_mode="chat_completions",
+        api_key="parent-key",
+        _client_kwargs={"api_key": "parent-key"},
+        providers_allowed=["ProviderA"],
+        providers_ignored=["ProviderB"],
+        providers_order=["ProviderA"],
+        provider_sort="throughput",
+        provider_require_parameters=True,
+        provider_data_collection="deny",
+        request_overrides={"temperature": 0},
+        openrouter_min_coding_score=42,
+        _fallback_chain=[{"provider": "fallback", "model": "fallback-model"}],
+        _session_db=None,
+        _delegate_depth=0,
+        _active_children=[],
+        _active_children_lock=threading.Lock(),
+        _print_fn=None,
+        tool_progress_callback=None,
+        thinking_callback=None,
+        _current_turn_id="turn-id",
+        _current_task_id="parent-task",
+    )
+    if session_policy_attr:
+        parent.session_write_policy = policy
+    else:
+        parent.session_write_policy = object()
+    return parent
+
+
+@pytest.fixture(autouse=True)
+def fake_agent_and_config(monkeypatch):
+    _reset_fake_agent()
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {"max_iterations": 1})
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: None)
+    yield
+    _reset_fake_agent()
+
+
+def _build(parent, **kwargs):
+    child_model = kwargs.pop("model", None)
+    return delegate_tool._build_child_agent(
+        task_index=0,
+        goal="do work",
+        context=None,
+        toolsets=None,
+        model=child_model,
+        max_iterations=1,
+        task_count=1,
+        parent_agent=parent,
+        **kwargs,
+    )
+
+
+def test_build_child_agent_derives_child_policy_once_with_none(monkeypatch):
+    parent_policy = SessionWritePolicy.normal("parent")
+    calls = []
+    original = SessionWritePolicy.derive_child
+
+    def spy(self, requested=None):
+        calls.append((self, requested))
+        return original(self, requested)
+
+    monkeypatch.setattr(SessionWritePolicy, "derive_child", spy)
+
+    _build(_parent(parent_policy))
+
+    assert calls == [(parent_policy, None)]
+    assert FakeAgent.constructed[0]["session_write_policy"] is parent_policy
+
+
+@pytest.mark.parametrize(
+    "parent_policy",
+    [
+        SessionWritePolicy.normal("normal-parent"),
+        SessionWritePolicy.deny_all("deny-parent"),
+        SessionWritePolicy(
+            session_id="allow-parent",
+            mode=SessionWritePolicyMode.ALLOWLIST,
+            allowed_roots=("/tmp/hermes-delegate-allow",),
+            capability_grants=(
+                CapabilityGrant(
+                    kind="filesystem",
+                    operation="write",
+                    roots=("/tmp/hermes-delegate-allow",),
+                ),
+            ),
+            protected=True,
+        ),
+    ],
+)
+def test_child_receives_semantically_identical_policy_and_preserves_identity(parent_policy):
+    _build(_parent(parent_policy))
+
+    constructed_policy = FakeAgent.constructed[0]["session_write_policy"]
+    assert constructed_policy is parent_policy
+    assert constructed_policy.mode is parent_policy.mode
+    assert constructed_policy.allowed_roots == parent_policy.allowed_roots
+    assert constructed_policy.capability_grants == parent_policy.capability_grants
+    assert constructed_policy.protected is parent_policy.protected
+
+
+def test_invalid_parent_policy_falls_back_to_current_policy_and_derives(monkeypatch):
+    fallback_policy = SessionWritePolicy.deny_all("fallback-parent")
+    calls = []
+    original = SessionWritePolicy.derive_child
+
+    def fake_current_session_write_policy(*, session_id, protected):
+        assert session_id == "parent-session"
+        assert protected is False
+        return fallback_policy
+
+    def spy(self, requested=None):
+        calls.append((self, requested))
+        return original(self, requested)
+
+    monkeypatch.setattr(
+        "agent.session_write_policy.get_current_session_write_policy",
+        fake_current_session_write_policy,
+    )
+    monkeypatch.setattr(SessionWritePolicy, "derive_child", spy)
+
+    _build(_parent(object(), session_policy_attr=False))
+
+    assert calls == [(fallback_policy, None)]
+    assert FakeAgent.constructed[0]["session_write_policy"] is fallback_policy
+
+
+def test_default_in_process_delegation_does_not_pre_spawn_or_create_subprocess(monkeypatch):
+    def fail_pre_spawn(*args, **kwargs):
+        raise AssertionError("delegate_tool must not pre-spawn consult in-process delegation")
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("delegate_tool must not create subprocesses in-process")
+
+    monkeypatch.setattr("agent.session_write_policy.pre_spawn_consult", fail_pre_spawn)
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    result = json.loads(
+        delegate_tool.delegate_task(
+            goal="default in-process run",
+            parent_agent=_parent(SessionWritePolicy.normal("parent")),
+        )
+    )
+
+    assert result["results"][0]["status"] == "completed"
+    assert FakeAgent.run_calls[0]["user_message"] == "default in-process run"
+
+
+def test_acp_command_and_args_forward_without_execution_or_pre_spawn(monkeypatch):
+    def fail_pre_spawn(*args, **kwargs):
+        raise AssertionError("delegate_tool must not pre-spawn consult ACP forwarding")
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("delegate_tool must not execute ACP command")
+
+    monkeypatch.setattr("agent.session_write_policy.pre_spawn_consult", fail_pre_spawn)
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+
+    _build(
+        _parent(SessionWritePolicy.normal("parent")),
+        override_acp_command="copilot",
+        override_acp_args=["--acp", "--stdio"],
+    )
+
+    constructed = FakeAgent.constructed[0]
+    assert constructed["provider"] == "copilot-acp"
+    assert constructed["acp_command"] == "copilot"
+    assert constructed["acp_args"] == ["--acp", "--stdio"]
+
+
+def test_dead_policy_helpers_are_not_exposed():
+    assert not hasattr(delegate_tool, "_replay_child_policy_validation")
+    assert not hasattr(delegate_tool, "_pre_spawn_consult_delegation")
+
+
+def test_provider_model_credentials_forwarding_and_run_single_child_call_preserved():
+    parent_policy = SessionWritePolicy.normal("parent")
+    parent = _parent(parent_policy)
+
+    child = _build(parent, model="child-model", override_provider="child-provider")
+    result = delegate_tool._run_single_child(0, "run child", child=child, parent_agent=parent)
+
+    constructed = FakeAgent.constructed[0]
+    assert constructed["base_url"] == parent.base_url
+    assert constructed["api_key"] == parent.api_key
+    assert constructed["model"] == "child-model"
+    assert constructed["provider"] == "child-provider"
+    assert constructed["session_write_policy"] is parent_policy
+    assert result["status"] == "completed"
+    assert FakeAgent.run_calls[0]["user_message"] == "run child"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1612,6 +1612,28 @@ def _build_child_agent(
 
     from agent.delegation_context import delegated_child_context
 
+    # ── Session write policy inheritance (C19 contract) ─────────────────
+    # Forward the parent's session write policy into the child AIAgent
+    # via the constructor kwarg.  When the parent has no real policy
+    # (or has an arbitrary non-SessionWritePolicy object), fall back to
+    # the active session's policy via get_current_session_write_policy
+    # before deriving.  This matches the C19 R03 contract: the child
+    # receives the parent's policy by identity when valid, and by a
+    # derived fallback otherwise.  Derive_child is called exactly once
+    # (C19 R01).
+    from agent.session_write_policy import (
+        SessionWritePolicy as _SessionWritePolicy,
+        get_current_session_write_policy as _get_current_session_write_policy,
+    )
+
+    parent_session_write_policy = getattr(parent_agent, "session_write_policy", None)
+    if not isinstance(parent_session_write_policy, _SessionWritePolicy):
+        parent_session_write_policy = _get_current_session_write_policy(
+            session_id=getattr(parent_agent, "session_id", "") or "",
+            protected=False,
+        )
+    child_session_write_policy = parent_session_write_policy.derive_child(None)
+
     with delegated_child_context():
         child = AIAgent(
             base_url=effective_base_url,
@@ -1652,6 +1674,7 @@ def _build_child_agent(
             openrouter_min_coding_score=child_openrouter_min_coding_score,
             tool_progress_callback=child_progress_cb,
             iteration_budget=None,  # fresh budget per subagent
+            session_write_policy=child_session_write_policy,
             **child_optional_kwargs,
         )
     child._print_fn = getattr(parent_agent, "_print_fn", None)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -18,6 +18,7 @@ never the child's intermediate tool calls or reasoning.
 """
 
 import enum
+import contextlib
 import contextvars
 import json
 import logging
@@ -2345,8 +2346,18 @@ def _run_single_child(
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
+            from agent.session_write_policy import (
+                SessionWritePolicy,
+                session_write_policy_scope,
+            )
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            child_policy = getattr(child, "session_write_policy", None)
+            policy_scope = (
+                session_write_policy_scope(child_policy)
+                if isinstance(child_policy, SessionWritePolicy)
+                else contextlib.nullcontext()
+            )
+            with delegated_child_context(str(getattr(child, "session_id", "") or "")), policy_scope:
                 return child.run_conversation(
                     user_message=goal,
                     task_id=child_task_id,


### PR DESCRIPTION
## Summary

- add a current-native session write policy module
- propagate session write policy into delegated child agents
- enforce policy before Copilot ACP subprocess spawn
- preserve existing delegation, provider, fallback, ACP, and cleanup behavior

## Validation

- C19 contract: 9/9 tests passed, 25/25 assertions preserved
- C23 contract: 10/10 tests passed, 48/48 assertions preserved
- sealed neighbor regression: 419/419 passed
- source provenance checks passed for agent, interrupt_compat, run_agent, and delegate_tool
- py_compile passed
- git diff --check passed

## Scope

7 files changed, 1034 insertions, 0 deletions.

The implementation is current-native and does not mechanically port the historical git mutation classifier, git target resolver, or self-improvement-policy dependency chain.
