### PR TITLE
fix(gateway): prevent multiplexed A2A credential cross-profile rejection

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -102,11 +102,25 @@ class GatewayAuthorizationMixin:
         ``self.adapters``. ``SessionSource.profile`` selects which map to consult.
         When a stamped profile has its own adapter registry entry, the default
         profile's same-platform adapter must not be consulted as a fallback.
+
+        Consult ``_profile_adapters`` *before* comparing against
+        ``_active_profile_name()``. Multiplex turns wrap authz in
+        ``_profile_runtime_scope``, which overrides ``HERMES_HOME`` so
+        ``get_active_profile_name()`` returns the secondary profile for the
+        duration of the turn. Treating that scoped name as "primary" would
+        look up ``self.adapters`` (empty for secondary-only platforms like
+        A2A) and default-deny an already-authenticated peer.
         """
         if not platform:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
+            profile_adapters = getattr(self, "_profile_adapters", None) or {}
+            if profile_name in profile_adapters:
+                return profile_adapters[profile_name].get(platform)
+            # Single-profile gateways stamp their active profile name but keep
+            # adapters in ``self.adapters``. Only use that path when the
+            # stamped profile has no secondary registry entry.
             active_profile = None
             active_profile_fn = getattr(self, "_active_profile_name", None)
             if callable(active_profile_fn):
@@ -117,9 +131,6 @@ class GatewayAuthorizationMixin:
             if profile_name == active_profile:
                 adapters = getattr(self, "adapters", None) or {}
                 return adapters.get(platform)
-            profile_adapters = getattr(self, "_profile_adapters", None) or {}
-            if profile_name in profile_adapters:
-                return profile_adapters[profile_name].get(platform)
             # Fail closed: a stamped secondary profile with no registry entry
             # (e.g. its adapter failed to connect) must NOT fall back to the
             # default profile's adapter — that sends replies out the wrong bot.

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -227,7 +227,7 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             }
             # Do not leak profile/tenant topology on remote unauthenticated GETs.
             # Agent Cards are intentionally public; health topology is not.
-            if security.localhost_only() or security.authenticate(
+            if self.adapter._security_context.localhost_only() or self.adapter._security_context.authenticate(
                 self.headers.get("Authorization"),
                 self.client_address[0] if self.client_address else "",
             ) is not None:
@@ -246,7 +246,9 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
 
         # Identity comes from the presented credential (or the socket in
         # localhost-only mode) — never from the request body.
-        identity = security.authenticate(self.headers.get("Authorization"), client_ip)
+        identity = adapter._security_context.authenticate(
+            self.headers.get("Authorization"), client_ip
+        )
         if identity is None:
             self._json(401, protocol.jsonrpc_error(None, protocol.ERR_UNAUTHORIZED, "unauthorized"))
             return
@@ -292,7 +294,7 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             self._json(429, protocol.jsonrpc_error(req_id, protocol.ERR_RATE_LIMITED, "rate limit exceeded"))
             return
 
-        if not security.is_trusted_peer(identity):
+        if not adapter._security_context.is_trusted_peer(identity):
             self._json(403, protocol.jsonrpc_error(
                 req_id, protocol.ERR_UNTRUSTED_PEER, f"peer '{identity}' not trusted"))
             return
@@ -343,8 +345,9 @@ class A2AAdapter(BasePlatformAdapter):
         super().__init__(config=config, platform=platform)
 
         extra = getattr(config, "extra", {}) or {}
+        self._security_context = security.A2ASecurityContext.capture()
         self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
-        self.host = security.resolve_bind_host()
+        self.host = self._security_context.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [
             t.strip() for t in (
@@ -440,7 +443,11 @@ class A2AAdapter(BasePlatformAdapter):
 
         self._mark_connected()
 
-        exposure = "localhost-only" if security.localhost_only() else "REMOTE (bearer auth)"
+        exposure = (
+            "localhost-only"
+            if self._security_context.localhost_only()
+            else "REMOTE (bearer auth)"
+        )
         logger.info(
             "A2A: serving Agent Card + JSON-RPC on http://%s:%s (%s) as %r; %d routed agent(s)",
             self.host, self.port, exposure, self.agent_name, len(self._agents),
@@ -611,7 +618,7 @@ class A2AAdapter(BasePlatformAdapter):
             skills=self._advertised_skills(agent),
             streaming=bool(agent.get("local", True)),
             push_notifications=True,
-            auth_required=not security.localhost_only(),
+            auth_required=not self._security_context.localhost_only(),
             tenant=str(agent.get("tenant") or ""),
         )
 
@@ -1190,7 +1197,10 @@ class A2AAdapter(BasePlatformAdapter):
         if not callback_url:
             return
 
-        if not security.is_safe_callback_url(callback_url):
+        if not security.is_safe_callback_url(
+            callback_url,
+            localhost_mode=self._security_context.localhost_only(),
+        ):
             logger.warning("A2A: push notification for task %s blocked — unsafe callback URL: %s",
                            task_id, callback_url)
             protocol.metrics.push_failed += 1
@@ -1199,7 +1209,7 @@ class A2AAdapter(BasePlatformAdapter):
         # Push payload uses the StreamResponse format (same as streaming).
         payload = protocol.status_update(task_id, context_id, state, (reply or "")[:2000])
 
-        signature = security.sign_push_payload(payload)
+        signature = self._security_context.sign_push_payload(payload)
         headers = {"Content-Type": "application/json"}
         if signature:
             headers["X-A2A-Signature"] = signature

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -31,29 +31,26 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-# --------------------------------------------------------------------------
-# Bearer auth + peer identity
-# --------------------------------------------------------------------------
+def _startup_env(name: str) -> str:
+    """Read one A2A setting from the adapter's active profile scope."""
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
 
