### PR TITLE
feat(doctor): restore upstream health diagnostics

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -714,6 +714,39 @@ def run_doctor(args):
     # checks (like cronjob management) should see the same context as `hermes`.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
 
+    # ------------------------------------------------------------------
+    # --upstream : READONLY diagnostic branch (UH1..UH5, UH9, UH10).
+    # Incompatible with --fix / --ack to keep the existing surface
+    # intact. Emits text, --json, or --compact and returns without
+    # touching the rest of the doctor workflow.
+    # ------------------------------------------------------------------
+    if getattr(args, 'upstream', False):
+        if should_fix or ack_target:
+            print(color(
+                "--upstream is incompatible with --fix and --ack",
+                Colors.RED,
+            ))
+            sys.exit(2)
+        from hermes_cli.doctor_upstream import (
+            run_upstream_health,
+            render_text,
+            render_compact,
+            serialize_json,
+        )
+        use_json = bool(getattr(args, 'json', False))
+        use_compact = bool(getattr(args, 'compact', False))
+        result = run_upstream_health(cwd=PROJECT_ROOT)
+        if use_json:
+            sys.stdout.write(serialize_json(result))
+            sys.stdout.write("\n")
+        elif use_compact:
+            sys.stdout.write(render_compact(result))
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(render_text(result))
+        sys.exit(result.exit_code)
+        return
+
     # Handle `hermes doctor --ack <id>` as a fast path. Persist the ack and
     # return without running the rest of the diagnostics — the user has
     # already seen the advisory and just wants to silence it.

