### PR TITLE
fix(desktop): render Nerd Font UI glyphs

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -57,6 +57,18 @@
   src: url('./fonts/JetBrainsMono-Italic.woff2') format('woff2');
 }
 
+/* Prefer a symbols-only Nerd Font when one is installed, then use a full Nerd
+   Font only for its private-use glyphs. The unicode range prevents these local
+   faces from changing ordinary UI typography or color emoji. */
+@font-face {
+  font-family: 'Hermes Nerd Glyphs';
+  font-display: swap;
+  src:
+    local('Symbols Nerd Font Mono'), local('Symbols Nerd Font'), local('JetBrainsMono Nerd Font Mono'),
+    local('JetBrainsMono Nerd Font');
+  unicode-range: U+E000-F8FF, U+F0000-F2FFF;
+}
+
 @theme inline {
   --color-background: var(--dt-background);
   --color-foreground: var(--dt-foreground);
@@ -388,16 +400,16 @@
     --dt-user-bubble-border: var(--ui-stroke-tertiary);
 
     --dt-font-sans:
-      'Segoe WPC', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
+      'Hermes Nerd Glyphs', 'Segoe WPC', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui,
+      sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
     /* Key caps always use the native UI face — never theme typography overrides. */
     --dt-font-kbd: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
     /* Menlo/Monaco first — Apple's native monospace faces — so code/diff read
        in the system mono on macOS, with SF Mono and bundled Courier Prime as
        fallbacks. */
     --dt-font-mono:
-      Menlo, Monaco, 'SF Mono', 'Courier Prime', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-      'Noto Color Emoji', emoji;
+      'Hermes Nerd Glyphs', Menlo, Monaco, 'SF Mono', 'Courier Prime', monospace, 'Apple Color Emoji',
+      'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;
     --dt-letter-spacing: 0;

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -19,7 +19,7 @@ import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 import { $backendThemes, $pendingSkinApply } from './backend-sync'
 import { hexToRgb, mix, readableOn } from './color'
-import { BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme } from './presets'
+import { BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme, withNerdGlyphFallback } from './presets'
 import type { DesktopTheme, DesktopThemeColors } from './types'
 import { $userThemes, listAllThemes, resolveTheme } from './user-themes'
 
@@ -180,7 +180,14 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
 
   const root = document.documentElement
   const c = theme.colors
-  const typo = { ...DEFAULT_TYPOGRAPHY, ...nousTheme.typography, ...theme.typography }
+  const configuredTypography = { ...DEFAULT_TYPOGRAPHY, ...nousTheme.typography, ...theme.typography }
+
+  const typo = {
+    ...configuredTypography,
+    fontSans: withNerdGlyphFallback(configuredTypography.fontSans),
+    fontMono: withNerdGlyphFallback(configuredTypography.fontMono)
+  }
+
   const rendered = renderedModeFor(c, mode)
   const isDark = rendered === 'dark'
   const midground = c.midground ?? c.ring

--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, NERD_GLYPH_FALLBACK, withNerdGlyphFallback } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,23 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+
+  it('keeps Nerd Font icon fallbacks available to the UI', () => {
+    expect(DEFAULT_TYPOGRAPHY.fontSans).toContain(NERD_GLYPH_FALLBACK)
+    expect(DEFAULT_TYPOGRAPHY.fontMono).toContain(NERD_GLYPH_FALLBACK)
+  })
+
+  it('adds the private-use fallback to external theme typography without changing its preferred stack', () => {
+    expect(withNerdGlyphFallback('ui-monospace, monospace')).toBe(
+      `${NERD_GLYPH_FALLBACK}, ui-monospace, monospace`
+    )
+  })
+
+  it('moves and deduplicates the private-use fallback ahead of external theme fonts', () => {
+    expect(withNerdGlyphFallback(`ui-monospace, ${NERD_GLYPH_FALLBACK}, monospace`)).toBe(
+      `${NERD_GLYPH_FALLBACK}, ui-monospace, monospace`
+    )
+    expect(withNerdGlyphFallback('')).toBe(NERD_GLYPH_FALLBACK)
   })
 })

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -11,13 +11,33 @@ import type { DesktopTheme, DesktopThemeTypography } from './types'
 // Covers macOS, Windows, Linux, plus the `emoji` generic for anything else.
 export const EMOJI_FALLBACK = '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", emoji'
 