-def get_bearer_token() -> str:
-    """Return the configured shared inbound bearer token (empty if none)."""
-    return os.getenv("A2A_BEARER_TOKEN", "").strip()
+        return (get_secret(name) or "").strip()
+    except UnscopedSecretError:
+        # Single/default-profile startup may be unscoped. Its process
+        # environment is authoritative, matching the legacy behavior.
+        return os.getenv(name, "").strip()
 
 
-def get_peer_tokens() -> dict[str, str]:
-    """Parse A2A_PEER_TOKENS ("alice:tok1,bob:tok2") into {token: peer_name}.
-
-    Per-peer tokens give each remote agent its own credential, so the identity
-    used for rate limiting, trust, and audit is authenticated — not whatever
-    the request body claims.
-    """
-    raw = os.getenv("A2A_PEER_TOKENS", "").strip()
+def _parse_peer_tokens(raw: str) -> dict[str, str]:
     out: dict[str, str] = {}
     for pair in raw.split(","):
         pair = pair.strip()
@@ -64,6 +61,115 @@ def get_peer_tokens() -> dict[str, str]:
         if name and token:
             out[token] = name
     return out
+
+
+def _configured_trusted_peers() -> frozenset[str]:
+    raw = _startup_env("A2A_TRUSTED_PEERS")
+    if raw:
+        return frozenset(p.strip() for p in raw.split(",") if p.strip())
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        peers = (cfg.get("a2a") or {}).get("trusted_peers", [])
+        if isinstance(peers, list):
+            return frozenset(str(peer).strip() for peer in peers if str(peer).strip())
+    except Exception:
+        pass
+    return frozenset()
+
+
+@dataclass(frozen=True)
+class A2ASecurityContext:
+    """Immutable, profile-scoped security settings captured at adapter startup.
+
+    ``ThreadingHTTPServer`` handles requests on fresh threads that do not inherit
+    the gateway's profile ContextVars. Keeping the resolved settings on the
+    adapter prevents those threads from falling back to another profile's
+    process-global environment.
+    """
+
+    bearer_token: str
+    peer_tokens: tuple[tuple[str, str], ...]
+    trusted_peers: frozenset[str]
+    allow_all_users: bool
+    requested_host: str
+    push_secret: str
+
+    @classmethod
+    def capture(cls) -> "A2ASecurityContext":
+        bearer_token = _startup_env("A2A_BEARER_TOKEN")
+        return cls(
+            bearer_token=bearer_token,
+            peer_tokens=tuple(_parse_peer_tokens(_startup_env("A2A_PEER_TOKENS")).items()),
+            trusted_peers=_configured_trusted_peers(),
+            allow_all_users=_startup_env("A2A_ALLOW_ALL_USERS").lower()
+            in {"1", "true", "yes"},
+            requested_host=_startup_env("A2A_HOST") or "127.0.0.1",
+            push_secret=_startup_env("A2A_PUSH_SECRET") or bearer_token,
+        )
+
+    def localhost_only(self) -> bool:
+        return not (self.bearer_token or self.peer_tokens)
+
+    def resolve_bind_host(self) -> str:
+        loopback = {"127.0.0.1", "localhost", "::1"}
+        if self.requested_host in loopback:
+            return self.requested_host
+        if self.localhost_only():
+            logger.warning(
+                "A2A: A2A_HOST=%s ignored — no A2A_BEARER_TOKEN or "
+                "A2A_PEER_TOKENS set; binding to 127.0.0.1. Configure a token "
+                "to expose A2A remotely.",
+                self.requested_host,
+            )
+            return "127.0.0.1"
+        return self.requested_host
+
+    def authenticate(self, auth_header: Optional[str], client_ip: str = "") -> Optional[str]:
+        if self.localhost_only():
+            return f"ip:{client_ip or 'local'}"
+        presented = _parse_bearer(auth_header)
+        if presented is None:
+            return None
+        for token, name in self.peer_tokens:
+            if hmac.compare_digest(presented, token):
+                return name
+        if self.bearer_token and hmac.compare_digest(presented, self.bearer_token):
+            return f"ip:{client_ip or 'unknown'}"
+        return None
+
+    def is_trusted_peer(self, identity: str) -> bool:
+        if self.allow_all_users or self.localhost_only() or not self.trusted_peers:
+            return True
+        return identity in self.trusted_peers
+
+    def sign_push_payload(self, payload: dict) -> str:
+        if not self.push_secret:
+            return ""
+        body = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        return hmac.new(
+            self.push_secret.encode("utf-8"), body, hashlib.sha256
+        ).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Bearer auth + peer identity
+# --------------------------------------------------------------------------
+
+def get_bearer_token() -> str:
+    """Return the configured shared inbound bearer token (empty if none)."""
+    return _startup_env("A2A_BEARER_TOKEN")
+
+
+def get_peer_tokens() -> dict[str, str]:
+    """Parse A2A_PEER_TOKENS ("alice:tok1,bob:tok2") into {token: peer_name}.
+
+    Per-peer tokens give each remote agent its own credential, so the identity
+    used for rate limiting, trust, and audit is authenticated — not whatever
+    the request body claims.
+    """
+    return _parse_peer_tokens(_startup_env("A2A_PEER_TOKENS"))
 
 
 def _parse_bearer(auth_header: Optional[str]) -> Optional[str]:
