### PR TITLE
chore: map texasich commit email to GitHub login

### DIFF
--- a/contributors/emails/texasich@users.noreply.github.com
+++ b/contributors/emails/texasich@users.noreply.github.com
@@ -1,0 +1,2 @@
+texasich
+# PR #80376 salvage (gateway: fail-closed turn-lease timeout)


### PR DESCRIPTION
Attribution mapping for the upcoming PR #80376 salvage. `texasich@users.noreply.github.com` is a bare noreply (no `NNN+` prefix), so check-attribution does not auto-skip it. One mapping file, per contributors/README.md convention.

Merge before the salvage PR so its attribution check runs against a main that already carries the mapping.