### PR TITLE
fix(agent): gate memory provider system_prompt_block on toolset config (#81014)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -107,6 +107,29 @@ def memory_provider_tools_enabled(
         return False
 
 
+def memory_provider_tools_exposed(agent: Any) -> bool:
+    """Whether external memory-provider tools are exposed on ``agent``.
+
+    Same gate as ``inject_memory_provider_tools`` so the provider's
+    ``system_prompt_block()`` and its tool schemas are presented to the
+    model together — otherwise the system prompt would advertise tools
+    that don't exist in the tool surface (#81014).
+    """
+    tools = getattr(agent, "tools", None)
+    if isinstance(tools, (list, tuple)):
+        memory_tool_present = any(
+            isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory"
+            for tool in tools
+        )
+    else:
+        memory_tool_present = False
+    return memory_provider_tools_enabled(
+        getattr(agent, "enabled_toolsets", None),
+        getattr(agent, "disabled_toolsets", None),
+        memory_tool_present=memory_tool_present,
+    )
+
+
 def inject_memory_provider_tools(agent: Any) -> int:
     """Append external memory-provider tool schemas to an agent tool surface."""
     memory_manager = getattr(agent, "_memory_manager", None)
@@ -119,11 +142,7 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
-    if not memory_provider_tools_enabled(
-        getattr(agent, "enabled_toolsets", None),
-        getattr(agent, "disabled_toolsets", None),
-        memory_tool_present="memory" in existing_tool_names,
-    ):
+    if not memory_provider_tools_exposed(agent):
         return 0
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -523,14 +523,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
+    # External memory provider system prompt block (additive to built-in).
+    # Gated on the same check ``inject_memory_provider_tools`` uses so we
+    # never advertise provider tools that the agent's toolset configuration
+    # has already gated off (#81014).
     if agent._memory_manager:
         try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
-            if _ext_mem_block:
-                volatile_parts.append(_ext_mem_block)
+            from agent.memory_manager import memory_provider_tools_exposed as _mem_exposed
         except Exception:
-            pass
+            _mem_exposed = None
+        if _mem_exposed is None or _mem_exposed(agent):
+            try:
+                _ext_mem_block = agent._memory_manager.build_system_prompt()
+                if _ext_mem_block:
+                    volatile_parts.append(_ext_mem_block)
+            except Exception:
+                pass
 
     from hermes_time import now as _hermes_now
     now = _hermes_now()

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1158,3 +1158,85 @@ class TestTrivialPromptClassifier:
                   "hello world", "ok so what's next", "what's my name",
                   "hey can you check the logs", "continue the migration plan"):
             assert not is_trivial_prompt(t), f"expected non-trivial: {t!r}"