@@ -85,24 +191,12 @@ def authenticate(auth_header: Optional[str], client_ip: str = "") -> Optional[st
 
     Comparisons are constant-time (hmac.compare_digest).
     """
-    peer_tokens = get_peer_tokens()
-    shared = get_bearer_token()
-    if not peer_tokens and not shared:
-        return f"ip:{client_ip or 'local'}"
-    presented = _parse_bearer(auth_header)
-    if presented is None:
-        return None
-    for token, name in peer_tokens.items():
-        if hmac.compare_digest(presented, token):
-            return name
-    if shared and hmac.compare_digest(presented, shared):
-        return f"ip:{client_ip or 'unknown'}"
-    return None
+    return A2ASecurityContext.capture().authenticate(auth_header, client_ip)
 
 
 def localhost_only() -> bool:
     """True when we must refuse non-loopback binds (no token of any kind set)."""
-    return not (get_bearer_token() or get_peer_tokens())
+    return A2ASecurityContext.capture().localhost_only()
 
 
 def resolve_bind_host() -> str:
@@ -112,18 +206,7 @@ def resolve_bind_host() -> str:
     per-peer) AND explicitly asked for a wider host. A token alone does not
     widen the bind — opting into remote exposure must be deliberate.
     """
-    requested = os.getenv("A2A_HOST", "").strip() or "127.0.0.1"
-    loopback = {"127.0.0.1", "localhost", "::1"}
-    if requested in loopback:
-        return requested
-    if localhost_only():
-        logger.warning(
-            "A2A: A2A_HOST=%s ignored — no A2A_BEARER_TOKEN or A2A_PEER_TOKENS "
-            "set; binding to 127.0.0.1. Configure a token to expose A2A remotely.",
-            requested,
-        )
-        return "127.0.0.1"
-    return requested
+    return A2ASecurityContext.capture().resolve_bind_host()
 
 
 # --------------------------------------------------------------------------
@@ -138,18 +221,7 @@ def get_trusted_peers() -> set[str]:
     names from ``authenticate()`` — peer-token names, or ``ip:<addr>`` for
     shared-token callers.
     """
-    env_peers = os.getenv("A2A_TRUSTED_PEERS", "").strip()
-    if env_peers:
-        return {p.strip() for p in env_peers.split(",") if p.strip()}
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config() or {}
-        peers_list = (cfg.get("a2a") or {}).get("trusted_peers", [])
-        if isinstance(peers_list, list):
-            return {str(p).strip() for p in peers_list if p}
-    except Exception:
-        pass
-    return set()
+    return set(_configured_trusted_peers())
 
 
 def is_trusted_peer(identity: str) -> bool:
@@ -160,14 +232,7 @@ def is_trusted_peer(identity: str) -> bool:
     otherwise any *authenticated* identity is allowed (authentication is the
     primary gate — the allow-list is an optional restriction on top).
     """
-    if os.getenv("A2A_ALLOW_ALL_USERS", "").strip().lower() in ("1", "true", "yes"):
-        return True
-    if localhost_only():
-        return True
-    trusted = get_trusted_peers()
-    if not trusted:
-        return True
-    return identity in trusted
+    return A2ASecurityContext.capture().is_trusted_peer(identity)
 
 
 # --------------------------------------------------------------------------
@@ -259,10 +324,7 @@ def get_push_secret() -> str:
     Falls back to the bearer token if no dedicated push secret is set.
     If neither is configured, push notifications are unsigned (localhost-only mode).
     """
-    secret = os.getenv("A2A_PUSH_SECRET", "").strip()
-    if secret:
-        return secret
-    return get_bearer_token()
+    return A2ASecurityContext.capture().push_secret
 
 
 def sign_push_payload(payload: dict) -> str:
@@ -304,12 +366,14 @@ _BLOCKED_PREFIXES = (
 )
 
 
-def is_safe_callback_url(url: str) -> bool:
+def is_safe_callback_url(url: str, *, localhost_mode: Optional[bool] = None) -> bool:
     """Check if a push notification callback URL is safe from SSRF.
 
     Blocks internal/private/loopback/metadata addresses.
     Only allows http:// and https:// schemes.
     """
+    if localhost_mode is None:
+        localhost_mode = localhost_only()
     if not url or not isinstance(url, str):
         return False
     try:
@@ -324,16 +388,16 @@ def is_safe_callback_url(url: str) -> bool:
     hostname_lower = hostname.lower()
     if hostname_lower == "localhost":
         # Loopback callbacks only make sense for local testing.
-        return localhost_only()
+        return localhost_mode
     for prefix in _BLOCKED_PREFIXES:
         if hostname_lower.startswith(prefix.lower()):
-            if localhost_only() and prefix in ("127.", "::1"):
+            if localhost_mode and prefix in ("127.", "::1"):
                 return True
             return False
     try:
         ip = ipaddress.ip_address(hostname)
         if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
-            if localhost_only() and ip.is_loopback:
+            if localhost_mode and ip.is_loopback:
                 return True
             return False
     except ValueError:

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -74,6 +74,39 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_secondary_a2a_source_keeps_upstream_authorization(monkeypatch):
+    """A source built by a secondary A2A adapter uses that adapter's auth verdict."""
+    from gateway.run import GatewayRunner
+    from plugins.platforms.a2a.adapter import A2AAdapter
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner._profile_name_for_source = lambda source: None
+
+    adapter = A2AAdapter(PlatformConfig(enabled=True))
+    adapter.gateway_runner = runner
+    runner._profile_adapters = {
+        "coder": {adapter.platform: adapter},
+    }
+
+    source = adapter.build_source(
+        chat_id="a2a-context",
+        user_id="alpha",
+        user_name="alpha",
+    )
+    source.profile = "coder"
+
+    assert runner._adapter_profile_for_source(source) == "coder"
+    assert runner._is_user_authorized(source) is True
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -1,5 +1,11 @@
 """Regression tests for multiplex profile-aware own-policy authorization."""
 
+import asyncio
+import json
+import socket
+import urllib.error
+import urllib.request
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -74,37 +80,117 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
-def test_secondary_a2a_source_keeps_upstream_authorization(monkeypatch):
-    """A source built by a secondary A2A adapter uses that adapter's auth verdict."""
+@pytest.mark.asyncio
+async def test_secondary_a2a_listener_keeps_upstream_authorization(
+    monkeypatch, tmp_path
+):
+    """A real secondary listener accepts its token through gateway authz."""
+    from agent.secret_scope import set_multiplex_active
     from gateway.run import GatewayRunner
     from plugins.platforms.a2a.adapter import A2AAdapter
+    from plugins.platforms.a2a import protocol
 
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
-    monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+    monkeypatch.setenv("A2A_PEER_TOKENS", "default:default-token")
+    monkeypatch.setenv("A2A_REPLY_TIMEOUT", "2")
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    monkeypatch.setenv("A2A_PORT", str(port))
+
+    profile_home = tmp_path / "coder"
+    profile_home.mkdir()
+    (profile_home / ".env").write_text(
+        "A2A_PEER_TOKENS=alpha:secondary-token\nA2A_HOST=127.0.0.1\n",
+        encoding="utf-8",
+    )
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(multiplex_profiles=True)
     runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.session_store = None
+    runner._busy_text_mode = "queue"
+    runner._handle_active_session_busy_message = None
+    runner._recover_telegram_topic_thread_id = None
     runner.pairing_store = MagicMock()
     runner.pairing_store.is_approved.return_value = False
     runner._profile_name_for_source = lambda source: None
 
-    adapter = A2AAdapter(PlatformConfig(enabled=True))
-    adapter.gateway_runner = runner
-    runner._profile_adapters = {
-        "coder": {adapter.platform: adapter},
-    }
-
-    source = adapter.build_source(
-        chat_id="a2a-context",
-        user_id="alpha",
-        user_name="alpha",
+    a2a = Platform("a2a")
+    profile_config = GatewayConfig(multiplex_profiles=True)
+    profile_config.platforms = {a2a: PlatformConfig(enabled=True)}
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_config)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda profile: profile_home
     )
