### PR TITLE
feat(deepseek): support Responses API native web search

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -716,9 +716,18 @@ def init_agent(
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
     if agent.provider == "deepseek":
-        # DeepSeek is model-dependent: only V4 Flash accepts Responses. Do not
-        # let a stale persisted/explicit mode route V4 Pro to an unsupported
-        # endpoint when AIAgent is constructed outside the runtime resolver.
+        # DeepSeek routing is model-capability-dependent. Do not let a stale
+        # persisted/explicit mode route a model to an unsupported endpoint when
+        # AIAgent is constructed outside the runtime resolver.
+        # Normalize retired aliases before looking up capabilities; the general
+        # normalization pass below otherwise runs too late and could leave a
+        # normalized Responses-capable model on Chat Completions for its first turn.
+        try:
+            from hermes_cli.model_normalize import normalize_model_for_provider
+
+            agent.model = normalize_model_for_provider(agent.model, agent.provider)
+        except Exception:
+            pass
         from hermes_cli.providers import deepseek_api_mode
 
         agent.api_mode = deepseek_api_mode(agent.model)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -715,7 +715,14 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if agent.provider == "deepseek":
+        # DeepSeek is model-dependent: only V4 Flash accepts Responses. Do not
+        # let a stale persisted/explicit mode route V4 Pro to an unsupported
+        # endpoint when AIAgent is constructed outside the runtime resolver.
+        from hermes_cli.providers import deepseek_api_mode
+
+        agent.api_mode = deepseek_api_mode(agent.model)
+    elif api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -773,6 +780,16 @@ def init_agent(
             agent.api_mode = _mandated
         else:
             agent.api_mode = "chat_completions"
+
+    if agent.provider == "deepseek":
+        from hermes_cli.providers import normalize_deepseek_base_url
+
+        agent.base_url = normalize_deepseek_base_url(
+            agent.provider, agent.api_mode, agent.base_url
+        )
+        # The explicit-client branch below still reads the constructor-local
+        # value, so keep it aligned with the normalized agent property.
+        base_url = agent.base_url
 
     # Credential-pool validation runs AFTER provider auto-detection so
     # a pool scoped to e.g. "anthropic" is not rejected when the agent

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -625,7 +625,14 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if agent.provider == "deepseek":
+        # DeepSeek is model-dependent: only V4 Flash accepts Responses. Do not
+        # let a stale persisted/explicit mode route V4 Pro to an unsupported
+        # endpoint when AIAgent is constructed outside the runtime resolver.
+        from hermes_cli.providers import deepseek_api_mode
+
+        agent.api_mode = deepseek_api_mode(agent.model)
+    elif api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -664,6 +671,16 @@ def init_agent(
         agent.api_mode = nous_api_mode(agent.model)
     else:
         agent.api_mode = "chat_completions"
+
+    if agent.provider == "deepseek":
+        from hermes_cli.providers import normalize_deepseek_base_url
+
+        agent.base_url = normalize_deepseek_base_url(
+            agent.provider, agent.api_mode, agent.base_url
+        )
+        # The explicit-client branch below still reads the constructor-local
+        # value, so keep it aligned with the normalized agent property.
+        base_url = agent.base_url
 
     # Credential-pool validation runs AFTER provider auto-detection so
     # a pool scoped to e.g. "anthropic" is not rejected when the agent

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -626,9 +626,9 @@ def init_agent(
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
     if agent.provider == "deepseek":
-        # DeepSeek is model-dependent: only V4 Flash accepts Responses. Do not
-        # let a stale persisted/explicit mode route V4 Pro to an unsupported
-        # endpoint when AIAgent is constructed outside the runtime resolver.
+        # DeepSeek routing is model-capability-dependent. Do not let a stale
+        # persisted/explicit mode route a model to an unsupported endpoint when
+        # AIAgent is constructed outside the runtime resolver.
         from hermes_cli.providers import deepseek_api_mode
 
         agent.api_mode = deepseek_api_mode(agent.model)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2736,7 +2736,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     change persists across turns (unlike fallback which is
     turn-scoped).
     """
-    from hermes_cli.providers import determine_api_mode
+    from hermes_cli.providers import (
+        deepseek_api_mode,
+        determine_api_mode,
+        normalize_deepseek_base_url,
+    )
 
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
@@ -2744,6 +2748,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # openai_chat overlay default.
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
+    if str(new_provider or "").strip().lower() == "deepseek":
+        # DeepSeek is dual-wire by model. Do not trust a stale mode supplied by
+        # a direct caller when switching Flash <-> Pro.
+        api_mode = deepseek_api_mode(new_model)
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to
@@ -2759,6 +2767,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         and base_url
     ):
         base_url = re.sub(r"/v1/?$", "", base_url)
+
+    # Direct runtime callers do not necessarily pass through
+    # hermes_cli.model_switch, so keep DeepSeek's model-dependent official
+    # endpoint paired with the selected wire here as well.
+    base_url = normalize_deepseek_base_url(new_provider, api_mode, base_url)
 
     old_model = agent.model
     old_provider = agent.provider

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2750,7 +2750,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
     if str(new_provider or "").strip().lower() == "deepseek":
         # DeepSeek is dual-wire by model. Do not trust a stale mode supplied by
-        # a direct caller when switching Flash <-> Pro.
+        # a direct caller when switching Flash <-> Pro. Direct callers may
+        # also bypass the CLI's model normalizer, so canonicalize retired
+        # aliases before both capability lookup and assignment.
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        new_model = normalize_model_for_provider(new_model, "deepseek")
         api_mode = deepseek_api_mode(new_model)
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2372,7 +2372,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     change persists across turns (unlike fallback which is
     turn-scoped).
     """
-    from hermes_cli.providers import determine_api_mode
+    from hermes_cli.providers import (
+        deepseek_api_mode,
+        determine_api_mode,
+        normalize_deepseek_base_url,
+    )
 
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
@@ -2380,6 +2384,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # openai_chat overlay default.
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
+    if str(new_provider or "").strip().lower() == "deepseek":
+        # DeepSeek is dual-wire by model. Do not trust a stale mode supplied by
+        # a direct caller when switching Flash <-> Pro.
+        api_mode = deepseek_api_mode(new_model)
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to
@@ -2393,6 +2401,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         and base_url
     ):
         base_url = re.sub(r"/v1/?$", "", base_url)
+
+    # Direct runtime callers do not necessarily pass through
+    # hermes_cli.model_switch, so keep DeepSeek's model-dependent official
+    # endpoint paired with the selected wire here as well.
+    base_url = normalize_deepseek_base_url(new_provider, api_mode, base_url)
 
     old_model = agent.model
     old_provider = agent.provider

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2643,7 +2643,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
 
         if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
-            if fb_provider == "openai-codex":
+            if fb_provider == "deepseek":
+                from hermes_cli.providers import deepseek_api_mode
+
+                fb_api_mode = deepseek_api_mode(fb_model)
+            elif fb_provider == "openai-codex":
                 fb_api_mode = "codex_responses"
             elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
                 # Portal is dual-wire: anthropic/* must land on /v1/messages.
@@ -2682,6 +2686,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 and base_url_host_matches(fb_base_url, "amazonaws.com")
             ):
                 fb_api_mode = "bedrock_converse"
+
+        if fb_provider == "deepseek":
+            from hermes_cli.providers import normalize_deepseek_base_url
+
+            fb_base_url = normalize_deepseek_base_url(
+                fb_provider,
+                fb_api_mode,
+                fb_base_url,
+            )
 
         old_model = agent.model
         old_provider = agent.provider
@@ -2763,6 +2776,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # Swap OpenAI client and config in-place
             agent.api_key = fb_client.api_key
             agent.client = fb_client
+            _fb_client_base_url = str(getattr(fb_client, "base_url", "") or "").rstrip("/")
+            _fb_route_changed = _fb_client_base_url != fb_base_url.rstrip("/")
             # Preserve provider-specific headers that
             # resolve_provider_client() may have baked into
             # fb_client via the default_headers kwarg.  The OpenAI
@@ -2781,10 +2796,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             }
             if _fb_timeout is not None:
                 agent._client_kwargs["timeout"] = _fb_timeout
-                # Rebuild the shared OpenAI client so the configured
-                # timeout takes effect on the very next fallback request,
-                # not only after a later credential-rotation rebuild.
-                agent._replace_primary_openai_client(reason="fallback_timeout_apply")
+            if _fb_route_changed or _fb_timeout is not None:
+                # Rebuild the shared OpenAI client so endpoint normalization
+                # and/or the configured timeout take effect on the very next
+                # fallback request, not only after a later credential rotation.
+                agent._replace_primary_openai_client(
+                    reason=(
+                        "fallback_timeout_apply"
+                        if _fb_timeout is not None
+                        else "fallback_route_apply"
+                    )
+                )
 
         from agent.agent_runtime_helpers import sync_credential_pool_entry_id
         sync_credential_pool_entry_id(agent)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1890,6 +1890,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        from hermes_cli.providers import deepseek_supports_responses
+
+        is_deepseek_responses = (
+            agent.provider == "deepseek"
+            and deepseek_supports_responses(agent.model)
+        )
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # Native server-side compaction (gpt-5.6 on direct OpenAI API /
@@ -1950,9 +1956,11 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_deepseek_responses=is_deepseek_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
-            replay_encrypted_reasoning=bool(
-                getattr(agent, "_codex_reasoning_replay_enabled", True)
+            replay_encrypted_reasoning=(
+                not is_deepseek_responses
+                and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
             ),
             context_management=_context_management,
         )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1959,6 +1959,8 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_deepseek_responses=is_deepseek_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
             replay_encrypted_reasoning=(
+                # DeepSeek supports plain reasoning input but not OpenAI's
+                # encrypted_content continuation envelope.
                 not is_deepseek_responses
                 and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
             ),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1389,6 +1389,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        from hermes_cli.providers import deepseek_supports_responses
+
+        is_deepseek_responses = (
+            agent.provider == "deepseek"
+            and deepseek_supports_responses(agent.model)
+        )
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -1437,9 +1443,11 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_deepseek_responses=is_deepseek_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
-            replay_encrypted_reasoning=bool(
-                getattr(agent, "_codex_reasoning_replay_enabled", True)
+            replay_encrypted_reasoning=(
+                not is_deepseek_responses
+                and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
             ),
         )
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2055,6 +2055,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
+        elif fb_provider == "deepseek":
+            from hermes_cli.providers import (
+                deepseek_api_mode,
+                normalize_deepseek_base_url,
+            )
+
+            fb_api_mode = deepseek_api_mode(fb_model)
+            fb_base_url = normalize_deepseek_base_url(
+                fb_provider,
+                fb_api_mode,
+                fb_base_url,
+            )
         elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
             # Portal is dual-wire: anthropic/* must land on /v1/messages.
             # resolve_provider_client still returns an OpenAI client for
@@ -2171,6 +2183,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # Swap OpenAI client and config in-place
             agent.api_key = fb_client.api_key
             agent.client = fb_client
+            _fb_client_base_url = str(getattr(fb_client, "base_url", "") or "").rstrip("/")
+            _fb_route_changed = _fb_client_base_url != fb_base_url.rstrip("/")
             # Preserve provider-specific headers that
             # resolve_provider_client() may have baked into
             # fb_client via the default_headers kwarg.  The OpenAI
@@ -2189,10 +2203,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             }
             if _fb_timeout is not None:
                 agent._client_kwargs["timeout"] = _fb_timeout
-                # Rebuild the shared OpenAI client so the configured
-                # timeout takes effect on the very next fallback request,
-                # not only after a later credential-rotation rebuild.
-                agent._replace_primary_openai_client(reason="fallback_timeout_apply")
+            if _fb_route_changed or _fb_timeout is not None:
+                # Rebuild the shared OpenAI client so endpoint normalization
+                # and/or the configured timeout take effect on the very next
+                # fallback request, not only after a later credential rotation.
+                agent._replace_primary_openai_client(
+                    reason=(
+                        "fallback_timeout_apply"
+                        if _fb_timeout is not None
+                        else "fallback_route_apply"
+                    )
+                )
 
         from agent.agent_runtime_helpers import sync_credential_pool_entry_id
         sync_credential_pool_entry_id(agent)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -448,6 +448,43 @@ _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 _MAX_RESPONSES_ITEM_ID_LENGTH = 64
 
 
+def _json_safe_responses_item(value: Any) -> Any:
+    """Convert an SDK Responses item into JSON-safe replay data.
+
+    DeepSeek's stateless native tools require the returned ``web_search_call``
+    item on later turns. Preserve provider-added action fields while dropping
+    private Python attributes and non-serializable values.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe_responses_item(item)
+            for key, item in value.items()
+            if not str(key).startswith("_") and item is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_responses_item(item) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _json_safe_responses_item(model_dump(exclude_none=True))
+        except TypeError:
+            return _json_safe_responses_item(model_dump())
+    raw = getattr(value, "__dict__", None)
+    if isinstance(raw, dict):
+        return _json_safe_responses_item(raw)
+    return str(value)
+
+
+def _normalize_server_tool_replay_item(raw_item: Any) -> Optional[Dict[str, Any]]:
+    """Return a safe server-side tool item accepted as later Responses input."""
+    item = _json_safe_responses_item(raw_item)
+    if not isinstance(item, dict) or item.get("type") != "web_search_call":
+        return None
+    return item
+
+
 def _normalize_responses_message_status(value: Any, *, default: str = "completed") -> str:
     """Normalize a Responses assistant message status for replay.
 
