### PR TITLE
fix(gateway): flush the undelivered tail when the first send fails, not just an edit

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1119,6 +1119,14 @@ class GatewayStreamConsumer:
                     return
 
                 if commentary_text is not None:
+                    # Same #8124 hazard as the segment-break reset below: this
+                    # reset wipes _accumulated, so any text the send above
+                    # failed to make visible has to be delivered first. (The
+                    # second reset, after _send_commentary, needs no flush —
+                    # _accumulated is already empty by then.)
+                    await self._flush_undelivered_tail_before_reset(
+                        current_update_visible
+                    )
                     self._reset_segment_state()
                     await self._send_commentary(commentary_text)
                     self._last_edit_time = time.monotonic()
@@ -1139,21 +1147,18 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
-                    # If the segment-break edit failed to deliver the
-                    # accumulated content (flood control that has not yet
-                    # promoted to fallback mode, or fallback mode itself),
-                    # _accumulated still holds pre-boundary text the user
-                    # never saw. Flush that tail as a continuation message
-                    # before the reset below wipes _accumulated — otherwise
-                    # text generated before the tool boundary is silently
-                    # dropped (issue #8124).
-                    if (
-                        self._accumulated
-                        and not current_update_visible
-                        and self._message_id
-                        and self._message_id != "__no_edit__"
-                    ):
-                        await self._flush_segment_tail_on_edit_failure()
+                    # If the send that should have shown this segment did not
+                    # deliver — a failed edit under flood control that has not
+                    # yet promoted to fallback mode, fallback mode itself, or a
+                    # failed *first* send after the previous boundary cleared
+                    # _message_id — _accumulated still holds pre-boundary text
+                    # the user never saw. Flush that tail as a continuation
+                    # message before the reset below wipes _accumulated —
+                    # otherwise text generated before the tool boundary is
+                    # silently dropped (issue #8124).
+                    await self._flush_undelivered_tail_before_reset(
+                        current_update_visible
+                    )
                     self._reset_segment_state(preserve_no_edit=True)
 
                 # Flush barrier satisfied: the buffered segment (if any) has now
@@ -1748,6 +1753,29 @@ class GatewayStreamConsumer:
         # Frame delivered.  Track text for parity with edit-based no-op skip.
         self._last_sent_text = text
         return True
