### PR TITLE
fix(agent): defer preflight compression by projecting real usage instead of a fixed growth tolerance

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1358,6 +1358,7 @@ class ContextCompressor(ContextEngine):
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
+        self._pending_request_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._last_compression_telemetry = None
         self._active_compression_telemetry = None
@@ -1629,6 +1630,7 @@ class ContextCompressor(ContextEngine):
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
+        self._pending_request_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._last_compression_telemetry = None
         self._active_compression_telemetry = None
@@ -2106,6 +2108,7 @@ class ContextCompressor(ContextEngine):
         self.last_real_prompt_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.last_compression_rough_tokens = 0
+        self._pending_request_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         # Strikes were judged against the PREVIOUS threshold; a recomputed
         # trigger invalidates them. Keep the durable copy in sync so a
@@ -2397,6 +2400,7 @@ class ContextCompressor(ContextEngine):
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
+        self._pending_request_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
 
         self.summary_model = summary_model_override or ""
@@ -2485,6 +2489,17 @@ class ContextCompressor(ContextEngine):
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
+                elif self._pending_request_rough_tokens > 0:
+                    # Pair the provider's real prompt count with the rough
+                    # estimate of the request that produced it (recorded via
+                    # note_request_rough_estimate just before the call). This
+                    # keeps the defer baseline synchronized with real usage on
+                    # EVERY fitting response, not only right after a
+                    # compaction — without it, sessions that never compressed
+                    # have no baseline and preflight fires on the raw rough
+                    # estimate alone, which overcounts CJK text and provider
+                    # replay blobs severalfold.
+                    self.last_rough_tokens_when_real_prompt_fit = self._pending_request_rough_tokens
                 # Any real provider reading below the trigger proves the prompt
                 # fits again. Clear the real-usage effectiveness latch even
                 # when this response was not immediately after compaction. The
@@ -2493,6 +2508,7 @@ class ContextCompressor(ContextEngine):
                 self._record_ineffective_compression_verdict(0)
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
+            self._pending_request_rough_tokens = 0
 
             # Anti-thrashing verdict, judged HERE because this is the only place
             # that sees the provider's real prompt count for the just-compacted
@@ -2543,16 +2559,45 @@ class ContextCompressor(ContextEngine):
             return
         self.last_prompt_tokens = snapshot
 
+    def note_request_rough_estimate(self, rough_tokens: int) -> None:
+        """Record the rough estimate of the request about to be sent.
+
+        ``update_from_response()`` pairs this with the provider's real
+        ``prompt_tokens`` for the same request, giving
+        ``should_defer_preflight_to_real_usage()`` a synchronized
+        (rough, real) anchor to project real usage from rough growth.
+        Usage-less responses do not consume the pending value, so a
+        transport that reports usage separately still pairs correctly.
+        """
+        try:
+            self._pending_request_rough_tokens = max(0, int(rough_tokens))
+        except (TypeError, ValueError):
+            self._pending_request_rough_tokens = 0
+
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
         """Return True when a high rough preflight estimate is known-noisy.
 
         ``estimate_request_tokens_rough(..., tools=...)`` intentionally
-        overestimates schema-heavy requests so Hermes compresses before a
-        provider rejects the payload. After a successful compressed API call,
-        though, provider ``prompt_tokens`` are a better signal than repeating
-        compaction from the same rough schema overhead. Defer only while the
-        rough estimate has grown modestly since a request the provider proved
-        fit under the threshold.
+        overestimates so Hermes compresses before a provider rejects the
+        payload — but the margin is not a fixed percentage: CJK text is
+        counted at ~1.7x its o200k cost and Responses-mode reasoning replay
+        blobs at several times their billed cost, so heavy sessions can show
+        a rough estimate 2-3x real usage and compact at 35-55% of the real
+        window (churn: each pass stalls the turn for minutes and discards
+        detail).
+
+        Instead of tolerating a fixed rough-growth allowance, project real
+        usage from the last synchronized (rough, real) pair::
+
+            projected_real = last_real + (rough_now - rough_at_last_real)
+
+        Rough growth is itself an overestimate of real growth (every content
+        class is counted at >= its tokenizer cost), so the projection is an
+        upper bound on real usage and deferring below the threshold is safe.
+        Compression fires when the projection — not the raw estimate —
+        crosses the threshold. Should a pathological delta still slip past
+        the threshold, the provider's context-overflow error handler
+        compacts with the authoritative signal, as before.
         """
         if rough_tokens < self.threshold_tokens:
             return False
