### PR TITLE
fix(mcp): always purge .meta/.client/.json OAuth state on mcp remove (#81050)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -638,13 +638,41 @@ def cmd_mcp_remove(args):
     _remove_mcp_server(name)
     _success(f"Removed '{name}' from config")
 
-    # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
-    # any provider instance cached in the current process (e.g. from an
-    # earlier `hermes mcp test` in the same session) is evicted too.
+    # Always wipe the three on-disk OAuth state files for this server
+    # (`<name>.json`, `<name>.client.json`, `<name>.meta.json`) so a removed
+    # OAuth server can never be revived on the next gateway restart. The
+    # manager path below additionally evicts any cached provider instance
+    # from the current process (e.g. from an earlier `hermes mcp test`).
+    # Without the explicit disk cleanup here, a manager-path failure would
+    # silently leak the `.meta.json` / `.client.json` files (#81050).
+    _purge_oauth_state_files(name)
+    _success("Cleaned up OAuth state")
+
+
+def _purge_oauth_state_files(name: str) -> None:
+    """Delete ``<name>.json`` / ``<name>.client.json`` / ``<name>.meta.json``.
+
+    Failures are logged but never raised so the CLI command can still report
+    success on the config removal — partial cleanup is strictly better than
+    a visible crash on a non-fatal concern, but the user should still see a
+    warning so they can investigate.
+    """
+    try:
+        from tools.mcp_oauth import HermesTokenStorage
+        HermesTokenStorage(name).remove()
+    except Exception as exc:
+        logger.warning(
+            "Failed to purge OAuth state files for MCP server %r: %s",
+            name,
+            exc,
+        )
+
+    # Best-effort: also evict any provider instance cached in this process
+    # via MCPOAuthManager. Errors here are non-fatal because the disk
+    # cleanup above already accomplished the user-visible goal.
     try:
         from tools.mcp_oauth_manager import get_manager
         get_manager().remove(name)
-        _success("Cleaned up OAuth tokens")
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -169,6 +169,56 @@ class TestMcpRemove:
         assert not token_file.exists()
 
 
+    def test_remove_cleans_all_oauth_files(self, tmp_path, capsys, monkeypatch):
+        """Regression for #81050: ``hermes mcp remove`` must delete *all* of
+        ``<name>.json``, ``<name>.client.json`` and ``<name>.meta.json`` so a
+        removed OAuth server cannot be revived on the next gateway restart.
+        Previously the command relied on ``MCPOAuthManager.remove()``, which
+        can fail silently (e.g. manager not initialised, or the lookup raises),
+        leaving the ``.meta.json`` / ``.client.json`` files behind.
+        """
+        _seed_config(tmp_path, {
+            "oauth-srv": {"url": "https://example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path
+        )
+
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        token_file = token_dir / "oauth-srv.json"
+        client_file = token_dir / "oauth-srv.client.json"
+        meta_file = token_dir / "oauth-srv.meta.json"
+        token_file.write_text("{}")
+        client_file.write_text("{}")
+        meta_file.write_text("{}")
+
+        # Make the OAuth manager raise on the remove path so we exercise the
+        # fallback (the bug surfaces when ``get_manager().remove(name)`` is
+        # not in fact available — e.g. in a fresh profile, or when the
+        # manager module is still importing).
+        from tools import mcp_oauth_manager as mgr_mod
+
+        monkeypatch.setattr(
+            mgr_mod.MCPOAuthManager,
+            "remove",
+            lambda self, name, *, hermes_home=None: (_ for _ in ()).throw(
+                RuntimeError("simulated manager failure for #81050")
+            ),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="oauth-srv"))
+
+        # The CLI's own cleanup must guarantee all three files are gone even
+        # when the manager path is unavailable.
+        assert not token_file.exists(), "<name>.json left behind"
+        assert not client_file.exists(), "<name>.client.json left behind"
+        assert not meta_file.exists(), "<name>.meta.json left behind"
+
+
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_add
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #81050

`hermes mcp remove` relied on `MCPOAuthManager.remove()` to wipe the three per-server OAuth state files (`<name>.json`, `<name>.client.json`, `<name>.meta.json`). When the manager path raised (e.g. during profile setup, when the manager module is still importing, or any path that bypasses the cache), the bare `except Exception: pass` silently kept all three files on disk. The leftover `.meta.json` / `.client.json` then caused the gateway bootstrap to revive the server on every restart, defeating the user's intent — a multi-day crash-loop root cause in the reporter's case.

Always call `HermesTokenStorage(name).remove()` first so the three files are guaranteed gone. The `manager.remove()` call remains as a best-effort in-process cache eviction (separate concern, also wrapped).

A regression test (`test_remove_cleans_all_oauth_files`) pre-seeds the three files, monkeypatches the manager to raise, and asserts all three files are gone after `cmd_mcp_remove`. Without the fix the test fails on `<name>.json` being left behind.