### PR TITLE
fix(desktop): normalize Windows absolute paths to file:// URLs

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1299,10 +1299,16 @@ function openExternalUrl(rawUrl) {
     return false
   }
 
+  // Windows absolute paths (C:\... or C:/...) arrive as plain paths (e.g. from
+  // the artifacts panel). `new URL('C:\Users\...')` parses as a bogus `c:`
+  // scheme instead of `file:`, which would trip the protocol allowlist below
+  // and surface a confusing "Invalid external URL". Normalize to file:// first.
+  const urlInput = /^[a-zA-Z]:[\\/]/.test(raw) ? pathToFileURL(raw).toString() : raw
+
   let parsed
 
   try {
-    parsed = new URL(raw)
+    parsed = new URL(urlInput)
   } catch {
     return false
   }

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -119,6 +119,14 @@ export async function artifactImageSrc(value: string, href = artifactHref(value)
 }
 
 function artifactLabel(value: string): string {
+  // Windows drive-letter paths parse `C:` as a scheme (protocol "c:") with a
+  // backslash pathname that split('/') cannot reduce — C:\Work\a.md would
+  // label as \Work\a.md (drive letter swallowed). Split on both separators
+  // up front so backslash and forward-slash forms label identically.
+  if (/^[a-zA-Z]:[\\/]/.test(value)) {
+    return value.split(/[\\/]/).filter(Boolean).pop() || value
+  }
+
   try {
     const url = new URL(value)
     const item = url.pathname.split('/').filter(Boolean).pop()

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -20,7 +20,7 @@ export interface ArtifactRecord {
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
-const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
+const PATH_RE = /(^|[\s("'`])((?:[a-zA-Z]:[\\/]|\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
 const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$/i
 const FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|mp3|wav|mp4|mov)(?:\?.*)?$/i
 const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target)/i
@@ -54,7 +54,8 @@ function looksLikePathOrUrl(value: string): boolean {
     value.startsWith('/') ||
     value.startsWith('./') ||
     value.startsWith('../') ||
-    value.startsWith('~/')
+    value.startsWith('~/') ||
+    /^[a-zA-Z]:[\\/]/.test(value)
   )
 }
 
@@ -80,7 +81,8 @@ function artifactKind(value: string): ArtifactKind {
     value.startsWith('./') ||
     value.startsWith('../') ||
     value.startsWith('~/') ||
-    value.startsWith('file://')
+    value.startsWith('file://') ||
+    /^[a-zA-Z]:[\\/]/.test(value)
   ) {
     return 'file'
   }
@@ -93,7 +95,11 @@ function artifactHref(value: string): string {
     return value
   }
 
-  if (value.startsWith('file://') || value.startsWith('/')) {
+  // Windows absolute paths (C:\... / C:/...) are file paths too — normalize
+  // them to file:// so openExternalUrl doesn't parse `C:` as a scheme and
+  // reject it. (The artifacts panel surfaces kanban attachments / local files
+  // as plain Windows paths on Windows hosts.)
+  if (value.startsWith('file://') || value.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(value)) {
     return mediaExternalUrl(value)
   }
 

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,23 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('indexes Windows absolute paths from assistant text as file artifacts', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Report saved to C:\\Work\\a.md for review.',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      href: 'file:///C:/Work/a.md',
+      kind: 'file',
+      value: 'C:\\Work\\a.md'
+    })
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -80,8 +80,30 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts[0]).toMatchObject({
       href: 'file:///C:/Work/a.md',
       kind: 'file',
+      label: 'a.md',
       value: 'C:\\Work\\a.md'
     })
+  })
+
+  it('labels forward-slash and backslash Windows paths identically', () => {
+    const backslash = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Report saved to C:\\Work\\a.md for review.',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    const forwardSlash = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Report saved to C:/Work/a.md for review.',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(backslash[0]?.label).toBe('a.md')
+    expect(forwardSlash[0]?.label).toBe('a.md')
   })
 
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -62,6 +62,58 @@ describe('mediaExternalUrl', () => {
     expect(mediaExternalUrl('file:///tmp/a.png')).toBe('file:///tmp/a.png')
   })
 
