### PR TITLE
Desktop SSH remote mode: boot fails with “Could not terminate the stale SSH backend” when remote dashboard ignores SIGTERM

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -79,6 +79,23 @@ function fakeSsh(rules: any[] = []) {
   }
 }
 
+function cleanupSsh(pid, { ownershipResults = ['OWNED', 'OWNED'], termResult = 'ALIVE', killResult = 'DEAD' }: any = {}) {
+  let ownershipChecks = 0
+
+  return fakeSsh([
+    [
+      command => command.includes('print("OWNED"'),
+      () => {
+        const result = ownershipResults[Math.min(ownershipChecks++, ownershipResults.length - 1)] || 'FOREIGN'
+
+        return `${result}\n`
+      }
+    ],
+    [command => command.includes(`kill -9 ${pid}`), `${killResult}\n`],
+    [command => command.includes(`kill ${pid}`), `${termResult}\n`]
+  ])
+}
+
 test('locateHermes prefers the explicit profile path when executable', async () => {
   const ssh = fakeSsh([[/\[ -x .*\/opt\/hermes/, 'OK']])
   assert.equal(await locateHermes(ssh, '/opt/hermes'), '/opt/hermes')
@@ -255,7 +272,7 @@ test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', a
   assert.ok(!notOurs.calls.some(c => /kill 5\b/.test(c)), 'must not kill a pid that is not our dashboard')
   assert.ok(notOurs.calls.some(c => /rm -f/.test(c)))
 
-  const ours = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  const ours = cleanupSsh(9)
   await cleanupStale(ours, OWNERSHIP_ID, {
     pid: 9,
     spawnNonce: SPAWN_NONCE,
@@ -267,7 +284,7 @@ test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', a
 })
 
 test('cleanupStale escalates an owned pid after the SIGTERM grace period', async () => {
-  const ssh = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  const ssh = cleanupSsh(9)
 
   await cleanupStale(ssh, OWNERSHIP_ID, {
     pid: 9,
@@ -276,12 +293,62 @@ test('cleanupStale escalates an owned pid after the SIGTERM grace period', async
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
   })
 
-  const killCommand = ssh.calls.find(command => command.includes('kill 9'))
+  const termCommand = ssh.calls.find(command => command.includes('kill 9 2>/dev/null'))
+  const killCommand = ssh.calls.find(command => command.includes('kill -9 9'))
+  assert.ok(termCommand)
   assert.ok(killCommand)
-  assert.match(killCommand, /kill 9/)
-  assert.match(killCommand, /-ge 50/)
+  assert.match(termCommand, /kill 9/)
+  assert.match(termCommand, /-ge 50/)
   assert.match(killCommand, /kill -9 9/)
   assert.match(killCommand, /-ge 10/)
+})
+
+test('cleanupStale preserves the lock when ownership changes before SIGKILL', async () => {
+  const ssh = cleanupSsh(9, { ownershipResults: ['OWNED', 'FOREIGN'] })
+
+  await assert.rejects(
+    () =>
+      cleanupStale(ssh, OWNERSHIP_ID, {
+        pid: 9,
+        spawnNonce: SPAWN_NONCE,
+        hermesPath: '/x/hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+      }),
+    (error: any) => error.kind === 'transient-transport-error'
+  )
+  assert.ok(!ssh.calls.some(command => /kill -9 9/.test(command)))
+  assert.ok(!ssh.calls.some(command => /rm -f/.test(command)))
+})
+
+test('cleanupStale preserves the lock when SIGKILL does not confirm death', async () => {
+  const ssh = cleanupSsh(9, { killResult: 'ALIVE' })
+
+  await assert.rejects(
+    () =>
+      cleanupStale(ssh, OWNERSHIP_ID, {
+        pid: 9,
+        spawnNonce: SPAWN_NONCE,
+        hermesPath: '/x/hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+      }),
+    (error: any) => error.kind === 'transient-transport-error'
+  )
+  assert.ok(ssh.calls.some(command => /kill -9 9/.test(command)))
+  assert.ok(!ssh.calls.some(command => /rm -f/.test(command)))
+})
+
+test('cleanupStale removes the lock without escalation when SIGTERM confirms death', async () => {
+  const ssh = cleanupSsh(9, { termResult: 'DEAD' })
+
+  await cleanupStale(ssh, OWNERSHIP_ID, {
+    pid: 9,
+    spawnNonce: SPAWN_NONCE,
+    hermesPath: '/x/hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+  assert.ok(!ssh.calls.some(command => /kill -9 9/.test(command)))
+  assert.ok(ssh.calls.some(command => /rm -f/.test(command)))
+  assert.equal(ssh.calls.filter(command => command.includes('print("OWNED"')).length, 1)
 })
 
 test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
@@ -512,6 +579,7 @@ test('connect() respawns when the requested remote profile differs from the lock
     [/uname/, 'Linux\nx86_64'],
     [/\[ -x/, 'OK'],
     [/cat .*lock\.json/, JSON.stringify(lock)],
+    [command => command.includes('kill -9 333'), 'DEAD'],
     [/kill -0 333/, 'ALIVE'],
     [/print\("OWNED"/, 'OWNED\n'],
     [/kill 333/, ''],
@@ -999,7 +1067,7 @@ test('readLockfile rejects a log path outside the exact ownership and spawn path
 })
 
 test('cleanupStale never deletes a lock-supplied unexpected log path', async () => {
-  const ssh = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  const ssh = cleanupSsh(333)
   await cleanupStale(ssh, OWNERSHIP_ID, ownedLock({ logPath: '~/.hermes/unrelated.log' }))
   assert.ok(!ssh.calls.some(command => command.includes('unrelated.log')))
 })
@@ -1062,6 +1130,7 @@ test('connect replaces an exact-owned backend only after authenticated stale pro
     [/uname/, 'Linux\nx86_64'],
     [/\[ -x/, 'OK'],
     [/cat .*lock\.json/, JSON.stringify(lock)],
+    [command => command.includes('kill -9 333'), 'DEAD'],
     [/kill -0 333/, 'ALIVE'],
     [/print\("OWNED"/, 'OWNED\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -266,6 +266,24 @@ test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', a
   assert.ok(ours.calls.some(c => /rm -f/.test(c)))
 })
 
+test('cleanupStale escalates an owned pid after the SIGTERM grace period', async () => {
+  const ssh = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+
+  await cleanupStale(ssh, OWNERSHIP_ID, {
+    pid: 9,
+    spawnNonce: SPAWN_NONCE,
+    hermesPath: '/x/hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+
+  const killCommand = ssh.calls.find(command => command.includes('kill 9'))
+  assert.ok(killCommand)
+  assert.match(killCommand, /kill 9/)
+  assert.match(killCommand, /-ge 50/)
+  assert.match(killCommand, /kill -9 9/)
+  assert.match(killCommand, /-ge 10/)
+})
+
 test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
   const cmd = buildSpawnCommand('/x/hermes', 'work', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
   assert.match(cmd, /serve --isolated/)

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -412,20 +412,37 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
 async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   if (pidAlive && lock && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
     try {
-      const result = (
+      const pid = Number(lock.pid)
+
+      const termResult = (
         await ssh.exec(
-          `kill ${Number(lock.pid)} 2>/dev/null || true; ` +
-            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
+          `kill ${pid} 2>/dev/null || true; ` +
+            `i=0; while kill -0 ${pid} 2>/dev/null; do ` +
             `i=$((i+1)); [ "$i" -ge ${STALE_TERM_WAIT_ITERATIONS} ] && break; sleep 0.1; done; ` +
-            `if kill -0 ${Number(lock.pid)} 2>/dev/null; then ` +
-            `kill -9 ${Number(lock.pid)} 2>/dev/null || true; ` +
-            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
-            `i=$((i+1)); [ "$i" -ge ${STALE_KILL_WAIT_ITERATIONS} ] && exit 1; sleep 0.1; done; ` +
-            `fi`
+            `if kill -0 ${pid} 2>/dev/null; then printf ALIVE; else printf DEAD; fi`
         )
       ).trim()
 
-      void result
+      if (termResult === 'ALIVE') {
+        if (!(await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
+          throw new Error('SSH backend ownership changed before forced termination.')
+        }
+
+        const killResult = (
+          await ssh.exec(
+            `kill -9 ${pid} 2>/dev/null || true; ` +
+              `i=0; while kill -0 ${pid} 2>/dev/null; do ` +
+              `i=$((i+1)); [ "$i" -ge ${STALE_KILL_WAIT_ITERATIONS} ] && break; sleep 0.1; done; ` +
+              `if kill -0 ${pid} 2>/dev/null; then printf ALIVE; else printf DEAD; fi`
+          )
+        ).trim()
+
+        if (killResult !== 'DEAD') {
+          throw new Error('SSH backend remained alive after forced termination.')
+        }
+      } else if (termResult !== 'DEAD') {
+        throw new Error('Could not determine whether the stale SSH backend terminated.')
+      }
     } catch (cause) {
       const error: any = new Error('Could not terminate the stale SSH backend.')
       error.kind = 'transient-transport-error'

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -37,6 +37,8 @@ const REMOTE_LOCK_DIR = '~/.hermes/desktop-ssh'
 const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
+const STALE_TERM_WAIT_ITERATIONS = 50
+const STALE_KILL_WAIT_ITERATIONS = 10
 
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
@@ -412,9 +414,14 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
     try {
       const result = (
         await ssh.exec(
-          `kill ${Number(lock.pid)} && ` +
+          `kill ${Number(lock.pid)} 2>/dev/null || true; ` +
             `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
-            `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
+            `i=$((i+1)); [ "$i" -ge ${STALE_TERM_WAIT_ITERATIONS} ] && break; sleep 0.1; done; ` +
+            `if kill -0 ${Number(lock.pid)} 2>/dev/null; then ` +
+            `kill -9 ${Number(lock.pid)} 2>/dev/null || true; ` +
+            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
+            `i=$((i+1)); [ "$i" -ge ${STALE_KILL_WAIT_ITERATIONS} ] && exit 1; sleep 0.1; done; ` +
+            `fi`
         )
       ).trim()
 


### PR DESCRIPTION
## Summary

After updating or relaunching Hermes Desktop in Remote Gateway (SSH) mode, boot can fail repeatedly with:

```text
Desktop boot failed: Could not terminate the stale SSH backend.
```

SSH authentication and ControlMaster setup succeed. The failure occurs while cleaning up the stale remote dashboard process.

## Environment

- Desktop remote SSH gateway mode
- Remote host: Linux (x86_64)
- Remote process: `hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce …`
- Ownership lock: `~/.hermes/desktop-ssh/<ownershipId>/backend.lock.json`

## Root cause

`cleanupStale()` in `apps/desktop/electron/remote-lifecycle.ts` sent SIGTERM and waited for roughly five seconds. A remote dashboard can catch SIGTERM and remain in graceful shutdown while MCP children or open state finish closing. The timeout then aborted Desktop boot even though the process was a known, owned Hermes backend.

Local Desktop child teardown and `hermes_cli/dashboard_procs.py` already use SIGTERM-to-SIGKILL escalation; the remote lifecycle path did not.

## Fix

After the existing SIGTERM grace period, `cleanupStale()` now:

1. Sends SIGKILL (`kill -9`) when the owned process is still alive.
2. Waits briefly for the process to disappear.
3. Reports the existing termination error only if the forced cleanup also fails.

The existing `--ssh-owner-nonce` process-ownership proof remains the gate before either signal is sent. Foreign processes are not affected.

## Test plan

- [x] `npm run test:desktop:platforms -- electron/remote-lifecycle.test.ts`
- [x] `npm run test:desktop:platforms` — 939 passed, 2 skipped
- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors; existing warnings remain
- [ ] Manual SSH remote-mode reproduction with a dashboard that ignores SIGTERM

The broader `npm test` command also ran and reported two unrelated existing billing UI failures (`src/app/settings/billing/index.test.tsx`); the full Electron test project is green.

## Workaround before this fix

```bash
ssh <remote> 'pkill -9 -f "hermes serve --isolated"; rm -f ~/.hermes/desktop-ssh/*/backend.lock.json'
```

Then relaunch Desktop.