@@ -642,6 +679,11 @@ def _chat_messages_to_responses_input(
                 if isinstance(codex_message_items, list):
                     for raw_item in codex_message_items:
                         if not isinstance(raw_item, dict):
+                            continue
+                        if raw_item.get("type") == "web_search_call":
+                            replay_item = _normalize_server_tool_replay_item(raw_item)
+                            if replay_item is not None:
+                                items.append(replay_item)
                             continue
                         if raw_item.get("type") != "message" or raw_item.get("role") != "assistant":
                             continue
@@ -1491,7 +1533,13 @@ def _normalize_codex_response(
             has_incomplete_items = True
             saw_streaming_or_item_incomplete = True
 
-        if item_type == "message":
+        if item_type == "web_search_call":
+            raw_server_item = _normalize_server_tool_replay_item(item)
+            if raw_server_item is not None:
+                # Keep it in the same ordered output-item carrier as assistant
+                # messages so replay preserves search-call-before-answer order.
+                message_items_raw.append(raw_server_item)
+        elif item_type == "message":
             item_phase = getattr(item, "phase", None)
             normalized_phase = None
             is_commentary_phase = False

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -468,9 +468,16 @@ def _json_safe_responses_item(value: Any) -> Any:
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
         try:
-            return _json_safe_responses_item(model_dump(exclude_none=True))
+            return _json_safe_responses_item(
+                model_dump(mode="json", exclude_none=True, warnings=False)
+            )
         except TypeError:
-            return _json_safe_responses_item(model_dump())
+            try:
+                return _json_safe_responses_item(
+                    model_dump(mode="json", exclude_none=True)
+                )
+            except TypeError:
+                return _json_safe_responses_item(model_dump())
     raw = getattr(value, "__dict__", None)
     if isinstance(raw, dict):
         return _json_safe_responses_item(raw)
@@ -964,6 +971,17 @@ def _preflight_codex_input_items(
                     "output": sanitize_text(output),
                 }
             )
+            continue
+
+        if item_type == "web_search_call":
+            # DeepSeek's Responses API is stateless and requires each search
+            # call output item to be passed back as-is so it can restore the
+            # server-held search result.  Preserve provider-added action
+            # fields (queries/sources/open-page metadata) while stripping only
+            # private/non-JSON Python state in the shared normalizer.
+            replay_item = _normalize_server_tool_replay_item(item)
+            if replay_item is not None:
+                normalized.append(replay_item)
             continue
 
         if item_type == "reasoning":

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -393,6 +393,43 @@ _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 _MAX_RESPONSES_ITEM_ID_LENGTH = 64
 
 
+def _json_safe_responses_item(value: Any) -> Any:
+    """Convert an SDK Responses item into JSON-safe replay data.
+
+    DeepSeek's stateless native tools require the returned ``web_search_call``
+    item on later turns. Preserve provider-added action fields while dropping
+    private Python attributes and non-serializable values.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe_responses_item(item)
+            for key, item in value.items()
+            if not str(key).startswith("_") and item is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_responses_item(item) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _json_safe_responses_item(model_dump(exclude_none=True))
+        except TypeError:
+            return _json_safe_responses_item(model_dump())
+    raw = getattr(value, "__dict__", None)
+    if isinstance(raw, dict):
+        return _json_safe_responses_item(raw)
+    return str(value)
+
+
+def _normalize_server_tool_replay_item(raw_item: Any) -> Optional[Dict[str, Any]]:
+    """Return a safe server-side tool item accepted as later Responses input."""
+    item = _json_safe_responses_item(raw_item)
+    if not isinstance(item, dict) or item.get("type") != "web_search_call":
+        return None
+    return item
+
+
 def _normalize_responses_message_status(value: Any, *, default: str = "completed") -> str:
     """Normalize a Responses assistant message status for replay.
 
@@ -547,6 +584,11 @@ def _chat_messages_to_responses_input(
                 if isinstance(codex_message_items, list):
                     for raw_item in codex_message_items:
                         if not isinstance(raw_item, dict):
+                            continue
+                        if raw_item.get("type") == "web_search_call":
+                            replay_item = _normalize_server_tool_replay_item(raw_item)
+                            if replay_item is not None:
+                                items.append(replay_item)
                             continue
                         if raw_item.get("type") != "message" or raw_item.get("role") != "assistant":
                             continue
@@ -1343,7 +1385,13 @@ def _normalize_codex_response(
             has_incomplete_items = True
             saw_streaming_or_item_incomplete = True
 
-        if item_type == "message":
+        if item_type == "web_search_call":
+            raw_server_item = _normalize_server_tool_replay_item(item)
+            if raw_server_item is not None:
+                # Keep it in the same ordered output-item carrier as assistant
+                # messages so replay preserves search-call-before-answer order.
+                message_items_raw.append(raw_server_item)
+        elif item_type == "message":
             item_phase = getattr(item, "phase", None)
             normalized_phase = None
             is_commentary_phase = False

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -487,6 +487,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ids (e.g. via custom endpoints).
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
     "deepseek-v4-pro": 1_000_000,
+    "deepseek-v4-flash-vision-exp": 1_000_000,
     "deepseek-v4-flash": 1_000_000,
     "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000,

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -129,6 +129,16 @@ GLM53_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 DEEPSEEK_V4_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
 DEEPSEEK_V4_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
+#: DeepSeek Responses API accepts none/low/high/max. Its documented mapping
+#: promotes medium to high and maps xhigh to high; ``none`` disables thinking.
+DEEPSEEK_RESPONSES_EFFORTS: tuple[str, ...] = ("none", "low", "high", "max")
+DEEPSEEK_RESPONSES_OVERRIDES: dict[str, str] = {
+    "minimal": "low",
+    "medium": "high",
+    "xhigh": "high",
+    "ultra": "max",
+}
+
 #: Ollama Cloud /v1/chat/completions: accepts {none, low, medium, high, max};
 #: rejects ``minimal`` with HTTP 400. ``xhigh`` requests the top tier.
 OLLAMA_CLOUD_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "max")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -594,6 +594,18 @@ class ResponsesApiTransport(ProviderTransport):
                 XAI_GROK46_EFFORTS if is_grok_46_family(model)
                 else XAI_LEGACY_EFFORTS
             )
+        elif is_deepseek_responses:
+            from agent.reasoning_effort import (
+                DEEPSEEK_RESPONSES_EFFORTS,
+                DEEPSEEK_RESPONSES_OVERRIDES,
+            )
+
+            _supported = DEEPSEEK_RESPONSES_EFFORTS
+            reasoning_effort = clamp_effort(
+                reasoning_effort,
+                _supported,
+                DEEPSEEK_RESPONSES_OVERRIDES,
+            )
         elif (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends:
             # none/low/medium/high/max.
@@ -603,7 +615,8 @@ class ResponsesApiTransport(ProviderTransport):
             # (live-verified: "max" is gpt-5.6-only, "minimal" always
             # rejected). #68365 premise confirmed.
             _supported = codex_supported_efforts(model)
-        reasoning_effort = clamp_effort(reasoning_effort, _supported)
+        if not is_deepseek_responses:
+            reasoning_effort = clamp_effort(reasoning_effort, _supported)
 
         response_tools = _responses_tools(tools)
 
@@ -789,6 +802,11 @@ class ResponsesApiTransport(ProviderTransport):
             and not is_deepseek_responses
         ):
             kwargs["include"] = []
+        elif is_deepseek_responses:
+            # DeepSeek thinking is enabled by default. Omitting ``reasoning``
+            # therefore does not honor reasoning.enabled=false; ``none`` is
+            # the provider's explicit Responses API disable value.
+            kwargs["reasoning"] = {"effort": "none"}
 
         request_overrides = params.get("request_overrides")
         if request_overrides:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -512,7 +512,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
-            is_deepseek_responses: bool — DeepSeek V4 Flash Responses backend
+            is_deepseek_responses: bool — capability-enabled DeepSeek Responses backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -535,6 +535,11 @@ class ResponsesApiTransport(ProviderTransport):
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
         is_deepseek_responses = params.get("is_deepseek_responses") is True
+        deepseek_native_web_search = False
+        if is_deepseek_responses:
+            from hermes_cli.providers import deepseek_supports_native_web_search
+
+            deepseek_native_web_search = deepseek_supports_native_web_search(model)
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -661,6 +666,7 @@ class ResponsesApiTransport(ProviderTransport):
         # configured Firecrawl/Tavily/etc. backend remains client-dispatched.
         if (
             is_deepseek_responses
+            and deepseek_native_web_search
             and response_tools
             and _deepseek_native_web_search_enabled()
         ):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -135,6 +135,69 @@ def _xai_prefers_native_web_search() -> bool:
         return True
 
 
+def _deepseek_prefers_native_web_search() -> bool:
+    """True only when the user explicitly selected DeepSeek web search.
+
+    Unlike xAI's collision workaround, DeepSeek native search is opt-in because
+    it can consume substantial server-side tokens. Merely having a DeepSeek API
+    key must not make the plugin registry auto-select this server-side tool.
+    """
+    try:
+        from agent.web_search_registry import (
+            _read_config_key,
+            get_active_search_provider,
+        )
+
+        configured = (
+            _read_config_key("web", "search_backend")
+            or _read_config_key("web", "backend")
+            or ""
+        ).strip().lower()
+        if configured != "deepseek":
+            return False
+
+        # Require the marker plugin to be enabled and registered as well.
+        provider = get_active_search_provider()
+        return getattr(provider, "name", None) == "deepseek"
+    except Exception:
+        return False
+
+
+def _sanitize_deepseek_responses_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove OpenAI-only Responses fields rejected by DeepSeek."""
+    for key in (
+        "include",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "service_tier",
+    ):
+        kwargs.pop(key, None)
+
+    reasoning = kwargs.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if effort:
+            kwargs["reasoning"] = {"effort": effort}
+        else:
+            kwargs.pop("reasoning", None)
+
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        cleaned = dict(extra_body)
+        for key in (
+            "include",
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "service_tier",
+        ):
+            cleaned.pop(key, None)
+        if cleaned:
+            kwargs["extra_body"] = cleaned
+        else:
+            kwargs.pop("extra_body", None)
+    return kwargs
+
+
 def _rename_client_web_search_for_xai(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Rename client ``web_search`` → alias so xAI won't hijack it server-side."""
     rewritten: List[Dict[str, Any]] = []
@@ -428,6 +491,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
+            is_deepseek_responses: bool — DeepSeek V4 Flash Responses backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -449,6 +513,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_deepseek_responses = params.get("is_deepseek_responses") is True
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -557,6 +622,36 @@ class ResponsesApiTransport(ProviderTransport):
                 else:
                     response_tools = _rename_client_web_search_for_xai(response_tools)
 
+        # DeepSeek native search is an explicit 1:1 replacement. It is never
+        # added unless Hermes already exposed its web_search function, and a
+        # configured Firecrawl/Tavily/etc. backend remains client-dispatched.
+        if (
+            is_deepseek_responses
+            and response_tools
+            and _deepseek_prefers_native_web_search()
+        ):
+            has_client_web_search = any(
+                isinstance(t, dict)
+                and t.get("type") == "function"
+                and t.get("name") == "web_search"
+                for t in response_tools
+            )
+            if has_client_web_search:
+                response_tools = [
+                    t
+                    for t in response_tools
+                    if not (
+                        isinstance(t, dict)
+                        and t.get("type") == "function"
+                        and t.get("name") == "web_search"
+                    )
+                ]
+                if not any(
+                    isinstance(t, dict) and t.get("type") == "web_search"
+                    for t in response_tools
+                ):
+                    response_tools.append({"type": "web_search"})
+
         # OpenCode Responses backends reserve web_search / search_files as
         # function names (HTTP 400 "custom function name 'X' is reserved",
         # #85589). Alias them on the wire; normalize_response maps them back.
@@ -623,7 +718,12 @@ class ResponsesApiTransport(ProviderTransport):
         ) or _cache_scope
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
-        if not is_github_responses and not is_xai_responses and cache_key:
+        if (
+            not is_github_responses
+            and not is_xai_responses
+            and not is_deepseek_responses
+            and cache_key
+        ):
             kwargs["prompt_cache_key"] = cache_key
 
         cache_retention = _default_prompt_cache_retention_for_request(
@@ -651,7 +751,9 @@ class ResponsesApiTransport(ProviderTransport):
             if grok_supports_reasoning_effort(model):
                 kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
-            if is_github_responses:
+            if is_deepseek_responses:
+                kwargs["reasoning"] = {"effort": reasoning_effort}
+            elif is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
@@ -660,12 +762,19 @@ class ResponsesApiTransport(ProviderTransport):
                 kwargs["include"] = (
                     ["reasoning.encrypted_content"] if replay_encrypted_reasoning else []
                 )
-        elif not is_github_responses and not is_xai_responses:
+        elif (
+            not is_github_responses
+            and not is_xai_responses
+            and not is_deepseek_responses
+        ):
             kwargs["include"] = []
 
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        if is_deepseek_responses:
+            kwargs = _sanitize_deepseek_responses_kwargs(kwargs)
 
         if "prompt_cache_key" in kwargs:
             bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -135,7 +135,7 @@ def _xai_prefers_native_web_search() -> bool:
         return True
 
 
-def _deepseek_prefers_native_web_search() -> bool:
+def _deepseek_native_web_search_enabled() -> bool:
     """True only when the user explicitly selected DeepSeek web search.
 
     Unlike xAI's collision workaround, DeepSeek native search is opt-in because
@@ -157,6 +157,9 @@ def _deepseek_prefers_native_web_search() -> bool:
             return False
 
         # Require the marker plugin to be enabled and registered as well.
+        # Explicit registry resolution intentionally returns registered
+        # providers even when their local ``is_available`` probe is false;
+        # this marker never executes a local request.
         provider = get_active_search_provider()
         return getattr(provider, "name", None) == "deepseek"
     except Exception:
@@ -164,12 +167,21 @@ def _deepseek_prefers_native_web_search() -> bool:
 
 
 def _sanitize_deepseek_responses_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
-    """Remove OpenAI-only Responses fields rejected by DeepSeek."""
+    """Remove unsupported DeepSeek Responses fields after user overrides."""
     for key in (
+        "background",
+        "context_management",
+        "conversation",
         "include",
+        "metadata",
+        "previous_response_id",
+        "prompt",
         "prompt_cache_key",
         "prompt_cache_retention",
+        "safety_identifier",
         "service_tier",
+        "stream_options",
+        "truncation",
     ):
         kwargs.pop(key, None)
 
@@ -185,10 +197,19 @@ def _sanitize_deepseek_responses_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any
     if isinstance(extra_body, dict):
         cleaned = dict(extra_body)
         for key in (
+            "background",
+            "context_management",
+            "conversation",
             "include",
+            "metadata",
+            "previous_response_id",
+            "prompt",
             "prompt_cache_key",
             "prompt_cache_retention",
+            "safety_identifier",
             "service_tier",
+            "stream_options",
+            "truncation",
         ):
             cleaned.pop(key, None)
         if cleaned:
@@ -628,7 +649,7 @@ class ResponsesApiTransport(ProviderTransport):
         if (
             is_deepseek_responses
             and response_tools
-            and _deepseek_prefers_native_web_search()
+            and _deepseek_native_web_search_enabled()
         ):
             has_client_web_search = any(
                 isinstance(t, dict)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -310,7 +310,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
-            is_deepseek_responses: bool — DeepSeek V4 Flash Responses backend
+            is_deepseek_responses: bool — DeepSeek Responses backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -333,6 +333,11 @@ class ResponsesApiTransport(ProviderTransport):
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
         is_deepseek_responses = params.get("is_deepseek_responses") is True
+        deepseek_native_web_search = False
+        if is_deepseek_responses:
+            from hermes_cli.providers import deepseek_supports_native_web_search
+
+            deepseek_native_web_search = deepseek_supports_native_web_search(model)
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -362,6 +367,9 @@ class ResponsesApiTransport(ProviderTransport):
         if params.get("is_xai_responses", False):
             # xAI Responses tops out at high; keep generic stronger values usable.
             _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+        elif is_deepseek_responses:
+            # DeepSeek accepts max but not Hermes/OpenAI product aliases.
+            _effort_clamp.update({"xhigh": "high", "ultra": "max"})
         if (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends that accept only
             # none/low/medium/high/max for reasoning effort — a forwarded
@@ -413,6 +421,7 @@ class ResponsesApiTransport(ProviderTransport):
         # configured Firecrawl/Tavily/etc. backend remains client-dispatched.
         if (
             is_deepseek_responses
+            and deepseek_native_web_search
             and response_tools
             and _deepseek_prefers_native_web_search()
         ):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -78,6 +78,69 @@ def _xai_prefers_native_web_search() -> bool:
         return True
 
 
+def _deepseek_prefers_native_web_search() -> bool:
+    """True only when the user explicitly selected DeepSeek web search.
+
+    Unlike xAI's collision workaround, DeepSeek native search is opt-in because
+    it can consume substantial server-side tokens. Merely having a DeepSeek API
+    key must not make the plugin registry auto-select this server-side tool.
+    """
+    try:
+        from agent.web_search_registry import (
+            _read_config_key,
+            get_active_search_provider,
+        )
+
+        configured = (
+            _read_config_key("web", "search_backend")
+            or _read_config_key("web", "backend")
+            or ""
+        ).strip().lower()
+        if configured != "deepseek":
+            return False
+
+        # Require the marker plugin to be enabled and registered as well.
+        provider = get_active_search_provider()
+        return getattr(provider, "name", None) == "deepseek"
+    except Exception:
+        return False
+
+
+def _sanitize_deepseek_responses_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove OpenAI-only Responses fields rejected by DeepSeek."""
+    for key in (
+        "include",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "service_tier",
+    ):
+        kwargs.pop(key, None)
+
+    reasoning = kwargs.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if effort:
+            kwargs["reasoning"] = {"effort": effort}
+        else:
+            kwargs.pop("reasoning", None)
+
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        cleaned = dict(extra_body)
+        for key in (
+            "include",
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "service_tier",
+        ):
+            cleaned.pop(key, None)
+        if cleaned:
+            kwargs["extra_body"] = cleaned
+        else:
+            kwargs.pop("extra_body", None)
+    return kwargs
+
+
 def _rename_client_web_search_for_xai(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Rename client ``web_search`` → alias so xAI won't hijack it server-side."""
     rewritten: List[Dict[str, Any]] = []
@@ -247,6 +310,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
+            is_deepseek_responses: bool — DeepSeek V4 Flash Responses backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -268,6 +332,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_deepseek_responses = params.get("is_deepseek_responses") is True
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -343,6 +408,36 @@ class ResponsesApiTransport(ProviderTransport):
                 else:
                     response_tools = _rename_client_web_search_for_xai(response_tools)
 
+        # DeepSeek native search is an explicit 1:1 replacement. It is never
+        # added unless Hermes already exposed its web_search function, and a
+        # configured Firecrawl/Tavily/etc. backend remains client-dispatched.
+        if (
+            is_deepseek_responses
+            and response_tools
+            and _deepseek_prefers_native_web_search()
+        ):
+            has_client_web_search = any(
+                isinstance(t, dict)
+                and t.get("type") == "function"
+                and t.get("name") == "web_search"
+                for t in response_tools
+            )
+            if has_client_web_search:
+                response_tools = [
+                    t
+                    for t in response_tools
+                    if not (
+                        isinstance(t, dict)
+                        and t.get("type") == "function"
+                        and t.get("name") == "web_search"
+                    )
+                ]
+                if not any(
+                    isinstance(t, dict) and t.get("type") == "web_search"
+                    for t in response_tools
+                ):
+                    response_tools.append({"type": "web_search"})
+
         # ``tools`` MUST be omitted entirely when there are no functions to
         # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``
         # eagerly call ``_make_tools(tools)`` which does ``for tool in tools``
@@ -383,7 +478,12 @@ class ResponsesApiTransport(ProviderTransport):
         ) or _cache_scope
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
-        if not is_github_responses and not is_xai_responses and cache_key:
+        if (
+            not is_github_responses
+            and not is_xai_responses
+            and not is_deepseek_responses
+            and cache_key
+        ):
             kwargs["prompt_cache_key"] = cache_key
 
         cache_retention = _default_prompt_cache_retention_for_request(
@@ -411,7 +511,9 @@ class ResponsesApiTransport(ProviderTransport):
             if grok_supports_reasoning_effort(model):
                 kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
-            if is_github_responses:
+            if is_deepseek_responses:
+                kwargs["reasoning"] = {"effort": reasoning_effort}
+            elif is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
@@ -420,12 +522,19 @@ class ResponsesApiTransport(ProviderTransport):
                 kwargs["include"] = (
                     ["reasoning.encrypted_content"] if replay_encrypted_reasoning else []
                 )
-        elif not is_github_responses and not is_xai_responses:
+        elif (
+            not is_github_responses
+            and not is_xai_responses
+            and not is_deepseek_responses
+        ):
             kwargs["include"] = []
 
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        if is_deepseek_responses:
+            kwargs = _sanitize_deepseek_responses_kwargs(kwargs)
 
         if "prompt_cache_key" in kwargs:
             bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -98,6 +98,7 @@ class NormalizedResponse:
 
     * Anthropic: ``{"reasoning_details": [...]}``
     * Codex: ``{"codex_reasoning_items": [...], "codex_message_items": [...]}``
+      (the latter also carries ordered server-side tool output items)
     * Others: ``None``
     """
 

--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -139,6 +139,16 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
+    def supports_auto_detection(self) -> bool:
+        """Return whether registry fallback may select this provider.
+
+        Most client-side backends preserve the historic behavior of becoming
+        active when their credentials are the only available option. Marker
+        providers for server-side model capabilities can override this to
+        require an explicit ``web.*_backend`` selection instead.
+        """
+        return True
+
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a web search.
 

--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -155,16 +155,6 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
-    def supports_auto_detection(self) -> bool:
-        """Return whether registry fallback may select this provider.
-
-        Most client-side backends preserve the historic behavior of becoming
-        active when their credentials are the only available option. Marker
-        providers for server-side model capabilities can override this to
-        require an explicit ``web.*_backend`` selection instead.
-        """
-        return True
-
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a web search.
 

--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -155,6 +155,16 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
+    def supports_auto_detection(self) -> bool:
+        """Return whether registry fallback may select this provider.
+
+        Most client-side backends preserve the historic behavior of becoming
+        active when their credentials are the only available option. Marker
+        providers for server-side model capabilities can override this to
+        require an explicit ``web.*_backend`` selection instead.
+        """
+        return True
+
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a web search.
 

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -14,8 +14,8 @@ The active provider is chosen by configuration with this precedence:
 1. ``web.search_backend`` / ``web.extract_backend``
    (per-capability override).
 2. ``web.backend`` (shared fallback).
-3. If exactly one capability-eligible provider is registered AND available,
-   use it.
+3. If exactly one capability-eligible, auto-detectable provider is registered
+   AND available, use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
    ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
@@ -219,7 +219,8 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
        :func:`tools.web_tools._get_backend` behavior for configured names.
 
     2. **Single-provider shortcut.** When only one registered provider
-       supports *capability* AND ``is_available()`` reports True, return it.
+       supports *capability*, permits auto-detection, AND ``is_available()``
+       reports True, return it.
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
@@ -254,6 +255,16 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
             logger.debug("provider %s.is_available() raised %s", p.name, exc)
             return False
 
+    def _supports_auto_detection_safe(p: WebSearchProvider) -> bool:
+        """Keep opt-in marker providers out of implicit fallback selection."""
+        try:
+            return bool(p.supports_auto_detection())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "provider %s.supports_auto_detection() raised %s", p.name, exc
+            )
+            return False
+
     # 1. Explicit config wins — return regardless of is_available() so the
     #    user gets a precise downstream error message rather than a silent
     #    backend switch. Matches _get_backend() in web_tools.py.
@@ -278,7 +289,11 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     #    a fresh install with no API keys at all.
     eligible = [
         p for p in snapshot.values()
-        if _capable(p) and _is_available_safe(p)
+        if (
+            _capable(p)
+            and _supports_auto_detection_safe(p)
+            and _is_available_safe(p)
+        )
     ]
     if len(eligible) == 1:
         return eligible[0]
@@ -288,6 +303,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
         if (
             provider is not None
             and _capable(provider)
+            and _supports_auto_detection_safe(provider)
             and _is_available_safe(provider)
         ):
             return provider

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -14,8 +14,8 @@ The active provider is chosen by configuration with this precedence:
 1. ``web.search_backend`` / ``web.extract_backend``
    (per-capability override).
 2. ``web.backend`` (shared fallback).
-3. If exactly one capability-eligible, auto-detectable provider is registered
-   AND available, use it.
+3. If exactly one capability-eligible provider is registered AND available,
+   use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
    ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
@@ -219,8 +219,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
        :func:`tools.web_tools._get_backend` behavior for configured names.
 
     2. **Single-provider shortcut.** When only one registered provider
-       supports *capability*, permits auto-detection, AND ``is_available()``
-       reports True, return it.
+       supports *capability* AND ``is_available()`` reports True, return it.
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
@@ -255,16 +254,6 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
             logger.debug("provider %s.is_available() raised %s", p.name, exc)
             return False
 
-    def _supports_auto_detection_safe(p: WebSearchProvider) -> bool:
-        """Keep opt-in marker providers out of implicit fallback selection."""
-        try:
-            return bool(p.supports_auto_detection())
-        except Exception as exc:  # noqa: BLE001
-            logger.debug(
-                "provider %s.supports_auto_detection() raised %s", p.name, exc
-            )
-            return False
-
     # 1. Explicit config wins — return regardless of is_available() so the
     #    user gets a precise downstream error message rather than a silent
     #    backend switch. Matches _get_backend() in web_tools.py.
@@ -289,11 +278,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     #    a fresh install with no API keys at all.
     eligible = [
         p for p in snapshot.values()
-        if (
-            _capable(p)
-            and _supports_auto_detection_safe(p)
-            and _is_available_safe(p)
-        )
+        if _capable(p) and _is_available_safe(p)
     ]
     if len(eligible) == 1:
         return eligible[0]
@@ -303,7 +288,6 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
         if (
             provider is not None
             and _capable(provider)
-            and _supports_auto_detection_safe(provider)
             and _is_available_safe(provider)
         ):
             return provider

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -14,8 +14,8 @@ The active provider is chosen by configuration with this precedence:
 1. ``web.search_backend`` / ``web.extract_backend``
    (per-capability override).
 2. ``web.backend`` (shared fallback).
-3. If exactly one capability-eligible provider is registered AND available,
-   use it.
+3. If exactly one capability-eligible, auto-detectable provider is registered
+   AND available, use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
    ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
@@ -144,7 +144,8 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
        :func:`tools.web_tools._get_backend` behavior for configured names.
 
     2. **Single-provider shortcut.** When only one registered provider
-       supports *capability* AND ``is_available()`` reports True, return it.
+       supports *capability*, permits auto-detection, AND ``is_available()``
+       reports True, return it.
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
@@ -178,6 +179,16 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
             logger.debug("provider %s.is_available() raised %s", p.name, exc)
             return False
 
+    def _supports_auto_detection_safe(p: WebSearchProvider) -> bool:
+        """Keep opt-in marker providers out of implicit fallback selection."""
+        try:
+            return bool(p.supports_auto_detection())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "provider %s.supports_auto_detection() raised %s", p.name, exc
+            )
+            return False
+
     # 1. Explicit config wins — return regardless of is_available() so the
     #    user gets a precise downstream error message rather than a silent
     #    backend switch. Matches _get_backend() in web_tools.py.
@@ -202,7 +213,11 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     #    a fresh install with no API keys at all.
     eligible = [
         p for p in snapshot.values()
-        if _capable(p) and _is_available_safe(p)
+        if (
+            _capable(p)
+            and _supports_auto_detection_safe(p)
+            and _is_available_safe(p)
+        )
     ]
     if len(eligible) == 1:
         return eligible[0]
@@ -212,6 +227,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
         if (
             provider is not None
             and _capable(provider)
+            and _supports_auto_detection_safe(provider)
             and _is_available_safe(provider)
         ):
             return provider

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -32,10 +32,12 @@ from hermes_cli.providers import (
     ProviderDef,
     custom_provider_aliases,
     custom_provider_slug,
+    deepseek_api_mode,
     determine_api_mode,
     get_label,
     host_mandated_api_mode,
     is_aggregator,
+    normalize_deepseek_base_url,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -2137,6 +2139,10 @@ def switch_model(
     if target_provider in {"opencode-zen", "opencode-go", "opencode"}:
         api_mode = opencode_model_api_mode(target_provider, new_model)
 
+    # --- DeepSeek model-dependent Responses override ---
+    if target_provider == "deepseek":
+        api_mode = deepseek_api_mode(new_model)
+
     # --- Nous Portal dual-wire override ---
     # Portal serves anthropic/* on /v1/messages and everything else on
     # /chat/completions. resolve_runtime_provider already sets this when it
@@ -2168,6 +2174,8 @@ def switch_model(
     if _oc_family_fn(target_provider) is not None and isinstance(base_url, str):
         from hermes_cli.models import normalize_opencode_base_url
         base_url = normalize_opencode_base_url(target_provider, api_mode, base_url)
+    elif target_provider == "deepseek" and isinstance(base_url, str):
+        base_url = normalize_deepseek_base_url(target_provider, api_mode, base_url)
 
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model, allow_network=True)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -29,10 +29,12 @@ from hermes_cli.providers import (
     ProviderDef,
     custom_provider_aliases,
     custom_provider_slug,
+    deepseek_api_mode,
     determine_api_mode,
     get_label,
     host_mandated_api_mode,
     is_aggregator,
+    normalize_deepseek_base_url,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -1790,6 +1792,10 @@ def switch_model(
     if target_provider in {"opencode-zen", "opencode-go", "opencode"}:
         api_mode = opencode_model_api_mode(target_provider, new_model)
 
+    # --- DeepSeek model-dependent Responses override ---
+    if target_provider == "deepseek":
+        api_mode = deepseek_api_mode(new_model)
+
     # --- Nous Portal dual-wire override ---
     # Portal serves anthropic/* on /v1/messages and everything else on
     # /chat/completions. resolve_runtime_provider already sets this when it
@@ -1820,6 +1826,8 @@ def switch_model(
     if target_provider in {"opencode-zen", "opencode-go"} and isinstance(base_url, str):
         from hermes_cli.models import normalize_opencode_base_url
         base_url = normalize_opencode_base_url(target_provider, api_mode, base_url)
+    elif target_provider == "deepseek" and isinstance(base_url, str):
+        base_url = normalize_deepseek_base_url(target_provider, api_mode, base_url)
 
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -463,6 +463,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "deepseek": [
         "deepseek-v4-pro",
         "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
     ],
     "xiaomi": [
         "mimo-v2.5-pro",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from utils import base_url_host_matches, base_url_hostname
 
@@ -649,6 +650,53 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     return None
 
 
+def deepseek_supports_responses(model: str = "") -> bool:
+    """Return whether *model* may use DeepSeek's Responses API.
+
+    DeepSeek currently exposes Responses only for the exact V4 Flash model.
+    Keep this check deliberately conservative: provider-qualified spelling and
+    case are normalized, but retired aliases, unknown names, dated variants,
+    and V4 Pro remain on Chat Completions until DeepSeek documents support.
+    """
+    candidate = str(model or "").strip().lower()
+    if candidate.startswith("deepseek/"):
+        candidate = candidate.split("/", 1)[1].strip()
+    return candidate == "deepseek-v4-flash"
+
+
+def deepseek_api_mode(model: str = "") -> str:
+    """Resolve DeepSeek's model-dependent wire protocol."""
+    return "codex_responses" if deepseek_supports_responses(model) else "chat_completions"
+
+
+def normalize_deepseek_base_url(provider: str, api_mode: str, base_url: str) -> str:
+    """Normalize only DeepSeek's official endpoint for the selected wire.
+
+    The official Responses endpoint lives at ``/responses`` while the OpenAI
+    compatible Chat Completions endpoint is rooted under ``/v1``. Custom
+    proxies are left byte-for-byte unchanged apart from a trailing slash.
+    """
+    value = str(base_url or "").strip().rstrip("/")
+    if str(provider or "").strip().lower() != "deepseek":
+        return value
+    if base_url_hostname(value) != "api.deepseek.com":
+        return value
+
+    # Only rewrite the two documented official roots. Preserve any explicit
+    # non-standard path on the official host rather than guessing.
+    lower = value.lower()
+    if lower.endswith("/v1"):
+        root = value[:-3].rstrip("/")
+    else:
+        root = value
+    parsed = urlparse(root)
+    if parsed.path not in {"", "/"}:
+        return value
+    if api_mode == "codex_responses":
+        return root.rstrip("/")
+    return root.rstrip("/") + "/v1"
+
+
 def nous_api_mode(model: str = "") -> str:
     """Resolve the wire protocol for a Nous Portal model.
 
@@ -690,6 +738,8 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     # (the majority of the Portal catalog), so the transport lookup below
     # would pin Claude on the wrong wire without this carve-out.
     provider_norm = (provider or "").strip().lower()
+    if provider_norm == "deepseek":
+        return deepseek_api_mode(model)
     if provider_norm in {"nous", "nous-portal", "nousresearch"}:
         return nous_api_mode(model)
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -650,18 +650,76 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     return None
 
 
-def deepseek_supports_responses(model: str = "") -> bool:
-    """Return whether *model* may use DeepSeek's Responses API.
+@dataclass(frozen=True)
+class DeepSeekModelCapabilities:
+    """First-party DeepSeek capabilities that affect the wire contract.
 
-    DeepSeek currently exposes Responses only for the exact V4 Flash model.
-    Keep this check deliberately conservative: provider-qualified spelling and
-    case are normalized, but retired aliases, unknown names, dated variants,
-    and V4 Pro remain on Chat Completions until DeepSeek documents support.
+    Keep Responses support separate from native web search: DeepSeek may expose
+    a model on the Responses API before enabling every server-side tool. A new
+    model is therefore enabled by changing one entry here, without touching the
+    routing, endpoint, request-sanitizing, or tool-replay paths.
     """
+
+    responses_api: bool = False
+    native_web_search: bool = False
+
+
+# Fail closed for unknown / dated model IDs. The current DeepSeek Responses
+# guide documents V4 Flash only and says V4 Pro support is not yet available.
+# Keep the Pro entry explicit so its future rollout is a localized capability
+# change rather than another cross-cutting routing patch.
+_DEEPSEEK_MODEL_CAPABILITIES: Dict[str, DeepSeekModelCapabilities] = {
+    "deepseek-v4-flash": DeepSeekModelCapabilities(
+        responses_api=True,
+        native_web_search=True,
+    ),
+    "deepseek-v4-pro": DeepSeekModelCapabilities(
+        responses_api=False,
+        native_web_search=False,
+    ),
+}
+_DEEPSEEK_NO_CAPABILITIES = DeepSeekModelCapabilities()
+
+
+def _normalize_deepseek_model_id(model: str = "") -> str:
     candidate = str(model or "").strip().lower()
     if candidate.startswith("deepseek/"):
         candidate = candidate.split("/", 1)[1].strip()
-    return candidate == "deepseek-v4-flash"
+    return candidate
+
+
+def deepseek_model_capabilities(model: str = "") -> DeepSeekModelCapabilities:
+    """Return the documented first-party capabilities for *model*."""
+    return _DEEPSEEK_MODEL_CAPABILITIES.get(
+        _normalize_deepseek_model_id(model),
+        _DEEPSEEK_NO_CAPABILITIES,
+    )
+
+
+def deepseek_supports_responses(model: str = "") -> bool:
+    """Return whether *model* may use DeepSeek's Responses API."""
+    return deepseek_model_capabilities(model).responses_api
+
+
+def deepseek_supports_native_web_search(model: str = "") -> bool:
+    """Return whether *model* supports DeepSeek's server-side web search.
+
+    Native search is a Responses tool, so a malformed future capability entry
+    that enables search without Responses still fails closed.
+    """
+    capabilities = deepseek_model_capabilities(model)
+    return capabilities.responses_api and capabilities.native_web_search
+
+
+def deepseek_native_web_search_models() -> Tuple[str, ...]:
+    """Return model IDs currently enabled for DeepSeek native web search."""
+    return tuple(
+        sorted(
+            model
+            for model, capabilities in _DEEPSEEK_MODEL_CAPABILITIES.items()
+            if capabilities.responses_api and capabilities.native_web_search
+        )
+    )
 
 
 def deepseek_api_mode(model: str = "") -> str:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from utils import base_url_host_matches, base_url_hostname
 
@@ -700,6 +701,53 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     return None
 
 
+def deepseek_supports_responses(model: str = "") -> bool:
+    """Return whether *model* may use DeepSeek's Responses API.
+
+    DeepSeek currently exposes Responses only for the exact V4 Flash model.
+    Keep this check deliberately conservative: provider-qualified spelling and
+    case are normalized, but retired aliases, unknown names, dated variants,
+    and V4 Pro remain on Chat Completions until DeepSeek documents support.
+    """
+    candidate = str(model or "").strip().lower()
+    if candidate.startswith("deepseek/"):
+        candidate = candidate.split("/", 1)[1].strip()
+    return candidate == "deepseek-v4-flash"
+
+
+def deepseek_api_mode(model: str = "") -> str:
+    """Resolve DeepSeek's model-dependent wire protocol."""
+    return "codex_responses" if deepseek_supports_responses(model) else "chat_completions"
+
+
+def normalize_deepseek_base_url(provider: str, api_mode: str, base_url: str) -> str:
+    """Normalize only DeepSeek's official endpoint for the selected wire.
+
+    The official Responses endpoint lives at ``/responses`` while the OpenAI
+    compatible Chat Completions endpoint is rooted under ``/v1``. Custom
+    proxies are left byte-for-byte unchanged apart from a trailing slash.
+    """
+    value = str(base_url or "").strip().rstrip("/")
+    if str(provider or "").strip().lower() != "deepseek":
+        return value
+    if base_url_hostname(value) != "api.deepseek.com":
+        return value
+
+    # Only rewrite the two documented official roots. Preserve any explicit
+    # non-standard path on the official host rather than guessing.
+    lower = value.lower()
+    if lower.endswith("/v1"):
+        root = value[:-3].rstrip("/")
+    else:
+        root = value
+    parsed = urlparse(root)
+    if parsed.path not in {"", "/"}:
+        return value
+    if api_mode == "codex_responses":
+        return root.rstrip("/")
+    return root.rstrip("/") + "/v1"
+
+
 def nous_api_mode(model: str = "") -> str:
     """Resolve the wire protocol for a Nous Portal model.
 
@@ -741,6 +789,8 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     # (the majority of the Portal catalog), so the transport lookup below
     # would pin Claude on the wrong wire without this carve-out.
     provider_norm = (provider or "").strip().lower()
+    if provider_norm == "deepseek":
+        return deepseek_api_mode(model)
     if provider_norm in {"nous", "nous-portal", "nousresearch"}:
         return nous_api_mode(model)
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -701,18 +701,74 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     return None
 
 
-def deepseek_supports_responses(model: str = "") -> bool:
-    """Return whether *model* may use DeepSeek's Responses API.
+@dataclass(frozen=True)
+class DeepSeekModelCapabilities:
+    """First-party DeepSeek capabilities that affect the wire contract.
 
-    DeepSeek currently exposes Responses only for the exact V4 Flash model.
-    Keep this check deliberately conservative: provider-qualified spelling and
-    case are normalized, but retired aliases, unknown names, dated variants,
-    and V4 Pro remain on Chat Completions until DeepSeek documents support.
+    Keep Responses support separate from native web search: DeepSeek may expose
+    a model on the Responses API before enabling every server-side tool. A new
+    model is therefore enabled by changing one entry here, without touching the
+    routing, endpoint, request-sanitizing, or tool-replay paths.
     """
+
+    responses_api: bool = False
+    native_web_search: bool = False
+
+
+# Fail closed for unknown / dated model IDs. Exact first-party IDs are enabled
+# only after DeepSeek documents the relevant Responses/tool capabilities.
+_DEEPSEEK_MODEL_CAPABILITIES: Dict[str, DeepSeekModelCapabilities] = {
+    "deepseek-v4-flash": DeepSeekModelCapabilities(
+        responses_api=True,
+        native_web_search=True,
+    ),
+    "deepseek-v4-pro": DeepSeekModelCapabilities(
+        responses_api=True,
+        native_web_search=True,
+    ),
+}
+_DEEPSEEK_NO_CAPABILITIES = DeepSeekModelCapabilities()
+
+
+def _normalize_deepseek_model_id(model: str = "") -> str:
     candidate = str(model or "").strip().lower()
     if candidate.startswith("deepseek/"):
         candidate = candidate.split("/", 1)[1].strip()
-    return candidate == "deepseek-v4-flash"
+    return candidate
+
+
+def deepseek_model_capabilities(model: str = "") -> DeepSeekModelCapabilities:
+    """Return the documented first-party capabilities for *model*."""
+    return _DEEPSEEK_MODEL_CAPABILITIES.get(
+        _normalize_deepseek_model_id(model),
+        _DEEPSEEK_NO_CAPABILITIES,
+    )
+
+
+def deepseek_supports_responses(model: str = "") -> bool:
+    """Return whether *model* may use DeepSeek's Responses API."""
+    return deepseek_model_capabilities(model).responses_api
+
+
+def deepseek_supports_native_web_search(model: str = "") -> bool:
+    """Return whether *model* supports DeepSeek's server-side web search.
+
+    Native search is a Responses tool, so a malformed future capability entry
+    that enables search without Responses still fails closed.
+    """
+    capabilities = deepseek_model_capabilities(model)
+    return capabilities.responses_api and capabilities.native_web_search
+
+
+def deepseek_native_web_search_models() -> Tuple[str, ...]:
+    """Return model IDs currently enabled for DeepSeek native web search."""
+    return tuple(
+        sorted(
+            model
+            for model, capabilities in _DEEPSEEK_MODEL_CAPABILITIES.items()
+            if capabilities.responses_api and capabilities.native_web_search
+        )
+    )
 
 
 def deepseek_api_mode(model: str = "") -> str:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -726,6 +726,10 @@ _DEEPSEEK_MODEL_CAPABILITIES: Dict[str, DeepSeekModelCapabilities] = {
         responses_api=True,
         native_web_search=True,
     ),
+    "deepseek-v4-flash-vision-exp": DeepSeekModelCapabilities(
+        responses_api=True,
+        native_web_search=True,
+    ),
 }
 _DEEPSEEK_NO_CAPABILITIES = DeepSeekModelCapabilities()
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -724,25 +724,30 @@ def normalize_deepseek_base_url(provider: str, api_mode: str, base_url: str) -> 
     """Normalize only DeepSeek's official endpoint for the selected wire.
 
     The official Responses endpoint lives at ``/responses`` while the OpenAI
-    compatible Chat Completions endpoint is rooted under ``/v1``. Custom
-    proxies are left byte-for-byte unchanged apart from a trailing slash.
+    compatible Chat Completions endpoint is rooted under ``/v1``. Other
+    providers, custom proxies, and non-canonical official URLs are returned
+    unchanged.
     """
-    value = str(base_url or "").strip().rstrip("/")
+    value = str(base_url or "").strip()
     if str(provider or "").strip().lower() != "deepseek":
         return value
     if base_url_hostname(value) != "api.deepseek.com":
         return value
 
-    # Only rewrite the two documented official roots. Preserve any explicit
-    # non-standard path on the official host rather than guessing.
-    lower = value.lower()
-    if lower.endswith("/v1"):
-        root = value[:-3].rstrip("/")
-    else:
-        root = value
-    parsed = urlparse(root)
-    if parsed.path not in {"", "/"}:
+    # Only rewrite the two documented official roots. Preserve query strings,
+    # fragments, userinfo, and any non-standard path rather than silently
+    # changing the route's meaning.
+    parsed = urlparse(value)
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/", "/v1", "/v1/"}
+    ):
         return value