+// `Hermes Nerd Glyphs` is a unicode-range-limited @font-face declared in
+// styles.css. It only participates for Nerd Font private-use codepoints, so a
+// locally installed full Nerd Font cannot change ordinary text metrics.
+export const NERD_GLYPH_FALLBACK = '"Hermes Nerd Glyphs"'
+
 const SYSTEM_SANS =
-  '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +
+  NERD_GLYPH_FALLBACK +
+  ', "Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +
   EMOJI_FALLBACK
 
-const SYSTEM_MONO = 'Menlo, Monaco, "SF Mono", "Courier Prime", monospace, ' + EMOJI_FALLBACK
+const SYSTEM_MONO =
+  NERD_GLYPH_FALLBACK + ', Menlo, Monaco, "SF Mono", "Courier Prime", monospace, ' + EMOJI_FALLBACK
 
 export const DEFAULT_TYPOGRAPHY: DesktopThemeTypography = { fontSans: SYSTEM_SANS, fontMono: SYSTEM_MONO }
+
+/**
+ * Give an external theme the same private-use glyph fallback as built-in
+ * themes. The face's unicode range prevents it from affecting normal text.
+ */
+export function withNerdGlyphFallback(fontFamily: string): string {
+  const withoutFallback = fontFamily
+    .trim()
+    .replace(/(?:^|,\s*)(?:"Hermes Nerd Glyphs"|'Hermes Nerd Glyphs'|Hermes Nerd Glyphs)(?=\s*(?:,|$))/gi, '')
+    .replace(/^,\s*|,\s*$/g, '')
+
+  return withoutFallback ? `${NERD_GLYPH_FALLBACK}, ${withoutFallback}` : NERD_GLYPH_FALLBACK
+}
 
 const NOUS_BLUE = '#0053FD'
 const PSYCHE_BLUE = '#1540B1'
