### PR TITLE
fix: refresh session list on profile rail switch

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -498,7 +498,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     void refreshCurrentModel(true)
     void refreshHermesConfig(true)
     void refreshActiveProfile()
-  }, [activeGatewayProfile, refreshCurrentModel, refreshHermesConfig])
+    void refreshSessions()
+  }, [activeGatewayProfile, refreshCurrentModel, refreshHermesConfig, refreshSessions])
 
   // New session anchored to a workspace. Seeds cwd + branch from the clicked
   // workspace; an explicit worktree path also drills the sidebar into that


### PR DESCRIPTION
## Summary

When switching profiles via the sidebar rail, the recents list stays empty until the user sends a prompt. This one-line fix ensures  is called when the active gateway profile changes.

## Root Cause

Two gaps combine to suppress the session refresh:

1. **** — The effect that fires on every  change refreshes the model, config, and active profile pill, but  was missing from the effect body.

2. **** — The fallback effect only fires on  transitions. But when switching between already-live pool backends (both sockets pre-opened),  stays  — React sees no value change and skips the effect.

The boot path () calls  unconditionally, which is why restarting with the correct boot profile worked as a workaround.

## Fix

Add  to the profile-switch effect body, and add  to the dependency array.

## Test Plan

- Switch between profiles via the sidebar rail and verify session list populates immediately
- Verify no regression on boot path (already calls refreshSessions unconditionally)