+    canonical = value.rstrip("/")
+    root = canonical[:-3].rstrip("/") if parsed.path in {"/v1", "/v1/"} else canonical
     if api_mode == "codex_responses":
         return root.rstrip("/")
     return root.rstrip("/") + "/v1"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -45,7 +45,12 @@ from hermes_cli.config import (
     load_config,
     normalize_extra_headers,
 )
-from hermes_cli.providers import custom_provider_aliases, custom_provider_slug
+from hermes_cli.providers import (
+    custom_provider_aliases,
+    custom_provider_slug,
+    deepseek_api_mode,
+    normalize_deepseek_base_url,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.providers import is_official_openai_host
 from utils import base_url_host_matches, base_url_hostname, env_int
@@ -543,7 +548,11 @@ def _resolve_runtime_from_pool_entry(
             if cfg_base_url:
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-        if provider in {"opencode-zen", "opencode-go"}:
+        if provider == "deepseek":
+            # DeepSeek is dual-wire by model. Never let a persisted mode from
+            # V4 Pro/Flash survive a model switch.
+            api_mode = deepseek_api_mode(effective_model)
+        elif provider in {"opencode-zen", "opencode-go"}:
             # Re-derive api_mode from the effective model rather than the
             # persisted api_mode: the opencode providers serve both
             # anthropic_messages and chat_completions models, so the previous
@@ -568,6 +577,8 @@ def _resolve_runtime_from_pool_entry(
         from hermes_cli.models import normalize_opencode_base_url
 
         base_url = normalize_opencode_base_url(provider, api_mode, base_url)
+    elif provider == "deepseek":
+        base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
 
     # Optional opt-in: route OpenAI/Codex turns through `codex app-server`.
     # Inert when `model.openai_runtime` is unset or "auto".
@@ -1638,7 +1649,9 @@ def _resolve_explicit_runtime(
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+            if provider == "deepseek":
+                api_mode = deepseek_api_mode(target_model or model_cfg.get("default", ""))
+            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             else:
                 # URL detection first, then the provider's declared transport
@@ -1647,6 +1660,8 @@ def _resolve_explicit_runtime(
                     provider, base_url, target_model or model_cfg.get("default", "")
                 )
 
+        if provider == "deepseek":
+            base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
         if provider == "actual" and not api_key and is_actual_local_base_url(base_url):
             api_key = ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
 
@@ -2244,7 +2259,10 @@ def resolve_runtime_provider(
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if provider in {"opencode-zen", "opencode-go"}:
+            if provider == "deepseek":
+                _effective = target_model or model_cfg.get("default", "")
+                api_mode = deepseek_api_mode(_effective)
+            elif provider in {"opencode-zen", "opencode-go"}:
                 # opencode-zen/go must always re-derive api_mode from the
                 # target model (not the stale persisted api_mode), because
                 # the same provider serves both anthropic_messages
@@ -2269,6 +2287,8 @@ def resolve_runtime_provider(
         if provider in {"opencode-zen", "opencode-go"}:
             from hermes_cli.models import normalize_opencode_base_url
             base_url = normalize_opencode_base_url(provider, api_mode, base_url)
+        elif provider == "deepseek":
+            base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
         if provider == "lmstudio":
             base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
         api_key = creds.get("api_key", "")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -45,7 +45,12 @@ from hermes_cli.config import (
     load_config,
     normalize_extra_headers,
 )
-from hermes_cli.providers import custom_provider_aliases, custom_provider_slug
+from hermes_cli.providers import (
+    custom_provider_aliases,
+    custom_provider_slug,
+    deepseek_api_mode,
+    normalize_deepseek_base_url,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.providers import is_official_openai_host
 from utils import base_url_host_matches, base_url_hostname, env_int
@@ -568,7 +573,11 @@ def _resolve_runtime_from_pool_entry(
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         from hermes_cli.models import opencode_provider_family
-        if opencode_provider_family(provider) is not None:
+        if provider == "deepseek":
+            # DeepSeek is dual-wire by model. Never let a persisted mode from
+            # one model survive a model switch.
+            api_mode = deepseek_api_mode(effective_model)
+        elif opencode_provider_family(provider) is not None:
             # Re-derive api_mode from the effective model rather than the
             # persisted api_mode: the opencode providers serve both
             # anthropic_messages and chat_completions models, so the previous
@@ -594,6 +603,8 @@ def _resolve_runtime_from_pool_entry(
         from hermes_cli.models import normalize_opencode_base_url
 
         base_url = normalize_opencode_base_url(provider, api_mode, base_url)
+    elif provider == "deepseek":
+        base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
 
     # Optional opt-in: route OpenAI/Codex turns through `codex app-server`.
     # Inert when `model.openai_runtime` is unset or "auto".
@@ -1746,7 +1757,9 @@ def _resolve_explicit_runtime(
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+            if provider == "deepseek":
+                api_mode = deepseek_api_mode(target_model or model_cfg.get("default", ""))
+            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             else:
                 # URL detection first, then the provider's declared transport
@@ -1755,6 +1768,8 @@ def _resolve_explicit_runtime(
                     provider, base_url, target_model or model_cfg.get("default", "")
                 )
 
+        if provider == "deepseek":
+            base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
         if provider == "actual" and not api_key and is_actual_local_base_url(base_url):
             api_key = ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
 
@@ -2396,7 +2411,10 @@ def resolve_runtime_provider(
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             from hermes_cli.models import opencode_provider_family
-            if opencode_provider_family(provider) is not None:
+            if provider == "deepseek":
+                _effective = target_model or model_cfg.get("default", "")
+                api_mode = deepseek_api_mode(_effective)
+            elif opencode_provider_family(provider) is not None:
                 # opencode-zen/go must always re-derive api_mode from the
                 # target model (not the stale persisted api_mode), because
                 # the same provider serves both anthropic_messages
@@ -2422,6 +2440,8 @@ def resolve_runtime_provider(
         if opencode_provider_family(provider) is not None:
             from hermes_cli.models import normalize_opencode_base_url
             base_url = normalize_opencode_base_url(provider, api_mode, base_url)
+        elif provider == "deepseek":
+            base_url = normalize_deepseek_base_url(provider, api_mode, base_url)
         if provider == "lmstudio":
             base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
         api_key = creds.get("api_key", "")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -56,6 +56,17 @@ from hermes_cli.providers import is_official_openai_host
 from utils import base_url_host_matches, base_url_hostname, env_int
 
 
+def _deepseek_runtime_api_mode(model: str = "") -> str:
+    """Resolve DeepSeek's wire after applying its API model normalization."""
+    try:
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        model = normalize_model_for_provider(model, "deepseek")
+    except Exception:
+        pass
+    return deepseek_api_mode(model)
+
+
 def _getenv(name: str, default: str = "") -> str:
     """Profile-scoped replacement for ``os.getenv`` on credential/provider reads.
 
@@ -576,7 +587,7 @@ def _resolve_runtime_from_pool_entry(
         if provider == "deepseek":
             # DeepSeek is dual-wire by model. Never let a persisted mode from
             # one model survive a model switch.
-            api_mode = deepseek_api_mode(effective_model)
+            api_mode = _deepseek_runtime_api_mode(effective_model)
         elif opencode_provider_family(provider) is not None:
             # Re-derive api_mode from the effective model rather than the
             # persisted api_mode: the opencode providers serve both
@@ -1758,7 +1769,9 @@ def _resolve_explicit_runtime(
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if provider == "deepseek":
-                api_mode = deepseek_api_mode(target_model or model_cfg.get("default", ""))
+                api_mode = _deepseek_runtime_api_mode(
+                    target_model or model_cfg.get("default", "")
+                )
             elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             else:
@@ -2413,7 +2426,7 @@ def resolve_runtime_provider(
             from hermes_cli.models import opencode_provider_family
             if provider == "deepseek":
                 _effective = target_model or model_cfg.get("default", "")
-                api_mode = deepseek_api_mode(_effective)
+                api_mode = _deepseek_runtime_api_mode(_effective)
             elif opencode_provider_family(provider) is not None:
                 # opencode-zen/go must always re-derive api_mode from the
                 # target model (not the stale persisted api_mode), because

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -103,6 +103,7 @@ deepseek = DeepSeekProfile(
     fallback_models=(
         "deepseek-v4-pro",
         "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
     ),
     base_url="https://api.deepseek.com/v1",
     default_aux_model="deepseek-v4-flash",

--- a/plugins/web/deepseek/__init__.py
+++ b/plugins/web/deepseek/__init__.py
@@ -1,0 +1,7 @@
+"""DeepSeek native web-search capability plugin."""
+
+from plugins.web.deepseek.provider import DeepSeekWebSearchProvider
+
+
+def register(ctx) -> None:
+    ctx.register_web_search_provider(DeepSeekWebSearchProvider())

--- a/plugins/web/deepseek/plugin.yaml
+++ b/plugins/web/deepseek/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-deepseek
 version: 1.0.0
-description: "DeepSeek native web search for deepseek-v4-flash Responses turns. Requires DEEPSEEK_API_KEY and explicit web.search_backend: deepseek."
+description: "DeepSeek native web search for capability-enabled Responses models. Requires DEEPSEEK_API_KEY and explicit web.search_backend: deepseek."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/deepseek/plugin.yaml
+++ b/plugins/web/deepseek/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-deepseek
+version: 1.0.0
+description: "DeepSeek native web search for deepseek-v4-flash Responses turns. Requires DEEPSEEK_API_KEY and explicit web.search_backend: deepseek."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - deepseek

--- a/plugins/web/deepseek/plugin.yaml
+++ b/plugins/web/deepseek/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-deepseek
 version: 1.0.0
-description: "DeepSeek native web search for deepseek-v4-flash Responses turns. Requires DEEPSEEK_API_KEY and explicit web.search_backend: deepseek."
+description: "DeepSeek native web search for capability-enabled Responses models. Requires a configured DeepSeek inference route and explicit web.search_backend: deepseek."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -41,6 +41,12 @@ class DeepSeekWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
+    def supports_auto_detection(self) -> bool:
+        # This provider is a selection marker for an in-turn server-side tool,
+        # not a local search implementation. A DEEPSEEK_API_KEY alone must not
+        # replace the user's normal client-side web backend.
+        return False
+
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         del query, limit
         return {

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -10,9 +10,10 @@ from agent.web_search_provider import WebSearchProvider, get_provider_env
 class DeepSeekWebSearchProvider(WebSearchProvider):
     """Expose ``web.search_backend: deepseek`` to the provider registry.
 
-    Search execution happens inside the active DeepSeek V4 Flash Responses
-    request. A local dispatch means the active route cannot provide that native
-    capability, so return an actionable error rather than silently falling back.
+    Search execution happens inside an active, capability-enabled DeepSeek
+    Responses request. A local dispatch means the active route cannot provide
+    that native capability, so return an actionable error rather than silently
+    falling back.
 
     This backend is intentionally opt-in because a server-side search turn can
     consume substantially more tokens than a normal model turn::
@@ -49,12 +50,16 @@ class DeepSeekWebSearchProvider(WebSearchProvider):
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         del query, limit
+        from hermes_cli.providers import deepseek_native_web_search_models
+
+        enabled_models = ", ".join(deepseek_native_web_search_models()) or "none"
         return {
             "success": False,
             "error": (
-                "DeepSeek native web search requires the active model to be "
-                "deepseek-v4-flash on the DeepSeek Responses API. Select a "
-                "client web backend such as Firecrawl or Tavily for other models."
+                "DeepSeek native web search requires an active DeepSeek model "
+                "with both Responses API and native web-search capabilities "
+                f"enabled (currently: {enabled_models}). Select a client web "
+                "backend such as Firecrawl or Tavily for other models."
             ),
         }
 

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -1,0 +1,65 @@
+"""Selection marker for DeepSeek's in-turn native Responses web search."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider, get_provider_env
+
+
+class DeepSeekWebSearchProvider(WebSearchProvider):
+    """Expose ``web.search_backend: deepseek`` to the provider registry.
+
+    Search execution happens inside the active DeepSeek V4 Flash Responses
+    request. A local dispatch means the active route cannot provide that native
+    capability, so return an actionable error rather than silently falling back.
+
+    This backend is intentionally opt-in because a server-side search turn can
+    consume substantially more tokens than a normal model turn::
+
+        model:
+          provider: deepseek
+          default: deepseek-v4-flash
+        web:
+          search_backend: deepseek
+    """
+
+    @property
+    def name(self) -> str:
+        return "deepseek"
+
+    @property
+    def display_name(self) -> str:
+        return "DeepSeek Native Web Search"
+
+    def is_available(self) -> bool:
+        return bool(get_provider_env("DEEPSEEK_API_KEY"))
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        del query, limit
+        return {
+            "success": False,
+            "error": (
+                "DeepSeek native web search requires the active model to be "
+                "deepseek-v4-flash on the DeepSeek Responses API. Select a "
+                "client web backend such as Firecrawl or Tavily for other models."
+            ),
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "env_vars": [
+                {
+                    "name": "DEEPSEEK_API_KEY",
+                    "prompt": "DeepSeek API key",
+                    "secret": True,
+                    "required": True,
+                }
+            ]
+        }

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from agent.web_search_provider import WebSearchProvider, get_provider_env
+from agent.web_search_provider import WebSearchProvider
 
 
 class DeepSeekWebSearchProvider(WebSearchProvider):
@@ -33,18 +33,28 @@ class DeepSeekWebSearchProvider(WebSearchProvider):
         return "DeepSeek Native Web Search"
 
     def is_available(self) -> bool:
-        return bool(get_provider_env("DEEPSEEK_API_KEY"))
+        # This is a selection marker for the active DeepSeek inference route,
+        # not an independently dispatched search client. It is available only
+        # after explicit user opt-in; this keeps it out of registry fallback
+        # while allowing the legacy web dispatcher to honor the more specific
+        # ``web.search_backend`` key instead of silently choosing another
+        # installed backend.
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+            web = config.get("web") if isinstance(config, dict) else None
+            if not isinstance(web, dict):
+                return False
+            configured = web.get("search_backend") or web.get("backend") or ""
+            return str(configured).strip().lower() == self.name
+        except Exception:
+            return False
 
     def supports_search(self) -> bool:
         return True
 
     def supports_extract(self) -> bool:
-        return False
-
-    def supports_auto_detection(self) -> bool:
-        # This provider is a selection marker for an in-turn server-side tool,
-        # not a local search implementation. A DEEPSEEK_API_KEY alone must not
-        # replace the user's normal client-side web backend.
         return False
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
@@ -60,12 +70,15 @@ class DeepSeekWebSearchProvider(WebSearchProvider):
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
-            "env_vars": [
-                {
-                    "name": "DEEPSEEK_API_KEY",
-                    "prompt": "DeepSeek API key",
-                    "secret": True,
-                    "required": True,
-                }
-            ]
+            "name": self.display_name,
+            "badge": "native · search only",
+            "tag": (
+                "Uses the active capability-enabled DeepSeek inference route; "
+                "configure DeepSeek under Models first."
+            ),
+            # Inference credentials are owned by the model-provider setup and
+            # may come from its credential pool rather than a singleton env
+            # key. Selecting native search must not prompt for or duplicate
+            # that credential in the web-provider flow.
+            "env_vars": [],
         }

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -10,9 +10,10 @@ from agent.web_search_provider import WebSearchProvider
 class DeepSeekWebSearchProvider(WebSearchProvider):
     """Expose ``web.search_backend: deepseek`` to the provider registry.
 
-    Search execution happens inside the active DeepSeek V4 Flash Responses
-    request. A local dispatch means the active route cannot provide that native
-    capability, so return an actionable error rather than silently falling back.
+    Search execution happens inside an active, capability-enabled DeepSeek
+    Responses request. A local dispatch means the active route cannot provide
+    that native capability, so return an actionable error rather than silently
+    falling back.
 
     This backend is intentionally opt-in because a server-side search turn can
     consume substantially more tokens than a normal model turn::
@@ -59,12 +60,16 @@ class DeepSeekWebSearchProvider(WebSearchProvider):
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         del query, limit
+        from hermes_cli.providers import deepseek_native_web_search_models
+
+        enabled_models = ", ".join(deepseek_native_web_search_models()) or "none"
         return {
             "success": False,
             "error": (
-                "DeepSeek native web search requires the active model to be "
-                "deepseek-v4-flash on the DeepSeek Responses API. Select a "
-                "client web backend such as Firecrawl or Tavily for other models."
+                "DeepSeek native web search requires an active DeepSeek model "
+                "with both Responses API and native web-search capabilities "
+                f"enabled (currently: {enabled_models}). Select a client web "
+                "backend such as Firecrawl or Tavily for other models."
             ),
         }
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6433,7 +6433,14 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
         self._credential_pool_entry_id = getattr(entry, "id", None)
+        from hermes_cli.providers import normalize_deepseek_base_url
         from hermes_cli.route_identity import normalize_route_base_url
+
+        runtime_base = normalize_deepseek_base_url(
+            self.provider,
+            self.api_mode,
+            runtime_base,
+        )
 
         route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(
             runtime_base

--- a/run_agent.py
+++ b/run_agent.py
@@ -5884,7 +5884,14 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
         self._credential_pool_entry_id = getattr(entry, "id", None)
+        from hermes_cli.providers import normalize_deepseek_base_url
         from hermes_cli.route_identity import normalize_route_base_url
+
+        runtime_base = normalize_deepseek_base_url(
+            self.provider,
+            self.api_mode,
+            runtime_base,
+        )
 
         route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(
             runtime_base

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -340,6 +340,7 @@ class TestDefaultContextLengths:
 
         expected_keys = {
             "deepseek-v4-pro": 1_000_000,
+            "deepseek-v4-flash-vision-exp": 1_000_000,
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
@@ -359,6 +360,7 @@ class TestDefaultContextLengths:
              mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
             cases = [
                 ("deepseek-v4-pro", 1_000_000),
+                ("deepseek-v4-flash-vision-exp", 1_000_000),
                 ("deepseek-v4-flash", 1_000_000),
                 ("deepseek/deepseek-v4-pro", 1_000_000),
                 ("deepseek/deepseek-v4-flash", 1_000_000),

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1393,18 +1393,44 @@ class TestDeepSeekNativeWebSearch:
             },
         ]
 
+    @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
     def test_explicit_deepseek_backend_swaps_client_tool_one_for_one(
-        self, transport, monkeypatch
+        self, transport, monkeypatch, model
     ):
         self._select_backend(monkeypatch, "deepseek")
         kw = transport.build_kwargs(
-            model="deepseek-v4-flash",
+            model=model,
             messages=[{"role": "user", "content": "latest news"}],
             tools=self._tools(),
             is_deepseek_responses=True,
         )
         assert [tool.get("name") for tool in kw["tools"] if tool.get("type") == "function"] == ["terminal"]
         assert [tool for tool in kw["tools"] if tool.get("type") == "web_search"] == [{"type": "web_search"}]
+
+    def test_responses_model_without_native_search_keeps_client_tool(
+        self, transport, monkeypatch
+    ):
+        from hermes_cli import providers as provider_registry
+        from hermes_cli.providers import DeepSeekModelCapabilities
+
+        self._select_backend(monkeypatch, "deepseek")
+        monkeypatch.setitem(
+            provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+            "deepseek-v4-future",
+            DeepSeekModelCapabilities(
+                responses_api=True,
+                native_web_search=False,
+            ),
+        )
+        kw = transport.build_kwargs(
+            model="deepseek-v4-future",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
 
     def test_non_deepseek_backend_preserves_client_web_search(
         self, transport, monkeypatch
@@ -1441,6 +1467,39 @@ class TestDeepSeekNativeWebSearch:
             is_deepseek_responses=True,
         )
         assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            ("minimal", "low"),
+            ("medium", "high"),
+            ("xhigh", "high"),
+            ("ultra", "max"),
+            ("max", "max"),
+        ],
+    )
+    def test_deepseek_reasoning_effort_clamps_product_aliases(
+        self, transport, configured, expected
+    ):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            is_deepseek_responses=True,
+            reasoning_config={"effort": configured},
+        )
+        assert kw["reasoning"] == {"effort": expected}
+
+    def test_deepseek_reasoning_disabled_sends_explicit_none(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            is_deepseek_responses=True,
+            reasoning_config={"enabled": False},
+        )
+        assert kw["reasoning"] == {"effort": "none"}
+
 
     def test_deepseek_sanitizer_runs_after_request_overrides(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1470,6 +1470,62 @@ class TestDeepSeekNativeWebSearch:
 
 
 class TestDeepSeekWebSearchReplay:
+    def test_streamed_search_call_normalizes_and_replays_in_order(self, transport):
+        from agent.codex_runtime import _consume_codex_event_stream
+
+        search_item = SimpleNamespace(
+            type="web_search_call",
+            id="ws_stream_1",
+            call_id="ws_call_stream_1",
+            status="completed",
+            action=SimpleNamespace(type="search", query="latest release"),
+        )
+        message_item = SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text="Latest result")],
+        )
+        response = _consume_codex_event_stream(
+            [
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=search_item,
+                ),
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=message_item,
+                ),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed", id="resp_1"),
+                ),
+            ],
+            model="deepseek-v4-flash",
+        )
+
+        normalized = transport.normalize_response(response)
+        replay = transport.convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": normalized.content,
+                    "codex_message_items": normalized.codex_message_items,
+                },
+                {"role": "user", "content": "source?"},
+            ],
+            base_url="https://api.deepseek.com",
+            replay_encrypted_reasoning=False,
+        )
+
+        assert [item["type"] for item in replay[:2]] == [
+            "web_search_call",
+            "message",
+        ]
+        assert replay[0]["call_id"] == "ws_call_stream_1"
+        assert replay[0]["action"]["query"] == "latest release"
+        assert replay[2] == {"role": "user", "content": "source?"}
+
     def test_completed_search_call_is_persisted_and_replayed_in_order(self, transport):
         response = SimpleNamespace(
             output=[

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1353,3 +1353,201 @@ class TestPreflightSlashEnumStrip:
         assert params["properties"]["model_id"].get("enum") == [
             "Qwen/Qwen3.5-0.8B", "plain-id"
         ]
+
+
+class TestDeepSeekNativeWebSearch:
+    @staticmethod
+    def _select_backend(monkeypatch, name, *, resolved_name=None):
+        monkeypatch.setattr(
+            "agent.web_search_registry._read_config_key",
+            lambda *path: name if path == ("web", "search_backend") else None,
+        )
+        resolved = resolved_name if resolved_name is not None else name
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: SimpleNamespace(name=resolved) if resolved else None,
+        )
+
+    @staticmethod
+    def _tools():
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            },
+        ]
+
+    def test_explicit_deepseek_backend_swaps_client_tool_one_for_one(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert [tool.get("name") for tool in kw["tools"] if tool.get("type") == "function"] == ["terminal"]
+        assert [tool for tool in kw["tools"] if tool.get("type") == "web_search"] == [{"type": "web_search"}]
+
+    def test_non_deepseek_backend_preserves_client_web_search(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "firecrawl")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_auto_resolved_deepseek_provider_is_not_enough(self, transport, monkeypatch):
+        self._select_backend(monkeypatch, None, resolved_name="deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_native_search_is_not_added_without_client_tool(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=self._tools()[:1],
+            is_deepseek_responses=True,
+        )
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_deepseek_sanitizer_runs_after_request_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            session_id="session-1",
+            is_deepseek_responses=True,
+            reasoning_config={"effort": "high"},
+            request_overrides={
+                "include": ["reasoning.encrypted_content"],
+                "prompt_cache_key": "override",
+                "prompt_cache_retention": "24h",
+                "service_tier": "priority",
+                "reasoning": {"effort": "high", "summary": "auto"},
+                "extra_body": {
+                    "prompt_cache_key": "nested",
+                    "service_tier": "priority",
+                    "kept": "yes",
+                },
+            },
+        )
+        for key in ("include", "prompt_cache_key", "prompt_cache_retention", "service_tier"):
+            assert key not in kw
+        assert kw["reasoning"] == {"effort": "high"}
+        assert kw["extra_body"] == {"kept": "yes"}
+
+
+class TestDeepSeekWebSearchReplay:
+    def test_completed_search_call_is_persisted_and_replayed_in_order(self, transport):
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_123",
+                    call_id="ws_call_123",
+                    status="completed",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="current DeepSeek release",
+                        sources=[{"url": "https://example.com"}],
+                    ),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    id="msg_123",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="DeepSeek released ...")],
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+        )
+
+        normalized = transport.normalize_response(response)
+        assert normalized.finish_reason == "stop"
+        assert normalized.codex_message_items[0] == {
+            "type": "web_search_call",
+            "id": "ws_123",
+            "call_id": "ws_call_123",
+            "status": "completed",
+            "action": {
+                "type": "search",
+                "query": "current DeepSeek release",
+                "sources": [{"url": "https://example.com"}],
+            },
+        }
+
+        replay = transport.convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "DeepSeek released ...",
+                    "codex_message_items": normalized.codex_message_items,
+                },
+                {"role": "user", "content": "What was the source?"},
+            ],
+            base_url="https://api.deepseek.com",
+            replay_encrypted_reasoning=False,
+        )
+        assert replay[0]["type"] == "web_search_call"
+        assert replay[0]["call_id"] == "ws_call_123"
+        assert replay[0]["action"]["query"] == "current DeepSeek release"
+        assert replay[1]["type"] == "message"
+        assert replay[2] == {"role": "user", "content": "What was the source?"}
+        assert all(item.get("content") != "ws_call_123" for item in replay)
+
+    def test_in_progress_server_call_does_not_force_incomplete(self, transport):
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_pending",
+                    status="in_progress",
+                    action=SimpleNamespace(type="search", query="query"),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="answer")],
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+        )
+        normalized = transport.normalize_response(response)
+        assert normalized.finish_reason == "stop"
+        assert normalized.content == "answer"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1451,25 +1451,72 @@ class TestDeepSeekNativeWebSearch:
             is_deepseek_responses=True,
             reasoning_config={"effort": "high"},
             request_overrides={
+                "background": True,
+                "context_management": [{"type": "compaction"}],
+                "conversation": "conv_123",
                 "include": ["reasoning.encrypted_content"],
+                "metadata": {"key": "value"},
+                "previous_response_id": "resp_123",
+                "prompt": {"id": "pmpt_123"},
                 "prompt_cache_key": "override",
                 "prompt_cache_retention": "24h",
+                "safety_identifier": "user-123",
                 "service_tier": "priority",
+                "stream_options": {"include_obfuscation": True},
+                "truncation": "auto",
                 "reasoning": {"effort": "high", "summary": "auto"},
                 "extra_body": {
+                    "background": True,
+                    "context_management": [{"type": "compaction"}],
                     "prompt_cache_key": "nested",
                     "service_tier": "priority",
                     "kept": "yes",
                 },
             },
         )
