### PR TITLE
fix(mcp): remove all per-server OAuth files via hermes mcp remove

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -104,17 +104,50 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     return True
 
 
-def _remove_mcp_server(name: str) -> bool:
-    """Remove a server from config.yaml.  Returns True if it existed."""
+def _remove_mcp_token_files(name: str) -> bool:
+    """Delete all per-server files under ``HERMES_HOME/mcp-tokens/``.
+
+    Always routes through :class:`tools.mcp_oauth.HermesTokenStorage` so
+    the ``.json``, ``.client.json``, and ``.meta.json`` siblings are
+    handled together — fixing the orphan-``.meta.json`` revival bug
+    where ``hermes mcp remove`` left cached OAuth metadata on disk and
+    the gateway bootstrap re-read it on the next restart (#81050).
+    """
+    from tools.mcp_oauth import HermesTokenStorage
+
+    storage = HermesTokenStorage(name)
+    paths = (
+        storage._tokens_path(),
+        storage._client_info_path(),
+        storage._meta_path(),
+    )
+    removed_any = any(p.exists() for p in paths)
+    storage.remove()
+    return removed_any
+
+
+def _remove_mcp_server(name: str, *, clean_token_files: bool = True) -> bool:
+    """Remove a server from config.yaml.  Returns True if it existed.
+
+    When ``clean_token_files`` is True (the default), also deletes the
+    per-server OAuth files under ``mcp-tokens/``. This is what callers
+    want for ``hermes mcp remove`` and the dashboard DELETE endpoint —
+    the orphan-``.meta.json`` revival bug (#81050) was caused by these
+    two paths each cleaning only part of the per-server state.
+    """
     config = load_config()
     servers = config.get("mcp_servers", {})
-    if name not in servers:
-        return False
-    del servers[name]
-    if not servers:
-        config.pop("mcp_servers", None)
-    save_config(config)
-    return True
+    existed = name in servers
+    if existed:
+        del servers[name]
+        if not servers:
+            config.pop("mcp_servers", None)
+        save_config(config)
+
+    if clean_token_files:
+        _remove_mcp_token_files(name)
+
+    return existed
 
 
 def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
@@ -620,33 +653,53 @@ def cmd_mcp_add(args):
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
 
 def cmd_mcp_remove(args):
-    """Remove an MCP server from config."""
+    """Remove an MCP server from config AND clean up all on-disk state.
+
+    Always deletes the per-server files under ``mcp-tokens/`` so an
+    orphan ``.meta.json`` (or ``.client.json``) cannot be re-read by the
+    gateway bootstrap on the next restart (#81050).
+    """
     name = args.name
     existing = _get_mcp_servers()
 
-    if name not in existing:
-        _error(f"Server '{name}' not found in config.")
+    in_config = name in existing
+    if not in_config:
+        _warning(f"Server '{name}' not found in config; checking for orphan token files...")
         servers = list(existing.keys())
         if servers:
             _info(f"Available servers: {', '.join(servers)}")
+
+    cleaned_tokens = _remove_mcp_token_files(name)
+
+    if in_config:
+        if not _confirm(f"Remove server '{name}'?", default=True):
+            _info("Cancelled.")
+            # Token cleanup already happened; surface it so the user
+            # knows the disk state is now clean even though config remains.
+            if cleaned_tokens:
+                _success("Cleaned up OAuth tokens (config left intact)")
+            return
+
+        # _remove_mcp_server also re-cleans tokens; the explicit call
+        # above made the orphan case observable to the user.
+        _remove_mcp_token_files(name)
+        _remove_mcp_server(name, clean_token_files=False)
+        _success(f"Removed '{name}' from config")
+    elif cleaned_tokens:
+        _success(f"Removed orphan token files for '{name}'")
+    else:
+        _error(f"Server '{name}' not found in config.")
         return
 
-    if not _confirm(f"Remove server '{name}'?", default=True):
-        _info("Cancelled.")
-        return
-
-    _remove_mcp_server(name)
-    _success(f"Removed '{name}' from config")
-
-    # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
-    # any provider instance cached in the current process (e.g. from an
-    # earlier `hermes mcp test` in the same session) is evicted too.
+    # Best-effort: evict any cached provider from this process. A failure
+    # here is not fatal — the on-disk cleanup already happened above.
     try:
         from tools.mcp_oauth_manager import get_manager
         get_manager().remove(name)
-        _success("Cleaned up OAuth tokens")
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("MCPOAuthManager.remove(%r) failed (non-fatal): %s", name, exc)
+
+    _success("Cleaned up OAuth tokens")
 
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -109,9 +109,8 @@ def _remove_mcp_token_files(name: str) -> bool:
 
     Always routes through :class:`tools.mcp_oauth.HermesTokenStorage` so
     the ``.json``, ``.client.json``, and ``.meta.json`` siblings are
