### PR TITLE
fix(gateway): deliver Matrix voice-only replies (#81030)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -162,7 +162,7 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
 
 
 def build_auto_tts_output_path(platform) -> str:
-    """Return a unique temp output path for gateway auto-TTS synthesis.
+    """Return a unique Hermes-owned output path for gateway auto-TTS synthesis.
 
     Platform-awareness lives HERE (the caller knows its platform), not in the
     TTS tool's ``HERMES_SESSION_PLATFORM`` contextvar — that contextvar is
@@ -178,12 +178,9 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
-    audio_path = os.path.join(
-        tempfile.gettempdir(),
-        "hermes_voice",
-        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
+    audio_path = str(
+        get_audio_cache_dir() / f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}"
     )
-    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
     return audio_path
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19425,7 +19425,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # When streaming already delivered the text (already_sent=True),
         # the base adapter will receive None and can't run auto-TTS,
         # so the runner must take over.
-        if is_voice_input and not already_sent:
+        # Matrix voice events are re-entered through the runner after STT;
+        # unlike the voice-channel adapters, Matrix does not complete the
+        # native voice reply in its base-adapter path.
+        if is_voice_input and not already_sent and event.source.platform != Platform.MATRIX:
             return False
 
         return True

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -93,6 +93,21 @@ class TestAutoVoiceReplyFormat:
         voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
         assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
+    def test_matrix_voice_input_voice_only_uses_runner_path(self):
+        """Matrix voice input must not be deduplicated before runner TTS."""
+        runner = _make_runner()
+        runner._voice_mode["matrix:!room:example.org"] = "voice_only"
+        adapter = _make_adapter(Platform.MATRIX)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.MATRIX] = adapter
+        event = _make_event(
+            Platform.MATRIX,
+            chat_id="!room:example.org",
+            message_type=MessageType.VOICE,
+        )
+
+        assert runner._should_send_voice_reply(event, "hello", []) is True
+
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):
         runner = GatewayRunner.__new__(GatewayRunner)


### PR DESCRIPTION
## Summary
- allow Matrix voice-only turns to use the runner auto-TTS path
- store gateway auto-TTS output under the Hermes-owned audio cache so TTS path safety accepts it
- add regression coverage for Matrix voice-only routing

Fixes #81030

## Tests
- `python3 -m pytest -q tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_base_auto_tts_output_format.py tests/gateway/test_voice_command.py` (89 passed, 2 pre-existing RuntimeWarnings)
