### PR TITLE
fix(gateway): suppress duplicate final send after queued-followup fallback (#81052)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25807,6 +25807,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 first_response,
                                 metadata=_status_thread_metadata,
                             )
+                            # Mark delivery on the stream consumer so the
+                            # normal completion pipeline that runs after this
+                            # branch recognises the response as already in
+                            # the user's chat and does not re-send the same
+                            # text moments later (#81052).
+                            if _sc is not None and hasattr(
+                                _sc, "mark_out_of_band_delivery"
+                            ):
+                                try:
+                                    _sc.mark_out_of_band_delivery(first_response)
+                                except Exception as _mark_exc:
+                                    logger.debug(
+                                        "Stream consumer mark_out_of_band_delivery failed: %s",
+                                        _mark_exc,
+                                    )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -362,6 +362,28 @@ class GatewayStreamConsumer:
         """The Discord/chat message ID of the last-sent or edited message."""
         return self._message_id
 
+    def mark_out_of_band_delivery(self, text: str) -> None:
+        """Record that ``text`` reached the user via a non-streaming send.
+
+        Used by paths like the queued-follow-up fallback in
+        ``gateway/run.py`` that hand ``first_response`` straight to
+        ``adapter.send()`` when streaming confirmation has not yet arrived.
+        Without this, the normal completion pipeline does not know the
+        message is already in the user's chat and re-sends the same text
+        moments later (#81052).
+
+        Sets ``final_response_sent`` / ``final_content_delivered`` so the
+        gateway's suppression check (the same ``_stream_confirmed_final_delivery``
+        predicate the streaming path uses) recognises the message as
+        delivered, and records the text so ``delivered_final_matches``
+        reconciles cleanly with the completed ``final_response``.
+        """
+        if not text:
+            return
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._record_turn_final_payload(text)
+
     @property
     def final_content_delivered(self) -> bool:
         """True when the final response content reached the user, even if

--- a/tests/gateway/test_81052_queued_followup_double_send.py
+++ b/tests/gateway/test_81052_queued_followup_double_send.py
@@ -1,0 +1,77 @@
+"""Regression test for #81052 — duplicate message delivery on slow turns.
+
+When the gateway takes the queued-follow-up fallback path (``adapter.send()``
+of ``first_response`` because streaming confirmation did not arrive in time),
+the normal completion pipeline that runs after the fallback was unaware the
+response had already been delivered. The user saw the same reply twice.
+
+The fix introduces ``GatewayStreamConsumer.mark_out_of_band_delivery`` so the
+gateway can record the non-streaming delivery and the subsequent
+``_stream_confirmed_final_delivery`` predicate returns ``True``, suppressing
+the second send.
+"""
+
+from unittest.mock import MagicMock
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _make_consumer() -> GatewayStreamConsumer:
+    """Build a bare GatewayStreamConsumer for the new flag tests."""
+    return GatewayStreamConsumer(
+        adapter=MagicMock(),
+        chat_id="123",
+        config=StreamConsumerConfig(cursor=" ▉"),
+        metadata=None,
+        run_still_current=lambda: True,
+    )
+
+
+class TestMarkOutOfBandDelivery:
+    def test_sets_final_response_sent_flag(self):
+        consumer = _make_consumer()
+        assert consumer.final_response_sent is False
+
+        consumer.mark_out_of_band_delivery("hello world")
+
+        assert consumer.final_response_sent is True
+
+    def test_sets_final_content_delivered_flag(self):
+        consumer = _make_consumer()
+        assert consumer.final_content_delivered is False
+
+        consumer.mark_out_of_band_delivery("hello world")
+
+        assert consumer.final_content_delivered is True
+
+    def test_records_payload_for_delivered_final_matches(self):
+        """``delivered_final_matches`` must return ``True`` for the recorded
+        text so ``_stream_confirmed_final_delivery`` recognises the message
+        as delivered when the normal completion pipeline runs."""
+        consumer = _make_consumer()
+        consumer.mark_out_of_band_delivery("queued follow-up reply")
+
+        assert consumer.delivered_final_matches("queued follow-up reply") is True
+
+    def test_mismatch_returns_false(self):
+        """If the recorded text differs from the completed ``final_response``,
+        ``delivered_final_matches`` returns ``False`` (mirroring the streaming
+        path's behaviour for stale preview snapshots — #71643). The caller
+        then keeps the normal send so the user gets the correct answer
+        instead of a phantom duplicate.
+        """
+        consumer = _make_consumer()
+        consumer.mark_out_of_band_delivery("first guess")
+
+        assert consumer.delivered_final_matches("completed response") is False
+
+    def test_empty_text_is_no_op(self):
+        """An empty ``text`` must not poison the flags — without this guard a
+        caller that hands ``first_response = ""`` would mark the consumer as
+        delivered even though nothing was sent."""
+        consumer = _make_consumer()
+
+        consumer.mark_out_of_band_delivery("")
+
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False


### PR DESCRIPTION
Fixes #81052

When the queued-follow-up path fell back to calling `adapter.send()` on `first_response` (because streaming confirmation had not arrived in time), the normal completion pipeline that runs after the fallback was unaware the response had already been delivered. The user saw the same reply twice in their Slack DM / Discord channel / etc.

Introduce `GatewayStreamConsumer.mark_out_of_band_delivery(text)` so the gateway can record a non-streaming delivery in a way the existing `_stream_confirmed_final_delivery` predicate recognises: it sets the same `final_response_sent` / `final_content_delivered` flags and records the payload via `_record_turn_final_payload` so `delivered_final_matches` reconciles cleanly with the completed `final_response`.

`gateway/run.py` calls `_sc.mark_out_of_band_delivery(first_response)` immediately after the fallback `adapter.send()` returns. Subsequent normal-completion `_stream_confirmed_final_delivery(...)` returns `True` and the second send is suppressed.

New tests in `tests/gateway/test_81052_queued_followup_double_send.py` lock in the flag set, the `delivered_final_matches` reconciliation (both `True` for matching text and `False` for stale payloads, mirroring #71643), and the empty-text no-op guard.