### PR TITLE
fix(delegation): bind subagent.interrupt to the caller's session, like subagent.steer

### DIFF
--- a/tests/tools/test_subagent_steer.py
+++ b/tests/tools/test_subagent_steer.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 from tools.delegate_tool import (
     _register_subagent,
     _unregister_subagent,
+    interrupt_subagent,
     steer_subagent,
 )
 
@@ -23,12 +24,16 @@ class _StubAgent:
         self.accept = accept
         self.boom = boom
         self.steered: list[str] = []
+        self.interrupted: list[str | None] = []
 
     def steer(self, text: str) -> bool:
         if self.boom:
             raise RuntimeError("steer exploded")
         self.steered.append(text)
         return self.accept
+
+    def hard_interrupt(self, message: str | None = None) -> None:
+        self.interrupted.append(message)
 
 
 def _with_registered(
@@ -122,6 +127,92 @@ def test_stale_agent_teardown_cannot_unregister_recycled_id():
         assert replacement.steered == ["replacement remains live"]
     finally:
         _unregister_subagent("sid-recycled-teardown", agent=replacement)
+
+
+def test_interrupt_reaches_the_live_child_without_an_owner():
+    """No owner supplied preserves the internal in-process helper contract
+    (test harnesses, same-process callers that already hold the record) —
+    same as steer_subagent's owner_session_id=None default."""
+    agent = _StubAgent()
+    _with_registered("sid-interrupt-1", agent)
+    try:
+        assert interrupt_subagent("sid-interrupt-1") is True
+        assert agent.interrupted == ["Interrupted via TUI (sid-interrupt-1)"]
+    finally:
+        _unregister_subagent("sid-interrupt-1")
+
+
+def test_interrupt_owned_by_the_correct_session_succeeds():
+    owner_transport = object()
+    owner_record = object()
+    agent = _StubAgent()
+    _with_registered(
+        "sid-interrupt-owned",
+        agent,
+        owner_session_id="owner-session",
+        owner_transport=owner_transport,
+        owner_session_record=owner_record,
+    )
+    try:
+        assert (
+            interrupt_subagent(
+                "sid-interrupt-owned",
+                owner_session_id="owner-session",
+                owner_transport=owner_transport,
+                owner_session_record=owner_record,
+            )
+            is True
+        )
+        assert agent.interrupted == ["Interrupted via TUI (sid-interrupt-owned)"]
+    finally:
+        _unregister_subagent("sid-interrupt-owned")
+
+
+def test_interrupt_from_a_foreign_session_is_denied():
+    """Same class of bug steer_subagent was hardened against: a session
+    must not be able to hard-stop a child it does not own just because it
+    can enumerate the id via delegation.status."""
+    agent = _StubAgent()
+    _with_registered("sid-interrupt-foreign", agent, owner_session_id="owner-session")
+    try:
+        assert (
+            interrupt_subagent(
+                "sid-interrupt-foreign",
+                owner_session_id="foreign-session",
+                owner_transport=object(),
+                owner_session_record=object(),
+            )
+            is False
+        )
+        assert agent.interrupted == []
+    finally:
+        _unregister_subagent("sid-interrupt-foreign")
+
+
+def test_interrupt_with_foreign_transport_and_correct_session_id_is_denied():
+    owner_transport = object()
+    owner_record = object()
+    agent = _StubAgent()
+    _with_registered(
+        "sid-interrupt-foreign-transport",
+        agent,
+        owner_session_id="owner-session",
+        owner_transport=owner_transport,
+        owner_session_record=owner_record,
+    )
+    try:
+        assert (
+            interrupt_subagent(
+                "sid-interrupt-foreign-transport",
+                owner_session_id="owner-session",
+                owner_transport=object(),
+                owner_session_record=owner_record,
+            )
+            is False
+        )
+        assert agent.interrupted == []
+    finally:
+        _unregister_subagent("sid-interrupt-foreign-transport")
 
 
 def test_status_snapshot_never_leaks_owner_or_lifecycle_metadata():
@@ -897,3 +988,166 @@ class TestSubagentSteerRPC:
             assert new_agent.steered == []
         finally:
             _unregister_subagent("sid-rpc-recycled")
+
+
+class TestSubagentInterruptRPC:
+    """subagent.interrupt gateway RPC — same caller-authority resolution as
+    subagent.steer (TestSubagentSteerRPC above). Before this, the RPC called
+    interrupt_subagent(subagent_id) with no owner check at all: any session
+    could enumerate every active subagent id via delegation.status and
+    hard-stop a child it did not own."""
+
+    class _Transport:
+        def __init__(self) -> None:
+            self.frames: list[dict] = []
+
+        def write(self, obj: dict) -> bool:
+            self.frames.append(obj)
+            return True
+
+        def close(self) -> None:
+            return None
+
+    def _call(self, params: dict, *, transport=None, session_record=None) -> dict:
+        import tui_gateway.server as srv
+
+        session_id = params.get("session_id")
+        if session_id:
+            srv._sessions[session_id] = session_record or {
+                "session_key": session_id,
+                "history": [],
+                "transport": transport,
+            }
+        try:
+            return srv.dispatch(
+                {"id": 1, "method": "subagent.interrupt", "params": params},
+                transport=transport,
+            )
+        finally:
+            if session_id:
+                srv._sessions.pop(session_id, None)
+
+    def test_missing_subagent_id_is_4000(self):
+        envelope = self._call({"session_id": "owner-session"})
+        assert envelope["error"]["code"] == 4000
+
+    def test_owned_child_is_interrupted(self):
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-interrupt-owned",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-interrupt-owned",
+                },
+                transport=owner_transport,
+                session_record=owner_record,
+            )
+            assert envelope["result"] == {
+                "found": True,
+                "subagent_id": "sid-rpc-interrupt-owned",
+            }
+            assert agent.interrupted == [
+                "Interrupted via TUI (sid-rpc-interrupt-owned)"
+            ]
+        finally:
+            _unregister_subagent("sid-rpc-interrupt-owned")
+
+    def test_unknown_child_is_not_found_not_an_error(self):
+        envelope = self._call(
+            {"session_id": "owner-session", "subagent_id": "sid-rpc-interrupt-gone"}
+        )
+        assert envelope["result"]["found"] is False
+
+    def test_foreign_session_cannot_interrupt_an_owned_child(self):
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-interrupt-foreign", agent, owner_session_id="owner-session"
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "foreign-session",
+                    "subagent_id": "sid-rpc-interrupt-foreign",
+                }
+            )
+            assert envelope["result"]["found"] is False
+            assert agent.interrupted == []
+        finally:
+            _unregister_subagent("sid-rpc-interrupt-foreign")
+
+    def test_foreign_transport_with_correct_session_id_is_denied(self):
+        owner_transport = self._Transport()
+        foreign_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-interrupt-foreign-transport",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-interrupt-foreign-transport",
+                },
+                transport=foreign_transport,
+                session_record=owner_record,
+            )
+            assert envelope["result"]["found"] is False
+            assert agent.interrupted == []
+        finally:
+            _unregister_subagent("sid-rpc-interrupt-foreign-transport")
+
+    def test_rpc_without_invoking_session_identity_is_denied(self):
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-interrupt-no-caller", agent, owner_session_id="owner-session"
+        )
+        try:
+            envelope = self._call({"subagent_id": "sid-rpc-interrupt-no-caller"})
+            assert envelope["error"]["code"] == 4001
+            assert agent.interrupted == []
+        finally:
+            _unregister_subagent("sid-rpc-interrupt-no-caller")
+
+    def test_recycled_id_does_not_preserve_the_old_sessions_authority(self):
+        old_agent = _StubAgent()
+        new_agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-interrupt-recycled", old_agent, owner_session_id="old-session"
+        )
+        _with_registered(
+            "sid-rpc-interrupt-recycled", new_agent, owner_session_id="new-session"
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "old-session",
+                    "subagent_id": "sid-rpc-interrupt-recycled",
+                }
+            )
+            assert envelope["result"]["found"] is False
+            assert old_agent.interrupted == []
+            assert new_agent.interrupted == []
+        finally:
+            _unregister_subagent("sid-rpc-interrupt-recycled")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -208,19 +208,40 @@ def _close_subagent_steering(subagent_id: str, agent: Any) -> Optional[str]:
         return pending if isinstance(pending, str) and pending.strip() else None
 
 
