### PR TITLE
fix(whatsapp): stop YAML config bridging from polluting global env

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -709,6 +710,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 _v = _wenv(_key)
                 if _v:
                     bridge_env[_key] = _v
+            # YAML-bridged values (the ``whatsapp:`` config block) live in this
+            # profile's ``extra``. The legacy path wrote WHATSAPP_* to
+            # process-global os.environ instead, so under multiplex_profiles a
+            # secondary profile's bridge inherited the first profile's
+            # allowlist/policy (#80099). Inject this profile's own values,
+            # leaving .env-derived values (set above) in place.
+            _seed_bridge_env_from_extra(
+                bridge_env, getattr(self.config, "extra", None) or {}
+            )
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
@@ -1833,38 +1843,83 @@ def interactive_setup() -> None:
             print_info("Home channel cleared.")
 
 
-def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
-    """Translate config.yaml whatsapp: keys into WHATSAPP_* env vars.
+def _seed_bridge_env_from_extra(bridge_env: dict, extra: dict) -> None:
+    """Inject YAML-bridged whatsapp config into a bridge subprocess env.
 
-    Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
-    whatsapp_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    The ``whatsapp:`` config block is stored per-profile in ``extra`` by
+    load_gateway_config's shared-key loop and apply_yaml_config_fn. The legacy
+    path wrote WHATSAPP_* to process-global os.environ instead, so under
+    ``multiplex_profiles`` a secondary profile's bridge inherited the first
+    profile's allowlist/policy (#80099). Values already present in
+    ``bridge_env`` (e.g. from the profile's .env) win; this only fills gaps.
     """
-    import json as _json
-    if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
-        os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
-    if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
-        os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
-    frc = whatsapp_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
+    if not isinstance(extra, dict):
+        return
+
+    def _bridge_seed(name: str, value: Any) -> None:
+        if value and name not in bridge_env:
+            bridge_env[name] = str(value)
+
+    if extra.get("require_mention") is not None:
+        _bridge_seed("WHATSAPP_REQUIRE_MENTION", str(extra["require_mention"]).lower())
+    if extra.get("mention_patterns") is not None:
+        try:
+            _bridge_seed(
+                "WHATSAPP_MENTION_PATTERNS", json.dumps(extra["mention_patterns"])
+            )
+        except (TypeError, ValueError):
+            # Unserializable value — leave the bridge default rather than crash.
+            pass
+    if extra.get("free_response_chats") is not None:
+        frc = extra["free_response_chats"]
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
-    if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
-        os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
-    af = whatsapp_cfg.get("allow_from")
-    if af is not None and not os.getenv("WHATSAPP_ALLOWED_USERS"):
+        _bridge_seed("WHATSAPP_FREE_RESPONSE_CHATS", str(frc))
+    if extra.get("dm_policy") is not None:
+        _bridge_seed("WHATSAPP_DM_POLICY", str(extra["dm_policy"]).lower())
+    if extra.get("allow_from") is not None:
+        af = extra["allow_from"]
         if isinstance(af, list):
             af = ",".join(str(v) for v in af)
-        os.environ["WHATSAPP_ALLOWED_USERS"] = str(af)
-    if "group_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_GROUP_POLICY"):
-        os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
-    gaf = whatsapp_cfg.get("group_allow_from")
-    if gaf is not None and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
+        _bridge_seed("WHATSAPP_ALLOWED_USERS", str(af))
+    if extra.get("group_policy") is not None:
+        _bridge_seed("WHATSAPP_GROUP_POLICY", str(extra["group_policy"]).lower())
+    if extra.get("group_allow_from") is not None:
+        gaf = extra["group_allow_from"]
         if isinstance(gaf, list):
             gaf = ",".join(str(v) for v in gaf)
-        os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
-    return None
+        _bridge_seed("WHATSAPP_GROUP_ALLOWED_USERS", str(gaf))
+
+
+def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
+    """Translate config.yaml whatsapp: keys into profile-scoped config values.
+
+    Implements the apply_yaml_config_fn contract (#24849). Returns the bridged
+    values as a dict, which gateway/config.py merges into this profile's
+    platform ``extra``. Under ``multiplex_profiles`` each profile's extra is
+    its own, so a secondary profile's adapter and Node bridge see its own
+    YAML-derived allowlist/policy instead of a sibling profile's process-global
+    env vars (#80099).
+    """
+    seeded: dict[str, Any] = {}
+    if "require_mention" in whatsapp_cfg:
+        seeded["require_mention"] = str(whatsapp_cfg["require_mention"]).lower()
+    if "mention_patterns" in whatsapp_cfg:
+        seeded["mention_patterns"] = whatsapp_cfg["mention_patterns"]
+    frc = whatsapp_cfg.get("free_response_chats")
+    if frc is not None:
+        seeded["free_response_chats"] = frc
+    if "dm_policy" in whatsapp_cfg:
+        seeded["dm_policy"] = str(whatsapp_cfg["dm_policy"]).lower()
+    af = whatsapp_cfg.get("allow_from")
+    if af is not None:
+        seeded["allow_from"] = af
+    if "group_policy" in whatsapp_cfg:
+        seeded["group_policy"] = str(whatsapp_cfg["group_policy"]).lower()
+    gaf = whatsapp_cfg.get("group_allow_from")
+    if gaf is not None:
+        seeded["group_allow_from"] = gaf
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
+++ b/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
@@ -9,6 +9,8 @@ inbound messages.
 The fix routes WHATSAPP_* reads through ``get_secret()`` (``agent.secret_scope``)
 which honours the active scope.
 """
+import os
+
 import pytest
 
 from agent import secret_scope as ss
@@ -156,3 +158,88 @@ class TestWhatsAppCloudAdapterUsesSecretScope:
             assert _get_wsecret("WHATSAPP_DM_POLICY", default="pairing") == "allowlist"
         finally:
             ss.reset_secret_scope(tok)
+
+
+class TestWhatsAppYamlBridgeScopeIsolation:
+    """#80099 — YAML-bridged whatsapp config must be profile-scoped.
+
+    The old ``_apply_yaml_config`` wrote WHATSAPP_* to process-global
+    os.environ (first-writer-wins), so under ``multiplex_profiles`` a
+    secondary profile's Node bridge inherited the first profile's
+    allowlist/policy. Values now flow through each profile's ``extra`` and are
+    injected into the bridge env per-profile.
+    """
+
+    def test_apply_yaml_config_returns_values_without_global_env(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        for key in (
+            "WHATSAPP_DM_POLICY", "WHATSAPP_GROUP_POLICY",
+            "WHATSAPP_GROUP_ALLOWED_USERS", "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_REQUIRE_MENTION", "WHATSAPP_MENTION_PATTERNS",
+            "WHATSAPP_FREE_RESPONSE_CHATS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        seeded = _apply_yaml_config(
+            {},
+            {
+                "dm_policy": "disabled",
+                "group_policy": "allowlist",
+                "group_allow_from": ["120363001234567890@g.us"],
+                "allow_from": ["120363001234567890@g.us"],
+                "require_mention": True,
+                "mention_patterns": ["(?i)bot"],
+                "free_response_chats": ["120363001234567890@g.us"],
+            },
+        )
+
+        assert seeded == {
+            "dm_policy": "disabled",
+            "group_policy": "allowlist",
+            "group_allow_from": ["120363001234567890@g.us"],
+            "allow_from": ["120363001234567890@g.us"],
+            "require_mention": "true",
+            "mention_patterns": ["(?i)bot"],
+            "free_response_chats": ["120363001234567890@g.us"],
+        }
+        # The bridged values must NOT leak into process-global env.
+        for key in (
+            "WHATSAPP_DM_POLICY", "WHATSAPP_GROUP_POLICY",
+            "WHATSAPP_GROUP_ALLOWED_USERS", "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_REQUIRE_MENTION", "WHATSAPP_MENTION_PATTERNS",
+            "WHATSAPP_FREE_RESPONSE_CHATS",
+        ):
+            assert key not in os.environ
+
+    def test_seed_bridge_env_injects_profile_values(self):
+        from plugins.platforms.whatsapp.adapter import _seed_bridge_env_from_extra
+
+        bridge_env = {}
+        _seed_bridge_env_from_extra(
+            bridge_env,
+            {
+                "dm_policy": "disabled",
+                "group_policy": "allowlist",
+                "group_allow_from": ["120363001234567890@g.us"],
+                "allow_from": ["120363001234567890@g.us"],
+                "require_mention": True,
+                "mention_patterns": ["(?i)bot"],
+                "free_response_chats": ["120363001234567890@g.us"],
+            },
+        )
+        assert bridge_env["WHATSAPP_DM_POLICY"] == "disabled"
+        assert bridge_env["WHATSAPP_GROUP_POLICY"] == "allowlist"
+        assert bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+        assert bridge_env["WHATSAPP_ALLOWED_USERS"] == "120363001234567890@g.us"
+        assert bridge_env["WHATSAPP_REQUIRE_MENTION"] == "true"
+        assert bridge_env["WHATSAPP_MENTION_PATTERNS"] == '["(?i)bot"]'
+        assert bridge_env["WHATSAPP_FREE_RESPONSE_CHATS"] == "120363001234567890@g.us"
+
+    def test_seed_bridge_env_does_not_override_env_values(self):
+        """A profile's .env-derived bridge value wins over YAML config."""
+        from plugins.platforms.whatsapp.adapter import _seed_bridge_env_from_extra
+
+        bridge_env = {"WHATSAPP_DM_POLICY": "open"}
+        _seed_bridge_env_from_extra(bridge_env, {"dm_policy": "disabled"})
+        assert bridge_env["WHATSAPP_DM_POLICY"] == "open"

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
@@ -178,9 +179,12 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert config.platforms[Platform.WHATSAPP].extra["dm_policy"] == "disabled"
     assert config.platforms[Platform.WHATSAPP].extra["group_policy"] == "allowlist"
     assert config.platforms[Platform.WHATSAPP].extra["group_allow_from"] == ["120363001234567890@g.us"]
-    assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "disabled"
-    assert __import__("os").environ["WHATSAPP_GROUP_POLICY"] == "allowlist"
-    assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+    # #80099: the YAML bridge must scope values to the profile's extra rather
+    # than write to process-global os.environ, which under multiplex_profiles
+    # leaks the first profile's allowlist/policy into every sibling bridge.
+    assert "WHATSAPP_DM_POLICY" not in os.environ
+    assert "WHATSAPP_GROUP_POLICY" not in os.environ
+    assert "WHATSAPP_GROUP_ALLOWED_USERS" not in os.environ
 
 
 # --- Broadcast / status / newsletter pseudo-chats are always dropped ---


### PR DESCRIPTION
Fixes #80099

`_apply_yaml_config()` wrote `WHATSAPP_*` to process-global `os.environ` with first-writer-wins guards, so under `multiplex_profiles` a secondary profile's Node bridge inherited the first profile's YAML-derived allowlist/policy. The bridged values already flow into each profile's per-profile `extra` via the shared config bridge; this change returns them from the `apply_yaml_config_fn` hook and injects them into the bridge env from `extra` instead, keeping `.env`-derived values authoritative.

## Tests
- `python -m pytest tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py tests/gateway/test_whatsapp_connect.py -x -q` → 31 passed
- Full whatsapp suite: 101 passed, 1 skipped
- New `TestWhatsAppYamlBridgeScopeIsolation` tests fail on the pre-fix code (red-green verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)