+
+    async def _flush_undelivered_tail_before_reset(
+        self, current_update_visible: bool
+    ) -> None:
+        """Flush pre-boundary text the user never saw, before a segment reset.
+
+        ``_reset_segment_state`` wipes ``_accumulated``/``_stream_ledger``/
+        ``_last_sent_text``.  When the send that should have shown the current
+        segment never became visible, that buffer holds the only copy of the
+        text, so it must be delivered first (issue #8124).
+
+        Deliberately does NOT test ``_message_id`` for truthiness: a *first*
+        send that fails returns from ``_send_or_edit`` without ever assigning
+        it, leaving it ``None`` from the previous boundary's reset — which is
+        precisely the case that loses text.  The ``__no_edit__`` sentinel is
+        still excluded: the matching reset preserves state for
+        ``_send_fallback_final``, so flushing there would double-send.
+        """
+        if not self._accumulated or current_update_visible:
+            return
+        if self._message_id == "__no_edit__":
+            return
+        await self._flush_segment_tail_on_edit_failure()
 
     async def _flush_segment_tail_on_edit_failure(self) -> None:
         """Deliver un-sent tail content before a segment-break reset.

--- a/tests/gateway/test_stream_consumer_first_send_tail.py
+++ b/tests/gateway/test_stream_consumer_first_send_tail.py
@@ -1,0 +1,180 @@
+"""A failed *first* send must not silently delete the pre-boundary segment.
+
+Sibling of the #8124 guard.  ``_reset_segment_state`` clears ``_message_id``
+at every tool boundary, so the next text segment re-enters the first-send
+branch of ``_send_or_edit``.  That branch returns without ever assigning
+``_message_id`` when the send fails, which is exactly the case the original
+recovery flush excluded (it required ``self._message_id`` to be truthy).  The
+result: the paragraph written between two tool calls is buffered, never shown,
+and then wiped by the reset — the user sees the reply jump from one tool
+bubble to the next with the explanation missing.
+
+The fakes below fail only the *streaming-preview* send path, which the
+consumer marks with ``expect_edits`` in its metadata (see
+``_metadata_for_send``).  Plain sends — the ones the tail flush and the
+commentary use — still succeed.  That mirrors a real platform split: Telegram
+keeps editable previews on the legacy send path, so a preview render that the
+platform rejects (or rate-limits) can fail for a whole turn while ordinary
+messages go through.
+
+Assertions are on delivered payloads, never on internal attributes.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+_SEGMENT_ONE = "Here's what I found in the config, let me check the processes too."
+_SEGMENT_TWO = "The gateway is running under systemd."
+_COMMENTARY = "Using the shell tool..."
+
+
+def _is_preview_send(kwargs) -> bool:
+    """True for sends the consumer routes through the editable-preview path."""
+    metadata = kwargs.get("metadata")
+    return isinstance(metadata, dict) and bool(metadata.get("expect_edits"))
+
+
+def _preview_hostile_adapter():
+    """Adapter whose editable-preview sends all fail; plain sends succeed.
+
+    ``adapter.delivered`` collects only the payloads the platform accepted --
+    a rejected send is an attempt, not something the user saw, so assertions
+    must not read it out of ``send.call_args_list``.
+    """
+    adapter = MagicMock()
+    adapter.delivered = []
+
+    async def _send(**kwargs):
+        if _is_preview_send(kwargs):
+            return SimpleNamespace(success=False, error="preview send rejected")
+        adapter.delivered.append(kwargs["content"])
+        return SimpleNamespace(
+            success=True, message_id="msg_%d" % len(adapter.delivered),
+        )
+
+    adapter.send = AsyncMock(side_effect=_send)
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    return adapter
+
+
+def _delivered_count(adapter, needle):
+    return sum(1 for payload in adapter.delivered if needle in payload)
+
+
+def _consumer(adapter):
+    config = StreamConsumerConfig(
+        edit_interval=0.01, buffer_threshold=5, cursor=" ▉",
+    )
+    return GatewayStreamConsumer(adapter, "chat_123", config)
+
+
+@pytest.mark.asyncio
+async def test_failed_first_send_tail_survives_tool_boundary():
+    """The segment-break reset must not discard a never-delivered buffer.
+
+    Every preview send fails here, so ``_message_id`` is still ``None`` when
+    the tool boundary arrives.  The old guard required a truthy
+    ``_message_id``, so it skipped the flush and the reset wiped the only copy
+    of the text.
+    """
+    adapter = _preview_hostile_adapter()
+    consumer = _consumer(adapter)
+
+    consumer.on_delta(_SEGMENT_ONE)
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.08)
+    consumer.on_delta(None)  # tool boundary
+    await asyncio.sleep(0.08)
+    consumer.on_delta(_SEGMENT_TWO)
+    consumer.finish()
+    await task
+
+    assert _delivered_count(adapter, "let me check the processes too") == 1, (
+        "pre-boundary segment was dropped by the reset: "
+        "delivered=%r" % (adapter.delivered,)
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_first_send_tail_survives_commentary_reset():
+    """The commentary reset had no guard at all, so it dropped the same buffer.
+
+    ``_send_commentary`` is preceded by an unconditional
+    ``_reset_segment_state()``; if the preview send for the current segment
+    never became visible, that reset destroys it and the user sees only the
+    interim status line.
+    """
+    adapter = _preview_hostile_adapter()
+    consumer = _consumer(adapter)
+
+    consumer.on_delta(_SEGMENT_ONE)
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.08)
+    consumer.on_commentary(_COMMENTARY)
+    await asyncio.sleep(0.08)
+    consumer.on_delta(_SEGMENT_TWO)
+    consumer.finish()
+    await task
+
+    payloads = adapter.delivered
+    assert _delivered_count(adapter, "let me check the processes too") == 1, (
+        "text buffered before the commentary reset was dropped: "
+        "delivered=%r" % (payloads,)
+    )
+    # The commentary itself must still be delivered, and after the prose it
+    # was interrupting.
+    assert _COMMENTARY in payloads
+    prose_at = next(
+        i for i, p in enumerate(payloads) if "let me check the processes too" in p
+    )
+    assert prose_at < payloads.index(_COMMENTARY)
+
+
+@pytest.mark.asyncio
+async def test_no_edit_sentinel_does_not_double_send():
+    """The ``__no_edit__`` exclusion must survive the widened guard.
+
+    When a platform accepts a message but returns no editable id, the
+    consumer parks ``_message_id`` on the ``__no_edit__`` sentinel and the
+    matching reset preserves the segment so ``_send_fallback_final`` can
+    deliver the whole continuation once.  Flushing there would re-send text
+    the user has already seen, so dropping the ``_message_id`` truthiness
+    term must not drop this exclusion too.
+    """
+    adapter = MagicMock()
+    adapter.delivered = []
+
+    async def _send(**kwargs):
+        # Accepted, but with no editable id -- the __no_edit__ trigger.
+        adapter.delivered.append(kwargs["content"])
+        return SimpleNamespace(success=True, message_id=None)
+
+    adapter.send = AsyncMock(side_effect=_send)
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    consumer = _consumer(adapter)
+
+    consumer.on_delta(_SEGMENT_ONE)
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.08)
+    consumer.on_delta(None)  # tool boundary
+    await asyncio.sleep(0.08)
+    consumer.on_delta(" " + _SEGMENT_TWO)
+    consumer.finish()
+    await task
+
+    payloads = adapter.delivered
+    assert _delivered_count(adapter, "let me check the processes too") == 1, (
+        "the __no_edit__ segment was delivered more than once: "
+        "delivered=%r" % (payloads,)
+    )
+    assert _delivered_count(adapter, _SEGMENT_TWO) == 1, (
+        "post-boundary continuation was lost or duplicated: "
+        "delivered=%r" % (payloads,)
+    )


