### PR TITLE
feat(email): opt-in session isolation by normalized subject (#26277)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -13,6 +13,7 @@ Environment variables:
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    EMAIL_SESSION_BY_SUBJECT — Isolate sessions by normalized subject (default: off)
 """
 
 import asyncio
@@ -89,6 +90,38 @@ def _esecret_int(name: str, default: int) -> int:
 def _esecret_bool(name: str, default: bool = False) -> bool:
     """Scope-aware boolean read (``env_bool`` variant of ``_get_esecret``)."""
     return is_truthy_value(_get_esecret(name, ""), default=default)
+
+
+# Placeholder subject used when an email has no Subject header.
+_NO_SUBJECT = "(no subject)"
+
+# Leading reply/forward prefixes stripped when normalizing a subject for
+# session-by-subject routing (#26277): Re/Fw/Fwd plus the common Chinese
+# forms, each followed by ":" or the fullwidth "：". Applied repeatedly so
+# chained prefixes ("答复: Re: …") all come off.
+_SUBJECT_PREFIX_RE = re.compile(
+    r"^\s*(?:re|fw|fwd|答复|回复|转发)\s*[:：]\s*", re.IGNORECASE
+)
+
+
+def _normalize_subject_thread_id(subject: Optional[str]) -> Optional[str]:
+    """Normalize an email subject into a session thread id slug.
+
+    Strips leading reply/forward prefixes (repeatedly, so ``Re: Fw: X`` and
+    ``答复: Re: X`` both reduce to ``X``), then slugs the remainder:
+    lowercase, every run of non-alphanumeric characters collapsed to a
+    single dash, dashes trimmed, capped at 80 chars. Returns ``None`` when
+    nothing usable remains (no subject, or only prefixes/punctuation) so
+    the caller falls back to per-sender session routing.
+    """
+    text = (subject or "").strip()
+    while True:
+        stripped = _SUBJECT_PREFIX_RE.sub("", text, count=1)
+        if stripped == text:
+            break
+        text = stripped
+    slug = re.sub(r"[\W_]+", "-", text.lower()).strip("-")
+    return slug[:80] or None
 
 
 # Automated sender patterns — emails from these are silently ignored
@@ -493,6 +526,19 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Isolate sessions by normalized email subject instead of one session
+        # per sender (#26277). Opt-in: default off preserves per-sender
+        # sessions. Configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       session_by_subject: true
+        # or the EMAIL_SESSION_BY_SUBJECT=true env mirror (parity with the
+        # other EMAIL_* vars).
+        if "session_by_subject" in extra:
+            self._session_by_subject = bool(extra["session_by_subject"])
+        else:
+            self._session_by_subject = _esecret_bool("EMAIL_SESSION_BY_SUBJECT", False)
+
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
         # attacker-controlled and unauthenticated by IMAP, so an allowlist keyed
@@ -746,7 +792,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if "<" in sender_name:
                         sender_name = sender_name.split("<")[0].strip().strip('"')
 
-                    subject = _decode_header_value(msg.get("Subject", "(no subject)"))
+                    subject = _decode_header_value(msg.get("Subject", _NO_SUBJECT))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
                     # Skip automated/noreply senders before any processing
@@ -914,12 +960,21 @@ class EmailAdapter(BasePlatformAdapter):
             "message_id": msg_data["message_id"],
         }
 
+        # Opt-in session isolation by normalized subject (#26277): the slugged
+        # subject becomes the DM thread_id, which build_session_key appends to
+        # the session key. A missing (_NO_SUBJECT placeholder) or prefix-only
+        # subject maps to None → per-sender session, unchanged from before.
+        thread_id = None
+        if self._session_by_subject and subject != _NO_SUBJECT:
+            thread_id = _normalize_subject_thread_id(subject)
+
         source = self.build_source(
             chat_id=sender_addr,
             chat_name=msg_data["sender_name"] or sender_addr,
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -10,6 +10,7 @@ Covers:
 7. check_email_requirements function
 8. Attachment extraction and caching
 9. Message dispatch and threading
+10. Session-by-subject thread id normalization and routing (#26277)
 """
 
 import os
@@ -905,6 +906,172 @@ class TestSenderAuthentication(unittest.TestCase):
             authserv_id="mx.ourserver.com",
         )
         self.assertFalse(ok, reason)
