### PR TITLE
fix(cron): preserve concurrent creates when saving jobs.json (salvage of #80687 + #80703)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -298,6 +298,12 @@ def _jobs_lock():
 
     with _jobs_file_lock:
         _jobs_lock_state.depth = 1
+        # Stamp of jobs.json as of this section's load_jobs() (#80703's
+        # fast-path, credit @JoaoMarcos44): lets _save_jobs_unlocked skip the
+        # shrink-merge parse when the file provably hasn't changed since this
+        # section read it. Reset on entry/exit so stale stamps from unlocked
+        # loads or prior sections can never suppress a needed merge.
+        _jobs_lock_state.load_stamp = None
         lock_fd = None
         try:
             try:
@@ -363,6 +369,7 @@ def _jobs_lock():
                         lock_fd.close()
         finally:
             _jobs_lock_state.depth = 0
+            _jobs_lock_state.load_stamp = None
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -1010,33 +1017,43 @@ def get_ticker_last_error() -> Optional[str]:
 # Job CRUD Operations
 # =============================================================================
 
+def _parse_jobs_file(jobs_file: Path) -> Tuple[Any, bool]:
+    """Tolerantly parse jobs.json; shared by load_jobs and the save-path peek.
+
+    Returns ``(data, used_strict_fallback)``. utf-8-sig absorbs a Windows
+    BOM; a strict parse failure is retried with ``strict=False`` to survive
+    bare control characters in string values. IO errors from the open and
+    parse errors from the fallback propagate to the caller, which decides
+    between repair (load_jobs) and bail-out (peek).
+    """
+    with open(jobs_file, "r", encoding="utf-8-sig") as f:
+        raw = f.read()
+    try:
+        return json.loads(raw), False
+    except json.JSONDecodeError:
+        return json.loads(raw, strict=False), True
+
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
+    # Stamp BEFORE reading (fail-safe direction — see _record_load_stamp):
+    # a sibling write racing this load leaves the stamp older than disk, so
+    # the save-path merge runs instead of being wrongly skipped.
+    pre_read_stamp = _jobs_file_stamp(jobs_file)
     if not jobs_file.exists():
+        _record_load_stamp(None)
         return []
 
-    _strict_retry = False  # track whether we used the strict=False fallback
-
     try:
-        # utf-8-sig: Windows Notepad / PowerShell 5.1 Set-Content -Encoding UTF8
-        # write a leading BOM; json.load under plain utf-8 raises
-        # JSONDecodeError("Unexpected UTF-8 BOM") and takes down cron.
-        with open(jobs_file, 'r', encoding='utf-8-sig') as f:
-            data = json.load(f)
-    except json.JSONDecodeError:
-        # Retry with strict=False to handle bare control chars in string values
-        _strict_retry = True
-        try:
-            with open(jobs_file, 'r', encoding='utf-8-sig') as f:
-                data = json.loads(f.read(), strict=False)
-        except Exception as e:
-            logger.error("Failed to auto-repair jobs.json: %s", e)
-            raise RuntimeError(f"Cron database corrupted and unrepairable: {e}") from e
+        data, _strict_retry = _parse_jobs_file(jobs_file)
     except IOError as e:
         logger.error("IOError reading jobs.json: %s", e)
         raise RuntimeError(f"Failed to read cron database: {e}") from e
+    except Exception as e:
+        logger.error("Failed to auto-repair jobs.json: %s", e)
+        raise RuntimeError(f"Cron database corrupted and unrepairable: {e}") from e
 
     # Validate the top-level JSON shape: accept a dict (expected) or a bare
     # list (auto-repair). Anything else (str/number/null) is corruption that
@@ -1048,6 +1065,7 @@ def load_jobs() -> List[Dict[str, Any]]:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)
             logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+        _record_load_stamp(pre_read_stamp)
         return jobs
     if isinstance(data, list):
         # Bare array — likely saved/edited outside save_jobs(). Wrap it back
@@ -1055,6 +1073,7 @@ def load_jobs() -> List[Dict[str, Any]]:
         if data:
             save_jobs(data)
             logger.warning("Auto-repaired jobs.json (bare list wrapped as dict)")