+
+
+# ---------------------------------------------------------------------------
+# System-prompt gate parity — #81014
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptGateParity:
+    """The memory provider's ``system_prompt_block()`` must be injected only
+    when ``inject_memory_provider_tools`` would actually expose its tools.
+
+    Otherwise the agent receives instructions for tools that don't exist
+    in its tool surface (issue #81014).
+    """
+
+    def _agent_with_provider(
+        self,
+        *,
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        tools=None,
+        prompt_block="Use mnemosyne_remember to save facts.",
+    ):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("mnemosyne", tools=[
+            {"name": "mnemosyne_remember", "description": "Remember", "parameters": {}},
+        ])
+        provider._prompt_block = prompt_block
+        mgr.add_provider(provider)
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            tools=list(tools) if tools is not None else [],
+        )
+        return agent, mgr, provider
+
+    def test_tools_exposed_when_memory_in_enabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is True
+
+    def test_tools_hidden_when_memory_in_disabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(disabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is False
+
+    def test_tools_hidden_when_memory_not_in_enabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["web_search"])
+        assert memory_provider_tools_exposed(agent) is False
+
+    def test_tools_exposed_when_memory_tool_already_present(self):
+        """The built-in "memory" tool is a sufficient opt-in even when the
+        toolset gate says nothing about memory."""
+        from agent.memory_manager import memory_provider_tools_exposed
+        tools = [
+            {"type": "function", "function": {"name": "memory", "description": "x", "parameters": {}}},
+        ]
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["web_search"], tools=tools)
+        assert memory_provider_tools_exposed(agent) is True
+
+    def test_inject_and_exposed_share_the_same_gate(self):
+        """``inject_memory_provider_tools`` and ``memory_provider_tools_exposed``
+        must agree — both determine whether provider tools are presented to
+        the model (#81014)."""
+        from agent.memory_manager import inject_memory_provider_tools, memory_provider_tools_exposed
+
+        # Disabled toolsets — neither path should add or advertise provider tools.
+        agent, _mgr, _p = self._agent_with_provider(disabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is False
+        assert inject_memory_provider_tools(agent) == 0
+
+        # Enabled with "memory" — both paths must add/advertise.
+        agent, _mgr, _p = self._agent_with_provider(
+            enabled_toolsets=["memory"], tools=[]
+        )
+        assert memory_provider_tools_exposed(agent) is True
+        added = inject_memory_provider_tools(agent)
+        assert added == 1
+        names = {t["function"]["name"] for t in agent.tools}
+        assert "mnemosyne_remember" in names

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -266,3 +266,61 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestMemoryProviderSystemPromptGating:
+    """Issue #81014: the provider's ``system_prompt_block()`` must be gated
+    on the same ``memory_provider_tools_enabled`` check as tool injection.
+    Otherwise the agent receives instructions for tools that don't exist in
+    its tool surface.
+    """
+
+    @staticmethod
+    def _make_fake_manager(prompt_block: str):
+        """Build a MemoryManager-like object exposing only what
+        ``build_system_prompt_parts`` touches."""
+        from unittest.mock import MagicMock
+        mgr = MagicMock()
+        mgr.build_system_prompt.return_value = prompt_block
+        return mgr
+
+    def _agent(self, *, enabled_toolsets, disabled_toolsets, prompt_block):
+        return _make_agent(
+            valid_tool_names=["skills_list"],
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            _memory_manager=self._make_fake_manager(prompt_block),
+        )
+
+    def test_block_injected_when_memory_toolset_enabled(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=["memory"], disabled_toolsets=None)
+        assert block in full
+
+    def test_block_dropped_when_memory_toolset_disabled(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=None,
+            disabled_toolsets=["memory"],
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=None, disabled_toolsets=["memory"])
+        assert block not in full
+
+    def test_block_dropped_when_memory_not_in_enabled_toolsets(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=["web_search"],
+            disabled_toolsets=None,
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=["web_search"], disabled_toolsets=None)
+        assert block not in full


### PR DESCRIPTION
Fixes #81014

When a memory provider (e.g. Mnemosyne) is configured via `memory.provider`
but the `memory` toolset is not in `platform_toolsets` (or is in
`agent.disabled_toolsets`), the provider still injected its
`system_prompt_block()` into the system prompt while its tools were
gated off by `memory_provider_tools_enabled()`. The agent received
instructions for tools that did not exist in its tool surface — a dangling
contract the model could not satisfy.

Centralize the gate into `memory_provider_tools_exposed(agent)` and use
it from both the tool-injection path and the system-prompt assembly
path, so the provider's prompt block and its tools stay in lock-step.

Regression tests cover:

* `tests/agent/test_memory_provider.py::TestSystemPromptGateParity` —
  unit-level: `memory_provider_tools_exposed` returns the right answer
  for each toolset state, and matches `inject_memory_provider_tools`.
* `tests/agent/test_system_prompt.py::TestMemoryProviderSystemPromptGating` —
  end-to-end via `build_system_prompt`: the provider block lands in the
  final prompt when memory is enabled and is dropped when it is gated
  off.