### PR TITLE
fix(cron): fail closed when the TERMINAL_CWD lock times out

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -556,14 +556,16 @@ _terminal_cwd_lock = _ReadWriteLock()
 
 # Ceiling on how long a cron job waits for the TERMINAL_CWD lock before
 # FAILING (fail-closed, #79768). Derived from the cron inactivity limit
-# (HERMES_CRON_TIMEOUT, default 600s): a *wedged* lock holder stops touching
-# its activity clock, so the inactivity monitor kills it and the lock is
-# released within roughly that limit — a waiter that outlasts it plus margin
-# is facing a holder even the monitor could not reap, and must not run:
-# proceeding without the lock lets the holder's process-global TERMINAL_CWD
-# override leak into this job's shell/file/code-exec commands (wrong-directory
-# execution — the exact corruption _ReadWriteLock exists to prevent, see
-# test_reader_never_observes_writer_override). A *healthy* long-running
+# (HERMES_CRON_TIMEOUT, default 600s): a wedged lock holder stops touching
+# its activity clock, so the inactivity monitor usually reaps it and the
+# lock is released within roughly that limit. The bound is measured from
+# the WAITER's arrival, so a holder that wedges late (or hangs in pre-agent
+# setup before the monitor arms) can still outlive it — waiters then fail
+# loudly rather than run: proceeding without the lock lets the holder's
+# process-global TERMINAL_CWD override leak into this job's shell/file/
+# code-exec commands (wrong-directory execution — the exact corruption
+# _ReadWriteLock exists to prevent, see
+# test_reader_never_observes_writer_override). A healthy long-running
 # workdir job past the bound also fails its waiters loudly rather than
 # corrupting them silently; the failure names the holder pattern so the fix
 # (stagger schedules / drop the workdir) is actionable.
@@ -571,13 +573,27 @@ _CWD_LOCK_TIMEOUT_FLOOR_SECONDS = 120.0
 _CWD_LOCK_TIMEOUT_MARGIN_SECONDS = 60.0
 
 
+def _cron_inactivity_seconds() -> float:
+    """Parse HERMES_CRON_TIMEOUT (seconds). 0 = unlimited; bad input = 600.
+
+    Shared by run_job's inactivity monitor (which maps 0 to "no limit") and
+    the cwd-lock bound below (which keeps the wait bounded regardless) so
+    the two sites cannot drift apart — the lock bound must stay at or above
+    the inactivity limit or waiters would fail while a healthy holder runs.
+    """
+    raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    if not raw:
+        return 600.0
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid HERMES_CRON_TIMEOUT=%r; using default 600s", raw)
+        return 600.0
+
+
 def _cwd_lock_timeout_seconds() -> float:
     """Bound for the TERMINAL_CWD lock wait: inactivity limit + margin."""
