### PR TITLE
feat(desktop): make project navigation predictable

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -643,24 +643,14 @@ export function ChatSidebar({
           },
           isPinnedSession
         )
-      ),
-      activeProjectId
+      )
     )
 
     // Layer the user's manual drag-order on top of the deterministic sort. Empty
-    // (default) returns `sorted` untouched; projects the user hasn't ordered yet
-    // keep their sorted position rather than jumping the hand-picked list.
+    // (default) returns `sorted` untouched; newly discovered projects append
+    // instead of jumping above the hand-picked list.
     return orderProjectsByIds(sorted, projectOrderIds)
-  }, [
-    showAllProfiles,
-    projectTree,
-    dismissedAutoProjects,
-    orderRepos,
-    activeProjectId,
-    projectOrderIds,
-    isPinnedSession,
-    s
-  ])
+  }, [showAllProfiles, projectTree, dismissedAutoProjects, orderRepos, projectOrderIds, isPinnedSession, s])
 
   // The overview only renders in grouped mode; the model stays live regardless
   // so scoping is consistent across views.

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -4,6 +4,7 @@ export {
   orderProjectsByIds,
   PROJECT_PREVIEW_COUNT,
   projectTreeCwd,
+  sortProjectsByLabel,
   sortProjectsForOverview,
   useRepoWorktreeMap
 } from './model'

--- a/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
@@ -42,7 +42,7 @@ describe('orderProjectsByIds', () => {
     // The regression: a disk scan keeps finding git checkouts the user has
     // never opened in Hermes. Surfacing every unsaved id at the top buried the
     // projects they deliberately dragged into place.
-    const projects = [makeProject('scanned-1', 0), makeProject('mine', 4), makeProject('scanned-2', 0)]
+    const projects = [makeProject('scanned-2', 0), makeProject('mine', 4), makeProject('scanned-1', 0)]
 
     expect(ids(orderProjectsByIds(projects, ['mine']))).toEqual(['mine', 'scanned-1', 'scanned-2'])
   })

