### PR TITLE
fix(desktop): branch no longer drops the conversation tail

### DIFF
--- a/apps/desktop/electron-main-entry.mjs
+++ b/apps/desktop/electron-main-entry.mjs
@@ -1,0 +1,17 @@
+// The production main bundle lives in dist/, which is intentionally unpacked
+// so the embedded web server can serve static files from a real directory.
+// Electron's ESM loader resolves package.json#main inside app.asar literally,
+// though, so an unpacked dist/electron-main.mjs cannot be the package entry.
+// Keep this tiny bridge inside app.asar and load the real bundle by filesystem
+// path from app.asar.unpacked.
+
+import { app } from 'electron'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const desktopRoot = fileURLToPath(new URL('.', import.meta.url))
+const mainPath = app.isPackaged
+  ? join(process.resourcesPath, 'app.asar.unpacked', 'dist', 'electron-main.mjs')
+  : join(desktopRoot, 'dist', 'electron-main.mjs')
+
+await import(pathToFileURL(mainPath).href)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "type": "module",
-  "main": "dist/electron-main.mjs",
+  "main": "electron-main-entry.mjs",
   "engines": {
     "node": ">=22.22.0"
   },
@@ -183,6 +183,7 @@
       "dist/**",
       "assets/**",
       "public/**",
+      "electron-main-entry.mjs",
       "package.json"
     ],
     "beforeBuild": "scripts/before-build.mjs",

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -358,10 +358,11 @@ function validateBundle() {
     }
   }
 
-  // Renderer payload check (either unpacked or in the asar)
-  if (exists(APP.unpackedDistIndex)) {
-    return { stamp, nodeBinaries }
-  }
+  // The package entry must remain inside app.asar. dist/** is intentionally
+  // unpacked for the embedded web server, so electron-main.mjs itself cannot
+  // be package.json#main: Node's ESM loader resolves that path literally as
+  // app.asar/dist/electron-main.mjs. The in-asar bridge loads the real main
+  // bundle from app.asar.unpacked.
   if (!exists(APP.asarPath)) {
     die(`Missing renderer payload: neither ${APP.unpackedDistIndex} nor ${APP.asarPath} exists`)
   }
