### PR TITLE
docs(discord): fix permission integer table and invite URL

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -188,7 +188,7 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 You can construct the invite URL directly using this format:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878286912
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878024768
 ```
 
 Replace `YOUR_APP_ID` with the Application ID from Step 1.
@@ -212,8 +212,8 @@ These are the minimum permissions your bot needs:
 
 | Level | Permissions Integer | What's Included |
 |-------|-------------------|-----------------|
-| Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files |
-| Recommended | `274878286912` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
+| Minimal | `117760` | View Channels, Send Messages, Embed Links, Attach Files, Read Message History |
+| Recommended | `274878024768` | All of the above plus Send Messages in Threads, Add Reactions |
 
 ## Step 6: Invite to Your Server
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
@@ -211,7 +211,7 @@ https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+application
 
 | 级别 | 权限整数 | 包含内容 |
 |-------|-------------------|-----------------|
-| 最低 | `117760` | View Channels、Send Messages、Read Message History、Attach Files |
+| 最低 | `117760` | View Channels、Send Messages、Embed Links、Attach Files、Read Message History |
 | 推荐 | `309237763136` | 以上所有权限，加上 Embed Links、Send Messages in Threads、Add Reactions, Create Public Threads |
 
 ## 第六步：邀请到你的服务器


### PR DESCRIPTION
## Summary

Align the Discord permissions table with the Required/Recommended bullet lists in the same file:

- Minimal row now includes Embed Links (that bit is already inside 117760, the text just understated it)
- Recommended integer drops unlisted USE_EXTERNAL_EMOJIS (274878286912 -> 274878024768) and no longer double-counts Embed Links
- Manual OAuth invite URL updated to match
- Minor zh-Hans minimal-row text sync

## Notes

- Docs-only change: 2 files, 4 lines.
- Verified the corrected integer against Discord's permission bit math before opening.

Fixes #73657