-        for key in ("include", "prompt_cache_key", "prompt_cache_retention", "service_tier"):
+        for key in (
+            "background",
+            "context_management",
+            "conversation",
+            "include",
+            "metadata",
+            "previous_response_id",
+            "prompt",
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "safety_identifier",
+            "service_tier",
+            "stream_options",
+            "truncation",
+        ):
             assert key not in kw
         assert kw["reasoning"] == {"effort": "high"}
         assert kw["extra_body"] == {"kept": "yes"}
 
 
 class TestDeepSeekWebSearchReplay:
+    def test_preflight_preserves_search_call_as_is(self, transport):
+        replay_item = {
+            "id": "ws_123",
+            "type": "web_search_call",
+            "status": "completed",
+            "action": {
+                "type": "search",
+                "query": "current release",
+                "sources": [{"type": "url", "url": "https://example.test"}],
+            },
+        }
+        kwargs = transport.preflight_kwargs(
+            {
+                "model": "deepseek-v4-flash",
+                "instructions": "Be helpful.",
+                "input": [replay_item, {"role": "user", "content": "Source?"}],
+                "store": False,
+            }
+        )
+
+        assert kwargs["input"][0] == replay_item
+
     def test_streamed_search_call_normalizes_and_replays_in_order(self, transport):
         from agent.codex_runtime import _consume_codex_event_stream
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1393,7 +1393,10 @@ class TestDeepSeekNativeWebSearch:
             },
         ]
 