-    handled together — fixing the orphan-``.meta.json`` revival bug
-    where ``hermes mcp remove`` left cached OAuth metadata on disk and
-    the gateway bootstrap re-read it on the next restart (#81050).
+    handled together — leftover per-server OAuth files can otherwise be
+    re-read when the server is re-added later (#81050).
     """
     from tools.mcp_oauth import HermesTokenStorage
 
@@ -655,9 +654,9 @@ def cmd_mcp_add(args):
 def cmd_mcp_remove(args):
     """Remove an MCP server from config AND clean up all on-disk state.
 
-    Always deletes the per-server files under ``mcp-tokens/`` so an
-    orphan ``.meta.json`` (or ``.client.json``) cannot be re-read by the
-    gateway bootstrap on the next restart (#81050).
+    Always deletes the per-server files under ``mcp-tokens/``, including
+    orphan files for servers no longer in config, so a later re-add of
+    the same server does not pick up stale OAuth state (#81050).
     """
     name = args.name
     existing = _get_mcp_servers()

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -142,12 +142,23 @@ async def replace_mcp_servers(body: MCPServersReplace, profile: Optional[str] = 
 
 @router.delete("/api/mcp/servers/{name}")
 async def remove_mcp_server(name: str, profile: Optional[str] = None):
-    from hermes_cli.mcp_config import _remove_mcp_server
+    from hermes_cli.mcp_config import _remove_mcp_server, _remove_mcp_token_files
 
     def _run():
         with _profile_scope(profile):
             with _CONFIG_MUTATION_LOCK:
-                return _remove_mcp_server(name)
+                removed = _remove_mcp_server(name)
+                # _remove_mcp_server also cleans token files, but if the
+                # server wasn't in config (orphan state) it still won't
+                # have been removed — heal the orphan so a later re-add
+                # of the same server can't pick up stale OAuth state
+                # (#81050).
+                if not removed:
+                    _remove_mcp_token_files(name)
+                    # Re-check: token files may have just been cleaned but
+                    # config never had the server, so it's still a 404.
+                    # We deliberately do NOT create a server here.
+                return removed
 
     removed = await asyncio.to_thread(_run)
     if not removed:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -168,6 +168,73 @@ class TestMcpRemove:
         cmd_mcp_remove(_make_args(name="oauth-srv"))
         assert not token_file.exists()
 
+    def test_remove_deletes_all_three_oauth_files(self, tmp_path, capsys, monkeypatch):
+        """Regression for issue #81050.
+
+        `hermes mcp remove` must delete the .json, .client.json, and
+        .meta.json siblings under mcp-tokens/, not just the token file.
+        """
+        _seed_config(tmp_path, {
+            "oauth-srv": {"url": "https://example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path
+        )
+
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        names = ["oauth-srv.json", "oauth-srv.client.json", "oauth-srv.meta.json"]
+        for fname in names:
+            (token_dir / fname).write_text("{}")
+
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="oauth-srv"))
+
+        remaining = sorted(p.name for p in token_dir.iterdir())
+        assert remaining == [], (
+            "expected all three oauth files deleted, leftover: " + repr(remaining)
+        )
+
+    def test_remove_orphan_cleans_token_files(self, tmp_path, capsys, monkeypatch):
+        """Regression for issue #81050.
+
+        If a server has already been removed from config but its token
+        files survive on disk (orphan state), `hermes mcp remove` must
+        still clean the leftover files so the server cannot be revived
+        on the next gateway restart.
+        """
+        # No config seeding — server is absent from mcp_servers, but
+        # token files still present on disk.
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        for fname in ("ghost.json", "ghost.client.json", "ghost.meta.json"):
+            (token_dir / fname).write_text("{}")
+
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="ghost"))
+
+        remaining = sorted(p.name for p in token_dir.iterdir())
+        assert remaining == [], (
+            "expected orphan token files deleted, leftover: " + repr(remaining)
+        )
+
+    def test_remove_keeps_config_when_orphan(self, tmp_path, capsys, monkeypatch):
+        """The orphan-cleanup branch must not create a config entry."""
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        (token_dir / "ghost.json").write_text("{}")
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="ghost"))
+
+        config = load_config()
+        assert "ghost" not in config.get("mcp_servers", {})
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_add

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -202,8 +202,8 @@ class TestMcpRemove:
 
         If a server has already been removed from config but its token
         files survive on disk (orphan state), `hermes mcp remove` must
-        still clean the leftover files so the server cannot be revived
-        on the next gateway restart.
+        still clean the leftover files so a later re-add of the same
+        server does not pick up stale OAuth state.
         """
         # No config seeding — server is absent from mcp_servers, but
         # token files still present on disk.


### PR DESCRIPTION
Addresses #81050

`hermes mcp remove <name>` left the `.client.json` and `.meta.json` siblings under `~/.hermes/mcp-tokens/` in two paths: the CLI orphan branch (name absent from `mcp_servers` in config.yaml) early-returned without touching token files, and the dashboard `DELETE /api/mcp/servers/{name}` removed the config entry only. Both paths now clean the per-server token files so a later re-add of the same server name cannot pick up stale OAuth state.

Centralises the per-server cleanup in a new `_remove_mcp_token_files()` helper that always routes through `HermesTokenStorage.remove()` so `.json`, `.client.json`, and `.meta.json` are handled together. `_remove_mcp_server()` now defaults to also cleaning token files, which propagates the fix to the dashboard endpoint. The in-config CLI path already deleted all three files via `get_manager().remove()` -> `remove_oauth_tokens()`; it is restructured to clean-before-confirm, with the manager-cache eviction as a best-effort debug log rather than a silent `except: pass`.

`cmd_mcp_remove()` now cleans token files BEFORE asking for confirmation, so an orphan server (missing from config but still on disk) heals instead of leaving stale OAuth state for a later re-add.

Regression tests:
- all three files deleted when the server is in config
- orphan token files cleaned when the server is already missing from config
- no phantom config entry is created during the orphan-cleanup branch