@@ -235,8 +255,8 @@ export const cyberpunkTheme: DesktopTheme = {
     userBubbleBorder: '#004800'
   },
   typography: {
-    fontMono: `"Courier New", Courier, monospace, ${EMOJI_FALLBACK}`,
-    fontSans: `"Courier New", Courier, monospace, ${EMOJI_FALLBACK}`
+    fontMono: `${NERD_GLYPH_FALLBACK}, "Courier New", Courier, monospace, ${EMOJI_FALLBACK}`,
+    fontSans: `${NERD_GLYPH_FALLBACK}, "Courier New", Courier, monospace, ${EMOJI_FALLBACK}`
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop can now render Nerd Font private-use glyphs in ordinary desktop UI text when a compatible Nerd Font is installed locally. This covers chat prose, code/mono surfaces, system messages, tool output, and theme-provided typography. Previously those glyphs could render as tofu boxes even though the same font worked in the embedded terminal.

### Root cause

The embedded terminal and the desktop renderer use separate typography paths. `terminal.font_family` configures xterm.js, while chat and the rest of the renderer use the CSS families exposed through `--dt-font-sans` and `--dt-font-mono`. Those UI stacks had no Nerd Font fallback, and a custom, user, or backend theme could replace the built-in typography entirely.

Putting a full Nerd Font directly at the front of every UI stack would fix the icons but could also change normal prose/code metrics and interfere with color emoji. This PR instead declares a virtual local face, `Hermes Nerd Glyphs`, whose `unicode-range` is restricted to the Nerd Font private-use planes:

- `U+E000-F8FF`
- `U+F0000-F2FFF`

The face prefers `Symbols Nerd Font Mono` / `Symbols Nerd Font`, then accepts JetBrains Mono Nerd Font as a fallback. It is placed first in the family list so platform fonts such as `Segoe UI Symbol` cannot claim a private-use codepoint first, but it is ineligible for ordinary text and emoji because of the restricted range. If none of the local font names exists, Chromium skips the face and the current typography continues unchanged.

Resolved theme typography is normalized at application time, so custom, user, and backend themes cannot accidentally drop the glyph fallback. Existing entries are moved to the front and deduplicated.

## Related Issue

No matching issue was found for the desktop **chat/UI** typography path.

Related but intentionally not duplicated:

- #76395 configures the embedded terminal font; it does not affect renderer CSS typography.
- #72153 proposes additional xterm.js terminal fallback names.
- #67151 reports missing glyphs on a Windows machine without a Nerd Font installed. This PR degrades safely in that environment but does **not** claim to fix or close it.
- #81037 separately replaces the self-improvement status's `💾` emoji with a bundled Codicon; that standard emoji is not a Nerd Font private-use glyph.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`apps/desktop/src/styles.css`** — declare the local-only, PUA-scoped `Hermes Nerd Glyphs` face and add it to the boot-time sans/mono variables.
- **`apps/desktop/src/themes/presets.ts`** — add the canonical glyph family, include it in built-in typography, and normalize external stacks without duplicates or invalid empty values.
- **`apps/desktop/src/themes/context.tsx`** — apply the normalization after built-in, user, and backend theme typography has been resolved.
- **`apps/desktop/src/themes/presets.test.ts`** — cover built-in presence, external-stack preservation, priority, deduplication, and the empty-stack edge case while retaining the existing emoji fallback contract.

## How to Test

1. Install either `Symbols Nerd Font Mono` or `JetBrainsMono Nerd Font Mono`.
2. Build and launch the packaged desktop app.
3. Render private-use test glyphs in chat, for example `󰣇 󰉋 󰆍 󰄬`.
4. Verify they render as icons rather than tofu boxes in prose and mono/code surfaces.
5. Verify ordinary prose/code typography and emoji remain unchanged.
6. Select a theme with custom typography and repeat the glyph check.
7. On a system without any matching Nerd Font, verify the app keeps its existing font stack and remains usable.

Automated and packaged-app validation on Bazzite Linux, KDE Plasma/Wayland, Electron 40.10.2:

| Check | Result |
| --- | --- |
| `npm run test:ui -- src/themes/presets.test.ts` | 13/13 passed |
| `npm run typecheck` | passed |
| `npm run lint` | 0 errors; existing unrelated warnings only |
| `git diff --check` | passed |
| `hermes desktop --build-only` | packaged successfully |
| Packaged-app UI check | Nerd private-use glyphs rendered in chat |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and merged issues/PRs and separated this renderer change from terminal work in #72153 and #76395
- [x] My PR contains **only** changes related to this fix (one commit, four desktop files)
- [ ] I've run `pytest tests/ -q` — not run; this change is isolated to the TypeScript/CSS desktop renderer and the relevant desktop checks above pass
- [x] I've added focused tests for the theme/fallback behavior
- [x] I've tested on my platform: Bazzite Linux, KDE Plasma/Wayland, Electron 40.10.2

### Documentation & Housekeeping

- [x] Documentation: N/A — no user-facing command, setting, or configuration key changed
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow contract changed
- [x] Cross-platform impact considered: macOS, Windows, and Linux local font names are optional; unresolved names degrade to the existing stack
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Screenshots / Logs

### Packaged desktop UI

![Hermes Desktop rendering Nerd Font private-use glyphs](https://raw.githubusercontent.com/Antikythera/hermes-agent/pr-assets/.github/pr-assets/81013/nerd-font-ui-after.png)

Manual packaged-app verification string:

```text
󰣇 󰉋 󰆍 󰄬
```

Before the change these private-use codepoints could render as tofu boxes in the renderer. With a matching local Nerd Font they render as icons; normal UI typography remains selected for non-PUA text.
