### PR TITLE
fix(streaming): recover Anthropic tool calls dropped after preamble text

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3124,6 +3124,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             stream_attempt_state["current"] += 1
             attempt_id = int(stream_attempt_state["current"])
         provider_tool_in_flight["yes"] = False
+        result["partial_tool_names"] = []
         return attempt_id
 
     def _cancel_current_stream_attempt(reason: str) -> None:
@@ -4105,7 +4106,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # Reset in-memory accumulators so the next
                         # attempt's chunks don't concat onto the dead
                         # stream's partial JSON.
-                        result["partial_tool_names"] = []
                         deltas_were_sent["yes"] = False
                         first_delta_fired["done"] = False
                         agent._emit_stream_drop(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3856,8 +3856,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
                         has_tool_use = True
+                        provider_tool_in_flight["yes"] = True
                         tool_name = getattr(block, "name", None)
                         if tool_name:
+                            result["partial_tool_names"].append(tool_name)
                             _fire_first_delta()
                             agent._fire_tool_gen_started(tool_name)
                 elif event_type == "content_block_delta":
@@ -4059,6 +4061,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             or _is_conn_err
                             or _is_sse_conn_err_preview
                             or _is_stream_parse_err
+                            or _is_empty_stream
                         )
                         _can_silent_retry = (
                             _partial_tool_in_flight

--- a/tests/run_agent/test_anthropic_mid_tool_call_drop.py
+++ b/tests/run_agent/test_anthropic_mid_tool_call_drop.py
@@ -195,3 +195,40 @@ class TestAnthropicMidToolCallStreamDrop:
             "Stream stalled mid tool-call (write_file)"
             in response.choices[0].message.content
         )
+
+    def test_retry_state_does_not_promote_later_text_only_drop(self, monkeypatch):
+        """A prior tool drop must not make a later text-only drop retryable."""
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        dropped_tool = MagicMock()
+        dropped_tool.content = [_tool_use_block()]
+        dropped_tool.stop_reason = None
+        dropped_tool.usage = SimpleNamespace(input_tokens=10, output_tokens=2)
+
+        dropped_text = MagicMock()
+        dropped_text.content = []
+        dropped_text.stop_reason = None
+        dropped_text.usage = SimpleNamespace(input_tokens=10, output_tokens=2)
+
+        unexpected_retry = MagicMock()
+        unexpected_retry.content = [_tool_use_block(input_obj={"path": "a.txt"})]
+        unexpected_retry.stop_reason = "tool_use"
+        unexpected_retry.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+
+        agent = _make_anthropic_agent()
+        agent.stream_delta_callback = MagicMock()
+        agent._anthropic_client.messages.stream = MagicMock(
+            side_effect=[
+                _stream_cm(dropped_tool, events=[_tool_use_start_event()]),
+                _stream_cm(dropped_text, events=[_text_delta_event()]),
+                _stream_cm(unexpected_retry, events=[_tool_use_start_event()]),
+            ]
+        )
+
+        response = agent._interruptible_streaming_api_call(
+            {"model": "claude-opus-4-7"}
+        )
+
+        assert agent._anthropic_client.messages.stream.call_count == 2
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response._dropped_tool_names is None

--- a/tests/run_agent/test_anthropic_mid_tool_call_drop.py
+++ b/tests/run_agent/test_anthropic_mid_tool_call_drop.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from hermes_constants import PARTIAL_STREAM_STUB_ID
+
 
 def _make_anthropic_agent(**kwargs):
     from run_agent import AIAgent
@@ -62,6 +64,13 @@ def _tool_use_start_event(name="write_file"):
     return SimpleNamespace(
         type="content_block_start",
         content_block=SimpleNamespace(type="tool_use", name=name),
+    )
+
+
+def _text_delta_event(text="I'll write that now."):
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="text_delta", text=text),
     )
 
 
@@ -117,3 +126,72 @@ class TestAnthropicMidToolCallStreamDrop:
             {"model": "claude-opus-4-7"}
         )
         assert response is text_only