-    @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+    @pytest.mark.parametrize(
+        "model",
+        ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"],
+    )
     def test_explicit_deepseek_backend_swaps_client_tool_one_for_one(
         self, transport, monkeypatch, model
     ):

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -829,3 +829,201 @@ class TestPreflightSlashEnumStrip:
         assert params["properties"]["model_id"].get("enum") == [
             "Qwen/Qwen3.5-0.8B", "plain-id"
         ]
+
+
+class TestDeepSeekNativeWebSearch:
+    @staticmethod
+    def _select_backend(monkeypatch, name, *, resolved_name=None):
+        monkeypatch.setattr(
+            "agent.web_search_registry._read_config_key",
+            lambda *path: name if path == ("web", "search_backend") else None,
+        )
+        resolved = resolved_name if resolved_name is not None else name
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: SimpleNamespace(name=resolved) if resolved else None,
+        )
+
+    @staticmethod
+    def _tools():
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            },
+        ]
+
+    def test_explicit_deepseek_backend_swaps_client_tool_one_for_one(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert [tool.get("name") for tool in kw["tools"] if tool.get("type") == "function"] == ["terminal"]
+        assert [tool for tool in kw["tools"] if tool.get("type") == "web_search"] == [{"type": "web_search"}]
+
+    def test_non_deepseek_backend_preserves_client_web_search(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "firecrawl")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_auto_resolved_deepseek_provider_is_not_enough(self, transport, monkeypatch):
+        self._select_backend(monkeypatch, None, resolved_name="deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_native_search_is_not_added_without_client_tool(
+        self, transport, monkeypatch
+    ):
+        self._select_backend(monkeypatch, "deepseek")
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=self._tools()[:1],
+            is_deepseek_responses=True,
+        )
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_deepseek_sanitizer_runs_after_request_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            session_id="session-1",
+            is_deepseek_responses=True,
+            reasoning_config={"effort": "high"},
+            request_overrides={
+                "include": ["reasoning.encrypted_content"],
+                "prompt_cache_key": "override",
+                "prompt_cache_retention": "24h",
+                "service_tier": "priority",
+                "reasoning": {"effort": "high", "summary": "auto"},
+                "extra_body": {
+                    "prompt_cache_key": "nested",
+                    "service_tier": "priority",
+                    "kept": "yes",
+                },
+            },
+        )
+        for key in ("include", "prompt_cache_key", "prompt_cache_retention", "service_tier"):
+            assert key not in kw
+        assert kw["reasoning"] == {"effort": "high"}
+        assert kw["extra_body"] == {"kept": "yes"}
+
+
+class TestDeepSeekWebSearchReplay:
+    def test_completed_search_call_is_persisted_and_replayed_in_order(self, transport):
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_123",
+                    call_id="ws_call_123",
+                    status="completed",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="current DeepSeek release",
+                        sources=[{"url": "https://example.com"}],
+                    ),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    id="msg_123",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="DeepSeek released ...")],
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+        )
+
+        normalized = transport.normalize_response(response)
+        assert normalized.finish_reason == "stop"
+        assert normalized.codex_message_items[0] == {
+            "type": "web_search_call",
+            "id": "ws_123",
+            "call_id": "ws_call_123",
+            "status": "completed",
+            "action": {
+                "type": "search",
+                "query": "current DeepSeek release",
+                "sources": [{"url": "https://example.com"}],
+            },
+        }
+
+        replay = transport.convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "DeepSeek released ...",
+                    "codex_message_items": normalized.codex_message_items,
+                },
+                {"role": "user", "content": "What was the source?"},
+            ],
+            base_url="https://api.deepseek.com",
+            replay_encrypted_reasoning=False,
+        )
+        assert replay[0]["type"] == "web_search_call"
+        assert replay[0]["call_id"] == "ws_call_123"
+        assert replay[0]["action"]["query"] == "current DeepSeek release"
+        assert replay[1]["type"] == "message"
+        assert replay[2] == {"role": "user", "content": "What was the source?"}
+        assert all(item.get("content") != "ws_call_123" for item in replay)
+
+    def test_in_progress_server_call_does_not_force_incomplete(self, transport):
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_pending",
+                    status="in_progress",
+                    action=SimpleNamespace(type="search", query="query"),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="answer")],
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+        )
+        normalized = transport.normalize_response(response)
+        assert normalized.finish_reason == "stop"
+        assert normalized.content == "answer"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -882,6 +882,60 @@ class TestDeepSeekNativeWebSearch:
         assert [tool.get("name") for tool in kw["tools"] if tool.get("type") == "function"] == ["terminal"]
         assert [tool for tool in kw["tools"] if tool.get("type") == "web_search"] == [{"type": "web_search"}]
 
+    def test_responses_model_without_native_search_keeps_client_tool(
+        self, transport, monkeypatch
+    ):
+        from hermes_cli import providers as provider_registry
+        from hermes_cli.providers import DeepSeekModelCapabilities
+
+        self._select_backend(monkeypatch, "deepseek")
+        monkeypatch.setitem(
+            provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+            "deepseek-v4-pro",
+            DeepSeekModelCapabilities(
+                responses_api=True,
+                native_web_search=False,
+            ),
+        )
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert any(tool.get("name") == "web_search" for tool in kw["tools"])
+        assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    def test_future_pro_capability_enables_existing_native_search_path(
+        self, transport, monkeypatch
+    ):
+        from hermes_cli import providers as provider_registry
+        from hermes_cli.providers import DeepSeekModelCapabilities
+
+        self._select_backend(monkeypatch, "deepseek")
+        monkeypatch.setitem(
+            provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+            "deepseek-v4-pro",
+            DeepSeekModelCapabilities(
+                responses_api=True,
+                native_web_search=True,
+            ),
+        )
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "latest news"}],
+            tools=self._tools(),
+            is_deepseek_responses=True,
+        )
+        assert [
+            tool.get("name")
+            for tool in kw["tools"]
+            if tool.get("type") == "function"
+        ] == ["terminal"]
+        assert [
+            tool for tool in kw["tools"] if tool.get("type") == "web_search"
+        ] == [{"type": "web_search"}]
+
     def test_non_deepseek_backend_preserves_client_web_search(
         self, transport, monkeypatch
     ):
