### PR TITLE
fix(desktop): ignore repeated keys during type-to-focus

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -15,7 +15,11 @@ import { onReleaseTypingFocus } from '@/components/ui/keyboard-first'
 import { findBarClaimsCombo } from '@/lib/find-in-page'
 import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
-import { composerFocusKeysAllowed, isComposerFocusSoftCombo, typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
+import {
+  composerFocusKeysAllowed,
+  isComposerFocusSoftCombo,
+  typeToFocusChar
+} from '@/lib/keybinds/composer-focus-keys'
 import { openWorktreeDialog } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
 import {

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -115,6 +115,11 @@ describe('typeToFocusChar', () => {
 
   it('rejects non-printables and modified chords', () => {
     expect(typeToFocusChar(keydown({ key: 'Enter', code: 'Enter' }))).toBeNull()
+    expect(typeToFocusChar(keydown({ key: '0', code: 'Numpad0' }))).toBe('0')
+    expect(typeToFocusChar(keydown({ key: '0', code: 'Numpad0', repeat: true }))).toBeNull()
+    expect(typeToFocusChar(keydown({ key: '0', code: 'Digit0' }))).toBe('0')
+    expect(typeToFocusChar(keydown({ key: '0', code: 'Digit0', repeat: true }))).toBeNull()
+    expect(typeToFocusChar(keydown({ key: 'a', code: 'KeyA', repeat: true }))).toBeNull()
     expect(typeToFocusChar(keydown({ key: 'a', code: 'KeyA', metaKey: true }))).toBeNull()
     expect(typeToFocusChar(keydown({ key: 'a', code: 'KeyA', isComposing: true }))).toBeNull()
   })

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -116,7 +116,14 @@ export function composerFocusBlockedBySurface(): boolean {
 
 /** Printable `event.key` for type-to-focus, or null (modifiers / non-printables / IME). */
 export function typeToFocusChar(event: KeyboardEvent): string | null {
-  if (event.defaultPrevented || event.isComposing || event.metaKey || event.ctrlKey || event.altKey) {
+  if (
+    event.defaultPrevented ||
+    event.repeat ||
+    event.isComposing ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey
+  ) {
     return null
   }
 


### PR DESCRIPTION
## Summary

- Prevent repeated `keydown` events from triggering Hermes Desktop's global type-to-focus behavior.
- Add regression coverage for the confirmed Linux/Electron `Numpad0` repeat signature while preserving initial keypad-zero behavior.

## Bug

On Linux/Wayland with the Electron desktop app, switching focus away from Hermes and back could expose a stale keyboard-repeat stream. Hermes treated the repeated events as fresh printable input, auto-focused the composer, and inserted a long stream of `0` characters.

The captured renderer events included:

```text
key: "0"
code: "Numpad0"
repeat: true
document.hasFocus(): true
target: BODY / DIV
```

The reproduction was independent of the USB MacroPad overlay and did not occur in Chrome. The final fix is hardware-agnostic and operates at the existing type-to-focus boundary: auto-repeat events are not treated as new type-to-focus input, while an initial `Numpad0` remains eligible and native input is unaffected when the composer already owns focus.

## Test plan

- [x] Focus-only reproduction verified against the rebuilt packaged Hermes artifact.
- [x] MacroPad/focus reproduction verified against the rebuilt packaged Hermes artifact.
- [x] Normal type-to-focus behavior remains functional.
- [x] Initial `Numpad0` remains eligible; repeated `Numpad0` is ignored by type-to-focus.
- [x] `npm exec vitest run --project ui src/lib/keybinds/composer-focus-keys.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`

Result: 57 test files passed, 438 tests passed, and full TypeScript typecheck passed.