+
+
+class TestNormalizeSubjectThreadId(unittest.TestCase):
+    """Subject → session thread id normalization (#26277)."""
+
+    def test_chained_prefixes_strip(self):
+        from plugins.platforms.email.adapter import _normalize_subject_thread_id
+        for subject in (
+            "Re: Fw: Project Status",
+            "Fwd: Re: Project Status",
+            "RE: FW: Project Status",
+        ):
+            self.assertEqual(
+                _normalize_subject_thread_id(subject), "project-status"
+            )
+
+    def test_localized_prefixes_strip(self):
+        from plugins.platforms.email.adapter import _normalize_subject_thread_id
+        # Fullwidth colon, and localized prefixes chained with Latin ones.
+        self.assertEqual(
+            _normalize_subject_thread_id("答复: Re: Project Status"),
+            "project-status",
+        )
+        self.assertEqual(_normalize_subject_thread_id("回复:Hello"), "hello")
+        self.assertEqual(_normalize_subject_thread_id("转发： 转发: Note"), "note")
+
+    def test_slug_rules(self):
+        from plugins.platforms.email.adapter import _normalize_subject_thread_id
+        # Non-alphanumeric runs collapse to one dash; dashes trimmed; lowercase.
+        self.assertEqual(
+            _normalize_subject_thread_id("  Multiple   Spaces — Here  "),
+            "multiple-spaces-here",
+        )
+        self.assertEqual(
+            _normalize_subject_thread_id("Re:Meeting @ 3pm!"), "meeting-3pm"
+        )
+        # Capped at 80 chars.
+        self.assertEqual(_normalize_subject_thread_id("a" * 200), "a" * 80)
+
+    def test_empty_or_prefix_only_returns_none(self):
+        from plugins.platforms.email.adapter import _normalize_subject_thread_id
+        for subject in ("", None, "Re:", "fwd: 答复：", "!!!"):
+            self.assertIsNone(_normalize_subject_thread_id(subject))
+
+
+class TestSessionBySubject(unittest.TestCase):
+    """Opt-in session isolation by normalized subject (#26277)."""
+
+    def setUp(self):
+        # Dispatch fails closed without allow-all (SECURITY.md 2.6); opt in to
+        # exercise the dispatch path, and start with the feature flag unset so
+        # the default-off tests are insulated from the ambient environment.
+        self._prev_allow_all = os.environ.get("EMAIL_ALLOW_ALL_USERS")
+        self._prev_flag = os.environ.get("EMAIL_SESSION_BY_SUBJECT")
+        os.environ["EMAIL_ALLOW_ALL_USERS"] = "true"
+        os.environ.pop("EMAIL_SESSION_BY_SUBJECT", None)
+
+    def tearDown(self):
+        for name, prev in (
+            ("EMAIL_ALLOW_ALL_USERS", self._prev_allow_all),
+            ("EMAIL_SESSION_BY_SUBJECT", self._prev_flag),
+        ):
+            if prev is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = prev
+
+    def _make_adapter(self, extra_env=None, config_extra=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        env.update(extra_env or {})
+        with patch.dict(os.environ, env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(
+                PlatformConfig(enabled=True, extra=config_extra or {})
+            )
+        return adapter
+
+    def _dispatch(self, adapter, subject, message_id="<m1@test.com>"):
+        """Dispatch one email from the same sender; return the MessageEvent."""
+        import asyncio
+        captured = []
+
+        async def capture_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = capture_handle
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": subject,
+            "message_id": message_id,
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }))
+        self.assertEqual(len(captured), 1)
+        return captured[0]
+
+    def test_flag_off_keeps_per_sender_session(self):
+        """Regression guard: flag off → no thread_id → today's session key."""
+        from gateway.session import build_session_key
+        adapter = self._make_adapter()
+        event = self._dispatch(adapter, "Project Status")
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(
+            build_session_key(event.source),
+            "agent:main:email:dm:user@test.com",
+        )
+
+    def test_flag_on_same_normalized_subject_same_session(self):
+        from gateway.session import build_session_key
+        adapter = self._make_adapter(
+            extra_env={"EMAIL_SESSION_BY_SUBJECT": "true"}
+        )
+        first = self._dispatch(adapter, "Project Status", "<m1@test.com>")
+        reply = self._dispatch(adapter, "Re: Fw: Project Status", "<m2@test.com>")
+        self.assertEqual(first.source.thread_id, "project-status")
+        self.assertEqual(reply.source.thread_id, "project-status")
+        self.assertEqual(
+            build_session_key(first.source), build_session_key(reply.source)
+        )
+        self.assertEqual(
+            build_session_key(first.source),
+            "agent:main:email:dm:user@test.com:project-status",
+        )
+
+    def test_flag_on_different_subject_different_session(self):
+        from gateway.session import build_session_key
+        adapter = self._make_adapter(
+            extra_env={"EMAIL_SESSION_BY_SUBJECT": "true"}
+        )
+        first = self._dispatch(adapter, "Project Status", "<m1@test.com>")
+        other = self._dispatch(adapter, "Budget Review", "<m2@test.com>")
+        self.assertNotEqual(
+            build_session_key(first.source), build_session_key(other.source)
+        )
+
+    def test_flag_on_via_config_extra(self):
+        """platforms.email.session_by_subject enables the feature without env."""
+        adapter = self._make_adapter(config_extra={"session_by_subject": True})
+        event = self._dispatch(adapter, "Project Status")
+        self.assertEqual(event.source.thread_id, "project-status")
+
+    def test_missing_or_prefix_only_subject_falls_back_to_per_sender(self):
+        from gateway.session import build_session_key
+        adapter = self._make_adapter(
+            extra_env={"EMAIL_SESSION_BY_SUBJECT": "true"}
+        )
+        # "(no subject)" is the placeholder the fetch layer substitutes for a
+        # missing Subject header; "Re:" normalizes to nothing. Both must keep
+        # the per-sender session.
+        for subject in ("(no subject)", "Re:"):
+            event = self._dispatch(adapter, subject)
+            self.assertIsNone(event.source.thread_id)
+            self.assertEqual(
+                build_session_key(event.source),
+                "agent:main:email:dm:user@test.com",
+            )
 
 
 if __name__ == "__main__":

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -138,6 +138,20 @@ platforms:
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
 