### PR DESCRIPTION
## This is a sibling follow-up to commit `1d1e1277e` (issue #8124)

- **What `1d1e1277e` covered:** a failed *edit* mid-segment. When an edit was rejected (flood control) and a tool boundary arrived before the retry, the guard at the `got_segment_break` reset flushed `_accumulated` as a fresh message so the pre-boundary tail was not lost.
- **What it did NOT touch:** a failed *first send*, where `_message_id` is never assigned; and the commentary reset, which has no guard at all.
- **What this adds:** both sites go through one shared helper that drops the `_message_id` truthiness term while keeping the `__no_edit__` exclusion, plus a regression that pins the sentinel so the fix cannot start double-sending.

## What does this PR do?

`_reset_segment_state` sets `self._message_id = None` at every tool boundary, so the next text segment enters the **first-send** branch of `_send_or_edit`. When that send fails, the branch does:

```python
else:
    # Initial send failed — disable streaming for this session
    self._edit_supported = False
    return False
```

`_message_id` is never assigned, so it stays `None`. `_last_sent_text` is never assigned either (that happens above the failure return), so `_reset_segment_state`'s `_delivered_segment_texts` bookkeeping records nothing.

The #8124 recovery flush was gated on:

```python
if (
    self._accumulated
    and not current_update_visible
    and self._message_id                      # <-- never true after a failed first send
    and self._message_id != "__no_edit__"
):
    await self._flush_segment_tail_on_edit_failure()
self._reset_segment_state(preserve_no_edit=True)
```

The `self._message_id` term is exactly the condition a failed first send can never satisfy, so the flush was skipped and the reset immediately wiped `_accumulated` — the only copy of the text. The commentary reset a few lines above (`if commentary_text is not None: self._reset_segment_state()`) had no guard at all and destroyed the same buffer.

**Symptom:** on a multi-tool turn where one send is rejected, the paragraph written between two tool calls ("Here's what I found, let me check X") never appears and is never re-sent. The final answer still lands, so the reply visibly jumps from tool bubble to tool bubble with the explanation missing. Every chat user on the default `transport: "edit"` path is exposed; no unusual config or exotic state is required.

The existing helper needs no change and is already safe with `_message_id = None`: `_try_strip_cursor()` early-returns on a falsy id, and `_visible_prefix()` returns `""` when `_last_sent_text` is `""`, so the prefix trim is skipped and the full buffer is sent as a new message. Only the caller's guard was excluding it.

## Related Issue

Relates to #8124 (closed; `1d1e1277e` was its fix — this completes the same guard for the first-send path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/stream_consumer.py` — new `_flush_undelivered_tail_before_reset()` next to `_flush_segment_tail_on_edit_failure()`. It keeps the `_accumulated` / `current_update_visible` / `__no_edit__` conditions and drops only the `_message_id` truthiness term.
- `gateway/stream_consumer.py` — the `got_segment_break` reset now calls the helper instead of carrying the inline guard; the surrounding `#8124` comment is updated to say the flush covers a failed first send as well as a failed edit.
- `gateway/stream_consumer.py` — the commentary reset calls the helper before `_reset_segment_state()`.
- `tests/gateway/test_stream_consumer_first_send_tail.py` — new, 3 tests (below).

