### PR TITLE
feat(stt): idle unload for local whisper model

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1197,7 +1197,7 @@ stt:
     # vad_min_silence_ms: 500  # min silence (ms) that splits speech chunks when vad is on
     # no_speech_prob_threshold: 0.6  # drop a segment only if no_speech_prob > this...
     # logprob_threshold: -1.0       # ...AND avg_logprob < this (both must hit — quiet real speech survives)
-    # unload_after_idle_seconds: 0  # 0=never unload (default); 300=frees RAM/VRAM after 5min with no voice messages
+    # unload_after_idle_seconds: 0  # 0=never unload (default); e.g. 300 releases the model after 5min idle (frees VRAM on GPU; next voice message reloads it)
   language: "en"               # GLOBAL language hint for every STT provider (per-provider language wins). Set "" for auto-detect.
   # groq:
   #   model: "whisper-large-v3-turbo"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1196,7 +1196,8 @@ stt:
     #                          # Set false to restore raw behavior (e.g. transcribing music/ambient audio).
     # vad_min_silence_ms: 500  # min silence (ms) that splits speech chunks when vad is on
     # no_speech_prob_threshold: 0.6  # drop a segment only if no_speech_prob > this...
-    # logprob_threshold: -1.0        # ...AND avg_logprob < this (both must hit — quiet real speech survives)
+    # logprob_threshold: -1.0       # ...AND avg_logprob < this (both must hit — quiet real speech survives)
+    # unload_after_idle_seconds: 0  # 0=never unload (default); 300=frees RAM/VRAM after 5min with no voice messages
   language: "en"               # GLOBAL language hint for every STT provider (per-provider language wins). Set "" for auto-detect.
   # groq:
   #   model: "whisper-large-v3-turbo"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1524,7 +1524,7 @@ DEFAULT_CONFIG = {
             "vad_min_silence_ms": 500,  # min silence (ms) that splits speech chunks when vad is on
             "no_speech_prob_threshold": 0.6,  # drop a segment only if no_speech_prob is ABOVE this...
             "logprob_threshold": -1.0,  # ...AND its avg_logprob is BELOW this (both must hit)
