### PR TITLE
fix(state): bind record_gateway_session_peer's ancestor walk to the queried parent

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3905,6 +3905,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             target_clause = "WHERE id = ?"
             query_params = []
             if include_compression_ancestors:
+                # Marker-PRESENCE (IS NULL) misclassifies a real continuation
+                # as a delegate/branch child: compression continuations
+                # inherit the rotated agent's model_config verbatim
+                # (publish_compression_child callers pass
+                # agent._session_init_model_config), so a delegate subagent's
+                # continuation carries _delegate_from=<the delegate's own
+                # parent> — a marker that exists but does NOT point at the
+                # parent being walked here. Same bug class fixed in
+                # find_live_compression_child / reopen_orphaned_compression_session
+                # (see _NON_CONTINUATION_CHILD_FILTER_SQL) but this recursive
+                # walk evaluates a different "parent" at every step, so the
+                # exclusion is bound to the correlated parent.id column
+                # rather than a single top-level bound parameter.
                 lineage_cte = """
                     WITH RECURSIVE compression_lineage(id) AS (
                         SELECT ?
@@ -3914,14 +3927,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         JOIN sessions child ON child.id = lineage.id
                         JOIN sessions parent ON parent.id = child.parent_session_id
                         WHERE parent.end_reason = 'compression'
-                          AND json_extract(
+                          AND COALESCE(json_extract(
                               COALESCE(child.model_config, '{}'),
                               '$._branched_from'
-                          ) IS NULL
-                          AND json_extract(
+                          ), '') != parent.id
+                          AND COALESCE(json_extract(
                               COALESCE(child.model_config, '{}'),
                               '$._delegate_from'
-                          ) IS NULL
+                          ), '') != parent.id
                           AND COALESCE(child.source, '') != 'tool'
                     )
                 """
@@ -7035,9 +7048,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
                       AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
+                    """
+                    + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="child.")
+                    + f"""
                     ORDER BY
                       CASE
                         WHEN child.end_reason = 'compression' THEN 0
