### PR TITLE
fix(lazy_deps): never downgrade a newer installed package

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -239,6 +239,33 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied(spec) is True
         assert ld.feature_missing("tool.trace_upload") == ()
 
+    def test_newer_than_exact_pin_counts_as_satisfied(self, monkeypatch):
+        """#80390: a newer installed build must not be downgraded.
+
+        The Hindsight embedded stack migrates its Postgres data directory
+        forward with each release, so an operator who installed hindsight-all
+        0.8.x (pulling hindsight-client 0.8.6) cannot be rolled back to the
+        pinned 0.6.1 without stranding the database at a newer schema. The pin
+        is a floor for upgrades, not a ceiling against newer installs.
+        """
+        self._fake_version(monkeypatch, {"hindsight-client": "0.8.6"})
+        assert ld._is_satisfied("hindsight-client==0.6.1") is True
+        assert ld.feature_missing("memory.hindsight") == ()
+
+    def test_newer_than_upper_bounded_range_counts_as_satisfied(self, monkeypatch):
+        """A version above an upper-bounded range is treated as current."""
+        self._fake_version(monkeypatch, {"slack-bolt": "2.5.0"})
+        assert ld._is_satisfied("slack-bolt>=1.18.0,<2") is True
+
+    def test_wildcard_pin_newer_than_prefix_counts_as_satisfied(self, monkeypatch):
+        self._fake_version(monkeypatch, {"demo-pkg": "1.5.0"})
+        assert ld._is_satisfied("demo-pkg==1.4.*") is True
+
+    def test_older_than_pin_still_requires_upgrade(self, monkeypatch):
+        """The never-downgrade rule must not block propagating pin bumps up."""
+        self._fake_version(monkeypatch, {"hindsight-client": "0.5.9"})
+        assert ld._is_satisfied("hindsight-client==0.6.1") is False
+
     @pytest.mark.parametrize(
         ("feature", "installed_versions", "expected_repairs"),
         [

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -595,6 +595,14 @@ def _is_satisfied(spec: str) -> bool:
     ``hermes update`` propagate pin bumps in :data:`LAZY_DEPS` to already-
     installed backends instead of silently leaving stale versions in place.
 
+    Downgrades are deliberately excluded: when the installed version is
+    strictly newer than everything the spec permits (e.g. ``==0.6.1`` with
+    0.8.6 installed), the spec counts as satisfied. A pin is a floor for
+    propagating upgrades, not a ceiling for rolling back a newer operator-
+    installed build — some lazy backends migrate their data forward with
+    each release, and an automatic downgrade can strand that data at a
+    schema the pinned client no longer understands (#80390).
+
     If ``packaging`` is unavailable for any reason (it's a transitive of
     pip so this should never happen), we fall back to a presence-only check
     so we err on the side of "don't churn".
@@ -623,8 +631,47 @@ def _is_satisfied(spec: str) -> bool:
         # packaging unavailable — fall back to "installed counts as satisfied".
         return True
 
+    def _spec_bound_version(spec_version: str) -> "Version | None":
+        """Parse a specifier operand, tolerating ``X.Y.*`` wildcards.
+
+        ``==1.4.*`` yields ``spec.version == "1.4.*"`` which ``Version`` cannot
+        parse; strip the wildcard so the prefix still gives a usable bound for
+        the "never downgrade" comparison.
+        """
+        candidate = spec_version
+        if candidate.endswith(".*"):
+            candidate = candidate[:-2]
+        try:
+            return Version(candidate)
+        except InvalidVersion:
+            return None
+
+    def _installed_is_newer_than_spec() -> bool:
+        """True when installed is strictly newer than the spec's ceiling.
+
+        Only upper-bounded specifiers (``<``, ``<=``, ``==``, ``~=``)
+        contribute a ceiling; ``>``/``>=`` have no ceiling and ``===`` is an
+        exact-string legacy match with no ordering we can rely on. Returns
+        False when the spec has no usable ceiling, so the caller keeps the
+        existing upgrade path for versions merely below the floor.
+        """
+        upper: "Version | None" = None
+        for spec in specset:
+            if spec.operator not in ("<", "<=", "==", "~="):
+                continue
+            ver = _spec_bound_version(spec.version)
+            if ver is None:
+                continue
+            if upper is None or ver < upper:
+                upper = ver
+        return upper is not None and installed_v > upper
+
     try:
-        return Version(installed) in SpecifierSet(spec_tail)
+        installed_v = Version(installed)
+        specset = SpecifierSet(spec_tail)
+        if installed_v in specset:
+            return True
+        return _installed_is_newer_than_spec()
     except (InvalidSpecifier, InvalidVersion, Exception):
         # Malformed spec or installed version we can't parse — don't churn.
         return True


### PR DESCRIPTION
Fixes #80390

`_is_satisfied()` treated any installed version outside the pinned spec as missing, so `ensure()` attempted an unattended downgrade whenever an operator had installed a newer build (e.g. `hindsight-client` 0.8.6 vs the pinned 0.6.1). Some lazy backends migrate their data forward with each release, so the downgrade can strand that data at a schema the pinned client no longer understands.

This change treats a strictly-newer installed version as satisfied, keeping pin bumps as upgrades only — the existing stale-pin upgrade path (`hermes update`) is unchanged.

## Tests
- `python -m pytest tests/tools/test_lazy_deps.py -x -q` → 62 passed (58 existing + 4 new regression tests)
- New tests fail on the pre-fix code (red-green verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)