@@ -917,6 +971,26 @@ class TestDeepSeekNativeWebSearch:
             is_deepseek_responses=True,
         )
         assert not any(tool.get("type") == "web_search" for tool in kw["tools"])
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            ("xhigh", "high"),
+            ("ultra", "max"),
+            ("max", "max"),
+        ],
+    )
+    def test_deepseek_reasoning_effort_clamps_product_aliases(
+        self, transport, configured, expected
+    ):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            is_deepseek_responses=True,
+            reasoning_config={"effort": configured},
+        )
+        assert kw["reasoning"] == {"effort": expected}
 
     def test_deepseek_sanitizer_runs_after_request_overrides(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -946,6 +946,62 @@ class TestDeepSeekNativeWebSearch:
 
 
 class TestDeepSeekWebSearchReplay:
+    def test_streamed_search_call_normalizes_and_replays_in_order(self, transport):
+        from agent.codex_runtime import _consume_codex_event_stream
+
+        search_item = SimpleNamespace(
+            type="web_search_call",
+            id="ws_stream_1",
+            call_id="ws_call_stream_1",
+            status="completed",
+            action=SimpleNamespace(type="search", query="latest release"),
+        )
+        message_item = SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text="Latest result")],
+        )
+        response = _consume_codex_event_stream(
+            [
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=search_item,
+                ),
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=message_item,
+                ),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed", id="resp_1"),
+                ),
+            ],
+            model="deepseek-v4-flash",
+        )
+
+        normalized = transport.normalize_response(response)
+        replay = transport.convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": normalized.content,
+                    "codex_message_items": normalized.codex_message_items,
+                },
+                {"role": "user", "content": "source?"},
+            ],
+            base_url="https://api.deepseek.com",
+            replay_encrypted_reasoning=False,
+        )
+
+        assert [item["type"] for item in replay[:2]] == [
+            "web_search_call",
+            "message",
+        ]
+        assert replay[0]["call_id"] == "ws_call_stream_1"
+        assert replay[0]["action"]["query"] == "latest release"
+        assert replay[2] == {"role": "user", "content": "source?"}
+
     def test_completed_search_call_is_persisted_and_replayed_in_order(self, transport):
         response = SimpleNamespace(
             output=[

--- a/tests/hermes_cli/test_deepseek_responses_routing.py
+++ b/tests/hermes_cli/test_deepseek_responses_routing.py
@@ -1,12 +1,17 @@
-"""DeepSeek V4 Flash model-aware Responses routing contracts."""
+"""DeepSeek model capability and Responses routing contracts."""
 
 from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import providers as provider_registry
 from hermes_cli import runtime_provider as rp
 from hermes_cli.providers import (
+    DeepSeekModelCapabilities,
     deepseek_api_mode,
+    deepseek_model_capabilities,
+    deepseek_native_web_search_models,
+    deepseek_supports_native_web_search,
     deepseek_supports_responses,
     determine_api_mode,
     normalize_deepseek_base_url,
@@ -23,6 +28,7 @@ from hermes_cli.providers import (
 )
 def test_only_v4_flash_supports_responses(model):
     assert deepseek_supports_responses(model)
+    assert deepseek_supports_native_web_search(model)
     assert deepseek_api_mode(model) == "codex_responses"
     assert determine_api_mode("deepseek", "https://api.deepseek.com/v1", model) == "codex_responses"
 
@@ -32,6 +38,7 @@ def test_only_v4_flash_supports_responses(model):
     [
         "",
         "deepseek-v4-pro",
+        "deepseek-v4-pro-20260801",
         "deepseek-chat",
         "deepseek-reasoner",
         "deepseek-v4-flash-20260423",
@@ -40,7 +47,55 @@ def test_only_v4_flash_supports_responses(model):
 )
 def test_other_deepseek_models_stay_on_chat_completions(model):
     assert not deepseek_supports_responses(model)
+    assert not deepseek_supports_native_web_search(model)
     assert deepseek_api_mode(model) == "chat_completions"
+
+
+def test_v4_pro_has_explicit_disabled_capability_reservation():
+    assert deepseek_model_capabilities("deepseek-v4-pro") == DeepSeekModelCapabilities(
+        responses_api=False,
+        native_web_search=False,
+    )
+    assert deepseek_native_web_search_models() == ("deepseek-v4-flash",)
+
+
+def test_v4_pro_future_enablement_is_localized_to_capability_entry(monkeypatch):
+    monkeypatch.setitem(
+        provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+        "deepseek-v4-pro",
+        DeepSeekModelCapabilities(
+            responses_api=True,
+            native_web_search=True,
+        ),
+    )
+
+    assert deepseek_api_mode("deepseek-v4-pro") == "codex_responses"
+    assert deepseek_api_mode("deepseek/deepseek-v4-pro") == "codex_responses"
+    assert deepseek_supports_native_web_search("deepseek-v4-pro")
+    assert deepseek_supports_native_web_search("DEEPSEEK/DEEPSEEK-V4-PRO")
+    assert determine_api_mode(
+        "deepseek",
+        "https://api.deepseek.com/v1",
+        "deepseek-v4-pro",
+    ) == "codex_responses"
+    assert deepseek_native_web_search_models() == (
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+    )
+
+
+def test_native_search_capability_fails_closed_without_responses(monkeypatch):
+    monkeypatch.setitem(
+        provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+        "deepseek-v4-pro",
+        DeepSeekModelCapabilities(
+            responses_api=False,
+            native_web_search=True,
+        ),
+    )
+
+    assert not deepseek_supports_native_web_search("deepseek-v4-pro")
+    assert deepseek_api_mode("deepseek-v4-pro") == "chat_completions"
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_deepseek_responses_routing.py
+++ b/tests/hermes_cli/test_deepseek_responses_routing.py
@@ -1,0 +1,264 @@
+"""DeepSeek V4 Flash model-aware Responses routing contracts."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.providers import (
+    deepseek_api_mode,
+    deepseek_supports_responses,
+    determine_api_mode,
+    normalize_deepseek_base_url,
+)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "deepseek-v4-flash",
+        "DEEPSEEK-V4-FLASH",
+        "deepseek/deepseek-v4-flash",
+    ],
+)
+def test_only_v4_flash_supports_responses(model):
+    assert deepseek_supports_responses(model)
+    assert deepseek_api_mode(model) == "codex_responses"
+    assert determine_api_mode("deepseek", "https://api.deepseek.com/v1", model) == "codex_responses"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "",
+        "deepseek-v4-pro",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "deepseek-v4-flash-20260423",
+        "unknown",
+    ],
+)
+def test_other_deepseek_models_stay_on_chat_completions(model):
+    assert not deepseek_supports_responses(model)
+    assert deepseek_api_mode(model) == "chat_completions"
+
+
+@pytest.mark.parametrize(
+    ("mode", "value", "expected"),
+    [
+        ("codex_responses", "https://api.deepseek.com/v1", "https://api.deepseek.com"),
+        ("codex_responses", "https://api.deepseek.com/", "https://api.deepseek.com"),
+        ("chat_completions", "https://api.deepseek.com", "https://api.deepseek.com/v1"),
+        ("chat_completions", "https://api.deepseek.com/v1/", "https://api.deepseek.com/v1"),
+    ],
+)
+def test_official_base_url_is_normalized_by_wire(mode, value, expected):
+    assert normalize_deepseek_base_url("deepseek", mode, value) == expected
+
+
+def test_custom_deepseek_proxy_is_not_rewritten():
+    value = "https://deepseek-proxy.example/v1"
+    assert normalize_deepseek_base_url("deepseek", "codex_responses", value) == value
+
+
+def test_lookalike_official_host_is_not_rewritten():
+    value = "https://api.deepseek.com.attacker.test/v1"
+    assert normalize_deepseek_base_url("deepseek", "codex_responses", value) == value
+
+
+@pytest.fixture
+def deepseek_runtime(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: {})
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "deepseek",
+        "default": "deepseek-v4-pro",
+        "api_mode": "chat_completions",
+    })
+    monkeypatch.setattr(rp, "resolve_provider", lambda *_a, **_kw: "deepseek")
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda _provider: {
+            "provider": "deepseek",
+            "api_key": "deepseek-key",
+            "base_url": "https://api.deepseek.com/v1",
+            "source": "env",
+        },
+    )
+
+
+def test_runtime_target_flash_overrides_stale_persisted_chat_mode(deepseek_runtime):
+    resolved = rp.resolve_runtime_provider(
+        requested="deepseek", target_model="deepseek-v4-flash"
+    )
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.deepseek.com"
+
+
+def test_runtime_target_pro_overrides_stale_persisted_responses_mode(deepseek_runtime, monkeypatch):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "deepseek",
+        "default": "deepseek-v4-flash",
+        "api_mode": "codex_responses",
+    })
+    resolved = rp.resolve_runtime_provider(
+        requested="deepseek", target_model="deepseek-v4-pro"
+    )
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+
+
+@pytest.mark.parametrize(
+    ("target_model", "stale_mode", "entry_url", "expected_mode", "expected_url"),
+    [
+        (
+            "deepseek-v4-flash",
+            "chat_completions",
+            "https://api.deepseek.com/v1",
+            "codex_responses",
+            "https://api.deepseek.com",
+        ),
+        (
+            "deepseek-v4-pro",
+            "codex_responses",
+            "https://api.deepseek.com",
+            "chat_completions",
+            "https://api.deepseek.com/v1",
+        ),
+    ],
+)
+def test_pool_runtime_recomputes_wire_and_official_root(
+    target_model, stale_mode, entry_url, expected_mode, expected_url
+):
+    entry = SimpleNamespace(
+        runtime_api_key="pool-key",
+        access_token="pool-key",
+        runtime_base_url=entry_url,
+        base_url=entry_url,
+        source="credential_pool",
+    )
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="deepseek",
+        entry=entry,
+        requested_provider="deepseek",
+        model_cfg={
+            "provider": "deepseek",
+            "default": "deepseek-v4-pro",
+            "api_mode": stale_mode,
+        },
+        target_model=target_model,
+    )
+    assert resolved["api_mode"] == expected_mode
+    assert resolved["base_url"] == expected_url
+
+
+def test_explicit_runtime_uses_model_aware_wire_and_official_root(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: {})
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "resolve_provider", lambda *_a, **_kw: "deepseek")
+    resolved = rp.resolve_runtime_provider(
+        requested="deepseek",
+        explicit_api_key="sk-test",
+        explicit_base_url="https://api.deepseek.com/v1",
+        target_model="deepseek-v4-flash",
+    )
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.deepseek.com"
+
+
+def test_direct_agent_init_routes_flash_to_responses(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    agent = AIAgent(
+        api_key="sk-test",
+        base_url="https://api.deepseek.com/v1",
+        provider="deepseek",
+        api_mode="chat_completions",
+        model="deepseek-v4-flash",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == "https://api.deepseek.com"
+
+
+def test_direct_agent_init_keeps_pro_on_chat_completions(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    agent = AIAgent(
+        api_key="sk-test",
+        base_url="https://api.deepseek.com",
+        provider="deepseek",
+        api_mode="codex_responses",
+        model="deepseek-v4-pro",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "chat_completions"
+    assert agent.base_url == "https://api.deepseek.com/v1"
+
+
+def test_main_request_builder_uses_explicit_native_search_backend(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(
+        "agent.web_search_registry._read_config_key",
+        lambda *path: "deepseek" if path == ("web", "search_backend") else None,
+    )
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_active_search_provider",
+        lambda: SimpleNamespace(name="deepseek"),
+    )
+    agent = AIAgent(
+        api_key="sk-test",
+        base_url="https://api.deepseek.com/v1",
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    kwargs = agent._build_api_kwargs(
+        [{"role": "user", "content": "latest news"}],
+        tools_for_api=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            }
+        ],
+    )
+    assert kwargs["tools"] == [{"type": "web_search"}]
+    assert "prompt_cache_key" not in kwargs
+    assert "include" not in kwargs

--- a/tests/hermes_cli/test_deepseek_responses_routing.py
+++ b/tests/hermes_cli/test_deepseek_responses_routing.py
@@ -1,4 +1,4 @@
-"""DeepSeek V4 Flash model-aware Responses routing contracts."""
+"""DeepSeek model-aware Responses and native-search routing contracts."""
 
 from types import SimpleNamespace
 
@@ -27,6 +27,9 @@ from hermes_cli.providers import (
         "deepseek-v4-pro",
         "DEEPSEEK-V4-PRO",
         "deepseek/deepseek-v4-pro",
+        "deepseek-v4-flash-vision-exp",
+        "DEEPSEEK-V4-FLASH-VISION-EXP",
+        "deepseek/deepseek-v4-flash-vision-exp",
     ],
 )
 def test_documented_v4_models_support_responses_and_native_search(model):
@@ -53,14 +56,17 @@ def test_other_deepseek_models_stay_on_chat_completions(model):
     assert deepseek_api_mode(model) == "chat_completions"
 
 
-def test_v4_pro_has_ga_responses_and_native_search_capabilities():
+def test_documented_models_are_all_listed_for_native_search():
     assert deepseek_model_capabilities("deepseek-v4-pro") == DeepSeekModelCapabilities(
         responses_api=True,
         native_web_search=True,
     )
     enabled = deepseek_native_web_search_models()
-    assert "deepseek-v4-flash" in enabled
-    assert "deepseek-v4-pro" in enabled
+    assert enabled == (
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
+        "deepseek-v4-pro",
+    )
 
 
 def test_native_search_capability_fails_closed_without_responses(monkeypatch):
@@ -303,7 +309,10 @@ def test_direct_agent_init_routes_pro_to_responses(monkeypatch, tmp_path):
     assert agent.base_url == "https://api.deepseek.com"
 
 
-@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+@pytest.mark.parametrize(
+    "model",
+    ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"],
+)
 def test_main_request_builder_uses_explicit_native_search_backend(
     monkeypatch, tmp_path, model
 ):

--- a/tests/hermes_cli/test_deepseek_responses_routing.py
+++ b/tests/hermes_cli/test_deepseek_responses_routing.py
@@ -4,9 +4,14 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import providers as provider_registry
 from hermes_cli import runtime_provider as rp
 from hermes_cli.providers import (
+    DeepSeekModelCapabilities,
     deepseek_api_mode,
+    deepseek_model_capabilities,
+    deepseek_native_web_search_models,
+    deepseek_supports_native_web_search,
     deepseek_supports_responses,
     determine_api_mode,
     normalize_deepseek_base_url,
@@ -19,10 +24,14 @@ from hermes_cli.providers import (
         "deepseek-v4-flash",
         "DEEPSEEK-V4-FLASH",
         "deepseek/deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "DEEPSEEK-V4-PRO",
+        "deepseek/deepseek-v4-pro",
     ],
 )
-def test_only_v4_flash_supports_responses(model):
+def test_documented_v4_models_support_responses_and_native_search(model):
     assert deepseek_supports_responses(model)
+    assert deepseek_supports_native_web_search(model)
     assert deepseek_api_mode(model) == "codex_responses"
     assert determine_api_mode("deepseek", "https://api.deepseek.com/v1", model) == "codex_responses"
 
@@ -31,7 +40,7 @@ def test_only_v4_flash_supports_responses(model):
     "model",
     [
         "",
-        "deepseek-v4-pro",
+        "deepseek-v4-pro-20260801",
         "deepseek-chat",
         "deepseek-reasoner",
         "deepseek-v4-flash-20260423",
@@ -40,8 +49,32 @@ def test_only_v4_flash_supports_responses(model):
 )
 def test_other_deepseek_models_stay_on_chat_completions(model):
     assert not deepseek_supports_responses(model)
+    assert not deepseek_supports_native_web_search(model)
     assert deepseek_api_mode(model) == "chat_completions"
 
+
+def test_v4_pro_has_ga_responses_and_native_search_capabilities():
+    assert deepseek_model_capabilities("deepseek-v4-pro") == DeepSeekModelCapabilities(
+        responses_api=True,
+        native_web_search=True,
+    )
+    enabled = deepseek_native_web_search_models()
+    assert "deepseek-v4-flash" in enabled
+    assert "deepseek-v4-pro" in enabled
+
+
+def test_native_search_capability_fails_closed_without_responses(monkeypatch):
+    monkeypatch.setitem(
+        provider_registry._DEEPSEEK_MODEL_CAPABILITIES,
+        "deepseek-v4-future",
+        DeepSeekModelCapabilities(
+            responses_api=False,
+            native_web_search=True,
+        ),
+    )
+
+    assert not deepseek_supports_native_web_search("deepseek-v4-future")
+    assert deepseek_api_mode("deepseek-v4-future") == "chat_completions"
 
 
 @pytest.mark.parametrize(
@@ -125,17 +158,17 @@ def test_runtime_normalizes_retired_alias_before_wire_selection(deepseek_runtime
     assert resolved["base_url"] == "https://api.deepseek.com"
 
 
-def test_runtime_target_pro_overrides_stale_persisted_responses_mode(deepseek_runtime, monkeypatch):
+def test_runtime_target_pro_overrides_stale_persisted_chat_mode(deepseek_runtime, monkeypatch):
     monkeypatch.setattr(rp, "_get_model_config", lambda: {
         "provider": "deepseek",
         "default": "deepseek-v4-flash",
-        "api_mode": "codex_responses",
+        "api_mode": "chat_completions",
     })
     resolved = rp.resolve_runtime_provider(
         requested="deepseek", target_model="deepseek-v4-pro"
     )
-    assert resolved["api_mode"] == "chat_completions"
-    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.deepseek.com"
 
 
 @pytest.mark.parametrize(
@@ -150,10 +183,10 @@ def test_runtime_target_pro_overrides_stale_persisted_responses_mode(deepseek_ru
         ),
         (
             "deepseek-v4-pro",
-            "codex_responses",
-            "https://api.deepseek.com",
             "chat_completions",
             "https://api.deepseek.com/v1",
+            "codex_responses",
+            "https://api.deepseek.com",
         ),
     ],
 )
@@ -246,7 +279,7 @@ def test_direct_agent_init_normalizes_alias_before_wire_selection(monkeypatch, t
     assert agent.base_url == "https://api.deepseek.com"
 
 
-def test_direct_agent_init_keeps_pro_on_chat_completions(monkeypatch, tmp_path):
+def test_direct_agent_init_routes_pro_to_responses(monkeypatch, tmp_path):
     from unittest.mock import MagicMock
 
     from run_agent import AIAgent
@@ -257,20 +290,23 @@ def test_direct_agent_init_keeps_pro_on_chat_completions(monkeypatch, tmp_path):
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     agent = AIAgent(
         api_key="sk-test",
-        base_url="https://api.deepseek.com",
+        base_url="https://api.deepseek.com/v1",
         provider="deepseek",
-        api_mode="codex_responses",
+        api_mode="chat_completions",
         model="deepseek-v4-pro",
         max_iterations=1,
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
     )
-    assert agent.api_mode == "chat_completions"
-    assert agent.base_url == "https://api.deepseek.com/v1"
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == "https://api.deepseek.com"
 
 
-def test_main_request_builder_uses_explicit_native_search_backend(monkeypatch, tmp_path):
+@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+def test_main_request_builder_uses_explicit_native_search_backend(
+    monkeypatch, tmp_path, model
+):
     from unittest.mock import MagicMock
 
     from run_agent import AIAgent
@@ -291,7 +327,7 @@ def test_main_request_builder_uses_explicit_native_search_backend(monkeypatch, t
         api_key="sk-test",
         base_url="https://api.deepseek.com/v1",
         provider="deepseek",
-        model="deepseek-v4-flash",
+        model=model,
         max_iterations=1,
         quiet_mode=True,
         skip_context_files=True,

--- a/tests/hermes_cli/test_deepseek_responses_routing.py
+++ b/tests/hermes_cli/test_deepseek_responses_routing.py
@@ -43,6 +43,7 @@ def test_other_deepseek_models_stay_on_chat_completions(model):
     assert deepseek_api_mode(model) == "chat_completions"
 
 
+
 @pytest.mark.parametrize(
     ("mode", "value", "expected"),
     [
@@ -57,12 +58,32 @@ def test_official_base_url_is_normalized_by_wire(mode, value, expected):
 
 
 def test_custom_deepseek_proxy_is_not_rewritten():
-    value = "https://deepseek-proxy.example/v1"
+    value = "https://deepseek-proxy.example/v1/"
     assert normalize_deepseek_base_url("deepseek", "codex_responses", value) == value
+
+
+def test_non_deepseek_url_is_not_changed():
+    value = "https://another-provider.example/v1/"
+    assert normalize_deepseek_base_url("custom", "codex_responses", value) == value
 
 
 def test_lookalike_official_host_is_not_rewritten():
     value = "https://api.deepseek.com.attacker.test/v1"
+    assert normalize_deepseek_base_url("deepseek", "codex_responses", value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://api.deepseek.com/v1?tenant=one",
+        "https://api.deepseek.com/v1#fragment",
+        "https://api.deepseek.com/v1?redirect=https://example.test/",
+        "https://api.deepseek.com/v1#section/",
+        "https://user@api.deepseek.com/v1",
+        "https://api.deepseek.com/custom/v1",
+    ],
+)
+def test_noncanonical_official_urls_are_not_rewritten(value):
     assert normalize_deepseek_base_url("deepseek", "codex_responses", value) == value
 
 
@@ -91,6 +112,14 @@ def deepseek_runtime(monkeypatch):
 def test_runtime_target_flash_overrides_stale_persisted_chat_mode(deepseek_runtime):
     resolved = rp.resolve_runtime_provider(
         requested="deepseek", target_model="deepseek-v4-flash"
+    )
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.deepseek.com"
+
+
+def test_runtime_normalizes_retired_alias_before_wire_selection(deepseek_runtime):
+    resolved = rp.resolve_runtime_provider(
+        requested="deepseek", target_model="deepseek-chat"
     )
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.deepseek.com"
@@ -187,6 +216,32 @@ def test_direct_agent_init_routes_flash_to_responses(monkeypatch, tmp_path):
         skip_context_files=True,
         skip_memory=True,
     )
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == "https://api.deepseek.com"
+
+
+def test_direct_agent_init_normalizes_alias_before_wire_selection(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    agent = AIAgent(
+        api_key="sk-test",
+        base_url="https://api.deepseek.com/v1",
+        provider="deepseek",
+        api_mode="chat_completions",
+        model="deepseek-chat",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent.model == "deepseek-v4-flash"
     assert agent.api_mode == "codex_responses"
     assert agent.base_url == "https://api.deepseek.com"
 

--- a/tests/hermes_cli/test_model_switch_deepseek_responses.py
+++ b/tests/hermes_cli/test_model_switch_deepseek_responses.py
@@ -1,0 +1,63 @@
+"""DeepSeek model switches must recompute wire mode and official base URL."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _run_switch(raw_input: str, *, current_model: str, runtime_mode: str, runtime_url: str):
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-test",
+                "base_url": runtime_url,
+                "api_mode": runtime_mode,
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider="deepseek",
+            current_model=current_model,
+            current_base_url=runtime_url,
+            current_api_key="sk-test",
+        )
+
+
+def test_switch_pro_to_flash_uses_responses_root():
+    result = _run_switch(
+        "deepseek-v4-flash",
+        current_model="deepseek-v4-pro",
+        runtime_mode="chat_completions",
+        runtime_url="https://api.deepseek.com/v1",
+    )
+    assert result.success
+    assert result.api_mode == "codex_responses"
+    assert result.base_url == "https://api.deepseek.com"
+
+
+def test_switch_flash_to_pro_restores_chat_v1():
+    result = _run_switch(
+        "deepseek-v4-pro",
+        current_model="deepseek-v4-flash",
+        runtime_mode="codex_responses",
+        runtime_url="https://api.deepseek.com",
+    )
+    assert result.success
+    assert result.api_mode == "chat_completions"
+    assert result.base_url == "https://api.deepseek.com/v1"

--- a/tests/hermes_cli/test_model_switch_deepseek_responses.py
+++ b/tests/hermes_cli/test_model_switch_deepseek_responses.py
@@ -51,13 +51,13 @@ def test_switch_pro_to_flash_uses_responses_root():
     assert result.base_url == "https://api.deepseek.com"
 
 
-def test_switch_flash_to_pro_restores_chat_v1():
+def test_switch_flash_to_pro_stays_on_responses_root():
     result = _run_switch(
         "deepseek-v4-pro",
         current_model="deepseek-v4-flash",
-        runtime_mode="codex_responses",
-        runtime_url="https://api.deepseek.com",
+        runtime_mode="chat_completions",
+        runtime_url="https://api.deepseek.com/v1",
     )
     assert result.success
-    assert result.api_mode == "chat_completions"
-    assert result.base_url == "https://api.deepseek.com/v1"
+    assert result.api_mode == "codex_responses"
+    assert result.base_url == "https://api.deepseek.com"

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -193,6 +193,7 @@ class TestDeepSeekAuxModel:
         assert deepseek_profile.fallback_models == (
             "deepseek-v4-pro",
             "deepseek-v4-flash",
+            "deepseek-v4-flash-vision-exp",
         )
 
     def test_consumer_api_returns_deepseek_v4_flash(self):

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All bundled plugins (brave-free, ddgs, searxng, exa, parallel,
   tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "DEEPSEEK_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,7 +69,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
     def test_all_seven_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -78,6 +79,7 @@ class TestBundledPluginsRegister:
         assert names == [
             "brave-free",
             "ddgs",
+            "deepseek",
             "exa",
             "firecrawl",
             "parallel",
@@ -91,6 +93,7 @@ class TestBundledPluginsRegister:
         [
             ("brave-free", True, False),
             ("ddgs", True, False),
+            ("deepseek", True, False),
             ("searxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
@@ -116,7 +119,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "deepseek", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -145,6 +148,44 @@ class TestIsAvailable:
         assert p.is_available() is False  # no BRAVE_SEARCH_API_KEY
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "real")
         assert p.is_available() is True
+
+    def test_deepseek_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("deepseek")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_deepseek_local_dispatch_returns_route_error(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("deepseek")
+        result = p.search("query")
+        assert result["success"] is False
+        assert "deepseek-v4-flash" in result["error"]
+
+    def test_deepseek_native_search_requires_explicit_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.transports.codex import _deepseek_prefers_native_web_search
+
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {},
+        )
+        assert _deepseek_prefers_native_web_search() is False
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"search_backend": "deepseek"}},
+        )
+        assert _deepseek_prefers_native_web_search() is True
 
     def test_searxng_requires_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -187,6 +187,20 @@ class TestIsAvailable:
         )
         assert _deepseek_prefers_native_web_search() is True
 
+    def test_deepseek_key_alone_never_auto_selects_marker_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        import agent.web_search_registry as registry
+
+        provider = registry.get_provider("deepseek")
+        assert provider is not None
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        monkeypatch.setattr(registry, "_providers", {"deepseek": provider})
+
+        assert registry._resolve(None, capability="search") is None
+        assert registry._resolve("deepseek", capability="search") is provider
+
     def test_searxng_requires_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider
@@ -351,5 +365,4 @@ class TestAsyncExtractDispatch:
 
 class TestErrorResponseShapes:
     """When credentials are missing, plugins return typed errors, not raises."""
-
 

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -206,10 +206,13 @@ class TestIsAvailable:
         provider = registry.get_provider("deepseek")
         assert provider is not None
         monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
-        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"keyless_fallback": False}},
+        )
         monkeypatch.setattr(registry, "_providers", {"deepseek": provider})
 
-        assert registry._resolve(None, capability="search") is None
+        assert registry._resolve(None, capability="search") is not provider
         assert registry._resolve("deepseek", capability="search") is provider
 
     def test_deepseek_setup_schema_uses_picker_contract(self) -> None:
@@ -233,15 +236,23 @@ class TestIsAvailable:
         )
         monkeypatch.setattr(
             "tools.web_tools._load_web_config",
-            lambda: {"search_backend": "deepseek"},
+            lambda: {
+                "search_backend": "deepseek",
+                "keyless_fallback": False,
+            },
         )
 
+        monkeypatch.setattr(
+            "tools.web_tools._keyless_rescue_enabled",
+            lambda: False,
+        )
         from tools.web_tools import _get_search_backend, web_search_tool
 
         assert _get_search_backend() == "deepseek"
         result = json.loads(web_search_tool("query"))
         assert result["success"] is False
         assert "active DeepSeek model" in result["error"]
+        assert "deepseek-v4-flash-vision-exp" in result["error"]
 
     def test_deepseek_picker_row_can_be_selected_without_credentials(self) -> None:
         _ensure_plugins_loaded()

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -188,6 +188,20 @@ class TestIsAvailable:
         )
         assert _deepseek_prefers_native_web_search() is True
 
+    def test_deepseek_key_alone_never_auto_selects_marker_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        import agent.web_search_registry as registry
+
+        provider = registry.get_provider("deepseek")
+        assert provider is not None
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        monkeypatch.setattr(registry, "_providers", {"deepseek": provider})
+
+        assert registry._resolve(None, capability="search") is None
+        assert registry._resolve("deepseek", capability="search") is provider
+
     def test_searxng_requires_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider
@@ -370,5 +384,4 @@ class TestAsyncExtractDispatch:
 
 class TestErrorResponseShapes:
     """When credentials are missing, plugins return typed errors, not raises."""
-
 

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -75,8 +75,8 @@ class TestBundledPluginsRegister:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
-        names = sorted(p.name for p in list_providers())
-        assert names == [
+        names = {p.name for p in list_providers()}
+        assert {
             "brave-free",
             "ddgs",
             "deepseek",
@@ -87,7 +87,7 @@ class TestBundledPluginsRegister:
             "searxng",
             "tavily",
             "xai",
-        ]
+        }.issubset(names)
 
     @pytest.mark.parametrize(
         "plugin_name,expected_search,expected_extract",
@@ -150,14 +150,23 @@ class TestIsAvailable:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "real")
         assert p.is_available() is True
 
-    def test_deepseek_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_deepseek_marker_is_never_implicitly_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider
 
         p = get_provider("deepseek")
         assert p is not None
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
         assert p.is_available() is False
         monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        assert p.is_available() is False
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"search_backend": "deepseek"}},
+        )
         assert p.is_available() is True
 
     def test_deepseek_local_dispatch_returns_route_error(self) -> None:
@@ -173,20 +182,20 @@ class TestIsAvailable:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _ensure_plugins_loaded()
-        from agent.transports.codex import _deepseek_prefers_native_web_search
+        from agent.transports.codex import _deepseek_native_web_search_enabled
 
         monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly",
             lambda: {},
         )
-        assert _deepseek_prefers_native_web_search() is False
+        assert _deepseek_native_web_search_enabled() is False
 
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly",
             lambda: {"web": {"search_backend": "deepseek"}},
         )
