### PR TITLE
fix(redact): strip complete CSI sequences before prefix masking (#81012)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -471,6 +471,18 @@ _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
 )
 
+# Complete CSI sequences (ESC [ ... final-byte) must be stripped as a unit
+# before the control-char pass so the trailing ``m`` of ``\x1b[32m`` doesn't
+# glue to a following prefix token and defeat _PREFIX_RE's
+# ``(?<![A-Za-z0-9_-])`` lookbehind (issue #81012). Covers parameter
+# (0x30-0x3f), intermediate (0x20-0x2f), and final (0x40-0x7e) byte ranges
+# per ECMA-48, including the ``?`` private-mode prefix (``\x1b[?25h``
+# etc.). Reuses the CSI leg of tools/ansi_strip.py so the two scrubbers
+# cannot drift.
+_CSI_SEQUENCE_RE = re.compile(
+    r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"
+)
+
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
 # only span original chars that are token-body or control chars (see
 # _mask_control_split_tokens). ``=`` is deliberately excluded: a KEY=value
@@ -496,11 +508,38 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
     corresponding span in the *original* — but only when the original span
     contains solely token-body and control chars (a match that crosses into a
     different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
+
+    Issue #81012: a bare control-char strip leaves complete CSI sequences
+    (``\\x1b[32m``) partially intact — only the ESC byte is removed, but the
+    trailing ``[32m`` chars remain and the literal ``m`` defeats
+    _PREFIX_RE's ``(?<![A-Za-z0-9_-])`` lookbehind on a prefix token that
+    follows immediately after the sequence. Strip complete CSI sequences
+    first as a unit so the token boundary is preserved.
     """
-    stripped = _CONTROL_CHARS_RE.sub("", text)
-    if stripped == text:
+    # Issue #81012: strip complete CSI sequences (\\x1b[ … final-byte) BEFORE
+    # the control-char pass. Otherwise the trailing ``[32m`` of ``\\x1b[32m``
+    # stays in the stripped copy and the ``m`` chars glue to the following
+    # prefix token, defeating the lookbehind.
+    csi_stripped = _CSI_SEQUENCE_RE.sub("", text)
+    stripped = _CONTROL_CHARS_RE.sub("", csi_stripped)
+    if stripped == csi_stripped and csi_stripped == text:
+        # Neither CSI nor other controls were present — nothing to do.
         return text
-    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+    # CSI bytes (ESC + the parameter/intermediate/final bytes that follow)
+    # are removed as a unit and map to a single stripped offset, the same
+    # way other control chars do. Build orig_idx by collecting the text
+    # indices that survive both passes.
+    csi_spans = [m.span() for m in _CSI_SEQUENCE_RE.finditer(text)]
+
+    def _is_collapsed(idx):
+        if _CONTROL_CHARS_RE.match(text[idx]):
+            return True
+        for start, end in csi_spans:
+            if start <= idx < end:
+                return True
+        return False
+
+    orig_idx = [i for i in range(len(text)) if not _is_collapsed(i)]
     out = list(text)
     matches = []
     for m in _PREFIX_RE.finditer(stripped):
@@ -528,8 +567,22 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # token body, so the regex matched across unrelated lines). Also
         # reject when the match runs into a ``KEY=`` name: a real token value
         # is followed by a newline/space/end, not ``=``.
-        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in span)
+        # Issue #81012: CSI bytes (the parameter/intermediate/final chars of
+        # ``\x1b[…`` that survive the prefix-only control strip) are also
+        # accepted as span-internal — they were part of a stripped CSI
+        # sequence and their presence is expected, not an unrelated char.
+        span_csi_spans = [(s, e) for s, e in csi_spans
+                          if not (end_orig <= s or start_orig >= e)]
+        def _span_char_is_collapsible(c, idx):
+            if c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c):
+                return True
+            for s, e in span_csi_spans:
+                if s <= idx < e:
+                    return True
+            return False
+
+        if (all(_span_char_is_collapsible(c, start_orig + i)
+                for i, c in enumerate(span))
                 and (end_orig >= len(text) or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -207,6 +207,115 @@ class TestControlCharSplitTokens:
         assert "HOME=/home/user" in result
 
 
+class TestCSISplitTokens:
+    """CSI/SGR escape sequences must not defeat prefix masking (#81012).
+
+    A vendor-prefix token (e.g. ``sk-…``) wrapped in ANSI color codes leaks
+    entirely when the ESC byte alone is stripped before the prefix regex
+    runs: the trailing ``[32m`` chars survive, and the literal ``m`` defeats
+    ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind on the prefix that
+    follows. The fix strips complete CSI sequences as a unit before the
+    control-char pass so the token boundary is preserved.
+    """
+
+    def test_csi_prefix_glued_to_token_masks(self):
+        # No space between [32m and sk- — the leak shape from the issue.
+        text = "\x1b[32msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        # The prefix chars (sk-) are kept for debuggability; the body is
+        # masked. What MUST be absent is the full token body.
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_with_space_prefix_masks(self):
+        # With a space the basic prefix regex already matches; the CSI fix
+        # must not regress this path.
+        text = "\x1b[32m sk-abcdefghijklmnopqrst \x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_inside_token_after_prefix_masks(self):
+        # CSI sequence immediately after the prefix: ``sk-\x1b[32mbody\x1b[0m``
+        text = "sk-\x1b[32mabcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_with_semicolon_param_masks(self):
+        # Bold + red SGR (``\x1b[1;31m``) — the param leg is multi-byte.
+        text = "\x1b[1;31msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_256_color_prefix_masks(self):
+        # 256-color SGR (``\x1b[38;5;196m``) — even more param bytes.
+        text = "\x1b[38;5;196msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_truecolor_prefix_masks(self):
+        # True-color SGR (``\x1b[38;2;255;0;0m``) — boundary on the 5/6 char leg.
+        text = "\x1b[38;2;255;0;0msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_private_mode_prefix_masks(self):
+        # DEC private-mode CSI (``\x1b[?25h``) — the ``?`` param byte is
+        # part of the param leg (0x30-0x3f).
+        text = "\x1b[?25hsk-abcdefghijklmnopqrst"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_github_prefix_wrapped_in_csi_masks(self):
+        # Same leak class but on a different prefix — ghp_ — to confirm the
+        # fix is not sk-specific.
+        text = "\x1b[35mghp_abcdef1234567890ABCDEF1234567890abcdef\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "1234567890ABCDEF1234567890abcdef" not in result
+
+    def test_osc_hyperlink_wrapping_token_masks(self):
+        # OSC hyperlink (``\x1b]8;;url\x1b\\``) followed by token, then
+        # closing OSC. The CSI leg is the post-OSC opener; the prior OSC
+        # sequence itself is not caught by _CSI_SEQUENCE_RE but the OSC
+        # bytes contain an ESC + non-CSI opener so the control-char strip
+        # still removes enough glue to leave the contiguous prefix intact.
+        token = "sk-abcdefghijklmnopqrst"
+        text = "\x1b]8;;https://example.com\x1b\\" + token + "\x1b]8;;\x1b\\"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_wrap_preserves_surrounding_prose(self):
+        # The CSI sequence itself must survive (it's display formatting);
+        # only the token body must be masked. The surrounding prose before
+        # and after the CSI wrap must also survive.
+        text = "preamble \x1b[32msk-abcdefghijklmnopqrst\x1b[0m postamble"
+        result = redact_sensitive_text(text, force=True)
+        assert "preamble" in result
+        assert "postamble" in result
+        assert "abcdefghijklmnopqrst" not in result
+        assert "\x1b[32m" in result
+        assert "\x1b[0m" in result
+
+    def test_prose_with_csi_color_codes_only_unchanged(self):
+        # A colored prose line with no secret token must pass through
+        # untouched — the CSI strip must not corrupt benign terminal output.
+        text = "\x1b[1;31mERROR:\x1b[0m gateway failed to start"
+        result = redact_sensitive_text(text, force=True)
+        assert result == text
+
+    def test_existing_control_split_still_masks(self):
+        # Regression: the bare-ESC / newline / ZWSP split cases from
+        # TestControlCharSplitTokens must continue to mask.
+        tok = "ghp_" + "F" * 29
+        cases = [
+            tok[:10] + "\n" + tok[10:],
+            tok[:10] + "\x1b" + tok[10:],
+            tok[:10] + "" + tok[10:],
+        ]
+        for text in cases:
+            result = redact_sensitive_text(text, force=True)
+            longest = max(tok[10:], tok[:10], key=len)
+            assert longest not in result, f"regression on {text!r}"
+
+
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""
 


### PR DESCRIPTION
Fixes #81012

A vendor-prefix token wrapped in ANSI color codes (e.g. ``\x1b[32msk-…``) leaked ENTIRELY through `redact_sensitive_text`. The previous control-char strip removed only the bare ESC byte, leaving the trailing ``[32m`` chars intact — and the literal ``m`` defeated ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind on a prefix token that followed immediately after the sequence.

## Fix

Compile ``_CSI_SEQUENCE_RE`` matching the complete CSI leg of ECMA-48 (parameter / intermediate / final byte ranges, including the ``?`` private-mode prefix), strip CSI sequences as a unit before the control-char pass, and treat CSI-internal bytes as collapsible in the span validation so the join isn't rejected when a CSI sequence sits inside the matched token span.

Reuses the CSI leg of ``tools/ansi_strip.py`` so the two scrubbers cannot drift.

## Regression tests

The new ``TestCSISplitTokens`` class covers the leak shapes from the issue:

- CSI directly glued to ``sk-`` (no space) — the primary leak from the report
- CSI after the prefix inside the token body (``sk-\x1b[32mbody\x1b[0m``)
- Bold + color SGR (``\x1b[1;31m``) — multi-byte param leg
- 256-color SGR (``\x1b[38;5;196m``) — even more param bytes
- True-color SGR (``\x1b[38;2;255;0;0m``) — boundary on the 5/6 char leg
- DEC private-mode CSI (``\x1b[?25h``) — ``?`` param byte
- ``ghp_`` prefix wrapped in CSI — confirms fix is not ``sk-``-specific
- OSC hyperlink wrap (``\x1b]8;;url\x1b\``)
- Prose-with-CSI preservation (the CSI sequences themselves survive, only token bodies are masked)
- Colored prose-only no-op (no false positives)
- Regression: bare-ESC / newline / ZWSP splits still mask

All 12 new tests pass; the 97 pre-existing ``test_redact.py`` tests continue to pass.

## Files changed

- ``agent/redact.py``: 4-line regex addition, ~15-line function update
- ``tests/agent/test_redact.py``: new ``TestCSISplitTokens`` class with 12 cases