--- a/hermes_cli/doctor_upstream.py
+++ b/hermes_cli/doctor_upstream.py
@@ -1,0 +1,1373 @@
+"""
+``hermes doctor --upstream`` diagnostic.
+
+Pure READONLY inspection of:
+
+  - upstream reference, tracking, ahead/behind, divergence age;
+  - mutual paths between local HEAD and upstream;
+  - scope health (UH1, UH2, UH3, UH4, UH5, UH9);
+  - safety of a future update operation (UH10).
+
+This module never invokes a mutating Git command. It uses an explicit
+allowlist (READONLY_GIT_SUBCOMMANDS) and only ever calls ``git`` via argv
+through ``subprocess.run`` (no shell), captures stdout/stderr, and has a
+hard timeout. Anything that doesn't match the allowlist raises
+:class:`GitCommandForbidden`.
+
+Diagnostic-only, no network, no persistence, no fixtures on disk other
+than temporary Git repos that are cleaned up by the caller (typically a
+test fixture). ``run_upstream_health`` is the single entry point and
+returns a serializable dict suitable for ``render_text``/``render_compact``/
+``serialize_json``.
+
+The contract is frozen by
+``HERMES_DOCTOR_UPSTREAM_HEALTH_CONTRACT_FINAL_FROZEN`` — see the
+docstrings on :func:`run_upstream_health` and :func:`update_safety_check`
+for the gating rules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any, Iterable, Optional
+
+
+# --------------------------------------------------------------------------- #
+# Git allowlist (READONLY).
+# --------------------------------------------------------------------------- #
+
+# Subcommands that may be invoked. Anything outside this set is forbidden
+# at runtime — see ``_run_git``. This is the *only* surface through which
+# the module touches Git; it never uses ``shell=True``.
+READONLY_GIT_SUBCOMMANDS: frozenset[str] = frozenset({
+    "rev-parse",
+    "rev-list",
+    "merge-base",
+    "diff",
+    "show",
+    "symbolic-ref",
+    "config",
+    "remote",
+    "status",
+})
+
+# Subcommands explicitly forbidden even if someone extends the allowlist
+# by accident (defense in depth).
+FORBIDDEN_GIT_SUBCOMMANDS: frozenset[str] = frozenset({
+    "fetch",
+    "pull",
+    "merge",
+    "rebase",
+    "checkout",
+    "switch",
+    "reset",
+    "stash",
+    "push",
+    "clean",
+    "update-ref",
+    "submodule",
+    "am",
+    "apply",
+    "cherry-pick",
+    "revert",
+    "rm",
+})
+
+GIT_COMMAND_TIMEOUT_SECONDS: int = 10
+
+
+class GitCommandForbidden(RuntimeError):
+    """Raised when a Git subcommand outside the allowlist is requested."""
+
+
+class GitCallError(RuntimeError):
+    """Raised when Git returns a non-zero exit or times out."""
+
+    def __init__(self, message: str, *, returncode: int | None = None,
+                 stderr: str = "", argv: tuple[str, ...] = ()):
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+        self.argv = argv
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "git_error",
+            "message": str(self),
+            "returncode": self.returncode,
+            "stderr": self.stderr,
+            "argv": list(self.argv),
+        }
+
+
+def _run_git(args: Iterable[str], *, cwd: Optional[str] = None,
+             timeout: Optional[int] = None) -> str:
+    """Run a Git subcommand from the allowlist, return stdout.
+
+    Never raises for normal Git failures — those raise :class:`GitCallError`
+    with structured fields. Forbidden subcommands raise
+    :class:`GitCommandForbidden`.
+    """
+    argv = ("git",) + tuple(args)
+    if len(argv) < 2:
+        raise GitCallError("empty git argv", argv=argv)
+    subcommand = argv[1]
+    if subcommand in FORBIDDEN_GIT_SUBCOMMANDS:
+        raise GitCommandForbidden(
+            f"git subcommand '{subcommand}' is forbidden in READONLY mode"
+        )
+    if subcommand not in READONLY_GIT_SUBCOMMANDS:
+        raise GitCommandForbidden(
+            f"git subcommand '{subcommand}' not in allowlist: "
+            f"{sorted(READONLY_GIT_SUBCOMMANDS)}"
+        )
+    try:
+        completed = subprocess.run(
+            list(argv),
+            cwd=cwd,
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout or GIT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise GitCallError(
+            f"git {subcommand} timed out after {timeout or GIT_COMMAND_TIMEOUT_SECONDS}s",
+            argv=argv,
+        ) from e
+    except FileNotFoundError as e:
+        raise GitCallError("git binary not found", argv=argv) from e
+    if completed.returncode != 0:
+        raise GitCallError(
+            f"git {subcommand} failed (rc={completed.returncode})",
+            returncode=completed.returncode,
+            stderr=completed.stderr.strip(),
+            argv=argv,
+        )
+    return completed.stdout
+
+
+def _shell_quote(value: str) -> str:
+    """Render a shell-quoted command for diagnostic display only — never
+    passed to a shell."""
+    return shlex.join([value]) if value else "''"
+
+
+# --------------------------------------------------------------------------- #
+# Enums.
+# --------------------------------------------------------------------------- #
+
+
+class BranchHealth(str, Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    ERROR = "ERROR"
+
+
+class UpdateSafetyDecision(str, Enum):
+    UPDATE_SAFETY_PASS = "UPDATE_SAFETY_PASS"
+    UPDATE_SAFETY_BLOCKED = "UPDATE_SAFETY_BLOCKED"
+
+
+class UpdateBehavior(str, Enum):
+    PULL_FF_ONLY = "PULL_FF_ONLY"
+    PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK = "PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK"
+    PULL_REBASE = "PULL_REBASE"
+    PULL_MERGE = "PULL_MERGE"
+    CHECKOUT_THEN_PULL_FF_ONLY = "CHECKOUT_THEN_PULL_FF_ONLY"
+    CHECKOUT_THEN_PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK = (
+        "CHECKOUT_THEN_PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK"
+    )
+    UNKNOWN = "UNKNOWN"
+
+
+# --------------------------------------------------------------------------- #
+# Dataclasses — frozen.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class UpdateBehaviorProfile:
+    """Orthogonal properties of the real Hermes update behavior."""
+
+    name: UpdateBehavior
+    implicit_branch_switch: bool
+    autostash: bool
+    hard_rollback_on_syntax_failure: bool
+    gateway_auto_restart: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name.value,
+            "implicit_branch_switch": self.implicit_branch_switch,
+            "autostash": self.autostash,
+            "hard_rollback_on_syntax_failure": self.hard_rollback_on_syntax_failure,
+            "gateway_auto_restart": self.gateway_auto_restart,
+        }
+
+
+# The behavior Hermes *actually* exhibits today, as established by the
+# contract freeze. This is the canonical profile passed into
+# ``update_safety_check`` when a profile isn't supplied (e.g. from tests
+# that need to inject a different one).
+CURRENT_UPDATE_BEHAVIOR = UpdateBehaviorProfile(
+    name=UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+    implicit_branch_switch=True,
+    autostash=True,
+    hard_rollback_on_syntax_failure=True,
+    gateway_auto_restart=True,
+)
+
+
+@dataclass(frozen=True)
+class UpstreamReference:
+    resolved: bool
+    ref: Optional[str]
+    remote: Optional[str]
+    branch: Optional[str]
+    resolution_chain: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TrackingInfo:
+    has_upstream: bool
+    upstream_ref: Optional[str]
+    remote: Optional[str]
+    merge_ref: Optional[str]
+    resolution: str  # "explicit" | "config_fallback" | "none"
+    publish_ref: Optional[str] = None
+    published_ahead: int = 0
+    published_behind: int = 0
+    fully_published: bool = False
+
+
+@dataclass(frozen=True)
+class AheadBehind:
+    ahead: int
+    behind: int
+
+
+@dataclass(frozen=True)
+class DivergenceInfo:
+    merge_base_sha: Optional[str]
+    merge_base_timestamp: Optional[int]
+    head_timestamp: Optional[int]
+    oldest_unique_commit_sha: Optional[str]
+    oldest_unique_commit_timestamp: Optional[int]
+    divergence_age_days: Optional[int]
+
+
+@dataclass(frozen=True)
+class MutualPaths:
+    local_paths: list[str]
+    upstream_paths: list[str]
+    mutual_paths: list[str]
+    critical_mutual_paths: list[str]
+
+
+@dataclass(frozen=True)
+class ScopeHealth:
+    unique_local_commits: int
+    changed_files: int
+    insertions: int
+    deletions: int
+
+
+@dataclass(frozen=True)
+class BranchHealthReport:
+    """Result of :func:`collect_branch_health`."""
+
+    branch: str
+    head_sha: str
+    head_short: str
+    repo_root: str
+    health: BranchHealth
+    reasons: list[str]
+    upstream: UpstreamReference
+    tracking: TrackingInfo
+    ahead_behind: AheadBehind
+    divergence: DivergenceInfo
+    mutual: MutualPaths
+    scope: ScopeHealth
+    raw_error: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "branch": self.branch,
+            "head_sha": self.head_sha,
+            "head_short": self.head_short,
+            "repo_root": self.repo_root,
+            "health": self.health.value,
+            "reasons": list(self.reasons),
+            "raw_error": self.raw_error,
+            "upstream": {
+                "resolved": self.upstream.resolved,
+                "ref": self.upstream.ref,
+                "remote": self.upstream.remote,
+                "branch": self.upstream.branch,
+                "resolution_chain": list(self.upstream.resolution_chain),
+                "error": self.upstream.error,
+            },
+            "canonical_upstream": {
+                "resolved": self.upstream.resolved,
+                "ref": self.upstream.ref,
+                "remote": self.upstream.remote,
+                "branch": self.upstream.branch,
+                "resolution_chain": list(self.upstream.resolution_chain),
+                "error": self.upstream.error,
+            },
+            "tracking": {
+                "has_upstream": self.tracking.has_upstream,
+                "upstream_ref": self.tracking.upstream_ref,
+                "publish_ref": self.tracking.publish_ref,
+                "remote": self.tracking.remote,
+                "merge_ref": self.tracking.merge_ref,
+                "resolution": self.tracking.resolution,
+                "published_ahead": self.tracking.published_ahead,
+                "published_behind": self.tracking.published_behind,
+                "fully_published": self.tracking.fully_published,
+            },
+            "ahead_behind": {
+                "ahead": self.ahead_behind.ahead,
+                "behind": self.ahead_behind.behind,
+            },
+            "divergence": {
+                "merge_base_sha": self.divergence.merge_base_sha,
+                "merge_base_timestamp": self.divergence.merge_base_timestamp,
+                "head_timestamp": self.divergence.head_timestamp,
+                "oldest_unique_commit_sha": self.divergence.oldest_unique_commit_sha,
+                "oldest_unique_commit_timestamp": (
+                    self.divergence.oldest_unique_commit_timestamp
+                ),
+                "divergence_age_days": self.divergence.divergence_age_days,
+            },
+            "mutual": {
+                "local_paths": list(self.mutual.local_paths),
+                "upstream_paths": list(self.mutual.upstream_paths),
+                "mutual_paths": list(self.mutual.mutual_paths),
+                "critical_mutual_paths": list(self.mutual.critical_mutual_paths),
+            },
+            "scope": {
+                "unique_local_commits": self.scope.unique_local_commits,
+                "changed_files": self.scope.changed_files,
+                "insertions": self.scope.insertions,
+                "deletions": self.scope.deletions,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class UpdateSafetyReport:
+    """Result of :func:`update_safety_check`."""
+
+    decision: UpdateSafetyDecision
+    requires_manual_confirmation: bool
+    confirmation_reason: Optional[str]
+    behavior_name: UpdateBehavior
+    behavior_profile: UpdateBehaviorProfile
+    reasoning: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision.value,
+            "requires_manual_confirmation": self.requires_manual_confirmation,
+            "confirmation_reason": self.confirmation_reason,
+            "behavior_name": self.behavior_name.value,
+            "behavior_profile": self.behavior_profile.to_dict(),
+            "reasoning": list(self.reasoning),
+        }
+
+
+@dataclass(frozen=True)
+class UpstreamHealthResult:
+    branch_health: BranchHealthReport
+    update_safety: UpdateSafetyReport
+    exit_code: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "branch_health": self.branch_health.to_dict(),
+            "update_safety": self.update_safety.to_dict(),
+            "exit_code": self.exit_code,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Critical paths (heuristic, conservative). Mutual path on any of these
+# surfaces but does not itself cause BLOCKED — only the update_safety
+# rules can produce BLOCKED.
+# --------------------------------------------------------------------------- #
+
+
+CRITICAL_PATH_FRAGMENTS: tuple[str, ...] = (
+    "hermes_cli/main.py",
+    "hermes_cli/config.py",
+    "cli.py",
+    "run_agent.py",
+    "model_tools.py",
+    "toolsets.py",
+    "hermes_constants.py",
+    "hermes_cli/__init__.py",
+)
+
+
+def _classify_critical_paths(mutual: list[str]) -> list[str]:
+    out: list[str] = []
+    for path in mutual:
+        for fragment in CRITICAL_PATH_FRAGMENTS:
+            if fragment in path:
+                out.append(path)
+                break
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Scope-thresholds (UH9, frozen by contract).
+# --------------------------------------------------------------------------- #
+
+
+SCOPE_PASS_MAX_COMMITS = 5
+SCOPE_PASS_MAX_FILES = 20
+SCOPE_WARN_MAX_COMMITS = 20
+SCOPE_WARN_MAX_FILES = 100
+
+
+def _classify_scope(scope: ScopeHealth) -> BranchHealth:
+    if scope.unique_local_commits > SCOPE_WARN_MAX_COMMITS or scope.changed_files > SCOPE_WARN_MAX_FILES:
+        return BranchHealth.ERROR
+    if (scope.unique_local_commits > SCOPE_PASS_MAX_COMMITS
+            or scope.changed_files > SCOPE_PASS_MAX_FILES):
+        return BranchHealth.WARN
+    return BranchHealth.PASS
+
+
+# --------------------------------------------------------------------------- #
+# Git collection.
+# --------------------------------------------------------------------------- #
+
+
+def _safe_stdout(fn, *args, **kwargs) -> tuple[Optional[str], Optional[str]]:
+    """Call ``fn`` (a ``_run_git``-style callable) returning (stdout_or_None, error_or_None)."""
+    try:
+        return fn(*args, **kwargs), None
+    except (GitCallError, GitCommandForbidden) as e:
+        return None, str(e)
+
+
+def _detect_repo_root(cwd: Optional[str] = None) -> Optional[str]:
+    out, err = _safe_stdout(_run_git, ("rev-parse", "--show-toplevel"), cwd=cwd)
+    if err or out is None:
+        return None
+    return out.strip()
+
+
+def _resolve_head(cwd: Optional[str] = None) -> tuple[str, str]:
+    head_sha = _run_git(("rev-parse", "HEAD"), cwd=cwd).strip()
+    head_short = _run_git(("rev-parse", "--short", "HEAD"), cwd=cwd).strip()
+    return head_sha, head_short
+
+
+def _resolve_branch(cwd: Optional[str] = None) -> str:
+    out, err = _safe_stdout(_run_git, ("symbolic-ref", "--short", "HEAD"), cwd=cwd)
+    if err or out is None:
+        # detached HEAD
+        return "HEAD"
+    return out.strip() or "HEAD"
+
+
+def _resolve_upstream_reference(
+    *, branch: str, cwd: Optional[str] = None,
+    canonical_upstream_ref: Optional[str] = None,
+) -> UpstreamReference:
+    """Resolve the canonical repository upstream ref.
+
+    Order:
+      1) explicit ``canonical_upstream_ref`` argument (tests/internal callers)
+      2) ``refs/remotes/origin/HEAD``
+      3) ``refs/remotes/origin/main``
+      4) ``refs/remotes/origin/master``
+      5) structured error
+
+    The branch's ``@{upstream}`` is publish tracking and is intentionally
+    resolved separately by :func:`_resolve_tracking`; it must not replace the
+    canonical upstream when a feature branch tracks a fork.
+    """
+    _ = branch  # kept for API symmetry and future branch-specific checks.
+    chain: list[str] = []
+
+    if canonical_upstream_ref:
+        chain.append("argument")
+        out, err = _safe_stdout(
+            _run_git,
+            ("rev-parse", "--verify", "--quiet", canonical_upstream_ref),
+            cwd=cwd,
+        )
+        if not err and out:
+            remote = canonical_upstream_ref.split("/", 1)[0] if "/" in canonical_upstream_ref else None
+            branch_name = canonical_upstream_ref.split("/", 1)[1] if "/" in canonical_upstream_ref else canonical_upstream_ref
+            return UpstreamReference(
+                resolved=True,
+                ref=canonical_upstream_ref,
+                remote=remote,
+                branch=branch_name,
+                resolution_chain=chain,
+            )
+        return UpstreamReference(
+            resolved=False,
+            ref=None,
+            remote=None,
+            branch=None,
+            resolution_chain=chain,
+            error=f"canonical upstream reference not found: {canonical_upstream_ref}",
+        )
+
+    # Try known canonical remote-tracking refs.
+    for hint in (
+        "refs/remotes/origin/HEAD",
+        "refs/remotes/origin/main",
+        "refs/remotes/origin/master",
+    ):
+        chain.append(hint)
+        if hint.endswith("/HEAD"):
+            out, err = _safe_stdout(_run_git, ("symbolic-ref", "--quiet", "--short", hint), cwd=cwd)
+            if not err and out:
+                ref = out.strip()
+                if ref:
+                    return UpstreamReference(
+                        resolved=True,
+                        ref=ref,
+                        remote=ref.split("/", 1)[0] if "/" in ref else "origin",
+                        branch=ref.split("/", 1)[1] if "/" in ref else ref,
+                        resolution_chain=chain,
+                    )
+            # Local test repos and some clones do not materialize
+            # origin/HEAD. Fall through to origin/main/master.
+            continue
+
+        out, err = _safe_stdout(_run_git, ("rev-parse", "--verify", "--quiet", hint), cwd=cwd)
+        if not err and out:
+            ref = hint[len("refs/remotes/"):]
+            return UpstreamReference(
+                resolved=True,
+                ref=ref,
+                remote="origin",
+                branch=ref.split("/", 1)[1] if "/" in ref else ref,
+                resolution_chain=chain,
+            )
+
+    return UpstreamReference(
+        resolved=False,
+        ref=None,
+        remote=None,
+        branch=None,
+        resolution_chain=chain,
+        error="canonical upstream reference not found",
+    )
+
+
+def _resolve_tracking(branch: str, cwd: Optional[str] = None) -> TrackingInfo:
+    out, err = _safe_stdout(
+        _run_git,
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"),
+        cwd=cwd,
+    )
+    if not err and out and not out.strip().endswith("@{upstream}"):
+        ref = out.strip()
+        remote = ref.split("/", 1)[0] if "/" in ref else None
+        return TrackingInfo(
+            has_upstream=True,
+            upstream_ref=ref,
+            remote=remote,
+            merge_ref=ref,
+            resolution="explicit",
+        )
+
+    if branch == "HEAD":
+        return TrackingInfo(
+            has_upstream=False,
+            upstream_ref=None,
+            remote=None,
+            merge_ref=None,
+            resolution="none",
+        )
+
+    remote_out, remote_err = _safe_stdout(
+        _run_git, ("config", "--get", f"branch.{branch}.remote"), cwd=cwd
+    )
+    merge_out, merge_err = _safe_stdout(
+        _run_git, ("config", "--get", f"branch.{branch}.merge"), cwd=cwd
+    )
+    if remote_out and merge_out and not remote_err and not merge_err:
+        remote = remote_out.strip()
+        merge_ref = merge_out.strip()
+        if merge_ref.startswith("refs/heads/"):
+            ref = f"{remote}/{merge_ref[len('refs/heads/'):]}"
+        else:
+            ref = f"{remote}/{merge_ref}"
+        return TrackingInfo(
+            has_upstream=True,
+            upstream_ref=ref,
+            remote=remote,
+            merge_ref=merge_ref,
+            resolution="config_fallback",
+        )
+
+    return TrackingInfo(
+        has_upstream=False,
+        upstream_ref=None,
+        remote=None,
+        merge_ref=None,
+        resolution="none",
+    )
+
+
+def _with_publish_metrics(tracking: TrackingInfo, *, cwd: Optional[str] = None) -> TrackingInfo:
+    """Attach publication metrics computed against ``@{upstream}`` only."""
+    publish_ref = tracking.upstream_ref if tracking.has_upstream else None
+    published = _ahead_behind(cwd=cwd, upstream_ref=publish_ref)
+    return TrackingInfo(
+        has_upstream=tracking.has_upstream,
+        upstream_ref=tracking.upstream_ref,
+        remote=tracking.remote,
+        merge_ref=tracking.merge_ref,
+        resolution=tracking.resolution,
+        publish_ref=publish_ref,
+        published_ahead=published.ahead,
+        published_behind=published.behind,
+        fully_published=tracking.has_upstream and published.ahead == 0,
+    )
+
+
+def _working_tree_clean(cwd: Optional[str]) -> bool:
+    out, err = _safe_stdout(_run_git, ("status", "--porcelain"), cwd=cwd)
+    return not err and out is not None and out.strip() == ""
+
+
+def _ahead_behind(cwd: Optional[str], upstream_ref: Optional[str]) -> AheadBehind:
+    if not upstream_ref:
+        return AheadBehind(ahead=0, behind=0)
+    out, err = _safe_stdout(
+        _run_git,
+        ("rev-list", "--left-right", "--count", f"HEAD...{upstream_ref}"),
+        cwd=cwd,
+    )
+    if err or out is None:
+        return AheadBehind(ahead=0, behind=0)
+    parts = out.strip().split()
+    if len(parts) != 2:
+        return AheadBehind(ahead=0, behind=0)
+    try:
+        return AheadBehind(ahead=int(parts[0]), behind=int(parts[1]))
+    except ValueError:
+        return AheadBehind_invalid()  # type: ignore[return-value]
+
+
+def AheadBehind_invalid() -> AheadBehind:  # pragma: no cover - defensive
+    return AheadBehind(ahead=0, behind=0)
+
+
+def _merge_base(cwd: Optional[str], upstream_ref: Optional[str]) -> Optional[str]:
+    if not upstream_ref:
+        return None
+    out, err = _safe_stdout(
+        _run_git, ("merge-base", "HEAD", upstream_ref), cwd=cwd
+    )
+    if err or out is None:
+        return None
+    return out.strip() or None
+
+
+def _timestamp_for(sha: Optional[str], cwd: Optional[str]) -> Optional[int]:
+    if not sha:
+        return None
+    out, err = _safe_stdout(
+        _run_git,
+        ("show", "-s", "--format=%ct", sha),
+        cwd=cwd,
+    )
+    if err or out is None:
+        return None
+    try:
+        return int(out.strip())
+    except ValueError:
+        return None
+
+
+def _oldest_unique_commit(
+    cwd: Optional[str], merge_base_sha: Optional[str], head_sha: Optional[str]
+) -> tuple[Optional[str], Optional[int]]:
+    """Oldest commit reachable from HEAD after the canonical merge base."""
+    if not merge_base_sha or not head_sha:
+        return None, None
+    if merge_base_sha == head_sha:
+        return None, None
+    out, err = _safe_stdout(
+        _run_git, ("rev-list", "--reverse", f"{merge_base_sha}..HEAD"), cwd=cwd
+    )
+    if err or out is None:
+        return None, None
+    lines = [line.strip() for line in out.splitlines() if line.strip()]
+    if not lines:
+        return None, None
+    oldest_sha = lines[0]
+    ts = _timestamp_for(oldest_sha, cwd=cwd)
+    return oldest_sha, ts
+
+
+def _divergence_info(cwd: Optional[str], upstream_ref: Optional[str]) -> DivergenceInfo:
+    merge_base_sha = _merge_base(cwd, upstream_ref)
+    head_out, head_err = _safe_stdout(_run_git, ("rev-parse", "HEAD"), cwd=cwd)
+    head_sha = head_out.strip() if not head_err and head_out else None
+    head_ts = _timestamp_for("HEAD", cwd=cwd)
+    merge_base_ts = _timestamp_for(merge_base_sha, cwd=cwd)
+    oldest_sha, oldest_ts = _oldest_unique_commit(cwd, merge_base_sha, head_sha)
+
+    age_days: Optional[int] = None
+    if merge_base_sha and head_sha and merge_base_sha == head_sha:
+        age_days = 0
+    elif head_ts is not None and oldest_ts is not None:
+        diff_seconds = max(0, head_ts - oldest_ts)
+        age_days = diff_seconds // 86_400
+
+    return DivergenceInfo(
+        merge_base_sha=merge_base_sha,
+        merge_base_timestamp=merge_base_ts,
+        head_timestamp=head_ts,
+        oldest_unique_commit_sha=oldest_sha,
+        oldest_unique_commit_timestamp=oldest_ts,
+        divergence_age_days=age_days,
+    )
+
+
+def _diff_name_only_range(cwd: Optional[str], revision_range: str) -> list[str]:
+    out, err = _safe_stdout(
+        _run_git, ("diff", "--name-only", revision_range), cwd=cwd
+    )
+    if err or out is None:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _diff_name_only(cwd: Optional[str], ref1: str, ref2: str) -> list[str]:
+    return _diff_name_only_range(cwd, f"{ref1}..{ref2}")
+
+
+def _shortstat(cwd: Optional[str], ref: Optional[str]) -> tuple[int, int, int]:
+    """Return (changed_files, insertions, deletions) for the diff vs ``ref``."""
+    if not ref:
+        return 0, 0, 0
+    out, err = _safe_stdout(
+        _run_git, ("diff", "--shortstat", f"{ref}...HEAD"), cwd=cwd
+    )
+    if err or out is None:
+        return 0, 0, 0
+    changed = insertions = deletions = 0
+    for chunk in out.strip().split(","):
+        chunk = chunk.strip()
+        if "file" in chunk:
+            try:
+                changed = int(chunk.split()[0])
+            except (ValueError, IndexError):
+                pass
+        elif "insertion" in chunk:
+            try:
+                insertions = int(chunk.split()[0])
+            except (ValueError, IndexError):
+                pass
+        elif "deletion" in chunk:
+            try:
+                deletions = int(chunk.split()[0])
+            except (ValueError, IndexError):
+                pass
+    return changed, insertions, deletions
+
+
+def _rev_count(cwd: Optional[str], ref1: str, ref2: str) -> int:
+    out, err = _safe_stdout(
+        _run_git, ("rev-list", "--count", f"{ref1}..{ref2}"), cwd=cwd
+    )
+    if err or out is None:
+        return 0
+    try:
+        return int(out.strip())
+    except ValueError:
+        return 0
+
+
+def _mutual_paths(cwd: Optional[str], upstream_ref: Optional[str],
+                  merge_base_sha: Optional[str]) -> MutualPaths:
+    local = _diff_name_only(cwd, merge_base_sha or "HEAD", "HEAD") if merge_base_sha else []
+    upstream = (
+        _diff_name_only(cwd, merge_base_sha or upstream_ref, upstream_ref)
+        if (merge_base_sha and upstream_ref)
+        else []
+    )
+    mutual = sorted(set(local) & set(upstream))
+    critical = _classify_critical_paths(mutual)
+    return MutualPaths(
+        local_paths=local,
+        upstream_paths=upstream,
+        mutual_paths=mutual,
+        critical_mutual_paths=critical,
+    )
+
+
+def _scope_health(cwd: Optional[str], upstream_ref: Optional[str]) -> ScopeHealth:
+    if not upstream_ref:
+        return ScopeHealth(0, 0, 0, 0)
+    unique_local = _rev_count(cwd, upstream_ref, "HEAD")
+    changed_paths = _diff_name_only_range(cwd, f"{upstream_ref}...HEAD")
+    shortstat_changed, ins, dele = _shortstat(cwd, upstream_ref)
+    changed = len(changed_paths) if changed_paths else shortstat_changed
+    return ScopeHealth(
+        unique_local_commits=unique_local,
+        changed_files=changed,
+        insertions=ins,
+        deletions=dele,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BranchHealth classification.
+# --------------------------------------------------------------------------- #
+
+
+def classify_branch_health(
+    *,
+    upstream: UpstreamReference,
+    tracking: TrackingInfo,
+    ahead_behind: AheadBehind,
+    divergence_age_days: int | None,
+    mutual: MutualPaths,
+    scope: ScopeHealth,
+) -> BranchHealth:
+    """Roll up the BranchHealth verdict from UH1–UH5, UH9.
+
+    Contract:
+      - missing upstream reference -> ERROR (UH1)
+      - no tracking on a feature branch with unique commits -> ERROR
+      - behind > 0 is not by itself a problem (UH3)
+      - divergence days > 30 is WARN, never ERROR
+      - mutual critical paths is WARN (UH5), never BLOCKED/ERROR
+      - scope (UH9) follows SCOPE_*_MAX_* thresholds
+    """
+    if not upstream.resolved:
+        return BranchHealth.ERROR
+    if not tracking.has_upstream and scope.unique_local_commits > 0:
+        return BranchHealth.ERROR
+    if scope.unique_local_commits > SCOPE_WARN_MAX_COMMITS or scope.changed_files > SCOPE_WARN_MAX_FILES:
+        return BranchHealth.ERROR
+    if (scope.unique_local_commits > SCOPE_PASS_MAX_COMMITS
+            or scope.changed_files > SCOPE_PASS_MAX_FILES):
+        return BranchHealth.WARN
+    if divergence_age_days is not None and divergence_age_days > 30:
+        return BranchHealth.WARN
+    if mutual.critical_mutual_paths:
+        return BranchHealth.WARN
+    return BranchHealth.PASS
+
+
+# --------------------------------------------------------------------------- #
+# Public collectors.
+# --------------------------------------------------------------------------- #
+
+
+def collect_branch_health(
+    *, cwd: Optional[str] = None,
+    repo_root: Optional[str] = None,
+    canonical_upstream_ref: Optional[str] = None,
+) -> BranchHealthReport:
+    """Read-only collection of BranchHealth components UH1–UH5 + UH9."""
+    reasons: list[str] = []
+    raw_error: Optional[str] = None
+
+    repo = repo_root or _detect_repo_root(cwd=cwd)
+    if not repo:
+        raw_error = "not inside a git working tree"
+        # Synthesize empty defaults so the typed result still renders.
+        empty = BranchHealthReport(
+            branch="HEAD",
+            head_sha="",
+            head_short="",
+            repo_root=cwd or "",
+            health=BranchHealth.ERROR,
+            reasons=["not inside a git working tree"],
+            upstream=UpstreamReference(False, None, None, None, error=raw_error),
+            tracking=TrackingInfo(False, None, None, None, "none"),
+            ahead_behind=AheadBehind(0, 0),
+            divergence=DivergenceInfo(None, None, None, None, None, None),
+            mutual=MutualPaths([], [], [], []),
+            scope=ScopeHealth(0, 0, 0, 0),
+            raw_error=raw_error,
+        )
+        return empty
+
+    try:
+        branch = _resolve_branch(cwd=repo)
+        head_sha, head_short = _resolve_head(cwd=repo)
+        upstream = _resolve_upstream_reference(
+            branch=branch,
+            cwd=repo,
+            canonical_upstream_ref=canonical_upstream_ref,
+        )
+        tracking = _with_publish_metrics(_resolve_tracking(branch=branch, cwd=repo), cwd=repo)
+        # UH1 collect
+        if not upstream.resolved:
+            reasons.append("UH1: canonical upstream reference unresolved")
+        # UH3 ahead/behind only when we have a canonical upstream
+        effective_upstream = upstream.ref if upstream.resolved else None
+        ab = _ahead_behind(cwd=repo, upstream_ref=effective_upstream)
+        # UH4 divergence
+        divergence = _divergence_info(cwd=repo, upstream_ref=effective_upstream)
+        merge_base_sha = divergence.merge_base_sha
+        # UH5 mutual paths
+        mutual = _mutual_paths(cwd=repo, upstream_ref=effective_upstream,
+                               merge_base_sha=merge_base_sha)
+        # UH9 scope
+        scope = _scope_health(cwd=repo, upstream_ref=effective_upstream)
+        health = classify_branch_health(
+            upstream=upstream,
+            tracking=tracking,
+            ahead_behind=ab,
+            divergence_age_days=divergence.divergence_age_days,
+            mutual=mutual,
+            scope=scope,
+        )
+        # Surface readable reasons that don't change the verdict:
+        if not tracking.has_upstream and branch != "HEAD":
+            reasons.append("UH2: no upstream tracking for branch")
+        if ab.behind > 0:
+            reasons.append(f"UH3: local behind upstream by {ab.behind} commit(s)")
+        if divergence.divergence_age_days is not None and divergence.divergence_age_days > 30:
+            reasons.append(
+                f"UH4: divergence age {divergence.divergence_age_days} day(s)"
+            )
+        if mutual.critical_mutual_paths:
+            reasons.append(
+                "UH5: critical mutual paths touched "
+                f"({len(mutual.critical_mutual_paths)} path(s))"
+            )
+        if health == BranchHealth.PASS and (
+            scope.unique_local_commits > SCOPE_PASS_MAX_COMMITS / 2 or scope.changed_files > SCOPE_PASS_MAX_FILES / 2
+        ):
+            reasons.append("UH9: scope approaching thresholds")
+        return BranchHealthReport(
+            health=health,
+            reasons=reasons,
+            upstream=upstream,
+            tracking=tracking,
+            ahead_behind=ab,
+            divergence=divergence,
+            mutual=mutual,
+            scope=scope,
+            branch=branch,
+            head_sha=head_sha,
+            head_short=head_short,
+            repo_root=repo,
+        )
+    except (GitCallError, GitCommandForbidden) as e:
+        raw_error = str(e)
+        return BranchHealthReport(
+            branch="HEAD",
+            head_sha="",
+            head_short="",
+            repo_root=repo or (cwd or ""),
+            health=BranchHealth.ERROR,
+            reasons=[f"git collection failed: {raw_error}"],
+            upstream=UpstreamReference(False, None, None, None, error=raw_error),
+            tracking=TrackingInfo(False, None, None, None, "none"),
+            ahead_behind=AheadBehind(0, 0),
+            divergence=DivergenceInfo(None, None, None, None, None, None),
+            mutual=MutualPaths([], [], [], []),
+            scope=ScopeHealth(0, 0, 0, 0),
+            raw_error=raw_error,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Update safety (UH10).
+# --------------------------------------------------------------------------- #
+
+
+def update_safety_check(
+    branch_health: BranchHealthReport,
+    *,
+    behavior: UpdateBehaviorProfile = CURRENT_UPDATE_BEHAVIOR,
+    is_published_clean_feature: bool = False,
+    is_untracked_target_with_unique_commits: bool = False,
+) -> UpdateSafetyReport:
+    """Pure decision over ``branch_health`` + behavior profile.
+
+    Rules frozen by the contract:
+
+      A. Same branch, synced/behind-only          -> PASS
+      B. Same branch, ahead-only                  -> PASS w/ confirmation
+      C. Same branch, diverged + reset fallback   -> BLOCKED
+      D. Feature branch distinct from target
+         with unique commits                      -> BLOCKED
+      E. Published clean feature, ahead=0
+         and clean tree                           -> PASS w/ confirmation
+      F. No tracking + unique commits             -> BranchHealth.ERROR;
+         only BLOCKED when the specific operation
+         could abandon or reset work.
+      G. Target local diverged + reset fallback   -> BLOCKED
+
+    Mutual paths never directly cause BLOCKED. WARN never changes exit
+    code. ``requires_manual_confirmation`` is True whenever a PASS
+    result is given for a non-trivial ahead-only or branch-switch case.
+    """
+    reasoning: list[str] = []
+    ahead = branch_health.ahead_behind.ahead
+    behind = branch_health.ahead_behind.behind
+    behind_only = ahead == 0 and behind > 0
+    ahead_only = ahead > 0 and behind == 0
+    diverged = ahead > 0 and behind > 0
+
+    # Reset-on-failure blocklist: only when the actual behavior profile
+    # would hard-reset.
+    reset_in_play = (
+        behavior.name in (
+            UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+            UpdateBehavior.CHECKOUT_THEN_PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+        )
+    )
+
+    # Rule F: no tracking + unique commits -> ERROR already captured by
+    # BranchHealth; we still need to BLOCKED because the operation can
+    # reset work.
+    if (not branch_health.tracking.has_upstream
+            and branch_health.scope.unique_local_commits > 0
+            and reset_in_play):
+        reasoning.append(
+            "Rule F: no tracking and reset fallback — operation could "
+            "abandon untracked work"
+        )
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+            requires_manual_confirmation=False,
+            confirmation_reason=None,
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Rule E: published clean feature, ahead=0.
+    if is_published_clean_feature and ahead == 0 and behind == 0:
+        reasoning.append("Rule E: published clean feature — pass with confirmation")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+            requires_manual_confirmation=True,
+            confirmation_reason="implicit branch switch on published clean feature",
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Case A: synced / behind-only.
+    if ahead == 0 and behind >= 0 and branch_health.health != BranchHealth.ERROR:
+        reasoning.append("Rule A: branch synced or behind-only — safe to pull")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+            requires_manual_confirmation=False,
+            confirmation_reason=None,
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Case B: ahead-only.
+    if ahead_only:
+        if branch_health.health == BranchHealth.ERROR:
+            reasoning.append("Rule B suppressed by BranchHealth.ERROR")
+            return UpdateSafetyReport(
+                decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+                requires_manual_confirmation=False,
+                confirmation_reason=None,
+                behavior_name=behavior.name,
+                behavior_profile=behavior,
+                reasoning=reasoning,
+            )
+        reasoning.append("Rule B: branch ahead of upstream — pass with confirmation")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+            requires_manual_confirmation=True,
+            confirmation_reason="local commits not yet on upstream; "
+            "fast-forward will replay them",
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Case C: diverged + reset fallback.
+    if diverged and reset_in_play:
+        reasoning.append(
+            "Rule C: diverged histories and reset fallback — could drop work"
+        )
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+            requires_manual_confirmation=False,
+            confirmation_reason=None,
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Case D: feature branch distinct from target with unique commits.
+    if (branch_health.tracking.has_upstream
+            and branch_health.branch != "HEAD"
+            and branch_health.scope.unique_local_commits > 0
+            and not is_published_clean_feature):
+        # Implicit branch switch + reset fallback would lose state — block.
+        if behavior.implicit_branch_switch and reset_in_play:
+            reasoning.append(
+                "Rule D: unique local commits on a feature branch with "
+                "implicit branch-switch and reset fallback"
+            )
+            return UpdateSafetyReport(
+                decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+                requires_manual_confirmation=False,
+                confirmation_reason=None,
+                behavior_name=behavior.name,
+                behavior_profile=behavior,
+                reasoning=reasoning,
+            )
+        # Otherwise, non-reset branches could still proceed safely.
+        reasoning.append("Rule D alt: behavior profile is non-resetting; safe to pull")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+            requires_manual_confirmation=True,
+            confirmation_reason="feature branch will be switched implicitly",
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Case G: target local diverged + reset fallback.
+    if diverged and reset_in_play and behind > 0:
+        reasoning.append("Rule G: diverged with reset fallback — BLOCKED")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+            requires_manual_confirmation=False,
+            confirmation_reason=None,
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Untracked target fallback path.
+    if is_untracked_target_with_unique_commits and reset_in_play:
+        reasoning.append("Untracked target with reset fallback — BLOCKED")
+        return UpdateSafetyReport(
+            decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+            requires_manual_confirmation=False,
+            confirmation_reason=None,
+            behavior_name=behavior.name,
+            behavior_profile=behavior,
+            reasoning=reasoning,
+        )
+
+    # Default: pass with no confirmation.
+    reasoning.append("No update-safety rule triggered")
+    return UpdateSafetyReport(
+        decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+        requires_manual_confirmation=False,
+        confirmation_reason=None,
+        behavior_name=behavior.name,
+        behavior_profile=behavior,
+        reasoning=reasoning,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Exit codes.
+# --------------------------------------------------------------------------- #
+
+
+def aggregate_exit_code(branch_health: BranchHealthReport,
+                        safety: UpdateSafetyReport) -> int:
+    """Frozen exit-code rule:
+
+        safety == BLOCKED     -> 2
+        branch_health.ERROR   -> 1
+        otherwise             -> 0
+
+    WARN and ``requires_manual_confirmation`` do NOT change the exit code.
+    """
+    if safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED:
+        return 2
+    if branch_health.health == BranchHealth.ERROR:
+        return 1
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Renderers.
+# --------------------------------------------------------------------------- #
+
+
+def render_text(result: UpstreamHealthResult) -> str:
+    """Human-readable, ANSI-free text mode output.
+
+    Never echoes a mutating command. Includes summarized evidence.
+    """
+    bh = result.branch_health
+    us = result.update_safety
+
+    lines: list[str] = []
+    lines.append("◆ Hermes Upstream Health (READONLY)")
+    lines.append("")
+    lines.append(f"  branch:    {bh.branch}")
+    lines.append(f"  head:      {bh.head_short}")
+    if bh.upstream.resolved:
+        lines.append(f"  canonical_upstream: {bh.upstream.ref}")
+    else:
+        lines.append(f"  canonical_upstream: (unresolved — {bh.upstream.error or 'no candidate'})")
+    lines.append(
+        f"  tracking:  publish_ref={bh.tracking.publish_ref or '(none)'} "
+        f"fully_published={'yes' if bh.tracking.fully_published else 'no'} "
+        f"published_ahead/behind={bh.tracking.published_ahead}/{bh.tracking.published_behind}"
+    )
+    lines.append(
+        f"  ahead/behind: {bh.ahead_behind.ahead}/{bh.ahead_behind.behind}"
+    )
+    if bh.divergence.divergence_age_days is not None:
+        lines.append(
+            f"  divergence age (days): {bh.divergence.divergence_age_days}"
+        )
+    lines.append(
+        f"  scope: {bh.scope.unique_local_commits} commit(s), "
+        f"{bh.scope.changed_files} file(s) changed"
+    )
+    if bh.mutual.mutual_paths:
+        lines.append(
+            f"  mutual paths: {len(bh.mutual.mutual_paths)} "
+            f"(critical: {len(bh.mutual.critical_mutual_paths)})"
+        )
+    lines.append(f"  branch_health: {bh.health.value}")
+    if bh.reasons:
+        for r in bh.reasons:
+            lines.append(f"    - {r}")
+    lines.append(f"  update_safety: {us.decision.value}")
+    lines.append(
+        f"  requires_manual_confirmation: "
+        f"{'yes' if us.requires_manual_confirmation else 'no'}"
+    )
+    if us.confirmation_reason:
+        lines.append(f"  confirmation_reason: {us.confirmation_reason}")
+    lines.append(
+        f"  behavior: {us.behavior_name.value}"
+    )
+    for r in us.reasoning:
+        lines.append(f"    - {r}")
+    lines.append(f"  exit_code: {result.exit_code}")
+    return "\n".join(lines) + "\n"
+
+
+def render_compact(result: UpstreamHealthResult) -> str:
+    """Single-line, ANSI-free stable format.
+
+    Order is contract-frozen: health, safety, ahead, behind, confirmation.
+    """
+    bh = result.branch_health
+    us = result.update_safety
+    confirm = "confirm" if us.requires_manual_confirmation else "auto"
+    return (
+        f"upstream-health health={bh.health.value} "
+        f"safety={us.decision.value} canonical={bh.upstream.ref or 'unresolved'} "
+        f"publish={bh.tracking.publish_ref or 'none'} ahead={bh.ahead_behind.ahead} "
+        f"behind={bh.ahead_behind.behind} confirmation={confirm} "
+        f"behavior={us.behavior_name.value}"
+    )
+
+
+def serialize_json(result: UpstreamHealthResult) -> str:
+    """Single JSON object, no ANSI, no banner, no surrounding text."""
+    return json.dumps(result.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+# --------------------------------------------------------------------------- #
+# Top-level entry point.
+# --------------------------------------------------------------------------- #
+
+
+def run_upstream_health(
+    *,
+    cwd: Optional[str] = None,
+    behavior: UpdateBehaviorProfile = CURRENT_UPDATE_BEHAVIOR,
+    is_published_clean_feature: Optional[bool] = None,
+    is_untracked_target_with_unique_commits: bool = False,
+    canonical_upstream_ref: Optional[str] = None,
+) -> UpstreamHealthResult:
+    """Single READONLY entry point used by ``hermes doctor --upstream``.
+
+    Steps:
+      1) ``collect_branch_health`` (UH1–UH5, UH9) — pure Git inspection.
+      2) ``update_safety_check``  (UH10) — pure decision over (1) + profile.
+      3) ``aggregate_exit_code``  — frozen rule, see :func:`aggregate_exit_code`.
+    """
+    bh = collect_branch_health(cwd=cwd, canonical_upstream_ref=canonical_upstream_ref)
+    published_clean = (
+        bool(
+            bh.branch != "HEAD"
+            and bh.branch != (bh.upstream.branch or "")
+            and bh.tracking.fully_published
+            and _working_tree_clean(bh.repo_root)
+        )
+        if is_published_clean_feature is None
+        else is_published_clean_feature
+    )
+    safety = update_safety_check(
+        bh,
+        behavior=behavior,
+        is_published_clean_feature=published_clean,
+        is_untracked_target_with_unique_commits=is_untracked_target_with_unique_commits,
+    )
+    exit_code = aggregate_exit_code(bh, safety)
+    return UpstreamHealthResult(
+        branch_health=bh,
+        update_safety=safety,
+        exit_code=exit_code,
+    )
+
+
+__all__ = [
+    "READONLY_GIT_SUBCOMMANDS",
+    "FORBIDDEN_GIT_SUBCOMMANDS",
+    "GIT_COMMAND_TIMEOUT_SECONDS",
+    "GitCallError",
+    "GitCommandForbidden",
+    "BranchHealth",
+    "UpdateSafetyDecision",
+    "UpdateBehavior",
+    "UpdateBehaviorProfile",
+    "CURRENT_UPDATE_BEHAVIOR",
+    "UpstreamReference",
+    "TrackingInfo",
+    "AheadBehind",
+    "DivergenceInfo",
+    "MutualPaths",
+    "ScopeHealth",
+    "BranchHealthReport",
+    "UpdateSafetyReport",
+    "UpstreamHealthResult",
+    "collect_branch_health",
+    "update_safety_check",
+    "aggregate_exit_code",
+    "render_text",
+    "render_compact",
+    "serialize_json",
+    "run_upstream_health",
+    "classify_branch_health",
+    "CRITICAL_PATH_FRAGMENTS",
+    "SCOPE_PASS_MAX_COMMITS",
+    "SCOPE_PASS_MAX_FILES",
+    "SCOPE_WARN_MAX_COMMITS",
+    "SCOPE_WARN_MAX_FILES",
+]

--- a/hermes_cli/doctor_upstream.py
+++ b/hermes_cli/doctor_upstream.py
@@ -33,6 +33,7 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from typing import Any, Iterable, Optional
@@ -700,6 +701,15 @@ def _timestamp_for(sha: Optional[str], cwd: Optional[str]) -> Optional[int]:
         return None
 
 
+def _now_timestamp() -> int:
+    """Clock seam: returns wall-clock seconds since the epoch.
+
+    Exposed at module scope so tests can monkeypatch a deterministic "now"
+    without scattering ``time.time()`` calls through divergence logic.
+    """
+    return int(time.time())
+
+
 def _oldest_unique_commit(
     cwd: Optional[str], merge_base_sha: Optional[str], head_sha: Optional[str]
 ) -> tuple[Optional[str], Optional[int]]:
@@ -731,9 +741,16 @@ def _divergence_info(cwd: Optional[str], upstream_ref: Optional[str]) -> Diverge
 
     age_days: Optional[int] = None
     if merge_base_sha and head_sha and merge_base_sha == head_sha:
+        # No local divergence: there is no "divergence" to age.
         age_days = 0
-    elif head_ts is not None and oldest_ts is not None:
-        diff_seconds = max(0, head_ts - oldest_ts)
+    elif oldest_ts is not None:
+        # Divergence age is "how long this branch has been diverged from
+        # upstream". The oldest unique commit is the first actual divergent
+        # commit; head_ts - oldest_ts is always zero on a single-commit
+        # branch and understates real age on any branch. Use wall-clock
+        # "now" minus the oldest unique commit's timestamp instead.
+        now_ts = _now_timestamp()
+        diff_seconds = max(0, now_ts - oldest_ts)
         age_days = diff_seconds // 86_400
 
     return DivergenceInfo(

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -32,4 +32,35 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    # ------------------------------------------------------------------
+    # --upstream : READONLY diagnostic for UH1..UH5, UH9 + UH10.
+    # Pure inspection. --json / --compact are only effective with
+    # --upstream and are mutually exclusive with --fix / --ack.
+    # ------------------------------------------------------------------
+    doctor_parser.add_argument(
+        "--upstream",
+        action="store_true",
+        help=(
+            "READONLY diagnostic of upstream reference, tracking, "
+            "ahead/behind, mutual paths, and update safety (UH10). "
+            "Combines with --json / --compact. Does not modify the "
+            "working tree or invoke any mutating git command."
+        ),
+    )
+    doctor_parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit a pure JSON object describing upstream health. "
+            "Only effective with --upstream."
+        ),
+    )
+    doctor_parser.add_argument(
+        "--compact",
+        action="store_true",
+        help=(
+            "Emit a single stable line summarizing upstream health. "
+            "Only effective with --upstream."
+        ),
+    )
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/tests/cli/test_doctor_upstream.py
+++ b/tests/cli/test_doctor_upstream.py
@@ -1,0 +1,798 @@
+"""Tests for ``hermes_cli.doctor_upstream`` (READONLY diagnostics).
+
+Every test sets up a temporary Git repository using the READONLY allowlist
+directly. The fixture never mutates the real repository. Tests marked by
+T1–T19 are referenced by the contract freeze and the file ordering
+preserves the contract numbering so reviewers can grep by tag.
+
+Each test is also marked with the expected ``branch_health`` and
+``update_safety`` verdict so a future pass/fail re-base stays
+self-explanatory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.doctor_upstream as du
+from hermes_cli.doctor_upstream import (
+    AheadBehind,
+    BranchHealth,
+    BranchHealthReport,
+    DivergenceInfo,
+    GitCallError,
+    GitCommandForbidden,
+    MutualPaths,
+    READONLY_GIT_SUBCOMMANDS,
+    SCOPE_PASS_MAX_COMMITS,
+    SCOPE_PASS_MAX_FILES,
+    SCOPE_WARN_MAX_COMMITS,
+    SCOPE_WARN_MAX_FILES,
+    ScopeHealth,
+    TrackingInfo,
+    UpdateBehavior,
+    UpdateBehaviorProfile,
+    UpdateSafetyDecision,
+    UpstreamReference,
+    UpstreamHealthResult,
+    UpdateSafetyReport,
+    aggregate_exit_code,
+    classify_branch_health,
+    collect_branch_health,
+    render_compact,
+    render_text,
+    run_upstream_health,
+    serialize_json,
+    update_safety_check,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers: temporary Git repo construction (used only by the test fixture).
+# --------------------------------------------------------------------------- #
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    """Allowlisted helper used only by the test fixture to build
+    temporary Git repositories. The module under test never goes
+    through this — it uses ``_run_git`` which restricts to the
+    READONLY_GIT_SUBCOMMANDS allowlist at the *module* level."""
+    p = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t",
+             "GIT_CONFIG_GLOBAL": "/dev/null",
+             "GIT_CONFIG_SYSTEM": "/dev/null"},
+    )
+    return p.stdout
+
+
+@pytest.fixture
+def gitrepo(tmp_path: Path):
+    """Build a temporary Git repository inside ``tmp_path``."""
+    cwd = tmp_path / "fixture"
+    cwd.mkdir()
+    _git(["init", "-q", "--initial-branch=main"], cwd)
+    _git(["config", "user.email", "test@test"], cwd)
+    _git(["config", "user.name", "test"], cwd)
+    _git(["config", "commit.gpgsign", "false"], cwd)
+
+    (cwd / "README.md").write_text("main\n")
+    _git(["add", "."], cwd)
+    _git(["commit", "-q", "-m", "init main"], cwd)
+
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    _git(["init", "--bare", "-q"], bare)
+    _git(["remote", "add", "origin", str(bare)], cwd)
+    _git(["push", "-q", "origin", "main"], cwd)
+    main_sha = _git(["rev-parse", "HEAD"], cwd).strip()
+
+    _git(["branch", "--set-upstream-to=origin/main"], cwd)
+
+    return SimpleNamespace(
+        cwd=cwd,
+        bare=bare,
+        main_sha=main_sha,
+        git=_git,
+    )
+
+
+def _make_feature_tracking_fork(gitrepo, *, branch: str = "feat/canonical"):
+    """Create one local feature commit published to a fork-tracking branch."""
+    gitrepo.git(["checkout", "-q", "-b", branch], gitrepo.cwd)
+    for index in range(1, 5):
+        (gitrepo.cwd / f"feature_{index}.txt").write_text(f"feature {index}\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "feature four files"], gitrepo.cwd)
+
+    fork = gitrepo.cwd.parent / "jrgros-ops.git"
+    fork.mkdir()
+    gitrepo.git(["init", "--bare", "-q"], fork)
+    gitrepo.git(["remote", "add", "jrgros-ops", str(fork)], gitrepo.cwd)
+    gitrepo.git(["push", "-q", "-u", "jrgros-ops", f"HEAD:{branch}"], gitrepo.cwd)
+    return SimpleNamespace(
+        branch=branch,
+        publish_ref=f"jrgros-ops/{branch}",
+        canonical_ref="origin/main",
+    )
+
+
+# =========================================================================== #
+# T1 — synchronized
+# =========================================================================== #
+
+
+def test_T1_synchronized_passes_no_confirmation(gitrepo) -> None:
+    """T1: T1_synchronized."""
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.branch_health.health == BranchHealth.PASS
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.update_safety.requires_manual_confirmation is False
+    assert result.exit_code == 0
+
+
+# =========================================================================== #
+# T2 — behind-only
+# =========================================================================== #
+
+
+def test_T2_behind_only_passes_no_confirmation(gitrepo) -> None:
+    """T2: behind-only."""
+    (gitrepo.cwd / "remote_only.md").write_text("remote only\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "remote commit"], gitrepo.cwd)
+    gitrepo.git(["push", "-q", "origin", "main"], gitrepo.cwd)
+    gitrepo.git(["reset", "--hard", "HEAD~1"], gitrepo.cwd)
+
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.branch_health.ahead_behind.behind >= 1
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.exit_code == 0
+
+
+# =========================================================================== #
+# T3 — ahead-only + confirmation
+# =========================================================================== #
+
+
+def test_T3_ahead_only_requires_manual_confirmation(gitrepo) -> None:
+    """T3: ahead-only."""
+    (gitrepo.cwd / "local_only.md").write_text("local only\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "local-only"], gitrepo.cwd)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.branch_health.ahead_behind.ahead == 1
+    assert result.branch_health.ahead_behind.behind == 0
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.update_safety.requires_manual_confirmation is True
+    assert result.exit_code == 0
+
+
+# =========================================================================== #
+# T4 — diverged + blocked
+# =========================================================================== #
+
+
+def test_T4_diverged_with_reset_fallback_blocks(gitrepo) -> None:
+    """T4: diverged."""
+    (gitrepo.cwd / "local.md").write_text("local\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "local divergence"], gitrepo.cwd)
+    gitrepo.git(["reset", "--hard", "HEAD~1"], gitrepo.cwd)
+    (gitrepo.cwd / "remote.md").write_text("remote\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "remote divergence"], gitrepo.cwd)
+    gitrepo.git(["push", "-q", "origin", "main"], gitrepo.cwd)
+    gitrepo.git(["reset", "--hard", "HEAD~1"], gitrepo.cwd)
+
+    p = subprocess.run(
+        ["git", "reflog"],
+        cwd=str(gitrepo.cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    divergent_sha = None
+    for line in p.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, *rest = line.split()
+        if rest and "local divergence" in " ".join(rest):
+            divergent_sha = sha
+            break
+    assert divergent_sha, "fixture failed to produce diverging commit"
+    gitrepo.git(["reset", "--hard", divergent_sha], gitrepo.cwd)
+
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.branch_health.ahead_behind.ahead >= 1
+    assert result.branch_health.ahead_behind.behind >= 1
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED
+    assert result.exit_code == 2
+
+
+# =========================================================================== #
+# T5 — feature dirty/unique + blocked
+# =========================================================================== #
+
+
+def test_T5_feature_dirty_unique_blocks(gitrepo) -> None:
+    """T5: feature branch with dirty + unique commits."""
+    (gitrepo.cwd / "local_unique.py").write_text("# unique on feature\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "feature commit"], gitrepo.cwd)
+    gitrepo.git(["checkout", "-q", "-b", "feature"], gitrepo.cwd)
+
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED
+    assert result.exit_code == 2
+
+
+# =========================================================================== #
+# T6 — published clean feature + confirmation
+# =========================================================================== #
+
+
+def test_T6_published_clean_feature_pass_with_confirmation(gitrepo) -> None:
+    """T6: published feature, ahead=0, clean tree, confirmation."""
+    gitrepo.git(["checkout", "-q", "-b", "feature"], gitrepo.cwd)
+    gitrepo.git(["push", "-q", "-u", "origin", "feature"], gitrepo.cwd)
+    result = run_upstream_health(
+        cwd=str(gitrepo.cwd),
+        is_published_clean_feature=True,
+    )
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.update_safety.requires_manual_confirmation is True
+
+
+# =========================================================================== #
+# T7 — no tracking + unique
+# =========================================================================== #
+
+
+def test_T7_no_tracking_with_unique_commits(gitrepo) -> None:
+    """T7: detached branch with unique commits."""
+    gitrepo.git(["checkout", "-q", "--detach", "main"], gitrepo.cwd)
+    (gitrepo.cwd / "lonely.md").write_text("lonely\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "detached commit"], gitrepo.cwd)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED
+
+
+# =========================================================================== #
+# T8 — detached HEAD with no unique commits
+# =========================================================================== #
+
+
+def test_T8_detached_head_baseline(gitrepo) -> None:
+    """T8: detached HEAD surface still parses."""
+    gitrepo.git(["checkout", "-q", "--detach", "main"], gitrepo.cwd)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    assert result.branch_health.health in {
+        BranchHealth.PASS,
+        BranchHealth.WARN,
+        BranchHealth.ERROR,
+    }
+    assert result.update_safety.decision in (
+        UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+        UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+    )
+
+
+# =========================================================================== #
+# T9 — structured Git failure
+# =========================================================================== #
+
+
+def test_T9_structured_git_failure(tmp_path: Path) -> None:
+    """T9: not a git repo -> structured error, no traceback."""
+    bare_dir = tmp_path / "norepo"
+    bare_dir.mkdir()
+    result = run_upstream_health(cwd=str(bare_dir))
+    assert result.exit_code == 1
+    assert result.branch_health.raw_error is not None
+    assert result.branch_health.health == BranchHealth.ERROR
+
+
+# =========================================================================== #
+# T10 — pure JSON
+# =========================================================================== #
+
+
+def test_T10_json_is_pure_object(gitrepo) -> None:
+    """T10: JSON output is a single object accepted by json.loads."""
+    bh = collect_branch_health(cwd=str(gitrepo.cwd))
+    safety = update_safety_check(bh)
+    result = UpstreamHealthResult(bh, safety, aggregate_exit_code(bh, safety))
+    text = serialize_json(result)
+    parsed = json.loads(text)
+    assert isinstance(parsed, dict)
+    assert "branch_health" in parsed
+    assert "update_safety" in parsed
+    assert "exit_code" in parsed
+
+
+# =========================================================================== #
+# T11 — no network or mutating Git commands
+# =========================================================================== #
+
+
+def test_T11_no_mutating_git_commands() -> None:
+    """T11: allowlist is closed; mutating commands raise."""
+    for sub in ("fetch", "pull", "merge", "rebase", "checkout",
+                "switch", "reset", "stash", "push", "clean",
+                "update-ref", "submodule", "am", "cherry-pick"):
+        with pytest.raises(GitCommandForbidden):
+            du._run_git((sub, "anything"))
+    assert "rev-parse" in READONLY_GIT_SUBCOMMANDS
+    assert "rev-list" in READONLY_GIT_SUBCOMMANDS
+    assert "merge-base" in READONLY_GIT_SUBCOMMANDS
+    assert "diff" in READONLY_GIT_SUBCOMMANDS
+    assert "show" in READONLY_GIT_SUBCOMMANDS
+    assert "symbolic-ref" in READONLY_GIT_SUBCOMMANDS
+    assert "config" in READONLY_GIT_SUBCOMMANDS
+    assert "remote" in READONLY_GIT_SUBCOMMANDS
+    assert "status" in READONLY_GIT_SUBCOMMANDS
+
+
+# =========================================================================== #
+# T12 — traditional doctor unchanged
+# =========================================================================== #
+
+
+def test_T12_traditional_doctor_path_unaffected() -> None:
+    """T12: hermes_cli/doctor.py gating logic stays intact."""
+    from pathlib import Path as _P
+
+    src = _P("hermes_cli/doctor.py").read_text(encoding="utf-8")
+    assert "getattr(args, 'upstream'" in src
+    # Original behavior remains the same path: --fix, --ack, and the rest of the doctor run.
+    assert "should_fix" in src
+    assert "ack_target" in src
+    # The new branch is the first conditional block after set_defaults.
+    src2 = _P("hermes_cli/subcommands/doctor.py").read_text(encoding="utf-8")
+    assert "--upstream" in src2
+    assert "--json" in src2
+    assert "--compact" in src2
+    assert "--fix" in src2
+    assert "--ack" in src2
+
+
+# =========================================================================== #
+# T13 — update_safety_check is pure
+# =========================================================================== #
+
+
+def test_T13_update_safety_check_is_pure(gitrepo) -> None:
+    """T13: same inputs -> same outputs (no hidden state, no clock)."""
+    bh = collect_branch_health(cwd=str(gitrepo.cwd))
+    s1 = update_safety_check(bh)
+    s2 = update_safety_check(bh)
+    assert s1 == s2
+    assert s1.decision == s2.decision
+    assert s1.requires_manual_confirmation == s2.requires_manual_confirmation
+
+
+# =========================================================================== #
+# T14 — missing upstream
+# =========================================================================== #
+
+
+def test_T14_missing_upstream_returns_error(gitrepo) -> None:
+    """T14: empty upstream ref produces BranchHealth.ERROR + safety PASS."""
+    bh = BranchHealthReport(
+        branch="some-branch",
+        head_sha="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        head_short="deadbee",
+        repo_root=str(gitrepo.cwd),
+        health=BranchHealth.ERROR,
+        reasons=["UH1: upstream reference unresolved"],
+        upstream=UpstreamReference(False, None, None, None,
+                                   resolution_chain=[],
+                                   error="upstream reference not found"),
+        tracking=TrackingInfo(False, None, None, None, "none"),
+        ahead_behind=AheadBehind(0, 0),
+        divergence=DivergenceInfo(None, None, None, None, None, None),
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(0, 0, 0, 0),
+        raw_error="upstream reference not found",
+    )
+    safety = update_safety_check(bh)
+    assert safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert aggregate_exit_code(bh, safety) == 1
+
+
+# =========================================================================== #
+# T15 — mutual paths never directly block
+# =========================================================================== #
+
+
+def test_T15_mutual_paths_never_directly_block(gitrepo) -> None:
+    """T15: critical mutual paths produce WARN but never BLOCKED."""
+    mut = MutualPaths(
+        local_paths=["hermes_cli/main.py"],
+        upstream_paths=["hermes_cli/main.py"],
+        mutual_paths=["hermes_cli/main.py"],
+        critical_mutual_paths=["hermes_cli/main.py"],
+    )
+    bh = BranchHealthReport(
+        branch="main",
+        head_sha="x" * 40,
+        head_short="x",
+        repo_root=str(gitrepo.cwd),
+        health=classify_branch_health(
+            upstream=UpstreamReference(True, "origin/main", "origin", "main",
+                                       resolution_chain=["tracking"]),
+            tracking=TrackingInfo(True, "origin/main", "origin",
+                                  "refs/heads/main", "explicit"),
+            ahead_behind=AheadBehind(0, 0),
+            divergence_age_days=None,
+            mutual=mut,
+            scope=ScopeHealth(0, 0, 0, 0),
+        ),
+        reasons=["UH5: critical mutual paths"],
+        upstream=UpstreamReference(True, "origin/main", "origin", "main",
+                                   resolution_chain=["tracking"]),
+        tracking=TrackingInfo(True, "origin/main", "origin",
+                              "refs/heads/main", "explicit"),
+        ahead_behind=AheadBehind(0, 0),
+        divergence=DivergenceInfo(None, None, None, None, None, None),
+        mutual=mut,
+        scope=ScopeHealth(0, 0, 0, 0),
+    )
+    safety = update_safety_check(bh)
+    assert safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+
+
+def test_UH4_divergence_age_over_30_warns() -> None:
+    """UH4: divergence age > 30 warns without making healthy inputs fail."""
+    upstream = UpstreamReference(
+        True,
+        "origin/main",
+        "origin",
+        "main",
+        resolution_chain=["tracking"],
+    )
+    tracking = TrackingInfo(
+        True,
+        "origin/main",
+        "origin",
+        "refs/heads/main",
+        "explicit",
+    )
+    ahead_behind = AheadBehind(0, 0)
+    mutual = MutualPaths([], [], [], [])
+    scope = ScopeHealth(0, 0, 0, 0)
+
+    def verdict(divergence_age_days: int | None) -> BranchHealth:
+        return classify_branch_health(
+            upstream=upstream,
+            tracking=tracking,
+            ahead_behind=ahead_behind,
+            divergence_age_days=divergence_age_days,
+            mutual=mutual,
+            scope=scope,
+        )
+
+    assert verdict(None) == BranchHealth.PASS
+    assert verdict(30) == BranchHealth.PASS
+    assert verdict(31) == BranchHealth.WARN
+    assert verdict(90) == BranchHealth.WARN
+
+
+# =========================================================================== #
+# T16 — updater behavior represented
+# =========================================================================== #
+
+
+def test_T16_updater_behavior_is_represented() -> None:
+    """T16: the contract freeze's update behavior profile is intact."""
+    profile = du.CURRENT_UPDATE_BEHAVIOR
+    assert profile.name == UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK
+    assert profile.implicit_branch_switch is True
+    assert profile.autostash is True
+    assert profile.hard_rollback_on_syntax_failure is True
+    assert profile.gateway_auto_restart is True
+    assert UpdateBehavior.PULL_FF_ONLY.value == "PULL_FF_ONLY"
+    assert UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK.value == "PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK"
+    assert UpdateBehavior.PULL_REBASE.value == "PULL_REBASE"
+    assert UpdateBehavior.PULL_MERGE.value == "PULL_MERGE"
+    assert UpdateBehavior.CHECKOUT_THEN_PULL_FF_ONLY.value == "CHECKOUT_THEN_PULL_FF_ONLY"
+    assert UpdateBehavior.CHECKOUT_THEN_PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK.value == "CHECKOUT_THEN_PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK"
+    assert UpdateBehavior.UNKNOWN.value == "UNKNOWN"
+
+
+# =========================================================================== #
+# T17 — confirmation does not change exit code
+# =========================================================================== #
+
+
+def test_T17_confirmation_does_not_change_exit(gitrepo) -> None:
+    """T17: requires_manual_confirmation=True does not raise exit_code."""
+    (gitrepo.cwd / "ahead.md").write_text("ahead\n")
+    gitrepo.git(["add", "."], gitrepo.cwd)
+    gitrepo.git(["commit", "-q", "-m", "ahead-only"], gitrepo.cwd)
+    bh = collect_branch_health(cwd=str(gitrepo.cwd))
+    safety = update_safety_check(bh)
+    assert safety.requires_manual_confirmation is True
+    assert aggregate_exit_code(bh, safety) == 0
+    warn_bh = BranchHealthReport(
+        branch=bh.branch,
+        head_sha=bh.head_sha,
+        head_short=bh.head_short,
+        repo_root=bh.repo_root,
+        health=BranchHealth.WARN,
+        reasons=list(bh.reasons) + ["warn"],
+        upstream=bh.upstream,
+        tracking=bh.tracking,
+        ahead_behind=bh.ahead_behind,
+        divergence=bh.divergence,
+        mutual=bh.mutual,
+        scope=bh.scope,
+    )
+    warn_safety = update_safety_check(warn_bh)
+    assert aggregate_exit_code(warn_bh, warn_safety) == 0
+
+
+# =========================================================================== #
+# T18 — reset fallback on divergence blocks
+# =========================================================================== #
+
+
+def test_T18_reset_fallback_on_divergence_blocks(gitrepo) -> None:
+    """T18: diverged + PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK -> BLOCKED."""
+    profile = UpdateBehaviorProfile(
+        name=UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+        implicit_branch_switch=True,
+        autostash=True,
+        hard_rollback_on_syntax_failure=True,
+        gateway_auto_restart=True,
+    )
+    bh = BranchHealthReport(
+        branch="main",
+        head_sha="x" * 40,
+        head_short="x",
+        repo_root=str(gitrepo.cwd),
+        health=BranchHealth.PASS,
+        reasons=[],
+        upstream=UpstreamReference(True, "origin/main", "origin", "main",
+                                   resolution_chain=["tracking"]),
+        tracking=TrackingInfo(True, "origin/main", "origin",
+                              "refs/heads/main", "explicit"),
+        ahead_behind=AheadBehind(2, 1),
+        divergence=DivergenceInfo("m" * 40, 1_700_000_000,
+                                  1_700_100_000, "c" * 40, 1_700_050_000,
+                                  1),
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(2, 4, 10, 0),
+    )
+    safety = update_safety_check(bh, behavior=profile)
+    assert safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED
+    no_reset = UpdateBehaviorProfile(
+        name=UpdateBehavior.PULL_FF_ONLY,
+        implicit_branch_switch=False,
+        autostash=False,
+        hard_rollback_on_syntax_failure=False,
+        gateway_auto_restart=False,
+    )
+    alt_safety = update_safety_check(bh, behavior=no_reset)
+    assert alt_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+
+
+# =========================================================================== #
+# T19 — implicit branch switch on published clean branch passes with confirmation
+# =========================================================================== #
+
+
+def test_T19_implicit_branch_switch_passes_with_confirmation(gitrepo) -> None:
+    """T19: published clean feature branch -> PASS with confirmation."""
+    gitrepo.git(["checkout", "-q", "-b", "feature"], gitrepo.cwd)
+    gitrepo.git(["push", "-q", "-u", "origin", "feature"], gitrepo.cwd)
+    result = run_upstream_health(
+        cwd=str(gitrepo.cwd),
+        is_published_clean_feature=True,
+    )
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.update_safety.requires_manual_confirmation is True
+
+
+# =========================================================================== #
+# R1-R6 — canonical upstream must be separate from fork publish tracking.
+# =========================================================================== #
+
+
+def test_R1_feature_tracks_fork_but_canonical_origin_main_counts_scope(gitrepo) -> None:
+    fixture = _make_feature_tracking_fork(gitrepo)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+
+    assert result.branch_health.upstream.ref == fixture.canonical_ref
+    assert result.branch_health.tracking.upstream_ref == fixture.publish_ref
+    assert result.branch_health.tracking.publish_ref == fixture.publish_ref
+    assert result.branch_health.tracking.published_ahead == 0
+    assert result.branch_health.tracking.published_behind == 0
+    assert result.branch_health.tracking.fully_published is True
+    assert result.branch_health.ahead_behind.ahead == 1
+    assert result.branch_health.ahead_behind.behind == 0
+    assert result.branch_health.scope.unique_local_commits == 1
+    assert result.branch_health.scope.changed_files == 4
+    assert sorted(result.branch_health.mutual.local_paths) == [
+        "feature_1.txt",
+        "feature_2.txt",
+        "feature_3.txt",
+        "feature_4.txt",
+    ]
+
+
+def test_R2_tracking_branch_does_not_replace_canonical_origin_main(gitrepo) -> None:
+    fixture = _make_feature_tracking_fork(gitrepo)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+
+    assert result.branch_health.tracking.upstream_ref == fixture.publish_ref
+    assert result.branch_health.upstream.ref == fixture.canonical_ref
+    assert result.branch_health.upstream.ref != result.branch_health.tracking.upstream_ref
+
+
+def test_R3_merge_base_equal_head_has_no_oldest_unique_commit(gitrepo) -> None:
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+
+    assert result.branch_health.divergence.merge_base_sha == result.branch_health.head_sha
+    assert result.branch_health.divergence.oldest_unique_commit_sha is None
+    assert result.branch_health.divergence.oldest_unique_commit_timestamp is None
+    assert result.branch_health.divergence.divergence_age_days == 0
+
+
+def test_R4_fully_published_feature_confirmed_but_not_canonical_synced(gitrepo) -> None:
+    fixture = _make_feature_tracking_fork(gitrepo)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+
+    assert result.branch_health.tracking.fully_published is True
+    assert result.update_safety.decision == UpdateSafetyDecision.UPDATE_SAFETY_PASS
+    assert result.update_safety.requires_manual_confirmation is True
+    assert result.branch_health.upstream.ref == fixture.canonical_ref
+    assert result.branch_health.ahead_behind.ahead == 1
+    assert result.branch_health.ahead_behind.behind == 0
+
+
+def test_R5_compact_output_reports_canonical_divergence(gitrepo) -> None:
+    _make_feature_tracking_fork(gitrepo)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    line = render_compact(result)
+
+    assert "canonical=origin/main" in line
+    assert "publish=jrgros-ops/feat/canonical" in line
+    assert "ahead=1" in line
+    assert "behind=0" in line
+
+
+def test_R6_json_exposes_publish_and_canonical_refs_separately(gitrepo) -> None:
+    fixture = _make_feature_tracking_fork(gitrepo)
+    result = run_upstream_health(cwd=str(gitrepo.cwd))
+    parsed = json.loads(serialize_json(result))
+    branch_health = parsed["branch_health"]
+
+    assert branch_health["canonical_upstream"]["ref"] == fixture.canonical_ref
+    assert branch_health["tracking"]["publish_ref"] == fixture.publish_ref
+    assert branch_health["tracking"]["fully_published"] is True
+    assert branch_health["ahead_behind"] == {"ahead": 1, "behind": 0}
+
+
+# =========================================================================== #
+# Renderers / JSON sanity.
+# =========================================================================== #
+
+
+def test_render_text_contains_required_lines(gitrepo) -> None:
+    bh = collect_branch_health(cwd=str(gitrepo.cwd))
+    safety = update_safety_check(bh)
+    result = UpstreamHealthResult(bh, safety, aggregate_exit_code(bh, safety))
+    text = render_text(result)
+    assert "branch:" in text
+    assert "head:" in text
+    assert "canonical_upstream:" in text
+    assert "tracking:" in text
+    assert "branch_health:" in text
+    assert "update_safety:" in text
+    assert "exit_code:" in text
+    for forbidden in ("git pull", "git fetch", "git reset", "git merge"):
+        assert forbidden not in text
+
+
+def test_render_compact_is_single_line_stable(gitrepo) -> None:
+    bh = collect_branch_health(cwd=str(gitrepo.cwd))
+    safety = update_safety_check(bh)
+    result = UpstreamHealthResult(bh, safety, aggregate_exit_code(bh, safety))
+    line = render_compact(result)
+    assert "\n" not in line
+    assert "health=" in line
+    assert "safety=" in line
+    assert "ahead=" in line
+    assert "behind=" in line
+    assert "confirmation=" in line
+    assert "behavior=" in line
+
+
+def test_aggregate_exit_code_table() -> None:
+    """Sanity: lock the exit-code matrix."""
+    bh_pass = BranchHealthReport(
+        branch="main",
+        head_sha="x" * 40,
+        head_short="x",
+        repo_root=".",
+        health=BranchHealth.PASS,
+        reasons=[],
+        upstream=UpstreamReference(True, "origin/main", "origin", "main"),
+        tracking=TrackingInfo(True, "origin/main", "origin",
+                              "refs/heads/main", "explicit"),
+        ahead_behind=AheadBehind(0, 0),
+        divergence=DivergenceInfo(None, None, None, None, None, None),
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(0, 0, 0, 0),
+    )
+    bh_error = BranchHealthReport(**{**bh_pass.__dict__, "health": BranchHealth.ERROR})
+    bh_warn = BranchHealthReport(**{**bh_pass.__dict__, "health": BranchHealth.WARN})
+    pass_safety = UpdateSafetyReport(
+        decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+        requires_manual_confirmation=False,
+        confirmation_reason=None,
+        behavior_name=UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+        behavior_profile=du.CURRENT_UPDATE_BEHAVIOR,
+        reasoning=[],
+    )
+    blocked = UpdateSafetyReport(
+        decision=UpdateSafetyDecision.UPDATE_SAFETY_BLOCKED,
+        requires_manual_confirmation=False,
+        confirmation_reason=None,
+        behavior_name=UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+        behavior_profile=du.CURRENT_UPDATE_BEHAVIOR,
+        reasoning=[],
+    )
+    confirm_pass = UpdateSafetyReport(
+        decision=UpdateSafetyDecision.UPDATE_SAFETY_PASS,
+        requires_manual_confirmation=True,
+        confirmation_reason="confirm",
+        behavior_name=UpdateBehavior.PULL_FF_ONLY_PLUS_RESET_HARD_FALLBACK,
+        behavior_profile=du.CURRENT_UPDATE_BEHAVIOR,
+        reasoning=[],
+    )
+    assert aggregate_exit_code(bh_pass, pass_safety) == 0
+    assert aggregate_exit_code(bh_pass, confirm_pass) == 0
+    assert aggregate_exit_code(bh_warn, pass_safety) == 0
+    assert aggregate_exit_code(bh_warn, blocked) == 2
+    assert aggregate_exit_code(bh_error, pass_safety) == 1
+    assert aggregate_exit_code(bh_error, blocked) == 2
+
+
+def test_git_command_forbidden_raises() -> None:
+    with pytest.raises(GitCommandForbidden):
+        du._run_git(("pull", "--ff-only"))
+    with pytest.raises(GitCommandForbidden):
+        du._run_git(("stash", "list"))
+    with pytest.raises(GitCommandForbidden):
+        du._run_git(("checkout", "main"))
+
+
+def test_run_git_surfaces_structured_failure(tmp_path: Path) -> None:
+    with pytest.raises(GitCallError) as exc:
+        du._run_git(("rev-parse", "definitely-not-a-real-ref-xyz-zzz"),
+                    cwd=str(tmp_path))
+    assert exc.value.returncode != 0
+    assert "git" in str(exc.value.argv[0])
+
+
+def test_scope_thresholds_frozen() -> None:
+    assert SCOPE_PASS_MAX_COMMITS == 5
+    assert SCOPE_PASS_MAX_FILES == 20
+    assert SCOPE_WARN_MAX_COMMITS == 20
+    assert SCOPE_WARN_MAX_FILES == 100

--- a/tests/cli/test_doctor_upstream.py
+++ b/tests/cli/test_doctor_upstream.py
@@ -12,9 +12,11 @@ self-explanatory.
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -58,11 +60,27 @@ from hermes_cli.doctor_upstream import (
 # --------------------------------------------------------------------------- #
 
 
-def _git(args: list[str], cwd: Path) -> str:
+def _git(args: list[str], cwd: Path, *, env: dict[str, str] | None = None) -> str:
     """Allowlisted helper used only by the test fixture to build
     temporary Git repositories. The module under test never goes
     through this — it uses ``_run_git`` which restricts to the
-    READONLY_GIT_SUBCOMMANDS allowlist at the *module* level."""
+    READONLY_GIT_SUBCOMMANDS allowlist at the *module* level.
+
+    Pass ``env`` to inject extra environment variables (e.g. dated
+    commits via ``GIT_AUTHOR_DATE`` / ``GIT_COMMITTER_DATE``); the
+    default test author/committer identity is preserved.
+    """
+    base_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    if env:
+        base_env.update(env)
     p = subprocess.run(
         ["git", *args],
         cwd=str(cwd),
@@ -70,10 +88,7 @@ def _git(args: list[str], cwd: Path) -> str:
         capture_output=True,
         text=True,
         timeout=15,
-        env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
-             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t",
-             "GIT_CONFIG_GLOBAL": "/dev/null",
-             "GIT_CONFIG_SYSTEM": "/dev/null"},
+        env=base_env,
     )
     return p.stdout
 
@@ -81,6 +96,40 @@ def _git(args: list[str], cwd: Path) -> str:
 @pytest.fixture
 def gitrepo(tmp_path: Path):
     """Build a temporary Git repository inside ``tmp_path``."""
+    cwd = tmp_path / "fixture"
+    cwd.mkdir()
+    _git(["init", "-q", "--initial-branch=main"], cwd)
+    _git(["config", "user.email", "test@test"], cwd)
+    _git(["config", "user.name", "test"], cwd)
+    _git(["config", "commit.gpgsign", "false"], cwd)
+
+    (cwd / "README.md").write_text("main\n")
+    _git(["add", "."], cwd)
+    _git(["commit", "-q", "-m", "init main"], cwd)
+
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    _git(["init", "--bare", "-q"], bare)
+    _git(["remote", "add", "origin", str(bare)], cwd)
+    _git(["push", "-q", "origin", "main"], cwd)
+    main_sha = _git(["rev-parse", "HEAD"], cwd).strip()
+
+    _git(["branch", "--set-upstream-to=origin/main"], cwd)
+
+    return SimpleNamespace(
+        cwd=cwd,
+        bare=bare,
+        main_sha=main_sha,
+        git=_git,
+    )
+
+
+def _build_minimal_gitrepo(tmp_path: Path):
+    """Reusable factory equivalent to the ``gitrepo`` fixture but taking
+    an explicit ``tmp_path`` so individual tests can mint fresh repos
+    with their own dated commits without depending on fixture injection
+    order. Mirrors the structure of ``gitrepo``.
+    """
     cwd = tmp_path / "fixture"
     cwd.mkdir()
     _git(["init", "-q", "--initial-branch=main"], cwd)
@@ -490,6 +539,205 @@ def test_UH4_divergence_age_over_30_warns() -> None:
     assert verdict(30) == BranchHealth.PASS
     assert verdict(31) == BranchHealth.WARN
     assert verdict(90) == BranchHealth.WARN
+
+
+# =========================================================================== #
+# UH4 — REAL divergence-age regression (real git fixture + deterministic dates)
+# =========================================================================== #
+
+
+_SECONDS_PER_DAY = 86_400
+
+
+def _make_stale_unique_commit(
+    gitrepo,
+    *,
+    age_days: int,
+    message: str,
+) -> None:
+    """Create exactly ONE local-only commit on a feature branch with both
+    GIT_AUTHOR_DATE and GIT_COMMITTER_DATE set to ``now - age_days``.
+
+    Uses Unix timestamps (locale-independent). Verifies the commit's
+    committer timestamp after creation so the fixture cannot silently
+    land at "now" because of a missing date env var.
+    """
+    # Pin "now" once so the test is internally consistent and the
+    # resulting divergence_age_days is exact (no clock drift between
+    # fixture build and assertion).
+    base_now = int(time.time())
+    commit_ts = base_now - (age_days * _SECONDS_PER_DAY)
+    iso_date = datetime.datetime.fromtimestamp(
+        commit_ts, tz=datetime.timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+    # Default fixture timestamp: now. Override BOTH author and committer.
+    date_env = {
+        "GIT_AUTHOR_DATE": iso_date,
+        "GIT_COMMITTER_DATE": iso_date,
+    }
+
+    gitrepo.git(["checkout", "-q", "-b", "feat/stale-divergence"], gitrepo.cwd)
+    (gitrepo.cwd / "stale_unique.txt").write_text("stale unique divergence\n")
+    gitrepo.git(["add", "."], gitrepo.cwd, env=date_env)
+    gitrepo.git(["commit", "-q", "-m", message], gitrepo.cwd, env=date_env)
+
+    # Verification: confirm HEAD actually has the requested committer date.
+    actual = _git(
+        ["show", "-s", "--format=%ct", "HEAD"], gitrepo.cwd
+    ).strip()
+    expected = str(commit_ts)
+    assert actual == expected, (
+        f"fixture date verification failed: actual={actual} "
+        f"expected={expected} (age_days={age_days})"
+    )
+
+
+def _divergence_age_in(gitrepo, monkeypatch) -> int | None:
+    """Force ``_now_timestamp`` to a deterministic value and call the real
+    ``_divergence_info`` against the fixture repo.
+
+    The monkeypatch is a no-op on OLD production (which has no
+    ``_now_timestamp`` seam) — in that case the production computes
+    ``head_ts - oldest_ts`` and the regression must observe the broken
+    value (zero). The seam is only installed when the symbol exists, so
+    the same test runs causally against both OLD and NEW production.
+    """
+    if hasattr(du, "_now_timestamp"):
+        pinned_now = int(time.time())
+        monkeypatch.setattr(du, "_now_timestamp", lambda: pinned_now)
+    info = du._divergence_info(
+        cwd=str(gitrepo.cwd), upstream_ref="origin/main"
+    )
+    return info.divergence_age_days
+
+
+def test_UH4_REGRESSION_stale_single_commit_warns(monkeypatch, tmp_path) -> None:
+    """UH4 primary reviewer regression: a branch with EXACTLY ONE
+    local-only commit older than 31 days must produce a divergence age
+    greater than 30 and a final WARN verdict.
+
+    Pre-fix: ``divergence_age_days`` is computed as ``head_ts - oldest_ts``
+    which is always 0 on a single-commit branch, so this case was
+    silently misclassified as PASS regardless of real age.
+    """
+    gitrepo = _build_minimal_gitrepo(tmp_path)
+    _make_stale_unique_commit(
+        gitrepo, age_days=45, message="stale single unique commit"
+    )
+
+    age_days = _divergence_age_in(gitrepo, monkeypatch)
+    assert age_days is not None and age_days > 30, (
+        f"stale single-commit divergence_age_days must be >30, got {age_days}"
+    )
+
+    # Final classifier verdict: must be WARN.
+    upstream = UpstreamReference(
+        True,
+        "origin/main",
+        "origin",
+        "main",
+        resolution_chain=["tracking"],
+    )
+    tracking = TrackingInfo(
+        True,
+        "origin/main",
+        "origin",
+        "refs/heads/main",
+        "explicit",
+    )
+    health = classify_branch_health(
+        upstream=upstream,
+        tracking=tracking,
+        ahead_behind=AheadBehind(1, 0),
+        divergence_age_days=age_days,
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(1, 1, 1, 0),
+    )
+    assert health == BranchHealth.WARN, (
+        f"stale single-commit branch must classify as WARN, got {health}"
+    )
+
+
+def test_UH4_REGRESSION_exact_30_day_boundary_passes(monkeypatch, tmp_path) -> None:
+    """UH4 boundary: a single unique commit aged EXACTLY 30 days must
+    classify as PASS (threshold is strict ``> 30``).
+    """
+    gitrepo = _build_minimal_gitrepo(tmp_path)
+    _make_stale_unique_commit(
+        gitrepo, age_days=30, message="boundary 30-day single commit"
+    )
+
+    age_days = _divergence_age_in(gitrepo, monkeypatch)
+    assert age_days == 30, (
+        f"exact 30-day boundary must yield divergence_age_days == 30, "
+        f"got {age_days}"
+    )
+
+    upstream = UpstreamReference(
+        True, "origin/main", "origin", "main", resolution_chain=["tracking"]
+    )
+    tracking = TrackingInfo(
+        True, "origin/main", "origin", "refs/heads/main", "explicit"
+    )
+    health = classify_branch_health(
+        upstream=upstream,
+        tracking=tracking,
+        ahead_behind=AheadBehind(1, 0),
+        divergence_age_days=age_days,
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(1, 1, 1, 0),
+    )
+    assert health == BranchHealth.PASS, (
+        f"30-day boundary must classify as PASS, got {health}"
+    )
+
+
+def test_UH4_REGRESSION_recent_single_commit_passes(monkeypatch, tmp_path) -> None:
+    """UH4 fresh: a single unique commit younger than 30 days must PASS."""
+    gitrepo = _build_minimal_gitrepo(tmp_path)
+    _make_stale_unique_commit(
+        gitrepo, age_days=5, message="recent single unique commit"
+    )
+
+    age_days = _divergence_age_in(gitrepo, monkeypatch)
+    assert age_days is not None and age_days < 30, (
+        f"recent single-commit divergence_age_days must be <30, got {age_days}"
+    )
+
+    upstream = UpstreamReference(
+        True, "origin/main", "origin", "main", resolution_chain=["tracking"]
+    )
+    tracking = TrackingInfo(
+        True, "origin/main", "origin", "refs/heads/main", "explicit"
+    )
+    health = classify_branch_health(
+        upstream=upstream,
+        tracking=tracking,
+        ahead_behind=AheadBehind(1, 0),
+        divergence_age_days=age_days,
+        mutual=MutualPaths([], [], [], []),
+        scope=ScopeHealth(1, 1, 1, 0),
+    )
+    assert health == BranchHealth.PASS, (
+        f"recent single-commit branch must classify as PASS, got {health}"
+    )
+
+
+def test_UH4_no_divergence_zero_age(gitrepo) -> None:
+    """UH4 no-divergence: when there are no local unique commits,
+    divergence_age_days must be exactly 0.
+    """
+    info = du._divergence_info(
+        cwd=str(gitrepo.cwd), upstream_ref="origin/main"
+    )
+    # On a fully-synced ``gitrepo`` (merge_base == HEAD) the oldest
+    # unique commit lookup returns ``None`` and the no-divergence branch
+    # of ``_divergence_info`` sets age_days = 0 directly.
+    assert info.divergence_age_days == 0, (
+        f"no-divergence fixture must produce divergence_age_days == 0, "
+        f"got {info.divergence_age_days}"
+    )
 
 
 # =========================================================================== #

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -770,11 +770,23 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 
 ```bash
 hermes doctor [--fix]
+hermes doctor --ack <ADVISORY_ID>
+hermes doctor --upstream
+hermes doctor --upstream --json
+hermes doctor --upstream --compact
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--ack ADVISORY_ID` | Acknowledge a doctor advisory so future runs can suppress it where supported. |
+| `--upstream` | Run the upstream health diagnostic in READONLY mode. It does not fetch, run mutating Git operations, or modify the worktree. Without an output flag, it prints human-readable text. |
+| `--json` | With `--upstream`, print pure JSON output. Outside upstream diagnostics, this flag has no effect. |
+| `--compact` | With `--upstream`, print a stable one-line summary. Outside upstream diagnostics, this flag has no effect. |
+
+`--upstream` is incompatible with `--fix` and with `--ack`. `--json` and
+`--compact` only affect `--upstream` output; when both are supplied, JSON output
+takes precedence.
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary

Restores the read-only upstream-health diagnostics on current `main`, as a current-main-native reconstruction that supersedes #62335.

- Restore the read-only upstream-health diagnostics on current main
- Preserve ordinary `hermes doctor` behavior unchanged
- Support compact and pure JSON upstream-health output
- Keep update/fix behavior unchanged
- Supersedes #62335 with a current-main-native reconstruction

All upstream-health inspection is read-only: no mutating git command is ever issued, and the test suite pins the allowlist.

## Maintainer review contracts

**Review A — divergence age is part of classification itself** (preserved)

Divergence age is an input to `classify_branch_health` rather than a separate cosmetic report, so it participates directly in the verdict:

| `divergence_age_days` | verdict |
| --- | --- |
| none / `None` | normal existing behavior (unchanged) |
| `30` | `PASS` |
| `31` | `WARN` |
| `90` | `WARN` |

The 30/31 boundary is pinned by `test_UH4_divergence_age_over_30_warns`, and thresholds are frozen by `test_scope_thresholds_frozen`.

**Review B — CLI surface documented** (preserved)

`website/docs/reference/cli-commands.md` documents:

- `--upstream`
- `--json`
- `--compact`

The incompatibility rules with `--fix` / `--ack` are preserved and enforced at runtime: `hermes doctor --upstream --fix` and `hermes doctor --upstream --ack` both exit `2` with an explicit message rather than silently ignoring a flag.

## Scope

Exactly five paths:

- `hermes_cli/doctor.py`
- `hermes_cli/doctor_upstream.py`
- `hermes_cli/subcommands/doctor.py`
- `tests/cli/test_doctor_upstream.py`
- `website/docs/reference/cli-commands.md`

## Validation

Validated against current `main`, with the results reported exactly as measured:

- **Focal:** 36/36 passed (`tests/cli/test_doctor_upstream.py`, canonical `scripts/run_tests.sh`)
- **UH4 divergence-age regressions:** 4/4 passed — stale single-commit (>30 days), exact 30-day boundary, recent single-commit, and no-divergence/zero-age.
- **Current-main neighbor selection** (`tests/hermes_cli/test_doctor.py`):
  - integration **48/49**
  - baseline **48/49**
- The single neighbor failure is `test_doctor_reports_vercel_backend_diagnostics`. It fails **identically on baseline current-main without any of this PR's changes**, with the same assertion at the same line and the same output payload. It is environmental: the validation host is classified container-like by `hermes_constants.is_container()`, which makes `doctor.py` force `terminal_env="local"` and skip the `vercel_sandbox` branch the test asserts on. It is **not** a port regression, and it is disclosed here rather than hidden.
- `PORT_REGRESSION_COUNT=0`
- Compact runtime: **PASS** (single-line output contract)
- JSON runtime: **PASS** (stdout parses as a pure JSON object, no banner/noise contamination)
- Ordinary `hermes doctor` runtime: **PASS**
- AST parse: **PASS**
- `py_compile`: **PASS**
- Import contract: **PASS**
- `git diff --check` / `git diff --cached --check`: **PASS**
- Latest-main integration compatibility: **PASS**
- Post-validation drift micro-gate: **PASS**
- Final publication-time `merge-tree`: clean, no textual conflicts
- No rebase and no force-push were required

## Supersession

This PR supersedes #62335. The older PR is not force-updated because this replacement is reconstructed and validated against current main while preserving the maintainer-requested contracts.