+
+    def test_preamble_then_dropped_tool_retries_in_place(self, monkeypatch):
+        """A tool drop remains retryable after Anthropic streamed preamble text."""
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        dropped = MagicMock()
+        dropped.content = [_tool_use_block()]
+        dropped.stop_reason = None
+        dropped.usage = SimpleNamespace(input_tokens=10, output_tokens=2)
+
+        done = MagicMock()
+        done.content = [_tool_use_block(input_obj={"path": "a.txt"})]
+        done.stop_reason = "tool_use"
+        done.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+
+        agent = _make_anthropic_agent()
+        agent.stream_delta_callback = MagicMock()
+        agent._anthropic_client.messages.stream = MagicMock(
+            side_effect=[
+                _stream_cm(
+                    dropped,
+                    events=[_text_delta_event(), _tool_use_start_event()],
+                ),
+                _stream_cm(done, events=[_tool_use_start_event()]),
+            ]
+        )
+
+        response = agent._interruptible_streaming_api_call(
+            {"model": "claude-opus-4-7"}
+        )
+
+        assert response is done
+        assert agent._anthropic_client.messages.stream.call_count == 2
+
+    def test_exhausted_retry_stub_names_dropped_anthropic_tool(self, monkeypatch):
+        """Retry exhaustion preserves the dropped tool name in the warning stub."""
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        dropped = MagicMock()
+        dropped.content = [_tool_use_block()]
+        dropped.stop_reason = None
+        dropped.usage = SimpleNamespace(input_tokens=10, output_tokens=2)
+
+        agent = _make_anthropic_agent()
+        agent.stream_delta_callback = MagicMock()
+        agent._anthropic_client.messages.stream = MagicMock(
+            side_effect=[
+                _stream_cm(
+                    dropped,
+                    events=[_text_delta_event(), _tool_use_start_event()],
+                ),
+                _stream_cm(
+                    dropped,
+                    events=[_text_delta_event(), _tool_use_start_event()],
+                ),
+            ]
+        )
+
+        response = agent._interruptible_streaming_api_call(
+            {"model": "claude-opus-4-7"}
+        )
+
+        assert agent._anthropic_client.messages.stream.call_count == 2
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response._dropped_tool_names == ["write_file"]
+        assert (
+            "Stream stalled mid tool-call (write_file)"
+            in response.choices[0].message.content
+        )


### PR DESCRIPTION
## What does this PR do?

Anthropic streams that emit preamble text and then lose an incomplete `tool_use` block currently fall back to a continuation turn instead of retrying the interrupted stream in place. The fallback also loses the dropped tool name, so users wait through a slower recovery without a useful warning about the action that was interrupted.

The Anthropic event parser now records the same in-flight tool state and tool name that the chat-completions path already records. `EmptyStreamError` is considered retryable only when that in-flight state is present, preserving the existing behavior for text-only stream failures. Per-attempt tool state is reset at the start of every retry so a prior interrupted tool cannot cause a later text-only failure to retry silently.

## Related Issue

Closes #81025

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py` - track Anthropic tool starts and names, retry interrupted incomplete tool streams, and reset partial tool state for each retry attempt.
- `tests/run_agent/test_anthropic_mid_tool_call_drop.py` - cover successful in-place recovery, exhausted-retry warnings with the dropped tool name, text-only boundaries, and stale-state isolation across attempts.

## How to Test

1. Simulate an Anthropic stream that emits preamble text, starts a named `tool_use` block, and ends before its input JSON is complete.
2. Verify Hermes retries the stream in place and executes the completed tool call from the retry.
3. Exhaust the retries and verify the recovery warning preserves the interrupted tool name.
4. Run the targeted and adjacent regression suites:

```bash
scripts/run_tests.sh tests/run_agent/test_anthropic_mid_tool_call_drop.py tests/run_agent/test_stream_interrupt_retry.py tests/run_agent/test_streaming.py -q
```

Result: 46 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change is provider-stream state handling with no OS-specific code
- [x] Tool descriptions/schemas: N/A - no tool schema changed

## Screenshots / Logs

N/A - automated stream fixtures exercise the failure and recovery paths.