-        assert _deepseek_prefers_native_web_search() is True
+        assert _deepseek_native_web_search_enabled() is True
 
     def test_deepseek_key_alone_never_auto_selects_marker_provider(
         self, monkeypatch: pytest.MonkeyPatch
@@ -197,10 +206,83 @@ class TestIsAvailable:
         provider = registry.get_provider("deepseek")
         assert provider is not None
         monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
         monkeypatch.setattr(registry, "_providers", {"deepseek": provider})
 
         assert registry._resolve(None, capability="search") is None
         assert registry._resolve("deepseek", capability="search") is provider
+
+    def test_deepseek_setup_schema_uses_picker_contract(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        schema = get_provider("deepseek").get_setup_schema()
+        assert schema["name"] == "DeepSeek Native Web Search"
+        assert schema["env_vars"] == []
+        assert "Models first" in schema["tag"]
+
+    def test_deepseek_search_backend_reaches_marker_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json
+
+        _ensure_plugins_loaded()
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"search_backend": "deepseek"}},
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config",
+            lambda: {"search_backend": "deepseek"},
+        )
+
+        from tools.web_tools import _get_search_backend, web_search_tool
+
+        assert _get_search_backend() == "deepseek"
+        result = json.loads(web_search_tool("query"))
+        assert result["success"] is False
+        assert "active DeepSeek model" in result["error"]
+
+    def test_deepseek_picker_row_can_be_selected_without_credentials(self) -> None:
+        _ensure_plugins_loaded()
+        from hermes_cli.tools_config import (
+            _plugin_web_search_providers,
+            _write_provider_config,
+        )
+
+        row = next(
+            item
+            for item in _plugin_web_search_providers()
+            if item["web_backend"] == "deepseek"
+        )
+        config = {}
+        _write_provider_config(row, config, managed_feature=None)
+
+        assert row["env_vars"] == []
+        assert config["web"]["backend"] == "deepseek"
+
+    def test_deepseek_selection_exposes_real_web_search_tool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        config = {"web": {"search_backend": "deepseek"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: config)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+        from model_tools import get_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        invalidate_check_fn_cache()
+        try:
+            definitions = get_tool_definitions(
+                enabled_toolsets=["web"],
+                quiet_mode=False,
+            )
+        finally:
+            invalidate_check_fn_cache()
+
+        names = {item["function"]["name"] for item in definitions}
+        assert "web_search" in names
 
     def test_searxng_requires_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()
@@ -384,4 +466,3 @@ class TestAsyncExtractDispatch:
 
 class TestErrorResponseShapes:
     """When credentials are missing, plugins return typed errors, not raises."""
-

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All bundled plugins (brave-free, ddgs, searxng, exa, parallel,
   tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "DEEPSEEK_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,7 +69,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
     def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -78,6 +79,7 @@ class TestBundledPluginsRegister:
         assert names == [
             "brave-free",
             "ddgs",
+            "deepseek",
             "exa",
             "firecrawl",
             "keenable",
@@ -92,6 +94,7 @@ class TestBundledPluginsRegister:
         [
             ("brave-free", True, False),
             ("ddgs", True, False),
+            ("deepseek", True, False),
             ("searxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
@@ -117,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "deepseek", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -146,6 +149,44 @@ class TestIsAvailable:
         assert p.is_available() is False  # no BRAVE_SEARCH_API_KEY
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "real")
         assert p.is_available() is True
+
+    def test_deepseek_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("deepseek")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_deepseek_local_dispatch_returns_route_error(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("deepseek")
+        result = p.search("query")
+        assert result["success"] is False
+        assert "deepseek-v4-flash" in result["error"]
+
+    def test_deepseek_native_search_requires_explicit_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.transports.codex import _deepseek_prefers_native_web_search
+
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {},
+        )
+        assert _deepseek_prefers_native_web_search() is False
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"search_backend": "deepseek"}},
+        )
+        assert _deepseek_prefers_native_web_search() is True
 
     def test_searxng_requires_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()

--- a/tests/run_agent/test_credential_rotation_route_settings.py
+++ b/tests/run_agent/test_credential_rotation_route_settings.py
@@ -139,7 +139,7 @@ def test_deepseek_credential_rotation_preserves_wire_specific_official_root(
         model=(
             "deepseek-v4-flash"
             if api_mode == "codex_responses"
-            else "deepseek-v4-pro"
+            else "deepseek-v4-pro-legacy"
         ),
         api_key="old",
         base_url=current_url,

--- a/tests/run_agent/test_credential_rotation_route_settings.py
+++ b/tests/run_agent/test_credential_rotation_route_settings.py
@@ -3,6 +3,8 @@
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -109,3 +111,54 @@ def test_credential_rotation_does_not_carry_global_headers_across_routes():
     headers = agent._client_kwargs["default_headers"]
     assert "Authorization" not in headers
     assert headers["X-Route"] == "b"
+
+
+@pytest.mark.parametrize(
+    "api_mode,current_url,entry_url,expected_url",
+    [
+        (
+            "codex_responses",
+            "https://api.deepseek.com",
+            "https://api.deepseek.com/v1",
+            "https://api.deepseek.com",
+        ),
+        (
+            "chat_completions",
+            "https://api.deepseek.com/v1",
+            "https://api.deepseek.com",
+            "https://api.deepseek.com/v1",
+        ),
+    ],
+)
+def test_deepseek_credential_rotation_preserves_wire_specific_official_root(
+    api_mode, current_url, entry_url, expected_url
+):
+    agent = SimpleNamespace(
+        api_mode=api_mode,
+        provider="deepseek",
+        model=(
+            "deepseek-v4-flash"
+            if api_mode == "codex_responses"
+            else "deepseek-v4-pro"
+        ),
+        api_key="old",
+        base_url=current_url,
+        _client_kwargs={"api_key": "old", "base_url": current_url},
+        _reapply_route_client_config=MagicMock(),
+        _replace_primary_openai_client=MagicMock(),
+    )
+    entry = SimpleNamespace(
+        id="pool-entry",
+        runtime_api_key="new",
+        access_token="",
+        runtime_base_url=entry_url,
+        base_url=entry_url,
+    )
+
+    AIAgent._swap_credential(agent, entry)
+
+    assert agent.base_url == expected_url
+    assert agent._client_kwargs["base_url"] == expected_url
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="credential_rotation"
+    )

--- a/tests/run_agent/test_deepseek_responses_wire.py
+++ b/tests/run_agent/test_deepseek_responses_wire.py
@@ -1,0 +1,263 @@
+"""Local-wire E2E coverage for DeepSeek Responses native web search.
+
+This uses the real OpenAI SDK against an in-process HTTP server. It verifies the
+route, request body, streamed ``web_search_call`` normalization, and stateless
+turn-N+1 replay without spending a DeepSeek API key.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+
+class _DeepSeekResponsesHandler(BaseHTTPRequestHandler):
+    captured_requests: list[dict] = []
+    response_items_queue: list[list[dict]] = []
+
+    def do_POST(self):  # noqa: N802 - stdlib handler API
+        length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(length)
+
+        # AIAgent probes custom endpoints during context-window discovery (for
+        # example POST /api/show). Those requests are not Responses API turns
+        # and must not consume the queued SSE fixtures.
+        if self.path != "/responses":
+            body = b'{"error":"not found"}'
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        request_body = json.loads(raw_body.decode("utf-8"))
+        type(self).captured_requests.append({"path": self.path, "body": request_body})
+        items = type(self).response_items_queue.pop(0)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        sequence = 0
+        for output_index, item in enumerate(items):
+            self._send_event({
+                "type": "response.output_item.done",
+                "sequence_number": sequence,
+                "output_index": output_index,
+                "item": item,
+            })
+            sequence += 1
+
+        self._send_event({
+            "type": "response.completed",
+            "sequence_number": sequence,
+            "response": _completed_response(items),
+        })
+
+    def _send_event(self, event: dict) -> None:
+        payload = json.dumps(event, separators=(",", ":"))
+        self.wfile.write(f"event: {event['type']}\ndata: {payload}\n\n".encode("utf-8"))
+        self.wfile.flush()
+
+    def log_message(self, *_args):
+        pass
+
+
+def _message_item(text: str, item_id: str) -> dict:
+    return {
+        "id": item_id,
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+                "logprobs": [],
+            }
+        ],
+    }
+
+
+def _completed_response(items: list[dict]) -> dict:
+    return {
+        "id": "resp_local",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "background": False,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "max_tool_calls": None,
+        "model": "deepseek-v4-flash",
+        "output": items,
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "prompt": None,
+        "reasoning": {"effort": "medium", "summary": None},
+        "service_tier": "default",
+        "store": False,
+        "temperature": 1.0,
+        "text": {"format": {"type": "text"}, "verbosity": "medium"},
+        "tool_choice": "auto",
+        "tools": [{"type": "web_search"}],
+        "top_logprobs": 0,
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": {
+            "input_tokens": 10,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 5,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 15,
+        },
+        "user": None,
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def deepseek_wire_server():
+    _DeepSeekResponsesHandler.captured_requests = []
+    _DeepSeekResponsesHandler.response_items_queue = [
+        [
+            {
+                "id": "ws_1",
+                "type": "web_search_call",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "latest DeepSeek release",
+                    "sources": [{"type": "url", "url": "https://example.test/source"}],
+                },
+            },
+            _message_item("DeepSeek released an update.", "msg_1"),
+        ],
+        [_message_item("The source is example.test.", "msg_2")],
+    ]
+    server = HTTPServer(("127.0.0.1", 0), _DeepSeekResponsesHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, _DeepSeekResponsesHandler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _web_search_tool() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def test_real_sdk_streams_and_replays_deepseek_web_search_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    deepseek_wire_server,
+):
+    from run_agent import AIAgent
+
+    server, handler = deepseek_wire_server
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kwargs: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(
+        "agent.web_search_registry._read_config_key",
+        lambda *path: "deepseek" if path == ("web", "search_backend") else None,
+    )
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_active_search_provider",
+        lambda: SimpleNamespace(name="deepseek"),
+    )
+
+    agent = AIAgent(
+        api_key="not-a-real-key",
+        base_url=base_url,
+        provider="deepseek",
+        api_mode="chat_completions",  # stale input must be corrected by model
+        model="deepseek-v4-flash",
+        max_iterations=1,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+    )
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == base_url
+
+    tools = [_web_search_tool()]
+    first_messages = [{"role": "user", "content": "What is new?"}]
+    first_kwargs = agent._build_api_kwargs(first_messages, tools_for_api=tools)
+    first_response = agent._run_codex_stream(first_kwargs)
+    normalized = agent._get_transport().normalize_response(first_response)
+
+    assert normalized.content == "DeepSeek released an update."
+    assert [item["type"] for item in normalized.codex_message_items] == [
+        "web_search_call",
+        "message",
+    ]
+
+    history = [
+        *first_messages,
+        {
+            "role": "assistant",
+            "content": normalized.content,
+            "codex_message_items": normalized.codex_message_items,
+        },
+        {"role": "user", "content": "Which source?"},
+    ]
+    second_kwargs = agent._build_api_kwargs(history, tools_for_api=tools)
+    second_response = agent._run_codex_stream(second_kwargs)
+    second_normalized = agent._get_transport().normalize_response(second_response)
+    assert second_normalized.content == "The source is example.test."
+
+    assert [request["path"] for request in handler.captured_requests] == [
+        "/responses",
+        "/responses",
+    ]
+    first_body = handler.captured_requests[0]["body"]
+    assert first_body["tools"] == [{"type": "web_search"}]
+    assert "prompt_cache_key" not in first_body
+    assert "include" not in first_body
+
+    replay_input = handler.captured_requests[1]["body"]["input"]
+    replayed_search = next(
+        item for item in replay_input if item.get("type") == "web_search_call"
+    )
+    assert replayed_search == {
+        "id": "ws_1",
+        "type": "web_search_call",
+        "status": "completed",
+        "action": {
+            "type": "search",
+            "query": "latest DeepSeek release",
+            "sources": [{"type": "url", "url": "https://example.test/source"}],
+        },
+    }
+    assert [item.get("type", item.get("role")) for item in replay_input] == [
+        "user",
+        "web_search_call",
+        "message",
+        "user",
+    ]

--- a/tests/run_agent/test_deepseek_responses_wire.py
+++ b/tests/run_agent/test_deepseek_responses_wire.py
@@ -56,7 +56,7 @@ class _DeepSeekResponsesHandler(BaseHTTPRequestHandler):
         self._send_event({
             "type": "response.completed",
             "sequence_number": sequence,
-            "response": _completed_response(items),
+            "response": _completed_response(items, request_body["model"]),
         })
 
     def _send_event(self, event: dict) -> None:
@@ -85,7 +85,7 @@ def _message_item(text: str, item_id: str) -> dict:
     }
 
 
-def _completed_response(items: list[dict]) -> dict:
+def _completed_response(items: list[dict], model: str) -> dict:
     return {
         "id": "resp_local",
         "object": "response",
@@ -97,7 +97,7 @@ def _completed_response(items: list[dict]) -> dict:
         "instructions": None,
         "max_output_tokens": None,
         "max_tool_calls": None,
-        "model": "deepseek-v4-flash",
+        "model": model,
         "output": items,
         "parallel_tool_calls": True,
         "previous_response_id": None,
@@ -169,10 +169,12 @@ def _web_search_tool() -> dict:
     }
 
 
+@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
 def test_real_sdk_streams_and_replays_deepseek_web_search_call(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
     deepseek_wire_server,
+    model,
 ):
     from run_agent import AIAgent
 
@@ -195,7 +197,7 @@ def test_real_sdk_streams_and_replays_deepseek_web_search_call(
         base_url=base_url,
         provider="deepseek",
         api_mode="chat_completions",  # stale input must be corrected by model
-        model="deepseek-v4-flash",
+        model=model,
         max_iterations=1,
         enabled_toolsets=[],
         quiet_mode=True,
@@ -241,7 +243,9 @@ def test_real_sdk_streams_and_replays_deepseek_web_search_call(
         "/responses",
     ]
     first_body = handler.captured_requests[0]["body"]
+    assert first_body["model"] == model
     assert first_body["tools"] == [{"type": "web_search"}]
+    assert first_body["reasoning"] == {"effort": "high"}
     assert "prompt_cache_key" not in first_body
     assert "include" not in first_body
     assert "context_management" not in first_body

--- a/tests/run_agent/test_deepseek_responses_wire.py
+++ b/tests/run_agent/test_deepseek_responses_wire.py
@@ -1,0 +1,268 @@
+"""Local-wire E2E coverage for DeepSeek Responses native web search.
+
+This uses the real OpenAI SDK against an in-process HTTP server. It verifies the
+route, request body, streamed ``web_search_call`` normalization, and stateless
+turn-N+1 replay without spending a DeepSeek API key.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+
+class _DeepSeekResponsesHandler(BaseHTTPRequestHandler):
+    captured_requests: list[dict] = []
+    response_items_queue: list[list[dict]] = []
+
+    def do_POST(self):  # noqa: N802 - stdlib handler API
+        length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(length)
+
+        # AIAgent probes custom endpoints during context-window discovery (for
+        # example POST /api/show). Those requests are not Responses API turns
+        # and must not consume the queued SSE fixtures.
+        if self.path != "/responses":
+            body = b'{"error":"not found"}'
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        request_body = json.loads(raw_body.decode("utf-8"))
+        type(self).captured_requests.append({"path": self.path, "body": request_body})
+        items = type(self).response_items_queue.pop(0)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        sequence = 0
+        for output_index, item in enumerate(items):
+            self._send_event({
+                "type": "response.output_item.done",
+                "sequence_number": sequence,
+                "output_index": output_index,
+                "item": item,
+            })
+            sequence += 1
+
+        self._send_event({
+            "type": "response.completed",
+            "sequence_number": sequence,
+            "response": _completed_response(items),
+        })
+
+    def _send_event(self, event: dict) -> None:
+        payload = json.dumps(event, separators=(",", ":"))
+        self.wfile.write(f"event: {event['type']}\ndata: {payload}\n\n".encode("utf-8"))
+        self.wfile.flush()
+
+    def log_message(self, *_args):
+        pass
+
+
+def _message_item(text: str, item_id: str) -> dict:
+    return {
+        "id": item_id,
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+                "logprobs": [],
+            }
+        ],
+    }
+
+
+def _completed_response(items: list[dict]) -> dict:
+    return {
+        "id": "resp_local",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "background": False,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "max_tool_calls": None,
+        "model": "deepseek-v4-flash",
+        "output": items,
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "prompt": None,
+        "reasoning": {"effort": "medium", "summary": None},
+        "service_tier": "default",
+        "store": False,
+        "temperature": 1.0,
+        "text": {"format": {"type": "text"}, "verbosity": "medium"},
+        "tool_choice": "auto",
+        "tools": [{"type": "web_search"}],
+        "top_logprobs": 0,
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": {
+            "input_tokens": 10,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 5,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 15,
+        },
+        "user": None,
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def deepseek_wire_server():
+    _DeepSeekResponsesHandler.captured_requests = []
+    _DeepSeekResponsesHandler.response_items_queue = [
+        [
+            {
+                "id": "ws_1",
+                "type": "web_search_call",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "latest DeepSeek release",
+                    "sources": [{"type": "url", "url": "https://example.test/source"}],
+                },
+            },
+            _message_item("DeepSeek released an update.", "msg_1"),
+        ],
+        [_message_item("The source is example.test.", "msg_2")],
+    ]
+    server = HTTPServer(("127.0.0.1", 0), _DeepSeekResponsesHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, _DeepSeekResponsesHandler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _web_search_tool() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def test_real_sdk_streams_and_replays_deepseek_web_search_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    deepseek_wire_server,
+):
+    from run_agent import AIAgent
+
+    server, handler = deepseek_wire_server
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kwargs: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(
+        "agent.web_search_registry._read_config_key",
+        lambda *path: "deepseek" if path == ("web", "search_backend") else None,
+    )
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_active_search_provider",
+        lambda: SimpleNamespace(name="deepseek"),
+    )
+
+    agent = AIAgent(
+        api_key="not-a-real-key",
+        base_url=base_url,
+        provider="deepseek",
+        api_mode="chat_completions",  # stale input must be corrected by model
+        model="deepseek-v4-flash",
+        max_iterations=1,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+    )
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == base_url
+
+    tools = [_web_search_tool()]
+    first_messages = [{"role": "user", "content": "What is new?"}]
+    first_kwargs = agent._get_transport().preflight_kwargs(
+        agent._build_api_kwargs(first_messages, tools_for_api=tools)
+    )
+    first_response = agent._run_codex_stream(first_kwargs)
+    normalized = agent._get_transport().normalize_response(first_response)
+
+    assert normalized.content == "DeepSeek released an update."
+    assert [item["type"] for item in normalized.codex_message_items] == [
+        "web_search_call",
+        "message",
+    ]
+
+    history = [
+        *first_messages,
+        {
+            "role": "assistant",
+            "content": normalized.content,
+            "codex_message_items": normalized.codex_message_items,
+        },
+        {"role": "user", "content": "Which source?"},
+    ]
+    second_kwargs = agent._get_transport().preflight_kwargs(
+        agent._build_api_kwargs(history, tools_for_api=tools)
+    )
+    second_response = agent._run_codex_stream(second_kwargs)
+    second_normalized = agent._get_transport().normalize_response(second_response)
+    assert second_normalized.content == "The source is example.test."
+
+    assert [request["path"] for request in handler.captured_requests] == [
+        "/responses",
+        "/responses",
+    ]
+    first_body = handler.captured_requests[0]["body"]
+    assert first_body["tools"] == [{"type": "web_search"}]
+    assert "prompt_cache_key" not in first_body
+    assert "include" not in first_body
+    assert "context_management" not in first_body
+
+    replay_input = handler.captured_requests[1]["body"]["input"]
+    replayed_search = next(
+        item for item in replay_input if item.get("type") == "web_search_call"
+    )
+    assert replayed_search == {
+        "id": "ws_1",
+        "type": "web_search_call",
+        "status": "completed",
+        "action": {
+            "type": "search",
+            "query": "latest DeepSeek release",
+            "sources": [{"type": "url", "url": "https://example.test/source"}],
+        },
+    }
+    assert [item.get("type", item.get("role")) for item in replay_input] == [
+        "user",
+        "web_search_call",
+        "message",
+        "user",
+    ]

--- a/tests/run_agent/test_deepseek_responses_wire.py
+++ b/tests/run_agent/test_deepseek_responses_wire.py
@@ -169,7 +169,10 @@ def _web_search_tool() -> dict:
     }
 
 
-@pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro"])
+@pytest.mark.parametrize(
+    "model",
+    ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"],
+)
 def test_real_sdk_streams_and_replays_deepseek_web_search_call(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -231,6 +231,64 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
 
+    def test_deepseek_flash_fallback_uses_responses_root(self):
+        fbs = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://api.deepseek.com/v1",
+                        api_key="deepseek-key",
+                    ),
+                    "deepseek-v4-flash",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "codex_responses"
+        assert agent.base_url == "https://api.deepseek.com"
+        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com"
+
+    def test_deepseek_pro_fallback_uses_chat_v1(self):
+        fbs = [{"provider": "deepseek", "model": "deepseek-v4-pro"}]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://api.deepseek.com",
+                        api_key="deepseek-key",
+                    ),
+                    "deepseek-v4-pro",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"
+        assert agent.base_url == "https://api.deepseek.com/v1"
+        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com/v1"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -328,6 +328,7 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "codex_responses"
         assert agent.base_url == "https://api.deepseek.com"
         assert agent._client_kwargs["base_url"] == "https://api.deepseek.com"
