### PR TITLE
refactor(security): upgrade sherlock skill to v2.0.0

### DIFF
--- a/optional-skills/security/sherlock/SKILL.md
+++ b/optional-skills/security/sherlock/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sherlock
 description: Find accounts for a username across 400+ platforms.
-version: 1.0.0
+version: 2.0.0
 author: unmodeled-tyler
 license: MIT
 platforms: [linux, macos, windows]
@@ -24,90 +24,80 @@ Hunt down social media accounts by username across 400+ social networks using th
 - User is conducting OSINT or reconnaissance research
 - User asks "where is this username registered?" or similar
 
+## When NOT to Use
+
+- User wants to search by email, phone number, or real name (Sherlock only works with usernames)
+- User needs deep profile data scraping (Sherlock only returns URLs)
+- User wants to search private/internal platforms not in Sherlock's data source
+
 ## Requirements
 
-- Sherlock CLI installed: `pipx install sherlock-project` or `pip install sherlock-project`
-- Alternatively: Docker available (`docker run -it --rm sherlock/sherlock`)
+- Sherlock CLI installed: `pipx install sherlock-project`
 - Network access to query social platforms
 
 ## Procedure
 
-### 1. Check if Sherlock is Installed
+### 1. Verify Installation
 
-**Before doing anything else**, verify sherlock is available:
+Check sherlock is available before proceeding:
 
 ```bash
 sherlock --version
 ```
 
 If the command fails:
-- Offer to install: `pipx install sherlock-project` (recommended) or `pip install sherlock-project`
-- **Do NOT** try multiple installation methods — pick one and proceed
-- If installation fails, inform the user and stop
+- Install with `pipx install sherlock-project`
+- If installation fails, inform the user and stop — do not try multiple installation methods
 
 ### 2. Extract Username
 
-**Extract the username directly from the user's message if clearly stated.**
+Extract the username directly from the user's message if clearly stated.
 
-Examples where you should **NOT** use clarify:
+**Do NOT use clarify when:**
 - "Find accounts for nasa" → username is `nasa`
 - "Search for johndoe123" → username is `johndoe123`
 - "Check if alice exists on social media" → username is `alice`
-- "Look up user bob on social networks" → username is `bob`
 
-**Only use clarify if:**
+**Only use clarify when:**
 - Multiple potential usernames mentioned ("search for alice or bob")
 - Ambiguous phrasing ("search for my username" without specifying)
 - No username mentioned at all ("do an OSINT search")
 
-When extracting, take the **exact** username as stated — preserve case, numbers, underscores, etc.
+Preserve the exact username as stated — case, numbers, underscores, etc.
 
-### 3. Build Command
+### 3. Build and Execute Command
 
-**Default command** (use this unless user specifically requests otherwise):
+**Default command:**
 ```bash
 sherlock --print-found --no-color "<username>" --timeout 90
 ```
 
 **Optional flags** (only add if user explicitly requests):
-- `--nsfw` — Include NSFW sites (only if user asks)
-- `--tor` — Route through Tor (only if user asks for anonymity)
+- `--nsfw` — Include NSFW sites
+- `--tor` — Route through Tor (requires Tor daemon running)
 
-**Do NOT ask about options via clarify** — just run the default search. Users can request specific options if needed.
+Do NOT ask about options via clarify — run the default search. Users can request specific options if needed.
 
-### 4. Execute Search
+Run via the `terminal` tool with a 180-second timeout. The command typically takes 30-120 seconds.
 
-Run via the `terminal` tool. The command typically takes 30-120 seconds depending on network conditions and site count.
+### 4. Parse and Present Results
 
-**Example terminal call:**
-```json
-{
-  "command": "sherlock --print-found --no-color \"target_username\"",
-  "timeout": 180
-}
-```
-
-### 5. Parse and Present Results
-
-Sherlock outputs found accounts in a simple format. Parse the output and present:
-
-1. **Summary line:** "Found X accounts for username 'Y'"
-2. **Categorized links:** Group by platform type if helpful (social, professional, forums, etc.)
-3. **Output file location:** Sherlock saves results to `<username>.txt` by default
-
-**Example output parsing:**
+Sherlock outputs found accounts in this format:
 ```
 [+] Instagram: https://instagram.com/username
 [+] Twitter: https://twitter.com/username
 [+] GitHub: https://github.com/username
 ```
 
