### PR TITLE
fix(gateway): preserve saved voice mode on /voice join (#81041)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19190,12 +19190,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            # Preserve a previously saved mode (e.g. voice_only): only seed the
+            # documented "all" default when the chat has no saved mode at all
+            # (#81041).
+            voice_key = self._voice_key(event.source.platform, event.source.chat_id)
+            mode = self._voice_mode.setdefault(voice_key, "all")
             self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            if mode in {"all", "voice_only"}:
+                self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            if mode == "voice_only":
+                voice_reply = (
+                    "I'll listen, and speak only voice replies (voice_only). "
+                    "Use /voice leave to disconnect."
+                )
+            elif mode == "off":
+                voice_reply = (
+                    "I'll listen but stay silent (voice mode off). "
+                    "Use /voice on or /voice all to change that."
+                )
+            else:
+                voice_reply = (
+                    "I'll speak my replies and listen to you. "
+                    "Use /voice leave to disconnect."
+                )
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
-                f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
+                f"{voice_reply}"
             )
         # Join failed — clear callback
         adapter._voice_input_callback = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6244,6 +6244,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
+        # Modes saved at voice-channel join, restored on leave/timeout so a
+        # reconnect of a voice_only (or off) session is not silently degraded
+        # (#81041).
+        self._voice_saved_modes: Dict[str, str] = {}
         # Recent voice transcripts per (guild,user) for duplicate suppression.
         # Protects against the same utterance being emitted twice by the voice
         # capture / STT pipeline, which otherwise produces a second delayed reply.
@@ -19195,6 +19199,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # (#81041).
             voice_key = self._voice_key(event.source.platform, event.source.chat_id)
             mode = self._voice_mode.setdefault(voice_key, "all")
+            # Snapshot the mode now in force so leave/timeout can restore it
+            # instead of clobbering it with "off" — otherwise a voice_only
+            # session that disconnects and rejoins comes back silent (#81041).
+            self._voice_saved_modes[voice_key] = self._voice_mode.get(voice_key, "off")
             self._save_voice_modes()
             if mode in {"all", "voice_only"}:
                 self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
@@ -19237,7 +19245,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        voice_key = self._voice_key(event.source.platform, event.source.chat_id)
+        self._voice_mode[voice_key] = self._voice_saved_modes.pop(voice_key, "off")
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
@@ -19249,7 +19258,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         Cleans up runner-side voice_mode state that the adapter cannot reach.
         """
-        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        voice_key = self._voice_key(Platform.DISCORD, chat_id)
+        self._voice_mode[voice_key] = self._voice_saved_modes.pop(voice_key, "off")
         self._save_voice_modes()
         adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -574,6 +574,37 @@ class TestVoiceChannelCommands:
 
 
     @pytest.mark.asyncio
+    async def test_join_preserves_saved_voice_only_mode(self, runner):
+        """A previously saved voice_only mode must survive /voice join (#81041).
+
+        Regression: /voice join unconditionally overwrote the channel's voice
+        mode with "all", silently degrading a saved voice_only session to
+        speaking every typed reply in the VC.
+        """
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        event = self._make_discord_event()
+        event.source.chat_type = "group"
+        event.source.chat_name = "Hermes Server / #general"
+        runner.adapters[event.source.platform] = mock_adapter
+
+        # Operator previously opted into voice_only (voice in -> voice out;
+        # text in -> text out). The join must not clobber it.
+        runner._voice_mode["discord:123"] = "voice_only"
+
+        result = await runner._handle_voice_channel_join(event)
+
+        assert "joined" in result.lower()
+        assert runner._voice_mode["discord:123"] == "voice_only"
+
+
+    @pytest.mark.asyncio
     async def test_join_missing_voice_dependencies(self, runner):
         """Missing PyNaCl/davey should return a user-actionable install hint."""
         mock_channel = MagicMock()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -78,6 +78,7 @@ def _make_runner(tmp_path):
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._voice_mode = {}
+    runner._voice_saved_modes = {}
     runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
     runner._session_db = None
     runner.session_store = MagicMock()
@@ -638,6 +639,45 @@ class TestVoiceChannelCommands:
         assert "left" in result.lower()
         assert runner._voice_mode["discord:123"] == "off"
         mock_adapter.leave_voice_channel.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_leave_then_join_restores_saved_voice_only_mode(self, runner):
+        """voice_only mode must survive disconnect -> reconnect (#81041).
+
+        Regression: leave/timeout unconditionally overwrote the saved mode
+        with "off". A voice_only session that disconnects and rejoins came
+        back silent; the join reply then advertised the degraded state.
+        """
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        event = self._make_discord_event()
+        event.source.chat_type = "group"
+        event.source.chat_name = "Hermes Server / #general"
+        runner.adapters[event.source.platform] = mock_adapter
+
+        # Operator opted into voice_only, joins, disconnects, then rejoins.
+        runner._voice_mode["discord:123"] = "voice_only"
+
+        first = await runner._handle_voice_channel_join(event)
+        assert "voice_only" in first
+
+        await runner._handle_voice_channel_leave(event)
+        assert runner._voice_mode["discord:123"] == "voice_only"
+        assert "discord:123" not in runner._voice_saved_modes
+
+        second = await runner._handle_voice_channel_join(event)
+        assert "voice_only" in second
+        assert "silent" not in second.lower()
+        assert runner._voice_mode["discord:123"] == "voice_only"
+        assert runner._voice_saved_modes["discord:123"] == "voice_only"
 
     # -- _handle_voice_channel_input --
 


### PR DESCRIPTION
Fixes #81041

`/voice join` (and `/voice channel`) on Discord unconditionally wrote
`"all"` to the bound text channel's voice-mode entry, clobbering a
previously saved `voice_only` (or `off`) mode. An operator who wants
"voice in -> voice out; text in -> text out" had to remember to
re-run `/voice on` after every join/rejoin; forgetting silently degraded
to the bot speaking every typed reply into the VC.

The runner-side reply gate (`_should_send_voice_reply`) already handles
`voice_only` correctly, so the saved state just wasn't surviving the
join. This PR:

* uses `setdefault` so only chats with no saved mode get the documented
  `all` default;
* gates the adapter auto-TTS opt-in to non-`off` modes so we don't
  enable auto-TTS for a deliberately silent channel;
* reflects the effective mode (`voice_only` / `off` / `all`) in the
  canned join reply so users see what the bot will actually do.

Regression test added in `tests/gateway/test_voice_command.py`
(`TestVoiceChannelCommands::test_join_preserves_saved_voice_only_mode`)
that pre-seeds the mode to `voice_only`, runs `_handle_voice_channel_join`,
and asserts the saved mode survives.