### PR TITLE
fix(desktop): keep tab strip when preview/Browser is open

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, hasCloseableMainTile, resolveZoneHeaderHidden } from './lone-header'
 
 describe('forceLoneHeaderForPanes', () => {
   const chrome =
@@ -33,5 +33,78 @@ describe('forceLoneHeaderForPanes', () => {
 
   it('leaves standing side chrome (files / sessions) headerless', () => {
     expect(forceLoneHeaderForPanes(['files'], chrome('right'), noCollapse)).toBe(false)
+  })
+})
+
+describe('resolveZoneHeaderHidden', () => {
+  const mainChrome = () => ({ placement: 'main' as const, uncloseable: false })
+  const workspaceChrome = () => ({ placement: 'main' as const, uncloseable: true })
+
+  it('keeps the strip visible when a sticky hide meets a closeable preview', () => {
+    const shown = ['workspace', 'preview-tile:url:x']
+    const chromeOf = (id: string) => (id === 'workspace' ? workspaceChrome() : mainChrome())
+
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: forceLoneHeaderForPanes(shown, chromeOf, () => false),
+        hasCloseableMainTile: hasCloseableMainTile(shown, chromeOf),
+        headerHiddenFlag: true,
+        shownLength: shown.length
+      })
+    ).toBe(false)
+  })
+
+  it('keeps the strip visible for a lone Browser/preview tile even when sticky-hidden', () => {
+    const shown = ['preview-tile:url:x']
+    const chromeOf = mainChrome
+
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: forceLoneHeaderForPanes(shown, chromeOf, () => false),
+        hasCloseableMainTile: hasCloseableMainTile(shown, chromeOf),
+        headerHiddenFlag: true,
+        shownLength: shown.length
+      })
+    ).toBe(false)
+  })
+
+  it('still honors sticky hide for a tool-only zone', () => {
+    const shown = ['terminal', 'logs']
+
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: forceLoneHeaderForPanes(shown, () => ({}), id => id === 'terminal' || id === 'logs'),
+        hasCloseableMainTile: false,
+        headerHiddenFlag: true,
+        shownLength: shown.length
+      })
+    ).toBe(true)
+  })
+
+  it('still auto-hides a lone uncloseable workspace', () => {
+    const shown = ['workspace']
+    const chromeOf = workspaceChrome
+
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: forceLoneHeaderForPanes(shown, chromeOf, () => false),
+        hasCloseableMainTile: hasCloseableMainTile(shown, chromeOf),
+        shownLength: shown.length
+      })
+    ).toBe(true)
+  })
+
+  it('still honors headerVeto for full-page views', () => {
+    const shown = ['preview-tile:url:x']
+    const chromeOf = mainChrome
+
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: true,
+        hasCloseableMainTile: hasCloseableMainTile(shown, chromeOf),
+        headerVeto: true,
+        shownLength: shown.length
+      })
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
@@ -14,6 +14,18 @@ export interface LoneHeaderChrome {
   uncloseable?: boolean
 }
 
+/** True when any shown pane is a closeable main-strip tile (preview / session / page). */
+export function hasCloseableMainTile(
+  shown: readonly string[],
+  chromeOf: (id: string) => LoneHeaderChrome
+): boolean {
+  return shown.some(id => {
+    const chrome = chromeOf(id)
+
+    return !chrome.uncloseable && chrome.placement === 'main'
+  })
+}
+
 export function forceLoneHeaderForPanes(
   shown: readonly string[],
   chromeOf: (id: string) => LoneHeaderChrome,
@@ -21,15 +33,36 @@ export function forceLoneHeaderForPanes(
 ): boolean {
   // "This pane can be closed, so it must expose the ✕." Only the uncloseable
   // workspace is exempt; standing side chrome (files / sessions) isn't 'main'.
-  if (
-    shown.some(id => {
-      const chrome = chromeOf(id)
-
-      return !chrome.uncloseable && chrome.placement === 'main'
-    })
-  ) {
+  if (hasCloseableMainTile(shown, chromeOf)) {
     return true
   }
 
   return shown.length === 1 && isCollapsePane(shown[0])
+}
+
+/**
+ * Whether the zone tab strip should stay hidden.
+ *
+ * `headerHiddenFlag` is the user's sticky "Hide tab bar" choice. That preference
+ * still applies to tool-only zones, but it must not win over a closeable main
+ * tile (in-app Browser / preview / session): otherwise the strip and close control
+ * disappear with no recovery surface on the body.
+ */
+export function resolveZoneHeaderHidden(options: {
+  headerVeto?: boolean
+  /** `node.headerHidden` — explicit sticky hide, or undefined for auto. */
+  headerHiddenFlag?: boolean
+  shownLength: number
+  forceLoneHeader: boolean
+  hasCloseableMainTile: boolean
+}): boolean {
+  if (options.headerVeto) {
+    return true
+  }
+
+  if (options.hasCloseableMainTile) {
+    return false
+  }
+
+  return options.headerHiddenFlag ?? (options.shownLength <= 1 && !options.forceLoneHeader)
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -69,7 +69,7 @@ import {
 } from '../tab-selection'
 
 import { type DoubleTapContext, startPaneDrag } from './drag-session'
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, hasCloseableMainTile, resolveZoneHeaderHidden } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
 
@@ -247,11 +247,20 @@ export function TreeGroup({
   // always shows its header (it IS the header).
   // Session-tile ids force the header even before chrome registers — cycling
   // onto a freshly-split tile used to land headerless ("name card missing").
-  const forceLoneHeader = forceLoneHeaderForPanes(shown, id => paneChrome(paneFor(id)), isCollapsePane)
+  const chromeOf = (id: string) => paneChrome(paneFor(id))
+  const forceLoneHeader = forceLoneHeaderForPanes(shown, chromeOf, isCollapsePane)
+  const closeableMainTile = hasCloseableMainTile(shown, chromeOf)
 
   // A full-page view (headerVeto) suppresses the strip while it's the active
   // pane — a page is not a tab-able surface; the bar returns with the chat.
-  const headerHidden = paneChrome(active).headerVeto || (node.headerHidden ?? (shown.length <= 1 && !forceLoneHeader))
+  // Sticky "Hide tab bar" must not trap a closeable preview/Browser without ✕.
+  const headerHidden = resolveZoneHeaderHidden({
+    forceLoneHeader,
+    hasCloseableMainTile: closeableMainTile,
+    headerHiddenFlag: node.headerHidden,
+    headerVeto: Boolean(paneChrome(active).headerVeto),
+    shownLength: shown.length
+  })
 
   // A group collapses ALONG its parent split's axis. In a row that means the
   // WIDTH collapses — a full-width horizontal header would strand a tall


### PR DESCRIPTION
## Summary
- Sticky "Hide tab bar" could leave an in-app Browser/preview open with no tab strip and no close control.
- Closeable main tiles (preview / Browser / session) now keep the strip visible so the close affordance stays available.
- Tool-only zones still honor a deliberate sticky hide.

## Test plan
- [x] `npx vitest run src/components/pane-shell/tree/renderer/lone-header.test.ts src/components/pane-shell/tree/tool-pane-toggle.test.ts` (from `apps/desktop`)
- [ ] In Hermes Desktop: open an HTML/URL preview, hide the tab bar (or double-tap the strip), confirm the strip/close control returns while the preview is open
- [ ] Hide the tab bar on a tools-only zone (terminal/logs), close and re-open a tool pane, confirm sticky hide still sticks
- [ ] Lone chat workspace still auto-hides the strip when no preview/session tile is open