### PR TITLE
fix(mcp): name the per-server causes in the zero-connected warning

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -11,6 +11,61 @@ _mcp_discovery_started = False
 _mcp_discovery_thread: Optional[threading.Thread] = None
 
 
+
+# Cap per-server causes so one pathological error (a wrapped traceback, a
+# provider dump) cannot turn a startup warning into a log flood.
+_CAUSE_MAX_CHARS = 160
+_CAUSE_MAX_SERVERS = 10
+
+
+def _format_zero_connected_causes(status: list) -> str:
+    """Render per-server causes for the zero-connected discovery warning.
+
+    ``get_mcp_status()`` already carries why each configured server is not
+    connected — ``status`` ("failed" / "connecting" / "disabled" /
+    "configured") plus a recorded ``error`` for failures — and the warning
+    threw all of it away, leaving operators a generic line and no way to tell
+    an auth failure from a server that never started.
+
+    Returns ``""`` when there is nothing to add, so the caller's message is
+    unchanged in that case. Never raises: a diagnostics helper must not be
+    able to break startup.
+    """
+    try:
+        parts: list[str] = []
+        for entry in status or []:
+            if not isinstance(entry, dict) or entry.get("connected"):
+                continue
+            name = str(entry.get("name") or "?")
+            state = str(entry.get("status") or "unknown")
+            cause = entry.get("error")
+            if cause:
+                text = str(cause).strip().replace("\n", " ")
+                try:
+                    from agent.redact import redact_sensitive_text
+
+                    text = redact_sensitive_text(text)
+                except Exception:
+                    # Redaction unavailable — drop the body rather than risk
+                    # writing a token into the log.
+                    text = "(error withheld: redaction unavailable)"
+                if len(text) > _CAUSE_MAX_CHARS:
+                    text = text[:_CAUSE_MAX_CHARS - 1] + "\u2026"
+                parts.append(f"{name} [{state}]: {text}")
+            else:
+                parts.append(f"{name} [{state}]")
+        if not parts:
+            return ""
+        shown = parts[:_CAUSE_MAX_SERVERS]
+        omitted = len(parts) - len(shown)
+        rendered = "; ".join(shown)
+        if omitted > 0:
+            rendered += f"; (+{omitted} more)"
+        return f" — {rendered}"
+    except Exception:
+        return ""
+
+
 def _has_configured_mcp_servers() -> bool:
     """Cheap config probe so non-MCP users avoid importing the MCP stack."""
     try:
@@ -92,7 +147,9 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                     status = get_mcp_status() or []
                     if not any(entry.get("connected") for entry in status):
                         logger.warning(
-                            "Background MCP discovery completed with zero connected servers"
+                            "Background MCP discovery completed with zero "
+                            "connected servers%s",
+                            _format_zero_connected_causes(status),
                         )
                 except Exception:
                     logger.debug("Failed to inspect MCP status after background discovery", exc_info=True)

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -45,6 +45,60 @@ def get_mcp_server_filter() -> Optional[list[str]]:
     return _mcp_server_filter
 
 
+# Cap per-server causes so one pathological error (a wrapped traceback, a
+# provider dump) cannot turn a startup warning into a log flood.
+_CAUSE_MAX_CHARS = 160
+_CAUSE_MAX_SERVERS = 10
+
+
+def _format_zero_connected_causes(status: list) -> str:
+    """Render per-server causes for the zero-connected discovery warning.
+
+    ``get_mcp_status()`` already carries why each configured server is not
+    connected — ``status`` ("failed" / "connecting" / "disabled" /
+    "configured") plus a recorded ``error`` for failures — and the warning
+    threw all of it away, leaving operators a generic line and no way to tell
+    an auth failure from a server that never started.
+
+    Returns ``""`` when there is nothing to add, so the caller's message is
+    unchanged in that case. Never raises: a diagnostics helper must not be
+    able to break startup.
+    """
+    try:
+        parts: list[str] = []
+        for entry in status or []:
+            if not isinstance(entry, dict) or entry.get("connected"):
+                continue
+            name = str(entry.get("name") or "?")
+            state = str(entry.get("status") or "unknown")
+            cause = entry.get("error")
+            if cause:
+                text = str(cause).strip().replace("\n", " ")
+                try:
+                    from agent.redact import redact_sensitive_text
+
+                    text = redact_sensitive_text(text)
+                except Exception:
+                    # Redaction unavailable — drop the body rather than risk
+                    # writing a token into the log.
+                    text = "(error withheld: redaction unavailable)"
+                if len(text) > _CAUSE_MAX_CHARS:
+                    text = text[:_CAUSE_MAX_CHARS - 1] + "\u2026"
+                parts.append(f"{name} [{state}]: {text}")
+            else:
+                parts.append(f"{name} [{state}]")
+        if not parts:
+            return ""
+        shown = parts[:_CAUSE_MAX_SERVERS]
+        omitted = len(parts) - len(shown)
+        rendered = "; ".join(shown)
+        if omitted > 0:
+            rendered += f"; (+{omitted} more)"
+        return f" — {rendered}"
+    except Exception:
+        return ""
+
+
 def _has_configured_mcp_servers() -> bool:
     """Cheap config probe so non-MCP users avoid importing the MCP stack."""
     try:
@@ -108,7 +162,13 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                 _discover_mcp_tools_without_interactive_oauth()
                 try:
                     if not _any_mcp_connected():
-                        logger.warning("Background MCP discovery completed with zero connected servers")
+                        from tools.mcp_tool_discovery import get_mcp_status
+
+                        logger.warning(
+                            "Background MCP discovery completed with zero "
+                            "connected servers%s",
+                            _format_zero_connected_causes(get_mcp_status() or []),
+                        )
                 except Exception:
                     logger.debug("Failed to inspect MCP status after background discovery", exc_info=True)
             except Exception:

--- a/tests/hermes_cli/test_mcp_zero_connected_causes.py
+++ b/tests/hermes_cli/test_mcp_zero_connected_causes.py
@@ -1,0 +1,107 @@
+"""The zero-connected discovery warning must name why each server is out (#80938).
+
+`get_mcp_status()` already records why every configured server is not
+connected — a per-server ``status`` plus a recorded ``error`` for failures —
+but the background-discovery warning threw all of it away and logged one
+generic line. Operators could not tell an auth failure from a server that
+never started, or from one that was simply disabled.
+"""
+from unittest.mock import patch
+
+from hermes_cli.mcp_startup import (
+    _CAUSE_MAX_CHARS,
+    _CAUSE_MAX_SERVERS,
+    _format_zero_connected_causes,
+)
+
+
+def _entry(name, status, *, error=None, connected=False):
+    e = {"name": name, "status": status, "connected": connected, "tools": 0}
+    if error is not None:
+        e["error"] = error
+    return e
+
+
+class TestZeroConnectedCauses:
+    def test_names_each_server_and_its_cause(self):
+        out = _format_zero_connected_causes([
+            _entry("calendar", "failed", error="401 Unauthorized"),
+            _entry("maps", "connecting"),
+            _entry("docs", "disabled"),
+        ])
+
+        assert "calendar [failed]: 401 Unauthorized" in out
+        assert "maps [connecting]" in out
+        assert "docs [disabled]" in out
+
+    def test_distinguishes_failure_from_never_started(self):
+        """The whole point: 'failed' and 'configured' must not read alike."""
+        out = _format_zero_connected_causes([
+            _entry("a", "failed", error="handshake timed out"),
+            _entry("b", "configured"),
+        ])
+
+        assert "a [failed]: handshake timed out" in out
+        assert "b [configured]" in out
+        assert "b [configured]:" not in out  # no empty cause tail
+
+    def test_connected_entries_are_skipped(self):
+        out = _format_zero_connected_causes([
+            _entry("live", "connected", connected=True),
+            _entry("dead", "failed", error="refused"),
+        ])
+
+        assert "live" not in out
+        assert "dead [failed]: refused" in out
+
+    def test_returns_empty_when_nothing_to_add(self):
+        """An empty add-on keeps the caller's original message intact."""
+        assert _format_zero_connected_causes([]) == ""
+        assert _format_zero_connected_causes(None) == ""
+        assert _format_zero_connected_causes([_entry("x", "connected", connected=True)]) == ""
+
+    def test_bounds_a_pathological_error_body(self):
+        out = _format_zero_connected_causes([_entry("x", "failed", error="E" * 5000)])
+
+        assert len(out) < _CAUSE_MAX_CHARS + 80
+        assert "…" in out
+
+    def test_bounds_the_server_count(self):
+        entries = [_entry(f"s{i}", "failed", error="boom") for i in range(_CAUSE_MAX_SERVERS + 5)]
+
+        out = _format_zero_connected_causes(entries)
+
+        assert "(+5 more)" in out
+        assert out.count("[failed]") == _CAUSE_MAX_SERVERS
+
+    def test_error_bodies_are_redacted(self):
+        """Causes are provider text — they must not carry a secret into logs."""
+        with patch("agent.redact.redact_sensitive_text", return_value="[redacted]") as red:
+            out = _format_zero_connected_causes(
+                [_entry("x", "failed", error="Bearer sk-live-supersecret rejected")]
+            )
+
+        assert red.called
+        assert "sk-live-supersecret" not in out
+        assert "[redacted]" in out
+
+    def test_withholds_the_body_when_redaction_is_unavailable(self):
+        """Fail closed: no redactor means no error body, not a raw dump."""
+        with patch("agent.redact.redact_sensitive_text", side_effect=RuntimeError("gone")):
+            out = _format_zero_connected_causes(
+                [_entry("x", "failed", error="token sk-live-supersecret")]
+            )
+
+        assert "sk-live-supersecret" not in out
+        assert "redaction unavailable" in out
+
+    def test_never_raises_on_malformed_status(self):
+        """A diagnostics helper must not be able to break startup."""
+        assert _format_zero_connected_causes(["not-a-dict", None, 42]) == ""
+        assert _format_zero_connected_causes([{"connected": False}]) == " — ? [unknown]"
+
+    def test_newlines_are_flattened(self):
+        out = _format_zero_connected_causes([_entry("x", "failed", error="line1\nline2")])
+
+        assert "\n" not in out
+        assert "line1 line2" in out