-def interrupt_subagent(subagent_id: str) -> bool:
+def interrupt_subagent(
+    subagent_id: str,
+    *,
+    owner_session_id: Optional[str] = None,
+    owner_transport: Any = None,
+    owner_session_record: Any = None,
+) -> bool:
     """Request that a single running subagent stop at its next iteration boundary.
 
     Does not hard-kill the worker thread (Python can't); sets the child's
     interrupt flag which propagates to in-flight tools and recurses into
     grandchildren via AIAgent.interrupt().  Returns True if a matching
-    subagent was found.
+    subagent was found (and, when an owner is supplied, owned by the caller).
+
+    Same ownership contract as steer_subagent(): ``owner_session_id=None``
+    deliberately preserves the internal in-process helper contract (test
+    harnesses, same-process callers that already hold the record); gateway
+    callers must pass exact authority — a session can otherwise enumerate
+    every subagent id system-wide via delegation.status and hard-stop a
+    child it does not own.
     """
     with _active_subagents_lock:
         record = _active_subagents.get(subagent_id)
-    if not record:
-        return False
-    agent = record.get("agent")
+        if not record:
+            return False
+        if owner_session_id is not None and (
+            record.get("owner_session_id") != owner_session_id
+            or owner_transport is None
+            or record.get("owner_transport") is not owner_transport
+            or owner_session_record is None
+            or record.get("owner_session_record") is not owner_session_record
+        ):
+            return False
+        agent = record.get("agent")
     if agent is None:
         return False
     try:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2925,12 +2925,35 @@ def _(rid, params: dict) -> dict:
 
 @method("subagent.interrupt")
 def _(rid, params: dict) -> dict:
