### PR TITLE
feat: humanize MCP and bridge tool progress labels in gateway

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -492,6 +492,25 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         else:
             return f"planning {len(todos_arg)} task(s)"
 
+    if tool_name == "tool_describe":
+        ref = args.get("name")
+        if isinstance(ref, str) and ref.strip():
+            return humanize_deferred_tool_reference(ref)
+        return None
+
+    if tool_name == "tool_search":
+        query = args.get("query")
+        if query is not None:
+            preview = _oneline(str(query))
+            return _truncate_preview(preview, max_len) if preview else None
+        return None
+
+    if tool_name == "tool_call":
+        ref = args.get("name")
+        if isinstance(ref, str) and ref.strip():
+            return humanize_deferred_tool_reference(ref)
+        return None
+
     if tool_name in {"terminal", "execute_code"}:
         key = "code" if tool_name == "execute_code" else "command"
         command = args.get(key)
@@ -596,12 +615,168 @@ def prepare_tool_preview(
 
 
 # =========================================================================
+# Tool-name humanization (MCP, bridge, plugin tools)
+#
+# Wire names like ``mcp__jigo_masterhub__get_daily_briefing`` are opaque in
+# chat progress bubbles.  These helpers derive short present-tense phrases
+# ("Getting daily briefing") from snake_case identifiers.
+# =========================================================================
+
+_ACTION_PREFIX_VERBS: dict[str, str] = {
+    "get": "Getting",
+    "fetch": "Fetching",
+    "search": "Searching",
+    "find": "Finding",
+    "list": "Listing",
+    "create": "Creating",
+    "update": "Updating",
+    "delete": "Deleting",
+    "remove": "Removing",
+    "emit": "Showing",
+    "show": "Showing",
+    "send": "Sending",
+    "run": "Running",
+    "sync": "Syncing",
+    "load": "Loading",
+    "save": "Saving",
+    "check": "Checking",
+    "validate": "Validating",
+    "approve": "Approving",
+    "reject": "Rejecting",
+    "link": "Linking",
+    "unlink": "Unlinking",
+    "describe": "Describing",
+    "resolve": "Resolving",
+    "confirm": "Confirming",
+}
+
+
+def humanize_snake_identifier(name: str) -> str:
+    """Convert ``get_daily_briefing`` to ``daily briefing`` (words, lowercase)."""
+    return " ".join(name.replace("-", "_").split("_")).strip()
+
+
+def _parse_mcp_prefixed_name(tool_name: str) -> tuple[str, str] | None:
+    """Return ``(server, tool)`` for ``mcp__<server>__<tool>`` names."""
+    if not tool_name.startswith("mcp__"):
+        return None
+    parts = tool_name.split("__")
+    if len(parts) < 3 or parts[0] != "mcp":
+        return None
+    server = parts[1]
+    tool_id = "__".join(parts[2:])
+    if not server or not tool_id:
+        return None
+    return server, tool_id
+
+
+def _tool_identifier_from_name(tool_name: str) -> str:
+    """Strip MCP prefix when present; otherwise return the raw tool name."""
+    parsed = _parse_mcp_prefixed_name(tool_name)
+    if parsed:
+        return parsed[1]
+    return tool_name
+
+
+def noun_phrase_from_tool_identifier(tool_id: str) -> str:
+    """Object phrase for describe-style labels: ``get_daily_briefing`` → ``daily briefing``."""
+    words = [w for w in tool_id.replace("-", "_").split("_") if w]
+    if not words:
+        return "tool"
+    first = words[0].lower()
+    if first in _ACTION_PREFIX_VERBS and len(words) > 1:
+        return " ".join(words[1:])
+    return humanize_snake_identifier(tool_id)
+
+
+def phrase_from_tool_identifier(tool_id: str) -> str:
+    """Present-tense phrase: ``get_daily_briefing`` → ``Getting daily briefing``."""
+    words = [w for w in tool_id.replace("-", "_").split("_") if w]
+    if not words:
+        return "Running tool"
+    first = words[0].lower()
+    rest = " ".join(words[1:])
+    verb = _ACTION_PREFIX_VERBS.get(first)
+    if verb and rest:
+        return f"{verb} {rest}"
+    if verb:
+        return verb
+    text = humanize_snake_identifier(tool_id)
+    return text[0].upper() + text[1:] if text else "Running tool"
+
+
+def phrase_for_tool_name(tool_name: str) -> str | None:
+    """Human phrase for MCP wire names, or None when not MCP-prefixed."""
+    if not tool_name or not tool_name.startswith("mcp__"):
+        return None
+    tool_id = _tool_identifier_from_name(tool_name)
+    return phrase_from_tool_identifier(tool_id)
+
+
+def fallback_tool_progress_name(tool_name: str) -> str:
+    """Wire-name fallback when no preview/label is available."""
+    if _friendly_tool_labels:
+        phrase = phrase_for_tool_name(tool_name)
+        if phrase:
+            return phrase
+    return tool_name
+
+
+def build_tool_progress_label(
+    tool_name: str,
+    args: dict | None,
+    *,
+    preview: str | None = None,
+    max_len: int | None = 40,
+    format_preview=None,
+) -> str | None:
+    """Build one tool-progress label for gateway/stream surfaces.
+
+    Centralizes friendly labels, MCP humanization, secret redaction, and
+    optional platform-specific preview formatting (e.g. clickable truncated
+    URLs on Discord).  ``format_preview`` receives a :class:`ToolPreview`
+    and should return display text — pass ``adapter.format_tool_preview`` when
+    available.
+    """
+    display_args = redact_tool_args_for_display(tool_name, args) or args or {}
+    fallback_preview = preview or ""
+
+    if fallback_preview and format_preview is not None:
+        cap = max_len if max_len and max_len > 0 else 40
+        prepared = prepare_tool_preview(
+            tool_name,
+            display_args,
+            fallback=fallback_preview,
+            max_len=0 if max_len is None else cap,
+        )
+        if prepared.url:
+            linked = format_preview(prepared)
+            verb = get_tool_verb(tool_name)
+            if verb:
+                if verb_drops_preview(tool_name):
+                    return verb
+                return f"{verb}{tool_verb_connector(tool_name)}{linked}"
+
+    label = build_tool_label(tool_name, display_args, max_len=max_len)
+    if label:
+        return label
+    if fallback_preview and _friendly_tool_labels:
+        return _truncate_preview(fallback_preview, max_len) if max_len else fallback_preview
+    return None
+
+
+def humanize_deferred_tool_reference(name: str) -> str:
+    """Humanize a tool name referenced by tool-search bridge tools."""
+    tool_id = _tool_identifier_from_name(name.strip())
+    return noun_phrase_from_tool_identifier(tool_id)
+
+
+# =========================================================================
 # Friendly tool labels (human-phrased verbs for built-in tools)
 #
 # Turns "web_search <query>" into "Searching the web for <query>" — the
-# ChatGPT-style "Searching…/Reading…" surface.  Curated and built-in only:
-# we know each core tool's semantics, so the verb is fixed, not computed.
-# Custom/plugin/MCP tools have no entry and fall back to the raw preview.
+# ChatGPT-style "Searching…/Reading…" surface.  Built-in tools use curated
+# verbs; MCP/plugin tools derive a phrase from the identifier.
 # =========================================================================
 
 # Each entry maps a built-in tool name to its present-participle verb phrase.
@@ -632,6 +807,9 @@ _TOOL_VERBS: dict[str, str] = {
     "clarify": "Asking",
     "memory": "Updating memory",
     "todo": "Updating tasks",
+    "tool_describe": "Loading details for",
+    "tool_search": "Searching tools for",
+    "tool_call": "Running",
 }
 
 # Verbs that read better without the raw argument preview appended.
@@ -711,8 +889,8 @@ def build_status_phrase(tool_name: str, args: dict | None, max_len: int = 49) ->
     if verb:
         head = f"is {verb[0].lower()}{verb[1:]}"
     else:
-        # Custom / plugin / MCP tools: generic but still informative.
-        head = f"is using {tool_name}"
+        phrase = phrase_for_tool_name(tool_name)
+        head = f"is {phrase[0].lower()}{phrase[1:]}" if phrase else f"is using {tool_name}"
 
     phrase = head
     if args and verb and tool_name not in _TOOL_VERBS_NO_PREVIEW:
@@ -735,26 +913,33 @@ def build_tool_label(tool_name: str, args: dict, max_len: int | None = None) -> 
 
     For built-in tools with a known verb (``web_search`` -> "Searching the
     web for ..."), returns the verb optionally followed by the argument
-    preview.  For everything else (custom/plugin/MCP tools, or when friendly
-    labels are disabled) returns the raw preview, so callers can use this as a
-    drop-in replacement for :func:`build_tool_preview`.
+    preview.  MCP and plugin tools derive a present-tense phrase from the
+    tool identifier (``mcp__srv__get_daily_briefing`` -> "Getting daily
+    briefing").  When friendly labels are disabled, returns the raw preview.
     """
     if not _friendly_tool_labels:
         return build_tool_preview(tool_name, args, max_len=max_len)
 
     verb = _TOOL_VERBS.get(tool_name)
-    if not verb:
-        return build_tool_preview(tool_name, args, max_len=max_len)
+    if verb:
+        if tool_name in _TOOL_VERBS_NO_PREVIEW:
+            return verb
 
-    if tool_name in _TOOL_VERBS_NO_PREVIEW:
-        return verb
+        preview = build_tool_preview(tool_name, args, max_len=max_len)
+        if not preview:
+            return verb
+        connector = tool_verb_connector(tool_name)
+        return f"{verb}{connector}{preview}"
 
-    preview = build_tool_preview(tool_name, args, max_len=max_len)
-    if not preview:
-        return verb
-    if tool_name in _TOOL_VERBS_FOR_CONNECTOR:
-        return f"{verb} for {preview}"
-    return f"{verb} {preview}"
+    phrase = phrase_for_tool_name(tool_name)
+    if phrase:
+        preview = build_tool_preview(tool_name, args, max_len=max_len)
+        if preview and preview != phrase:
+            combined = f"{phrase} — {preview}"
+            return _truncate_preview(combined, max_len)
+        return _truncate_preview(phrase, max_len)
+
+    return build_tool_preview(tool_name, args, max_len=max_len)
 
 
 # =========================================================================

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3080,36 +3080,46 @@ class BasePlatformAdapter(ABC):
         if not isinstance(event, ToolCallChunk):
             return None
 
-        from agent.display import get_tool_emoji
+        from agent.display import (
+            build_tool_progress_label,
+            fallback_tool_progress_name,
+            get_tool_emoji,
+            redact_tool_args_for_display,
+        )
         emoji = get_tool_emoji(event.tool_name, default="⚙️")
+        display_args = (
+            redact_tool_args_for_display(event.tool_name, event.args)
+            or event.args
+            or {}
+        )
+        cap = preview_max_len if preview_max_len > 0 else 40
+
+        def _label(*, verbose: bool) -> str | None:
+            return build_tool_progress_label(
+                event.tool_name,
+                display_args,
+                preview=event.preview,
+                max_len=None if verbose else cap,
+                format_preview=self.format_tool_preview,
+            )
 
         if mode == "verbose":
-            if event.args:
+            if display_args:
                 import json
-                args_str = json.dumps(event.args, ensure_ascii=False, default=str)
+                args_str = json.dumps(display_args, ensure_ascii=False, default=str)
                 if preview_max_len > 0 and len(args_str) > preview_max_len:
                     args_str = args_str[:preview_max_len - 3] + "..."
-                return f"{emoji} {event.tool_name}({list(event.args.keys())})\n{args_str}"
-            if event.preview:
-                return f"{emoji} {event.tool_name}: \"{event.preview}\""
-            return f"{emoji} {event.tool_name}..."
+                header = _label(verbose=True) or fallback_tool_progress_name(event.tool_name)
+                return f"{emoji} {header}({list(display_args.keys())})\n{args_str}"
+            label = _label(verbose=True)
+            if label:
+                return f"{emoji} {label}"
+            return f"{emoji} {fallback_tool_progress_name(event.tool_name)}..."
 
-        # "all" / "new": short preview, capped (default 40 to keep gateway
-        # progress bubbles compact — they persist as permanent messages).
-        preview = event.preview
-        if preview:
-            from agent.display import prepare_tool_preview
-
-            cap = preview_max_len if preview_max_len > 0 else 40
-            prepared = prepare_tool_preview(
-                event.tool_name,
-                event.args,
-                fallback=preview,
-                max_len=cap,
-            )
-            rendered = self.format_tool_preview(prepared)
-            return f"{emoji} {event.tool_name}: \"{rendered}\""
-        return f"{emoji} {event.tool_name}..."
+        label = _label(verbose=False)
+        if label:
+            return f"{emoji} {label}"
+        return f"{emoji} {fallback_tool_progress_name(event.tool_name)}..."
 
     def format_tool_preview(self, preview: "ToolPreview") -> str:
         """Apply platform-native formatting to a compact tool preview.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3748,20 +3748,45 @@ class TurnRunner:
                 ctx.progress_queue.put(_code_block_full)
                 return
             ctx.last_was_terminal_block[0] = False
+            from agent.display import (
+                build_tool_progress_label,
+                fallback_tool_progress_name,
+                get_tool_preview_max_len,
+                redact_tool_args_for_display,
+            )
+            display_args = (
+                redact_tool_args_for_display(tool_name, args)
+                if isinstance(args, dict)
+                else {}
+            ) or (args if isinstance(args, dict) else {})
+            _format_preview = (
+                _progress_adapter.format_tool_preview
+                if _progress_adapter is not None
+                else None
+            )
+            header = (
+                build_tool_progress_label(
+                    tool_name,
+                    display_args,
+                    preview=preview,
+                    max_len=None,
+                    format_preview=_format_preview,
+                )
+                or fallback_tool_progress_name(tool_name)
+            )
             if args:
-                from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
-                args_str = json.dumps(args, ensure_ascii=False, default=str)
+                args_str = json.dumps(display_args, ensure_ascii=False, default=str)
                 # When tool_preview_length is 0 (default), don't truncate
                 # in verbose mode — the user explicitly asked for full
                 # detail.  Platform message-length limits handle the rest.
                 if _pl > 0 and len(args_str) > _pl:
                     args_str = args_str[:_pl - 3] + "..."
-                msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                msg = f"{emoji} {header}({list(display_args.keys())})\n{args_str}"
             elif preview:
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                msg = f"{emoji} {header}"
             else:
-                msg = f"{emoji} {tool_name}..."
+                msg = f"{emoji} {header}..."
             ctx.progress_queue.put(msg)
             return
 
@@ -3773,42 +3798,57 @@ class TurnRunner:
         if _code_block_short is not None:
             msg = _code_block_short
             ctx.last_was_terminal_block[0] = True
-        elif preview:
+        elif preview or (isinstance(args, dict) and args):
             from agent.display import (
+                build_tool_progress_label,
+                fallback_tool_progress_name,
                 get_tool_preview_max_len,
-                get_tool_verb,
-                prepare_tool_preview,
-                tool_verb_connector,
-                verb_drops_preview,
+                redact_tool_args_for_display,
             )
             _pl = get_tool_preview_max_len()
             _cap = _pl if _pl > 0 else 40
-            _prepared_preview = prepare_tool_preview(
-                tool_name,
-                args,
-                fallback=preview,
-                max_len=_cap,
+            display_args = (
+                redact_tool_args_for_display(tool_name, args)
+                if isinstance(args, dict)
+                else {}
+            ) or (args if isinstance(args, dict) else {})
+            _format_preview = (
+                _progress_adapter.format_tool_preview
+                if _progress_adapter is not None
+                else None
             )
-            if _progress_adapter is not None:
-                preview = _progress_adapter.format_tool_preview(_prepared_preview)
-            else:
-                preview = _prepared_preview.text
-            # Friendly labels: render a human-phrased line for built-in
-            # tools ("🔍 Searching the web for ...") by prefixing the verb
-            # onto the preview the callback already computed (so the
-            # command/url/query is preserved).  Custom/plugin/MCP tools
-            # have no verb and fall back to the raw "tool_name: ..." form.
-            _verb = get_tool_verb(tool_name)
-            if _verb:
-                if verb_drops_preview(tool_name):
-                    msg = f"{emoji} {_verb}"
-                else:
-                    msg = f"{emoji} {_verb}{tool_verb_connector(tool_name)}{preview}"
-            else:
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+            label = build_tool_progress_label(
+                tool_name,
+                display_args,
+                preview=preview,
+                max_len=_cap,
+                format_preview=_format_preview,
+            )
+            msg = (
+                f"{emoji} {label}"
+                if label
+                else f"{emoji} {fallback_tool_progress_name(tool_name)}..."
+            )
             ctx.last_was_terminal_block[0] = False
         else:
-            msg = f"{emoji} {tool_name}..."
+            from agent.display import (
+                build_tool_progress_label,
+                fallback_tool_progress_name,
+            )
+            _format_preview = (
+                _progress_adapter.format_tool_preview
+                if _progress_adapter is not None
+                else None
+            )
+            label = build_tool_progress_label(
+                tool_name,
+                args or {},
+                preview=preview,
+                max_len=None,
+                format_preview=_format_preview,
+            )
+            fallback = label or fallback_tool_progress_name(tool_name)
+            msg = f"{emoji} {fallback}..."
             ctx.last_was_terminal_block[0] = False
 
         # Dedup: collapse consecutive identical progress messages.

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -264,6 +264,70 @@ class TestBuildToolLabel:
         assert label.startswith("Reading ")
         assert "example.com/page" in label
 
+    def test_mcp_tool_humanized(self):
+        from agent.display import build_tool_label
+        label = build_tool_label(
+            "mcp__jigo_masterhub__get_daily_briefing",
+            {},
+        )
+        assert label == "Getting daily briefing"
+
+    def test_tool_describe_humanized(self):
+        from agent.display import build_tool_label
+        label = build_tool_label(
+            "tool_describe",
+            {"name": "mcp__jigo_masterhub__get_daily_briefing"},
+        )
+        assert label == "Loading details for daily briefing"
+
+    def test_tool_search_humanized(self):
+        from agent.display import build_tool_label
+        label = build_tool_label("tool_search", {"query": "daily briefing"})
+        assert label == "Searching tools for daily briefing"
+
+    def test_non_mcp_underscore_tool_keeps_preview_only(self):
+        from agent.display import build_tool_label
+        label = build_tool_label(
+            "send_message",
+            {"target": "alice", "message": "hello"},
+        )
+        assert label == 'to alice: "hello"'
+
+    def test_friendly_disabled_falls_back_to_raw_name(self):
+        from agent.display import (
+            build_tool_label,
+            fallback_tool_progress_name,
+            set_friendly_tool_labels,
+        )
+        set_friendly_tool_labels(False)
+        assert build_tool_label("mcp__srv__get_daily_briefing", {}) is None
+        assert fallback_tool_progress_name("mcp__srv__get_daily_briefing") == (
+            "mcp__srv__get_daily_briefing"
+        )
+        set_friendly_tool_labels(True)
+
+    def test_progress_label_applies_format_preview_for_urls(self):
+        from agent.display import ToolPreview, build_tool_progress_label
+
+        url = "https://hermes-agent.nousresearch.com/docs/gateway/discord/tool-progress"
+        visible = url[:37] + "..."
+
+        def _format_preview(preview: ToolPreview) -> str:
+            assert preview.url == url
+            return f"[{preview.text}](<{preview.url}>)"
+
+        label = build_tool_progress_label(
+            "web_extract",
+            {"urls": [url]},
+            preview=url,
+            max_len=40,
+            format_preview=_format_preview,
+        )
+        assert label is not None
+        assert label.startswith("Reading [")
+        assert visible.removeprefix("https://") in label
+        assert f"](<{url}>)" in label
+
 
 
 


### PR DESCRIPTION
## Summary

Slack/Hermes gateway tool progress bubbles now show plain-language status instead of raw wire names.

**Before**
- `⚙️ tool_describe: "mmp__jigo_masterhub__get_daily_briefing"`
- `⚙️ mcp__jigo_masterhub__get_daily_briefing...`

**After**
- `⚙️ Loading details for daily briefing`
- `⚙️ Getting daily briefing`

Changes:
- Add MCP-only humanization helpers and `build_tool_progress_label()` shared entry point
- Route `gateway/run.py` and `gateway/platforms/base.py` through the shared helper
- Restore adapter `format_tool_preview` hook for truncated URL links (Discord/Slack)
- Scope heuristic humanization to `mcp__*` tools only (built-ins like `send_message` unchanged)
- Respect `display.friendly_tool_labels=false` via `fallback_tool_progress_name()`

## Test plan

- [x] `pytest tests/agent/test_display.py::TestBuildToolLabel tests/gateway/test_discord_format.py` — 16 passed
- [ ] Deploy to broker VM and verify Slack DM shows friendly labels during `get_daily_briefing`

## Pre-Landing Review

Ship Step 9 review not run (display-only UX change). Targeted unit tests cover MCP, bridge tools, URL adapter path, and friendly-labels-off fallback.

## Test Coverage

New tests in `tests/agent/test_display.py`:
- MCP tool humanization
- `tool_describe` / `tool_search` bridge labels
- Non-MCP underscore tools keep preview-only behavior
- `friendly_tool_labels=false` fallback
- `build_tool_progress_label` URL adapter formatting