-            "unload_after_idle_seconds": 0,  # 0=never (default); 300=frees RAM/VRAM after 5min idle
+            "unload_after_idle_seconds": 0,  # 0=never (default); e.g. 300 releases the model after 5min idle
         },
         "groq": {
             "model": "whisper-large-v3-turbo",  # whisper-large-v3, whisper-large-v3-turbo, distil-whisper-large-v3-en

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1524,6 +1524,7 @@ DEFAULT_CONFIG = {
             "vad_min_silence_ms": 500,  # min silence (ms) that splits speech chunks when vad is on
             "no_speech_prob_threshold": 0.6,  # drop a segment only if no_speech_prob is ABOVE this...
             "logprob_threshold": -1.0,  # ...AND its avg_logprob is BELOW this (both must hit)
+            "unload_after_idle_seconds": 0,  # 0=never (default); 300=frees RAM/VRAM after 5min idle
         },
         "groq": {
             "model": "whisper-large-v3-turbo",  # whisper-large-v3, whisper-large-v3-turbo, distil-whisper-large-v3-en

--- a/tests/tools/test_stt_idle_unload.py
+++ b/tests/tools/test_stt_idle_unload.py
@@ -1,0 +1,189 @@
+"""Tests for the local whisper model idle-unload mechanism.
+
+The local faster-whisper model singleton (``_local_model``) is loaded once
+and never released — hundreds of MB of RAM/VRAM sit idle between voice
+messages on long-running gateway processes. These tests verify the
+config-driven idle unload: after ``unload_after_idle_seconds`` of no
+transcription activity, a daemon thread sets ``_local_model = None`` so the
+memory can be reclaimed. The next transcription reloads the model
+transparently.
+
+Contract under test:
+
+1. Default is 0 (never unload) — no thread is started.
+2. After a successful transcription with a non-zero timeout, the watcher
+   thread is started and eventually unloads the model.
+3. ``_touch_transcription_time`` resets the idle timer.
+4. ``_unload_local_model`` is safe to call when the model is already None.
+5. Config resolution handles garbage values gracefully.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.transcription_tools import (
+    _get_idle_unload_seconds,
+    _touch_transcription_time,
+    _unload_local_model,
+    _start_idle_unload_watcher,
+    _IDLE_UNLOAD_CHECK_INTERVAL,
+)
+import tools.transcription_tools as tt
+
+
+# ============================================================================
+# Config resolution
+# ============================================================================
+
+
+class TestGetIdleUnloadSeconds:
+    def test_default_is_zero(self):
+        assert _get_idle_unload_seconds({}) == 0
+
+    def test_explicit_value(self):
+        assert _get_idle_unload_seconds({"unload_after_idle_seconds": 300}) == 300
+
+    def test_zero_means_never(self):
+        assert _get_idle_unload_seconds({"unload_after_idle_seconds": 0}) == 0
+
+    def test_negative_clamped_to_zero(self):
+        assert _get_idle_unload_seconds({"unload_after_idle_seconds": -5}) == 0
+
+    def test_garbage_falls_back_to_zero(self):
+        assert _get_idle_unload_seconds({"unload_after_idle_seconds": "never"}) == 0
+
+    def test_none_falls_back_to_zero(self):
+        assert _get_idle_unload_seconds({"unload_after_idle_seconds": None}) == 0
+
+
+# ============================================================================
+# _unload_local_model
+# ============================================================================
+
+
+class TestUnloadLocalModel:
+    def test_unloads_when_model_present(self):
+        mock_model = MagicMock(name="whisper_model")
+        with patch.object(tt, "_local_model", mock_model), \
+             patch.object(tt, "_local_model_name", "base"):
+            _unload_local_model()
+        assert tt._local_model is None
+        assert tt._local_model_name is None
+
+    def test_safe_when_already_none(self):
+        with patch.object(tt, "_local_model", None), \
+             patch.object(tt, "_local_model_name", None):
+            # Must not raise
+            _unload_local_model()
+        assert tt._local_model is None
+
+    def test_acquires_model_lock(self):
+        """The unload must hold _local_model_lock to prevent races with
+        concurrent transcriptions that are mid-load."""
+        mock_model = MagicMock(name="whisper_model")
+        with patch.object(tt, "_local_model", mock_model), \
+             patch.object(tt, "_local_model_name", "base"), \
+             patch.object(tt, "_local_model_lock") as mock_lock:
+            _unload_local_model()
+            mock_lock.__enter__.assert_called()
+            mock_lock.__exit__.assert_called()
+
+
+# ============================================================================
+# _touch_transcription_time
+# ============================================================================
+
+
+class TestTouchTranscriptionTime:
+    def test_sets_timestamp(self):
+        original = tt._last_transcription_time
+        try:
+            tt._last_transcription_time = 0.0
+            _touch_transcription_time()
+            assert tt._last_transcription_time > 0
+        finally:
+            tt._last_transcription_time = original
+
+
+# ============================================================================
+# Watcher thread (with mocked time)
+# ============================================================================
+
+
+class TestIdleUnloadWatcher:
+    def test_default_zero_does_not_start_thread(self):
+        """When unload_after_idle_seconds is 0, no watcher should be started."""
+        with patch.object(tt, "_local_model", MagicMock()), \
+             patch.object(tt, "_start_idle_unload_watcher") as mock_start:
+            # Simulate _transcribe_local's behavior: only start if > 0
+            idle_timeout = _get_idle_unload_seconds({"unload_after_idle_seconds": 0})
+            if idle_timeout > 0:
+                _start_idle_unload_watcher(idle_timeout)
+        mock_start.assert_not_called()
+
+    def test_watcher_unloads_after_timeout(self):
+        """The watcher unloads the model after the configured idle period."""
+        mock_model = MagicMock(name="whisper_model")
+        # Use a very short timeout and patch the check interval to 0.01s
+        # so the test runs in < 1 second.
+        with patch.object(tt, "_local_model", mock_model), \
+             patch.object(tt, "_local_model_name", "base"), \
+             patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.01), \
+             patch.object(tt, "_last_transcription_time", time.monotonic() - 100):
+            _start_idle_unload_watcher(timeout_seconds=1)
+            # Wait for the watcher to fire
+            for _ in range(100):
+                if tt._local_model is None:
+                    break
+                time.sleep(0.02)
+        assert tt._local_model is None
+
+    def test_watcher_does_not_unload_within_timeout(self):
+        """The watcher does NOT unload when the model was recently used."""
+        mock_model = MagicMock(name="whisper_model")
+        original_model = tt._local_model
+        original_name = tt._local_model_name
+        original_interval = tt._IDLE_UNLOAD_CHECK_INTERVAL
+        original_ts = tt._last_transcription_time
+        try:
+            tt._local_model = mock_model
+            tt._local_model_name = "base"
+            tt._IDLE_UNLOAD_CHECK_INTERVAL = 0.01
+            tt._last_transcription_time = time.monotonic()
+            _start_idle_unload_watcher(timeout_seconds=100)
+            # Give it a few check cycles — model must survive
+            time.sleep(0.1)
+            assert tt._local_model is not None
+        finally:
+            tt._local_model = original_model
+            tt._local_model_name = original_name
+            tt._IDLE_UNLOAD_CHECK_INTERVAL = original_interval
+            tt._last_transcription_time = original_ts
+
+    def test_watcher_exits_when_model_already_none(self):
+        """If the model was unloaded by another path, the watcher exits."""
+        with patch.object(tt, "_local_model", None), \
+             patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.01), \
+             patch.object(tt, "_last_transcription_time", 0.0):
+            _start_idle_unload_watcher(timeout_seconds=1)
+            time.sleep(0.05)
+        # No crash, no hang — watcher detected _local_model is None and exited
+
+    def test_watcher_stopped_on_new_start(self):
+        """Starting a new watcher stops the previous one."""
+        mock_model = MagicMock(name="whisper_model")
+        with patch.object(tt, "_local_model", mock_model), \
+             patch.object(tt, "_local_model_name", "base"), \
+             patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.01), \
+             patch.object(tt, "_last_transcription_time", time.monotonic()):
+            _start_idle_unload_watcher(timeout_seconds=100)
+            first_thread = tt._idle_unload_thread
+            assert first_thread is not None and first_thread.is_alive()
+            _start_idle_unload_watcher(timeout_seconds=200)
+            second_thread = tt._idle_unload_thread
+            assert second_thread is not first_thread
+            # First thread should have been stopped
+            time.sleep(0.05)
+            assert not first_thread.is_alive()

--- a/tests/tools/test_stt_idle_unload.py
+++ b/tests/tools/test_stt_idle_unload.py
@@ -16,9 +16,16 @@ Contract under test:
 3. ``_touch_transcription_time`` resets the idle timer.
 4. ``_unload_local_model`` is safe to call when the model is already None.
 5. Config resolution handles garbage values gracefully.
+6. Watcher start is idempotent (single long-lived thread, no churn on the
+   transcription response path) and the loop re-reads config each cycle.
+7. RACE GUARD: an unload firing mid-transcription must not fail the
+   in-flight transcription — ``_transcribe_local`` binds a strong local
+   reference to the model instance instead of re-reading the global.
 """
 
+import struct
 import time
+import wave
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -127,10 +134,13 @@ class TestIdleUnloadWatcher:
         """The watcher unloads the model after the configured idle period."""
         mock_model = MagicMock(name="whisper_model")
         # Use a very short timeout and patch the check interval to 0.01s
-        # so the test runs in < 1 second.
+        # so the test runs in < 1 second. The watcher re-reads config each
+        # cycle, so patch _load_stt_config to keep the timeout active.
         with patch.object(tt, "_local_model", mock_model), \
              patch.object(tt, "_local_model_name", "base"), \
              patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.01), \
+             patch.object(tt, "_load_stt_config",
+                          return_value={"local": {"unload_after_idle_seconds": 1}}), \
              patch.object(tt, "_last_transcription_time", time.monotonic() - 100):
             _start_idle_unload_watcher(timeout_seconds=1)
             # Wait for the watcher to fire
@@ -152,10 +162,12 @@ class TestIdleUnloadWatcher:
             tt._local_model_name = "base"
             tt._IDLE_UNLOAD_CHECK_INTERVAL = 0.01
             tt._last_transcription_time = time.monotonic()
-            _start_idle_unload_watcher(timeout_seconds=100)
-            # Give it a few check cycles — model must survive
-            time.sleep(0.1)
-            assert tt._local_model is not None
+            with patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 100}}):
+                _start_idle_unload_watcher(timeout_seconds=100)
+                # Give it a few check cycles — model must survive
+                time.sleep(0.1)
+                assert tt._local_model is not None
         finally:
             tt._local_model = original_model
             tt._local_model_name = original_name
