### PR TITLE
chore: map soheil.fakour@gmail.com -> thatssoheil for attribution

### DIFF
--- a/contributors/emails/soheil.fakour@gmail.com
+++ b/contributors/emails/soheil.fakour@gmail.com
@@ -1,0 +1,1 @@
+thatssoheil


### PR DESCRIPTION
Adds the contributor email mapping for @thatssoheil ahead of salvaging PR #77768's mask_secret + checkpoint-redaction pieces (attribution audit requires the mapping on main before the salvage PR lands).