### PR TITLE
fix(streaming): never execute a tool whose arguments were lost to a mid-stream drop (#80498)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3617,6 +3617,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True
+                elif finish_reason is None:
+                    # Stream ended with no finish_reason AND this tool call's
+                    # arguments never received a single byte (name arrived,
+                    # argument generation never started before the connection
+                    # died). Left unflagged, this fell through to
+                    # `effective_finish_reason = finish_reason or "stop"`
+                    # below — a normal "stop" turn carrying a tool call whose
+                    # empty arguments string later gets silently coerced to
+                    # "{}" at the dispatch boundary and executed with no
+                    # arguments and no retry (#80498). Route it through the
+                    # same dropped-mid-tool-call stub path already used for a
+                    # truncated-but-nonempty JSON string.
+                    has_truncated_tool_args = True
                 mock_tool_calls.append(SimpleNamespace(
                     id=tc["id"],
                     type=tc["type"],

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3897,6 +3897,34 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         if agent._interrupt_requested:
             return None
+
+        def _tool_use_dropped_mid_stream(message) -> bool:
+            """True when the stream died mid tool call (#80498 sibling).
+
+            Mirror of the chat_completions zero-byte/truncated-args gate: a
+            legitimate completion always carries a ``stop_reason``
+            (``tool_use``/``end_turn``/...), so a message that contains a
+            ``tool_use`` block but NO stop_reason means the SSE closed after
+            ``content_block_start`` and before ``message_delta`` — the
+            block's ``input`` is whatever partial state the SDK snapshot
+            accumulated (typically ``{}`` when no ``input_json_delta`` ever
+            arrived). Without this gate the empty-input call passed the
+            empty-stream guards (content is non-empty) and executed the tool
+            with no arguments and no retry. Raising EmptyStreamError blocks
+            that execution on every path; when no assistant text streamed
+            before the drop it additionally rides the bounded stream-retry
+            the eventless case uses (probe-verified recovery), while a
+            drop after streamed preamble text degrades to the
+            partial-stream-stub/continuation path instead — still never an
+            empty-args execution.
+            """
+            if getattr(message, "stop_reason", None) is not None:
+                return False
+            for block in getattr(message, "content", None) or []:
+                if getattr(block, "type", None) == "tool_use":
+                    return True
+            return False
+
         if (
             base_final_message is not None
             and not getattr(base_final_message, "content", None)
@@ -3907,6 +3935,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(possible upstream error or malformed event stream)."
             )
         if base_final_message is not None and not stream.output_modified:
+            if _tool_use_dropped_mid_stream(base_final_message):
+                raise EmptyStreamError(
+                    "Stream ended with no stop_reason while a tool_use "
+                    "block was still incomplete; treating as a "
+                    "mid-tool-call stream drop (#80498)."
+                )
             return base_final_message
         final_message = accumulator.response(base_final_message)
         if (
@@ -3916,6 +3950,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             raise EmptyStreamError(
                 "Provider returned an empty stream with no stop_reason "
                 "(possible upstream error or malformed event stream)."
+            )
+        if _tool_use_dropped_mid_stream(final_message):
+            raise EmptyStreamError(
+                "Stream ended with no stop_reason while a tool_use "
+                "block was still incomplete; treating as a "
+                "mid-tool-call stream drop (#80498)."
             )
         return final_message
 

--- a/tests/run_agent/test_anthropic_mid_tool_call_drop.py
+++ b/tests/run_agent/test_anthropic_mid_tool_call_drop.py
@@ -1,0 +1,119 @@
+"""The Anthropic streaming path must not accept a tool_use block whose stream
+died before its input arrived (#80498 sibling).
+
+The chat_completions accumulator flags zero-byte tool-call arguments on a
+clean no-finish_reason stream end and routes them through the
+partial-stream-stub retry path. The Anthropic path had the same gap in a
+different shape: a clean SSE close after ``content_block_start(tool_use)``
+but before any ``input_json_delta``/``message_delta`` yields an SDK
+final-message snapshot whose content is NON-empty (the tool_use block is
+there, ``input={}``) and whose ``stop_reason`` is None — which sailed past
+both empty-stream guards and executed the tool with empty input, no retry.
+
+The fix raises EmptyStreamError for a tool_use-bearing message with no
+stop_reason, riding the same bounded stream-retry the eventless case uses.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_anthropic_agent(**kwargs):
+    from run_agent import AIAgent
+
+    defaults = dict(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="claude-opus-4-7",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    defaults.update(kwargs)
+    agent = AIAgent(**defaults)
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._anthropic_api_key = "test-anthropic-key"
+    agent._create_request_anthropic_client = lambda *a, **k: agent._anthropic_client
+    return agent
+
+
+def _stream_cm(final_message, events=()):
+    cm = MagicMock()
+    stream = MagicMock()
+    stream.__iter__ = MagicMock(return_value=iter(list(events)))
+    stream.get_final_message = MagicMock(return_value=final_message)
+    cm.__enter__ = MagicMock(return_value=stream)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def _tool_use_block(name="write_file", input_obj=None):
+    return SimpleNamespace(
+        type="tool_use",
+        id="toolu_x",
+        name=name,
+        input=input_obj if input_obj is not None else {},
+    )
+
+
+def _tool_use_start_event(name="write_file"):
+    return SimpleNamespace(
+        type="content_block_start",
+        content_block=SimpleNamespace(type="tool_use", name=name),
+    )
+
+
+class TestAnthropicMidToolCallStreamDrop:
+    def test_tool_use_without_stop_reason_raises_empty_stream(self):
+        """The #80498-sibling shape: tool_use block present, stop_reason None."""
+        from agent.chat_completion_helpers import EmptyStreamError
+
+        dropped = MagicMock()
+        dropped.content = [_tool_use_block()]
+        dropped.stop_reason = None
+        dropped.usage = SimpleNamespace(input_tokens=10, output_tokens=2)
+
+        agent = _make_anthropic_agent()
+        agent._anthropic_client.messages.stream = MagicMock(
+            return_value=_stream_cm(dropped, events=[_tool_use_start_event()])
+        )
+
+        with pytest.raises(EmptyStreamError, match="tool_use"):
+            agent._interruptible_streaming_api_call({"model": "claude-opus-4-7"})
+
+    def test_completed_tool_use_with_stop_reason_passes(self):
+        """A legitimate tool_use completion (stop_reason set) is untouched."""
+        done = MagicMock()
+        done.content = [_tool_use_block(input_obj={"path": "a.txt"})]
+        done.stop_reason = "tool_use"
+        done.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+
+        agent = _make_anthropic_agent()
+        agent._anthropic_client.messages.stream = MagicMock(
+            return_value=_stream_cm(done, events=[_tool_use_start_event()])
+        )
+
+        response = agent._interruptible_streaming_api_call(
+            {"model": "claude-opus-4-7"}
+        )
+        assert response is done
+
+    def test_text_only_message_without_stop_reason_passes(self):
+        """No tool_use block -> the new gate stays out of the way (text-only
+        no-stop_reason handling keeps its pre-existing behavior)."""
+        text_only = MagicMock()
+        text_only.content = [SimpleNamespace(type="text", text="partial answer")]
+        text_only.stop_reason = None
+        text_only.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+
+        agent = _make_anthropic_agent()
+        agent._anthropic_client.messages.stream = MagicMock(
+            return_value=_stream_cm(text_only)
+        )
+
+        response = agent._interruptible_streaming_api_call(
+            {"model": "claude-opus-4-7"}
+        )
+        assert response is text_only

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -207,6 +207,68 @@ class TestCleanStreamEndBeforeAnyToolArgs:
         assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
 
 
+# ── Mixed response: one complete call, one dropped (#80498) ─────────────────
+
+class TestMixedToolCallsOneDroppedOneComplete:
+    """A single response can carry more than one tool call in parallel. If
+    the stream dies before one call's arguments ever start while a sibling
+    call in the SAME response already completed with valid, parseable
+    arguments, the whole response is still discarded as one partial-stream
+    stub — ``_build_partial_stream_stub`` unconditionally sets
+    ``tool_calls=None``, so the valid sibling is not selectively kept.
+
+    This all-or-nothing behavior predates #80498 (it already applied to the
+    partial-but-nonempty-JSON case); this test just locks it in now that the
+    zero-byte case routes through the same stub path, so a future change
+    towards per-tool-call granularity doesn't silently regress either case.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_valid_sibling_tool_call_is_discarded_with_dropped_one(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _clean_ending_stream():
+            # Tool call 0: complete, valid JSON arguments.
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_ok", name="read_file"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "a.txt"}'),
+            ])
+            # Tool call 1: name arrives, then the stream dies before a
+            # single argument byte — the #80498 zero-byte case.
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=1, tc_id="call_x", name="write_file"),
+            ])
+            # falls off the end — clean close, no terminator
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None, (
+            "The valid 'read_file' call must not be selectively kept — the "
+            "whole response is discarded as one stub so the retry "
+            "regenerates every call in it together."
+        )
+        assert getattr(response, "_dropped_tool_names", None) == [
+            "read_file", "write_file",
+        ], (
+            "_dropped_tool_names lists every tool call in the response, "
+            "not just the one that actually failed to complete."
+        )
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -151,6 +151,62 @@ class TestCleanStreamEndMidToolCall:
 
 
 
+# ── Clean stream-end before any argument byte arrives (#80498) ─────────────
+
+class TestCleanStreamEndBeforeAnyToolArgs:
+    """The upstream closes the SSE stream cleanly right after delivering the
+    tool NAME — not a single byte of the arguments delta ever arrived, no
+    exception, no finish_reason, no [DONE].
+
+    Before the fix, an empty ``arguments`` string skipped the
+    truncated-JSON check entirely (it only ran when ``arguments and
+    arguments.strip()``), so ``has_truncated_tool_args`` stayed False. With
+    no other guard catching this shape, the stub-builder fell through to
+    ``effective_finish_reason = finish_reason or "stop"`` and returned a
+    normal "stop" turn carrying a tool call with ``arguments=""`` — which
+    the dispatch boundary silently coerces to "{}" and executes with no
+    retry (#80498, e.g. ``write_file`` running with no arguments).
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_empty_tool_args_routes_to_stub_not_silent_empty_object(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _clean_ending_stream():
+            # Tool name arrives, then the generator simply RETURNS
+            # (StopIteration) before any arguments delta chunk — no raise,
+            # no finish_reason chunk, no [DONE].
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_x", name="write_file"),
+            ])
+            # falls off the end — clean close, no terminator, zero args bytes
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID, (
+            "A tool call whose arguments never started streaming before a "
+            "clean stream end must be tagged as a partial-stream stub, not "
+            "silently returned as a completed 'stop' turn with empty "
+            "arguments (#80498)."
+        )
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None, (
+            "A tool call with zero argument bytes delivered must never "
+            "auto-execute with a silently substituted empty object."
+        )
+        assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4030,6 +4030,47 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
+    def test_zero_byte_tool_args_stub_recovers_within_retries(self, agent):
+        """#80498: a stream that dies before a single argument byte arrives
+        (name-only tool call) produces a stub with tool_calls=None and
+        _dropped_tool_names set — the real shape _build_partial_stream_stub
+        returns, distinct from the truncated-JSON stub above (which still
+        carries a tool_calls list). Confirms the zero-byte trigger is wired
+        end-to-end through the retry loop, not just detected at the
+        chat_completion_helpers unit level."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+
+        stall = _mock_response(content="", finish_reason="length", tool_calls=None)
+        stall.id = PARTIAL_STREAM_STUB_ID
+        stall._dropped_tool_names = ["write_file"]
+
+        good_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"full content"}',
+            call_id="c2",
+        )
+        good_resp = _mock_response(content="", finish_reason="stop", tool_calls=[good_tc])
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [
+                stall, good_resp, final_resp,
+            ]
+            result = agent.run_conversation("write the report")
+
+        # The zero-byte stub must trigger a retry, not silently execute
+        # write_file with coerced empty arguments (the #80498 regression).
+        mock_hfc.assert_called_once()
+        assert result["final_response"] == "Done!"
+
 
     def test_truncated_tool_json_after_tool_batch_closes_tool_tail(self, agent):
         """finish_reason=tool_calls + truncated args after a real tool must close tool→user."""


### PR DESCRIPTION
## Summary

Closes the behavior half of #80498: a provider stream that dies mid tool call no longer executes the tool with silently-substituted empty arguments — on both the chat_completions and Anthropic streaming paths it is now detected as a mid-tool-call stream drop and retried.

Salvages @JoaoMarcos44's #80623 (both commits cherry-picked, authorship preserved) and widens the fix to the Anthropic sibling path found in review.

## The incident path (#80498)

Stream dies right after delivering a tool call's *name*, before a single argument byte. The truncation guard only ran for non-empty argument strings, so `has_truncated_tool_args` stayed False, the turn was stamped a normal `"stop"`, and the dispatch boundary coerced the empty string to `{}` — `write_file` executed with no arguments, no retry, no error. The user believed the file was written; nothing hit disk; the model drifted off-task.

## Commits

1. **@JoaoMarcos44** — `elif finish_reason is None:` branch in the stream accumulator flags the zero-byte case and routes it through the existing partial-stream-stub retry path (the same one truncated-but-nonempty JSON already uses)
2. **@JoaoMarcos44** — gap-filling tests: mixed complete+dropped parallel calls (locks in the pre-existing all-or-nothing stub contract so per-call granularity can't silently regress it), plus an end-to-end retry-loop test
3. follow-up — the **Anthropic path had the same gap in a different shape**: a clean SSE close after `content_block_start(tool_use)` but before any `input_json_delta`/`message_delta` yields an SDK snapshot with NON-empty content (the tool_use block, `input={}`) and `stop_reason=None`, which sailed past both empty-stream guards (they only fire on empty content) and executed the tool with empty input via `_STOP_REASON_MAP.get(None, "stop")`. A legitimate completion always carries a stop_reason, so a tool_use-bearing message without one now raises `EmptyStreamError`, riding the bounded stream-retry (probe-verified recovery: drop on attempt 1, complete message on attempt 2 → good message returned; a drop after streamed preamble text degrades to the partial-stream-stub/continuation path — still never an empty-args execution)

## Verification

- Premise reproduced on current main: the PR's unit tests fail without the fix (the zero-byte case still falls through today)
- Mutations killed: disabling the chat_completions branch fails both unit tests; disabling the Anthropic gate fails its regression test
- False-positive audit: legit no-arg tool calls always carry a finish_reason/stop_reason, so neither gate fires on them; the only trigger is a double provider anomaly, and the consequence is a whole-turn retry
- Composition with #80963 (the transcript-corruption half, merged) verified green together; codex path audited — no equivalent gap (function_call items only collected on `output_item.done`)
- Adversarial probes: mixed text+tool_use content, `max_tokens` stop_reason (truncation path keeps ownership), dict-shaped blocks (accumulator normalizes to namespaces before the gate — not reachable), retry recovery driven live
- Suites: 21 streaming/stub tests + 155 `-k 'stream or stub or truncat'` green; ruff clean; ty identical to base

Credit: @JoaoMarcos44 for the diagnosis, the fix, and the carefully-scoped contract tests.

Fixes #80498. Closes #80623 (salvaged).
