### PR TITLE
fix(desktop): rebind Files pane cwd when switching sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -11,6 +11,7 @@ import type { SessionInfo } from '@/types/hermes'
 import {
   appendLiveSessionProjection,
   applyRuntimeInfo,
+  applyStoredSessionPreviewRuntimeInfo,
   chatMessageArraysEquivalent,
   chatMessagesEquivalent,
   chatPartsEquivalent,
@@ -109,6 +110,41 @@ describe('applyRuntimeInfo foreground scoping', () => {
     expect($currentBranch.get()).toBe('main')
     // ...while the caller still gets everything it needs for its own session.
     expect(patch).toMatchObject({ branch: 'bb/tile', cwd: '/other-worktree' })
+  })
+
+  it('clears the Files/workspace cwd when a foreground detached session reports empty cwd', () => {
+    const patch = applyRuntimeInfo({ cwd: '' })
+
+    expect($currentCwd.get()).toBe('')
+    expect(patch).toMatchObject({ cwd: '' })
+  })
+})
+
+describe('applyStoredSessionPreviewRuntimeInfo workspace paint', () => {
+  beforeEach(() => {
+    setCurrentCwd('/previous-project')
+  })
+
+  afterEach(() => {
+    setCurrentCwd('')
+  })
+
+  it('rebinds $currentCwd from the selected session row before resume settles', () => {
+    applyStoredSessionPreviewRuntimeInfo({ cwd: '/next-project', model: 'gpt' })
+
+    expect($currentCwd.get()).toBe('/next-project')
+  })
+
+  it('clears a stale project tree when the selected session is detached', () => {
+    applyStoredSessionPreviewRuntimeInfo({ cwd: '', model: 'gpt' })
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  it('falls back to git_repo_root when cwd is missing', () => {
+    applyStoredSessionPreviewRuntimeInfo({ git_repo_root: '/repo-root', model: 'gpt' })
+
+    expect($currentCwd.get()).toBe('/repo-root')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -12,6 +12,7 @@ import {
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdTransient,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -1017,7 +1018,10 @@ export function applyRuntimeInfo(
     sessionState.provider = info.provider
   }
 
-  if (info.cwd) {
+  // Empty string is authoritative: a detached/bare session must clear the
+  // previous project's Files pane root. Truthy-only used to leave `$currentCwd`
+  // stuck on the last project after switching away.
+  if (typeof info.cwd === 'string') {
     sessionState.cwd = info.cwd
   }
 
@@ -1056,7 +1060,9 @@ export function applyRuntimeInfo(
   return sessionState
 }
 
-export function applyStoredSessionPreviewRuntimeInfo(stored: { model?: null | string } | undefined) {
+export function applyStoredSessionPreviewRuntimeInfo(
+  stored: { cwd?: null | string; git_repo_root?: null | string; model?: null | string } | undefined
+) {
   setCurrentModel(stored?.model || '')
   setCurrentProvider('')
   setCurrentReasoningEffort('')
@@ -1064,6 +1070,13 @@ export function applyStoredSessionPreviewRuntimeInfo(stored: { model?: null | st
   setCurrentFastMode(false)
   setYoloActive(false)
   setCurrentPersonality('')
+
+  // Cold resume paints the transcript before `session.resume` returns. Mirror
+  // the selected row's workspace into `$currentCwd` on the same tick so the
+  // Files pane doesn't keep showing the previous project's tree. Transient —
+  // persistence waits for `applyRuntimeInfo` after the runtime binds.
+  const previewCwd = (stored?.cwd ?? stored?.git_repo_root ?? '').trim()
+  setCurrentCwdTransient(previewCwd)
 }
 
 // A "session genuinely doesn't exist" failure (deleted, or an id from a wiped /


### PR DESCRIPTION
## Summary
- Cold session resume now paints `$currentCwd` from the selected session row immediately, so the Files pane does not keep showing the previous project's tree while `session.resume` is in flight.
- Empty/detached runtime cwd is treated as authoritative and clears the previous workspace root (truthy-only `if (info.cwd)` left Files stuck on the last project).

## Test plan
- [x] `cd apps/desktop && npx vitest run src/app/session/hooks/use-session-actions/utils.test.ts`
- [ ] Desktop: open session A in project `/a`, then switch to session B in project `/b` — Files pane should show `/b` without waiting on a long resume
- [ ] Desktop: switch from a project session to a detached/bare session — Files pane should clear / show the empty workspace hint
- [ ] Desktop: warm resume between two project sessions still shows the correct tree

Related: #79724 (multi-tile focus redesign is broader; this covers primary session-switch Files desync).