+### Sessions by Subject
+
+By default, all emails from the same sender share one Hermes session. To give each email thread its own session — a new subject starts fresh (like `/new`), while `Re:`/`Fw:` replies continue the existing session — opt in via `config.yaml`:
+
+```yaml
+platforms:
+  email:
+    session_by_subject: true
+```
+
+or the `EMAIL_SESSION_BY_SUBJECT=true` environment variable.
+
+The subject is normalized before routing: leading reply/forward prefixes (`Re:`, `Fw:`, `Fwd:`, plus `答复:`, `回复:`, `转发:`) are stripped repeatedly, and the remainder is slugged (lowercase, punctuation runs collapsed to single dashes, 80-character cap). `Re: Fw: Project Status` and `答复: Re: Project Status` both map to `project-status`. Emails with no usable subject keep the per-sender session.
+
 ---
 
 ## Access Control
@@ -196,3 +210,4 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_SESSION_BY_SUBJECT` | No | `false` | Isolate sessions by normalized email subject |


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in mode for the email gateway that isolates Hermes sessions by normalized email subject, instead of treating every message from the same sender as one continuous session.

When enabled (`EMAIL_SESSION_BY_SUBJECT=true` or `platforms.email.session_by_subject: true`; default off), the adapter:

- repeatedly strips leading reply/forward prefixes (`Re:`, `Fw:`, `Fwd:`, plus the localized `答复:`, `回复:`, `转发:`, each with an ASCII or fullwidth `：` colon) — `Re: Fw: Project Status` and `答复: Re: Project Status` both reduce to `Project Status`
- slugs the remainder: lowercase, non-alphanumeric runs collapsed to single dashes, dashes trimmed, capped at 80 chars
- passes the slug as the DM `thread_id`, which `build_session_key` already appends to the session key (`agent:main:email:dm:<sender>:<slug>`) — no session-layer changes needed

The sender address stays in the key, so identical subjects from different senders never share context. Empty, missing (`(no subject)` placeholder), or prefix-only subjects normalize to `None` and keep today's per-sender routing. With the flag off, `thread_id=None` is passed — byte-identical to current behavior.

This is provider-independent and works on any IMAP mailbox, unlike the Gmail-only `X-GM-THRID` approach in #11422.

Intentionally out of scope:

- The issue's second half — marking quoted body content as reference-only context — is not included.
- The status-email volume complaint in #27804. Its other complaint is covered when the flag is on: a new subject maps to a different session key, and busy/interrupt handling is keyed by session key, so the new message routes to its own session instead of interrupting the running task.

## Related Issue

Implements #26277 (quoted-content half intentionally excluded, so no auto-close keyword)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/email/adapter.py`: `EMAIL_SESSION_BY_SUBJECT` env var / `platforms.email.session_by_subject` config key (default off); `_normalize_subject_thread_id()` (chained prefix stripping + slug); dispatch passes the slug as `thread_id` to `build_source`; the `(no subject)` placeholder is hoisted to `_NO_SUBJECT` so it falls back to per-sender routing
- `tests/gateway/test_email.py`: `TestNormalizeSubjectThreadId` and `TestSessionBySubject` — chained/localized/fullwidth-colon prefix stripping, slug rules (collapse, trim, 80-char cap), empty/prefix-only → `None`, flag-off regression (no `thread_id`, per-sender key), same-subject-same-key / different-subject-different-key, both config paths, `(no subject)` fallback
- `website/docs/user-guide/messaging/email.md`: new "Sessions by Subject" section + environment variable reference row

## How to Test

1. `pytest tests/gateway/test_email.py -q` — 41 passed (9 new)
2. `ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py` — clean
3. Manual: set `EMAIL_SESSION_BY_SUBJECT=true`, then from an allowed sender send two emails with different subjects → two independent sessions; reply `Re:` on the first subject → continues that subject's session; with the flag unset, behavior is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#11422 targets the pre-migration path with a Gmail-specific approach; #45600 stalled on mixed concerns — this PR is single-purpose against `plugins/platforms/email/adapter.py`)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — the local failures (missing `acp` module, systemd socket, sandbox-dependent tools) fail identically on a clean `main` worktree; every email/gateway/session test passes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests; no live IMAP server run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no email platform keys are documented there today)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string handling, stdlib `re` only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
