### PR TITLE
fix(providers): don't disable deepseek thinking on opencode-go when reasoning_effort=none

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -104,20 +104,21 @@ class OpenCodeGoProfile(ProviderProfile):
         if not _is_deepseek_thinking_model(model):
             return extra_body, top_level
 
-        enabled = True
-        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
-            enabled = False
-
-        if not enabled:
-            extra_body["thinking"] = {"type": "disabled"}
+        # DeepSeek thinking models on OpenCode Go: when reasoning is disabled
+        # or unset, leave the server default (thinking on) alone instead of
+        # sending thinking={"type": "disabled"}. With thinking disabled,
+        # DeepSeek skips reasoning_content and writes its planning drafts
+        # directly into content, leaking them into the visible reply.
+        if not isinstance(reasoning_config, dict):
+            return extra_body, top_level
+        if reasoning_config.get("enabled") is False:
             return extra_body, top_level
 
-        if isinstance(reasoning_config, dict):
-            effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max", "ultra"}:
-                top_level["reasoning_effort"] = "max"
-            elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if effort in {"xhigh", "max", "ultra"}:
+            top_level["reasoning_effort"] = "max"
+        elif effort in {"low", "medium", "high"}:
+            top_level["reasoning_effort"] = effort
 
         # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
         # only send extra_body["thinking"] when no reasoning_effort is set.

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -90,6 +90,33 @@ class TestOpenCodeGoDeepSeekThinking:
             assert extra_body == {}
             assert top_level == {"reasoning_effort": "max"}
 
+    def test_disabled_does_not_disable_thinking(self, opencode_go_profile):
+        # reasoning_effort: none must not map to thinking={"type": "disabled"}:
+        # with thinking off, DeepSeek skips reasoning_content and writes its
+        # planning drafts into content, leaking them into the visible reply.
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_no_config_preserves_server_default(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_high_effort_emits_reasoning_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
 
 class TestOpenCodeGoGLM52Reasoning:
     """GLM-5.2 uses its native high/max reasoning_effort knob on OpenCode Go."""


### PR DESCRIPTION
## Summary

`reasoning_effort: none` on the `opencode-go` provider with `deepseek-v4-flash` disabled DeepSeek thinking, causing the model to write its internal planning drafts (`card run.`, `card：<plan>`) directly into `content` instead of `reasoning_content` — leaking scratch notes into the user-visible reply (515 leaks in 2 days in the reporter's session).

## Root Cause

`OpenCodeGoProfile.build_api_kwargs_extras` (plugins/model-providers/opencode-zen/__init__.py) mapped `reasoning_config={"enabled": False}` (the result of `resolve_reasoning_config("none")`) to:

```python
extra_body["thinking"] = {"type": "disabled"}
```

Per the DeepSeek thinking-mode docs, `effort: none` disables thinking entirely. With thinking disabled, DeepSeek emits no `reasoning_content` and writes its planning notes straight into `content`, so they appear in the visible reply.

## Change

In the DeepSeek branch of `OpenCodeGoProfile.build_api_kwargs_extras`, return early — leaving the server default (thinking ON, reasoning goes to `reasoning_content`) — whenever `reasoning_config` is not a dict or `enabled` is `False`. This mirrors the existing GLM-5.2 branch behavior in the same function. The visible reply never contains planning drafts; the positive path (`enabled: True` with an effort) is unchanged (`top_level["reasoning_effort"]` is still emitted).

Files changed:
- `plugins/model-providers/opencode-zen/__init__.py`
- `tests/plugins/model_providers/test_opencode_go_profile.py` (3 new DeepSeek cases: disabled config sends nothing, unset config sends nothing, high effort still maps to `reasoning_effort: high`)

Note (not changed, out of scope): the legacy openai-compatible path in `agent/transports/chat_completions.py` (~line 549) still replaces `{"enabled": False}` with `extra_body["reasoning"] = {"enabled": True, "effort": "medium"}` — the opposite behavior, and `medium` is not a valid DeepSeek effort. Worth a follow-up.

## Verification

- `pytest tests/plugins/model_providers/test_opencode_go_profile.py -q` → **23 passed** (incl. 3 new DeepSeek regression cases)
- `pytest tests/providers/test_provider_profiles.py -q` → **16 passed**
- Total: **39 passed**, 0 failures

## Closes

Closes #80833