-    raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-    try:
-        inactivity = float(raw) if raw else 600.0
-    except (ValueError, TypeError):
-        inactivity = 600.0
+    inactivity = _cron_inactivity_seconds()
     if inactivity <= 0:  # 0 = unlimited job runtime; keep the wait bounded.
         inactivity = 600.0
     return (
@@ -3236,12 +3252,13 @@ def run_job(
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
 
     _holds_cwd_write = _job_workdir is not None
+    _cwd_lock_timeout = _cwd_lock_timeout_seconds()
     _cwd_lock_acquired = True
     if _holds_cwd_write:
-        if not _terminal_cwd_lock.acquire_write(timeout=_cwd_lock_timeout_seconds()):
+        if not _terminal_cwd_lock.acquire_write(timeout=_cwd_lock_timeout):
             _cwd_lock_acquired = False
     else:
-        if not _terminal_cwd_lock.acquire_read(timeout=_cwd_lock_timeout_seconds()):
+        if not _terminal_cwd_lock.acquire_read(timeout=_cwd_lock_timeout):
             _cwd_lock_acquired = False
 
     # Everything after the acquire MUST live inside this try, so the finally
@@ -3263,11 +3280,11 @@ def run_job(
             raise TimeoutError(
                 f"Timed out waiting for the TERMINAL_CWD "
                 f"{'write' if _holds_cwd_write else 'read'} lock after "
-                f"{_cwd_lock_timeout_seconds():.0f}s — another workdir cron "
-                f"job has held it for longer than the cron inactivity limit "
-                f"(wedged, or legitimately long-running). Stagger its "
-                f"schedule or remove its workdir to unblock this job "
-                f"(#79768)."
+                f"{_cwd_lock_timeout:.0f}s — another cron job (a workdir "
+                f"writer, or long-running readers) has held it for longer "
+                f"than the cron inactivity limit. If a workdir job is the "
+                f"holder, stagger its schedule or remove its workdir to "
+                f"unblock this job (#79768)."
             )
         # Scope cron approval policy to this job. Keep the token so the finally
         # restores the pre-job state instead of pinning an explicit empty value,
@@ -3693,18 +3710,7 @@ def run_job(
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-        if _raw_cron_timeout:
-            try:
-                _cron_timeout = float(_raw_cron_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_TIMEOUT=%r; using default 600s",
-                    _raw_cron_timeout,
-                )
-                _cron_timeout = 600.0
-        else:
-            _cron_timeout = 600.0
+        _cron_timeout = _cron_inactivity_seconds()
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
@@ -3923,9 +3929,11 @@ def run_job(
 
     finally:
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
-        # only ever mutate it when the job has a workdir; see the setup block
-        # at the top of run_job for the serialization guarantee.
-        if _job_workdir:
+        # only ever mutate it when the job has a workdir AND actually held
+        # the write lock — a fail-closed timeout raised before the env-set,
+        # so restoring there would replay a pre-wait snapshot over the
+        # ACTIVE holder's live override.
+        if _job_workdir and _cwd_lock_acquired:
             if _prior_terminal_cwd == "_UNSET_":
                 os.environ.pop("TERMINAL_CWD", None)
             else:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -554,11 +554,36 @@ class _ReadWriteLock:
 # running cron job.  See _ReadWriteLock and run_job for the usage contract.
 _terminal_cwd_lock = _ReadWriteLock()
 
-# Maximum time a cron job waits for the TERMINAL_CWD lock before proceeding
-# in degraded mode (without the lock, risking a leaked cwd override).  This
-# prevents a wedged or extremely long-running workdir job from silently
-# parking every concurrently-firing job behind the unbounded acquire (#79768).
-_CWD_LOCK_TIMEOUT_SECONDS = 120.0
+# Ceiling on how long a cron job waits for the TERMINAL_CWD lock before
+# FAILING (fail-closed, #79768). Derived from the cron inactivity limit
+# (HERMES_CRON_TIMEOUT, default 600s): a *wedged* lock holder stops touching
+# its activity clock, so the inactivity monitor kills it and the lock is
+# released within roughly that limit — a waiter that outlasts it plus margin
+# is facing a holder even the monitor could not reap, and must not run:
+# proceeding without the lock lets the holder's process-global TERMINAL_CWD
+# override leak into this job's shell/file/code-exec commands (wrong-directory
+# execution — the exact corruption _ReadWriteLock exists to prevent, see
+# test_reader_never_observes_writer_override). A *healthy* long-running
+# workdir job past the bound also fails its waiters loudly rather than
+# corrupting them silently; the failure names the holder pattern so the fix
+# (stagger schedules / drop the workdir) is actionable.
+_CWD_LOCK_TIMEOUT_FLOOR_SECONDS = 120.0
+_CWD_LOCK_TIMEOUT_MARGIN_SECONDS = 60.0
+
+
+def _cwd_lock_timeout_seconds() -> float:
+    """Bound for the TERMINAL_CWD lock wait: inactivity limit + margin."""
+    raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    try:
+        inactivity = float(raw) if raw else 600.0
+    except (ValueError, TypeError):
+        inactivity = 600.0
+    if inactivity <= 0:  # 0 = unlimited job runtime; keep the wait bounded.
+        inactivity = 600.0
+    return (
+        max(inactivity, _CWD_LOCK_TIMEOUT_FLOOR_SECONDS)
+        + _CWD_LOCK_TIMEOUT_MARGIN_SECONDS
+    )
 
 
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
@@ -3213,24 +3238,11 @@ def run_job(
     _holds_cwd_write = _job_workdir is not None
     _cwd_lock_acquired = True
     if _holds_cwd_write:
-        if not _terminal_cwd_lock.acquire_write(timeout=_CWD_LOCK_TIMEOUT_SECONDS):
+        if not _terminal_cwd_lock.acquire_write(timeout=_cwd_lock_timeout_seconds()):
             _cwd_lock_acquired = False
-            logger.warning(
-                "Job '%s': TERMINAL_CWD write-lock timed out after "
-                "%.0fs — proceeding without serialization (another "
-                "workdir job may be stuck). The job's cwd override "
-                "may leak into concurrent jobs (#79768).",
-                job_name, _CWD_LOCK_TIMEOUT_SECONDS,
-            )
     else:
-        if not _terminal_cwd_lock.acquire_read(timeout=_CWD_LOCK_TIMEOUT_SECONDS):
+        if not _terminal_cwd_lock.acquire_read(timeout=_cwd_lock_timeout_seconds()):
             _cwd_lock_acquired = False
-            logger.warning(
-                "Job '%s': TERMINAL_CWD read-lock timed out after "
-                "%.0fs — a workdir job is likely stuck. Proceeding "
-                "without serialization (#79768).",
-                job_name, _CWD_LOCK_TIMEOUT_SECONDS,
-            )
 
     # Everything after the acquire MUST live inside this try, so the finally
     # below always releases the lock even if the env override or any later
@@ -3241,6 +3253,22 @@ def run_job(
     _cron_session_token = None
     _non_dispatcher_token = None
     try:
+        if not _cwd_lock_acquired:
+            # Fail closed (#79768): running without the lock would let a
+            # concurrent workdir job's process-global TERMINAL_CWD override
+            # leak into this job's shell/file/code-exec commands — silent
+            # wrong-directory execution, the exact corruption the lock
+            # exists to prevent. A loud failure is recoverable (next tick /
+            # manual rerun); a job that ran in the wrong directory is not.
+            raise TimeoutError(
+                f"Timed out waiting for the TERMINAL_CWD "
+                f"{'write' if _holds_cwd_write else 'read'} lock after "
+                f"{_cwd_lock_timeout_seconds():.0f}s — another workdir cron "
+                f"job has held it for longer than the cron inactivity limit "
+                f"(wedged, or legitimately long-running). Stagger its "
+                f"schedule or remove its workdir to unblock this job "
+                f"(#79768)."
+            )
         # Scope cron approval policy to this job. Keep the token so the finally
         # restores the pre-job state instead of pinning an explicit empty value,
         # which would suppress the legacy os.environ fallback used by standalone

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -11,6 +11,7 @@ These tests assert that contract.
 """
 
 import threading
+import time
 
 
 def _lock():
@@ -82,6 +83,30 @@ def test_writer_waits_for_active_reader():
     assert not rt.is_alive() and not wt.is_alive()
     # The writer only ran after the reader released — never alongside it.
     assert order == ["reader-release", "writer-acquire"]
+
+
+def test_writer_acquire_times_out_behind_active_reader():
+    """Bounded acquire prevents a stuck reader from blocking a writer forever."""
+    lock = _lock()
+    lock.acquire_read()
+    started = time.monotonic()
+    try:
+        assert lock.acquire_write(timeout=0.01) is False
+    finally:
+        lock.release_read()
+    assert time.monotonic() - started < 1.0
+
+
+def test_reader_acquire_times_out_behind_active_writer():
+    """Bounded acquire prevents a stuck writer from blocking readers forever."""
+    lock = _lock()
+    lock.acquire_write()
+    started = time.monotonic()
+    try:
+        assert lock.acquire_read(timeout=0.01) is False
+    finally:
+        lock.release_write()
+    assert time.monotonic() - started < 1.0
 
 
 def test_reader_never_observes_writer_override():

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -10,6 +10,7 @@ jobs as readers (concurrent with each other, excluded from a writer's run).
 These tests assert that contract.
 """
 
+import os
 import threading
 import time
 
@@ -214,3 +215,86 @@ def test_run_job_releases_cwd_lock_when_body_raises(tmp_path):
     t.start()
     assert acquired.wait(timeout=5), "writer lock was leaked by run_job on exception"
     t.join(timeout=5)
+
+
+def test_run_job_fails_fast_when_cwd_lock_is_stuck(monkeypatch):
+    """Fail-closed (#79768): a reader blocked past the bound FAILS as a
+    normal cron error instead of proceeding without the lock (which would
+    expose the stuck writer's TERMINAL_CWD override to its commands)."""
+    import cron.scheduler as sched
+
+    monkeypatch.setattr(sched, "_cwd_lock_timeout_seconds", lambda: 0.05)
+    sched._terminal_cwd_lock.acquire_write()
+    try:
+        start = time.monotonic()
+        success, _out, _final, error = sched.run_job(
+            {"id": "blocked-reader", "name": "blocked-reader", "prompt": "hi"}
+        )
+    finally:
+        sched._terminal_cwd_lock.release_write()
+
+    assert success is False
+    assert "TERMINAL_CWD read lock" in (error or "")
+    assert time.monotonic() - start < 10.0
+
+
+def test_run_job_writer_fails_fast_and_never_sets_env(monkeypatch, tmp_path):
+    """A WRITER that times out must fail before touching TERMINAL_CWD —
+    the fail-open design let it clobber the active holder's override."""
+    import cron.scheduler as sched
+
+    monkeypatch.setattr(sched, "_cwd_lock_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("TERMINAL_CWD", "/holder/dir")
+    sched._terminal_cwd_lock.acquire_write()
+    try:
+        success, _out, _final, error = sched.run_job(
+            {
+                "id": "blocked-writer",
+                "name": "blocked-writer",
+                "prompt": "hi",
+                "workdir": str(tmp_path),
+            }
+        )
+        observed_during = os.environ.get("TERMINAL_CWD")
+    finally:
+        sched._terminal_cwd_lock.release_write()
+
+    assert success is False
+    assert "TERMINAL_CWD write lock" in (error or "")
+    assert observed_during == "/holder/dir", (
+        "timed-out writer mutated the active holder's TERMINAL_CWD override"
+    )
+    assert os.environ.get("TERMINAL_CWD") == "/holder/dir"
+
+
+def test_lock_wait_shorter_than_bound_still_succeeds(monkeypatch, tmp_path):
+    """A waiter whose holder finishes inside the bound proceeds normally —
+    the fail-closed path only fires past the derived ceiling."""
+    import cron.scheduler as sched
+
+    lock = sched._terminal_cwd_lock
+    lock.acquire_write()
+    releaser = threading.Timer(0.1, lock.release_write)
+    releaser.start()
+    try:
+        assert lock.acquire_read(timeout=5.0) is True
+        lock.release_read()
+    finally:
+        releaser.cancel()
+
+
+def test_cwd_lock_timeout_derivation(monkeypatch):
+    """The bound tracks HERMES_CRON_TIMEOUT (+margin) with a floor, and
+    stays finite when the job runtime is unlimited (0)."""
+    import cron.scheduler as sched
+
+    monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+    assert sched._cwd_lock_timeout_seconds() == 660.0
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "1800")
+    assert sched._cwd_lock_timeout_seconds() == 1860.0
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "30")
+    assert sched._cwd_lock_timeout_seconds() == 180.0
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+    assert sched._cwd_lock_timeout_seconds() == 660.0
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "bogus")
+    assert sched._cwd_lock_timeout_seconds() == 660.0


### PR DESCRIPTION
## Summary

The TERMINAL_CWD lock timeout that landed in #80912 proceeds WITHOUT the lock on timeout — and that degraded mode fires on every overlap with a healthy long-running workdir job, letting workdir-less jobs execute their shell/file/code-exec commands with the holder's process-global cwd override visible (silent wrong-directory execution, the exact corruption `_ReadWriteLock` exists to prevent). This flips the timeout to fail-closed — the blocked job errors loudly and is retried next tick — and derives the bound from the cron inactivity limit instead of a flat 120s, so waiters only fail after the window in which the inactivity monitor would normally have reaped a wedged holder.

Follow-up to #80912 / issue #79768. Closes #63959.

## Changes

- `cron/scheduler.py`:
  - Fail-closed: on lock timeout `run_job` raises `TimeoutError` (a normal cron failure with an actionable message) instead of proceeding unlocked. The raise fires before the env override and before any agent/model work; a timed-out WRITER no longer clobbers the active holder's `TERMINAL_CWD` mid-run (the fail-open path did — it set the override and later restored a pre-wait snapshot over the holder's live value).
  - Bound derived, not flat: `max(HERMES_CRON_TIMEOUT, 120s) + 60s` (default 660s). A wedged holder stops touching its activity clock, so the inactivity monitor reaps it — the monitor raises from run_job's own frame, whose `finally` releases the lock — inside that window; healthy workdir jobs shorter than the inactivity limit can no longer fail their waiters (the flat 120s did, on every overlap).
  - One shared `HERMES_CRON_TIMEOUT` parser for the inactivity monitor and the lock bound, so the two sites can't drift.
  - `finally`'s env restore gated on the lock actually having been held.
- `tests/cron/test_terminal_cwd_lock.py`: 2 lock-primitive timeout tests cherry-picked from #63959 (@necoweb3, authorship preserved) + 4 new: reader and writer `run_job` fail-fast paths (writer proven to never touch the holder's override), holder-finishes-inside-bound success, bound derivation (floor/margin/0/garbage).

## Why fail-closed

A failed job is visible in `last_status` and retried on its next tick. A job that ran in the wrong directory is silent, unrecoverable corruption. #63959 had this semantic right in July; its flat 30s bound (which would have failed every waiter overlapping a healthy >30s workdir run) is why the bound is derived instead.

## Validation

| | #80912 (main) | This PR |
|---|---|---|
| Waiter blocked past bound | runs UNLOCKED — holder's cwd visible to its commands | fails loudly, retried next tick |
| Timed-out writer | sets env over active holder, restores stale snapshot | never touches env (test-pinned) |
| Healthy 5-min workdir job + concurrent jobs | all waiters degrade at 120s → wrong-directory risk | waiters wait (bound ≥ 660s) and proceed normally |
| Wedged holder | waiters degrade at 120s | monitor reaps holder ≤ ~600s → lock released → waiters proceed; only unreapable holders fail waiters |

- `tests/cron/`: 447 passed (all 10 cwd-lock tests incl. the 6 new).
- Mutation check: the 3 new behavior tests fail against main's fail-open implementation.
- Live smoke (isolated HERMES_HOME, real `run_job`): workdir writer + concurrent reader serialize correctly (reader never sees the override); blocked reader and blocked writer both fail loudly with the holder's env untouched.

## Known limitations (documented in code, follow-up material)

- The bound is measured from the waiter's arrival: a holder that wedges late, or hangs in pre-agent setup before the inactivity monitor arms (dotenv/MCP discovery inside the lock), can outlive it — waiters then fail until the holder clears. Loud-and-attributed beats the old silent corruption; an activity-aware wait (waiter consults the holder's activity clock) is the natural next step if this bites in practice.
- One-shot jobs that fire into a blocked window fail permanently (no next tick); recurring jobs self-heal.

## Credit

Fail-closed design and the run_job fail-fast test shape from @necoweb3's #63959 (lock-primitive tests cherry-picked with authorship preserved; Co-authored-by on the test commit).