-    source.profile = "coder"
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, config: A2AAdapter(config),
+    )
 
-    assert runner._adapter_profile_for_source(source) == "coder"
-    assert runner._is_user_authorized(source) is True
+    async def connect(adapter, platform):
+        return await adapter.connect()
+
+    monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", connect)
+
+    observed = {}
+
+    async def handle_message(event):
+        observed["profile"] = event.source.profile
+        observed["authorized"] = runner._is_user_authorized(event.source)
+        await runner._profile_adapters["coder"][a2a].send(
+            event.source.chat_id,
+            "authorized" if observed["authorized"] else "unauthorized",
+            metadata={"notify": True},
+        )
+
+    runner._handle_message = handle_message
+
+    def post(token):
+        message = protocol.text_message(protocol.ROLE_USER, "profile auth")
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "message/send",
+                "params": {"message": message},
+            }
+        ).encode()
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return json.loads(response.read().decode())
+
+    set_multiplex_active(True)
+    adapter = None
+    try:
+        assert await runner._start_one_profile_adapters(
+            "coder", profile_home, {}
+        ) == 1
+        adapter = runner._profile_adapters["coder"][a2a]
+
+        response = await asyncio.to_thread(post, "secondary-token")
+        assert response["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
+        assert observed == {"profile": "coder", "authorized": True}
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            await asyncio.to_thread(post, "default-token")
+        assert exc_info.value.code == 401
+    finally:
+        if adapter is not None:
+            await adapter.disconnect()
+        set_multiplex_active(False)
 
 
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -80,6 +80,47 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_scoped_secondary_profile_still_uses_profile_adapters(monkeypatch):
+    """Runtime scope must not redirect secondary authz to primary adapters.
+
+    ``_make_profile_message_handler`` wraps ``_handle_message`` in
+    ``_profile_runtime_scope``, which overrides HERMES_HOME so
+    ``get_active_profile_name()`` equals the secondary profile for that turn.
+    Authorization must still read ``_profile_adapters[profile]``, not the
+    empty primary ``self.adapters`` map — otherwise upstream-auth platforms
+    such as A2A default-deny an already-authenticated peer (#80884).
+    """
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    secondary = SimpleNamespace(
+        authorization_is_upstream=True,
+        enforces_own_access_policy=False,
+    )
+    runner._profile_adapters = {"beta": {Platform("a2a"): secondary}}
+    # Simulate the scoped turn: active profile name collapses to the secondary.
+    runner._active_profile_name = lambda: "beta"
+
+    assert runner._authorization_adapter(Platform("a2a"), profile="beta") is secondary
+
+    source = SessionSource(
+        platform=Platform("a2a"),
+        chat_id="a2a-context",
+        user_id="alpha",
+        user_name="alpha",
+        chat_type="dm",
+        profile="beta",
+    )
+    assert runner._is_user_authorized(source) is True
+
+
 @pytest.mark.asyncio
 async def test_secondary_a2a_listener_keeps_upstream_authorization(
     monkeypatch, tmp_path

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1223,6 +1223,54 @@ class TestInboundRoundTrip:
 
         asyncio.run(run())
 
+    def test_multiplex_adapter_keeps_profile_scoped_peer_tokens(self, monkeypatch):
+        """A secondary listener must not authenticate with the default profile's tokens."""
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+
+        monkeypatch.setenv("A2A_PEER_TOKENS", "default:default-token")
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+
+        set_multiplex_active(True)
+        scope_token = set_secret_scope(
+            {"A2A_PEER_TOKENS": "secondary:secondary-token"}
+        )
+        try:
+            adapter, base = _make_live_adapter(monkeypatch)
+        finally:
+            reset_secret_scope(scope_token)
+
+        async def run():
+            try:
+                assert await adapter.connect() is True
+                response = await asyncio.to_thread(
+                    _post_json,
+                    base + "/",
+                    _send_body("profile-scoped auth"),
+                    {"Authorization": "Bearer secondary-token"},
+                )
+                assert response["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
+
+                with pytest.raises(urllib.error.HTTPError) as exc_info:
+                    await asyncio.to_thread(
+                        _post_json,
+                        base + "/",
+                        _send_body("wrong profile"),
+                        {"Authorization": "Bearer default-token"},
+                    )
+                assert exc_info.value.code == 401
+            finally:
+                await adapter.disconnect()
+
+        try:
+            asyncio.run(run())
+        finally:
+            set_multiplex_active(False)
+
 
 # --------------------------------------------------------------------------
 # Push notifications end-to-end (inline config in message/send)


### PR DESCRIPTION
## What does this PR do?

Secondary-profile A2A listeners in a multiplexed gateway can reject their own valid peer credentials or accept the default profile's credentials because request threads lose the profile secret scope. This change captures an immutable, adapter-owned security context at startup, preserving each profile's authentication, trust, bind, Agent Card, callback, and push-signing policy across request threads without changing standalone behavior.

### Symptom

With `gateway.multiplex_profiles` enabled, an A2A request using a valid secondary-profile bearer token can return HTTP 401. Moving the token to the default profile can restore transport authentication, but it crosses the intended profile credential boundary.

### Impact

Multiplexed secondary profiles can become unreachable to their configured A2A peers. Their listener can also evaluate authentication and trust against another profile's process environment, violating profile isolation even though invalid credentials remain rejected by the transport.

### Bug Cause

**Trigger:** `plugins/platforms/a2a/security.py:A2ASecurityContext.capture` and `plugins/platforms/a2a/adapter.py:A2AAdapter.__init__`

**Causal chain:**
1. The profile multiplexer constructs a secondary A2A adapter while that profile's secret scope is active.
2. `ThreadingHTTPServer` later handles requests on fresh threads that do not inherit the profile ContextVars, while the legacy security helpers resolve settings from request-time environment state.
3. The request is authenticated with default-profile or empty A2A settings, so a valid secondary peer receives HTTP 401 or the listener falls back to the wrong exposure policy.

**Why it is wrong:** Authentication, trust, bind safety, callback policy, and push signing are adapter-specific security decisions, but their inputs were resolved from thread-local or process-global state after adapter startup.

**Working sibling / contrast:** A standalone A2A gateway remains correct because its process environment is authoritative for the single adapter. The gateway's transport provenance already maps a secondary A2A source back to its registered adapter and honors `authorization_is_upstream=True` once transport authentication succeeds.

**Ruled out:** The gateway authorization failure is not caused by an A2A platform key mismatch. A source built by the real secondary adapter resolves to that adapter and passes upstream authorization in the regression test.

### Fix

Capture bearer tokens, peer tokens, trusted peers, allow-all policy, requested bind host, and push secret in an immutable `A2ASecurityContext` while the adapter's profile scope is active. Route every adapter security decision through that captured context, while retaining process-environment fallback for standalone startup. Add a live `ThreadingHTTPServer` isolation regression and a gateway provenance regression.

## Related Issue

Fixes #80884

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made

- `plugins/platforms/a2a/security.py` - add immutable startup-captured A2A security settings and context-aware callback validation.
- `plugins/platforms/a2a/adapter.py` - use the adapter-owned context for inbound auth, trust, exposure, Agent Card, callback, and push-signing paths.
- `tests/plugins/test_a2a_plugin.py` - verify a live secondary listener accepts only its own profile token after the startup scope is gone.
- `tests/gateway/test_multiplex_profile_authz.py` - verify secondary A2A sources preserve upstream authorization through gateway provenance.

## How to Test

1. Configure different `A2A_PEER_TOKENS` for the default and secondary profiles with `gateway.multiplex_profiles` enabled.
2. Send an A2A task to the secondary listener with its own token and verify completion; retry with the default-profile token and verify HTTP 401.
3. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_adapter_startup_secret_scope.py -k 'not forward_to_profile_first_contact_creates_then_resumes_fake_hermes' -v
scripts/run_tests.sh tests/plugins/test_a2a_plugin.py -m integration -k 'InboundRoundTrip or PushNotificationEndToEnd' -v
scripts/run_tests.sh tests/gateway/test_relay_upstream_authz.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_adapter_startup_secret_scope.py -v
```

Results: 186, 11, and 85 tests passed respectively; `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

N/A - automated live HTTP and gateway regression tests cover the failure and fix.
