### PR TITLE
docs: document Telnyx as an OpenAI-compatible provider and mem0 OSS backend

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1175,6 +1175,7 @@ Any service with an OpenAI-compatible API works. Some popular options:
 | [DeepSeek](https://deepseek.com) | `https://api.deepseek.com/v1` | DeepSeek models |
 | [Fireworks AI](https://fireworks.ai) | `https://api.fireworks.ai/inference/v1` | Fast open model hosting |
 | [GMI Cloud](https://www.gmicloud.ai/) | `https://api.gmi-serving.com/v1` | Managed OpenAI-compatible inference |
+| [Telnyx](https://developers.telnyx.com/docs/inference/getting-started) | `https://api.telnyx.com/v2/ai/openai` | GPU-hosted open models (Kimi, GLM, MiniMax, Qwen) + embeddings |
 | [Actual Computer](https://actual.inc) | `https://api.actual.inc/v1` | Private relay to your own cluster; local daemon at `http://127.0.0.1:8080/v1` |
 | [Cerebras](https://cerebras.ai) | `https://api.cerebras.ai/v1` | Wafer-scale chip inference |
 | [Mistral AI](https://mistral.ai) | `https://api.mistral.ai/v1` | Mistral models |
@@ -1192,6 +1193,30 @@ model:
   base_url: https://api.together.xyz/v1
   api_key: your-together-key
 ```
+
+#### Telnyx
+
+[Telnyx](https://telnyx.com/products/inference) serves OpenAI-compatible chat
+completions and embeddings from its own GPU cloud. Create an API key at
+[portal.telnyx.com → API Keys](https://portal.telnyx.com/#/app/api-keys) and
+set `TELNYX_API_KEY` in `~/.hermes/.env`.
+
+For first-class support (live model catalog in `hermes model`, automatic key
+injection), install the vendor-maintained provider plugin
+([team-telnyx/hermes-inference-provider](https://github.com/team-telnyx/hermes-inference-provider)):
+
+```bash
+hermes plugins install team-telnyx/hermes-inference-provider
+mv ~/.hermes/plugins/telnyx-provider ~/.hermes/plugins/model-providers/
+```
+
+```bash
+hermes chat --provider telnyx -m moonshotai/Kimi-K3
+```
+
+Telnyx also works as the
+[mem0 memory plugin's LLM + embedder](../user-guide/features/memory-providers.md#mem0)
+— one key covers inference, memory extraction, and embeddings.
 
 ---
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -407,6 +407,53 @@ The plugin authenticates with `X-API-Key` and uses the server's `/search` / `/me
 | Embedder | openai, ollama |
 | Vector Store | qdrant (local/server), pgvector |
 
+**Pointing OSS mode at an OpenAI-compatible endpoint (e.g. Telnyx):**
+
+The `openai` provider works with any OpenAI-compatible API: set
+`openai_base_url` and (when the service uses its own key) `api_key` in the
+component's `config` block in `mem0.json`. A per-component `api_key`
+overrides `OPENAI_API_KEY` for that component only, so a real OpenAI key
+stays usable elsewhere.
+
+For example, [Telnyx AI inference](https://developers.telnyx.com/docs/inference/getting-started)
+can serve both memory extraction (LLM) and embeddings with a single API key
+(create one in the [Telnyx portal](https://portal.telnyx.com/#/app/api-keys)):
+
+```json
+{
+  "mode": "oss",
+  "oss": {
+    "llm": {
+      "provider": "openai",
+      "config": {
+        "model": "moonshotai/Kimi-K3",
+        "openai_base_url": "https://api.telnyx.com/v2/ai/openai",
+        "api_key": "YOUR_TELNYX_API_KEY"
+      }
+    },
+    "embedder": {
+      "provider": "openai",
+      "config": {
+        "model": "Qwen/Qwen3-Embedding-8B",
+        "openai_base_url": "https://api.telnyx.com/v2/ai/openai",
+        "api_key": "YOUR_TELNYX_API_KEY",
+        "embedding_dims": 4096
+      }
+    },
+    "vector_store": { "provider": "qdrant", "config": { "path": "~/.hermes/mem0_qdrant" } }
+  }
+}
+```
+
+- `embedding_dims` must match the embedding model (4096 for
+  `Qwen/Qwen3-Embedding-8B`) so the vector collection is sized correctly.
+- Prefer `Qwen/Qwen3-Embedding-8B` on Telnyx: when `embedding_dims` is set,
+  mem0 sends OpenAI's `dimensions` request parameter, which Telnyx's other
+  embedding models (`thenlper/gte-large`, `intfloat/multilingual-e5-large`)
+  reject.
+- To use Telnyx as the main agent's inference provider too, see
+  [Providers → Other Compatible Providers](../../integrations/providers.md#other-compatible-providers).
+
 **Switching modes:** Re-run `hermes memory setup mem0 --mode <platform|selfhosted|oss>` or edit `mem0.json` directly.
 
 ---


### PR DESCRIPTION
## What

**Docs-only** (+72/-0, two files). Documents how to use [Telnyx AI inference](https://developers.telnyx.com/docs/inference/getting-started) with Hermes — no code, registry, or plugin-tree changes, per the project's third-party-integration policy (CONTRIBUTING → "Third-Party Product Integrations: Ship as a Standalone Plugin").

- `website/docs/integrations/providers.md`
  - Telnyx row in the **Other Compatible Providers** table (`https://api.telnyx.com/v2/ai/openai`).
  - Short **Telnyx** subsection: where to get the API key ([portal.telnyx.com → API Keys](https://portal.telnyx.com/#/app/api-keys)), and how to install the **vendor-maintained** provider plugin ([team-telnyx/hermes-inference-provider](https://github.com/team-telnyx/hermes-inference-provider)) for first-class `hermes model` support. The plugin lives in a Telnyx-owned repo and registers through the documented external model-provider surface — maintenance stays on Telnyx, not on this tree.
- `website/docs/user-guide/features/memory-providers.md` (Mem0 → OSS)
  - Documents the existing generic mechanic: any OpenAI-compatible endpoint via `openai_base_url` + per-component `api_key` in `mem0.json`, with Telnyx as the worked example (one key for extraction LLM + embeddings).
  - Load-bearing `embedding_dims` guidance: mem0 sends OpenAI's `dimensions` request param when `embedding_dims` is set; of Telnyx's embedding models only `Qwen/Qwen3-Embedding-8B` (4096d) accepts it, so the recipe pins that model — and without `embedding_dims` the qdrant collection would be sized wrong.

## Verification

The documented recipe was live-verified end-to-end on current `main` (2026-08-07, real key, scratch qdrant path, `OPENAI_API_KEY` removed from the environment):

- `OSSBackend` built from the exact `mem0.json` snippet in the docs → `add(infer=False)` ×2 → `search()` returns correct semantic ranking (0.474 vs 0.311) through `Qwen/Qwen3-Embedding-8B`.
- `add(infer=True)` memory extraction works through `moonshotai/Kimi-K3` on the same key.
- Live API probes: `dimensions` param → HTTP 500 on `thenlper/gte-large` / `intfloat/multilingual-e5-large`, accepted on Qwen3 (basis for the model guidance).