@@ -7049,7 +7062,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       child.id DESC
                     LIMIT 1
                     """,
-                    (current,),
+                    (current, current, current),
                 )
                 row = cursor.fetchone()
             if row is None:
@@ -8634,11 +8647,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     child_row = self._conn.execute(
                         "SELECT id FROM sessions "
                         "WHERE parent_session_id = ? "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND COALESCE(source, '') != 'tool' "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
-                        (current,),
+                        + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="")
+                        + "ORDER BY started_at DESC, id DESC LIMIT 1",
+                        (current, current, current),
                     ).fetchone()
                 except Exception:
                     return session_id

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -136,6 +136,67 @@ def test_find_live_child_returns_continuation_with_foreign_markers(
     assert child["id"] == "inherited-continuation"
 
 
+def test_record_gateway_session_peer_walks_multi_hop_compression_lineage(
+    db: SessionDB,
+) -> None:
+    """Control case: a plain (no foreign markers) two-hop compression chain
+    must have the routing peer propagated to every ancestor."""
+    _compression_parent(db, "peer-root")
+    db.create_session(
+        "peer-mid", source="webui", parent_session_id="peer-root"
+    )
+    db.end_session("peer-mid", "compression")
+    db.create_session(
+        "peer-tip", source="webui", parent_session_id="peer-mid"
+    )
+
+    db.record_gateway_session_peer(
+        "peer-tip",
+        source="webui",
+        session_key="new-routing-key",
+        include_compression_ancestors=True,
+    )
+
+    assert db.get_session("peer-root")["session_key"] == "new-routing-key"
+    assert db.get_session("peer-mid")["session_key"] == "new-routing-key"
+    assert db.get_session("peer-tip")["session_key"] == "new-routing-key"
+
+
+def test_record_gateway_session_peer_walks_past_continuation_with_foreign_marker(
+    db: SessionDB,
+) -> None:
+    """Same bug class as the reopen/find_live tests above, in the recursive
+    ancestor walk ``record_gateway_session_peer(include_compression_ancestors=True)``
+    uses. A REAL continuation can carry ``_delegate_from`` pointing at some
+    OTHER session (the delegate's own original parent, not this parent) —
+    marker-PRESENCE matching stopped the walk one hop too early and left the
+    compression parent on a stale routing peer after an explicit gateway
+    ``/resume`` moved the tip to a new session_key."""
+    _compression_parent(db, "peer-parent-with-foreign-marker")
+    db.create_session(
+        "peer-continuation-foreign-marker",
+        source="subagent",
+        parent_session_id="peer-parent-with-foreign-marker",
+        model_config={"_delegate_from": "some-unrelated-original-parent"},
+    )
+
+    db.record_gateway_session_peer(
+        "peer-continuation-foreign-marker",
+        source="webui",
+        session_key="new-routing-key",
+        include_compression_ancestors=True,
+    )
+
+    assert (
+        db.get_session("peer-parent-with-foreign-marker")["session_key"]
+        == "new-routing-key"
+    )
+    assert (
+        db.get_session("peer-continuation-foreign-marker")["session_key"]
+        == "new-routing-key"
+    )
+
+
 def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
     db: SessionDB,
 ) -> None:
@@ -296,3 +357,54 @@ def test_compression_lease_blocks_non_owner_but_allows_owner_flush(
         compression_lock_holder="winner",
     )
     assert [m["content"] for m in db.get_messages("leased")] == ["winner flush"]
+
+
+def test_get_compression_tip_walks_past_continuation_with_foreign_marker(
+    db: SessionDB,
+) -> None:
+    """Same bug class as the reopen/find_live/record_gateway_session_peer
+    tests above, in the forward tip walk ``get_compression_tip`` uses. A REAL
+    continuation can carry ``_delegate_from`` pointing at some OTHER session
+    (the delegate's own original parent, not this parent) — marker-PRESENCE
+    matching stopped the walk one hop too early and returned the dead parent
+    as the "tip" instead of the live continuation that actually holds the
+    post-compression messages."""
+    _compression_parent(db, "tip-parent-with-foreign-marker")
+    db.create_session(
+        "tip-continuation-foreign-marker",
+        source="subagent",
+        parent_session_id="tip-parent-with-foreign-marker",
+        model_config={"_delegate_from": "some-unrelated-original-parent"},
+    )
+
+    assert (
+        db.get_compression_tip("tip-parent-with-foreign-marker")
+        == "tip-continuation-foreign-marker"
+    )
+
+
+def test_resolve_resume_session_id_walks_past_continuation_with_foreign_marker(
+    db: SessionDB,
+) -> None:
+    """Same bug class again, in the message-bearing-descendant walk
+    ``resolve_resume_session_id`` uses once ``get_compression_tip`` has
+    already redirected to the tip. Without the parent-bound marker check,
+    a continuation inheriting a foreign ``_delegate_from`` is excluded as if
+    it were an unrelated delegate child, and ``--resume`` on the parent
+    reloads the pre-compression transcript missing every post-compression
+    turn."""
+    _compression_parent(db, "resume-parent-with-foreign-marker")
+    db.create_session(
+        "resume-continuation-foreign-marker",
+        source="subagent",
+        parent_session_id="resume-parent-with-foreign-marker",
+        model_config={"_delegate_from": "some-unrelated-original-parent"},
+    )
+    db.append_message(
+        "resume-continuation-foreign-marker", "assistant", "post-compression reply"
+    )
+
+    assert (
+        db.resolve_resume_session_id("resume-parent-with-foreign-marker")
+        == "resume-continuation-foreign-marker"
+    )


### PR DESCRIPTION
## Summary

Today's `a0801b878` fixed a marker-PRESENCE-vs-marker-BINDING bug in `find_live_compression_child` / `reopen_orphaned_compression_session`: a real compression continuation can inherit the rotated agent's `model_config` verbatim (`publish_compression_child` callers pass `agent._session_init_model_config`), so a delegate subagent's continuation carries `_delegate_from=<the delegate's own original parent>` — a marker that *exists* but does not point at the parent being evaluated. Matching on presence alone misclassified such a continuation as a delegate/branch child.

`record_gateway_session_peer(include_compression_ancestors=True)`'s recursive CTE (used by `gateway/session.py::switch_session` on an explicit `/resume` to keep a compression lineage on one routing peer) has the exact same marker-presence check and was not touched by that fix — it wasn't in the list of read-only sites `a0801b878` deliberately left alone (those fail closed and self-heal at next turn start; this is a write path with no such self-heal).

**Effect:** resuming into a live continuation whose compression parent carries a foreign delegate/branch marker stops the lineage walk one hop too early — the parent keeps its old `session_key` while the continuation gets the new one, splitting the lineage's routing peer across two keys.

## Fix

Same pattern as `a0801b878` (`COALESCE(json_extract(...), '') != <id>` instead of `IS NULL`), but bound to the recursive CTE's correlated `parent.id` column rather than a single top-level bound parameter — this walk evaluates a *different* parent at every hop (unlike the two functions `a0801b878` fixed, which query one fixed parent/session id), so the exclusion has to be re-evaluated per row rather than bound once.

## Testing

- Added `test_record_gateway_session_peer_walks_multi_hop_compression_lineage` (control: plain two-hop chain, no foreign markers) and `test_record_gateway_session_peer_walks_past_continuation_with_foreign_marker` (repro) to `tests/state/test_compression_lineage_guard.py`.
- Mutation-verified: reverted the `hermes_state.py` change and confirmed the foreign-marker test fails on pre-fix code (`AssertionError: assert None == 'new-routing-key'`).
- `tests/state/`, `tests/gateway/test_session.py`, and the full `tests/test_hermes_state.py` (187 tests) all pass.
- `ruff check` clean on both changed files.

## Competing PRs

Searched `record_gateway_session_peer`, `compression lineage marker`, `gateway session peer compression ancestors`, `switch_session compression ancestors` — no PR targets this function. #71486 ("recover live tip across rotation chains") touches `hermes_state.py` and the same test file but a different function (`find_latest_gateway_session_for_peer`, ~250 lines away) with no overlap.