--- a/tests/hermes_cli/test_mcp_zero_connected_causes.py
+++ b/tests/hermes_cli/test_mcp_zero_connected_causes.py
@@ -1,0 +1,181 @@
+"""The zero-connected discovery warning must name why each server is out (#80938).
+
+`get_mcp_status()` already records why every configured server is not
+connected — a per-server ``status`` plus a recorded ``error`` for failures —
+but the background-discovery warning threw all of it away and logged one
+generic line. Operators could not tell an auth failure from a server that
+never started, or from one that was simply disabled.
+"""
+import logging
+import threading
+from unittest.mock import patch
+
+import hermes_cli.mcp_startup as mcp_startup
+
+# Resolved at call time, not import time: a module-level import of the new
+# symbols would turn "the fix is missing" into a collection error for the whole
+# file, which proves nothing about behaviour.
+_CAUSE_MAX_CHARS = getattr(mcp_startup, "_CAUSE_MAX_CHARS", 160)
+_CAUSE_MAX_SERVERS = getattr(mcp_startup, "_CAUSE_MAX_SERVERS", 10)
+
+
+def _format_zero_connected_causes(status):
+    return mcp_startup._format_zero_connected_causes(status)
+
+
+def _entry(name, status, *, error=None, connected=False):
+    e = {"name": name, "status": status, "connected": connected, "tools": 0}
+    if error is not None:
+        e["error"] = error
+    return e
+
+
+class TestZeroConnectedCauses:
+    def test_names_each_server_and_its_cause(self):
+        out = _format_zero_connected_causes([
+            _entry("calendar", "failed", error="401 Unauthorized"),
+            _entry("maps", "connecting"),
+            _entry("docs", "disabled"),
+        ])
+
+        assert "calendar [failed]: 401 Unauthorized" in out
+        assert "maps [connecting]" in out
+        assert "docs [disabled]" in out
+
+    def test_distinguishes_failure_from_never_started(self):
+        """The whole point: 'failed' and 'configured' must not read alike."""
+        out = _format_zero_connected_causes([
+            _entry("a", "failed", error="handshake timed out"),
+            _entry("b", "configured"),
+        ])
+
+        assert "a [failed]: handshake timed out" in out
+        assert "b [configured]" in out
+        assert "b [configured]:" not in out  # no empty cause tail
+
+    def test_connected_entries_are_skipped(self):
+        out = _format_zero_connected_causes([
+            _entry("live", "connected", connected=True),
+            _entry("dead", "failed", error="refused"),
+        ])
+
+        assert "live" not in out
+        assert "dead [failed]: refused" in out
+
+    def test_returns_empty_when_nothing_to_add(self):
+        """An empty add-on keeps the caller's original message intact."""
+        assert _format_zero_connected_causes([]) == ""
+        assert _format_zero_connected_causes(None) == ""
+        assert _format_zero_connected_causes([_entry("x", "connected", connected=True)]) == ""
+
+    def test_bounds_a_pathological_error_body(self):
+        out = _format_zero_connected_causes([_entry("x", "failed", error="E" * 5000)])
+
+        assert len(out) < _CAUSE_MAX_CHARS + 80
+        assert "…" in out
+
+    def test_bounds_the_server_count(self):
+        entries = [_entry(f"s{i}", "failed", error="boom") for i in range(_CAUSE_MAX_SERVERS + 5)]
+
+        out = _format_zero_connected_causes(entries)
+
+        assert "(+5 more)" in out
+        assert out.count("[failed]") == _CAUSE_MAX_SERVERS
+
+    def test_error_bodies_are_redacted(self):
+        """Causes are provider text — they must not carry a secret into logs."""
+        with patch("agent.redact.redact_sensitive_text", return_value="[redacted]") as red:
+            out = _format_zero_connected_causes(
+                [_entry("x", "failed", error="Bearer sk-live-supersecret rejected")]
+            )
+
+        assert red.called
+        assert "sk-live-supersecret" not in out
+        assert "[redacted]" in out
+
+    def test_withholds_the_body_when_redaction_is_unavailable(self):
+        """Fail closed: no redactor means no error body, not a raw dump."""
+        with patch("agent.redact.redact_sensitive_text", side_effect=RuntimeError("gone")):
+            out = _format_zero_connected_causes(
+                [_entry("x", "failed", error="token sk-live-supersecret")]
+            )
+
+        assert "sk-live-supersecret" not in out
+        assert "redaction unavailable" in out
+
+    def test_never_raises_on_malformed_status(self):
+        """A diagnostics helper must not be able to break startup."""
+        assert _format_zero_connected_causes(["not-a-dict", None, 42]) == ""
+        assert _format_zero_connected_causes([{"connected": False}]) == " — ? [unknown]"
+
+    def test_newlines_are_flattened(self):
+        out = _format_zero_connected_causes([_entry("x", "failed", error="line1\nline2")])
+
+        assert "\n" not in out
+        assert "line1 line2" in out
+
+
+class TestWarningNamesTheCauses:
+    """The integration point: the warning the operator actually reads.
+
+    The unit tests above pin the formatter; this one pins that the discovery
+    thread feeds it the live status and logs the result. Reverting the fix
+    leaves the generic line here, so this fails on the message, not on an
+    import.
+    """
+
+    def _run_discovery(self, status):
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        logger = logging.getLogger("test.mcp_startup.zero_connected")
+        logger.setLevel(logging.DEBUG)
+        logger.handlers = [_Capture()]
+        logger.propagate = False
+
+        done = threading.Event()
+        real_thread = threading.Thread
+
+        def _tracking_thread(*args, **kwargs):
+            t = real_thread(*args, **kwargs)
+            original = t.run
+
+            def _run():
+                try:
+                    original()
+                finally:
+                    done.set()
+
+            t.run = _run
+            return t
+
+        with patch.object(mcp_startup, "_has_configured_mcp_servers", return_value=True), \
+                patch.object(mcp_startup, "_discover_mcp_tools_without_interactive_oauth"), \
+                patch.object(mcp_startup, "_any_mcp_connected", return_value=False), \
+                patch("tools.mcp_tool_discovery.get_mcp_status", return_value=status), \
+                patch.object(mcp_startup.threading, "Thread", _tracking_thread):
+            mcp_startup._mcp_discovery_thread = None
+            mcp_startup.start_background_mcp_discovery(
+                logger=logger, thread_name="test-mcp-discovery")
+        assert done.wait(10), "discovery thread did not finish"
+        return [m for m in records if "zero" in m]
+
+    def test_the_warning_carries_the_per_server_cause(self):
+        warnings = self._run_discovery([
+            _entry("github", "failed", error="401 Unauthorized"),
+            _entry("notion", "configured"),
+        ])
+
+        assert warnings, "no zero-connected warning was logged"
+        message = warnings[0]
+        assert "github" in message and "401 Unauthorized" in message, message
+        assert "notion" in message and "configured" in message, message
+
+    def test_the_warning_still_reads_cleanly_with_nothing_to_add(self):
+        warnings = self._run_discovery([])
+
+        assert warnings, "no zero-connected warning was logged"
+        assert warnings[0].rstrip().endswith("zero connected servers"), warnings[0]