+    """Hard-stop a live delegated child.
+
+    Same caller-authority resolution as subagent.steer: the public
+    subagent_id is only a lookup hint, delegation.status enumerates every
+    active subagent's id system-wide, so without this a session could stop
+    a child it does not own. Authority is the identity of both the ContextVar-
+    bound transport and the live in-memory session record for the supplied
+    session_id, not the id string itself.
+    """
     from tools.delegate_tool import interrupt_subagent
 
     subagent_id = str(params.get("subagent_id") or "").strip()
     if not subagent_id:
         return _err(rid, 4000, "subagent_id required")
-    ok = interrupt_subagent(subagent_id)
+    _invoking_session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    invoking_session_id = str(params.get("session_id") or "").strip()
+    invoking_transport, invoking_session = _current_session_steer_authority(
+        invoking_session_id
+    )
+    ok = False
+    if invoking_transport is not None and invoking_session is not None:
+        ok = interrupt_subagent(
+            subagent_id,
+            owner_session_id=invoking_session_id,
+            owner_transport=invoking_transport,
+            owner_session_record=invoking_session,
+        )
     return _ok(rid, {"found": ok, "subagent_id": subagent_id})
 
 

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -594,7 +594,7 @@ function DiffView({
 
 // ── Main overlay ─────────────────────────────────────────────────────
 
-export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: AgentsOverlayProps) {
+export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, sessionId, t }: AgentsOverlayProps) {
   const liveSubagents = useTurnSelector(state => state.subagents)
   const delegation = useStore($delegationState)
   const history = useStore($spawnHistory)
@@ -702,7 +702,15 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
     }
   }
 
