### PR TITLE
fix(desktop): make logs pane text selectable and auto-scroll to bottom

### DIFF
--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -18,6 +18,7 @@ import type { GroupSetter } from '@/app/shell/group-setter'
 import type { StatusbarItem } from '@/app/shell/statusbar-controls'
 import type { TitlebarTool } from '@/app/shell/titlebar-controls'
 import { DecodeText } from '@/components/ui/decode-text'
+import { LogTail } from '@/components/chat/log-tail'
 import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
@@ -53,12 +54,9 @@ export function LogsPane() {
   }
 
   // No chrome of its own — the zone header (when the user summons it) is the
-  // pane's only label. Just the tail.
-  return (
-    <pre className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)">
-      {data.lines.join('\n')}
-    </pre>
-  )
+  // pane's only label. Just the tail, on the shared LogTail surface so log text
+  // is selectable and the tail follows unless the user scrolls up.
+  return <LogTail emptyLabel="no log output yet" lines={data.lines} />
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app logs pane (⌘K → "Toggle logs"): log text couldn't be selected or copied, and the pane didn't follow new output.

Instead of hand-rolling selectable text and autoscroll into the pane, this swaps the raw `<pre>` for the app's existing shared `LogTail` component — the one already used behind every other log surface (command center, skills hub, MCP tab). That gives the logs pane the same behavior everywhere else in the app already has:

- selectable/copyable log text (`data-selectable-text`)
- follow-the-tail auto-scroll that releases when the user scrolls up
- hover-reveal copy button

## Related Issue

Fixes #77794

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/contrib/panes.tsx`: replaced `LogsPane`'s `<pre>` with `<LogTail lines={data.lines} />` (the shared log surface; same pattern as command-center, skills hub, MCP tab)

## How to Test

1. Open the desktop app, press ⌘K, run "Toggle logs"
2. Try selecting and copying log text — it works now
3. Watch new log lines arrive — the pane follows the tail
4. Scroll up — the tail releases; scroll back to bottom — it re-sticks

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: frontend-only TypeScript change; desktop workspace typecheck (`npm run typecheck`, all 3 tsconfigs) passes clean
- [ ] I've added tests for my changes — N/A: one-line component swap onto an existing shared surface already covered by the app's patterns
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A: no docs, config keys, architecture, or tool behavior changed

## Screenshots / Logs

N/A — behavior is identical to every other LogTail-backed surface in the app.

---

*This diff was drafted with AI assistance and reviewed before submission.*