@@ -370,6 +371,13 @@ function validateBundle() {
   // backslash-prefixed entries on Windows ('\\dist\\index.html') and
   // forward-slash on Unix.
   const normalized = files.map(f => f.replace(/\\/g, '/').replace(/^\/+/, ''))
+  if (!normalized.includes('electron-main-entry.mjs')) {
+    die(`Missing in-asar Electron entry bridge: ${APP.asarPath} (expected electron-main-entry.mjs)`)
+  }
+  // Renderer payload check (either unpacked or in the asar)
+  if (exists(APP.unpackedDistIndex)) {
+    return { stamp, nodeBinaries }
+  }
   if (!normalized.includes('dist/index.html')) {
     die(`Missing renderer payload file in app.asar: ${APP.asarPath} (expected dist/index.html)`)
   }

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -175,6 +175,11 @@ function TileChat({
   const onRemoveAttachment = useCallback((id: string) => void removeAttachment(id), [removeAttachment])
   const onRetryResume = useCallback(() => patchSessionTile(storedSessionId, { error: undefined }), [storedSessionId])
 
+  const onBranchInNewChat = useCallback(
+    (messageId: string) => void sessionTileDelegate()?.branchMessage(runtimeId, storedSessionId, messageId),
+    [runtimeId, storedSessionId]
+  )
+
   // Per-tile model menu — rendered under this tile's SessionView so the pill
   // + switch target THIS runtime, not the primary (which may be mid-turn).
   const modelMenuContent = useMemo(
@@ -200,6 +205,7 @@ function TileChat({
           onAddUrl={onAddUrl}
           onAttachDroppedItems={composer.attachDroppedItems}
           onAttachImageBlob={composer.attachImageBlob}
+          onBranchInNewChat={onBranchInNewChat}
           onCancel={actions.cancelRun}
           onDeleteSelectedSession={noop}
           onDismissError={actions.dismissError}

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -37,6 +37,7 @@ function renderTile(requestGateway: ReturnType<typeof vi.fn>) {
   renderHook(() =>
     useSessionTileDelegate({
       archiveSession: vi.fn(async () => undefined),
+      branchSessionMessage: vi.fn(async () => undefined),
       branchStoredSession: vi.fn(async () => undefined),
       executeSlashCommand: vi.fn(async () => undefined) as never,
       removeSession: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -7,6 +7,7 @@ import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
 import { withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
+import type { BranchSessionMessageOptions } from '../../session/hooks/use-session-actions'
 import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
 import type { GatewayRequester } from '../types'
@@ -15,6 +16,7 @@ type SessionStateCache = ReturnType<typeof useSessionStateCache>
 
 interface SessionTileDelegateParams {
   archiveSession: (storedSessionId: string) => Promise<unknown>
+  branchSessionMessage: (options: BranchSessionMessageOptions) => Promise<unknown>
   branchStoredSession: (storedSessionId: string) => Promise<unknown>
   executeSlashCommand: ReturnType<typeof usePromptActions>['executeSlashCommand']
   removeSession: (storedSessionId: string) => Promise<unknown>
@@ -33,6 +35,7 @@ interface SessionTileDelegateParams {
  */
 export function useSessionTileDelegate({
   archiveSession,
+  branchSessionMessage,
   branchStoredSession,
   executeSlashCommand,
   removeSession,
@@ -74,6 +77,22 @@ export function useSessionTileDelegate({
     setSessionTileDelegate({
       archiveSession: async storedSessionId => {
         await archiveSession(storedSessionId)
+      },
+      branchMessage: async (runtimeId, storedSessionId, messageId) => {
+        const state = sessionStateByRuntimeIdRef.current.get(runtimeId)
+
+        if (!state) {
+          throw new Error('session state is not available')
+        }
+
+        await branchSessionMessage({
+          busy: state.busy,
+          cwd: state.cwd,
+          messageId,
+          messages: state.messages,
+          parentStoredId: storedSessionId,
+          sourceSessionId: runtimeId
+        })
       },
       branchSession: async storedSessionId => {
         await branchStoredSession(storedSessionId)
@@ -150,6 +169,7 @@ export function useSessionTileDelegate({
     })
   }, [
     archiveSession,
+    branchSessionMessage,
     branchStoredSession,
     executeSlashCommand,
     removeSession,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -439,6 +439,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const {
     archiveSession,
     branchCurrentSession,
+    branchSessionMessage,
     branchStoredSession,
     createBackendSessionForSend,
     openNewSessionTile,
@@ -608,6 +609,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // the tile TAB menu needs, without touching the primary view).
   useSessionTileDelegate({
     archiveSession,
+    branchSessionMessage,
     branchStoredSession,
     executeSlashCommand,
     removeSession,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1129,7 +1129,7 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
-  it('branches an open live chat via session.branch with a trimmed message count (bug #1/#3 fix)', async () => {
+  it('branches an open live chat via session.branch with no merged-count truncation (branch context-loss bug)', async () => {
     let branchParams: Record<string, unknown> | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -1140,7 +1140,7 @@ describe('branchStoredSession desktop source tagging', () => {
           session_id: 'branch-runtime',
           stored_session_id: 'branch-stored',
           title: 'Branch',
-          message_count: 2,
+          message_count: 4,
           messages: [],
           info: {}
         } as never
@@ -1167,16 +1167,61 @@ describe('branchStoredSession desktop source tagging', () => {
     )
     await waitFor(() => expect(branchCurrentSession).not.toBeNull())
 
-    // Branch from the FIRST assistant reply ("a1"), not the last message �
-    // this is exactly the scenario that used to drop the question (bug #1):
-    // only the clicked message survived instead of everything up to it.
-    await expect(branchCurrentSession!('a1')).resolves.toBe(true)
+    // Branching the whole open chat sends NO truncation: the backend copies
+    // the full raw history. A merged-message count used to be sent here and
+    // silently dropped the conversation tail (the branch context-loss bug).
+    await expect(branchCurrentSession!()).resolves.toBe(true)
 
     expect(requestGateway).toHaveBeenCalledWith('session.branch', {
-      session_id: 'live-parent',
-      count: 2
+      session_id: 'live-parent'
     })
-    expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
+    expect(branchParams).toEqual({ session_id: 'live-parent' })
+  })
+
+  it('branches from a specific message by durable row id', async () => {
+    let branchParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.branch') {
+        branchParams = params
+
+        return {
+          session_id: 'branch-runtime',
+          stored_session_id: 'branch-stored',
+          title: 'Branch',
+          message_count: 3,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    setMessages([
+      { id: 'q1', role: 'user', parts: [{ type: 'text', text: 'question one' }], rowId: 101 },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'answer one' }], rowId: 102 },
+      { id: 'q2', role: 'user', parts: [{ type: 'text', text: 'question two' }], rowId: 103 },
+      { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'answer two' }], rowId: 104 }
+    ])
+
+    let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="live-parent"
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    // Branch from the first assistant reply ("a1"): the request names its
+    // durable DB row id so the backend truncates the RAW history at exactly
+    // that row instead of a merged-message count.
+    await expect(branchCurrentSession!('a1')).resolves.toBe(true)
+
+    expect(branchParams).toEqual({ session_id: 'live-parent', up_to_row_id: 102 })
   })
 
   // #67603: right-clicking a session outside the paginated sidebar window is a

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,7 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
-import { getAllSessionMessages, getLatestSessionMessages, getSession, type SessionInfo } from '@/hermes'
+import {
+  getAllSessionMessages,
+  getLatestSessionMessages,
+  getSession,
+  getSessionMessages,
+  type SessionInfo
+} from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
@@ -41,6 +47,7 @@ import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
+import type { BranchSessionMessageOptions } from './use-session-actions'
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -48,6 +55,7 @@ vi.mock('@/hermes', async importOriginal => ({
   getSession: vi.fn(),
   getAllSessionMessages: vi.fn(),
   getLatestSessionMessages: vi.fn(),
+  getSessionMessages: vi.fn(),
   listAllProfileSessions: vi.fn(),
   setApiRequestProfile: vi.fn(),
   setSessionArchived: vi.fn()
@@ -1014,14 +1022,20 @@ function BranchHarness({
   activeSessionId = null,
   navigate = vi.fn(),
   onCurrentReady,
+  onTileReady,
   onReady,
-  requestGateway
+  onStateUpdate,
+  requestGateway,
+  selectedStoredSessionId = null
 }: {
   activeSessionId?: string | null
   navigate?: ReturnType<typeof vi.fn>
   onCurrentReady?: (branchCurrentSession: (messageId?: string) => Promise<boolean>) => void
+  onTileReady?: (branchSessionMessage: (options: BranchSessionMessageOptions) => Promise<boolean>) => void
   onReady: (branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) => void
+  onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  selectedStoredSessionId?: string | null
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -1037,17 +1051,31 @@ function BranchHarness({
     requestGateway,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
-    selectedStoredSessionId: null,
-    selectedStoredSessionIdRef: ref<string | null>(null),
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: () => ({}) as ClientSessionState
+    updateSessionState: (sessionId, updater) => {
+      const next = updater({} as ClientSessionState)
+      onStateUpdate?.(sessionId, next)
+
+      return next
+    }
   })
 
   useEffect(() => {
     onReady(actions.branchStoredSession)
     onCurrentReady?.(actions.branchCurrentSession)
-  }, [actions.branchCurrentSession, actions.branchStoredSession, onCurrentReady, onReady])
+    onTileReady?.(actions.branchSessionMessage)
+  }, [
+    actions.branchCurrentSession,
+    actions.branchSessionMessage,
+    actions.branchStoredSession,
+    onCurrentReady,
+    onReady,
+    onStateUpdate,
+    onTileReady
+  ])
 
   return null
 }
@@ -1131,6 +1159,7 @@ describe('branchStoredSession desktop source tagging', () => {
 
   it('branches an open live chat via session.branch with no merged-count truncation (branch context-loss bug)', async () => {
     let branchParams: Record<string, unknown> | undefined
+    let branchStateMessages: ClientSessionState['messages'] | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === 'session.branch') {
@@ -1141,7 +1170,12 @@ describe('branchStoredSession desktop source tagging', () => {
           stored_session_id: 'branch-stored',
           title: 'Branch',
           message_count: 4,
-          messages: [],
+          messages: [
+            { id: 201, role: 'user', content: 'question one' },
+            { id: 202, role: 'assistant', content: 'answer one' },
+            { id: 203, role: 'user', content: 'question two' },
+            { id: 204, role: 'assistant', content: 'answer two' }
+          ],
           info: {}
         } as never
       }
@@ -1162,6 +1196,11 @@ describe('branchStoredSession desktop source tagging', () => {
         activeSessionId="live-parent"
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
+        onStateUpdate={(_sessionId, state) => {
+          if (state.messages?.length) {
+            branchStateMessages = state.messages
+          }
+        }}
         requestGateway={requestGateway}
       />
     )
@@ -1176,9 +1215,10 @@ describe('branchStoredSession desktop source tagging', () => {
       session_id: 'live-parent'
     })
     expect(branchParams).toEqual({ session_id: 'live-parent' })
+    expect(branchStateMessages?.map(message => message.rowId)).toEqual([201, 202, 203, 204])
   })
 
-  it('branches from a specific message by durable row id', async () => {
+  it('resolves a durable row id before branching from a fresh live message', async () => {
     let branchParams: Record<string, unknown> | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -1198,11 +1238,22 @@ describe('branchStoredSession desktop source tagging', () => {
       return {} as never
     })
 
+    setSessions([storedSession({ id: 'stored-parent', message_count: 4 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        { id: 101, role: 'user', content: 'question one' },
+        { id: 102, role: 'assistant', content: 'answer one' },
+        { id: 103, role: 'user', content: 'question two' },
+        { id: 104, role: 'assistant', content: 'answer two' }
+      ],
+      session_id: 'stored-parent'
+    } as never)
+
     setMessages([
-      { id: 'q1', role: 'user', parts: [{ type: 'text', text: 'question one' }], rowId: 101 },
-      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'answer one' }], rowId: 102 },
-      { id: 'q2', role: 'user', parts: [{ type: 'text', text: 'question two' }], rowId: 103 },
-      { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'answer two' }], rowId: 104 }
+      { id: 'q1', role: 'user', parts: [{ type: 'text', text: 'question one' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'answer one' }] },
+      { id: 'q2', role: 'user', parts: [{ type: 'text', text: 'question two' }] },
+      { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'answer two' }] }
     ])
 
     let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
@@ -1212,16 +1263,104 @@ describe('branchStoredSession desktop source tagging', () => {
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
         requestGateway={requestGateway}
+        selectedStoredSessionId="stored-parent"
       />
     )
     await waitFor(() => expect(branchCurrentSession).not.toBeNull())
 
-    // Branch from the first assistant reply ("a1"): the request names its
-    // durable DB row id so the backend truncates the RAW history at exactly
-    // that row instead of a merged-message count.
+    // The live messages have no rowId. The desktop must resolve the selected
+    // message against the persisted REST transcript before calling session.branch.
     await expect(branchCurrentSession!('a1')).resolves.toBe(true)
 
+    expect(getSessionMessages).toHaveBeenCalledWith('stored-parent', undefined)
     expect(branchParams).toEqual({ session_id: 'live-parent', up_to_row_id: 102 })
+  })
+
+  it('does not silently turn an unresolved specific fork into a full-history branch', async () => {
+    const requestGateway = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}) as never)
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 2 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ id: 101, role: 'user', content: 'question one' }],
+      session_id: 'stored-parent'
+    } as never)
+    setMessages([
+      { id: 'q1', role: 'user', parts: [{ type: 'text', text: 'question one' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'live only' }] }
+    ])
+
+    let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="live-parent"
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-parent"
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    await expect(branchCurrentSession!('a1')).resolves.toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('session.branch', expect.anything())
+  })
+
+  it('resolves a tile fork against the child transcript, not inherited parent row ids', async () => {
+    let branchParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.branch') {
+        branchParams = params
+
+        return {
+          session_id: 'grandchild-runtime',
+          stored_session_id: 'grandchild-stored',
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-child', message_count: 4 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        { id: 201, role: 'user', content: 'question one' },
+        { id: 202, role: 'assistant', content: 'answer one' },
+        { id: 203, role: 'user', content: 'question two' },
+        { id: 204, role: 'assistant', content: 'answer two' }
+      ],
+      session_id: 'stored-child'
+    } as never)
+
+    let branchSessionMessage: ((options: BranchSessionMessageOptions) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        onReady={() => undefined}
+        onTileReady={branch => (branchSessionMessage = branch)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(branchSessionMessage).not.toBeNull())
+
+    await expect(
+      branchSessionMessage!({
+        busy: false,
+        cwd: '/tmp/worktree',
+        messageId: 'a2',
+        messages: [
+          { id: 'q1', rowId: 101, role: 'user', parts: [{ type: 'text', text: 'question one' }] },
+          { id: 'a1', rowId: 102, role: 'assistant', parts: [{ type: 'text', text: 'answer one' }] },
+          { id: 'q2', rowId: 103, role: 'user', parts: [{ type: 'text', text: 'question two' }] },
+          { id: 'a2', rowId: 104, role: 'assistant', parts: [{ type: 'text', text: 'answer two' }] }
+        ],
+        parentStoredId: 'stored-child',
+        sourceSessionId: 'child-runtime'
+      })
+    ).resolves.toBe(true)
+
+    expect(branchParams).toEqual({ session_id: 'child-runtime', up_to_row_id: 204 })
   })
 
   // #67603: right-clicking a session outside the paginated sidebar window is a

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1175,13 +1175,18 @@ export function useSessionActions({
   // Shared fork: create a child session seeded with `branchMessages`, linked to
   // `parentStoredId` so it nests under its parent, then open it as its own tab
   // and switch to it — the parent chat stays put (mirrors openNewSessionTile).
+  // `upToRowId` (optional) is the durable DB row id of the message the branch
+  // was cut at. session.branch truncates the parent's raw history by row id —
+  // NOT by a merged-message count, which has no stable mapping onto the raw
+  // rows and silently dropped the conversation tail (branch context-loss bug).
   const forkBranch = useCallback(
     async (
       branchMessages: BranchMessage[],
       sourceSessionId: null | string,
       parentStoredId: null | string,
       cwd?: string,
-      profile?: null | string
+      profile?: null | string,
+      upToRowId?: number
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
@@ -1196,10 +1201,13 @@ export function useSessionActions({
         await ensureGatewayProfile(profile)
 
         // No title: the backend auto-names the branch from its parent's lineage.
+        // Full-history fork (no row id) omits any truncation; a specific-message
+        // fork names the durable row id so the backend cuts the RAW history at
+        // exactly that row (a merged-message count would land in the wrong place).
         const branched = sourceSessionId
           ? await requestGateway<SessionCreateResponse>('session.branch', {
               session_id: sourceSessionId,
-              count: branchMessages.length
+              ...(upToRowId ? { up_to_row_id: upToRowId } : {})
             })
           : await requestGateway<SessionCreateResponse>('session.create', {
               cols: 96,
@@ -1318,7 +1326,13 @@ export function useSessionActions({
         activeSessionIdRef.current,
         selectedStoredSessionIdRef.current,
         $currentCwd.get().trim(),
-        profile
+        profile,
+        // Forking from a specific message: name its durable DB row id so the
+        // backend truncates the RAW history at exactly that row. Without an id
+        // (branch the whole chat) no truncation is sent — a merged-message
+        // count has no stable mapping onto the backend's raw rows and used to
+        // silently drop the conversation tail (branch context-loss bug).
+        messageId && at >= 0 ? messages[at]?.rowId : undefined
       )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, selectedStoredSessionIdRef]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -3,7 +3,13 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
 import { revealTreePane } from '@/components/pane-shell/tree/store'
-import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
+import {
+  deleteSession,
+  getAllSessionMessages,
+  getLatestSessionMessages,
+  getSessionMessages,
+  setSessionArchived
+} from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
@@ -84,6 +90,7 @@ import {
   patchSessionWorkspace,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveDurableRowIdForMessage,
   resolveSessionProfile,
   resolveStoredSession,
   sessionMatchesStoredId,
@@ -114,6 +121,16 @@ interface SessionActionsOptions {
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
+}
+
+/** Inputs for branching from a message rendered inside a background/session tile. */
+export interface BranchSessionMessageOptions {
+  busy: boolean
+  cwd: string
+  messageId: string
+  messages: ChatMessage[]
+  parentStoredId: string
+  sourceSessionId: string
 }
 
 // Stored ids created in THIS renderer run. A brand-new session lives only in the
@@ -1219,6 +1236,17 @@ export function useSessionActions({
             })
 
         const routedSessionId = branched.stored_session_id ?? branched.session_id
+        // session.branch returns the copied transcript with the child's new
+        // durable row ids. Prefer it over the source ChatMessage objects,
+        // which still carry the parent's row ids in a freshly-created tile.
+        // session.create may not return a transcript, so retain the source
+        // projection as the fallback for that path.
+
+        const initialMessages =
+          sourceSessionId && branched.messages?.length
+            ? toChatMessages(branched.messages)
+            : branchMessages.map(({ source }) => source)
+
         const preview = branchMessages.map(({ content }) => content).find(Boolean) ?? null
         // Draft until submit: nest under the parent at the parent's recency so it
         // doesn't bubble to the top until a real message lands (backend persists
@@ -1244,7 +1272,7 @@ export function useSessionActions({
           branched.session_id,
           state => ({
             ...state,
-            messages: branchMessages.map(({ source }) => source),
+            messages: initialMessages,
             busy: false,
             awaitingResponse: false
           }),
@@ -1304,6 +1332,12 @@ export function useSessionActions({
         ? messages.findIndex(message => message.id === messageId)
         : messages.findLastIndex(message => message.role === 'assistant' || message.role === 'user')
 
+      if (messageId && at < 0) {
+        notifyError(new Error('The selected message is no longer available in this session.'), copy.branchFailed)
+
+        return false
+      }
+
       const start = 0
       const end = at >= 0 ? at + 1 : messages.length
       const branchMessages = toBranchMessages(messages.slice(start, end))
@@ -1321,6 +1355,36 @@ export function useSessionActions({
       // must stay on that thread's backend (cache hit for an open session).
       const profile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
 
+      let upToRowId = messageId && at >= 0 ? messages[at]?.rowId : undefined
+
+      if (messageId && at >= 0 && upToRowId === undefined) {
+        const parentStoredId = selectedStoredSessionIdRef.current
+
+        if (!parentStoredId) {
+          notifyError(new Error('The selected message is not persisted yet.'), copy.branchFailed)
+
+          return false
+        }
+
+        try {
+          const persisted = await getSessionMessages(parentStoredId, profile)
+          upToRowId = resolveDurableRowIdForMessage(messages, at, persisted.messages)
+        } catch (error) {
+          notifyError(error, copy.branchFailed)
+
+          return false
+        }
+
+        if (upToRowId === undefined) {
+          notifyError(
+            new Error('The selected message is not available in the persisted transcript yet.'),
+            copy.branchFailed
+          )
+
+          return false
+        }
+      }
+
       return forkBranch(
         branchMessages,
         activeSessionIdRef.current,
@@ -1332,10 +1396,76 @@ export function useSessionActions({
         // (branch the whole chat) no truncation is sent — a merged-message
         // count has no stable mapping onto the backend's raw rows and used to
         // silently drop the conversation tail (branch context-loss bug).
-        messageId && at >= 0 ? messages[at]?.rowId : undefined
+        upToRowId
       )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, selectedStoredSessionIdRef]
+  )
+
+  // Branch a message rendered by a session tile. Tile transcripts are kept in
+  // the per-runtime cache rather than the primary $messages atom, so the
+  // primary-session callback above cannot be reused here. Always resolve the
+  // target against the tile's own persisted transcript: a freshly-created
+  // branch initially reuses the parent's ChatMessage objects, whose rowId
+  // belongs to the parent database and is therefore invalid in the child.
+  const branchSessionMessage = useCallback(
+    async ({
+      busy,
+      cwd,
+      messageId,
+      messages,
+      parentStoredId,
+      sourceSessionId
+    }: BranchSessionMessageOptions): Promise<boolean> => {
+      if (busy) {
+        notify({ kind: 'warning', title: copy.sessionBusy, message: copy.branchStopCurrent })
+
+        return false
+      }
+
+      const at = messages.findIndex(message => message.id === messageId)
+
+      if (at < 0) {
+        notifyError(new Error('The selected message is no longer available in this session.'), copy.branchFailed)
+
+        return false
+      }
+
+      const branchMessages = toBranchMessages(messages.slice(0, at + 1))
+
+      if (!branchMessages.length) {
+        notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNoText })
+
+        return false
+      }
+
+      clearNotifications()
+
+      let profile: string | undefined
+      let upToRowId: number | undefined
+
+      try {
+        profile = await resolveSessionProfile(parentStoredId)
+        const persisted = await getSessionMessages(parentStoredId, profile)
+        upToRowId = resolveDurableRowIdForMessage(messages, at, persisted.messages)
+      } catch (error) {
+        notifyError(error, copy.branchFailed)
+
+        return false
+      }
+
+      if (upToRowId === undefined) {
+        notifyError(
+          new Error('The selected message is not available in the persisted transcript yet.'),
+          copy.branchFailed
+        )
+
+        return false
+      }
+
+      return forkBranch(branchMessages, sourceSessionId, parentStoredId, cwd.trim(), profile, upToRowId)
+    },
+    [copy, forkBranch]
   )
 
   // Branch any listed session, not just the open one. Reads the target's stored
@@ -1529,6 +1659,7 @@ export function useSessionActions({
   return {
     archiveSession,
     branchCurrentSession,
+    branchSessionMessage,
     branchStoredSession,
     closeSettings,
     createBackendSessionForSend,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -25,6 +25,7 @@ import {
   isSessionGoneError,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveDurableRowIdForMessage,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
   toBranchMessages
@@ -243,6 +244,28 @@ describe('toBranchMessages', () => {
 
     expect(out.map(b => b.source.id)).toEqual(['u', 'a'])
     expect(out[0]).toMatchObject({ content: 'hi', role: 'user' })
+  })
+})
+
+describe('resolveDurableRowIdForMessage', () => {
+  it('resolves the matching occurrence when live messages have ephemeral ids', () => {
+    const liveMessages = [msg('u1', 'user', 'repeat'), msg('a1', 'assistant', 'first'), msg('u2', 'user', 'repeat')]
+
+    const persistedMessages = [
+      { id: 11, role: 'user' as const, content: 'repeat' },
+      { id: 12, role: 'assistant' as const, content: 'first' },
+      { id: 13, role: 'user' as const, content: 'repeat' }
+    ]
+
+    expect(resolveDurableRowIdForMessage(liveMessages, 2, persistedMessages)).toBe(13)
+  })
+
+  it('returns undefined when the selected message is not in the persisted transcript', () => {
+    expect(
+      resolveDurableRowIdForMessage([msg('a1', 'assistant', 'live only')], 0, [
+        { id: 11, role: 'user', content: 'older' }
+      ])
+    ).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,6 +1,6 @@
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { getSession } from '@/hermes'
-import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import { assistantTextPart, type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -30,7 +30,13 @@ import {
 // it from here; the canonical definition lives in @/store/session.
 export { sessionMatchesStoredId }
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
-import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
+import type {
+  SessionCreateResponse,
+  SessionInfo,
+  SessionMessage,
+  SessionResumeResponse,
+  SessionRuntimeInfo
+} from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -774,6 +780,46 @@ export const toBranchMessages = (messages: ChatMessage[]): BranchMessage[] =>
   messages
     .map(message => ({ content: chatMessageText(message), role: message.role, source: message }))
     .filter(({ content, role }) => content.trim() && (role === 'assistant' || role === 'user'))
+
+const normalizedForkMessageText = (message: ChatMessage): string => chatMessageText(message).replace(/\s+/g, ' ').trim()
+
+/**
+ * Resolve a live renderer message to the durable row represented by the
+ * authoritative REST transcript. Live bubbles use ephemeral ids and do not
+ * receive row ids until a resume round-trip, while the REST path exposes the
+ * SQLite id on every raw row. Match the same visible role/text occurrence so
+ * repeated messages do not resolve to the wrong row.
+ */
+export function resolveDurableRowIdForMessage(
+  messages: ChatMessage[],
+  targetIndex: number,
+  persistedMessages: SessionMessage[]
+): number | undefined {
+  const target = messages[targetIndex]
+
+  if (!target || target.hidden) {
+    return undefined
+  }
+
+  const targetText = normalizedForkMessageText(target)
+
+  if (!targetText) {
+    return undefined
+  }
+
+  const isSameVisibleMessage = (candidate: ChatMessage) =>
+    !candidate.hidden && candidate.role === target.role && normalizedForkMessageText(candidate) === targetText
+
+  const occurrence = messages.slice(0, targetIndex + 1).filter(isSameVisibleMessage).length
+
+  if (!occurrence) {
+    return undefined
+  }
+
+  const authoritative = toChatMessages(persistedMessages).filter(isSameVisibleMessage)
+
+  return authoritative[occurrence - 1]?.rowId
+}
 
 export function upsertOptimisticSession(
   created: SessionCreateResponse,

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -506,6 +506,8 @@ export function resetTileRuntimeBindings() {
 export interface SessionTileDelegate {
   /** Archive a stored session (the sidebar's archive, incl. tile cleanup). */
   archiveSession(storedSessionId: string): Promise<void>
+  /** Branch a specific message from a tile's own runtime transcript. */
+  branchMessage(runtimeId: string, storedSessionId: string, messageId: string): Promise<void>
   /** Branch a stored session into a new chat (the sidebar's branch). */
   branchSession(storedSessionId: string): Promise<void>
   /** Delete a stored session (the sidebar's delete, incl. tile cleanup). */

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -43,7 +43,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -7569,7 +7569,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
-    ) -> int:
+        return_row_ids: bool = False,
+    ) -> Union[int, List[int]]:
         """Append multiple messages atomically in ONE write transaction.
 
         ``messages`` is a list of dicts in the same shape
@@ -7588,6 +7589,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         as :meth:`append_message` run once for the batch — same session,
         same instant.
 
+        When ``return_row_ids`` is true, return the SQLite row IDs in insert
+        order instead of the inserted count. The live agent uses this to stamp
+        durable identity back onto its in-memory message dicts before a warm
+        session can be branched.
+
         ``chunk_rows`` bounds the transaction size for LARGE copies (branch
         seeds can be thousands of rows; measured: 10k rows ≈ 2.4s inside one
         BEGIN IMMEDIATE because the FTS triggers run per row, which would
@@ -7595,28 +7601,40 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the batch commits in chunks of at most that many rows — same
         recovery semantics as the old per-row loops (a mid-copy failure
         leaves a partial seed), just with bounded lock holds. A turn flush
-        never needs it. Returns the inserted row count.
+        never needs it. Returns the inserted row count unless
+        ``return_row_ids`` is true.
         """
         if not messages:
-            return 0
+            return [] if return_row_ids else 0
 
         if chunk_rows is not None and len(messages) > chunk_rows:
             inserted_total = 0
+            inserted_row_ids: List[int] = []
             for start in range(0, len(messages), chunk_rows):
-                inserted_total += self.append_messages_batch(
+                result = self.append_messages_batch(
                     session_id,
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
+                    return_row_ids=return_row_ids,
                 )
-            return inserted_total
+                if return_row_ids:
+                    inserted_row_ids.extend(result)  # type: ignore[arg-type]
+                else:
+                    inserted_total += result  # type: ignore[operator]
+            return inserted_row_ids if return_row_ids else inserted_total
 
         def _do(conn):
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
-            inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, messages
-            )
+            if return_row_ids:
+                inserted, tool_calls_total, row_ids = self._insert_message_rows(
+                    conn, session_id, messages, return_ids=True
+                )
+            else:
+                inserted, tool_calls_total = self._insert_message_rows(
+                    conn, session_id, messages
+                )
             # One aggregated counter update for the whole batch.
             if tool_calls_total > 0:
                 conn.execute(
@@ -7629,7 +7647,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
                     (inserted, session_id),
                 )
-            return inserted
+            return row_ids if return_row_ids else inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
         return self._execute_write(
@@ -7878,18 +7896,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return row[0] if row else None
 
-    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+    def _insert_message_rows(
+        self,
+        conn,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        return_ids: bool = False,
+    ) -> Union[Tuple[int, int], Tuple[int, int, List[int]]]:
         """Insert *messages* as fresh active rows for *session_id*.
 
         Shared by :meth:`replace_messages` (delete-then-insert) and
         :meth:`archive_and_compact` (soft-archive-then-insert). Runs inside the
         caller's write transaction (takes the live ``conn``). Returns
-        ``(inserted_count, tool_call_count)``. Does NOT touch sessions.* counters
-        — the caller owns that, since the two flows reconcile counts differently.
+        ``(inserted_count, tool_call_count)``. When ``return_ids`` is true, a
+        third item contains the inserted SQLite row IDs in order. Does NOT
+        touch sessions.* counters — the caller owns that, since the two flows
+        reconcile counts differently.
         """
         now_ts = time.time()
         inserted = 0
         tool_calls_total = 0
+        row_ids: List[int] = []
         for msg in messages:
             role = msg.get("role", "unknown")
             tool_calls = msg.get("tool_calls")
@@ -7931,7 +7958,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
-            conn.execute(
+            cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
@@ -7962,11 +7989,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ),
             )
             inserted += 1
+            if return_ids:
+                row_ids.append(int(cursor.lastrowid))
             if tool_calls is not None:
                 tool_calls_total += (
                     len(tool_calls) if isinstance(tool_calls, list) else 1
                 )
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
+        if return_ids:
+            return inserted, tool_calls_total, row_ids
         return inserted, tool_calls_total
 
     def replace_messages(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2282,15 +2282,24 @@ class AIAgent:
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
             if _batch_rows:
-                self._session_db.append_messages_batch(
+                row_ids = self._session_db.append_messages_batch(
                     session_id=self.session_id,
                     messages=_batch_rows,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
+                    return_row_ids=True,
                 )
-                for _written in _batch_msgs:
-                    _written[_DB_PERSISTED_MARKER] = True
+                if isinstance(row_ids, (list, tuple)) and len(row_ids) == len(_batch_msgs):
+                    for _written, row_id in zip(_batch_msgs, row_ids):
+                        _written["_row_id"] = row_id
+                        _written[_DB_PERSISTED_MARKER] = True
+                else:
+                    # Keep compatibility with lightweight SessionDB doubles
+                    # and alternate persistence adapters that only return the
+                    # historical inserted count.
+                    for _written in _batch_msgs:
+                        _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -113,6 +113,20 @@ class TestAppendMessagesBatch:
     def test_returns_inserted_count(self, db):
         assert db.append_messages_batch("sess-batch", _turn_messages()) == 4
 
+    def test_returns_row_ids_when_requested(self, db):
+        messages = _turn_messages()
+
+        row_ids = db.append_messages_batch("sess-batch", messages, return_row_ids=True)
+
+        assert row_ids == [
+            row[0]
+            for row in db._conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? ORDER BY id",
+                ("sess-batch",),
+            ).fetchall()
+        ]
+        assert len(row_ids) == len(messages)
+
     def test_empty_batch_is_noop(self, db):
         assert db.append_messages_batch("sess-batch", []) == 0
         row = db._conn.execute(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -117,6 +117,26 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
 
 
+def test_flush_stamps_durable_row_ids_on_live_messages(agent):
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent._session_db.append_messages_batch.return_value = [27481, 27482]
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+
+    messages = [
+        {"role": "user", "content": "1"},
+        {"role": "assistant", "content": "reply"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, [])
+
+    assert [message["_row_id"] for message in messages] == [27481, 27482]
+
+
 def test_direct_session_db_flushes_share_marker_claim(agent):
     """A direct flush cannot interleave its marker check with `_persist_session`."""
     class _BarrierDB:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11742,7 +11742,8 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
 
         def append_messages_batch(self, session_id, messages, **kwargs):
             captured["msgs"] = [dict(m, session_id=session_id) for m in messages]
-            return list(range(1, len(messages) + 1))
+            captured["return_row_ids"] = kwargs.get("return_row_ids")
+            return list(range(101, 101 + len(messages)))
 
         def set_session_title(self, key, title):
             return True
@@ -11787,9 +11788,12 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
         monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
         req = {"id": "1", "method": "session.branch", "params": {"session_id": "parent", "name": "forked"}}
         req["params"].update(params or {})
-        resp = server.handle_request(req)
-        assert "result" in resp, resp
-        return captured["msgs"]
+        captured.pop("msgs", None)
+        response = server.handle_request(req)
+        if "result" in response:
+            child_sid = response["result"]["session_id"]
+            captured["live_history"] = server._sessions[child_sid]["history"]
+        return response
 
     try:
         history = [
@@ -11803,18 +11807,28 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
         # No truncation params → the whole raw history is copied, tool rows
         # included. (The desktop used to send a merged-message count here,
         # which sliced history[:4] and lost a2 + t2 — the branch bug.)
-        msgs = _run_branch(history, {"count": 4})
+        resp = _run_branch(history, {"count": 4})
+        assert "result" in resp, resp
+        msgs = captured["msgs"]
         assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result", "q2", "a2", "t2-result"]
+        assert captured["return_row_ids"] is True
+        assert [m["_row_id"] for m in captured["live_history"]] == [101, 102, 103, 104, 105, 106]
 
         # Branch from the first assistant reply: up_to_row_id=2 keeps exactly
         # the rows up to and including that durable row.
-        msgs = _run_branch(history, {"up_to_row_id": 2})
+        resp = _run_branch(history, {"up_to_row_id": 2})
+        assert "result" in resp, resp
+        msgs = captured["msgs"]
         assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result"]
+        assert [m["_row_id"] for m in captured["live_history"]] == [101, 102, 103]
 
-        # A row id that is not in the live history (unflushed turn) falls back
-        # to the full history instead of mis-slicing.
-        msgs = _run_branch(history, {"up_to_row_id": 999})
-        assert len(msgs) == 6
+        # A row id that is not in the live history must fail instead of silently
+        # becoming a full-history branch. The desktop resolves the id from the
+        # authoritative transcript before calling session.branch, but this is
+        # still a critical backend guard for stale or display-only ids.
+        resp = _run_branch(history, {"up_to_row_id": 999})
+        assert resp["error"]["code"] == 4009
+        assert "branch target row not found" in resp["error"]["message"]
     finally:
         for k in list(server._sessions):
             server._sessions.pop(k, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11720,6 +11720,106 @@ def test_teardown_ends_session_in_profile_db(monkeypatch, tmp_path):
     assert str(seen.get("db_path")).endswith("state.db")
 
 
+def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch, tmp_path):
+    """session.branch copies the WHOLE raw history by default; a legacy
+    merged-message ``count`` is ignored (it has no mapping onto raw rows and
+    used to silently drop the conversation tail); ``up_to_row_id`` truncates
+    at exactly that durable DB row."""
+    captured = {}
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            pass
+
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, new_key, **kwargs):
+            captured["created"] = new_key
+
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            captured["msgs"] = [dict(m, session_id=session_id) for m in messages]
+            return list(range(1, len(messages) + 1))
+
+        def set_session_title(self, key, title):
+            return True
+
+        def get_session(self, key):
+            return {"id": key, "cwd": str(tmp_path)}
+
+        def update_session_cwd(self, *a, **k):
+            return None
+
+        def close(self):
+            pass
+
+    class FakeAgent:
+        def __init__(self):
+            self.model = "test-model"
+            self.session_id = None
+
+    def _run_branch(history, params=None):
+        parent = {
+            "session_key": "parent-key",
+            "history": history,
+            "history_lock": __import__("threading").Lock(),
+            "running": False,
+            "cols": 80,
+            "profile_home": None,
+            "source": "tui",
+            "agent": FakeAgent(),
+            "created_at": 1.0,
+            "last_active": 1.0,
+            "cwd": str(tmp_path),
+        }
+        server._sessions["parent"] = parent
+        monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+        monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+        monkeypatch.setattr(server, "_make_agent", lambda *a, **k: FakeAgent())
+        monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+        monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+        monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+        req = {"id": "1", "method": "session.branch", "params": {"session_id": "parent", "name": "forked"}}
+        req["params"].update(params or {})
+        resp = server.handle_request(req)
+        assert "result" in resp, resp
+        return captured["msgs"]
+
+    try:
+        history = [
+            {"role": "user", "content": "q1", "_row_id": 1},
+            {"role": "assistant", "content": "a1", "_row_id": 2},
+            {"role": "tool", "content": "t1-result", "_row_id": 3},
+            {"role": "user", "content": "q2", "_row_id": 4},
+            {"role": "assistant", "content": "a2", "_row_id": 5},
+            {"role": "tool", "content": "t2-result", "_row_id": 6},
+        ]
+        # No truncation params → the whole raw history is copied, tool rows
+        # included. (The desktop used to send a merged-message count here,
+        # which sliced history[:4] and lost a2 + t2 — the branch bug.)
+        msgs = _run_branch(history, {"count": 4})
+        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result", "q2", "a2", "t2-result"]
+
+        # Branch from the first assistant reply: up_to_row_id=2 keeps exactly
+        # the rows up to and including that durable row.
+        msgs = _run_branch(history, {"up_to_row_id": 2})
+        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result"]
+
+        # A row id that is not in the live history (unflushed turn) falls back
+        # to the full history instead of mis-slicing.
+        msgs = _run_branch(history, {"up_to_row_id": 999})
+        assert len(msgs) == 6
+    finally:
+        for k in list(server._sessions):
+            server._sessions.pop(k, None)
+
+
 def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -456,7 +456,11 @@ def _(rid, params: dict) -> dict:
                 # history becomes the resumed session record's working conversation),
                 # so heal a durable ``user;user`` violation once here instead of
                 # re-firing the pre-request repair on every subsequent turn.
-                history = db.get_messages_as_conversation(target, repair_alternation=True)
+                # include_row_ids: session.branch truncates by durable row id
+                # (up_to_row_id) when the desktop branches from a specific message.
+                history = db.get_messages_as_conversation(
+                    target, repair_alternation=True, include_row_ids=True
+                )
             except Exception as e:
                 if lease is not None:
                     lease.release()
@@ -538,7 +542,12 @@ def _(rid, params: dict) -> dict:
                 # inspection/export must show what is actually stored.
                 if omit_messages:
                     raw_history = db.get_messages_as_conversation(
-                        target, repair_alternation=True
+                        target,
+                        repair_alternation=True,
+                        # session.branch truncates by durable row id
+                        # (up_to_row_id) when the desktop branches from a
+                        # specific message.
+                        include_row_ids=True,
                     )
                     display_history = []
                 else:
@@ -2772,9 +2781,26 @@ def _(rid, params: dict) -> dict:
             history = [dict(msg) for msg in session.get("history", [])]
         if not history:
             return _err(rid, 4008, "nothing to branch — send a message first")
-        count = params.get("count")
-        if isinstance(count, int) and count > 0:
-            history = history[:count]
+        # Truncate to a specific message ONLY when the client names it by its
+        # durable row id. The desktop's transcript is the toChatMessages MERGED
+        # projection (tool rows folded into assistant bubbles), so a "count" of
+        # merged messages has no stable mapping onto this raw row history — the
+        # desktop's count-based slice silently dropped the conversation tail
+        # (branch context-loss bug). Default (no up_to_row_id) = copy the whole
+        # history; a legacy ``count`` param is ignored for the same reason.
+        up_to_row_id = params.get("up_to_row_id")
+        if isinstance(up_to_row_id, int) and up_to_row_id > 0:
+            for _idx, msg in enumerate(history):
+                if msg.get("_row_id") == up_to_row_id:
+                    # Include the target row plus any tool rows that follow it:
+                    # the desktop's merged bubbles can carry a tool result
+                    # paired to the target's tool_calls, and an orphaned
+                    # tool_calls tail breaks replay.
+                    _end = _idx + 1
+                    while _end < len(history) and history[_end].get("role") == "tool":
+                        _end += 1
+                    history = history[:_end]
+                    break
         new_key = _new_session_key()
         new_sid = uuid.uuid4().hex[:8]
         source = _session_source(session)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2790,8 +2790,10 @@ def _(rid, params: dict) -> dict:
         # history; a legacy ``count`` param is ignored for the same reason.
         up_to_row_id = params.get("up_to_row_id")
         if isinstance(up_to_row_id, int) and up_to_row_id > 0:
+            matched_row_id = False
             for _idx, msg in enumerate(history):
                 if msg.get("_row_id") == up_to_row_id:
+                    matched_row_id = True
                     # Include the target row plus any tool rows that follow it:
                     # the desktop's merged bubbles can carry a tool result
                     # paired to the target's tool_calls, and an orphaned
@@ -2801,6 +2803,8 @@ def _(rid, params: dict) -> dict:
                         _end += 1
                     history = history[:_end]
                     break
+            if not matched_row_id:
+                return _err(rid, 4009, f"branch target row not found: {up_to_row_id}")
         new_key = _new_session_key()
         new_sid = uuid.uuid4().hex[:8]
         source = _session_source(session)
@@ -2840,7 +2844,7 @@ def _(rid, params: dict) -> dict:
             # Copy the whole parent history in bounded-chunk transactions —
             # a branch seed can be hundreds of rows, and per-row transactions
             # were the write-amplification pattern removed in #23254.
-            db.append_messages_batch(
+            copied_row_ids = db.append_messages_batch(
                 new_key,
                 [
                     {
@@ -2858,7 +2862,17 @@ def _(rid, params: dict) -> dict:
                     for msg in history
                 ],
                 chunk_rows=500,
+                return_row_ids=True,
             )
+            # The copied rows get NEW SQLite ids. The in-memory history must
+            # use those child ids as well: retaining the parent's _row_id makes
+            # a second-generation branch send a row id that exists in the
+            # child's REST transcript but not in its live history, so the
+            # backend rejects it as "branch target row not found".
+            if not isinstance(copied_row_ids, (list, tuple)) or len(copied_row_ids) != len(history):
+                raise RuntimeError("branch seed did not return durable row ids")
+            for message, row_id in zip(history, copied_row_ids):
+                message["_row_id"] = int(row_id)
             db.set_session_title(new_key, title)
         except Exception as e:
             if lease is not None:


### PR DESCRIPTION
## Summary

- Preserve the original branch fix: whole-chat branches copy the complete raw history, while message forks truncate at a durable row id.
- Resolve a live message's durable row id from the authoritative transcript when it has not completed a resume round-trip.
- Stamp inserted row ids onto live messages, remap copied rows to the child session's new ids, and seed the child UI from the branch response so nested branches remain valid.
- Keep specific-message branching available from background/session tiles.
- Add a packaged Electron entry bridge so the desktop starts correctly when `dist/` is unpacked from `app.asar`.

## Validation

- `npm run test:ui`: 400 files / 3,548 tests passed.
- Targeted branch/session tests after the final changes: 122 passed.
- `npm run typecheck` passed.
- Session-branch backend tests: 3 passed; durable-row-id tests: 2 passed.
- `npm run pack` completed successfully.