--- a/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { orderProjectsByIds, sortProjectsForOverview } from './model'
+import { orderProjectsByIds, sortProjectsByLabel, sortProjectsForOverview } from './model'
 import { NO_PROJECT_ID, type SidebarProjectTree } from './workspace-groups'
 
 function makeProject(id: string, sessionCount: number): SidebarProjectTree {
@@ -47,12 +47,10 @@ describe('orderProjectsByIds', () => {
     expect(ids(orderProjectsByIds(projects, ['mine']))).toEqual(['mine', 'scanned-1', 'scanned-2'])
   })
 
-  it('still surfaces a new project that has real activity', () => {
-    // A project you just started working in should not sink beneath the saved
-    // order — only the zero-session discoveries do.
+  it('appends newly discovered active projects instead of jumping the manual order', () => {
     const projects = [makeProject('ordered', 1), makeProject('just-started', 3)]
 
-    expect(ids(orderProjectsByIds(projects, ['ordered']))).toEqual(['just-started', 'ordered'])
+    expect(ids(orderProjectsByIds(projects, ['ordered']))).toEqual(['ordered', 'just-started'])
   })
 
   it('drops ids that are no longer present', () => {
@@ -69,10 +67,30 @@ describe('orderProjectsByIds', () => {
 })
 
 describe('sortProjectsForOverview', () => {
-  it('puts Home above the active project', () => {
-    const active = { ...makeProject('active', 5), isAuto: false }
-    const projects = [makeProject('scanned', 0), active, home()]
+  it('puts Home first and sorts the remaining projects alphabetically', () => {
+    const projects = [makeProject('zebra', 5), makeProject('Alpha', 0), home(), makeProject('beta', 2)]
 
-    expect(ids(sortProjectsForOverview(projects, 'active'))).toEqual([NO_PROJECT_ID, 'active', 'scanned'])
+    expect(ids(sortProjectsForOverview(projects))).toEqual([NO_PROJECT_ID, 'Alpha', 'beta', 'zebra'])
+  })
+
+  it('is unaffected by activity changes', () => {
+    const before = [makeProject('zebra', 0), makeProject('alpha', 3)]
+
+    const after = [
+      { ...before[0], lastActive: 999, sessionCount: 8 },
+      { ...before[1], lastActive: 1, sessionCount: 0 }
+    ]
+
+    expect(ids(sortProjectsForOverview(before))).toEqual(['alpha', 'zebra'])
+    expect(ids(sortProjectsForOverview(after))).toEqual(['alpha', 'zebra'])
+  })
+})
+
+describe('sortProjectsByLabel', () => {
+  it('uses project id as a stable tie-breaker for duplicate names', () => {
+    const first = { ...makeProject('p_1', 1), label: 'Demo' }
+    const second = { ...makeProject('p_2', 1), label: 'demo' }
+
+    expect(ids(sortProjectsByLabel([second, first]))).toEqual(['p_1', 'p_2'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -77,7 +77,7 @@ export function orderProjectsByIds(projects: SidebarProjectTree[], orderIds: str
   const byId = new Map(projects.map(project => [project.id, project]))
   const ordered = orderIds.map(id => byId.get(id)).filter((p): p is SidebarProjectTree => Boolean(p))
   const seen = new Set(ordered.map(project => project.id))
-  const fresh = projects.filter(project => !seen.has(project.id))
+  const fresh = sortProjectsByLabel(projects.filter(project => !seen.has(project.id)))
 
   if (!fresh.length) {
     return homeFirst(ordered)

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -33,17 +33,17 @@ const projectSessions = (project: SidebarProjectTree): SessionInfo[] =>
 export const projectTreeCwd = (project: SidebarProjectTree): null | string =>
   project.path || project.repos.find(repo => repo.path)?.path || null
 
-// Overview rows carry their activity stamp from the backend (lanes are empty in
-// overview mode), falling back to loaded session times when present.
-const projectActivityTime = (project: SidebarProjectTree): number =>
-  Math.max(
-    project.lastActive ?? 0,
-    projectSessions(project).reduce((latest, s) => Math.max(latest, sessionRecency(s)), 0)
-  )
-
 // The project's most-recent sessions, for the overview preview under each row.
 export const latestProjectSessions = (project: SidebarProjectTree, limit: number): SessionInfo[] =>
   [...projectSessions(project)].sort((a, b) => sessionRecency(b) - sessionRecency(a)).slice(0, limit)
+
+// One ordering contract for every project picker/list: case-insensitive labels,
+// with id as a deterministic tie-breaker when two projects share a name.
+export const compareProjectsByLabel = (a: SidebarProjectTree, b: SidebarProjectTree): number =>
+  a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }) || a.id.localeCompare(b.id)
+
+export const sortProjectsByLabel = (projects: SidebarProjectTree[]): SidebarProjectTree[] =>
+  [...projects].sort(compareProjectsByLabel)
 
 // Home is a fixture, not a project: it always leads the overview, above the
 // active project and outside any hand-picked order.
@@ -52,37 +52,11 @@ const homeFirst = (projects: SidebarProjectTree[]): SidebarProjectTree[] =>
     ? projects
     : [...projects.filter(project => project.isNoProject), ...projects.filter(project => !project.isNoProject)]
 
-export function sortProjectsForOverview(
-  projects: SidebarProjectTree[],
-  activeProjectId: null | string
-): SidebarProjectTree[] {
-  const sorted = [...projects].sort((a, b) => {
-    const aActive = Boolean(activeProjectId && a.id === activeProjectId && !a.isAuto)
-    const bActive = Boolean(activeProjectId && b.id === activeProjectId && !b.isAuto)
-
-    if (aActive !== bActive) {
-      return aActive ? -1 : 1
-    }
-
-    if (!a.isAuto !== !b.isAuto) {
-      return a.isAuto ? 1 : -1
-    }
-
-    const aHasSessions = a.sessionCount > 0
-    const bHasSessions = b.sessionCount > 0
-
-    if (aHasSessions !== bHasSessions) {
-      return aHasSessions ? -1 : 1
-    }
-
-    return (
-      projectActivityTime(b) - projectActivityTime(a) ||
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    )
-  })
-
-  return homeFirst(sorted)
-}
+// The overview is navigation, not an activity feed. Keep rows stable while
+// sessions start/finish or the active project changes; Home remains the fixed
+// first destination and the user can still override the rest by dragging.
+export const sortProjectsForOverview = (projects: SidebarProjectTree[]): SidebarProjectTree[] =>
+  homeFirst(sortProjectsByLabel(projects))
 
 // Layer the user's manual drag-order over the deterministic sort.
 //
@@ -93,9 +67,8 @@ export function sortProjectsForOverview(
 // anything, every freshly-scanned checkout jumped above the projects they
 // actually work in.
 //
-// Fresh projects keep their place in the deterministic sort instead: ones with
-// real activity go on top (a project you just started still surfaces), and
-// zero-session discoveries sink below the hand-ordered list.
+// Fresh projects append in deterministic label order. They must not jump above
+// rows the user deliberately placed just because a session became active.
 export function orderProjectsByIds(projects: SidebarProjectTree[], orderIds: string[]): SidebarProjectTree[] {
   if (!orderIds.length) {
     return projects
@@ -110,11 +83,7 @@ export function orderProjectsByIds(projects: SidebarProjectTree[], orderIds: str
     return homeFirst(ordered)
   }
 
-  return homeFirst([
-    ...fresh.filter(project => project.sessionCount > 0),
-    ...ordered,
-    ...fresh.filter(project => project.sessionCount <= 0)
-  ])
+  return homeFirst([...ordered, ...fresh])
 }
 
 // Project drill-in lanes are git-driven: source them from `git worktree list` so

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -124,34 +124,37 @@ export function ProjectOverviewRow({
           {!project.isNoProject && <ProjectMenu anchorRef={rowRef} isActive={isActive} project={project} />}
         </>
       }
-      className={cn('group/workspace', dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
+      className={cn(
+        'group/workspace',
+        isActive && 'bg-(--ui-control-active-background)',
+        dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)'
+      )}
       ref={rowRef}
     >
       <SidebarRowCluster className="min-w-0 flex-1">
         {lead}
         <SidebarRowLink
           aria-label={s.projects.enter(project.label)}
+          className="flex grow self-stretch items-center"
           labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
           onClick={() => onEnter?.(project.id)}
         >
           {project.label}
         </SidebarRowLink>
-        {preview.length > 0 ? (
+        {preview.length > 0 && (
           <Tip label={s.projects.toggle(project.label, !open)}>
             <button
               aria-label={s.projects.toggle(project.label, !open)}
-              className="flex flex-1 items-center self-stretch bg-transparent p-0"
+              className="grid size-5 shrink-0 place-items-center rounded bg-transparent p-0 text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-(--ui-text-secondary)"
               onClick={toggleOpen}
               type="button"
             >
               <DisclosureCaret
-                className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/workspace:opacity-100"
+                className="shrink-0 opacity-70 transition-opacity group-hover/workspace:opacity-100"
                 open={open}
               />
             </button>
           </Tip>
-        ) : (
-          <span className="flex-1" />
         )}
       </SidebarRowCluster>
     </SidebarRowShell>

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -145,7 +145,7 @@ export function ProjectOverviewRow({
           <Tip label={s.projects.toggle(project.label, !open)}>
             <button
               aria-label={s.projects.toggle(project.label, !open)}
-              className="grid size-5 shrink-0 place-items-center rounded bg-transparent p-0 text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-(--ui-text-secondary)"
+              className="grid size-6 shrink-0 place-items-center rounded bg-transparent p-0 text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-(--ui-text-secondary)"
               onClick={toggleOpen}
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,10 +1,17 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $projectTree, projectRootCwd } from '@/store/projects'
+
+import type { SidebarProjectTree } from './projects/workspace-groups'
 import { SessionActionsMenu } from './session-actions-menu'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  $projectTree.set([])
+  vi.clearAllMocks()
+})
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
 // a broken asChild composition on the kebab trigger fails here — the menu
@@ -94,6 +101,18 @@ function renderMenu() {
   )
 }
 
+function project(id: string, label: string): SidebarProjectTree {
+  return {
+    id,
+    isAuto: false,
+    label,
+    path: `/projects/${id}`,
+    previewSessions: [],
+    repos: [],
+    sessionCount: 0
+  }
+}
+
 describe('SessionActionsMenu', () => {
   it('opens the dropdown on click without a tooltip on the kebab', async () => {
     renderMenu()
@@ -112,5 +131,32 @@ describe('SessionActionsMenu', () => {
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+  })
+
+  it('sorts Move to project targets alphabetically', async () => {
+    $projectTree.set([project('z', 'zeta'), project('a', 'Alpha'), project('b', 'beta')])
+    vi.mocked(projectRootCwd).mockImplementation(node => node.path ?? '')
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const moveTrigger = await screen.findByRole('menuitem', { name: 'Move to project' })
+
+    fireEvent.pointerMove(moveTrigger, { pointerType: 'mouse' })
+    fireEvent.click(moveTrigger)
+
+    const alpha = await screen.findByRole('menuitem', { name: 'Alpha' })
+    const submenu = alpha.closest('[role="menu"]')
+
+    expect(submenu).not.toBeNull()
+    expect(
+      within(submenu as HTMLElement)
+        .getAllByRole('menuitem')
+        .map(item => item.textContent)
+    ).toEqual(['Alpha', 'beta', 'zeta'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -45,6 +45,8 @@ import { canOpenSessionWindow } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
 
+import { sortProjectsByLabel } from './projects/model'
+
 // Rename a session, preferring the gateway's session.title RPC over REST.
 //
 // A freshly *branched* session (and any brand-new chat) lives only in the
@@ -147,7 +149,10 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
   const cwd = session?.cwd?.trim() || ''
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
-  const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
+
+  const targets = sortProjectsByLabel(
+    tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
+  )
 
   if (targets.length === 0) {
     return <kit.Item disabled>{p.moveNoProjects}</kit.Item>
@@ -157,6 +162,7 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
     <>
       {targets.map(node => (
         <kit.Item
+          className="w-72 max-w-[calc(100vw-2rem)]"
           key={node.id}
           onSelect={() => {
             triggerHaptic('selection')
@@ -165,7 +171,7 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
               .catch(err => notifyError(err, p.moveFailed))
           }}
         >
-          {node.label}
+          <span className="min-w-0 flex-1 truncate">{node.label}</span>
         </kit.Item>
       ))}
     </>


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop Projects overview behave like stable navigation instead of an activity feed.

- Keeps **Home** first and sorts the default project list alphabetically (case-insensitive, with project id as a deterministic tie-breaker).
- Preserves manual drag order. Newly discovered projects append instead of jumping above the user's saved order when they gain activity.
- Uses the same alphabetical ordering in **Move to project**.
- Constrains the move submenu to a consistent width and truncates very long labels, while retaining the existing scrollable max height.
- Makes the project name the primary wide click target, replaces the invisible half-row session-toggle area with a compact visible disclosure control, and gives the active project a persistent background state.

## Why?

Project rows currently move as activity changes, and a newly active project can override the order a user deliberately dragged into place. That makes a navigation surface hard to scan and remember. The session move submenu also exposes the backend/tree order directly, so the same project appears in a different place depending on the surface.

This gives every project navigation surface one predictable ordering contract while keeping manual ordering as the explicit override.

## Related issues / PRs

- Addresses the ordering and navigation UX described in #70444.
- The remote folder picker's missing **New folder** action is intentionally not duplicated here; #70078 already implements that focused change.

## Testing

- `npm --workspace apps/desktop run test:ui` — **399 files, 3,527 tests passed**
- Focused post-rebase run:
  - `projects/model.test.ts`
  - `projects/overview-row.test.tsx`
  - `session-actions-menu.test.tsx`
  - **15 tests passed**
- `npm --workspace apps/desktop run typecheck` — passed
- `npm --workspace apps/desktop run lint` — passed with 88 pre-existing warnings and no errors
- Targeted ESLint for all touched files with `--max-warnings 0` — passed
- Prettier check for all touched files — passed
- `npm --workspace apps/desktop run build` — passed

## Manual desktop verification

Built and launched the Electron app against an isolated copy of the real desktop user-data profile on macOS:

- Project overview rendered Home first, then case-insensitive alphabetical project names.
- Move-to-project rendered the same alphabetical sequence in a fixed-width, scrollable submenu.
- Accessibility bounds confirmed the project-name button now consumes the available row width; the disclosure control is a separate WCAG-sized 24px target.
- QA process was stopped after verification.

## Checklist

- [x] Read the repository and Desktop contribution/design guidance
- [x] Searched existing issues and PRs before implementation
- [x] Added/updated regression tests
- [x] Tested on macOS
- [x] Kept the change scoped to Desktop project navigation