@@ -171,19 +183,101 @@ class TestIdleUnloadWatcher:
             time.sleep(0.05)
         # No crash, no hang — watcher detected _local_model is None and exited
 
-    def test_watcher_stopped_on_new_start(self):
-        """Starting a new watcher stops the previous one."""
+    def test_start_is_idempotent_while_watcher_alive(self):
+        """A second start while a watcher is alive is a no-op (single
+        long-lived watcher — no stop/join/restart churn on the hot path)."""
         mock_model = MagicMock(name="whisper_model")
         with patch.object(tt, "_local_model", mock_model), \
              patch.object(tt, "_local_model_name", "base"), \
-             patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.01), \
+             patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.5), \
+             patch.object(tt, "_load_stt_config",
+                          return_value={"local": {"unload_after_idle_seconds": 100}}), \
              patch.object(tt, "_last_transcription_time", time.monotonic()):
             _start_idle_unload_watcher(timeout_seconds=100)
             first_thread = tt._idle_unload_thread
             assert first_thread is not None and first_thread.is_alive()
             _start_idle_unload_watcher(timeout_seconds=200)
-            second_thread = tt._idle_unload_thread
-            assert second_thread is not first_thread
-            # First thread should have been stopped
-            time.sleep(0.05)
-            assert not first_thread.is_alive()
+            assert tt._idle_unload_thread is first_thread  # same thread, no churn
+            tt._idle_unload_stop.set()  # clean up
+            first_thread.join(timeout=2)
+
+    def test_watcher_rereads_config_and_stands_down_when_disabled(self):
+        """Setting unload_after_idle_seconds to 0 mid-idle stops the watcher
+        without unloading — config edits apply within one check interval."""
+        mock_model = MagicMock(name="whisper_model")
+        original_model = tt._local_model
+        original_name = tt._local_model_name
+        original_interval = tt._IDLE_UNLOAD_CHECK_INTERVAL
+        original_ts = tt._last_transcription_time
+        try:
+            tt._local_model = mock_model
+            tt._local_model_name = "base"
+            tt._IDLE_UNLOAD_CHECK_INTERVAL = 0.01
+            tt._last_transcription_time = time.monotonic() - 1000  # long idle
+            with patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 0}}):
+                _start_idle_unload_watcher(timeout_seconds=1)
+                thread = tt._idle_unload_thread
+                assert thread is not None
+                thread.join(timeout=2)
+                assert not thread.is_alive()  # stood down...
+                assert tt._local_model is not None  # ...without unloading
+        finally:
+            tt._local_model = original_model
+            tt._local_model_name = original_name
+            tt._IDLE_UNLOAD_CHECK_INTERVAL = original_interval
+            tt._last_transcription_time = original_ts
+
+
+# ============================================================================
+# Race guard: unload mid-transcription must not break the in-flight call
+# ============================================================================
+
+
+class TestUnloadDuringTranscriptionRace:
+    def test_transcribe_survives_concurrent_unload(self, tmp_path):
+        """_transcribe_local binds a strong local ref under the lock; an
+        idle unload nulling the module global mid-transcription must not
+        produce 'NoneType has no attribute transcribe'."""
+        wav_path = tmp_path / "a.wav"
+        n = 16000
+        with wave.open(str(wav_path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(struct.pack(f"<{n}h", *([0] * n)))
+
+        seg = MagicMock()
+        seg.text = " hello"
+        seg.no_speech_prob = 0.0
+        seg.avg_logprob = -0.2
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        mock_model = MagicMock(name="whisper_model")
+        mock_model.transcribe.return_value = (iter([seg]), info)
+
+        real_kwargs_builder = tt.build_local_transcribe_kwargs
+
+        def kwargs_then_unload(*args, **kwargs):
+            # Simulate the watcher firing in the window BETWEEN the model
+            # load and the transcribe call (build_local_transcribe_kwargs
+            # runs exactly there): the module global goes away while this
+            # transcription is still in flight.
+            out = real_kwargs_builder(*args, **kwargs)
+            _unload_local_model()
+            assert tt._local_model is None
+            return out
+
+        with patch.object(tt, "_HAS_FASTER_WHISPER", True), \
+             patch.object(tt, "_load_stt_config", return_value={"local": {}}), \
+             patch.object(tt, "build_local_transcribe_kwargs",
+                          side_effect=kwargs_then_unload), \
+             patch.object(tt, "_local_model", mock_model), \
+             patch.object(tt, "_local_model_name", "base"):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(wav_path), "base")
+
+        assert result["success"] is True, result.get("error")
+        assert result["transcript"] == "hello"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -139,6 +139,19 @@ _local_model_name: Optional[str] = None
 # None` and download/load the whisper model twice (#24767).
 _local_model_lock = threading.Lock()
 
+# --- Idle unload ---------------------------------------------------------------
+# The model singleton above is loaded once and never released — hundreds of MB
+# of RAM/VRAM sit idle between voice messages. On long-running gateway
+# processes (especially with local LLMs competing for the same GPU) this is
+# wasteful. A lightweight daemon thread checks _last_transcription_time and
+# unloads the model after a configurable idle period. The next voice message
+# reloads it transparently.
+_last_transcription_time: float = 0.0
+_idle_unload_thread: Optional[threading.Thread] = None
+_idle_unload_stop = threading.Event()
+
+_IDLE_UNLOAD_CHECK_INTERVAL = 30  # seconds between idle checks
+
 # ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------
@@ -1448,6 +1461,72 @@ def _should_force_faster_whisper_cpu() -> bool:
     return _sysctl_value("hw.optional.arm64") == "1"
 
 
+def _get_idle_unload_seconds(local_cfg: Dict[str, Any]) -> int:
+    """Resolve the idle unload timeout from config.
+
+    0 = never unload (default). Negative values are treated as 0.
+    """
+    try:
+        val = int(local_cfg.get("unload_after_idle_seconds", 0))
+    except (TypeError, ValueError):
+        return 0
+    return max(val, 0)
+
+
+def _unload_local_model() -> None:
+    """Release the cached local whisper model and free its memory.
+
+    Safe to call from any thread. The model lock prevents races with a
+    concurrent transcription that is mid-load.
+    """
+    global _local_model, _local_model_name
+    with _local_model_lock:
+        if _local_model is not None:
+            logger.info(
+                "Unloading local whisper model '%s' after idle timeout",
+                _local_model_name or "unknown",
+            )
+            _local_model = None
+            _local_model_name = None
+
+
+def _start_idle_unload_watcher(timeout_seconds: int) -> None:
+    """Start (or replace) the background idle-unload thread.
+
+    The thread checks every ``_IDLE_UNLOAD_CHECK_INTERVAL`` seconds whether
+    ``_last_transcription_time`` is older than ``timeout_seconds``. If so, it
+    unloads the model and exits. The next transcription restarts it.
+    """
+    global _idle_unload_thread
+    # Stop any existing watcher — a new timeout may have been configured
+    _idle_unload_stop.set()
+    if _idle_unload_thread is not None and _idle_unload_thread.is_alive():
+        _idle_unload_thread.join(timeout=5)
+    _idle_unload_stop.clear()
+
+    def _watch():
+        while not _idle_unload_stop.is_set():
+            if _idle_unload_stop.wait(_IDLE_UNLOAD_CHECK_INTERVAL):
+                break
+            if _local_model is None:
+                break
+            idle_for = time.monotonic() - _last_transcription_time
+            if idle_for >= timeout_seconds:
+                _unload_local_model()
+                break
+
+    _idle_unload_thread = threading.Thread(
+        target=_watch, name="hermes-stt-idle-unload", daemon=True
+    )
+    _idle_unload_thread.start()
+
+
+def _touch_transcription_time() -> None:
+    """Record that a transcription just completed (resets the idle timer)."""
+    global _last_transcription_time
+    _last_transcription_time = time.monotonic()
+
+
 def _load_local_whisper_model(model_name: str, device: str = "auto", compute_type: str = "auto"):
     """Load faster-whisper with graceful CUDA → CPU fallback.
 
@@ -1682,6 +1761,11 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             "Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
             Path(file_path).name, model_name, info.language, info.duration,
         )
+
+        _touch_transcription_time()
+        idle_timeout = _get_idle_unload_seconds(local_cfg)
+        if idle_timeout > 0:
+            _start_idle_unload_watcher(idle_timeout)
 
         return {"success": True, "transcript": transcript, "provider": "local"}
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -143,12 +143,15 @@ _local_model_lock = threading.Lock()
 # The model singleton above is loaded once and never released — hundreds of MB
 # of RAM/VRAM sit idle between voice messages. On long-running gateway
 # processes (especially with local LLMs competing for the same GPU) this is
-# wasteful. A lightweight daemon thread checks _last_transcription_time and
-# unloads the model after a configurable idle period. The next voice message
-# reloads it transparently.
+# wasteful. A single long-lived daemon thread checks _last_transcription_time
+# and unloads the model after a configurable idle period, then exits. The next
+# voice message reloads the model and restarts the watcher transparently.
 _last_transcription_time: float = 0.0
 _idle_unload_thread: Optional[threading.Thread] = None
 _idle_unload_stop = threading.Event()
+# Serializes watcher start checks so two concurrent transcriptions can't
+# both observe "no watcher alive" and spawn duplicates.
+_idle_unload_mgmt_lock = threading.Lock()
 
 _IDLE_UNLOAD_CHECK_INTERVAL = 30  # seconds between idle checks
 
@@ -1491,38 +1494,56 @@ def _unload_local_model() -> None:
 
 
 def _start_idle_unload_watcher(timeout_seconds: int) -> None:
-    """Start (or replace) the background idle-unload thread.
+    """Ensure the idle-unload watcher thread is running.
 
-    The thread checks every ``_IDLE_UNLOAD_CHECK_INTERVAL`` seconds whether
-    ``_last_transcription_time`` is older than ``timeout_seconds``. If so, it
-    unloads the model and exits. The next transcription restarts it.
+    A single long-lived watcher: started only when none is alive, so the
+    per-transcription cost is one lock + one ``is_alive()`` check — no
+    stop/join/restart churn on the response path. The loop re-reads the
+    configured timeout from config every cycle, so changing
+    ``stt.local.unload_after_idle_seconds`` takes effect within one check
+    interval without a restart. After unloading (or when the timeout is set
+    to 0/never, or the model is already gone) the thread exits; the next
+    transcription restarts it.
+
+    ``timeout_seconds`` seeds the first cycle so a just-written config is
+    honored even if a concurrent config read would race.
     """
     global _idle_unload_thread
-    # Stop any existing watcher — a new timeout may have been configured
-    _idle_unload_stop.set()
-    if _idle_unload_thread is not None and _idle_unload_thread.is_alive():
-        _idle_unload_thread.join(timeout=5)
-    _idle_unload_stop.clear()
+    with _idle_unload_mgmt_lock:
+        if _idle_unload_thread is not None and _idle_unload_thread.is_alive():
+            return
 
-    def _watch():
-        while not _idle_unload_stop.is_set():
-            if _idle_unload_stop.wait(_IDLE_UNLOAD_CHECK_INTERVAL):
-                break
-            if _local_model is None:
-                break
-            idle_for = time.monotonic() - _last_transcription_time
-            if idle_for >= timeout_seconds:
-                _unload_local_model()
-                break
+        def _watch(initial_timeout=timeout_seconds):
+            timeout = initial_timeout
+            while not _idle_unload_stop.is_set():
+                if _idle_unload_stop.wait(_IDLE_UNLOAD_CHECK_INTERVAL):
+                    break
+                if _local_model is None:
+                    break
+                # Re-read the timeout each cycle: config edits apply without
+                # waiting for the next voice message.
+                try:
+                    timeout = _get_idle_unload_seconds(
+                        _load_stt_config().get("local") or {}
+                    )
+                except Exception:  # noqa: BLE001 - keep the seed value
+                    timeout = initial_timeout
+                if timeout <= 0:
+                    break  # unload disabled mid-flight — stand down
+                idle_for = time.monotonic() - _last_transcription_time
+                if idle_for >= timeout:
+                    _unload_local_model()
+                    break
 
-    _idle_unload_thread = threading.Thread(
-        target=_watch, name="hermes-stt-idle-unload", daemon=True
-    )
-    _idle_unload_thread.start()
+        _idle_unload_stop.clear()
+        _idle_unload_thread = threading.Thread(
+            target=_watch, name="hermes-stt-idle-unload", daemon=True
+        )
+        _idle_unload_thread.start()
 
 
 def _touch_transcription_time() -> None:
-    """Record that a transcription just completed (resets the idle timer)."""
+    """Record transcription activity (resets the idle timer)."""
     global _last_transcription_time
     _last_transcription_time = time.monotonic()
 
@@ -1707,10 +1728,18 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 
     try:
         local_cfg = _load_stt_config().get("local") or {}
+        # Reset the idle timer BEFORE loading/transcribing so the idle-unload
+        # watcher can't count a long in-flight transcription as idle time and
+        # unload mid-use.
+        _touch_transcription_time()
         # Lazy-load the model (downloads on first use, ~150 MB for 'base').
         # Double-checked lock: concurrent voice messages must not both
         # download/load the model (#24767).
-        if _local_model is None or _local_model_name != model_name:
+        # ``model`` is a strong local reference bound under the lock: the idle
+        # watcher may null the module global at any time, but this
+        # transcription keeps using the instance it grabbed.
+        model = _local_model
+        if model is None or _local_model_name != model_name:
             with _local_model_lock:
                 if _local_model is None or _local_model_name != model_name:
                     logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
@@ -1725,7 +1754,10 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
                         compute_type=local_cfg.get("compute_type", "auto"),
                     )
                     _local_model_name = model_name