-  const interrupt = (id: string) => gw.request<SubagentInterruptResponse>('subagent.interrupt', { subagent_id: id })
+  const interrupt = (id: string) =>
+    gw.request<SubagentInterruptResponse>('subagent.interrupt', {
+      subagent_id: id,
+      // The gateway resolves caller authority from this session_id (an
+      // unforgeable ContextVar-bound transport + live session record look-up,
+      // not the id string itself) — without it every interrupt is rejected
+      // as owner-less, same contract as subagent.steer.
+      ...(sessionId ? { session_id: sessionId } : {})
+    })
 
   const killOne = (id: string) =>
     guardLive(() => {
@@ -969,6 +977,7 @@ interface AgentsOverlayProps {
   gw: GatewayClient
   initialHistoryIndex?: number
   onClose: () => void
+  sessionId: string | null
   t: Theme
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -461,6 +461,7 @@ const AgentsOverlayPane = memo(function AgentsOverlayPane() {
       gw={gw}
       initialHistoryIndex={overlay.agentsInitialHistoryIndex}
       onClose={() => patchOverlayState({ agents: false, agentsInitialHistoryIndex: 0 })}
+      sessionId={ui.sid}
       t={ui.theme}
     />
   )


### PR DESCRIPTION
## Summary

This week's `60e1f7517`/`a94ebf5f5`/`9d4ef04ed` series hardened `steer_subagent()` to require exact `owner_session_id` + `owner_transport` (ContextVar-bound, unforgeable) + `owner_session_record` identity before a steer is accepted, closing a cross-session authority hole. `interrupt_subagent()` — which `steer_subagent()`'s own docstring says it mirrors ("The redirection-side mirror of `interrupt_subagent()`") — never got the same treatment: it takes only `subagent_id` and performs zero ownership validation. The `subagent.interrupt` RPC handler doesn't even resolve a caller identity before calling it.

`_active_subagents` is a bare module-level dict, not session- or profile-scoped. `delegation.status` (`list_active_subagents()`) returns every active subagent's id system-wide with no session filter, so any session can enumerate ids and then hard-stop a child it does not own via `subagent.interrupt`.

## Fix

Mirrors `steer_subagent()`'s exact ownership contract:
- `tools/delegate_tool.py::interrupt_subagent()` gains `owner_session_id`/`owner_transport`/`owner_session_record` kwargs, checked identically to `steer_subagent()`. `owner_session_id=None` (the default) deliberately preserves the internal in-process helper contract — the one existing caller (`tests/agent/test_interrupt_compat.py`) needs no changes.
- `tui_gateway/methods_session.py`'s `subagent.interrupt` handler now resolves caller authority via `_current_session_steer_authority()`, identical to `subagent.steer`'s handler.
- The only production client, `ui-tui`'s `agentsOverlay.tsx`, never sent a `session_id` at all — without threading it through, the ownership check would have silently broken the interrupt button for every legitimate caller. Added a `sessionId` prop (`AgentsOverlayPane` → `ui.sid`, mirroring `ModelPicker`'s existing `sessionId` threading pattern) and pass `session_id` in the RPC params.

## Testing

- Added registry-level ownership tests for `interrupt_subagent()` (owned succeeds, foreign session denied, foreign transport with correct session_id denied) and a `TestSubagentInterruptRPC` class mirroring the existing `TestSubagentSteerRPC` coverage to `tests/tools/test_subagent_steer.py`.
- Mutation-verified: stashed the backend fix, confirmed all 7 new authority-check tests fail on pre-fix code.
- `tests/tools/test_subagent_steer.py` (41), `tests/agent/test_interrupt_compat.py`, `tests/tools/test_delegate.py` + 5 neighboring delegate/subagent suites (96 tests), and the full `tests/test_tui_gateway_server.py` (517/518 — the one failure is a pre-existing threading-timing flake in an unrelated `write_json` test, confirmed by isolated re-runs and against pre-fix code) all pass.
- `ui-tui`: `npm run typecheck` clean; full vitest suite 138/138 files, 1528 passed.
- `ruff check` clean on all changed Python files.

## Note on a related open PR

#70899 ("Mission Control" async-delegation panel, branched 2026-07-24 before the `steer_subagent` hardening landed) adds a parallel `send_to_subagent()` whose docstring explicitly states it matches `interrupt_subagent()`'s *current* no-ownership-check posture, and touches the same four files this PR touches. The maintainer has commented it will be salvaged/expanded. This fix doesn't depend on or block that PR — it hardens a real, currently-exploitable gap in `main` today — but whichever lands second will likely need a rebase against the other.