### PR TITLE
fix(cron): bound the inline non-streaming call with a stale watchdog (salvage of #80809)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -564,28 +564,62 @@ def should_use_direct_api_call(agent) -> bool:
 _DIRECT_API_ACTIVITY_HEARTBEAT_SECONDS = 15.0
 
 
+def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Stale budget for the inline non-streaming call.
+
+    Same derivation the interrupt-worker path uses for its stale-call
+    detector (provider ``stale_timeout_seconds`` →
+    ``HERMES_API_CALL_STALE_TIMEOUT`` → reasoning-model floor → context-size
+    scaling, ``inf`` for a local endpoint on the implicit default), so cron and
+    delegated turns get exactly the patience every other non-streaming request
+    already gets.
+
+    A non-numeric result — an agent stub that never implements the resolver —
+    leaves the watchdog disarmed rather than arming it on a bogus budget.
+    """
+    resolver = getattr(agent, "_compute_non_stream_stale_timeout", None)
+    if not callable(resolver):
+        return float("inf")
+    try:
+        value = resolver(api_kwargs)
+    except Exception:
+        logger.debug("non-stream stale timeout resolution failed", exc_info=True)
+        return float("inf")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return float("inf")
+    return float(value)
+
+
 def direct_api_call(agent, api_kwargs: dict):
     """Run a non-streaming LLM call inline on the conversation thread.
 
     Used when ``should_use_direct_api_call`` is True (cron turns and
     delegated children). Skips the interrupt worker (whose only job is
     interactive-interrupt responsiveness, which these contexts do not have)
-    so the nested-pool deadlock (#62151, #60203) cannot occur. Because the
-    request runs in-flight normally, the per-request OpenAI client's own httpx
-    timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
-    a genuinely hung provider — the same bound interactive calls already rely on.
+    so the nested-pool deadlock (#62151, #60203) cannot occur.
 
     While the inline request blocks, a lightweight activity heartbeat keeps
     ``last_activity_ts`` advancing. Subagents use this path (non-streaming),
     and without mid-call ticks the async stall monitor / sync heartbeat treat
     a slow-but-healthy local model wait as "no progress" and interrupt around
     450s — surfacing as ``Operation interrupted: waiting for model response``.
+
+    A stale-call watchdog bounds the request the same way the interrupt
+    worker's poll loop does (#80759). The httpx read timeout alone is not a
+    usable bound: it defaults to 1800s and a provider that accepts the request
+    and then goes silent (connection held open, zero bytes, no error) never
+    trips it, so a cron run hangs until something external kills it — which
+    also orphans the execution row. The watchdog aborts the in-flight sockets
+    through the already-registered abort hook and surfaces a retryable
+    ``TimeoutError`` so the outer retry loop reconnects with backoff /
+    credential rotation / provider fallback.
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
     request_client_lock = threading.Lock()
     activity_hb_stop = threading.Event()
+    stale_fired = threading.Event()
 
     def _abort_active_request(reason: str) -> None:
         """Abort the inline request from a watchdog/interrupt thread."""
@@ -628,6 +662,52 @@ def direct_api_call(agent, api_kwargs: dict):
     )
     activity_hb.start()
 
+    call_start = time.time()
+    stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
+
+    def _on_stale() -> None:
+        # Runs on the timer thread. It only aborts the in-flight sockets —
+        # it never issues a request — so the inline / no-worker property that
+        # fixes #62151 and #60203 is preserved.
+        if stale_fired.is_set():
+            return
+        stale_fired.set()
+        elapsed = time.time() - call_start
+        model = api_kwargs.get("model", "unknown")
+        logger.warning(
+            "Inline non-streaming API call stale for %.0fs (threshold %.0fs). "
+            "model=%s context=~%s tokens. Killing connection.",
+            elapsed,
+            stale_timeout,
+            model,
+            f"{estimate_request_context_tokens(api_kwargs):,}",
+        )
+        try:
+            agent._buffer_status(
+                f"⚠️ No response from provider for {int(elapsed)}s "
+                f"(non-streaming, model: {model}). Aborting call."
+            )
+        except Exception:
+            logger.debug("stale status buffering failed", exc_info=True)
+        _bump_stale_streak(agent)
+        try:
+            agent._touch_activity(
+                f"stale non-streaming call killed after {int(elapsed)}s"
+            )
+        except Exception:
+            logger.debug("stale activity touch failed", exc_info=True)
+        try:
+            _abort_active_request("stale_call_kill")
+        except Exception:
+            logger.debug("stale abort failed", exc_info=True)
+
+    stale_watchdog = None
+    if math.isfinite(stale_timeout) and stale_timeout > 0:
+        stale_watchdog = threading.Timer(stale_timeout, _on_stale)
+        stale_watchdog.name = "direct-api-stale-watchdog"
+        stale_watchdog.daemon = True
+        stale_watchdog.start()
+
     # Only a clean return may report the reuse reason (request_complete):
     # after an error or interrupt the wire client is really closed so the
     # retry builds a fresh pool (see _REQUEST_CLIENT_REUSE_REASONS).
@@ -639,6 +719,16 @@ def direct_api_call(agent, api_kwargs: dict):
     except Exception:
         if getattr(agent, "_interrupt_requested", False):
             raise InterruptedError("Agent interrupted during API call") from None
+        if stale_fired.is_set():
+            # The transport error is the expected consequence of our own
+            # abort. Raise a retryable TimeoutError (never InterruptedError,
+            # which the outer loop treats as "the user wants to stop") so the
+            # retry loop reconnects on a fresh pool.
+            raise TimeoutError(
+                f"Non-streaming API call timed out after "
+                f"{int(time.time() - call_start)}s with no response "
+                f"(threshold: {int(stale_timeout)}s)"
+            ) from None
         raise
     else:
         if getattr(agent, "_interrupt_requested", False):
@@ -647,6 +737,8 @@ def direct_api_call(agent, api_kwargs: dict):
         succeeded = True
         return response
     finally:
+        if stale_watchdog is not None:
+            stale_watchdog.cancel()
         activity_hb_stop.set()
         activity_hb.join(timeout=2.0)
         if getattr(agent, "_active_request_abort", None) is _abort_active_request:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -332,6 +332,51 @@ def _reset_stale_streak(agent) -> None:
         pass
 
 
+def _report_stale_nonstream_kill(
+    agent,
+    api_kwargs: dict,
+    elapsed: float,
+    stale_timeout: float,
+    *,
+    inline: bool = False,
+    hint: Optional[str] = None,
+) -> None:
+    """Emit the user/operator-facing trio for a stale non-streaming kill.
+
+    Shared by the interrupt-worker poll loop and the inline
+    ``direct_api_call`` watchdog so the log line, status message, and
+    activity token stay identical across both paths. Only reporting lives
+    here — the kill/state sequences differ deliberately between the two
+    callers (locking models are not the same).
+    """
+    model = api_kwargs.get("model", "unknown")
+    logger.warning(
+        "%son-streaming API call stale for %.0fs (threshold %.0fs). "
+        "model=%s context=~%s tokens. Killing connection.",
+        "Inline n" if inline else "N",
+        elapsed,
+        stale_timeout,
+        model,
+        f"{estimate_request_context_tokens(api_kwargs):,}",
+    )
+    try:
+        agent._buffer_status(
+            f"⚠️ No response from provider for {int(elapsed)}s "
+            f"(non-streaming, model: {model}). {hint or 'Aborting call.'}"
+        )
+    except Exception:
+        logger.debug("stale status buffering failed", exc_info=True)
+
+
+def _touch_stale_kill_activity(agent, elapsed: float) -> None:
+    try:
+        agent._touch_activity(
+            f"stale non-streaming call killed after {int(elapsed)}s"
+        )
+    except Exception:
+        logger.debug("stale activity touch failed", exc_info=True)
+
+
 def _check_stale_giveup(agent) -> None:
     """Raise immediately when the consecutive-stale streak is past the
     give-up threshold — no network attempt, no stale-timeout wait."""
@@ -576,15 +621,14 @@ def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
 
     A non-numeric result — an agent stub that never implements the resolver —
     leaves the watchdog disarmed rather than arming it on a bogus budget.
+    A resolver that *raises* propagates, exactly as it does on the worker
+    path's stale detector: swallowing it into ``inf`` would silently disarm
+    the watchdog and reinstate the unbounded hang this exists to fix.
     """
     resolver = getattr(agent, "_compute_non_stream_stale_timeout", None)
     if not callable(resolver):
         return float("inf")
-    try:
-        value = resolver(api_kwargs)
-    except Exception:
-        logger.debug("non-stream stale timeout resolution failed", exc_info=True)
-        return float("inf")
+    value = resolver(api_kwargs)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return float("inf")
     return float(value)
@@ -616,13 +660,23 @@ def direct_api_call(agent, api_kwargs: dict):
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
-    request_client_holder = {"client": None}
+    # Request-lifecycle state, every transition under ``request_client_lock``
+    # (ported from the #75301 design): ``done`` stops a late timer from
+    # bumping the stale streak after the call already unwound; ``cancelled``
+    # marks a user/monitor interrupt as the owner of the outcome so a racing
+    # stale timer cannot misclassify the kill as provider staleness;
+    # ``stale`` is the one-shot stale transition itself.
+    request_state = {"client": None, "done": False, "stale": False, "cancelled": False}
     request_client_lock = threading.Lock()
     activity_hb_stop = threading.Event()
-    stale_fired = threading.Event()
 
-    def _abort_active_request(reason: str) -> None:
-        """Abort the inline request from a watchdog/interrupt thread."""
+    def _abort_active_request(reason: str) -> bool:
+        """Abort the inline request from a watchdog/interrupt thread.
+
+        Returns True when this call owned the stale transition (so the
+        timer callback only reports/bumps once, and never after an
+        interrupt or a completed request).
+        """
         # Abort while still holding the holder lock: the instant it is
         # released, the inline finally may pop + cache the client for reuse
         # and the NEXT call check it out — a late abort would then poison
@@ -630,9 +684,33 @@ def direct_api_call(agent, api_kwargs: dict):
         # (same atomicity contract as _close_request_client_once in the
         # interruptible variants; the abort itself never blocks).
         with request_client_lock:
-            request_client = request_client_holder["client"]
+            if request_state["done"]:
+                return False
+            if reason == "stale_call_kill" and request_state["cancelled"]:
+                return False
+            if reason != "stale_call_kill":
+                # A user interrupt/redirect that wins this lock owns the
+                # request outcome. Do not let a later timer misclassify the
+                # cancelled call as provider staleness and advance the
+                # cross-turn circuit breaker.
+                request_state["cancelled"] = True
+            newly_stale = reason == "stale_call_kill" and not request_state["stale"]
+            if newly_stale:
+                request_state["stale"] = True
+                # Advance the breaker before releasing the lock: the inline
+                # owner can unwind the moment the socket abort lands, and a
+                # fast retry's success/reset must not be overtaken by this
+                # older timer restoring the streak afterwards.
+                _bump_stale_streak(agent)
+            request_client = request_state["client"]
             if request_client is not None:
-                agent._abort_request_openai_client(request_client, reason=reason)
+                try:
+                    agent._abort_request_openai_client(request_client, reason=reason)
+                except Exception:
+                    logger.debug(
+                        "Inline request abort failed (%s)", reason, exc_info=True
+                    )
+            return newly_stale
 
     def _make_client(reason: str, kind: str = "openai"):
         # direct_api_call only runs for OpenAI-wire chat_completions cron
@@ -640,8 +718,33 @@ def direct_api_call(agent, api_kwargs: dict):
         # the dispatch — the only caller that passes kind — is never reached
         # here; the ``kind`` parameter exists purely for signature parity.
         client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
+        stale_before_dispatch = False
         with request_client_lock:
-            request_client_holder["client"] = client
+            request_state["client"] = client
+            if request_state["stale"]:
+                # The timer expired while client construction was in flight
+                # (registration race): the abort found no sockets to kill, so
+                # handing this client to dispatch would open a brand-new
+                # socket after the only watchdog already fired. Abort it here
+                # and fail the call instead. (The residual window — timer
+                # firing between this registration and httpx opening its
+                # socket — is accepted: it is ms-scale against a >=90s budget
+                # and self-bounds at the OS connect-retry cap.)
+                stale_before_dispatch = True
+                try:
+                    agent._abort_request_openai_client(
+                        client, reason="stale_call_kill"
+                    )
+                except Exception:
+                    logger.debug(
+                        "Inline abort after late client registration failed",
+                        exc_info=True,
+                    )
+        if stale_before_dispatch:
+            raise TimeoutError(
+                "Non-streaming API call timed out before request dispatch "
+                f"(threshold: {int(stale_timeout)}s)"
+            )
         agent._active_request_abort = _abort_active_request
         return client
 
@@ -660,46 +763,28 @@ def direct_api_call(agent, api_kwargs: dict):
         name="direct-api-activity-hb",
         daemon=True,
     )
-    activity_hb.start()
-
+    # Resolve the budget BEFORE starting the heartbeat: the resolver may
+    # raise (fail-closed contract), and a raise after start() would leak the
+    # heartbeat thread — ticking last_activity_ts forever and masking real
+    # stalls from the stall monitor.
     call_start = time.time()
     stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
+    activity_hb.start()
 
     def _on_stale() -> None:
         # Runs on the timer thread. It only aborts the in-flight sockets —
         # it never issues a request — so the inline / no-worker property that
-        # fixes #62151 and #60203 is preserved.
-        if stale_fired.is_set():
+        # fixes #62151 and #60203 is preserved. The abort helper owns the
+        # stale transition under the request lock: it returns False (and this
+        # callback stays silent) when the request already finished or a user
+        # interrupt owns the outcome.
+        if not _abort_active_request("stale_call_kill"):
             return
-        stale_fired.set()
         elapsed = time.time() - call_start
-        model = api_kwargs.get("model", "unknown")
-        logger.warning(
-            "Inline non-streaming API call stale for %.0fs (threshold %.0fs). "
-            "model=%s context=~%s tokens. Killing connection.",
-            elapsed,
-            stale_timeout,
-            model,
-            f"{estimate_request_context_tokens(api_kwargs):,}",
+        _report_stale_nonstream_kill(
+            agent, api_kwargs, elapsed, stale_timeout, inline=True
         )
-        try:
-            agent._buffer_status(
-                f"⚠️ No response from provider for {int(elapsed)}s "
-                f"(non-streaming, model: {model}). Aborting call."
-            )
-        except Exception:
-            logger.debug("stale status buffering failed", exc_info=True)
-        _bump_stale_streak(agent)
-        try:
-            agent._touch_activity(
-                f"stale non-streaming call killed after {int(elapsed)}s"
-            )
-        except Exception:
-            logger.debug("stale activity touch failed", exc_info=True)
-        try:
-            _abort_active_request("stale_call_kill")
-        except Exception:
-            logger.debug("stale abort failed", exc_info=True)
+        _touch_stale_kill_activity(agent, elapsed)
 
     stale_watchdog = None
     if math.isfinite(stale_timeout) and stale_timeout > 0:
@@ -719,7 +804,9 @@ def direct_api_call(agent, api_kwargs: dict):
     except Exception:
         if getattr(agent, "_interrupt_requested", False):
             raise InterruptedError("Agent interrupted during API call") from None
-        if stale_fired.is_set():
+        with request_client_lock:
+            was_stale = request_state["stale"]
+        if was_stale:
             # The transport error is the expected consequence of our own
             # abort. Raise a retryable TimeoutError (never InterruptedError,
             # which the outer loop treats as "the user wants to stop") so the
@@ -733,19 +820,30 @@ def direct_api_call(agent, api_kwargs: dict):
     else:
         if getattr(agent, "_interrupt_requested", False):
             raise InterruptedError("Agent interrupted during API call")
+        # Close the race window against a timer firing between response
+        # arrival and this unwind: marking ``done`` under the lock makes any
+        # later timer callback a no-op, so the reset below cannot be
+        # overwritten by a stray bump after a successful call. A timer that
+        # already won the lock left ``stale`` set — the request still
+        # completed, so return the response (the streak reset undoes the
+        # bump; the poisoned client is discarded by the finally).
+        with request_client_lock:
+            request_state["done"] = True
         _reset_stale_streak(agent)
         succeeded = True
         return response
     finally:
         if stale_watchdog is not None:
             stale_watchdog.cancel()
+        with request_client_lock:
+            request_state["done"] = True
         activity_hb_stop.set()
         activity_hb.join(timeout=2.0)
         if getattr(agent, "_active_request_abort", None) is _abort_active_request:
             agent._active_request_abort = None
         with request_client_lock:
-            request_client = request_client_holder["client"]
-            request_client_holder["client"] = None
+            request_client = request_state["client"]
+            request_state["client"] = None
         if request_client is not None:
             agent._close_request_openai_client(
                 request_client,
@@ -1162,7 +1260,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Stale-call detector: kill the connection if no response
         # arrives within the configured timeout.
         if _elapsed > _stale_timeout:
-            _est_ctx = estimate_request_context_tokens(api_kwargs)
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
             if callable(_hint_fn):
@@ -1170,24 +1267,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _silent_hint = _hint_fn(model=api_kwargs.get("model"))
                 except Exception:
                     _silent_hint = None
-            logger.warning(
-                "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+            _report_stale_nonstream_kill(
+                agent, api_kwargs, _elapsed, _stale_timeout, hint=_silent_hint
             )
-            if _silent_hint:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
-                )
-            else:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Aborting call."
-                )
             try:
                 # #67142: routes by client kind — anthropic now aborts the
                 # request-local client's sockets from this poll (stranger)
@@ -1198,9 +1280,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)
-            agent._touch_activity(
-                f"stale non-streaming call killed after {int(_elapsed)}s"
-            )
+            _touch_stale_kill_activity(agent, _elapsed)
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -261,3 +261,124 @@ def test_e2e_cron_turn_is_bounded_through_the_real_agent_routing(monkeypatch):
     # The aborted pool is poisoned, so the killed client is really closed
     # instead of being cached for the retry.
     assert wire.close_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Salvage follow-up (#75301 state discipline): locked lifecycle transitions.
+# ---------------------------------------------------------------------------
+
+
+def test_interrupt_abort_is_not_misclassified_as_provider_staleness():
+    """A user/monitor interrupt that kills the call must not advance the
+    cross-turn stale circuit breaker, even if the stale timer fires right
+    after — the ``cancelled`` flag owns the outcome (#75301 design)."""
+    agent = _make_agent(stale_timeout=30.0)
+    release_after_abort = threading.Event()
+    fake_client = MagicMock()
+
+    def _stalled_request(**_kwargs):
+        assert release_after_abort.wait(timeout=5.0)
+        raise ConnectionError("socket shut down")
+
+    fake_client.chat.completions.create.side_effect = _stalled_request
+    agent._create_request_openai_client.return_value = fake_client
+
+    def _abort(client, reason):
+        release_after_abort.set()
+
+    agent._abort_request_openai_client.side_effect = _abort
+
+    interrupt_fired = threading.Event()
+
+    def _interrupt_soon():
+        # Wait until the abort hook is registered, then interrupt like
+        # run_agent.interrupt() does (registered under the same name).
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            hook = agent._active_request_abort
+            if callable(hook) and not isinstance(hook, MagicMock):
+                agent._interrupt_requested = True
+                # interrupt owns the outcome...
+                assert hook("interrupt_abort") is False
+                # ...so a stale timer racing in afterwards is inert:
+                assert hook("stale_call_kill") is False
+                interrupt_fired.set()
+                return
+            time.sleep(0.005)
+
+    worker = threading.Thread(target=_interrupt_soon, daemon=True)
+    worker.start()
+
+    with pytest.raises(InterruptedError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert interrupt_fired.wait(timeout=1.0)
+    assert agent._consecutive_stale_streams == 0, (
+        "interrupt was misclassified as provider staleness"
+    )
+
+
+def test_late_stale_timer_after_completion_is_inert():
+    """A timer callback that loses the race to a completed request must not
+    bump the streak: ``done`` is set under the lock before the unwind."""
+    agent = _make_agent(stale_timeout=30.0)
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="ok")
+    agent._create_request_openai_client.return_value = fake_client
+
+    captured = {}
+    real_timer = threading.Timer
+
+    class CapturingTimer(real_timer):
+        def __init__(self, interval, function, *a, **k):
+            captured["fn"] = function
+            super().__init__(interval, function, *a, **k)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(threading, "Timer", CapturingTimer)
+        assert direct_api_call(agent, {"model": "m", "messages": []}).id == "ok"
+
+    # Fire the (already-cancelled) timer callback manually, simulating a
+    # timer thread that had already dequeued before cancel().
+    captured["fn"]()
+    assert agent._consecutive_stale_streams == 0
+    agent._abort_request_openai_client.assert_not_called()
+
+
+def test_timer_firing_before_client_registration_fails_the_dispatch():
+    """Registration race: if the budget expires while the client is still
+    being constructed, the freshly-registered client is aborted and the call
+    fails with a retryable TimeoutError instead of opening a new socket
+    after the only watchdog was spent."""
+    agent = _make_agent(stale_timeout=0.05)
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="late")
+
+    def _slow_create(*, reason, api_kwargs):
+        # The timer (50ms budget) fires while construction is in flight.
+        time.sleep(0.4)
+        return fake_client
+
+    agent._create_request_openai_client.side_effect = _slow_create
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+    fake_client.chat.completions.create.assert_not_called()
+    agent._abort_request_openai_client.assert_called_once_with(
+        fake_client, reason="stale_call_kill"
+    )
+
+
+def test_resolver_exception_propagates_instead_of_disarming_the_watchdog():
+    """A raising stale-timeout resolver must propagate (fail closed), not be
+    swallowed into an infinite budget that silently reinstates the hang."""
+    agent = _make_agent(stale_timeout=0.2)
+
+    def _broken_resolver(api_payload):
+        raise RuntimeError("resolver regression")
+
+    agent._compute_non_stream_stale_timeout = _broken_resolver
+
+    with pytest.raises(RuntimeError, match="resolver regression"):
+        direct_api_call(agent, {"model": "m", "messages": []})

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -1,0 +1,263 @@
+"""Regression guard for #80759 — the inline non-streaming call must be bounded.
+
+Cron turns (and delegated children) are routed by ``should_use_direct_api_call``
+onto ``direct_api_call``, which ran the request inline with no stale detector:
+the abort plumbing was registered but nothing ever invoked it. A provider that
+accepted the request and then went silent — connection held open, zero bytes,
+no error — hung the cron run until an external actor killed it (which also
+orphaned the execution row). The only other bound was the 1800s-default httpx
+read timeout, and the job-level inactivity monitor was observed not to fire.
+
+These tests pin the watchdog contract: it aborts the in-flight sockets through
+the already-registered abort hook, surfaces a retryable ``TimeoutError`` (never
+``InterruptedError``), feeds the cross-turn stale circuit breaker, and stays
+out of the way of a healthy call.
+"""
+
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+from agent.chat_completion_helpers import direct_api_call
+
+
+def _make_agent(*, stale_timeout, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent._interrupt_requested = False
+    agent._consecutive_stale_streams = 0
+    agent._touch_activity = MagicMock()
+    agent._buffer_status = MagicMock()
+    agent._create_request_openai_client = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+    agent._compute_non_stream_stale_timeout = lambda api_payload: stale_timeout
+    return agent
+
+
+def _stalling_client(agent, *, aborted, release_after=5.0):
+    """A client whose request blocks until the watchdog aborts its sockets."""
+    fake_client = MagicMock()
+    release_after_abort = threading.Event()
+
+    def _abort(client, reason):
+        aborted.append(reason)
+        release_after_abort.set()
+
+    def _stalled_request(**_kwargs):
+        # The provider accepted the request and went silent. The socket
+        # shutdown is what unblocks it, exactly as in production.
+        if not release_after_abort.wait(timeout=release_after):
+            raise AssertionError("watchdog never aborted the stalled request")
+        raise ConnectionError("socket shut down")
+
+    fake_client.chat.completions.create.side_effect = _stalled_request
+    agent._abort_request_openai_client.side_effect = _abort
+    agent._create_request_openai_client.return_value = fake_client
+    return fake_client
+
+
+def test_stalled_inline_call_is_aborted_and_raises_retryable_timeout():
+    agent = _make_agent(stale_timeout=0.2)
+    aborted: list[str] = []
+    _stalling_client(agent, aborted=aborted)
+
+    started = time.time()
+    with pytest.raises(TimeoutError) as excinfo:
+        direct_api_call(agent, {"model": "m", "messages": []})
+    elapsed = time.time() - started
+
+    assert aborted == ["stale_call_kill"]
+    assert "no response" in str(excinfo.value)
+    assert elapsed < 4.0, "watchdog did not bound the call"
+
+
+def test_watchdog_abort_never_surfaces_as_interrupted_error():
+    """InterruptedError means "the user wants to stop" — the outer loop does
+    not retry it. A watchdog abort must stay retryable."""
+    agent = _make_agent(stale_timeout=0.2)
+    _stalling_client(agent, aborted=[])
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+
+def test_watchdog_kill_feeds_the_cross_turn_stale_circuit_breaker():
+    """Without a bump the #58962 breaker can never trip for cron sessions."""
+    agent = _make_agent(stale_timeout=0.2)
+    _stalling_client(agent, aborted=[])
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert agent._consecutive_stale_streams == 1
+
+
+def test_retry_after_a_watchdog_kill_gets_a_fresh_pool_and_succeeds():
+    agent = _make_agent(stale_timeout=0.2)
+    _stalling_client(agent, aborted=[])
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+    # The kill must really close the wire client so the retry rebuilds it.
+    assert agent._close_request_openai_client.call_args.kwargs["reason"] == (
+        "request_error_cleanup"
+    )
+
+    healthy_client = MagicMock()
+    healthy_client.chat.completions.create.return_value = SimpleNamespace(id="ok")
+    agent._create_request_openai_client.side_effect = None
+    agent._create_request_openai_client.return_value = healthy_client
+
+    assert direct_api_call(agent, {"model": "m", "messages": []}).id == "ok"
+    assert agent._consecutive_stale_streams == 0
+
+
+def test_healthy_call_is_untouched_by_the_watchdog():
+    agent = _make_agent(stale_timeout=30.0)
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="fast")
+    agent._create_request_openai_client.return_value = fake_client
+
+    assert direct_api_call(agent, {"model": "m", "messages": []}).id == "fast"
+    agent._abort_request_openai_client.assert_not_called()
+    assert agent._close_request_openai_client.call_args.kwargs["reason"] == (
+        "request_complete"
+    )
+
+
+def test_local_endpoint_infinite_budget_leaves_the_watchdog_disarmed():
+    """``_compute_non_stream_stale_timeout`` returns inf for a local endpoint
+    on the implicit default — that opt-out must survive on this path too."""
+    agent = _make_agent(stale_timeout=float("inf"))
+    fake_client = MagicMock()
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow(**_kwargs):
+        started.set()
+        assert release.wait(timeout=2.0)
+        return SimpleNamespace(id="slow-but-healthy")
+
+    fake_client.chat.completions.create.side_effect = _slow
+    agent._create_request_openai_client.return_value = fake_client
+
+    box = {}
+
+    def _run():
+        box["response"] = direct_api_call(agent, {"model": "m", "messages": []})
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    assert started.wait(timeout=2.0)
+    time.sleep(0.3)
+    release.set()
+    worker.join(timeout=3.0)
+
+    assert box["response"].id == "slow-but-healthy"
+    agent._abort_request_openai_client.assert_not_called()
+
+
+def test_watchdog_uses_the_same_budget_as_the_interrupt_worker_path():
+    """The budget comes from ``_compute_non_stream_stale_timeout`` — the same
+    resolver the worker path's stale detector uses — with the live request
+    payload, so provider config and context scaling both apply."""
+    seen: list[dict] = []
+    agent = _make_agent(stale_timeout=30.0)
+    agent._compute_non_stream_stale_timeout = lambda payload: (
+        seen.append(payload) or 30.0
+    )
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="ok")
+    agent._create_request_openai_client.return_value = fake_client
+
+    payload = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+    direct_api_call(agent, payload)
+
+    assert seen == [payload]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a real AIAgent on the real cron routing + client lifecycle.
+# ---------------------------------------------------------------------------
+
+
+class _StallingWireClient:
+    """An OpenAI-shaped client whose request stalls until its sockets die."""
+
+    def __init__(self):
+        self._client = SimpleNamespace(is_closed=False)
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self.responses = SimpleNamespace()
+        self.close_calls = 0
+        self.sockets_shut_down = threading.Event()
+
+    def _create(self, **_kwargs):
+        if not self.sockets_shut_down.wait(timeout=5.0):
+            raise AssertionError("watchdog never shut the stalled request down")
+        raise ConnectionError("socket shut down")
+
+    def close(self):
+        self.close_calls += 1
+        self._client.is_closed = True
+
+
+def _build_cron_agent(monkeypatch):
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.platform = "cron"
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent._base_url = agent.base_url
+    agent.model = "some/model"
+    agent.log_prefix = ""
+    agent.quiet_mode = True
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
+    agent._client_lock = threading.RLock()
+    agent._client_kwargs = {"api_key": "***", "base_url": agent.base_url}
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    agent.reasoning_callback = None
+    agent.status_callback = None
+    monkeypatch.setenv("HERMES_API_CALL_STALE_TIMEOUT", "0.3")
+    return agent
+
+
+def test_e2e_cron_turn_is_bounded_through_the_real_agent_routing(monkeypatch):
+    """The real chain: cron platform → ``should_use_direct_api_call`` →
+    ``direct_api_call`` → the agent's own stale-timeout resolver → the real
+    cross-thread abort → a retryable ``TimeoutError`` on the caller."""
+    wire = _StallingWireClient()
+    agent = _build_cron_agent(monkeypatch)
+    agent.client = wire
+    monkeypatch.setattr(run_agent, "OpenAI", lambda **_kwargs: wire)
+    monkeypatch.setattr(
+        run_agent.AIAgent,
+        "_force_close_tcp_sockets",
+        lambda self, client: (client.sockets_shut_down.set(), 1)[1],
+    )
+
+    started = time.time()
+    with pytest.raises(TimeoutError):
+        agent._interruptible_api_call({"model": agent.model, "messages": []})
+    elapsed = time.time() - started
+
+    assert elapsed < 4.0, "cron turn was not bounded by the watchdog"
+    # The aborted pool is poisoned, so the killed client is really closed
+    # instead of being cached for the retry.
+    assert wire.close_calls == 1

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -982,6 +982,8 @@ The **stale stream detection** kills connections that receive SSE keep-alive pin
 
 The **stale non-stream detection** kills non-streaming calls that produce no response for too long. By default Hermes disables this on local endpoints to avoid false positives during long prefills. If you explicitly set `providers.<id>.stale_timeout_seconds`, `providers.<id>.models.<model>.stale_timeout_seconds`, or `HERMES_API_CALL_STALE_TIMEOUT`, that explicit value is honored even on local endpoints.
 
+This budget bounds every non-streaming call, including the ones cron jobs and delegated subagents run inline. A provider that accepts a request and then goes silent — connection held open, no bytes, no error — is aborted at the stale timeout and retried, rather than hanging until the much longer socket read timeout (or, for an unattended cron run, until something external kills the process).
+
 ## Context Pressure Warnings
 
 Separate from iteration budget pressure, context pressure tracks how close the conversation is to the **compaction threshold** — the point where context compression fires to summarize older messages. This helps both you and the agent understand when the conversation is getting long.


### PR DESCRIPTION
## Summary

Cron turns and delegated subagents run their non-streaming LLM calls inline via `direct_api_call` — which registered abort plumbing but nothing ever invoked it. A provider that accepts the request and then goes silent (connection held open, zero bytes, no error) hangs the run until something external kills it, also leaving the execution row stuck in `running`. This salvages @HexLab98's #80809, which arms a `threading.Timer` watchdog on the same stale budget (`_compute_non_stream_stale_timeout`) the interrupt-worker path already uses, then hardens the watchdog's concurrency in a follow-up commit that ports the locked state-machine design from @Zeraphim's #75301.

Fixes #80759. Closes #80809. Closes #75301.

## Changes

- `agent/chat_completion_helpers.py` (cherry-picked from #80809, authorship preserved): stale watchdog for `direct_api_call` — aborts in-flight sockets via the already-registered `_abort_active_request`, bumps the #58962 cross-turn stale circuit breaker, surfaces a retryable `TimeoutError` (never `InterruptedError`). No new env vars or config keys; local endpoints on the implicit default stay disarmed (`inf`).
- Follow-up commit (review findings, design ported from #75301 with credit):
  - All watchdog lifecycle transitions (`stale`/`cancelled`/`done`) moved under `request_client_lock`. A user/monitor interrupt now owns the outcome (`cancelled`), so a racing stale timer can't misclassify the kill as provider staleness and feed false data into the giveup breaker.
  - `done` set under the lock on completion — a late timer callback after a successful response is inert (no spurious residual streak).
  - Registration race closed: budget expiring during client construction aborts the freshly-registered client and raises a retryable `TimeoutError` instead of opening a new socket after the only watchdog fired.
  - `_resolve_direct_stale_timeout` fails closed: a raising resolver propagates (same as the worker path) instead of being swallowed into an `inf` budget that would silently disarm the watchdog.
- `tests/cron/test_cron_direct_api_call_watchdog.py`: 8 tests from #80809 (incl. a real-`AIAgent` E2E through the actual routing + client-cache/poison lifecycle) + 4 new regression tests for the follow-up fixes.
- `website/docs/user-guide/configuration.md`: notes the stale budget covers cron/subagent inline calls.

## Validation

| | Before | After |
|---|---|---|
| Cron turn vs silent provider | hangs until external kill (httpx 1800s never trips) | aborted at stale budget (90s default), retried |
| Interrupt racing the stale timer | streak +1 misattributed to provider | `cancelled` owns outcome, streak untouched |
| Timer vs successful completion race | possible residual streak=1 | `done` gate — late timer inert |
| Resolver regression | silently disarmed watchdog (`inf`) | propagates loudly |

- `tests/cron/` + inline-call/stale/interrupt suites: 445 passed.
- Watchdog file: 12/12; the 4 new tests each fail against the pre-follow-up watchdog (mutation-verified).
- `tests/run_agent/`: full sweep green except one pre-existing failure (`test_manual_approvals_keep_codex_server_requests_fail_closed`) that fails identically on unmodified main.

## Credit

- Base fix cherry-picked from #80809 by @HexLab98 (authorship preserved on both commits).
- Locked state-machine + pre-dispatch stale check design from #75301 by @Zeraphim (`Co-authored-by` on the follow-up commit). #75301 targeted the same bug class but is ~1300 commits stale (predates the activity heartbeat) — every hunk conflicts, so its design was ported rather than cherry-picked.