### Sibling-site sweep

`grep -n "_reset_segment_state" gateway/stream_consumer.py` → 5 hits. Every call site is accounted for:

| site | verdict |
| --- | --- |
| `:285` | a comment, not a call site — excluded |
| `:552` | the definition — excluded |
| `:1122` (commentary, pre-send) | **COVERED** |
| `:1125` (commentary, post-send) | excluded — runs after `_send_commentary` delivered; `_accumulated` is already empty |
| `:1157` (segment break) | **COVERED** |

Plus the manual reset inside `_suppress_silence_marker` (`~:2047`), which is **excluded on purpose**: it is a deliberate retraction of the preview when the agent emits a bare `[SILENT]`/`NO_REPLY` marker, and it even deletes the previously-sent preview messages. Flushing there would resurrect text the agent chose not to send.

## How to Test

```
pytest tests/gateway/test_stream_consumer_first_send_tail.py -v
```

Three tests, all asserting on **delivered payloads** rather than internal attributes. The fake adapter fails only the editable-preview send path (the one the consumer marks with `expect_edits` in `_metadata_for_send`) and accepts plain sends — mirroring a real platform split, since Telegram keeps editable previews on the legacy send path.

1. `test_failed_first_send_tail_survives_tool_boundary` — deltas → tool boundary → deltas → done. Every preview send fails, so `_message_id` is still `None` at the boundary.
2. `test_failed_first_send_tail_survives_commentary_reset` — same, driven through the commentary path so the unguarded reset is the one under test. Also asserts the prose is delivered *before* the commentary that interrupted it.
3. `test_no_edit_sentinel_does_not_double_send` — adapter accepts the send but returns no `message_id`, driving `_message_id = "__no_edit__"`. Asserts the segment is delivered exactly once, pinning the sentinel exclusion so this change cannot regress into double-sending.

**Regression guard, both directions verified.** Reverting only the production hunks (tests untouched) turns 1 and 2 red:

```
E   AssertionError: text buffered before the commentary reset was dropped: delivered=['Using the shell tool...']
E   assert 0 == 1
```

The prose is entirely absent from what reached the user. Restoring the production change makes all three pass. Test 3 passes in both states by design — it pins existing behavior rather than demonstrating the bug.

**Adjacent suites, all green with the change applied:**

```
tests/gateway/test_stream_consumer_first_send_tail.py
tests/gateway/test_stream_consumer.py
tests/gateway/test_stream_consumer_draft.py
tests/gateway/test_stream_consumer_fresh_final.py
tests/gateway/test_stream_consumer_silence.py
tests/gateway/test_stream_consumer_thread_routing.py
tests/gateway/test_stale_finalize_suppression.py
tests/gateway/test_telegram_final_delivery.py
tests/gateway/test_telegram_overflow_partial.py
tests/gateway/test_duplicate_reply_suppression.py
tests/gateway/test_code_fence_tracking.py
tests/gateway/test_escape_reasoning_fences.py
tests/gateway/test_fence_chunker.py
tests/gateway/relay/test_relay_adapter.py
tests/gateway/relay/test_relay_slack_dm_streaming.py
tests/gateway/test_relay_capability_surface.py
tests/gateway/test_slack.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent gateway suites listed above instead of the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helper and the updated `#8124` comment block
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] N/A — pure Python, no platform-specific code paths touched
- [x] N/A — no tool descriptions or schemas changed

## Related / Positioning

**#8116** (@chinadbo, *"preserve accumulated text on chunk send failure"*) is the closest open PR by concern. Its hunk is `@@ -343,13` in the `_send_new_chunk` chunk-splitting path, i.e. a different failure site; this PR covers the segment-reset path and both of its call sites, so the two are disjoint and this is the broader of the two. Its test file (`tests/gateway/test_stream_consumer_text_loss.py`) is deliberately not the path used here, so there is no filename collision on merge.

Other open PRs touching `gateway/stream_consumer.py` were hunk-checked and are disjoint from `1112-1160`: **#80823** (`@@1078`, `@@2239`), **#79592** (`@@261`, `@@362`, `@@812`, `@@1164`), **#80173** (`@@971`, `@@1433`), **#10194** (leading-newline stripping), **#71725** (`gateway/run.py` only).