@@ -2577,13 +2622,13 @@ class ContextCompressor(ContextEngine):
         if baseline <= 0:
             return False
 
+        # No baseline ratchet here: the (rough, real) pair is refreshed by
+        # update_from_response() on every fitting response. Advancing the
+        # rough baseline without a matching real reading would shrink
+        # apparent growth and defer on stale data — the unsafe direction.
         growth = max(0, rough_tokens - baseline)
-        tolerated_growth = max(4096, int(self.threshold_tokens * 0.05))
-        if growth > tolerated_growth:
-            return False
-
-        self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
-        return True
+        projected_real = self.last_real_prompt_tokens + growth
+        return projected_real < self.threshold_tokens
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1976,6 +1976,15 @@ def run_conversation(
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
         total_chars = approx_tokens * 4
+        # Stash this request's rough estimate so update_from_response() can
+        # pair it with the provider's real prompt count — the (rough, real)
+        # anchor behind should_defer_preflight_to_real_usage()'s projection.
+        # getattr guard: test doubles built via object.__new__ lack the method.
+        _note_rough = getattr(
+            agent.context_compressor, "note_request_rough_estimate", None
+        )
+        if callable(_note_rough):
+            _note_rough(request_pressure_tokens)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -98,14 +98,89 @@ class TestUpdateFromResponse:
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
 
+    def test_pairs_noted_rough_estimate_with_fitting_real_usage(self, compressor):
+        """note_request_rough_estimate() + a fitting response must anchor the
+        defer baseline even when no compression ever ran — this is what gives
+        fresh sessions a (rough, real) pair before their first compaction."""
+        compressor.note_request_rough_estimate(120_000)
+        compressor.update_from_response({"prompt_tokens": 60_000})
+
+        assert compressor.last_real_prompt_tokens == 60_000
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 120_000
+        # Consumed: a later usage-bearing response without a fresh note keeps
+        # the previous pair instead of re-pairing against a stale estimate.
+        assert compressor._pending_request_rough_tokens == 0
+
+    def test_post_compression_pairing_wins_over_noted_estimate(self, compressor):
+        """Right after a compaction the post-compression rough count is the
+        authoritative baseline (#36718); a stale pre-compression note must not
+        displace it."""
+        compressor.note_request_rough_estimate(120_000)
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_compression_rough_tokens = 40_000
+        compressor.update_from_response({"prompt_tokens": 30_000})
+
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 40_000
+
+    def test_usage_less_response_preserves_pending_note(self, compressor):
+        """Transports that report usage separately send usage-less responses
+        first; the pending pair must survive until real usage arrives."""
+        compressor.note_request_rough_estimate(120_000)
+        compressor.update_from_response({})
+
+        assert compressor._pending_request_rough_tokens == 120_000
+
+    def test_over_threshold_real_usage_clears_pending_note(self, compressor):
+        compressor.note_request_rough_estimate(120_000)
+        compressor.update_from_response({"prompt_tokens": 90_000})
+
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 0
+        assert compressor._pending_request_rough_tokens == 0
+
 class TestPreflightDeferral:
 
-    def test_does_not_defer_when_rough_growth_is_large(self, compressor):
+    def test_defers_while_projected_real_usage_fits(self, compressor):
+        """Large rough growth alone must not trigger compaction: with real
+        usage at 50K and 10K of rough growth since that reading, projected
+        real usage is 60K — far under the 85K threshold. The old fixed 5%
+        growth tolerance compacted here at ~59% of the real window (CJK /
+        replay-blob overcount churn)."""
         compressor.threshold_tokens = 85_000
         compressor.last_real_prompt_tokens = 50_000
         compressor.last_rough_tokens_when_real_prompt_fit = 90_000
 
+        assert compressor.should_defer_preflight_to_real_usage(100_000) is True
+
+    def test_does_not_defer_when_projected_real_usage_crosses_threshold(self, compressor):
+        """Projection = last real + rough growth. 80K real + 6K growth = 86K
+        >= 85K threshold: compression must run."""
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 80_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 90_000
+
+        assert compressor.should_defer_preflight_to_real_usage(96_000) is False
+
+    def test_does_not_defer_without_a_baseline(self, compressor):
+        """No synchronized (rough, real) pair yet — fall back to trusting the
+        rough estimate (conservative: compress)."""
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 50_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 0
+        compressor.last_compression_rough_tokens = 0
+
         assert compressor.should_defer_preflight_to_real_usage(100_000) is False
+
+    def test_defer_does_not_ratchet_baseline(self, compressor):
+        """The baseline is refreshed only by update_from_response() pairing.
+        Deferring must not advance it: without a fresh real reading, a
+        ratcheted baseline would shrink apparent growth and defer on stale
+        data."""
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 50_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 90_000
+
+        assert compressor.should_defer_preflight_to_real_usage(100_000) is True
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 90_000
 
 
     def test_defers_immediately_after_compaction_with_stale_real_prompt(self, compressor):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -771,13 +771,16 @@ class TestPreflightCompression:
         assert not any("Preflight compression" in msg for msg in lifecycle_messages)
 
 
-    def test_preflight_compresses_when_rough_growth_after_fit_is_large(self, agent):
-        """Large rough growth after a fitting request still triggers preflight."""
+    def test_preflight_compresses_when_projected_real_usage_crosses(self, agent):
+        """Projected real usage (last real + rough growth) crossing the
+        threshold still triggers preflight: 95K real + 12K rough growth =
+        107K >= 100K. Growth alone no longer decides — real usage far below
+        the threshold defers instead (see TestPreflightDeferral)."""
         agent.compression_enabled = True
         agent.context_compressor.context_length = 200_000
         agent.context_compressor.threshold_tokens = 100_000
-        agent.context_compressor.last_prompt_tokens = 58_000
-        agent.context_compressor.last_real_prompt_tokens = 58_000
+        agent.context_compressor.last_prompt_tokens = 95_000
+        agent.context_compressor.last_real_prompt_tokens = 95_000
         agent.context_compressor.last_rough_tokens_when_real_prompt_fit = 113_000
 
         big_history = []


### PR DESCRIPTION
## What does this PR do?

Stops preflight compression from firing at 35–55% of the model's real context window on sessions where the rough token estimate runs far ahead of provider-reported usage.

`estimate_request_tokens_rough` intentionally overestimates, but the margin is not a fixed percentage — it depends on content class. Measured against o200k on a live Responses-mode session: CJK text is counted at ~1.7x its tokenizer cost, and encrypted reasoning replay items (`codex_reasoning_items`, counted at base64-length/4) at several times their billed cost. On a CJK-heavy session with reasoning replay, the preflight estimate reached ~413K tokens while the provider had just reported `prompt_tokens=150K` for the preceding call — a 2.76x gap. The result is compaction churn: the session compacts minutes-long summary passes at half the real window, discards conversation detail (220 → 71 messages), regrows, and re-fires within the hour.

The existing defer guard (#36718) can't help, for two reasons:

- it tolerates only `max(4096, 5% of threshold)` rough growth since the last proven-fit request — a single heavy tool turn exceeds that; and
- sessions that never compressed have no baseline at all (`last_rough_tokens_when_real_prompt_fit` is only seeded post-compaction), so a fresh session gets zero deferral — observed as a session force-compacted 24 minutes after it started, at ~35% real usage.

**The change**: pair every request's rough estimate with the provider's real `prompt_tokens` for that same request, then defer preflight while *projected* real usage stays under the threshold:

```
projected_real = last_real_prompt_tokens + (rough_now − rough_at_last_real)
```

- `note_request_rough_estimate()` records the request-pressure estimate in the conversation loop right after it is computed;
- `update_from_response()` consumes it when real usage arrives and fits, keeping the (rough, real) anchor synchronized on every fitting response — not only right after a compaction;
- `should_defer_preflight_to_real_usage()` compares the projection, not a fixed growth allowance, against the threshold. Compression fires when the projection crosses it.

Safety: rough growth over-counts every content class relative to the tokenizer, so the projection is an upper bound on real usage and deferring below the threshold cannot skip a needed compaction. The baseline deliberately no longer ratchets inside the defer check — advancing it without a matching real reading would shrink apparent growth and defer on stale data. All existing backstops are untouched: the post-compaction `awaiting_real_usage` single-turn defer, the anti-thrash verdicts, model-switch state clearing (#23767), and the provider context-overflow error handler as the authoritative last resort.

This also improves the opposite failure mode (#62605, rough estimate *under*-counting for some tokenizers): because the trigger is anchored on provider-reported usage, the projection crosses the threshold earlier than the raw estimate would, instead of trusting an undercount until the server rejects the request.

Related: #36718 (the defer mechanism this generalizes), #62605 (underestimate direction, helped but the output-budget component is out of scope), #58784 (per-class CJK coefficient disputes — moot under this approach, since the trigger self-corrects from real usage regardless of coefficient sign), #14695 (why the rough estimate intentionally overestimates schemas).

## Related Issue

No open issue describes the overestimate-churn defect exactly; closest reports are linked above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — new `note_request_rough_estimate()`; `update_from_response()` pairs the pending estimate with real usage (post-compaction pairing still wins, #36718); `should_defer_preflight_to_real_usage()` projects real usage instead of tolerating fixed growth; `_pending_request_rough_tokens` reset alongside the existing calibration state at all four reset sites (init, session end, cross-session guard, model switch).
- `agent/conversation_loop.py` — record the request-pressure estimate right after it is computed (getattr-guarded for minimal test doubles / third-party context engines).
- `tests/agent/test_context_compressor.py` — 4 new deferral tests (projection under/over threshold, no-baseline fallback, no-ratchet) and 4 new pairing tests (pairing, post-compaction precedence, usage-less response preservation, over-threshold clearing); 1 test updated to the projection semantics.
- `tests/run_agent/test_413_compression.py` — preflight integration test updated: fires when the projection crosses the threshold.

## How to Test

1. `pytest tests/agent/test_context_compressor.py tests/run_agent/test_413_compression.py tests/agent/test_preflight_lock_defer.py tests/agent/test_engine_preflight_wire.py tests/run_agent/test_compression_lock_defer.py tests/agent/test_compaction_anti_thrash.py tests/agent/test_compression_anti_thrash_recovery.py -q` — 169 passed on this branch.
2. Churn repro: run a long CJK-heavy conversation (or any session that accumulates encrypted reasoning replay items) against a ~272K-context model and watch the logs. Before: `Preflight compression: ~413,524 tokens >= 244,800 threshold` fires while the preceding API call reported ~150K real prompt tokens, and a session can be compacted within its first half hour. After: preflight logs show deferral until projected real usage reaches the threshold; compaction frequency drops from several per session to near zero until real usage genuinely approaches the window.
3. Regression check: force a compaction (`/compress` or shrink the threshold) and confirm the post-compaction flow is unchanged — one-turn defer while awaiting real usage, then normal operation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the compression/conversation-loop suites listed above (169 passed); the full `tests/` run on my machine has environment-dependent failures (i18n catalogs, models.dev fetch, etc.) that are identical on clean `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11
- [x] Verified live on a production gateway (Codex Responses transport, gpt-5.6-sol @ 272K): deploy, graceful restart, warmup call healthy

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — behavior documented in `should_defer_preflight_to_real_usage` / `note_request_rough_estimate`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