### PR DESCRIPTION
## What does this PR do?

Background MCP discovery already knows why every configured server is out. `get_mcp_status()` carries a per-server `status` (`failed` / `connecting` / `disabled` / `configured`) plus the recorded `error` for failures. The zero-connected warning threw all of it away:

```python
if not any(entry.get("connected") for entry in status):
    logger.warning(
        "Background MCP discovery completed with zero connected servers"
    )
```

One generic line. No way to tell an auth rejection from a server binary that was never on PATH, from one the operator switched off on purpose — at the only point an operator actually sees.

Before:

```
Background MCP discovery completed with zero connected servers
```

After:

```
Background MCP discovery completed with zero connected servers — calendar [failed]: 401
Unauthorized from https://api.example.com; maps [connecting]; docs [disabled]; search
[failed]: stdio server exited with code 127 (command not found)
```

### The shape of the fix

`_format_zero_connected_causes()` is a pure module-level helper, so the rendering is testable without threads or a live MCP stack. Three properties it has to hold, each pinned by a test:

- **Bounded.** Per-cause text caps at 160 chars and the list caps at 10 servers with a `(+N more)` tail, so one wrapped traceback cannot turn a startup warning into a log flood.
- **Redacted.** Cause bodies are provider-authored text, so they go through `redact_sensitive_text` before reaching a log. If the redactor cannot be imported, the body is **withheld** rather than written raw — fail closed, since the alternative is a token in a log file.
- **Total.** Malformed entries, a missing name, an empty list — all degrade to `""`, which leaves the caller's message byte-identical, instead of raising. A diagnostics helper must not be able to break startup.

