### PR TITLE
fix(desktop): replace review emoji with bundled icon

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/system-message.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseSelfImprovementReview } from './system-message'
+
+describe('parseSelfImprovementReview', () => {
+  it('extracts the review text without the emoji prefix', () => {
+    expect(parseSelfImprovementReview('💾 Self-improvement review: Patched one skill.')).toBe(
+      'Self-improvement review: Patched one skill.'
+    )
+  })
+
+  it('ignores unrelated system messages', () => {
+    expect(parseSelfImprovementReview('model → openai/gpt-5')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -8,12 +8,31 @@ import { cn } from '@/lib/utils'
 
 const SLASH_STATUS_RE = /^slash:(?<command>\/[^\n]+)\n(?<output>[\s\S]*)$/
 const STEER_NOTE_RE = /^steer:(?<text>[\s\S]+)$/
+const SELF_IMPROVEMENT_RE = /^💾\s+(?<text>Self-improvement review:[\s\S]+)$/
+
+export const parseSelfImprovementReview = (text: string): string | null =>
+  text.match(SELF_IMPROVEMENT_RE)?.groups?.text.trim() ?? null
 
 export const SystemMessage: FC = () => {
   const text = useAuiState(s => messageContentText(s.message.content))
 
   if (!text) {
     return null
+  }
+
+  const selfImprovementReview = parseSelfImprovementReview(text)
+
+  if (selfImprovementReview) {
+    return (
+      <MessagePrimitive.Root
+        className="flex max-w-[min(86%,44rem)] items-start gap-1.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/55"
+        data-role="system"
+        data-slot="aui_system-message-root"
+      >
+        <Codicon className="mt-1 shrink-0 text-muted-foreground/50" name="save" size="0.75rem" />
+        <span className="whitespace-pre-wrap">{selfImprovementReview}</span>
+      </MessagePrimitive.Root>
+    )
   }
 
   const steerNote = text.match(STEER_NOTE_RE)


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now renders the `💾 Self-improvement review: …` system notification with the bundled `save` Codicon instead of asking Chromium to render the literal floppy-disk emoji.

On Linux/Electron, the small inline system-message typography could render `💾` as a tofu box even when Noto Color Emoji was installed. The message is structured application chrome, so a bundled UI icon is more reliable and visually consistent than depending on host color-emoji fallback.

The original message text is preserved; only the emoji prefix is replaced at render time. CLI and other output paths are unchanged.

### Root cause

`agent/background_review.py` emits a plain-text notification beginning with U+1F4BE (`💾`). Desktop rendered the complete string through the generic `SystemMessage` text path. Chromium's Linux color-font fallback did not resolve that codepoint in this compact inline surface, producing the visible missing-glyph box.

This is separate from the private-use Nerd Font fallback in #81013: U+1F4BE is an emoji, not a Nerd Font PUA character. Expanding the Nerd Font fallback cannot correctly solve it.

### Implementation

- Recognize the structured self-improvement notification in `SystemMessage`.
- Strip only its known emoji prefix.
- Render the existing bundled Codicon `save` glyph alongside the unchanged notification text.
- Leave unrelated system messages on the existing generic path.

## Related Issue

Follow-up found while visually validating #81013. It intentionally remains separate because this is a structured-message rendering fix rather than font fallback.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

| Check | Result |
|---|---|
| `npm run test:ui -- src/components/assistant-ui/thread/system-message.test.ts` | 2 passed |
| `npm run typecheck` | Passed |
| `npm run lint -- --quiet` | Passed |
| `hermes desktop --build-only` on a local integration branch containing #81013 and this commit | Passed; Electron 40.10.2 Linux package produced |

The regression test verifies that the structured notification is recognized, its text is retained without the emoji prefix, and unrelated system messages are ignored.

## Screenshots / Logs

### Before

![Self-improvement notification showing a tofu box before its text](https://raw.githubusercontent.com/Antikythera/hermes-agent/pr-assets/.github/pr-assets/self-improvement-status-icon/before.png)

### After

<img width="1392" height="155" alt="image" src="https://github.com/user-attachments/assets/8faf5d4a-a48e-4ea5-a37f-bb02bd6cf826" />

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - Not applicable: this is an internal rendering correction with no user-facing API or setting.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have run `pytest tests/ -q` and all tests pass
  - Not run: the change is isolated to desktop TypeScript/React; the focused UI test, desktop typecheck, lint, and packaged build passed.
- [x] Any dependent changes have been merged and published
  - No dependencies; this PR is independent of #81013.

## Platform Information

- OS: Bazzite Linux / KDE Plasma / Wayland
- Electron: 40.10.2
