### PR TITLE
fix(skills): parse JSON-looking skills.external_dirs scalar

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,7 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import json
 import logging
 import os
 import re
@@ -496,6 +497,24 @@ def _external_dirs_cache_clear() -> None:
     _raw_config_cache_clear()
 
 
+def _parse_external_dirs_scalar(raw: str) -> List[str]:
+    """Parse a scalar ``skills.external_dirs`` value into a list of entries.
+
+    ``hermes config set skills.external_dirs '["/a","/b"]'`` persists a JSON
+    array verbatim as one YAML scalar string. A plain single-directory value
+    stays a one-element list so a literal path is never mis-split.
+    """
+    text = raw.strip()
+    if text.startswith("[") and text.endswith("]"):
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return [raw]
+
+
 def get_external_skills_dirs() -> List[Path]:
     """Read ``skills.external_dirs`` from config.yaml and return validated paths.
 
@@ -541,7 +560,12 @@ def get_external_skills_dirs() -> List[Path]:
             _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
         return result
     if isinstance(raw_dirs, str):
-        raw_dirs = [raw_dirs]
+        # A JSON array can reach the config as one YAML scalar via
+        # `hermes config set skills.external_dirs '["/a","/b"]'` (the CLI
+        # persists the value verbatim). Parse it back into a sequence so the
+        # entries are discovered instead of being treated as one literal path
+        # that never exists and is silently skipped (#79270).
+        raw_dirs = _parse_external_dirs_scalar(raw_dirs)
     if not isinstance(raw_dirs, list):
         return []
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -6,6 +6,7 @@ tool registration or provider resolution.
 """
 
 import ast
+import json
 import logging
 import os
 import re
@@ -519,6 +520,24 @@ def _external_dirs_cache_clear() -> None:
     _raw_config_cache_clear()
 
 
+def _parse_external_dirs_scalar(raw: str) -> List[str]:
+    """Parse a scalar ``skills.external_dirs`` value into a list of entries.
+
+    ``hermes config set skills.external_dirs '["/a","/b"]'`` persists a JSON
+    array verbatim as one YAML scalar string. A plain single-directory value
+    stays a one-element list so a literal path is never mis-split.
+    """
+    text = raw.strip()
+    if text.startswith("[") and text.endswith("]"):
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return [raw]
+
+
 def get_external_skills_dirs() -> List[Path]:
     """Read ``skills.external_dirs`` from config.yaml and return validated paths.
 
@@ -564,7 +583,12 @@ def get_external_skills_dirs() -> List[Path]:
             _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
         return result
     if isinstance(raw_dirs, str):
-        raw_dirs = [raw_dirs]
+        # A JSON array can reach the config as one YAML scalar via
+        # `hermes config set skills.external_dirs '["/a","/b"]'` (the CLI
+        # persists the value verbatim). Parse it back into a sequence so the
+        # entries are discovered instead of being treated as one literal path
+        # that never exists and is silently skipped (#79270).
+        raw_dirs = _parse_external_dirs_scalar(raw_dirs)
     if not isinstance(raw_dirs, list):
         return []
 

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -48,6 +48,46 @@ class TestGetExternalSkillsDirs:
         assert result[0] == external_skills_dir.resolve()
 
 
+    def test_json_scalar_is_split_into_dirs(self, hermes_home, tmp_path):
+        """#79270: `hermes config set ... '["/a","/b"]'` persists a JSON array
+        as one YAML scalar; it must be parsed back into separate entries rather
+        than treated as one literal (non-existent) directory."""
+        ext_a = tmp_path / "ext-a"
+        ext_a.mkdir()
+        ext_b = tmp_path / "ext-b"
+        ext_b.mkdir()
+        scalar = json.dumps(
+            [str(ext_a).replace(os.sep, "/"), str(ext_b).replace(os.sep, "/")]
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs: '{scalar}'\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_external_skills_dirs
+            result = get_external_skills_dirs()
+        assert result == [ext_a.resolve(), ext_b.resolve()]
+
+    def test_plain_string_scalar_is_single_entry(self, hermes_home, external_skills_dir):
+        """A scalar that is a plain path (no JSON brackets) stays one entry."""
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs: {external_skills_dir}\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_external_skills_dirs
+            result = get_external_skills_dirs()
+        assert result == [external_skills_dir.resolve()]
+
+    def test_malformed_json_scalar_is_skipped_not_crashed(self, hermes_home):
+        """A scalar that starts with '[' but is not valid JSON must not crash."""
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs: '[not valid json'\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_external_skills_dirs
+            result = get_external_skills_dirs()
+        assert result == []
+
+
 
 
 


### PR DESCRIPTION
Fixes #79270

`hermes config set skills.external_dirs '["/a","/b"]'` persists the JSON array verbatim as one YAML scalar string. `get_external_skills_dirs()` wrapped the whole scalar as a single directory entry, so the real external skill directories were silently skipped. This change parses a bracket-delimited scalar back into its entries; plain paths keep their existing one-entry behavior and malformed scalars still fail gracefully.

## Tests
- `python -m pytest tests/agent/test_external_skills.py tests/agent/test_external_skills_dirs_cache.py -x -q` → 11 passed
- New `test_json_scalar_is_split_into_dirs` fails on the pre-fix code (red-green verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)