+        _record_load_stamp(pre_read_stamp)
         return data
 
     raise RuntimeError(
@@ -1067,20 +1086,18 @@ def _peek_jobs_unlocked() -> Optional[List[Dict[str, Any]]]:
 
     Caller must hold ``_jobs_lock()``. Returns ``[]`` when the file is
     missing, ``None`` when the payload is unreadable/corrupt (caller should
-    not attempt a shrink-merge against an unknown baseline).
+    not attempt a shrink-merge against an unknown baseline). Never calls
+    ``save_jobs`` — the repair-free property is what keeps the save path
+    re-entrancy-safe (a repairing read here would recurse through
+    ``_save_jobs_unlocked``).
     """
     jobs_file = _current_cron_store().jobs_file
     if not jobs_file.exists():
         return []
     try:
-        with open(jobs_file, "r", encoding="utf-8-sig") as f:
-            data = json.load(f)
+        data, _ = _parse_jobs_file(jobs_file)
     except Exception:
-        try:
-            with open(jobs_file, "r", encoding="utf-8-sig") as f:
-                data = json.loads(f.read(), strict=False)
-        except Exception:
-            return None
+        return None
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
         return jobs if isinstance(jobs, list) else None
@@ -1089,12 +1106,48 @@ def _peek_jobs_unlocked() -> Optional[List[Dict[str, Any]]]:
     return None
 
 
+def _jobs_file_stamp(jobs_file: Path) -> Optional[Tuple[int, int, int]]:
+    """Cheap change-detection stamp for jobs.json: ``(mtime_ns, size, ino)``.
+
+    ``None`` means the file is missing/unstatable. Used as a fast-path gate
+    in front of the shrink-merge so the healthy no-race save costs one
+    ``stat()`` instead of a full read+parse (the ``advance_next_runs``
+    batching exists because this path is hot — see its docstring).
+    ``st_ino`` is included because every legitimate writer goes through
+    mkstemp+rename (new inode), so even a same-size write inside one mtime
+    quantum on a coarse-clock filesystem (ext4 jiffies, network mounts)
+    cannot false-match.
+    """
+    try:
+        st = jobs_file.stat()
+        return (st.st_mtime_ns, st.st_size, st.st_ino)
+    except OSError:
+        return None
+
+
+def _record_load_stamp(stamp: Optional[Tuple[int, int, int]]) -> None:
+    """Remember jobs.json's stamp for the enclosing _jobs_lock() section.
+
+    No-op outside a critical section. Lets the save path skip the
+    shrink-merge parse when the file provably hasn't changed since this
+    section loaded it (#80703's fast-path). The caller must capture the
+    stamp BEFORE reading the file: a sibling landing mid-read then leaves
+    the recorded stamp OLDER than disk — a mismatch, so the merge runs
+    (fail-safe direction). Stamping after the read would let that sibling's
+    write be certified as "seen" without being in the loaded payload,
+    wrongly suppressing the recovery.
+    """
+    if not getattr(_jobs_lock_state, "depth", 0):
+        return
+    _jobs_lock_state.load_stamp = stamp
+
+
 def _merge_unexpected_disk_jobs(
     jobs: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Collection[str]] = None,
 ) -> List[Dict[str, Any]]:
-    """Re-attach on-disk jobs missing from a save payload (#80624).
+    """Return *jobs* plus any on-disk jobs missing from the save payload (#80624).
 
     Under ``_jobs_lock()``'s degraded flock-timeout path (#60703), two
     processes can both believe they own the store. A writer that loaded an
@@ -1105,8 +1158,18 @@ def _merge_unexpected_disk_jobs(
 
     Intentional deletes pass ``removed_ids``. Any other id present on disk
     but absent from *jobs* is treated as a concurrent create and merged
-    back before the atomic write.
+    back before the atomic write. The caller's list is never mutated — a
+    new list is returned when anything was recovered.
+
+    Fast path: when the enclosing critical section recorded a load stamp
+    and the file's ``(mtime_ns, size)`` still matches, nothing can have
+    changed underneath us, so the read+parse is skipped entirely — one
+    ``stat()`` on the healthy no-race save.
     """
+    stamp = getattr(_jobs_lock_state, "load_stamp", None)
+    if stamp is not None and _jobs_file_stamp(_current_cron_store().jobs_file) == stamp:
+        return jobs
+
     disk_jobs = _peek_jobs_unlocked()
     if disk_jobs is None:
         return jobs
@@ -1117,7 +1180,7 @@ def _merge_unexpected_disk_jobs(
         if isinstance(job, dict) and job.get("id"):
             new_ids.add(str(job["id"]))
 
-    preserved = 0
+    recovered: List[Dict[str, Any]] = []
     for disk_job in disk_jobs:
         if not isinstance(disk_job, dict):
             continue
@@ -1127,18 +1190,19 @@ def _merge_unexpected_disk_jobs(
         disk_id = str(disk_id)
         if disk_id in new_ids or disk_id in intended_remove:
             continue
-        jobs.append(disk_job)
+        recovered.append(disk_job)
         new_ids.add(disk_id)
-        preserved += 1
 
-    if preserved:
-        logger.warning(
-            "Preserved %d cron job(s) present on disk but missing from the "
-            "in-memory save payload (concurrent create under degraded lock "
-            "or stale writer) (#80624)",
-            preserved,
-        )
-    return jobs
+    if not recovered:
+        return jobs
+    logger.warning(
+        "Preserved %d cron job(s) present on disk but missing from the "
+        "in-memory save payload (concurrent create under degraded lock "
+        "or stale writer) (#80624): %s",
+        len(recovered),
+        [j.get("id") for j in recovered],
+    )
+    return jobs + recovered
 
 
 def _save_jobs_unlocked(
@@ -1173,11 +1237,13 @@ def _save_jobs_unlocked(
     # path another process can create a job between our load and our write.
     # Merge unexpected disk ids into the payload, stage the write, then
     # re-peek; if new ids appeared, merge again and restage before replace.
+    # The merge itself fast-paths to a single stat() when the enclosing
+    # section's load stamp still matches (see _merge_unexpected_disk_jobs).
     tmp_path = None
     try:
         for _attempt in range(5):
             if not replace:
-                _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
+                jobs = _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
             fd, tmp_path = tempfile.mkstemp(
                 dir=str(jobs_file.parent), suffix=".tmp", prefix=".jobs_"
             )
@@ -1199,7 +1265,15 @@ def _save_jobs_unlocked(
                 raise
 
             if not replace:
-                disk_jobs = _peek_jobs_unlocked()
+                # Verify-after-stage: a sibling landing while we serialized
+                # the payload must trigger another merge round. Same stamp
+                # fast path as the merge — an unchanged stamp proves nothing
+                # was written, so the full parse is skipped.
+                _stamp = getattr(_jobs_lock_state, "load_stamp", None)
+                _unchanged = (
+                    _stamp is not None and _jobs_file_stamp(jobs_file) == _stamp
+                )
+                disk_jobs = None if _unchanged else _peek_jobs_unlocked()
                 if disk_jobs is not None:
                     payload_ids = {
                         str(j["id"])
@@ -1225,11 +1299,20 @@ def _save_jobs_unlocked(
             tmp_path = None
             _secure_file(jobs_file)
             _preserve_file_ownership(jobs_file, _stat_before)
+            # Invalidate (never refresh) the stamp after writing: the stamp
+            # certifies "this section's loaded payload still matches disk",
+            # which stops being provable the moment anyone writes. A refresh
+            # here would let a nested save (e.g. create_job inside a broader
+            # section) certify disk against an OUTER caller's stale payload
+            # and deterministically clobber the nested create; it also races
+            # a degraded sibling landing between replace and stat. Later
+            # saves in this section simply take the full merge (fail-safe).
+            _record_load_stamp(None)
             return
 
         # Exhausted retries — last merge + write without another re-peek.
         if not replace:
-            _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
+            jobs = _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
         fd, tmp_path = tempfile.mkstemp(
             dir=str(jobs_file.parent), suffix=".tmp", prefix=".jobs_"
         )

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -34,7 +34,7 @@ except ImportError:  # pragma: no cover - non-Windows
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Set, Tuple, Union
+from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
 logger = logging.getLogger(__name__)
 
@@ -1062,8 +1062,97 @@ def load_jobs() -> List[Dict[str, Any]]:
     )
 
 
-def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
-    """Save all jobs to storage. Caller must hold _jobs_lock()."""
+def _peek_jobs_unlocked() -> Optional[List[Dict[str, Any]]]:
+    """Best-effort read of on-disk jobs without repair side-effects.
+
+    Caller must hold ``_jobs_lock()``. Returns ``[]`` when the file is
+    missing, ``None`` when the payload is unreadable/corrupt (caller should
+    not attempt a shrink-merge against an unknown baseline).
+    """
+    jobs_file = _current_cron_store().jobs_file
+    if not jobs_file.exists():
+        return []
+    try:
+        with open(jobs_file, "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+    except Exception:
+        try:
+            with open(jobs_file, "r", encoding="utf-8-sig") as f:
+                data = json.loads(f.read(), strict=False)
+        except Exception:
+            return None
+    if isinstance(data, dict):
+        jobs = data.get("jobs", [])
+        return jobs if isinstance(jobs, list) else None
+    if isinstance(data, list):
+        return data
+    return None
+
+
+def _merge_unexpected_disk_jobs(
+    jobs: List[Dict[str, Any]],
+    *,
+    removed_ids: Optional[Collection[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Re-attach on-disk jobs missing from a save payload (#80624).
+
+    Under ``_jobs_lock()``'s degraded flock-timeout path (#60703), two
+    processes can both believe they own the store. A writer that loaded an
+    older/smaller snapshot then calls ``save_jobs`` and would otherwise
+    clobber concurrent creates (the filed ``no_agent`` watchdog pattern:
+    CLI/tool create succeeds, then a gateway tick/remove rewrites
+    ``jobs.json`` empty or without the new id).
+
+    Intentional deletes pass ``removed_ids``. Any other id present on disk
+    but absent from *jobs* is treated as a concurrent create and merged
+    back before the atomic write.
+    """
+    disk_jobs = _peek_jobs_unlocked()
+    if disk_jobs is None:
+        return jobs
+
+    intended_remove = {str(i) for i in (removed_ids or ()) if i}
+    new_ids: Set[str] = set()
+    for job in jobs:
+        if isinstance(job, dict) and job.get("id"):
+            new_ids.add(str(job["id"]))
+
+    preserved = 0
+    for disk_job in disk_jobs:
+        if not isinstance(disk_job, dict):
+            continue
+        disk_id = disk_job.get("id")
+        if not disk_id:
+            continue
+        disk_id = str(disk_id)
+        if disk_id in new_ids or disk_id in intended_remove:
+            continue
+        jobs.append(disk_job)
+        new_ids.add(disk_id)
+        preserved += 1
+
+    if preserved:
+        logger.warning(
+            "Preserved %d cron job(s) present on disk but missing from the "
+            "in-memory save payload (concurrent create under degraded lock "
+            "or stale writer) (#80624)",
+            preserved,
+        )
+    return jobs
+
+
+def _save_jobs_unlocked(
+    jobs: List[Dict[str, Any]],
+    *,
+    removed_ids: Optional[Collection[str]] = None,
+    replace: bool = False,
+):
+    """Save all jobs to storage. Caller must hold _jobs_lock().
+
+    ``removed_ids`` lists job ids this mutation intentionally deleted.
+    ``replace=True`` skips the shrink-merge guard (tests / disaster recovery
+    that mean to rewrite the store wholesale).
+    """
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     # Snapshot the current owner BEFORE the atomic replace so a privileged
@@ -1079,27 +1168,105 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
             _stat_before = os.stat(jobs_file.parent)
         except OSError:
             _stat_before = None
-    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
+
+    # Shrink-merge + rewrite loop (#80624): under the degraded flock-timeout
+    # path another process can create a job between our load and our write.
+    # Merge unexpected disk ids into the payload, stage the write, then
+    # re-peek; if new ids appeared, merge again and restage before replace.
+    tmp_path = None
     try:
-        with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+        for _attempt in range(5):
+            if not replace:
+                _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(jobs_file.parent), suffix=".tmp", prefix=".jobs_"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(
+                        {"jobs": jobs, "updated_at": _hermes_now().isoformat()},
+                        f,
+                        indent=2,
+                    )
+                    f.flush()
+                    os.fsync(f.fileno())
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                tmp_path = None
+                raise
+
+            if not replace:
+                disk_jobs = _peek_jobs_unlocked()
+                if disk_jobs is not None:
+                    payload_ids = {
+                        str(j["id"])
+                        for j in jobs
+                        if isinstance(j, dict) and j.get("id")
+                    }
+                    intended = {str(i) for i in (removed_ids or ()) if i}
+                    if any(
+                        isinstance(dj, dict)
+                        and dj.get("id")
+                        and str(dj["id"]) not in payload_ids
+                        and str(dj["id"]) not in intended
+                        for dj in disk_jobs
+                    ):
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+                        tmp_path = None
+                        continue
+
+            atomic_replace(tmp_path, jobs_file)
+            tmp_path = None
+            _secure_file(jobs_file)
+            _preserve_file_ownership(jobs_file, _stat_before)
+            return
+
+        # Exhausted retries — last merge + write without another re-peek.
+        if not replace:
+            _merge_unexpected_disk_jobs(jobs, removed_ids=removed_ids)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(jobs_file.parent), suffix=".tmp", prefix=".jobs_"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(
+                {"jobs": jobs, "updated_at": _hermes_now().isoformat()},
+                f,
+                indent=2,
+            )
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, jobs_file)
+        tmp_path = None
         _secure_file(jobs_file)
         _preserve_file_ownership(jobs_file, _stat_before)
     except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
         raise
 
 
-def save_jobs(jobs: List[Dict[str, Any]]):
-    """Save all jobs to storage."""
+def save_jobs(
+    jobs: List[Dict[str, Any]],
+    *,
+    removed_ids: Optional[Collection[str]] = None,
+    replace: bool = False,
+):
+    """Save all jobs to storage.
+
+    See ``_save_jobs_unlocked`` for ``removed_ids`` / ``replace`` semantics
+    (shrink-merge guard against concurrent-create clobber, #80624).
+    """
     with _jobs_lock():
-        _save_jobs_unlocked(jobs)
+        _save_jobs_unlocked(jobs, removed_ids=removed_ids, replace=replace)
 
 
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
@@ -1678,7 +1845,7 @@ def remove_job(job_id: str) -> bool:
             # left over from before the create-time guard) fails closed without
             # half-applying the removal.
             job_output_dir = _job_output_dir(canonical_id)
-            save_jobs(jobs)
+            save_jobs(jobs, removed_ids={canonical_id})
             # Clean up output directory to prevent orphaned dirs accumulating
             if job_output_dir.exists():
                 shutil.rmtree(job_output_dir)
@@ -1890,7 +2057,7 @@ def claim_dispatch(job_id: str) -> bool:
                 # it stops appearing as due, and leave an operator-visible
                 # diagnostic instead of vanishing silently.
                 jobs.pop(i)
-                save_jobs(jobs)
+                save_jobs(jobs, removed_ids={job_id})
                 _write_wedged_oneshot_diagnostic(job)
                 logger.info(
                     "Job '%s': dispatch limit reached (%d/%d) — removing",
@@ -2102,15 +2269,22 @@ def _completed_oneshot_retention_days() -> float:
         return float(COMPLETED_ONESHOT_RETENTION_DAYS)
 
 
-def _sweep_completed_oneshots(raw_jobs: List[Dict[str, Any]], now: datetime) -> bool:
+def _sweep_completed_oneshots(
+    raw_jobs: List[Dict[str, Any]],
+    now: datetime,
+    *,
+    removed_ids: Optional[Set[str]] = None,
+) -> bool:
     """Prune terminal ``state == "completed"`` one-shot records past retention.
 
     Mutates *raw_jobs* in place; returns True when anything was removed (the
-    caller persists). Only one-shot (``schedule.kind == "once"``) records in
-    the terminal completed state are candidates; recurring jobs and non-
-    terminal one-shots are never touched. Age is measured from
-    ``last_run_at`` — a completed record without a parseable ``last_run_at``
-    is kept (never guess a record into deletion).
+    caller persists). Ids removed are added to *removed_ids* when provided so
+    ``save_jobs``'s shrink-merge guard (#80624) allows the intentional delete.
+    Only one-shot (``schedule.kind == "once"``) records in the terminal
+    completed state are candidates; recurring jobs and non-terminal one-shots
+    are never touched. Age is measured from ``last_run_at`` — a completed
+    record without a parseable ``last_run_at`` is kept (never guess a record
+    into deletion).
     """
     retention_days = _completed_oneshot_retention_days()
     if retention_days <= 0:
@@ -2136,6 +2310,9 @@ def _sweep_completed_oneshots(raw_jobs: List[Dict[str, Any]], now: datetime) -> 
                 continue
             raw_jobs.remove(rj)
             removed = True
+            rid = rj.get("id")
+            if removed_ids is not None and rid:
+                removed_ids.add(str(rid))
             logger.info(
                 "Job '%s': pruning completed one-shot record "
                 "(finished %s, retention %.1f days)",
@@ -2175,6 +2352,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     now = _hermes_now()
     raw_jobs = load_jobs()
     needs_save = False
+    intentionally_removed: Set[str] = set()
 
     # Repair id-less records BEFORE anything keys off ``job["id"]``. A direct
     # jobs.json edit that bypassed add_job() can leave a record without an "id"
@@ -2276,7 +2454,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     # being deleted on completion, but they must not accumulate in jobs.json
     # forever. Prune terminal one-shot records older than the retention
     # window each scan.
-    if _sweep_completed_oneshots(raw_jobs, now):
+    if _sweep_completed_oneshots(raw_jobs, now, removed_ids=intentionally_removed):
         needs_save = True
         jobs = [j for j in jobs if any(rj.get("id") == j.get("id") for rj in raw_jobs)]
 
@@ -2473,6 +2651,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             for rj in raw_jobs:
                                 if rj["id"] == job["id"]:
                                     raw_jobs.remove(rj)
+                                    intentionally_removed.add(str(rj["id"]))
                                     needs_save = True
                                     break
                             # The claimed run never completed here by
@@ -2516,7 +2695,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             continue
 
     if needs_save:
-        save_jobs(raw_jobs)
+        save_jobs(raw_jobs, removed_ids=intentionally_removed or None)
 
     return due
 

--- a/tests/cron/test_jobs_shrink_merge_80624.py
+++ b/tests/cron/test_jobs_shrink_merge_80624.py
@@ -1,0 +1,137 @@
+"""Regression for #80624 — concurrent creates must not be clobbered on save.
+
+``no_agent`` watchdog jobs (and any CLI/tool create while the gateway ticker
+or a ``cron remove`` is live) were vanishing from ``jobs.json`` when a writer
+persisted a stale/smaller in-memory snapshot. The save path now merges
+unexpected on-disk ids back unless the caller passes ``removed_ids``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+    (home / "scripts" / "watch.sh").write_text("#!/bin/bash\necho alert\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    import cron.jobs
+
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+    return home
+
+
+def test_stale_empty_save_preserves_concurrent_no_agent_create(hermes_env):
+    """Gateway-style stale writer with [] must not wipe a concurrent create."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    job = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    assert [j["id"] for j in load_jobs()] == [job["id"]]
+
+    # Simulate a degraded-lock writer that still holds an empty snapshot from
+    # before the create (the filed incident: jobs.json rewritten empty).
+    save_jobs([])
+
+    remaining = load_jobs()
+    assert [j["id"] for j in remaining] == [job["id"]]
+    assert remaining[0].get("no_agent") is True
+    assert remaining[0].get("script") == "watch.sh"
+
+
+def test_remove_other_job_preserves_concurrent_create(hermes_env):
+    """``cron remove`` of job A must not drop job B created mid-flight."""
+    from cron.jobs import create_job, load_jobs, remove_job, save_jobs
+
+    agent = create_job(
+        prompt="hello",
+        schedule="every 5m",
+        name="agent",
+        deliver="local",
+    )
+    # Stale remove payload: only knew about `agent`, never saw the watchdog.
+    stale_after_remove = []
+    save_jobs(stale_after_remove, removed_ids={agent["id"]})
+
+    watchdog = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    # A second stale remove of `agent` (already gone) with empty payload —
+    # must keep the watchdog that landed on disk in between.
+    save_jobs([], removed_ids={agent["id"]})
+
+    ids = {j["id"] for j in load_jobs()}
+    assert ids == {watchdog["id"]}
+
+
+def test_intentional_remove_still_deletes(hermes_env):
+    from cron.jobs import create_job, get_job, remove_job
+
+    job = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    assert remove_job(job["id"]) is True
+    assert get_job(job["id"]) is None
+
+
+def test_replace_flag_allows_wholesale_rewrite(hermes_env):
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    save_jobs([], replace=True)
+    assert load_jobs() == []
+
+
+def test_jobs_json_on_disk_matches_merge(hermes_env):
+    from cron.jobs import create_job, save_jobs
+
+    job = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    save_jobs([])
+    payload = json.loads((Path(hermes_env) / "cron" / "jobs.json").read_text())
+    assert [j["id"] for j in payload["jobs"]] == [job["id"]]

--- a/tests/cron/test_jobs_shrink_merge_80624.py
+++ b/tests/cron/test_jobs_shrink_merge_80624.py
@@ -135,3 +135,103 @@ def test_jobs_json_on_disk_matches_merge(hermes_env):
     save_jobs([])
     payload = json.loads((Path(hermes_env) / "cron" / "jobs.json").read_text())
     assert [j["id"] for j in payload["jobs"]] == [job["id"]]
+
+
+def test_stamp_fast_path_skips_merge_when_file_unchanged(hermes_env, monkeypatch):
+    """Inside a critical section whose load stamp still matches, the save
+    must not re-read jobs.json at all (#80703's single-stat fast path)."""
+    import cron.jobs as jobs
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+
+    peeks = {"count": 0}
+    real_peek = jobs._peek_jobs_unlocked
+
+    def _counting_peek():
+        peeks["count"] += 1
+        return real_peek()
+
+    monkeypatch.setattr(jobs, "_peek_jobs_unlocked", _counting_peek)
+
+    # load -> save inside ONE critical section, no sibling write in between:
+    # the stamp matches, so the merge (and its peek) must be skipped.
+    with jobs._jobs_lock():
+        current = jobs.load_jobs()
+        jobs._save_jobs_unlocked(current)
+    assert peeks["count"] == 0, "healthy same-section save should not re-parse"
+
+    # A sibling write invalidates the stamp -> the merge runs again.
+    with jobs._jobs_lock():
+        current = jobs.load_jobs()
+        (jobs._current_cron_store().jobs_file).write_text(
+            json.dumps({"jobs": [dict(job), {"id": "bbbbbbbbbbbb", "name": "b"}]}),
+            encoding="utf-8",
+        )
+        jobs._save_jobs_unlocked(current)
+    assert peeks["count"] > 0, "changed stamp must re-trigger the merge"
+    ids = {j["id"] for j in jobs.load_jobs()}
+    assert ids == {job["id"], "bbbbbbbbbbbb"}
+
+
+def test_merge_does_not_mutate_caller_list(hermes_env):
+    """The shrink-merge returns a new list; the caller's payload object must
+    not grow as a side effect of save_jobs()."""
+    from cron.jobs import create_job, save_jobs
+
+    job = create_job(
+        prompt=None,
+        schedule="every 2m",
+        script="watch.sh",
+        no_agent=True,
+        deliver="local",
+        name="watchdog",
+        repeat=0,
+    )
+    my_payload = []  # stale snapshot from before the create
+    save_jobs(my_payload)
+    assert my_payload == [], "caller's list was mutated in place by the merge"
+
+
+def test_corrupt_disk_file_does_not_break_save(hermes_env):
+    """A corrupt jobs.json under a save must not recurse or crash: the
+    non-repairing peek returns None and the save overwrites cleanly."""
+    import cron.jobs as jobs
+    from cron.jobs import load_jobs, save_jobs
+
+    jobs.ensure_dirs()
+    jobs_file = jobs._current_cron_store().jobs_file
+    jobs_file.write_text('{"jobs": [{"id": "ccc', encoding="utf-8")
+    save_jobs([{"id": "aaaaaaaaaaaa", "name": "a"}])
+    assert [j["id"] for j in load_jobs()] == ["aaaaaaaaaaaa"]
+
+
+def test_nested_create_survives_outer_stale_save(hermes_env):
+    """A save inside a critical section invalidates the section's stamp, so
+    an outer caller's later save with a pre-create payload must re-merge and
+    keep the nested create (stamp refresh here would deterministically
+    clobber it)."""
+    import cron.jobs as jobs
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    seed = {"id": "aaaaaaaaaaaa", "name": "a"}
+    save_jobs([seed], replace=True)
+
+    with jobs._jobs_lock():
+        stale = jobs.load_jobs()  # records the stamp
+        created = create_job(
+            prompt="x", schedule="every 5m", name="nested", deliver="local"
+        )
+        jobs._save_jobs_unlocked(stale)  # outer save with pre-create payload
+
+    ids = {j["id"] for j in load_jobs()}
+    assert created["id"] in ids, "nested create was clobbered by outer stale save"
+    assert seed["id"] in ids


### PR DESCRIPTION
## Summary

Under `_jobs_lock()`'s degraded flock-timeout path (#60703), two processes can both believe they own `jobs.json`; the last writer's load→mutate→save silently discards jobs the other process created in between — CLI-created `no_agent` watchdog jobs vanish while the gateway ticks. This salvages @HexLab98's #80687 (shrink-merge save contract: every save re-attaches on-disk jobs missing from the payload unless the caller declares them intentionally `removed_ids`), then folds in the stat-stamp fast path from @JoaoMarcos44's competing #80703 so the healthy no-race save costs one `stat()` instead of two full JSON parses.

Fixes #80624. Closes #80687. Closes #80703.

## Changes

- `cron/jobs.py` (cherry-picked from #80687, authorship preserved):
  - `_merge_unexpected_disk_jobs`: on every non-`replace` save, ids present on disk but absent from the payload and not in `removed_ids` are merged back before the atomic write; staged-write re-peek loop catches siblings landing mid-save.
  - `_peek_jobs_unlocked`: repair-free disk read for the save path (a repairing read would recurse through `_save_jobs_unlocked` — the defect the stamp-reconcile approach in #80703 had; probed at 47 nested re-entries on a corrupt file).
  - All six intentional-delete sites pass `removed_ids` (`remove_job`, `claim_dispatch` wedged-pop, retention sweep, due-scan wedged removal, final tick save).
- Follow-up commit (mine, Co-authored-by @JoaoMarcos44):
  - Stat-stamp fast path: `load_jobs()` inside a critical section records `(mtime_ns, size, ino)` BEFORE reading; merge + post-stage verify skip the parse when the stamp still matches.
  - Fail-safe stamp discipline (fixes found by the review pass, probe-verified): pre-read capture (racing sibling ⇒ stamp older than disk ⇒ merge runs), `st_ino` in the stamp (rename ⇒ new inode ⇒ coarse-mtime filesystems can't false-match), stamp invalidated — never refreshed — after any write (refresh would let a nested `create_job` be clobbered by an outer caller's stale payload).
  - `_merge_unexpected_disk_jobs` returns a new list instead of mutating the caller's payload; recovered ids are logged.
  - Shared `_parse_jobs_file` (utf-8-sig + strict-fallback cascade) used by both `load_jobs` and the peek.
- `tests/cron/test_jobs_shrink_merge_80624.py`: 5 tests from #80687 + 4 new (stamp fast path, no caller-list mutation, corrupt-file save safety, nested-create vs stale outer save).

## Validation

| | Before | After |
|---|---|---|
| Concurrent create under degraded lock | silently discarded by next save | merged back, warning logged with ids |
| Intentional delete | — | sticks (`removed_ids` contract, all six sites) |
| Healthy no-race save cost | 1 load already paid | +1 `stat()` (was: +2 full JSON parses in #80687 as submitted) |
| Corrupt jobs.json during save | #80703: unbounded recursion (probed, 47 frames) | non-repairing peek returns None, save proceeds |
| Nested create inside broader section | — | survives outer stale save (stamp invalidation) |

- `tests/cron/` + cron CLI/tool suites: 513 passed.
- Shrink-merge file: 9/9; each new test mutation-verified against the implementation it guards.
- E2E probes (isolated HERMES_HOME, real create/remove/save API): clobber recovery, delete-stickiness, corrupt-under-lock save, zero-parse healthy path, degraded-sibling-after-write recovery, nested-create survival.

## Known limitation (inherited, documented)

A sibling's *delete* can be resurrected by a stale writer that still carries the job (add-only merge, last-write-wins). Same tradeoff as #60703: a lost job (silent, permanent) is strictly worse than a resurrected one (visible, re-deletable).

## Credit

- Base fix cherry-picked from #80687 by @HexLab98 (authorship preserved on both commits).
- Stat-stamp fast-path design from #80703 by @JoaoMarcos44 (`Co-authored-by` on the follow-up commit). #80703's reconcile approach also fixed the bug but re-entered `load_jobs`'s auto-repair from the save path (unbounded recursion on corrupt input) and only covered saves preceded by a same-section load; the save-contract approach covers every save.
