### PR TITLE
fix: suppress RuntimeError in MCP task shutdown when event loop is closed

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2320,11 +2320,15 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                        t.cancel()
+                    except RuntimeError:
+                        pass  # loop already closed during shutdown; skip cancel
+                    else:
+                        try:
+                            await t
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -2364,11 +2368,15 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                        t.cancel()
+                    except RuntimeError:
+                        pass  # loop already closed during shutdown; skip cancel
+                    else:
+                        try:
+                            await t
+                        except (asyncio.CancelledError, Exception):
+                            pass
         if self._shutdown_event.is_set():
             return "shutdown"
         self._reconnect_event.clear()
@@ -3518,11 +3526,15 @@ class MCPServerTask:
         finally:
             for task in (shutdown_task, reconnect_task):
                 if not task.done():
-                    task.cancel()
                     try:
-                        await task
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                        task.cancel()
+                    except RuntimeError:
+                        pass  # loop already closed during shutdown; skip cancel
+                    else:
+                        try:
+                            await task
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
 
 # ---------------------------------------------------------------------------
@@ -7205,7 +7217,7 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
                     )
                 except BaseException as exc:
                     logger.warning("Error draining MCP loop tasks: %s", exc)
-        elif not loop.is_closed():
+        if not stop_owned_by_loop and not loop.is_closed():
             try:
                 loop.run_until_complete(
                     _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT)


### PR DESCRIPTION
## Problem

When exiting Hermes, MCP server tasks that are still pending can encounter an already-closed event loop during cancellation. Calling `t.cancel()` after the loop is closed raises `RuntimeError('Event loop is closed')`, which surfaces as `Exception ignored in: <coroutine object MCPServerTask.run>` during garbage collection.

## Symptom

```
Exception ignored in: <coroutine object MCPServerTask.run at 0x10d3f5d20>
RuntimeError: Event loop is closed
```

## Fix (4 call sites in `tools/mcp_tool.py`)

1. **`_wait_for_lifecycle_event` finally** — wrap `t.cancel()` in `try/except RuntimeError` so cancelled tasks clean up silently when the loop is already gone
2. **`_wait_for_reconnect_or_shutdown` finally** — same pattern
3. **`_wait_for_lazy_reconnect` finally** — same pattern
4. **`_stop_mcp_loop` drain path** — change `elif not loop.is_closed()` to `if not stop_owned_by_loop and not loop.is_closed()` so drain is always attempted regardless of schedule success

## Tested

Verified on macOS — the "Exception ignored" traceback no longer appears on `hermes` exit.

## Consolidation

This PR is the consolidated fix for the closed-loop cancellation family, superseding #60032, #60104, and #60380. Coverage comparison:

| Call site | This PR | #60032 | #60104 | #60380 |
|---|---|---|---|---|
| `_wait_for_lifecycle_event` finally | ✅ | ✅ | ❌ | ❌ |
| `_wait_for_reconnect_or_shutdown` finally | ✅ | ✅ | ❌ | ❌ |
| `_wait_for_lazy_reconnect` finally | ✅ | ❌ | ❌ | ❌ |
| `_stop_mcp_loop` drain path | ✅ | ❌ | ❌ | ❌ |

This PR fixes the whole bug class — every `finally` block that calls `t.cancel()` on a possibly-closed loop, plus the drain path in `_stop_mcp_loop` so tasks are always cancelled before `loop.close()`. Happy to coordinate with #60032's author (open) so we land one shared shutdown strategy rather than overlapping fixes.
