### PR TITLE
test(api_server): add regression test for HERMES_SESSION_ID in /v1/runs

### DIFF
--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -190,6 +190,54 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @pytest.mark.asyncio
+    async def test_start_binds_session_id_for_subprocess_env(self, adapter):
+        """/v1/runs must bind HERMES_SESSION_ID so a tool subprocess spawned
+        during the run sees the run's session id, not an empty or foreign value.
+
+        Without passing ``session_id`` to ``_bind_api_server_session``,
+        ``set_session_vars`` leaves ``_SESSION_ID`` unset (later cleared to ``""``)
+        and ``tools.environments.local.build_subprocess_env`` produces an empty
+        ``HERMES_SESSION_ID`` for every command the run executes."""
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    from tools.environments.local import build_subprocess_env
+
+                    env = build_subprocess_env()
+                    captured["hermes_session_id"] = env.get("HERMES_SESSION_ID")
+                    captured["task_id"] = task_id
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "runs-raw-sid"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("hermes_session_id") == "runs-raw-sid", (
+            "runs route must bind session_id so tool subprocesses see HERMES_SESSION_ID"
+        )
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -302,6 +302,54 @@ class TestStartRun:
         mock_create.assert_not_called()
         assert adapter._run_statuses == {}
 
+    @pytest.mark.asyncio
+    async def test_start_binds_session_id_for_subprocess_env(self, adapter):
+        """/v1/runs must bind HERMES_SESSION_ID so a tool subprocess spawned
+        during the run sees the run's session id, not an empty or foreign value.
+
+        Without passing ``session_id`` to ``_bind_api_server_session``,
+        ``set_session_vars`` leaves ``_SESSION_ID`` unset (later cleared to ``""``)
+        and ``tools.environments.local.build_subprocess_env`` produces an empty
+        ``HERMES_SESSION_ID`` for every command the run executes."""
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    from tools.environments.local import build_subprocess_env
+
+                    env = build_subprocess_env()
+                    captured["hermes_session_id"] = env.get("HERMES_SESSION_ID")
+                    captured["task_id"] = task_id
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "runs-raw-sid"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("hermes_session_id") == "runs-raw-sid", (
+            "runs route must bind session_id so tool subprocesses see HERMES_SESSION_ID"
+        )
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):


### PR DESCRIPTION
## What does this PR do?

Adds a regression test that proves `/v1/runs` binds the run's `session_id` to the request-scoped session context so that any tool subprocess spawned during the run receives the correct `HERMES_SESSION_ID` value. Without passing `session_id` to `_bind_api_server_session`, `set_session_vars` leaves `_SESSION_ID` unset (later cleared to `""`), and `tools.environments.local.build_subprocess_env` produces an empty `HERMES_SESSION_ID` for every command the run executes.

The test was verified to fail when the `session_id` argument is omitted from the `_bind_api_server_session` call and to pass when it is present.

## Related Issue

Fixes #79461

## Type of Change

<!-- Check the one that applies. -->

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/gateway/test_api_server_runs.py`: add `test_start_binds_session_id_for_subprocess_env`
  - Sends `POST /v1/runs` with `session_id: "runs-raw-sid"`
  - Inside the mocked `run_conversation`, calls `build_subprocess_env()` and asserts `HERMES_SESSION_ID` equals the run's session id

## How to Test

1. Run the new test directly:
   ```bash
   scripts/run_tests.sh tests/gateway/test_api_server_runs.py -k test_start_binds_session_id
   ```
2. Run the full `/v1/runs` test file:
   ```bash
   scripts/run_tests.sh tests/gateway/test_api_server_runs.py
   ```
3. Run the local audit gate:
   ```bash
   scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/79461
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A