### PR TITLE
fix(gateway): skip session-expiry finalize for running turns; fix(state): keep rewind counts accurate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11966,6 +11966,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for key, entry in list(self.session_store._entries.items()):
                     if entry.expiry_finalized:
                         continue
+                    if self._is_session_running(key):
+                        # Don't finalize a session whose agent turn is running.
+                        continue
                     if not await self.async_session_store._is_session_expired(entry):
                         continue
                     _expired_entries.append((key, entry))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7908,6 +7908,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return False
         return False
 
+    def _refresh_session_message_counts(self, conn, session_id: str) -> None:
+        """Recompute message_count / tool_call_count from the active rows."""
+        msg_count = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+            (session_id,),
+        ).fetchone()[0]
+        tool_count = conn.execute(
+            "SELECT COALESCE(SUM(CASE WHEN tool_calls IS NULL THEN 0 "
+            "WHEN json_valid(tool_calls) AND json_type(tool_calls) = 'array' "
+            "THEN json_array_length(tool_calls) ELSE 1 END), 0) "
+            "FROM messages WHERE session_id = ? AND active = 1",
+            (session_id,),
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+            (msg_count, tool_count, session_id),
+        )
+
     # =========================================================================
     # Rewind (soft-delete) — see /rewind slash command + issue #21910
     # =========================================================================
@@ -7981,6 +7999,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "WHERE id = ?",
                 (session_id,),
             )
+            self._refresh_session_message_counts(conn, session_id)
             return ids
 
         rewound = self._execute_write(_do)
@@ -8019,6 +8038,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"UPDATE messages SET active = 1 WHERE id IN ({placeholders})",
                     ids,
                 )
+            self._refresh_session_message_counts(conn, session_id)
             return len(ids)
 
         return self._execute_write(_do)

--- a/tests/gateway/test_expiry_watcher_skips_running.py
+++ b/tests/gateway/test_expiry_watcher_skips_running.py
@@ -1,0 +1,108 @@
+"""Session-expiry watcher must skip sessions whose agent turn is still running."""
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionEntry
+from gateway.session_state import SessionState
+
+
+def _make_runner(session_key: str, session_id: str):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._clear_conversation_scope = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+    return runner, entry
+
+
+async def _run_once(runner, interval=1):
+    """Drive the watcher through one pass, then stop."""
+    _orig = asyncio.sleep
+    calls = {"n": 0}
+
+    async def _fast_sleep(_):
+        calls["n"] += 1
+        if calls["n"] > 1:  # initial startup + one tail sleep => one pass done
+            runner._running = False
+        await _orig(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval)
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_expiry_watcher_skips_running_session(mock_invoke_hook):
+    """A session whose agent turn is running is not finalized by expiry."""
+    key = "agent:main:telegram:dm:42"
+    runner, _ = _make_runner(key, "sess-running")
+    runner._sessions = {key: SessionState()}
+    runner._sessions[key].turn.agent = MagicMock()  # turn is mid-flight
+
+    await _run_once(runner)
+
+    assert mock_invoke_hook.call_args_list == [], (
+        "running session must not be finalized on_session_finalize"
+    )
+    runner._evict_cached_agent.assert_not_called()
+    runner._cleanup_agent_resources.assert_not_called()
+    runner._clear_conversation_scope.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_expiry_watcher_still_finalizes_idle_session(mock_invoke_hook):
+    """A truly idle session must still be finalized (guard is not a blanket)."""
+    key = "agent:main:telegram:dm:43"
+    runner, _ = _make_runner(key, "sess-idle")
+    runner._sessions = {}  # no running turn
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    await _run_once(runner)
+
+    finalize = [
+        c for c in mock_invoke_hook.call_args_list
+        if c.args and c.args[0] == "on_session_finalize"
+    ]
+    assert any(c[1].get("session_id") == "sess-idle" for c in finalize), (
+        "idle session should still be finalized by expiry"
+    )


### PR DESCRIPTION
## Issues
- Session-starting watcher resetting a session while its turn was still running, tearing down the in-flight turn.
- `rewind_to_message` / `restore_rewound` only flipped message `active` flags and never recomputed `message_count` / `tool_call_count`, leaving them stale after `/undo`.

## Fixes
- Skip finalizing a session whose turn is running (`if self._is_session_running(key): continue`).
- Recompute `message_count` / `tool_call_count` from the active rows in both rewind/restore write transactions.

## Validation
New regression test covers both sides (running session skipped, idle session still finalized); rewind counters verified end-to-end. 12 gateway + 195 hermes_state tests pass.