### PR TITLE
fix(a2a): log rejected 401/403 requests to a2a_audit.jsonl (#81003)

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -248,6 +248,15 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
         # localhost-only mode) — never from the request body.
         identity = security.authenticate(self.headers.get("Authorization"), client_ip)
         if identity is None:
+            security.audit(
+                "inbound",
+                None,
+                None,
+                "unauthorized",
+                decision="rejected_bad_token",
+                status=401,
+                ip=client_ip,
+            )
             self._json(401, protocol.jsonrpc_error(None, protocol.ERR_UNAUTHORIZED, "unauthorized"))
             return
 
@@ -293,6 +302,15 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             return
 
         if not security.is_trusted_peer(identity):
+            security.audit(
+                "inbound",
+                identity,
+                req_id,
+                f"peer '{identity}' not trusted",
+                decision="rejected_untrusted_peer",
+                status=403,
+                ip=client_ip,
+            )
             self._json(403, protocol.jsonrpc_error(
                 req_id, protocol.ERR_UNTRUSTED_PEER, f"peer '{identity}' not trusted"))
             return

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -354,16 +354,36 @@ def _audit_path() -> Path:
     return base / "a2a_audit.jsonl"
 
 
-def audit(direction: str, peer: str, task_id: str, summary: str) -> None:
-    """Append an audit record. Best-effort — never raises into the caller."""
+def audit(
+    direction: str,
+    peer: str | None,
+    task_id: str | None,
+    summary: str,
+    *,
+    decision: str | None = None,
+    status: int | None = None,
+    ip: str | None = None,
+) -> None:
+    """Append an audit record. Best-effort — never raises into the caller.
+
+    ``decision`` and ``status`` capture auth/rejection outcomes so the audit
+    log can record 401/403 rejections alongside accepted inbound/outbound
+    traffic. ``ip`` is the caller's address when known.
+    """
     try:
-        rec = {
+        rec: dict[str, object] = {
             "ts": time.time(),
             "direction": direction,  # "inbound" | "outbound" | "push"
             "peer": peer,
             "task_id": task_id,
             "summary": (summary or "")[:500],
         }
+        if decision is not None:
+            rec["decision"] = decision
+        if status is not None:
+            rec["status"] = status
+        if ip is not None:
+            rec["ip"] = ip
         path = _audit_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -206,6 +206,21 @@ class TestAudit:
         assert rec["peer"] == "peer-y"
         assert rec["task_id"] == "task-1"
 
+    def test_audit_rejected_record(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        security.audit(
+            "inbound", None, None, "unauthorized",
+            decision="rejected_bad_token", status=401, ip="127.0.0.1",
+        )
+        audit_file = tmp_path / "a2a_audit.jsonl"
+        assert audit_file.exists()
+        rec = json.loads(audit_file.read_text().strip().splitlines()[-1])
+        assert rec["direction"] == "inbound"
+        assert rec["peer"] is None
+        assert rec["decision"] == "rejected_bad_token"
+        assert rec["status"] == 401
+        assert rec["ip"] == "127.0.0.1"
+
 
 # --------------------------------------------------------------------------
 # Protocol v1.0 shapes
@@ -1220,6 +1235,74 @@ class TestInboundRoundTrip:
             assert "'alice'" in seen["text"]
             assert "the-operator" not in seen["text"]
             await adapter.disconnect()
+
+        asyncio.run(run())
+
+    def test_401_unauthorized_is_audited(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("A2A_BEARER_TOKEN", "topsecret")
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter, base = _make_live_adapter(monkeypatch)
+
+        async def run():
+            assert await adapter.connect() is True
+
+            def _post_unauth():
+                try:
+                    _post_json(base + "/", _send_body("x"))
+                    raise AssertionError("expected 401")
+                except urllib.error.HTTPError as e:
+                    assert e.code == 401
+                    return json.loads(e.read().decode())
+
+            err = await asyncio.to_thread(_post_unauth)
+            assert err["error"]["code"] == protocol.ERR_UNAUTHORIZED
+
+            await adapter.disconnect()
+
+            # The rejected request must appear in the audit log.
+            audit_file = tmp_path / "a2a_audit.jsonl"
+            assert audit_file.exists()
+            rec = json.loads(audit_file.read_text().strip().splitlines()[-1])
+            assert rec["direction"] == "inbound"
+            assert rec["decision"] == "rejected_bad_token"
+            assert rec["status"] == 401
+
+        asyncio.run(run())
+
+    def test_403_untrusted_peer_is_audited(self, monkeypatch, tmp_path):
+        """A valid token from a non-trusted peer is rejected *and* logged."""
+        monkeypatch.setenv("A2A_PEER_TOKENS", "mallory:tok-mallory")
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.setenv("A2A_TRUSTED_PEERS", "alice")
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter, base = _make_live_adapter(monkeypatch)
+
+        async def run():
+            assert await adapter.connect() is True
+
+            def _post_untrusted():
+                body = _send_body("do a thing")
+                try:
+                    _post_json(base + "/", body, {"Authorization": "Bearer tok-mallory"})
+                    raise AssertionError("expected 403")
+                except urllib.error.HTTPError as e:
+                    assert e.code == 403
+                    return json.loads(e.read().decode())
+
+            err = await asyncio.to_thread(_post_untrusted)
+            assert err["error"]["code"] == protocol.ERR_UNTRUSTED_PEER
+
+            await adapter.disconnect()
+
+            audit_file = tmp_path / "a2a_audit.jsonl"
+            assert audit_file.exists()
+            rec = json.loads(audit_file.read_text().strip().splitlines()[-1])
+            assert rec["direction"] == "inbound"
+            assert rec["peer"] == "mallory"
+            assert rec["decision"] == "rejected_untrusted_peer"
+            assert rec["status"] == 403
 
         asyncio.run(run())
 


### PR DESCRIPTION
## What does this PR do?

The A2A audit log (`a2a_audit.jsonl`) only recorded accepted inbound/outbound traffic. Rejected 401 (missing/invalid bearer token) and 403 (untrusted peer) POST requests produced no audit entry, making credential-stuffing, revoked-token probing, and lateral-movement attempts invisible to audit-based monitoring.

This change logs every auth rejection to the same append-only audit sink with a `decision` field and the HTTP `status`, plus the caller's `ip` as a bonus field for fleet monitoring.

## Related Issue

Fixes #81003

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/a2a/security.py`
  - `audit()` now accepts optional keyword-only `decision`, `status`, and `ip` fields so rejection records carry the auth outcome.
  - Existing four-argument calls remain backward-compatible.
- `plugins/platforms/a2a/adapter.py`
  - `do_POST()` now calls `security.audit()` before returning 401 (`rejected_bad_token`) and 403 (`rejected_untrusted_peer`).
- `tests/plugins/test_a2a_plugin.py`
  - Added `TestAudit::test_audit_rejected_record` for the new record shape.
  - Added `TestInboundRoundTrip::test_401_unauthorized_is_audited` and `test_403_untrusted_peer_is_audited` live-HTTP regression tests that fail on the base and pass with the fix.

## How to Test

```sh
# Focused regression suite
scripts/run_tests.sh tests/plugins/test_a2a_plugin.py

# Full local gate (ruff, uv lock, ty advisory, changed tests)
scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/81003
```

On the base branch, the new `test_401_unauthorized_is_audited` and `test_403_untrusted_peer_is_audited` assertions fail because `a2a_audit.jsonl` does not exist for the rejected request. With this PR, both produce a record with the expected `decision` and `status`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Apple Silicon

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A