+  it('normalizes Windows absolute paths to file:/// form (regression: c: scheme)', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\Work\\a.md')).toBe('file:///C:/Work/a.md')
+    expect(mediaExternalUrl('C:/Work/a.md')).toBe('file:///C:/Work/a.md')
+    expect(mediaExternalUrl('d:\\data\\file.txt')).toBe('file:///d:/data/file.txt')
+  })
+
+  it('encodes # in Windows paths so URL parsing cannot treat it as a fragment', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\Work\\a#b.md')).toBe('file:///C:/Work/a%23b.md')
+  })
+
+  it('encodes % in Windows paths so %25 is not double-decoded', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\Work\\100%25.md')).toBe('file:///C:/Work/100%2525.md')
+  })
+
+  it('leaves spaces raw in the emitted URL (WHATWG parses them as %20)', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\Work\\My Docs\\a b.md')).toBe('file:///C:/Work/My Docs/a b.md')
+    // Behavior contract: URL parsing must recover the exact filesystem path.
+    expect(new URL(mediaExternalUrl('C:\\Work\\My Docs\\a b.md')).pathname).toBe('/C:/Work/My%20Docs/a%20b.md')
+  })
+
+  it('handles a drive root', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\')).toBe('file:///C:/')
+  })
+
+  // UNC paths and the legacy `file://C:` form are out of scope for this PR
+  // (declared in the PR description). These tests lock in current behavior so
+  // a future change has to consciously extend the drive-letter branch.
+  it('does not touch UNC paths (out of scope, documented)', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('\\\\server\\share\\a.md')).toBe('file://\\\\server\\share\\a.md')
+  })
+
+  it('passes legacy file://C: URLs through unchanged (out of scope, documented)', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('file://C:/x/a.md')).toBe('file://C:/x/a.md')
+  })
+
+  it('rewrites Windows paths through the authenticated download URL in remote mode', () => {
+    $connection.set({ mode: 'remote', baseUrl: 'https://gw', token: 't' } as never)
+    expect(mediaExternalUrl('C:\\Work\\a.md')).toBe('https://gw/api/files/download?path=C%3A%5CWork%5Ca.md&token=t')
+  })
+
+  it('URL-encodes special characters in the remote download query', () => {
+    $connection.set({ mode: 'remote', baseUrl: 'https://gw', token: 't' } as never)
+    expect(mediaExternalUrl('C:\\a b#c.md')).toBe('https://gw/api/files/download?path=C%3A%5Ca%20b%23c.md&token=t')
+  })
+
   it('rewrites gateway-local paths to an authenticated download URL', () => {
     $connection.set({ mode: 'remote', baseUrl: 'https://gw', token: 's e/cret' } as never)
     expect(mediaExternalUrl('file:///tmp/a b.png')).toBe(

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -116,6 +116,18 @@ export function mediaExternalUrl(path: string): string {
     }
   }
 
+  // Windows absolute paths (C:\... / C:/...) arrive as plain paths. Build the
+  // canonical file:/// form (pathToFileURL shape) so the main process can
+  // resolve and open them; `file://C:\...` (bare backslash, one slash) is not
+  // a valid file URL. # and % are legal in Windows filenames — encode them so
+  // URL parsing doesn't treat `#...` as a fragment or double-decode `%XX`.
+  // `%` must be replaced first or the %25 we emit would itself get re-encoded.
+  if (/^[a-zA-Z]:[\\/]/.test(path)) {
+    const p = path.replace(/\\/g, '/').replace(/%/g, '%25').replace(/#/g, '%23').replace(/\?/g, '%3F')
+
+    return `file:///${p}`
+  }
+
   return /^file:/i.test(path) ? path : `file://${path}`
 }
 


### PR DESCRIPTION
### What changed and why

On Windows, local absolute paths (`C:\...` / `C:/...`) could not be opened from the
desktop app: `mediaExternalUrl` emitted the invalid `file://C:\...` form, the main
process parsed `C:\...` as a bogus `c:` scheme that the protocol allowlist rejected
with "Invalid external URL", and the artifacts panel dropped drive-letter paths
before they ever reached rendering.

This PR normalizes drive-letter absolute paths to canonical `file:///C:/...` URLs
at every layer:

1. **`apps/desktop/src/lib/media.ts`** — `mediaExternalUrl` maps drive-letter paths
   to the canonical `file:///` form and percent-encodes `%`, `#`, `?` (all legal in
   Windows filenames; previously `#` was parsed as a URL fragment and `%XX` was
   double-decoded, silently opening the wrong file). `%` is escaped first so the
   emitted `%25` is not re-encoded.
2. **`apps/desktop/electron/main.ts`** — `openExternalUrl` normalizes drive-letter
   input via `pathToFileURL` before the protocol allowlist check, so the `c:`
   scheme never reaches the allowlist. This is defense in depth on top of (1).
3. **`apps/desktop/src/app/artifacts/artifact-utils.ts`** — the collection layer
   (`PATH_RE`, `looksLikePathOrUrl`, `artifactKind`) now recognizes drive-letter
   absolute paths, so Windows paths in assistant text are indexed as file
   artifacts and `artifactHref` renders them as canonical `file:///` URLs.
4. **Tests** — 9 new `mediaExternalUrl` cases (special-char encoding, space
   contract, drive root, out-of-scope locking for UNC / legacy `file://C:` form,
   remote-gateway query encoding) and 1 artifacts end-to-end case.

### How to test it

```
cd apps/desktop
npx vitest run src/lib/media.remote.test.ts   # 28/28 pass
npx vitest run src/app/artifacts/index.test.ts # 4/4 pass
```

Manual (Windows): a message referencing `C:\Work\a.md` shows a file artifact in the
artifacts panel; clicking it opens the file. Files whose names contain `#` or `%`
(e.g. `C:\Work\a#b.md`) open the correct file.

### What platforms you tested on

- **Windows 11** — local mode (media links + artifacts panel) and remote gateway
  mode (authenticated download URL rewrite). Manual verification was performed on
  Windows 11 only.
- **POSIX** — covered by the pre-existing test suite. The renderer-side
  drive-letter branches (media.ts / artifact-utils.ts) are gated on a
  `/^[a-zA-Z]:[\\/]/` prefix that no POSIX path matches, so those paths are
  byte-for-byte unchanged on macOS/Linux; `main.ts`'s `pathToFileURL`
  normalization also only rewrites input that already starts with a drive-letter
  prefix, which POSIX paths never do.
- The pre-existing `apps/desktop` electron test failures are identical before/after
  this change (verified via `git stash`) and unrelated to this PR.

### Related issues

Fixes #80946 — "Opening local file paths (C:\...) from artifacts panel fails".

Related: #48620 (open, unmerged; relative / `~` / URL-special-char paths,
macOS-focused). Its fix plan mentions "Canonical handling for Windows drive paths"
but does not cover the `c:` scheme rejection in `openExternalUrl`, and its review
notes it targets the removed `main.cjs` surface. If #48620 lands first, happy to
rebase.

Note: #55390 (a similar drive-letter fix in `local-preview.ts`) was closed unmerged;
the `media.ts` drive-path gap flagged in its review is exactly what this PR
addresses.

### Type of change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change

### Checklist

- [x] Code follows project style (eslint / prettier pass on changed files)
- [x] Tests added/updated and passing (28/28 + 4/4)
- [x] Verified on Windows 11 (local + remote gateway mode)
- [x] POSIX behavior unchanged (regex-gated branches; covered by existing tests)

### Out of scope (documented)

- **UNC paths** (`\\server\share\...`) and the extended-length `\\?\` prefix — not
  matched by the drive-letter regex; locked by tests as out of scope. Can be added
  in a follow-up via `pathToFileURL` (which handles them natively).
- **Legacy `file://C:\...` form** produced by the previous broken code — passed
  through unchanged; migrating already-persisted URLs is a separate data-migration
  concern.

---