### PR TITLE
fix(redact): narrow control-split join guard to line-crossing spans

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -512,14 +512,16 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # A complete token at end-of-line followed by a word line
         # (``ghp_<token>\nbutton [ref=e3]``) joins into one stripped-copy
         # match and the mask eats ``button``. Line structure is legitimate;
-        # the self-matching fragment is handled by the ordinary prefix pass.
+        # the self-matching fragment is handled by the ordinary prefix pass
+        # (any remainder past the newline is left unmasked — accepted
+        # residual to preserve line structure).
         # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
         # when a fragment self-matches: those bytes never legitimately sit
         # between a token and adjacent prose, and skipping there let the
         # non-matching remainder of a split token leak
         # (``sk-<head>\x1b<tail>`` masked only the head).
         span = text[start_orig:end_orig]
-        if _PREFIX_RE.search(span) and ("\n" in span or "\r" in span):
+        if ("\n" in span or "\r" in span) and _PREFIX_RE.search(span):
             continue
         # Reject matches whose original span crosses a non-token char
         # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
@@ -527,7 +529,7 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # reject when the match runs into a ``KEY=`` name: a real token value
         # is followed by a newline/space/end, not ``=``.
         if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in text[start_orig:end_orig])
+                for c in span)
                 and (end_orig >= len(text) or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -507,14 +507,19 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         body = m.group(1)
         start_orig = orig_idx[m.start(1)]
         end_orig = orig_idx[m.end(1) - 1] + 1
-        # If any fragment inside the original span already matches _PREFIX_RE
-        # on its own, the ordinary prefix pass will mask it — do NOT join.
-        # Joining here would swallow adjacent legitimate text: a complete
-        # token at end-of-line followed by a word line (``ghp_<token>\n
-        # button [ref=e3]``) joins into one stripped-copy match and the
-        # mask eats ``button``. Join only when fragments alone are too
-        # short/broken to match (the actual smuggling shape).
-        if _PREFIX_RE.search(text[start_orig:end_orig]):
+        # If a fragment inside the span already matches _PREFIX_RE on its
+        # own AND the span crosses a LINE boundary (\n / \r), do NOT join.
+        # A complete token at end-of-line followed by a word line
+        # (``ghp_<token>\nbutton [ref=e3]``) joins into one stripped-copy
+        # match and the mask eats ``button``. Line structure is legitimate;
+        # the self-matching fragment is handled by the ordinary prefix pass.
+        # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
+        # when a fragment self-matches: those bytes never legitimately sit
+        # between a token and adjacent prose, and skipping there let the
+        # non-matching remainder of a split token leak
+        # (``sk-<head>\x1b<tail>`` masked only the head).
+        span = text[start_orig:end_orig]
+        if _PREFIX_RE.search(span) and ("\n" in span or "\r" in span):
             continue
         # Reject matches whose original span crosses a non-token char
         # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -183,6 +183,17 @@ class TestControlCharSplitTokens:
         assert "button" in result
         assert "ref=e3" in result
 
+    def test_selfmatching_head_esc_split_tail_masked(self):
+        # A split where the HEAD fragment alone already matches _PREFIX_RE
+        # (>= 10 body chars) but the tail doesn't: the join must still run
+        # for non-newline controls, or the tail leaks in cleartext. Only
+        # LINE-crossing spans skip the join (see the annotation test).
+        head = "sk-" + "a" * 15
+        tail = "b" * 25
+        result = redact_sensitive_text(head + "\x1b" + tail, force=True)
+        assert tail not in result
+        assert "a" * 12 not in result
+
     def test_env_dump_lines_not_joined(self):
         # Control-stripping must not join unrelated env lines into one match
         env_dump = (


### PR DESCRIPTION
## Summary
Narrows the control-split join guard added in #80965 (aecb9ca89) so a token split by ESC/zero-width bytes is fully masked again — the guard as merged skipped the join whenever any fragment self-matched `_PREFIX_RE`, which left the non-matching tail of such a split in cleartext.

## Root cause
The guard existed to stop a real bug (a complete token at end-of-line joining with the next text line and the mask swallowing "button [ref=e3]"). But its condition was broader than the bug: it also fired for non-newline splits where the head fragment alone was long enough to self-match, so `sk-<15 chars>\x1b<25 chars>` masked only the head and leaked the 25-char tail. (Upstream main never masked this shape at all — the merged state was still strictly >= main — but the salvage's own split coverage regressed.)

## Fix
Skip the join only when the candidate span crosses a line boundary (`\n`/`\r`) — the only shape where adjacent legitimate text can be swallowed. ESC/zero-width controls never legitimately separate a token from prose, so joining there is safe.

## Validation
| Probe | Before (merged main) | After |
|---|---|---|
| `sk-<head≥10>\x1b<tail>` | tail LEAKED | head+tail masked |
| `ghp_<token>\nbutton [ref=e3]` annotation | preserved | preserved (unchanged) |
| ESC/ZWSP/NL splits, short fragments | masked | masked (unchanged) |
| two complete tokens sep. by ESC | both masked | both masked |
| env dump lines | intact | intact |

- `tests/agent/test_redact.py` + `tests/tools/test_browser_secret_exfil.py`: 113 passed
- Both guard legs mutation-checked: reverting to unconditional skip fails the new tail-mask test; deleting the guard fails the annotation test
- ruff clean

Found by the post-merge final-stack review of my own follow-up commit on #80965. Refs #77484.
