### PR TITLE
fix(desktop): keep the chat in front of the terminal in Focus layout

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -2,9 +2,16 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { hiddenPaneProps, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { $paneStates } from '@/store/panes'
 
+import { $terminalTakeover } from '../store'
+
 import { PersistentTerminal, TerminalSlot } from './persistent'
+
+vi.mock('../store', async () => ({
+  $terminalTakeover: (await import('nanostores')).atom(false)
+}))
 
 vi.mock('./terminals', () => ({
   ensureTerminal: vi.fn()
@@ -125,6 +132,17 @@ function Harness() {
   )
 }
 
+function HiddenPaneHarness({ hidden }: { hidden: boolean }) {
+  return (
+    <>
+      <div {...hiddenPaneProps(hidden)}>
+        <TerminalSlot className="slot" />
+      </div>
+      <PersistentTerminal onAddSelectionToChat={() => undefined} />
+    </>
+  )
+}
+
 describe('PersistentTerminal rect tracking', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -164,6 +182,7 @@ describe('PersistentTerminal rect tracking', () => {
 
   afterEach(() => {
     cleanup()
+    $terminalTakeover.set(false)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     setVisibility(false)
@@ -332,5 +351,63 @@ describe('PersistentTerminal rect tracking', () => {
     act(() => window.dispatchEvent(new Event('focus')))
 
     expect(raf.pending()).toBe(1)
+  })
+
+  it('hides the overlay but keeps its workspace mounted when the terminal tab becomes inactive', () => {
+    const raf = installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+    $terminalTakeover.set(true)
+
+    render(<HiddenPaneHarness hidden={false} />)
+
+    const overlay = container!.lastElementChild as HTMLElement
+    const workspace = container!.querySelector('[data-testid="terminal-workspace"]')
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(workspace).not.toBeNull()
+    expect(mutationObserveCalls.some(call => call.options?.attributeFilter?.includes(PANE_HIDDEN_ATTR))).toBe(true)
+
+    // Let the initial changed-rect follow-up settle. The hidden-pane transition
+    // must wake the observer from an otherwise idle state.
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.opacity).toBe('0')
+    expect(overlay.style.pointerEvents).toBe('none')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
+
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden={false} />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
   })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
@@ -50,6 +51,7 @@ interface PersistentTerminalProps {
 }
 
 interface Rect {
+  hidden: boolean
   top: number
   left: number
   width: number
@@ -57,7 +59,7 @@ interface Rect {
 }
 
 const sameRect = (a: Rect | null, b: Rect) =>
-  !!a && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
+  !!a && a.hidden === b.hidden && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
 
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
@@ -112,7 +114,16 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
       // full pixel footprint, so half-pixel rects can't leak page bg through.
       const top = Math.floor(r.top)
       const left = Math.floor(r.left)
-      const next: Rect = { top, left, width: Math.ceil(r.right) - left, height: Math.ceil(r.bottom) - top }
+
+      // Inactive keep-alive panes deliberately retain the same rect as the
+      // foreground pane, so visibility must be sampled independently.
+      const next: Rect = {
+        hidden: isElementInHiddenPane(slot),
+        top,
+        left,
+        width: Math.ceil(r.right) - left,
+        height: Math.ceil(r.bottom) - top
+      }
 
       if (!sameRect(prev, next)) {
         prev = next
@@ -182,7 +193,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
     for (let node: HTMLElement | null = slot; node; node = node.parentElement) {
       positionObserver?.observe(node, {
-        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state'],
+        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state', PANE_HIDDEN_ATTR],
         attributes: true,
         childList: true,
         subtree: false
@@ -218,7 +229,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     }
   }, [slot])
 
-  const visible = Boolean(rect && rect.width > 0 && rect.height > 0)
+  const visible = Boolean(rect && !rect.hidden && rect.width > 0 && rect.height > 0)
 
   const style: CSSProperties = {
     position: 'fixed',
@@ -229,6 +240,10 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     display: 'flex',
     flexDirection: 'column',
     visibility: visible ? 'visible' : 'hidden',
+    // Electron may keep xterm's WebGL canvas visually composited after an
+    // ancestor becomes visibility:hidden. Opacity clears that compositor layer
+    // while preserving the mounted DOM, terminal dimensions, and live PTY.
+    opacity: visible ? 1 : 0,
     pointerEvents: visible ? 'auto' : 'none',
     zIndex: 4,
     // Match the live skin surface so the header strip (transparent) and body

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -434,11 +434,14 @@ describe('startFreshSessionDraft', () => {
     expect($newChatWorkspaceTarget.get()).toBeNull()
   })
 
-  it('clears the terminal takeover so the fresh chat takes the screen', async () => {
-    // Regression: a persisted terminal takeover (⌃` / statusbar toggle) kept
-    // the terminal pane fronted after New Session / ⌘N, bouncing the user
-    // straight back to the terminal. A fresh chat must collapse the pane to
-    // its rail (PTYs stay alive) and surface the new session.
+  it('fronts the workspace without closing a terminal that is merely behind a tab', async () => {
+    // Regression: a persisted terminal takeover kept the terminal fronted
+    // after New Session / ⌘N. The fix is to reveal the workspace — NOT to
+    // clear the takeover atom. That atom is the terminal's open/closed state
+    // in every layout: clearing it here closed a terminal sitting in its own
+    // zone (Default / Terminal deck / Quad), and persisted a `false` that left
+    // the Focus tab unable to mount its workspace after a restart. Behind a
+    // tab the terminal is hidden, not closed.
     const navigate = vi.fn()
     const requestGateway = vi.fn(async () => ({}) as never)
     let handle: HarnessHandle | null = null
@@ -451,7 +454,8 @@ describe('startFreshSessionDraft', () => {
 
     act(() => handle!.startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null }))
 
-    expect($terminalTakeover.get()).toBe(false)
+    expect(revealTreePane).toHaveBeenCalledWith('workspace')
+    expect($terminalTakeover.get()).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
@@ -431,6 +432,26 @@ describe('startFreshSessionDraft', () => {
     expect(navigate).not.toHaveBeenCalled()
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
+  it('clears the terminal takeover so the fresh chat takes the screen', async () => {
+    // Regression: a persisted terminal takeover (⌃` / statusbar toggle) kept
+    // the terminal pane fronted after New Session / ⌘N, bouncing the user
+    // straight back to the terminal. A fresh chat must collapse the pane to
+    // its rail (PTYs stay alive) and surface the new session.
+    const navigate = vi.fn()
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    setTerminalTakeover(true)
+    expect($terminalTakeover.get()).toBe(true)
+
+    render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null }))
+
+    expect($terminalTakeover.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,7 +2,6 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
-import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -298,12 +297,15 @@ export function useSessionActions({
       setAwaitingResponse(false)
       clearNotifications()
       setIntroSeed(seed => seed + 1)
-      // A fresh chat takes the screen: the terminal's persisted takeover flag
-      // (⌃` / the statusbar toggle) must not keep the pane fronted over the
-      // new session — otherwise New Session / ⌘N bounces straight back to the
-      // terminal. The terminal itself stays alive (tool panels collapse to a
-      // rail, PTYs are never torn down); only the fronting flag is cleared.
-      setTerminalTakeover(false)
+      // A fresh chat takes the screen. Front the workspace — and ONLY that:
+      // `$terminalTakeover` is the terminal's open/closed state in every
+      // layout, not a Focus-only overlay flag, so clearing it here would close
+      // a terminal sitting harmlessly in its own zone (Default, Terminal deck,
+      // Quad) and would persist a `false` that leaves the Focus tab unable to
+      // mount its workspace on the next boot. Behind another tab the terminal
+      // is hidden, not closed: it keeps its PTYs and the overlay stops
+      // painting on the pane-hidden marker, which is what actually cleared the
+      // chat.
       revealTreePane('workspace')
       // Clear the durable route intent synchronously, before React Router
       // publishes /new. Submit uses that intent to heal an existing-session

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
+import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -297,6 +298,13 @@ export function useSessionActions({
       setAwaitingResponse(false)
       clearNotifications()
       setIntroSeed(seed => seed + 1)
+      // A fresh chat takes the screen: the terminal's persisted takeover flag
+      // (⌃` / the statusbar toggle) must not keep the pane fronted over the
+      // new session — otherwise New Session / ⌘N bounces straight back to the
+      // terminal. The terminal itself stays alive (tool panels collapse to a
+      // rail, PTYs are never torn down); only the fronting flag is cleared.
+      setTerminalTakeover(false)
+      revealTreePane('workspace')
       // Clear the durable route intent synchronously, before React Router
       // publishes /new. Submit uses that intent to heal an existing-session
       // rebind race, so leaving the old id here could revive it on a very fast

--- a/apps/desktop/src/components/pane-shell/pane-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/pane-visibility.ts
@@ -42,9 +42,12 @@ export const PaneGroupContext = createContext(NO_PANE_GROUP)
 
 export const usePaneGroup = (): string => useContext(PaneGroupContext)
 
+/** Whether an element belongs to an inactive keep-alive pane. */
+export const isElementInHiddenPane = (element: Element): boolean => Boolean(element.closest(HIDDEN_PANE))
+
 /** `querySelectorAll` minus anything inside an inactive tab. */
 export const queryAllVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): T[] =>
-  [...root.querySelectorAll<T>(selector)].filter(el => !el.closest(HIDDEN_PANE))
+  [...root.querySelectorAll<T>(selector)].filter(el => !isElementInHiddenPane(el))
 
 /** `querySelector` minus anything inside an inactive tab. */
 export const queryVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): null | T =>

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1380,11 +1380,22 @@ export function setPaneCollapsed(paneId: string, collapsed: boolean) {
   if (group.panes.length > 1) {
     if (collapsed && group.active === paneId) {
       if (group.panes.some(isUncloseablePane)) {
-        // Workspace can't minimize (strands the app) → tab-switch to a sibling
-        // (guaranteed to exist by length > 1).
+        // Workspace can't minimize (strands the app) → hand the active slot to
+        // the uncloseable (workspace) pane rather than an arbitrary adjacent
+        // sibling. [workspace, files, review, terminal] with the terminal
+        // active must land on workspace (New Session semantics), not on review
+        // via `panes[at - 1]` — which left the user stranded on a tool pane
+        // and (before the overlay fix) the terminal visually foreground.
+        const anchor = group.panes.find(isUncloseablePane)
         const at = group.panes.indexOf(paneId)
 
-        activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
+        if (anchor && anchor !== paneId) {
+          activateTreePane(group.id, anchor)
+        } else {
+          // Defensive: collapsing the uncloseable pane itself (never bound to
+          // a tool toggle store) — fall back to the sibling.
+          activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
+        }
       } else {
         setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
       }

--- a/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
@@ -9,6 +9,7 @@ import {
   $dismissedPanes,
   $hiddenTreePanes,
   $layoutTree,
+  activateTreePane,
   bindToolPaneCollapse,
   closeToolPane,
   isPaneVisible,
@@ -175,12 +176,13 @@ describe('toggling the terminal while it is stacked with logs', () => {
 })
 
 describe('collapsing the active terminal in a shared group with the workspace', () => {
-  // Ground truth for PR #79864's second act: New Session from a Focus-layout
-  // group [workspace, files, review, terminal] with the terminal active used to
-  // land on 'review' (`panes[at - 1]`) — an arbitrary adjacent sibling — so
-  // after the takeover atom cleared, the wrong pane held the slot: blank pane
-  // with the terminal overlay hidden. Collapsing an active tool pane must hand
-  // the slot to the uncloseable workspace pane, not a strip neighbour.
+  // The terminal is a TAB in the workspace's own group under the Focus preset:
+  // [workspace, files, review, terminal]. Collapsing it used to hand the slot
+  // to `panes[at - 1]` — 'review' — so ⌃` / the rail / the statusbar toggle
+  // dropped the user on a diff pane they never opened, and with the overlay
+  // still painting it read as "the terminal came back". The slot belongs to
+  // the uncloseable workspace, the one member guaranteed to be a real
+  // destination.
 
   function focusGroup() {
     $layoutTree.set(group(['workspace', 'files', 'review', 'terminal'], { active: 'terminal', id: 'g-focus' }))
@@ -192,7 +194,7 @@ describe('collapsing the active terminal in a shared group with the workspace', 
     return tree?.type === 'group' ? tree.active : undefined
   }
 
-  it('startFreshSessionDraft: clearing takeover lands on workspace, not review', () => {
+  it('⌃` / the rail toggle lands on workspace, not review', () => {
     focusGroup()
 
     // Production wiring (controller.tsx): the takeover atom IS the terminal's
@@ -210,7 +212,9 @@ describe('collapsing the active terminal in a shared group with the workspace', 
     expect(focusActive()).toBe('terminal')
     expect(isPaneVisible('terminal')).toBe(true)
 
-    // Exactly what startFreshSessionDraft does on ⌘N / the sidebar button.
+    // The user presses ⌃` (or clicks the rail / statusbar toggle) to put the
+    // terminal away. bindToolPaneCollapse routes a false store through
+    // setPaneCollapsed.
     setTerminalTakeover(false)
 
     expect($terminalTakeover.get()).toBe(false)
@@ -223,6 +227,7 @@ describe('collapsing the active terminal in a shared group with the workspace', 
   it('openNewSessionTile (+ / ⌘T): the new session tab fronts and the terminal tab goes hidden', () => {
     const stored = 'stored-1'
     const tilePaneId = `session-tile:${stored}`
+
     const dispose = registry.register({
       area: 'panes',
       data: { placement: 'main' },
@@ -230,6 +235,7 @@ describe('collapsing the active terminal in a shared group with the workspace', 
       render: () => null,
       title: 'new session'
     })
+
     disposers.push(dispose)
 
     // The tile lands in the same shared zone as the workspace + terminal
@@ -260,6 +266,98 @@ describe('collapsing the active terminal in a shared group with the workspace', 
     // measures — so the terminal surface stops covering the new session tab.
     expect(isPaneVisible(tilePaneId)).toBe(true)
     expect($terminalTakeover.get()).toBe(true) // toggle store stays truthful
+  })
+
+  it('startFreshSessionDraft (⌘N): fronts the workspace and leaves the terminal open behind its tab', () => {
+    focusGroup()
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    setTerminalTakeover(true)
+    expect(focusActive()).toBe('terminal')
+
+    // What startFreshSessionDraft does: reveal, and nothing else. It must NOT
+    // clear the takeover atom — that is the terminal's open/closed state, not
+    // a fronting flag.
+    revealTreePane('workspace')
+
+    expect(focusActive()).toBe('workspace')
+    expect(isPaneVisible('workspace')).toBe(true)
+    // Hidden behind the workspace tab, so the overlay stops painting (the
+    // actual cause of the chat being covered) …
+    expect(isPaneVisible('terminal')).toBe(false)
+    // … while the terminal stays OPEN: its PTYs live and clicking the tab
+    // brings back a mounted workspace.
+    expect($terminalTakeover.get()).toBe(true)
+  })
+})
+
+describe('a terminal that owns its own zone (Default / Terminal deck / Quad)', () => {
+  // Only the Focus preset stacks the terminal with the workspace. Everywhere
+  // else it sits in a group of its own, beside the chat rather than over it —
+  // so a fresh chat has no reason to touch it.
+  it('stays open and visible when a fresh chat fronts the workspace', () => {
+    $layoutTree.set(
+      split('row', [group(['workspace'], { id: 'grp-main' }), group(['terminal'], { id: 'grp-terminal' })], [3, 1])
+    )
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    setTerminalTakeover(true)
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    revealTreePane('workspace')
+
+    expect(isPaneVisible('workspace')).toBe(true)
+    // Regression: clearing takeover inside startFreshSessionDraft minimized
+    // this zone, folding a terminal that was never obscuring anything.
+    expect(isPaneVisible('terminal')).toBe(true)
+    expect($terminalTakeover.get()).toBe(true)
+  })
+
+  it('survives a restart with a clickable, mountable terminal tab', () => {
+    $layoutTree.set(group(['workspace', 'files', 'review', 'terminal'], { active: 'terminal', id: 'g-focus' }))
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    setTerminalTakeover(true)
+    revealTreePane('workspace')
+
+    // ── restart: the tree and the takeover atom are both persisted ──
+    const persistedTakeover = $terminalTakeover.get()
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    // Regression: a persisted `false` left the tab in the strip and
+    // un-minimized, but PersistentTerminal mounts its workspace only while
+    // takeover is true — so clicking the tab (a bare activateTreePane) fronted
+    // an empty pane.
+    expect(persistedTakeover).toBe(true)
+
+    activateTreePane('g-focus', 'terminal')
+
+    expect(isPaneVisible('terminal')).toBe(true)
+    expect($terminalTakeover.get()).toBe(true)
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { registry } from '@/contrib/registry'
 
 import { allPaneIds, group, split } from './model'
@@ -11,6 +12,7 @@ import {
   bindToolPaneCollapse,
   closeToolPane,
   isPaneVisible,
+  revealTreePane,
   setTreeGroupHeaderHidden,
   togglePaneVisible
 } from './store'
@@ -44,6 +46,8 @@ beforeEach(() => {
 
   for (const [id, data] of [
     ['workspace', { placement: 'main', uncloseable: true }],
+    ['files', { placement: 'right' }],
+    ['review', { placement: 'right' }],
     ['terminal', { placement: 'bottom' }],
     ['logs', { placement: 'bottom' }]
   ] as const) {
@@ -167,6 +171,95 @@ describe('toggling the terminal while it is stacked with logs', () => {
 
     expect(allPaneIds($layoutTree.get()!)).toContain('terminal')
     expect(isPaneVisible('terminal')).toBe(true)
+  })
+})
+
+describe('collapsing the active terminal in a shared group with the workspace', () => {
+  // Ground truth for PR #79864's second act: New Session from a Focus-layout
+  // group [workspace, files, review, terminal] with the terminal active used to
+  // land on 'review' (`panes[at - 1]`) — an arbitrary adjacent sibling — so
+  // after the takeover atom cleared, the wrong pane held the slot: blank pane
+  // with the terminal overlay hidden. Collapsing an active tool pane must hand
+  // the slot to the uncloseable workspace pane, not a strip neighbour.
+
+  function focusGroup() {
+    $layoutTree.set(group(['workspace', 'files', 'review', 'terminal'], { active: 'terminal', id: 'g-focus' }))
+  }
+
+  const focusActive = () => {
+    const tree = $layoutTree.get()
+
+    return tree?.type === 'group' ? tree.active : undefined
+  }
+
+  it('startFreshSessionDraft: clearing takeover lands on workspace, not review', () => {
+    focusGroup()
+
+    // Production wiring (controller.tsx): the takeover atom IS the terminal's
+    // toggle store; the closer/opener write it back.
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    // User had the terminal open and active.
+    setTerminalTakeover(true)
+    expect($terminalTakeover.get()).toBe(true)
+    expect(focusActive()).toBe('terminal')
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    // Exactly what startFreshSessionDraft does on ⌘N / the sidebar button.
+    setTerminalTakeover(false)
+
+    expect($terminalTakeover.get()).toBe(false)
+    expect(isPaneVisible('terminal')).toBe(false)
+    // THE regression: used to be 'review' (group.panes[at - 1]).
+    expect(focusActive()).toBe('workspace')
+    expect(isPaneVisible('workspace')).toBe(true)
+  })
+
+  it('openNewSessionTile (+ / ⌘T): the new session tab fronts and the terminal tab goes hidden', () => {
+    const stored = 'stored-1'
+    const tilePaneId = `session-tile:${stored}`
+    const dispose = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: tilePaneId,
+      render: () => null,
+      title: 'new session'
+    })
+    disposers.push(dispose)
+
+    // The tile lands in the same shared zone as the workspace + terminal
+    // (Focus preset: docked 'center' into the focused chat zone).
+    $layoutTree.set(
+      group(['workspace', 'files', 'review', 'terminal', tilePaneId], { active: 'terminal', id: 'g-focus' })
+    )
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    setTerminalTakeover(true)
+    expect(focusActive()).toBe('terminal')
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    // Exactly what openNewSessionTile does after openSessionTile + patch:
+    // `revealTreePane(`session-tile:${stored}`)` (use-session-actions:521).
+    revealTreePane(tilePaneId)
+
+    expect(focusActive()).toBe(tilePaneId)
+    expect(isPaneVisible('terminal')).toBe(false)
+    // The terminal layer gets data-pane-hidden (tree-group spreads
+    // hiddenPaneProps(!isActive)), which the PersistentTerminal overlay now
+    // measures — so the terminal surface stops covering the new session tab.
+    expect(isPaneVisible(tilePaneId)).toBe(true)
+    expect($terminalTakeover.get()).toBe(true) // toggle store stays truthful
   })
 })
 


### PR DESCRIPTION
In the Focus layout the terminal shares a tab group with the workspace. Opening it and then trying to get back to a chat — via ⌘N, the sidebar's New Session, or the tab strip's `+` — could leave the terminal painted over the new chat and swallowing its clicks, or drop you on a `review` pane you never opened.

Three separate defects produce that, one per layer, and they chain: the fresh-session reset skipped the terminal's toggle atom; clearing that atom collapses the terminal, which selected the wrong sibling; and the overlay kept painting regardless of which tab was actually in front. Fixing any one alone just changes which symptom you get, which is why the earlier attempts each looked partly right and partly wrong in the field.

This consolidates the three open PRs on that bug into one fix set, keeping each author's commit.

### The three layers

**1. The overlay ignored hidden panes** — `persistent.tsx`, `pane-visibility.ts`

Keep-alive tab layers stay mounted when inactive and deliberately keep their layout box, so an inactive terminal slot reports a rect identical to the front tab's. Gating the fixed overlay on `rect.width > 0 && rect.height > 0` therefore can't tell "I am the visible tab" from "I am a parked tab", and the overlay stayed composited at z-4 over whatever the user switched to. `Rect` now carries `hidden` from `isElementInHiddenPane(slot)`, `sameRect` compares it, the ancestor `MutationObserver` watches `PANE_HIDDEN_ATTR`, and the overlay gates on `!rect.hidden`. `TerminalWorkspace` stays mounted throughout — PTYs are never torn down, only the surface stops painting. `opacity: 0` rides along because Electron can keep xterm's WebGL canvas composited after an ancestor goes `visibility: hidden`.

**2. Collapsing an active tool pane picked a positional neighbour** — `tree/store.ts`

The workspace can't minimize, so a shared zone tab-switches instead — but it switched to `group.panes[at - 1]`. For `[workspace, files, review, terminal]` that means collapsing the terminal selects `review`: the user asked for the terminal to go away and landed on a diff pane. It now hands the slot to the uncloseable pane, the one member guaranteed to be a real destination rather than another tool nobody asked for. The positional fallback remains for the defensive case of collapsing the uncloseable pane itself.

**3. A fresh chat never fronted the workspace** — `use-session-actions/index.ts`

`startFreshSessionDraft` resets messages, usage, timers, route intent, and cwd, but never said which pane should hold the slot, so ⌘N could leave the terminal tab active over the new chat. It now calls `revealTreePane('workspace')`.

That is the *whole* change — it deliberately does **not** touch `$terminalTakeover`. An earlier revision of this branch cleared that atom too; [Copilot caught](https://github.com/NousResearch/hermes-agent/pull/81019#discussion_r3735812264) that it is the terminal's open/closed state in every layout rather than a Focus-only fronting flag, and both failure modes reproduce. Only Focus stacks the terminal with the workspace — Default, Terminal deck, and Quad each give it its own zone, where clearing minimized a terminal that obscured nothing. The atom is also persisted, so a cleared flag survived restart and left the Focus tab fronting empty (`PersistentTerminal` mounts only while takeover is true). Behind another tab the terminal is hidden, not closed: layer 1 stops the overlay painting, which is what was actually covering the chat.

### Behavior change worth flagging

Layer 2 is intentionally broader than New Session. Every route into `setPaneCollapsed` for a shared zone gets the new target — the rail, the tab toggle, and ⌃`. Pure tool-only zones are untouched and still fold as a unit.

### Coverage

Three regression tests, one per layer, each verified to **fail on unpatched `main`** before the fix:

- `tool-pane-toggle.test.ts` — Focus group `[workspace, files, review, terminal]` with the terminal active collapses to `workspace`. Fails on main with `expected 'review' to be 'workspace'`.
- `persistent.test.tsx` — the overlay goes visible → hidden → visible across a tab switch while the same `TerminalWorkspace` instance stays mounted. Fails on main with `expected '' to be '1'`.
- `use-session-actions.test.tsx` — `startFreshSessionDraft` fronts the workspace and leaves takeover alone.

Two more guard the review fix, both verified to fail when the takeover clear is reinstated (`expected false to be true`): a terminal in its own zone stays open and visible across a fresh chat, and a Focus terminal tab still mounts after a restart.

Desktop suite: 4416 passed, +56 over main's 4360, no new failures. `eslint src/ electron/` reports 0 errors. The 10 pre-existing `frimousse` transform failures and the `store.ts:673` prettier warning are identical on untouched `main` and are not touched here.

### Credit

Salvaged from three PRs that each found part of this, with commits kept under their original authors:

- @izumi0uu — the hidden-pane overlay fix (#71457), carried as the original commit
- @DECRUX9812 — the fresh-session and collapse-target layers (#79864), plus the diagnosis tying all three together
- @HexLab98 — independently diagnosed the same overlay defect (#75522)

#79864 was already rebased onto current `main` and honestly flagged its overlay hunks as a port of #71457 to be reconciled; this does that reconciliation, restoring the original authorship it couldn't carry. #71457 and #75522 both now conflict with `main` after the recent `persistent.tsx` perf work.

Supersedes #71457, #75522, #79864
Closes #71407

Co-authored-by: izumi0uu <izumi0uu@gmail.com>
Co-authored-by: Ritesh Patel <60716910+DECRUX9812@users.noreply.github.com>
Co-authored-by: HexLab98 <liruixinch@outlook.com>

