### PR TITLE
fix(tui-gateway): preserve custom:<name> provider in session.info

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7164,6 +7164,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         runtime = {
             "provider": getattr(agent, "provider", None),
+            "requested_provider": getattr(agent, "requested_provider", None),
             "base_url": getattr(agent, "base_url", None),
             "api_mode": getattr(agent, "api_mode", None),
             "fallback_active": bool(getattr(agent, "_fallback_activated", False)),
@@ -18409,7 +18410,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Resolve runtime credentials for probing
         try:
             runtime = _resolve_runtime_agent_kwargs()
-            provider = runtime.get("provider") or provider
+            runtime_provider = runtime.get("provider") or ""
+            # Custom providers are normalized to bare "custom" at runtime
+            # (the canonical form is "custom:<name>").  For display, prefer
+            # the original configured provider ("custom:<name>") so the user
+            # can distinguish which custom endpoint is active.
+            if runtime_provider == "custom":
+                runtime_requested = runtime.get("requested_provider") or ""
+                if runtime_requested and runtime_requested.startswith("custom:"):
+                    provider = runtime_requested
+                elif provider and provider.startswith("custom:"):
+                    pass  # keep the config value
+                else:
+                    provider = runtime_provider or provider
+            else:
+                provider = runtime_provider or provider
             base_url = runtime.get("base_url") or base_url
             api_key = runtime.get("api_key")
         except Exception:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8807,6 +8807,39 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_shows_custom_provider_name_not_bare_custom(monkeypatch):
+    """Custom providers are normalized to bare "custom" at runtime for routing,
+    but session.info must report the original "custom:<name>" identity so the
+    desktop model indicator doesn't jump from custom:<name>:model to custom:model
+    on the first message of a new session."""
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="glm-5.2",
+        provider="custom",
+        requested_provider="custom:volcengine-agent-plan",
+    )
+    session = {"session_key": "", "history": []}
+
+    info = server._session_info(agent, session)
+    assert info["provider"] == "custom:volcengine-agent-plan"
+
+
+def test_session_info_keeps_bare_custom_when_no_requested_provider(monkeypatch):
+    """When requested_provider is also bare "custom" (e.g. a legacy session
+    row), session.info should still report "custom" rather than fabricating
+    a name."""
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="test-model",
+        provider="custom",
+        requested_provider="custom",
+    )
+    session = {"session_key": "", "history": []}
+
+    info = server._session_info(agent, session)
+    assert info["provider"] == "custom"
+
+
 def test_session_info_reports_pending_model_switch(monkeypatch):
     """A model queued mid-turn shows as the session's model in session.info, so
     the end-of-turn settle doesn't blip the UI back to the still-live old model

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5108,10 +5108,27 @@ def _session_info(agent, session: dict | None = None) -> dict:
     pending_switch = (session or {}).get("pending_model_switch") or {}
     pending_model = str(pending_switch.get("display_model") or "").strip()
     pending_provider = str(pending_switch.get("display_provider") or "").strip()
+
+    # Custom providers are normalized to bare "custom" at runtime for routing,
+    # but the display name should retain the "custom:<name>" identity so the
+    # user can distinguish which custom endpoint is active.  Prefer the
+    # requested_provider (the original configured form) when the runtime
+    # provider has been canonicalized to "custom".
+    runtime_provider = getattr(agent, "provider", "")
+    runtime_requested = getattr(agent, "requested_provider", "") or ""
+    if (
+        not pending_provider
+        and runtime_provider == "custom"
+        and runtime_requested.startswith("custom:")
+    ):
+        display_provider = runtime_requested
+    else:
+        display_provider = runtime_provider
+
     info: dict = {
         "model": pending_model or mirror.get("model", getattr(agent, "model", "")),
         "provider": pending_provider
-        or mirror.get("provider", getattr(agent, "provider", "")),
+        or mirror.get("provider", display_provider),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
@@ -6489,6 +6506,7 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=runtime.get("requested_provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),


### PR DESCRIPTION
## Problem

When using a named custom provider (e.g. `custom:volcengine-agent-plan`), the desktop model indicator jumps from `custom:volcengine-agent-plan: glm-5.2` to `custom: glm-5.2` after the first message in a new session.

## Root Cause

The `session.info` event (consumed by the desktop UI) is emitted by `tui_gateway/server.py` `_session_info()`, which reads `agent.provider`. The chain:

1. User configures `model.provider: custom:volcengine-agent-plan`
2. `resolve_runtime_provider()` normalizes `custom:<name>` → bare `custom` for routing (correct — routing uses `base_url`, not the provider string), but preserves `requested_provider: custom:volcengine-agent-plan` in the runtime dict
3. **`_make_agent()` constructs `AIAgent(...)` but omits `requested_provider`** — only passes `provider=runtime.get("provider")` (i.e. bare `"custom"`)
4. `agent_init.py` falls back `agent.requested_provider = agent.provider` when `requested_provider` is not passed → `agent.requested_provider == "custom"` (bare)
5. `_session_info()` reads `getattr(agent, "provider", "")` → emits `provider: "custom"` in the `session.info` event
6. Frontend receives bare `custom` and updates the model indicator → **display jump**

Contrast: `gateway/run.py` (messaging gateway) uses `**turn_route["runtime"]` which includes `requested_provider` — so it was **not affected**.

## Fix

1. **`tui_gateway/server.py` `_make_agent()`** (root cause): Pass `requested_provider=runtime.get("requested_provider")` to `AIAgent(...)`, so `agent.requested_provider` retains the `custom:<name>` identity.

2. **`tui_gateway/server.py` `_session_info()`** (display-layer defense): When `agent.provider == "custom"` and `agent.requested_provider` starts with `"custom:"`, use the latter as the `provider` field in `session.info`. Same strategy as the existing `gateway/run.py` display path.

3. **`gateway/run.py` `_format_session_info()`**: Apply the same `requested_provider` display fallback for the CLI `/status` text path.

4. **`gateway/run.py` `_sync_session_model_from_agent()`**: Persist `requested_provider` into the session DB runtime dict so the name survives across turns.

## What stays the same

- Routing logic is unchanged — still routes via `base_url`, not the provider string
- `agent.provider` remains the normalized `"custom"` that the OpenAI client uses for API call format decisions
- Non-custom providers are unaffected

## Tests

Two new unit tests in `test_tui_gateway_server.py`:
- `test_session_info_shows_custom_provider_name_not_bare_custom` — verifies `_session_info()` returns `custom:<name>` when `agent.requested_provider` is set
- `test_session_info_keeps_bare_custom_when_no_requested_provider` — verifies bare `custom` is preserved for legacy sessions where `requested_provider` is not `custom:<name>`

Verified end-to-end on desktop: the model indicator no longer jumps after the first message of a new session.