### PR TITLE
fix(voice): apply the TTS-echo guard to the TUI/desktop full-duplex listener

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15940,6 +15940,11 @@ def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, li
             get_env_value=lambda key, default="": default,
         ),
     )
+    # Real is_tts_echo (not a stub) — the fake namespace below replaces the
+    # whole tools.voice_mode module, so the echo guard's own
+    # `from tools.voice_mode import is_tts_echo` needs it present here too.
+    from tools.voice_mode import is_tts_echo as _real_is_tts_echo
+
     monkeypatch.setitem(
         sys.modules,
         "tools.voice_mode",
@@ -15949,10 +15954,15 @@ def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, li
             full_duplex_listen=listen or default_fd_listen,
             is_audio_output_active=lambda: False,
             transcribe_recording=transcribe or (lambda path, model=None: {"success": True, "transcript": ""}),
+            is_tts_echo=_real_is_tts_echo,
         ),
     )
     # Fresh listener slot per test — the arm is idempotent per process.
     monkeypatch.setattr(server, "_fd_listener_active", False)
+    # Fresh echo-guard state per test (#75780) — both are bare module globals
+    # that persist across tests otherwise.
+    monkeypatch.setattr(server, "_fd_last_tts_text", "")
+    monkeypatch.setattr(server, "_fd_barge_phase", None)
     return started
 
 