+        assert str(agent.client.base_url).rstrip("/") == "https://api.deepseek.com"
 
     def test_deepseek_pro_fallback_uses_chat_v1(self):
         fbs = [{"provider": "deepseek", "model": "deepseek-v4-pro"}]
@@ -357,6 +358,7 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "chat_completions"
         assert agent.base_url == "https://api.deepseek.com/v1"
         assert agent._client_kwargs["base_url"] == "https://api.deepseek.com/v1"
+        assert str(agent.client.base_url).rstrip("/") == "https://api.deepseek.com/v1"
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -300,6 +300,64 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
 
+    def test_deepseek_flash_fallback_uses_responses_root(self):
+        fbs = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://api.deepseek.com/v1",
+                        api_key="deepseek-key",
+                    ),
+                    "deepseek-v4-flash",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "codex_responses"
+        assert agent.base_url == "https://api.deepseek.com"
+        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com"
+
+    def test_deepseek_pro_fallback_uses_chat_v1(self):
+        fbs = [{"provider": "deepseek", "model": "deepseek-v4-pro"}]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://api.deepseek.com",
+                        api_key="deepseek-key",
+                    ),
+                    "deepseek-v4-pro",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"
+        assert agent.base_url == "https://api.deepseek.com/v1"
+        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com/v1"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -330,7 +330,7 @@ class TestFallbackChainAdvancement:
         assert agent._client_kwargs["base_url"] == "https://api.deepseek.com"
         assert str(agent.client.base_url).rstrip("/") == "https://api.deepseek.com"
 
-    def test_deepseek_pro_fallback_uses_chat_v1(self):
+    def test_deepseek_pro_fallback_uses_responses_root(self):
         fbs = [{"provider": "deepseek", "model": "deepseek-v4-pro"}]
         agent = _make_agent(fallback_model=fbs)
         with (
@@ -342,7 +342,7 @@ class TestFallbackChainAdvancement:
                 "agent.auxiliary_client.resolve_provider_client",
                 return_value=(
                     _mock_client(
-                        base_url="https://api.deepseek.com",
+                        base_url="https://api.deepseek.com/v1",
                         api_key="deepseek-key",
                     ),
                     "deepseek-v4-pro",
@@ -355,10 +355,10 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
 
-        assert agent.api_mode == "chat_completions"
-        assert agent.base_url == "https://api.deepseek.com/v1"
-        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com/v1"
-        assert str(agent.client.base_url).rstrip("/") == "https://api.deepseek.com/v1"
+        assert agent.api_mode == "codex_responses"
+        assert agent.base_url == "https://api.deepseek.com"
+        assert agent._client_kwargs["base_url"] == "https://api.deepseek.com"
+        assert str(agent.client.base_url).rstrip("/") == "https://api.deepseek.com"
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -255,3 +255,20 @@ def test_direct_runtime_switch_normalizes_deepseek_wire_and_official_root(
 
     assert agent.api_mode == expected_mode
     assert agent.base_url == expected_url
+
+
+def test_direct_runtime_switch_normalizes_deepseek_alias_before_wire_selection():
+    agent = _make_agent("deepseek", "deepseek-v4-pro", _make_pool("deepseek"))
+
+    switch_model(
+        agent,
+        new_model="deepseek-chat",
+        new_provider="deepseek",
+        api_key="deepseek-key",
+        base_url="https://api.deepseek.com/v1",
+        api_mode="chat_completions",
+    )
+
+    assert agent.model == "deepseek-v4-flash"
+    assert agent.api_mode == "codex_responses"
+    assert agent.base_url == "https://api.deepseek.com"

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -231,10 +231,10 @@ class TestSwitchModelReloadsCredentialPool:
         ),
         (
             "deepseek-v4-pro",
-            "codex_responses",
-            "https://api.deepseek.com",
             "chat_completions",
             "https://api.deepseek.com/v1",
+            "codex_responses",
+            "https://api.deepseek.com",
         ),
     ],
 )

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -217,3 +217,41 @@ class TestSwitchModelReloadsCredentialPool:
         assert agent.provider == "groq"
         assert agent.model == "llama-3.3-70b"
         assert agent._credential_pool is None
+
+
+@pytest.mark.parametrize(
+    "new_model,stale_mode,stale_url,expected_mode,expected_url",
+    [
+        (
+            "deepseek-v4-flash",
+            "chat_completions",
+            "https://api.deepseek.com/v1",
+            "codex_responses",
+            "https://api.deepseek.com",
+        ),
+        (
+            "deepseek-v4-pro",
+            "codex_responses",
+            "https://api.deepseek.com",
+            "chat_completions",
+            "https://api.deepseek.com/v1",
+        ),
+    ],
+)
+def test_direct_runtime_switch_normalizes_deepseek_wire_and_official_root(
+    new_model, stale_mode, stale_url, expected_mode, expected_url
+):
+    agent = _make_agent("deepseek", "deepseek-v4-pro", _make_pool("deepseek"))
+    agent.base_url = stale_url
+
+    switch_model(
+        agent,
+        new_model=new_model,
+        new_provider="deepseek",
+        api_key="deepseek-key",
+        base_url=stale_url,
+        api_mode=stale_mode,
+    )
+
+    assert agent.api_mode == expected_mode
+    assert agent.base_url == expected_url

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -308,6 +308,31 @@ Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_U
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
 :::
 
+### DeepSeek — model-aware Responses API
+
+Hermes keeps the canonical `deepseek` provider and selects the wire protocol by model:
+
+- `deepseek-v4-flash` uses DeepSeek's Responses API at `https://api.deepseek.com/responses`.
+- `deepseek-v4-pro`, dated variants, and unknown models remain on Chat Completions under `https://api.deepseek.com/v1`.
+- Custom `DEEPSEEK_BASE_URL` proxies are not rewritten; only the official DeepSeek endpoint is normalized.
+
+Set `DEEPSEEK_API_KEY` in `~/.hermes/.env`, then select Flash normally:
+
+```yaml
+model:
+  provider: deepseek
+  default: deepseek-v4-flash
+```
+
+DeepSeek V4 Flash also supports server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
+
+```yaml
+web:
+  search_backend: deepseek
+```
+
+Hermes replaces the enabled client-side `web_search` function one-for-one with DeepSeek's native `{"type": "web_search"}` tool. It does not grant search when the Hermes web tool is disabled, and selecting Firecrawl, Tavily, or another backend keeps client-side dispatch unchanged. Native `web_search_call` items are retained across turns so follow-up questions can reuse the server-side search context. This backend is search-only; configure a separate `web.extract_backend` when you also need page extraction.
+
 ### xAI (Grok) — Responses API + Prompt Caching
 
 xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -318,6 +318,31 @@ Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_U
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
 :::
 
+### DeepSeek — model-aware Responses API
+
+Hermes keeps the canonical `deepseek` provider and selects the wire protocol by model:
+
+- `deepseek-v4-flash` uses DeepSeek's Responses API at `https://api.deepseek.com/responses`.
+- `deepseek-v4-pro`, dated variants, and unknown models remain on Chat Completions under `https://api.deepseek.com/v1`.
+- Custom `DEEPSEEK_BASE_URL` proxies are not rewritten; only the official DeepSeek endpoint is normalized.
+
+Set `DEEPSEEK_API_KEY` in `~/.hermes/.env`, then select Flash normally:
+
+```yaml
+model:
+  provider: deepseek
+  default: deepseek-v4-flash
+```
+
+DeepSeek V4 Flash also supports server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
+
+```yaml
+web:
+  search_backend: deepseek
+```
+
+Hermes replaces the enabled client-side `web_search` function one-for-one with DeepSeek's native `{"type": "web_search"}` tool. It does not grant search when the Hermes web tool is disabled, and selecting Firecrawl, Tavily, or another backend keeps client-side dispatch unchanged. Native `web_search_call` items are retained across turns so follow-up questions can reuse the server-side search context. This backend is search-only; configure a separate `web.extract_backend` when you also need page extraction.
+
 ### xAI (Grok) — Responses API + Prompt Caching
 
 xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -322,11 +322,11 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 
 Hermes keeps the canonical `deepseek` provider and selects the wire protocol by model:
 
-- `deepseek-v4-flash` uses DeepSeek's Responses API at `https://api.deepseek.com/responses`.
-- `deepseek-v4-pro`, dated variants, and other capability-disabled first-party IDs remain on Chat Completions under `https://api.deepseek.com/v1`.
+- `deepseek-v4-flash` and the GA `deepseek-v4-pro` (`DeepSeek-V4-Pro-0813`) use DeepSeek's Responses API at `https://api.deepseek.com/responses`.
+- Unknown aliases and dated IDs not listed in Hermes' capability table fail closed to Chat Completions under `https://api.deepseek.com/v1`.
 - Custom `DEEPSEEK_BASE_URL` proxies are not rewritten; only the official DeepSeek endpoint is normalized.
 
-Set `DEEPSEEK_API_KEY` in `~/.hermes/.env`, then select Flash normally:
+Set `DEEPSEEK_API_KEY` in `~/.hermes/.env`, then select either supported model normally:
 
 ```yaml
 model:
@@ -334,7 +334,7 @@ model:
   default: deepseek-v4-flash
 ```
 
-DeepSeek V4 Flash also supports server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
+DeepSeek V4 Flash and V4 Pro also support server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
 
 ```yaml
 web:

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -322,7 +322,7 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 
 Hermes keeps the canonical `deepseek` provider and selects the wire protocol by model:
 
-- `deepseek-v4-flash` and the GA `deepseek-v4-pro` (`DeepSeek-V4-Pro-0813`) use DeepSeek's Responses API at `https://api.deepseek.com/responses`.
+- `deepseek-v4-flash`, the GA `deepseek-v4-pro` (`DeepSeek-V4-Pro-0813`), and the experimental `deepseek-v4-flash-vision-exp` use DeepSeek's Responses API at `https://api.deepseek.com/responses`.
 - Unknown aliases and dated IDs not listed in Hermes' capability table fail closed to Chat Completions under `https://api.deepseek.com/v1`.
 - Custom `DEEPSEEK_BASE_URL` proxies are not rewritten; only the official DeepSeek endpoint is normalized.
 
@@ -334,7 +334,7 @@ model:
   default: deepseek-v4-flash
 ```
 
-DeepSeek V4 Flash and V4 Pro also support server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
+DeepSeek V4 Flash, V4 Pro, and V4 Flash Vision Exp also support server-side native web search. It is deliberately opt-in because search turns can consume substantially more tokens than ordinary inference:
 
 ```yaml
 web:

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -323,7 +323,7 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 Hermes keeps the canonical `deepseek` provider and selects the wire protocol by model:
 
 - `deepseek-v4-flash` uses DeepSeek's Responses API at `https://api.deepseek.com/responses`.
-- `deepseek-v4-pro`, dated variants, and unknown models remain on Chat Completions under `https://api.deepseek.com/v1`.
+- `deepseek-v4-pro`, dated variants, and other capability-disabled first-party IDs remain on Chat Completions under `https://api.deepseek.com/v1`.
 - Custom `DEEPSEEK_BASE_URL` proxies are not rewritten; only the official DeepSeek endpoint is normalized.
 
 Set `DEEPSEEK_API_KEY` in `~/.hermes/.env`, then select Flash normally:

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -317,6 +317,26 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ---
 
+### DeepSeek native search
+
+`deepseek-v4-flash` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  provider: deepseek
+  default: deepseek-v4-flash
+web:
+  search_backend: "deepseek"
+  extract_backend: "firecrawl"  # optional; native DeepSeek search does not extract
+```
+
+Only `deepseek-v4-flash` uses this route. `deepseek-v4-pro` and unsupported variants remain on Chat Completions and will return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
+
+Native search can be token-intensive because DeepSeek may run multiple searches and page opens in one turn. Server-side `web_search_call` items are saved and replayed on follow-up turns so the search context is preserved.
+
+---
+
 ## Configuration
 
 ### Single backend
@@ -326,7 +346,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai | deepseek
 ```
 
 ### Per-capability configuration
@@ -361,7 +381,7 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `BRAVE_SEARCH_API_KEY` | brave-free |
 | `ddgs` package importable | ddgs |
 
-xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+xAI and DeepSeek native Web Search are **not** in the auto-detection chain. Their credentials are also used for inference and native search can have different cost/behavior from a client-side search provider, so opt in explicitly with `web.search_backend: "xai"` or `web.search_backend: "deepseek"`.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -363,6 +363,26 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ---
 
+### DeepSeek native search
+
+`deepseek-v4-flash` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  provider: deepseek
+  default: deepseek-v4-flash
+web:
+  search_backend: "deepseek"
+  extract_backend: "firecrawl"  # optional; native DeepSeek search does not extract
+```
+
+Only `deepseek-v4-flash` uses this route. `deepseek-v4-pro` and unsupported variants remain on Chat Completions and will return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
+
+Native search can be token-intensive because DeepSeek may run multiple searches and page opens in one turn. Server-side `web_search_call` items are saved and replayed on follow-up turns so the search context is preserved.
+
+---
+
 ## Configuration
 
 ### Single backend
@@ -372,7 +392,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai | deepseek
 ```
 
 ### Per-capability configuration
@@ -412,7 +432,7 @@ If no backend has **ever** been selected (no `web.backend` / per-capability key 
 
 **One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
 
-xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+xAI and DeepSeek native Web Search are **not** in the auto-detection chain. Their credentials are also used for inference and native search can have different cost/behavior from a client-side search provider, so opt in explicitly with `web.search_backend: "xai"` or `web.search_backend: "deepseek"`.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -365,7 +365,7 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ### DeepSeek native search
 
-`deepseek-v4-flash` and `deepseek-v4-pro` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
+`deepseek-v4-flash`, `deepseek-v4-pro`, and the experimental `deepseek-v4-flash-vision-exp` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -377,7 +377,7 @@ web:
   extract_backend: "firecrawl"  # optional; native DeepSeek search does not extract
 ```
 
-Both exact GA model IDs use this route. Unknown or dated variants that are not capability-enabled remain on Chat Completions and return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
+All three exact documented model IDs use this route. Unknown or dated variants that are not capability-enabled remain on Chat Completions and return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
 
 Native search can be token-intensive because DeepSeek may run multiple searches and page opens in one turn. Server-side `web_search_call` items are saved and replayed on follow-up turns so the search context is preserved.
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -365,7 +365,7 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ### DeepSeek native search
 
-`deepseek-v4-flash` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
+`deepseek-v4-flash` and `deepseek-v4-pro` can execute `web_search` inside the model's Responses API turn. Use the regular DeepSeek inference credential and opt in explicitly:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -377,7 +377,7 @@ web:
   extract_backend: "firecrawl"  # optional; native DeepSeek search does not extract
 ```
 
-Only `deepseek-v4-flash` uses this route. `deepseek-v4-pro` and unsupported variants remain on Chat Completions and will return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
+Both exact GA model IDs use this route. Unknown or dated variants that are not capability-enabled remain on Chat Completions and return an actionable error if the native backend is selected. Hermes never auto-enables this backend merely because `DEEPSEEK_API_KEY` exists, and it only swaps in the native tool when the `web_search` function is already enabled for the agent.
 
 Native search can be token-intensive because DeepSeek may run multiple searches and page opens in one turn. Server-side `web_search_call` items are saved and replayed on follow-up turns so the search context is preserved.
 


### PR DESCRIPTION
## What does this PR do?

Adds first-class, model-aware DeepSeek Responses API support without introducing a second provider identity:

- `deepseek-v4-flash`, the GA `deepseek-v4-pro`, and the experimental `deepseek-v4-flash-vision-exp` use DeepSeek's Responses API.
- All three documented models support opt-in native server-side `web_search` and stateless `web_search_call` replay.
- Unknown/dated model IDs fail closed to Chat Completions until their capabilities are explicitly documented.
- Responses support and native search remain separate capability flags in one central table.

DeepSeek announced `deepseek-v4-pro` GA on 2026-08-13 (model version `DeepSeek-V4-Pro-0813`) and released the experimental `deepseek-v4-flash-vision-exp` on 2026-08-21. The current [Responses API guide](https://api-docs.deepseek.com/guides/responses_api/) documents both V4 Flash and V4 Pro, function/native `web_search` tools, and replaying `web_search_call` items as-is. See also the [DeepSeek updates](https://api-docs.deepseek.com/updates/) and [thinking-mode guide](https://api-docs.deepseek.com/guides/thinking_mode/).

The implementation keeps the canonical `deepseek` provider, recomputes the wire protocol whenever the model changes, and only normalizes the official `api.deepseek.com` endpoint. Custom proxies are left alone.

This builds on and supersedes #79103. Thanks to @hutao562 for the initial DeepSeek native-search exploration and one-for-one tool-swap approach.

## Related Issue

Closes #80901

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor

## Changes Made

- Added a centralized, fail-closed DeepSeek capability table with independent `responses_api` and `native_web_search` flags; both GA text models and the documented Vision Exp ID are enabled.
- Added model-aware routing across runtime resolution, credential pools/rotation, direct `AIAgent` construction, live and `/model` switches, and fallback activation.
- Normalized only the official endpoint:
  - Responses: `https://api.deepseek.com` → SDK sends `/responses`
  - Chat Completions: `https://api.deepseek.com/v1`
  - custom proxies/lookalike/noncanonical URLs: unchanged
- Added the `deepseek` web provider marker as explicit opt-in via `web.search_backend: deepseek`; a credential alone never auto-enables native search.
- Replaced an already-enabled Hermes `web_search` function one-for-one with `{"type":"web_search"}`. Search is never granted additively, and Firecrawl/Tavily/etc. remain client-dispatched.
- Captured, JSON-normalized, persisted, and replayed `web_search_call` items in original output order and preserved provider action/source data.
- Preserved `web_search_call` through production Responses preflight on turn N+1.
- Sanitized unsupported DeepSeek Responses fields after request overrides without regressing native compaction on other providers.
- Normalized DeepSeek Responses reasoning levels to its documented wire values (`minimal→low`, `medium/xhigh→high`, `ultra→max`) and send `reasoning.effort: none` when thinking is disabled, since omission leaves DeepSeek thinking enabled by default.
- Updated provider and web-search documentation for V4 Pro GA.

## How to Test

Rebased onto current `main` at `8d30c2044` and ran:

```bash
.venv/bin/python -m pytest -q \
  tests/agent/transports \
  tests/agent/test_codex_responses_adapter.py \
  tests/cli/test_cli_provider_resolution.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_model_switch_*.py \
  tests/hermes_cli/test_custom_provider_model_switch.py \
  tests/hermes_cli/test_user_providers_model_switch.py \
  tests/run_agent/test_credential_rotation_route_settings.py \
  tests/run_agent/test_provider_fallback.py \
  tests/run_agent/test_switch_model_pool_reload_52727.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_native_compaction.py \
  tests/run_agent/test_deepseek_responses_wire.py \
  tests/run_agent/test_deepseek_reasoning_content_echo.py \
  tests/plugins/model_providers/test_deepseek_profile.py \
  tests/plugins/web/test_web_search_provider_plugins.py
```

Result: **952 passed**.

Additional validation:

- focused changed-path suite: **200 passed**
- broader DeepSeek/Responses suite: **477 passed, 2 skipped** (the skips are credential-gated live tests)
- Ruff: pass
- `compileall`: pass
- `git diff --check`: pass

The local-wire E2E is parameterized over V4 Flash, V4 Pro, and V4 Flash Vision Exp and uses the real OpenAI SDK against an in-process HTTP server. It verifies `/responses`, native tool serialization, default reasoning normalization, SSE parsing, field sanitization, production preflight, exact `web_search_call` preservation, and turn-N+1 replay without requiring a DeepSeek key.

Authenticated live smoke testing against **both** `deepseek-v4-pro` and `deepseek-v4-flash` on 2026-08-14 passed through the production Hermes request builder and Responses transport. For each model, stale Chat Completions routing was corrected to `/responses`, native search produced `web_search_call` items plus a message, every call was replayed successfully on turn N+1, and a separate request with thinking disabled was accepted with `reasoning.effort: none`. Pro returned eight search calls and used 24,877 input tokens (18,176 cached) plus 1,164 output tokens, approximately **$0.004**. Flash returned two search calls and used 9,335 input tokens (4,224 cached) plus 364 output tokens, approximately **$0.00083**. The credential was loaded only into the test processes and was not logged or committed.

## Checklist

- [x] Read contribution/repository guidance
- [x] Conventional commits
- [x] Changes are scoped to DeepSeek Responses/native search
- [x] Added behavior and real-wire integration tests
- [x] Updated documentation and provider descriptions
- [x] Tested on macOS
- [ ] Full `pytest tests/ -q` (broad affected-path suites above pass)