-Present findings as clickable links when possible.
+Present findings as:
+1. **Summary line:** "Found X accounts for username 'Y'"
+2. **Categorized links:** Group by platform type if helpful (social, professional, forums, etc.)
+3. **Output file location:** Sherlock saves results to `<username>.txt` by default
 
 ## Pitfalls
 
 ### No Results Found
-If Sherlock finds no accounts, this is often correct — the username may not be registered on checked platforms. Suggest:
+This is often correct — the username may not be registered on checked platforms. Suggest:
 - Checking spelling/variation
 - Trying similar usernames with `?` wildcard: `sherlock "user?name"`
 - The user may have privacy settings or deleted accounts
@@ -116,9 +106,7 @@ If Sherlock finds no accounts, this is often correct — the username may not be
 Some sites are slow or block automated requests. Use `--timeout 120` to increase wait time, or `--site` to limit scope.
 
 ### Tor Configuration
-`--tor` requires Tor daemon running. If user wants anonymity but Tor isn't available, suggest:
-- Installing Tor service
-- Using `--proxy` with an alternative proxy
+`--tor` requires Tor daemon running. If user wants anonymity but Tor isn't available, suggest installing Tor service or using `--proxy` with an alternative proxy.
 
 ### False Positives
 Some sites always return "found" due to their response structure. Cross-reference unexpected results with manual checks.
@@ -133,19 +121,20 @@ Aggressive searches may trigger rate limits. For bulk username searches, add del
 pipx install sherlock-project
 ```
 
-### pip
+### Alternative Methods
+
+**pip:**
 ```bash
 pip install sherlock-project
 ```
 
-### Docker
+**Docker:**
 ```bash
 docker pull sherlock/sherlock
 docker run -it --rm sherlock/sherlock <username>
 ```
 
-### Linux packages
-Available on Debian 13+, Ubuntu 22.10+, Homebrew, Kali, BlackArch.
+**Linux packages:** Available on Debian 13+, Ubuntu 22.10+, Homebrew, Kali, BlackArch.
 
 ## Ethical Use
 
@@ -161,33 +150,3 @@ After running sherlock, verify:
 1. Output lists found sites with URLs
 2. `<username>.txt` file created (default output) if using file output
 3. If `--print-found` used, output should only contain `[+]` lines for matches
-
-## Example Interaction
-
-**User:** "Can you check if the username 'johndoe123' exists on social media?"
-
-**Agent procedure:**
-1. Check `sherlock --version` (verify installed)
-2. Username provided — proceed directly
-3. Run: `sherlock --print-found --no-color "johndoe123" --timeout 90`
-4. Parse output and present links
-
-**Response format:**
-> Found 12 accounts for username 'johndoe123':
->
-> • https://twitter.com/johndoe123
-> • https://github.com/johndoe123
-> • https://instagram.com/johndoe123
-> • [... additional links]
->
-> Results saved to: johndoe123.txt
-
----
-
-**User:** "Search for username 'alice' including NSFW sites"
-
-**Agent procedure:**
-1. Check sherlock installed
-2. Username + NSFW flag both provided
-3. Run: `sherlock --print-found --no-color --nsfw "alice" --timeout 90`
-4. Present results


### PR DESCRIPTION
CC: @ani6439walc

## 摘要

重構 sherlock OSINT 技能，從 v1.0.0 升級至 v2.0.0。

## 變更內容

- 版本升級至 2.0.0
- 新增「When NOT to Use」區段，明確界定適用範圍（email/電話/真實姓名搜尋不適用）
- 精簡程序說明，移除冗餘描述與重複的安裝選項
- 統一 clarify 工具的使用時機，避免不必要的用戶互動
- 簡化安裝指引，僅保留推薦的 pipx 方式，其他方法移至替代區段
- 減少 41 行冗餘內容，結構更清晰

## 測試

- [x] 文件格式正確
- [x] YAML front matter 語法正確
- [x] 程序步驟邏輯連貫

請協助審查，謝謝！