@@ -16171,6 +16181,164 @@ def test_full_duplex_stop_phrase_mid_generation_ends_voice_chat(monkeypatch, tmp
     assert interrupted.is_set()
     assert ("voice.transcript", {"stop_phrase": True, "text": "stop"}) in events
     assert os.environ.get("HERMES_VOICE") == "0"  # voice chat ended
+
+
+def test_full_duplex_playback_phase_drops_tts_echo_transcript(monkeypatch, tmp_path):
+    """#75780 TUI counterpart of the CLI fix: a playback-phase capture that
+    closely matches the TTS text Hermes just spoke is speaker bleed, not
+    real user speech -- the full-duplex listener has no acoustic echo
+    cancellation. It must be dropped instead of emitted as voice.transcript
+    (which the client would otherwise submit as the next turn, replying to
+    itself), and the mic re-armed so real listening continues.
+
+    Uses the REAL _arm_full_duplex_listener (not a stub) — the bug this
+    pins only shows up through its actual idempotency check against
+    _fd_listener_active: calling arm() inline, while THIS call's own
+    _fd_listener_active flag is still True (not yet cleared by the outer
+    finally), is a same-thread no-op that early-returns before ever
+    spawning a new listener, silently dropping the mic. A stub that just
+    records "was arm() called" can't observe that early return. Instead we
+    patch threading.Thread so arm()'s eventual real spawn is observable
+    without actually starting a second listener thread that would recurse
+    into this test.
+    """
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
+    events: list = []
+    monkeypatch.setattr(
+        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+    )
+    # Simulate the real precondition: _arm_full_duplex_listener() already
+    # set this True before spawning the thread that runs
+    # _full_duplex_listener() (called directly here instead).
+    spawned_targets: list = []
+
+    class _FakeThread:
+        def __init__(self, target=None, daemon=None, name=None):
+            spawned_targets.append(target)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server.threading, "Thread", _FakeThread)
+
+    wav = tmp_path / "echo.wav"
+    wav.write_bytes(b"RIFF")
+
+    def fake_listen(should_stop, is_playing=None, on_trigger=None, **_kw):
+        on_trigger("playback")
+        return str(wav)
+
+    _fake_tts_modules(
+        monkeypatch,
+        listen=fake_listen,
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "yes that has already been said before",
+        },
+    )
+    monkeypatch.setattr(
+        server, "_fd_last_tts_text", "yes, that's already been said before"
+    )
+    # Simulate the real precondition: _arm_full_duplex_listener() already
+    # set this True before spawning the thread that runs
+    # _full_duplex_listener() (called directly here instead). Must come
+    # AFTER _fake_tts_modules(), which itself resets this False as its own
+    # "fresh listener slot per test" isolation — setting it earlier would
+    # be silently overwritten.
+    monkeypatch.setattr(server, "_fd_listener_active", True)
+
+    server._full_duplex_listener()
+
+    assert not any(event == "voice.transcript" for event, _payload in events)
+    # A genuinely new listener thread must have been spawned AFTER
+    # _fd_listener_active was cleared — not a no-op early return.
+    assert spawned_targets == [server._full_duplex_listener], (
+        "mic was never handed back after dropping the echo — the re-arm "
+        "ran while _fd_listener_active was still True and no-op'd"
+    )
+    # A successful re-arm sets this back True (a new listener is now
+    # active) — proving _arm_full_duplex_listener()'s idempotency check
+    # actually let the re-arm through instead of early-returning.
+    assert server._fd_listener_active is True
+    assert not wav.exists()  # capture temp file still cleaned up
+    assert server._fd_barge_phase is None  # cleared in the finally block
+
+
+def test_full_duplex_playback_phase_genuine_interjection_is_still_queued(
+    monkeypatch, tmp_path
+):
+    """A real user interjection during playback -- unrelated to the TTS
+    text -- must still reach the agent as voice.transcript."""
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
+    events: list = []
+    monkeypatch.setattr(
+        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+    )
+
+    wav = tmp_path / "interject.wav"
+    wav.write_bytes(b"RIFF")
+
+    def fake_listen(should_stop, is_playing=None, on_trigger=None, **_kw):
+        on_trigger("playback")
+        return str(wav)
+
+    _fake_tts_modules(
+        monkeypatch,
+        listen=fake_listen,
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "actually can you check my calendar for tomorrow",
+        },
+    )
+    monkeypatch.setattr(
+        server, "_fd_last_tts_text", "The weather today is sunny with a light breeze."
+    )
+
+    server._full_duplex_listener()
+
+    assert (
+        "voice.transcript",
+        {"text": "actually can you check my calendar for tomorrow"},
+    ) in events
+
+
+def test_full_duplex_generation_phase_transcript_not_echo_checked(
+    monkeypatch, tmp_path
+):
+    """Generation-phase barges (no TTS playing) are never treated as echo,
+    even if the transcript happens to match old TTS text -- the guard only
+    applies to playback-phase trips, which is where speaker bleed can
+    occur."""
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
+    events: list = []
+    monkeypatch.setattr(
+        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+    )
+    monkeypatch.setattr(server, "_sessions", {})
+
+    wav = tmp_path / "gen.wav"
+    wav.write_bytes(b"RIFF")
+
+    def fake_listen(should_stop, is_playing=None, on_trigger=None, **_kw):
+        on_trigger("generation")
+        return str(wav)
+
+    _fake_tts_modules(
+        monkeypatch,
+        listen=fake_listen,
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "stop, do it differently",
+        },
+    )
+    monkeypatch.setattr(server, "_fd_last_tts_text", "stop, do it differently")
+
+    server._full_duplex_listener()
+
+    assert ("voice.transcript", {"text": "stop, do it differently"}) in events
 
 
 def test_speak_text_with_barge_arms_monitor_and_cuts_playback(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9911,6 +9911,8 @@ def _run_prompt_submit(
             # begin() first — it cuts any still-speaking previous turn, and
             # that cut IS this turn's barge-in, so it must latch before we
             # consume the latch below.
+            global _fd_last_tts_text
+            _fd_last_tts_text = ""  # new turn, new spoken text (echo guard)
             tts_queue = _tts_stream_begin()
 
             # Full-duplex agent-turn listener: armed at utterance-submit so
@@ -9973,6 +9975,11 @@ def _run_prompt_submit(
                     payload["rendered"] = r
                 if tts_queue is not None and isinstance(delta, str):
                     tts_queue.put(delta)
+                    # Track what's actually being spoken so a playback-phase
+                    # barge capture can be checked against it (echo guard,
+                    # #75780).
+                    global _fd_last_tts_text
+                    _fd_last_tts_text = (_fd_last_tts_text or "") + delta
                 _emit("message.delta", sid, payload)
 
             # Surface interim assistant text (commentary emitted alongside
@@ -13205,6 +13212,15 @@ _fd_listener_active = False
 # the listener must cut THEIR private stop events too, and must keep
 # listening while any of them is still speaking.
 _fd_speak_pipelines: "set[tuple[threading.Event, threading.Event]]" = set()
+# Most recently spoken TTS text + the phase of the last barge trip (echo
+# guard, mirrors cli.py's _voice_last_tts_text/_voice_barge_phase, #75780:
+# the full-duplex listener has no acoustic echo cancellation, so speaker
+# bleed alone can trip it during playback and get transcribed as a self-
+# capture of Hermes' own reply, creating a TTS -> STT -> TTS feedback
+# loop). Process-global like the rest of this listener: voice is one mic,
+# one TTS output, regardless of which session is speaking.
+_fd_last_tts_text: str = ""
+_fd_barge_phase: "Optional[str]" = None
 
 
 def _arm_full_duplex_listener() -> None:
@@ -13244,7 +13260,8 @@ def _full_duplex_listener() -> None:
     Stop phrase is honored in both phases: mid-generation it interrupts the
     turn AND ends the voice chat ("stop everything").
     """
-    global _fd_listener_active
+    global _fd_listener_active, _fd_barge_phase
+    _rearm_on_exit = False
     try:
         from tools.tts_streaming import mark_speech_interrupted
         from tools.voice_mode import (
@@ -13286,6 +13303,8 @@ def _full_duplex_listener() -> None:
             stop_playback()
 
         def _on_trigger(phase: str) -> None:
+            global _fd_barge_phase
+            _fd_barge_phase = phase
             tripped.set()
             mark_speech_interrupted()
             if phase == "playback":
@@ -13354,7 +13373,37 @@ def _full_duplex_listener() -> None:
                         pass
                     _voice_emit("voice.transcript", {"stop_phrase": True, "text": text})
                 else:
-                    _voice_emit("voice.transcript", {"text": text})
+                    # Fail-closed echo guard (#75780): a playback-phase
+                    # capture has no acoustic echo cancellation, so speaker
+                    # bleed alone can trip the barge trigger. If the
+                    # transcript is a close match for what Hermes just
+                    # spoke, treat it as self-capture instead of emitting it
+                    # as the next user turn.
+                    _dropped_as_echo = False
+                    if _fd_barge_phase == "playback":
+                        try:
+                            from tools.voice_mode import is_tts_echo
+                            _dropped_as_echo = is_tts_echo(text, _fd_last_tts_text)
+                        except Exception:
+                            _dropped_as_echo = False
+                    if _dropped_as_echo:
+                        logger.debug(
+                            "Dropping playback-phase barge transcript as "
+                            "TTS echo: %r", text,
+                        )
+                        # No voice.transcript emitted, so the client will not
+                        # submit a new turn — real listening must continue.
+                        # Deferred to the finally below: this thread IS the
+                        # currently-armed listener (_fd_listener_active is
+                        # still True here), so calling
+                        # _arm_full_duplex_listener() at this point is a
+                        # no-op — its idempotency check returns immediately,
+                        # no new listener thread spawns, and the outer
+                        # finally then clears the flag, leaving the mic off
+                        # with nothing listening.
+                        _rearm_on_exit = True
+                    else:
+                        _voice_emit("voice.transcript", {"text": text})
         finally:
             try:
                 os.unlink(wav_path)
@@ -13365,6 +13414,12 @@ def _full_duplex_listener() -> None:
     finally:
         with _fd_listener_lock:
             _fd_listener_active = False
+        _fd_barge_phase = None
+        if _rearm_on_exit:
+            # Now that _fd_listener_active is False, this actually spawns a
+            # fresh listener thread instead of hitting the idempotency
+            # early-return above.
+            _arm_full_duplex_listener()
 
 
 def _speak_text_with_barge(text: str) -> None:
@@ -13378,6 +13433,9 @@ def _speak_text_with_barge(text: str) -> None:
     on a playback trip and keeps listening while this speak is pending.
     """
     from hermes_cli.voice import speak_text
+
+    global _fd_last_tts_text
+    _fd_last_tts_text = text  # echo guard (#75780) — see _full_duplex_listener
 
     stop = threading.Event()
     done = threading.Event()


### PR DESCRIPTION
## Summary

`d4a753ea4`/`979bf0cc4`/`b7bff6f2d`/`20e01f935` (#75780) hardened `cli.py`'s full-duplex barge-in listener against speaker-bleed self-capture: with no acoustic echo cancellation, TTS bleed alone can cross the barge threshold during playback, get transcribed, and get queued as the next user turn — whose reply is then spoken, captured, and queued again, producing an unbounded TTS → STT → TTS feedback loop. The fix compares a playback-phase transcript against the TTS text Hermes just spoke (`tools.voice_mode.is_tts_echo`) and drops a close match instead of queuing it.

`tui_gateway/server.py`'s `_full_duplex_listener()` is a second, independent implementation of the same feature (both added by `5081551f0`) serving the TUI/desktop voice surface, and never got the same guard: it had no tracking of "what did Hermes just say" at all, and unconditionally emitted every playback-phase transcript as `voice.transcript`, which the client submits as the next turn.

## Fix

Mirrors the CLI fix's exact mechanism, adapted to this file's process-global voice state (one mic, one TTS output, matching the existing `_fd_listener_active`/`_fd_speak_pipelines` pattern):
- `_fd_last_tts_text` accumulates streaming TTS deltas in `_stream()` (same accumulate-as-spoken approach as `cli.py`'s `stream_callback`) and is reset at turn start; `_speak_text_with_barge()` (the whole-reply fallback path + `voice.tts` RPC) sets it directly to the full text.
- `_fd_barge_phase` records the phase from `_on_trigger()`, cleared in the listener's `finally` block (matching `20e01f935`'s "clear stale phase" fix) so it can't leak into a future trip.
- On a playback-phase trip, `is_tts_echo(transcript, _fd_last_tts_text)` is checked before emitting `voice.transcript`; a match is dropped and the listener is re-armed instead (idempotent — a no-op if nothing is left to listen for) so real listening continues without the client having submitted a new turn to trigger it.

## Testing

- Added 3 regression tests to `tests/test_tui_gateway_server.py` mirroring `tests/tools/test_voice_cli_integration.py`'s `TestVoiceBargeCaptureSubmit` coverage: playback-phase echo dropped + listener re-armed, playback-phase genuine interjection still queued, generation-phase transcript never echo-checked even when it happens to match old TTS text.
- `_fake_tts_modules()` (shared harness) needed the real `is_tts_echo` attached to its fake `tools.voice_mode` namespace — it replaces the whole module, so the guard's own import would otherwise silently no-op through its except-Exception fallback (the first test run genuinely caught this).
- Mutation-verified: with the echo-check forced to always return `False`, the echo-drop test fails; with the real logic restored, all 12 `full_duplex`/`tts_stream` tests pass.
- Full `tests/test_tui_gateway_server.py`: 520/521 pass (the one failure, `test_write_json_serializes_concurrent_writes`, is a pre-existing threading-timing flake unrelated to voice code — passes reliably in isolation, confirmed failing the same way against pre-fix code).
- `ruff check` clean.

(`tests/tools/test_voice_mode.py` has 4 pre-existing failures — `TestPulseSocketReachable`, `TestWSL2PowerShellFallback` — on the sandbox this was developed on; confirmed unrelated by re-running against pre-fix code.)