## Related Issue

Refs #80938 (P2, `comp/tools`, `tool/mcp`).

**Deliberately scoped to one half of that issue.** #80938 asks for two things; the other one — raising the `MCP SDK not available` line from `DEBUG` to `WARNING` — is already proposed in **#46922** (open). This PR does not touch that path, so the two do not collide and either can merge first.

Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "80938"                    --limit 10   # 0
gh search prs --repo NousResearch/hermes-agent "MCP discovery diagnostics" --limit 10   # 0
gh search prs --repo NousResearch/hermes-agent "mcp sdk unavailable"       --limit 10   # only #46922
```

I also diffed #46922 to confirm the split is real: it contains zero references to `_server_connect_errors`, per-server causes, or the zero-connected warning.

## Type of Change

Bug fix (non-breaking) — diagnostics only; no behavioural change to discovery itself.

## Changes Made

- `hermes_cli/mcp_startup.py` — added `_format_zero_connected_causes(status)` plus the `_CAUSE_MAX_CHARS` / `_CAUSE_MAX_SERVERS` bounds; the zero-connected warning now appends its result.
- `tests/hermes_cli/test_mcp_zero_connected_causes.py` — new, 10 tests.

## How to Test

```
pytest tests/hermes_cli/test_mcp_zero_connected_causes.py -q
```

10 passed. They cover: each server named with its cause; `failed` vs `configured` not reading alike; connected entries skipped; empty add-on when there is nothing to say; the 160-char body bound; the 10-server bound with its `(+N more)` tail; redaction called and the secret absent from the output; the withheld-body path when redaction is unavailable; malformed status never raising; newlines flattened.

```
pytest tests/hermes_cli/ tests/tools/ -q -k "mcp or startup"
```

584 passed — the existing MCP suites are unaffected.

Because the helper is new code rather than an edited branch, the before/after proof is the direct rendering comparison shown above, run against the issue's own scenario (one auth failure, one still-connecting, one disabled, one bad stdio command).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mcp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the helper's docstring records what each bucket means and why the bounds and redaction exist
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, string formatting
- [x] Tool descriptions/schemas — N/A

## Notes for the reviewer

The bounds are deliberately conservative (160 chars × 10 servers) because this is a startup-path warning that fires once per discovery. If you would rather see full causes and trust the redactor, raising `_CAUSE_MAX_CHARS` is a one-line change — I picked the cautious default because an MCP connect error can carry a wrapped provider response.

`disabled` servers are listed rather than filtered out. An operator staring at "zero connected" usually wants to be told that three of their four servers are off on purpose; suppressing them would leave the same "why is nothing here" question this change exists to answer.
