### PR TITLE
fix(secrets): close redaction emission gaps — env-name variants, control-splits, process(list), mask_secret, checkpoint (salvage #80643 + #77768)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -521,6 +521,15 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
     return "".join(out)
 
 
+# Display-mask strip for mask_secret: EVERY control char incl. \n/\t, C1,
+# DEL, and zero-width/format chars — a masked secret must never emit
+# multiline, tabbed, or invisible bytes into config/status/dump display
+# output (#55319, #55321).
+_DISPLAY_CONTROL_RE = re.compile(
+    r"[\x00-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]"
+)
+
+
 def mask_secret(
     value: str,
     *,
@@ -561,6 +570,12 @@ def mask_secret(
         >>> mask_secret("long-token", head=6, tail=4, floor=18)
         '***'
     """
+    if not value:
+        return empty
+    # Visible head/tail must not carry control bytes (newline, NUL, DEL, C1)
+    # into config/status/dump output (#55319, #55321). Strip them before
+    # slicing — the length check below then sees the displayable length.
+    value = _DISPLAY_CONTROL_RE.sub("", value)
     if not value:
         return empty
     if len(value) < floor:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -507,6 +507,15 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         body = m.group(1)
         start_orig = orig_idx[m.start(1)]
         end_orig = orig_idx[m.end(1) - 1] + 1
+        # If any fragment inside the original span already matches _PREFIX_RE
+        # on its own, the ordinary prefix pass will mask it — do NOT join.
+        # Joining here would swallow adjacent legitimate text: a complete
+        # token at end-of-line followed by a word line (``ghp_<token>\n
+        # button [ref=e3]``) joins into one stripped-copy match and the
+        # mask eats ``button``. Join only when fragments alone are too
+        # short/broken to match (the actual smuggling shape).
+        if _PREFIX_RE.search(text[start_orig:end_orig]):
+            continue
         # Reject matches whose original span crosses a non-token char
         # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
         # token body, so the regex matched across unrelated lines). Also

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -140,9 +140,25 @@ _PREFIX_PATTERNS = [
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.
 # Uppercase keys tolerate spaces around "=" (e.g. ``FOO_SECRET = bar``) because
 # an all-caps key is almost never prose/code.
-_SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
+# Bare ``KEY`` / ``PASS`` / ``PW`` suffixes are included (``FAL_KEY=…``,
+# ``MYSQL_PASS=…``, ``DB_PW=…``) — issue #77484. The regex is IGNORECASE so
+# lowercase env names (``openai_key=…``) are caught here too. The secret name
+# must sit at a word boundary (``_``-delimited or whole-word) so generic
+# prose words (``password=``, ``token=``, ``KEYBOARD=``, ``PASSAGE=``) do not
+# match — those are handled by the config/form/URL paths, and a bare
+# ``password=…`` in a form body must not be swallowed greedily by ``\S+``.
+_SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDENTIAL|AUTH)"
+# Uppercase keys keep the legacy embedded match (``MYTOKEN=…``, ``FOO_SECRET``)
+# — an all-caps key is almost never prose.
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+)
+# Lowercase env names: only underscore-boundary forms (``openai_key=…``,
+# ``FAL_KEY=…``, ``db_pw=…``) — NOT bare ``password=``/``token=``/``secret=``,
+# which appear in prose, URLs, and form bodies (issue #77484).
+_ENV_ASSIGN_LOWER_RE = re.compile(
+    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    re.IGNORECASE,
 )
 
 # Lowercase / dotted / hyphenated config keys from config files
@@ -236,8 +252,8 @@ _YAML_ASSIGN_RE = re.compile(
 # match. ALL-CAPS keys keep the legacy embedded matching (``MYTOKEN=…``) — an
 # all-caps key is almost never prose, the same rationale as _ENV_ASSIGN_RE.
 _KEY_KEYWORD_RE = re.compile(
-    r"(?:api|auth|access|refresh|session|secret)[ _.\-]?(?:key|token)"
-    r"|token|secret|passwd|password|credential|auth",
+    r"(?:api|auth|access|refresh|session|secret)[ _.\\-]?(?:key|token)"
+    r"|token|secret|passwd|password|pass|pw|credential|auth|key",
     re.IGNORECASE,
 )
 
@@ -283,7 +299,15 @@ def _key_has_secret_keyword(key: str) -> bool:
     """
     letters = [c for c in key if c.isalpha()]
     if letters and all(c.isupper() for c in letters):
-        return True  # legacy all-caps behavior (MYTOKEN=…)
+        # Legacy all-caps behavior (MYTOKEN=…): an all-caps key is almost
+        # never prose. Exception: a bare ``KEY``/``PASS``/``PW`` embedded in
+        # a longer all-caps word (``KEYBOARD``, ``PASSAGE``) is prose, not a
+        # credential — only a word-bounded compound (``API_KEY``,
+        # ``MYSQL_PASSWORD``, ``FAL_KEY``, ``DB_PW``) counts (issue #77484).
+        for m in _KEY_KEYWORD_RE.finditer(key):
+            if _is_word_start(key, m.start()) and _is_word_end(key, m.end()):
+                return True
+        return False
     for m in _KEY_KEYWORD_RE.finditer(key):
         if _is_word_start(key, m.start()) and _is_word_end(key, m.end()):
             return True
@@ -440,10 +464,61 @@ _FORM_BODY_RE = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*(?:&[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*)+$"
 )
 
+# Control / zero-width characters that can split a token body: a secret
+# smuggled as ``sk-abc\x1bdef…`` or ``ghp_abc\n123…`` escapes the contiguous
+# prefix regexes (issue #77484). Used by _mask_control_split_tokens.
+_CONTROL_CHARS_RE = re.compile(
+    r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
+)
+
+# Union of every _PREFIX_PATTERNS body class — a control-stripped match may
+# only span original chars that are token-body or control chars (see
+# _mask_control_split_tokens). ``=`` is deliberately excluded: a KEY=value
+# assignment separator must never let a match span across unrelated text.
+_TOKEN_BODY_CHARS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-."
+)
+
 # Compile known prefix patterns into one alternation
 _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
 )
+
+
+def _mask_control_split_tokens(text: str, mask_fn) -> str:
+    """Mask tokens whose body is split by control/zero-width characters.
+
+    A credential like ``sk-abc\\x1bdef456…`` or ``ghp_abc\\n123def…`` has its
+    token body interrupted, so the contiguous _PREFIX_RE cannot match it and
+    the secret leaks verbatim (issue #77484). Strategy: build a copy with all
+    control chars removed (the token is contiguous again, matching even when
+    each fragment alone is too short), match on that, then mask the
+    corresponding span in the *original* — but only when the original span
+    contains solely token-body and control chars (a match that crosses into a
+    different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
+    """
+    stripped = _CONTROL_CHARS_RE.sub("", text)
+    if stripped == text:
+        return text
+    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+    out = list(text)
+    matches = []
+    for m in _PREFIX_RE.finditer(stripped):
+        body = m.group(1)
+        start_orig = orig_idx[m.start(1)]
+        end_orig = orig_idx[m.end(1) - 1] + 1
+        # Reject matches whose original span crosses a non-token char
+        # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
+        # token body, so the regex matched across unrelated lines). Also
+        # reject when the match runs into a ``KEY=`` name: a real token value
+        # is followed by a newline/space/end, not ``=``.
+        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
+                for c in text[start_orig:end_orig])
+                and (end_orig >= len(text) or text[end_orig] != "=")):
+            matches.append((start_orig, end_orig, mask_fn(body)))
+    for start_orig, end_orig, replacement in reversed(matches):
+        out[start_orig:end_orig] = list(replacement)
+    return "".join(out)
 
 
 def mask_secret(
@@ -725,6 +800,13 @@ def redact_sensitive_text(
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
         _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
+        # Control/zero-width chars (\\n, \\r, ESC, U+200B, …) split a token
+        # body so _PREFIX_RE cannot match across them — a secret smuggled as
+        # ``sk-abc\\x1bdef…`` leaks verbatim (issue #77484). Mask such runs by
+        # first matching on a control-stripped copy, then re-masking the
+        # corresponding span in the original (the stripped copy and the
+        # original are aligned 1:1 for non-control chars).
+        text = _mask_control_split_tokens(text, _prefix_sub)
         text = _PREFIX_RE.sub(lambda m: _prefix_sub(m.group(1)), text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
@@ -746,6 +828,14 @@ def redact_sensitive_text(
                     return m.group(0)
                 return f"{name}={quote}{_mask_token(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
+            # Lowercase env names (``openai_key=…``). Skip URLs — the query
+            # string may contain ``token=``/``key=`` params that are
+            # intentionally passed through (see note near the bottom of this
+            # function; _redact_strict_url_credentials handles the opt-in
+            # case). The uppercase regex above is all-caps-only, so it never
+            # matches URL params; the lowercase one would (issue #77484).
+            if "://" not in text:
+                text = _ENV_ASSIGN_LOWER_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note
             # near the bottom of this function); _DB_CONNSTR_RE still guards

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -114,6 +114,68 @@ class TestEnvAssignments:
         assert "mypassword" not in result
 
 
+class TestBareSecretEnvSuffixes:
+    """Bare *_KEY / *_PASS / *_PW env suffixes mask, incl. lowercase — #77484."""
+
+    def test_upper_suffix_keys_mask(self):
+        for text in ("FAL_KEY=sk-abc123def456", "OPENAI_KEY=sk-abc123def456",
+                     "MYSQL_PASS=ghi789", "DB_PW=jkl012"):
+            result = redact_sensitive_text(text, force=True)
+            assert "=" in result and result.split("=", 1)[1] != text.split("=", 1)[1]
+
+    def test_lowercase_env_name_masks(self):
+        result = redact_sensitive_text("openai_key=sk-abc123def456", force=True)
+        assert "sk-abc123def456" not in result
+
+    def test_prose_words_with_keyword_unchanged(self):
+        # KEYBOARD / PASSAGE embed the bare keyword but are prose, not creds
+        for text in ("KEYBOARD=notsecret", "PASSAGE=notsecret"):
+            result = redact_sensitive_text(text, force=True)
+            assert result == text
+
+    def test_form_body_not_swallowed(self):
+        # A bare `password=`/`token=` in a form body must not be eaten greedily
+        text = "password=mysecret&username=bob&token=opaqueValue"
+        result = redact_sensitive_text(text, force=True)
+        assert "mysecret" not in result
+        assert "opaqueValue" not in result
+        assert "username=bob" in result
+
+
+class TestControlCharSplitTokens:
+    """Tokens split by control/zero-width chars must still mask — #77484."""
+
+    def test_newline_split_token_masks(self):
+        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        text = f"token={tok[:10]}\n{tok[10:]}"
+        result = redact_sensitive_text(text, force=True)
+        assert tok not in result
+
+    def test_esc_split_token_masks(self):
+        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        text = f"token={tok[:10]}\x1b{tok[10:]}"
+        result = redact_sensitive_text(text, force=True)
+        assert tok not in result
+
+    def test_zero_width_split_token_masks(self):
+        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        text = f"token={tok[:10]}\u200b{tok[10:]}"
+        result = redact_sensitive_text(text, force=True)
+        assert tok not in result
+
+    def test_env_dump_lines_not_joined(self):
+        # Control-stripping must not join unrelated env lines into one match
+        env_dump = (
+            "HOME=/home/user\n"
+            "ELEVENLABS_API_KEY=sk_abc123def456ghi789jkl\n"
+            "EXA_API_KEY=exa_XY789abcdef01234\n"
+            "SHELL=/bin/bash\n"
+        )
+        result = redact_sensitive_text(env_dump, force=True)
+        assert "SHELL=/bin/bash" in result
+        assert "HOME=/home/user" in result
+
+
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -1009,3 +1009,21 @@ class TestKeywordWordBoundary:
         assert "hunter2hunter2hunter2hh" not in result
 
 
+class TestMaskSecretControlStripping:
+    """Issue #55319/#55321: mask_secret() must not emit control bytes
+    (newline, NUL, DEL, C1) in the visible head/tail of a masked secret —
+    they corrupt config/status/dump display output."""
+
+    def test_newline_stripped_from_mask(self):
+        # The #55319 probe: a newline inside the preserved head.
+        assert mask_secret("ab\ncd0123456789zzzz") == "abcd...zzzz"
+
+    def test_c1_control_stripped_from_mask(self):
+        assert mask_secret("abcd0123456789zz\x85q") == "abcd...9zzq"
+
+    def test_printable_mask_unchanged(self):
+        assert mask_secret("abcdef0123456789zzzz") == "abcd...zzzz"
+
+    def test_all_control_value_returns_empty_fallback(self):
+        assert mask_secret("\n\x85\u200b") == ""
+        assert mask_secret("\n\x85\u200b", empty="(not set)") == "(not set)"

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -170,6 +170,19 @@ class TestControlCharSplitTokens:
         tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
         self._assert_split_masked(f"{tok[:10]}\u200b{tok[10:]}", tok)
 
+    def test_complete_token_does_not_swallow_next_line(self):
+        # A COMPLETE token at end-of-line followed by ordinary text must not
+        # be joined across the newline — the ordinary prefix pass masks the
+        # token; joining would swallow the adjacent line (browser
+        # accessibility annotations regressed this way: "button [ref=e3]"
+        # disappeared into the mask).
+        tok = "ghp_" + "F" * 29
+        text = f"text: Token: {tok}\nbutton [ref=e3]: Copy\n"
+        result = redact_sensitive_text(text, force=True)
+        assert "F" * 20 not in result
+        assert "button" in result
+        assert "ref=e3" in result
+
     def test_env_dump_lines_not_joined(self):
         # Control-stripping must not join unrelated env lines into one match
         env_dump = (

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -124,8 +124,11 @@ class TestBareSecretEnvSuffixes:
             assert "=" in result and result.split("=", 1)[1] != text.split("=", 1)[1]
 
     def test_lowercase_env_name_masks(self):
-        result = redact_sensitive_text("openai_key=sk-abc123def456", force=True)
-        assert "sk-abc123def456" not in result
+        # Opaque value with NO known prefix: only the env-name regex can
+        # catch it — a sk-/ghp_ value would be masked by _PREFIX_RE on old
+        # code too, making this test false-pass (review finding).
+        result = redact_sensitive_text("openai_key=xyzzyplugh1234567890abcd", force=True)
+        assert "xyzzyplugh1234567890abcd" not in result
 
     def test_prose_words_with_keyword_unchanged(self):
         # KEYBOARD / PASSAGE embed the bare keyword but are prose, not creds
@@ -145,23 +148,27 @@ class TestBareSecretEnvSuffixes:
 class TestControlCharSplitTokens:
     """Tokens split by control/zero-width chars must still mask — #77484."""
 
+    def _assert_split_masked(self, text, tok):
+        # Bare token (no KEY= context). Assert the LONGEST FRAGMENT is gone
+        # from the result: the token is split in the input, so `tok` (whole,
+        # contiguous) is absent from ANY output — even one that leaks every
+        # fragment verbatim (review finding: whole-token assertion is a false
+        # negative; the tail fragment appears contiguously in the leak).
+        result = redact_sensitive_text(text, force=True)
+        longest = max(tok[10:], tok[:10], key=len)
+        assert longest not in result
+
     def test_newline_split_token_masks(self):
         tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
-        text = f"token={tok[:10]}\n{tok[10:]}"
-        result = redact_sensitive_text(text, force=True)
-        assert tok not in result
+        self._assert_split_masked(f"{tok[:10]}\n{tok[10:]}", tok)
 
     def test_esc_split_token_masks(self):
         tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
-        text = f"token={tok[:10]}\x1b{tok[10:]}"
-        result = redact_sensitive_text(text, force=True)
-        assert tok not in result
+        self._assert_split_masked(f"{tok[:10]}\x1b{tok[10:]}", tok)
 
     def test_zero_width_split_token_masks(self):
         tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
-        text = f"token={tok[:10]}\u200b{tok[10:]}"
-        result = redact_sensitive_text(text, force=True)
-        assert tok not in result
+        self._assert_split_masked(f"{tok[:10]}\u200b{tok[10:]}", tok)
 
     def test_env_dump_lines_not_joined(self):
         # Control-stripping must not join unrelated env lines into one match

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -903,6 +903,26 @@ class TestCheckpoint:
             data = json.loads(checkpoint.read_text())
             assert data == []
 
+    def test_checkpoint_redacts_command_with_inline_secret(self, registry, tmp_path):
+        """Issue #77484: the checkpoint file persists raw commands; inline
+        credentials (e.g. ``curl -H 'Authorization: Bearer sk-...'``) must be
+        redacted before write. Recovery only uses command for display/logging
+        (the process is already running), so masking is lossless."""
+        checkpoint = tmp_path / "procs.json"
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            secret = "sk-secret1234567890"
+            command = f"curl -H 'Authorization: Bearer {secret}' http://x"
+            s = _make_session(sid="proc_secret", command=command)
+            s.pid = 12345
+            s.host_start_time = int(time.time())
+            registry._running[s.id] = s
+            registry._write_checkpoint()
+
+            data = json.loads(checkpoint.read_text())
+            assert data[0]["session_id"] == "proc_secret"
+            assert secret not in data[0]["command"]
+            assert data[0]["command"] != command
+
 # =========================================================================
 # Kill process
 # =========================================================================

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1417,6 +1417,24 @@ class TestHandleProcessRedaction:
         out = json.loads(pr._handle_process({"action": "poll", "session_id": sess.id}))
         assert "abc123def456" not in out["output_preview"]
 
+    def test_list_redacts_command_and_output(self, monkeypatch):
+        """`process(action=list)` redacts command + output_preview — issue #77484.
+
+        The list branch previously returned raw ``command[:200]`` and
+        ``output_preview[-200:]`` with no redaction wrap, leaking inline
+        secrets (unlike poll/log/wait/kill).
+        """
+        pr, sess = self._setup(
+            monkeypatch, "curl -H 'Authorization: Bearer sk-abc123def456ghi789jkl012345'",
+            "opaque token sk-proj-AAAABBBBCCCCDDDDEEEEFFFFGGGG output",
+        )
+        out = json.loads(pr._handle_process({"action": "list"}))
+        assert len(out["processes"]) >= 1
+        entry = out["processes"][0]
+        assert "sk-abc123def456ghi789jkl012345" not in entry["command"]
+        assert "sk-proj-AAAABBBBCCCCDDDDEEEEFFFFGGGG" not in entry["output_preview"]
+        assert "curl" in entry["command"]
+
     def test_disabled_passes_through(self, monkeypatch):
         import agent.redact as _r
         monkeypatch.setattr(_r, "_REDACT_ENABLED", False)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -49,6 +49,8 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
 
+from agent.redact import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -2067,7 +2069,14 @@ class ProcessRegistry:
                             s.host_start_time = self._safe_host_start_time(s.pid)
                         entries.append({
                             "session_id": s.id,
-                            "command": s.command,
+                            # Redact inline credentials before persisting to
+                            # disk — the checkpoint file lives under
+                            # ~/.hermes/processes.json with the raw command
+                            # (issue #77484). Recovery only uses command for
+                            # display/logging (the process is already running;
+                            # adoption re-validates the PID, never re-runs the
+                            # command), so masking is lossless.
+                            "command": redact_sensitive_text(s.command, code_file=True),
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
                             "host_start_time": s.host_start_time,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2493,7 +2493,12 @@ def _handle_process(args, **kw):
         except Exception:
             session_key = ""
         return json.dumps(
-            {"processes": process_registry.list_sessions(task_id=task_id, session_key=session_key or None)},
+            {
+                "processes": [
+                    _redact_process_result(p)
+                    for p in process_registry.list_sessions(task_id=task_id, session_key=session_key or None)
+                ]
+            },
             ensure_ascii=False,
         )
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:


### PR DESCRIPTION
## Summary
Closes four verified secret-emission gaps (#77484, #55319, #55321): `*_KEY`/`*_PASS`/`*_PW` + lowercase env names now mask, control-char-split tokens no longer bypass the prefix regexes, `process(action=list)` and the `processes.json` checkpoint are redacted, and `mask_secret()` no longer emits control bytes in its visible head/tail.

Salvage combining the best halves of two PRs by @thatssoheil (all four commits cherry-picked, authorship preserved):
- **#80643** (body): env-name gap + span-local control-split masking + process(list)
- **#77768** (two unique pieces): `mask_secret` control stripping (#55319/#55321) + checkpoint-file command redaction

## Why #80643's body and not #77768's
Both PRs fix the same #77484 gaps; live main-vs-PR probes showed #77768's implementation regresses while #80643's doesn't:

| Probe | #77768 | #80643 (this PR) |
|---|---|---|
| `run with MY_TOKEN_2=<opaque>` (suffixed env key, masked on main) | **leaks verbatim** (misplaced `\b` makes the suffix class unsatisfiable) | masked |
| `MONKEY=banana`, `KEYBOARD=logitech`, `BYPASS=enabled` (prose) | **masked to `***`** | untouched |
| ANSI-colored output / ZWJ emoji with zero secrets present | **mangled** (global control strip: `\x1b[31m` → visible `[31m`, 👨‍👩‍👧 broken) | byte-identical |
| `sk-…` token split by `\n` | leaks | masked (span-masking on a control-stripped shadow copy) |

#77768's two pieces that #80643 lacks are cherry-picked on top with a conflict resolution that keeps only the `_DISPLAY_CONTROL_RE` + `mask_secret` change and the checkpoint redaction (its global-strip machinery and its versions of the #77484 tests were dropped in favor of #80643's hardened ones).

## Changes
- `agent/redact.py`: widened `_SECRET_ENV_NAMES` (bare KEY/PASS/PW), new `_ENV_ASSIGN_LOWER_RE` (underscore-bounded lowercase names, URL-guarded), word-boundary fix in `_key_has_secret_keyword`'s all-caps branch, `_mask_control_split_tokens` (masks tokens split by control/zero-width chars without touching non-secret text), `mask_secret` strips control bytes from the visible mask (all-control values fall back to `empty`).
- `tools/process_registry.py`: `process(action=list)` entries run through `_redact_process_result` (was raw `command[:200]` + `output_preview[-200:]`); `_write_checkpoint` redacts `command` before persisting to `~/.hermes/processes.json` (recovery only uses it for display; adoption re-validates the PID).
- Tests: hardened #77484 regression tests (value-specific asserts, opaque fixtures — the earlier vacuous versions were caught in #80643's own review round), `TestMaskSecretControlStripping`, checkpoint + list redaction tests.

## Validation
| | Result |
|---|---|
| tests/agent/test_redact.py + tests/tools/test_process_registry.py | 141 passed |
| kanban + monitoring redaction suites | 9 passed |
| Combined with the #61352 salvage branch (merge + full suites) | 167 passed, no conflicts |
| E2E probes: env-name gaps masked, NO suffix regression, prose untouched, ANSI/ZWJ preserved, ESC/newline-split masked, mask_secret control-free, list+checkpoint redacted | all pass |
| Checkpoint→recovery safety | redaction masks values, never command tokens → `is_env_dump_command(redacted)` branch selection stable |
| ruff | clean |

## Residual (known, shared with every variant)
Env keys whose names carry no secret keyword (`SPOTIFY_CLIENT_ID`) still pass the ENV regexes — follow-up issue filed.

Closes #80643
Closes #77768
Fixes #77484
Fixes #55319
Fixes #55321