+                model = _local_model
 
+        if model is None:  # defensive: load failed without raising
+            return {"success": False, "transcript": "", "error": "Local whisper model failed to load"}
         # Shared hardened kwargs: VAD filter (default on), no cross-window
         # conditioning, language/initial_prompt resolution — one owner for
         # every local faster-whisper call site.
@@ -1734,7 +1766,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         transcribe_kwargs = build_local_transcribe_kwargs(stt_config)
 
         try:
-            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+            segments, info = model.transcribe(file_path, **transcribe_kwargs)
             transcript = _join_confident_segments(segments, local_config)
         except Exception as exc:
             # CUDA runtime libs sometimes only fail at dlopen-on-first-use,
@@ -1749,12 +1781,12 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
                 "evicting cached model and retrying on CPU (int8).",
                 exc,
             )
-            _local_model = None
-            _local_model_name = None
             from faster_whisper import WhisperModel
-            _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
-            _local_model_name = model_name
-            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+            model = WhisperModel(model_name, device="cpu", compute_type="int8")
+            with _local_model_lock:
+                _local_model = model
+                _local_model_name = model_name
+            segments, info = model.transcribe(file_path, **transcribe_kwargs)
             transcript = _join_confident_segments(segments, local_config)
 
         logger.info(

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1851,7 +1851,7 @@ stt:
     vad_min_silence_ms: 500    # min silence (ms) that splits speech chunks when vad is on
     no_speech_prob_threshold: 0.6  # drop a segment only when no_speech_prob > this...
     logprob_threshold: -1.0        # ...AND avg_logprob < this (both must hit — quiet real speech survives)
-    unload_after_idle_seconds: 0   # 0=never unload (default); 300=frees ~370MB RAM after 5min idle
+    unload_after_idle_seconds: 0   # 0=never unload (default); e.g. 300 = release the model after 5min idle
   groq:
     language: ""               # per-provider override of stt.language
   openai:
@@ -1866,7 +1866,7 @@ Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes
 
 Provider behavior:
 
-- `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior. The model stays loaded in memory between voice messages for low-latency transcription; set `stt.local.unload_after_idle_seconds` (e.g. `300` for 5 minutes) to automatically release the model when idle — useful on gateway processes or machines with limited RAM/VRAM.
+- `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior. The model stays loaded in memory between voice messages for low-latency transcription; set `stt.local.unload_after_idle_seconds` (e.g. `300` for 5 minutes) to automatically release the model when idle. This frees GPU memory on CUDA hosts (the main win when a local LLM shares the GPU); on CPU the memory becomes reusable by the process, though the OS-visible footprint may not shrink until the process needs the space for something else. The next voice message reloads the model transparently.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`. Pass `stt.groq.language` (or the global `HERMES_LOCAL_STT_LANGUAGE` env var) to skip auto-detection and reduce latency.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1851,6 +1851,7 @@ stt:
     vad_min_silence_ms: 500    # min silence (ms) that splits speech chunks when vad is on
     no_speech_prob_threshold: 0.6  # drop a segment only when no_speech_prob > this...
     logprob_threshold: -1.0        # ...AND avg_logprob < this (both must hit — quiet real speech survives)
+    unload_after_idle_seconds: 0   # 0=never unload (default); 300=frees ~370MB RAM after 5min idle
   groq:
     language: ""               # per-provider override of stt.language
   openai:
@@ -1865,7 +1866,7 @@ Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes
 
 Provider behavior:
 
-- `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior.
+- `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior. The model stays loaded in memory between voice messages for low-latency transcription; set `stt.local.unload_after_idle_seconds` (e.g. `300` for 5 minutes) to automatically release the model when idle — useful on gateway processes or machines with limited RAM/VRAM.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`. Pass `stt.groq.language` (or the global `HERMES_LOCAL_STT_LANGUAGE` env var) to skip auto-detection and reduce latency.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
 


### PR DESCRIPTION
## Context — what this does for users, concretely

**Who benefits:** anyone running a long-running Hermes gateway (or CLI session) with local STT, especially machines where the whisper model competes with local LLMs for GPU memory.

**The problem:** the local faster-whisper model singleton (`_local_model`) is loaded on the first voice message and never released — the `base` model holds ~370 MB for the entire lifetime of the process, even if no voice messages arrive for hours or days.

**What unloading actually frees (measured honestly):**
- **CUDA/GPU**: VRAM is released back to the device when the ctranslate2 model is garbage-collected — this is the big win for gateways sharing a GPU with a local LLM.
- **CPU (macOS, measured)**: the Python references are dropped and the memory becomes reusable by the process, but ctranslate2's C++ allocator does not return freed pages to the OS, so RSS does not visibly shrink (measured: 388 MB RSS before and after del+gc on macOS/CPU). On Linux, glibc's `malloc_trim` behavior may return some.
- Either way the model no longer pins hundreds of MB of *live* objects, and a differently-sized model configured later loads into reclaimed arena space instead of growing the process further.

## What it does

After `stt.local.unload_after_idle_seconds` (default `0` = never) of no transcription activity, a daemon watcher unloads the model. The next voice message reloads it transparently via the existing lazy-load path.

**Design (post-review):**
- **Single long-lived watcher** — started only when none is alive (per-transcription cost: one lock + one `is_alive()` check). No stop/join/restart churn on the voice-message response path.
- The loop **re-reads the configured timeout from config every cycle** (30s interval), so editing `unload_after_idle_seconds` in config.yaml takes effect within one interval — including standing down without unloading when set to 0 mid-idle.
- Watcher start is serialized by a management lock; unload takes the model lock.

**Concurrency (reviewed and regression-guarded):** a review pass found two races in the initial design; both are fixed in the second commit:
1. *Unload-vs-use null deref*: `_transcribe_local` re-read the module global at the transcribe call site, so an unload firing mid-transcription produced `'NoneType' object has no attribute 'transcribe'`. Fixed by binding a strong local reference under the model lock (the in-flight call keeps its instance; the watcher can null the global freely) and touching the idle timer at the START of transcription so long transcriptions don't count as idle. **Mutation-verified**: reverting to the global-re-read shape makes the new race-guard test fail with that exact error.
2. *Watcher replacement race*: the old stop/join(5)/clear/start sequence was unlocked over shared globals — two concurrent voice messages could leave two live watchers (one with a stale timeout), and the `join(timeout=5)` sat on the user-visible response path. Fixed by the single-watcher design above.

**Default is 0 (never unload)** — zero behavior change for existing users. Recommended for gateway processes: `300` (5 minutes).

## Config

```yaml
stt:
  local:
    unload_after_idle_seconds: 0   # 0=never (default); e.g. 300 = unload after 5min idle
```

## Testing

- 17 tests in `tests/tools/test_stt_idle_unload.py`: config resolution (garbage/negative/None fallbacks), unload safety (already-None, lock acquisition), watcher lifecycle (unloads after timeout, survives within timeout, exits when model gone, idempotent start — same thread, no churn), config re-read + stand-down-when-disabled, and the mid-transcription race guard (mutation-verified against the buggy shape)
- Existing STT suite: 100 passed; 1 pre-existing failure confirmed identical on clean `upstream/main` baseline (`test_config_device_and_compute_type_passed_to_whisper`, unrelated)
- `ruff` clean, `cli-config.yaml.example` YAML-parses, `DEFAULT_CONFIG` key verified importable