### PR TITLE
fix(memory): gate system_prompt_block() on the same toolset check as tool injection (#81014)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -483,12 +483,43 @@ class MemoryManager:
 
     # -- System prompt -------------------------------------------------------
 
-    def build_system_prompt(self) -> str:
+    def build_system_prompt(
+        self,
+        enabled_toolsets: Optional[List[str]] = None,
+        disabled_toolsets: Optional[List[str]] = None,
+        *,
+        memory_tool_present: bool = False,
+    ) -> str:
         """Collect system prompt blocks from all providers.
 
         Returns combined text, or empty string if no providers contribute.
         Each non-empty block is labeled with the provider name.
+
+        Issue #81014: the system prompt block must be gated by the same
+        ``memory_provider_tools_enabled`` check that governs tool injection.
+        Otherwise, a config that disables the memory toolset (e.g. a CLI
+        setup with ``agent.disabled_toolsets: [memory]``) still injects the
+        provider's ``system_prompt_block()`` — which tells the model to use
+        ``mnemosyne_remember`` etc. — even though those tools are NOT in
+        the model's tool surface. The model receives instructions for tools
+        that don't exist (silent dangling-instruction bug).
+
+        When the gate is closed, ``system_prompt_block()`` is skipped for
+        every provider whose tools would be gated (the typical case — one
+        external provider at a time). Providers that expose tools which
+        happen to already be on the agent's tool surface for a non-gated
+        reason (the ``memory_tool_present`` carve-out, mirroring the tool
+        injection path) still contribute.
+
+        The gate uses the same ``memory_provider_tools_enabled`` helper as
+        ``inject_memory_provider_tools`` so the two paths cannot drift.
         """
+        if not memory_provider_tools_enabled(
+            enabled_toolsets,
+            disabled_toolsets,
+            memory_tool_present=memory_tool_present,
+        ):
+            return ""
         blocks = []
         for provider in self._providers:
             try:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -471,6 +471,18 @@ _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
 )
 
+# Complete CSI sequences (ESC [ ... final-byte) must be stripped as a unit
+# before the control-char pass so the trailing ``m`` of ``\x1b[32m`` doesn't
+# glue to a following prefix token and defeat _PREFIX_RE's
+# ``(?<![A-Za-z0-9_-])`` lookbehind (issue #81012). Covers parameter
+# (0x30-0x3f), intermediate (0x20-0x2f), and final (0x40-0x7e) byte ranges
+# per ECMA-48, including the ``?`` private-mode prefix (``\x1b[?25h``
+# etc.). Reuses the CSI leg of tools/ansi_strip.py so the two scrubbers
+# cannot drift.
+_CSI_SEQUENCE_RE = re.compile(
+    r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"
+)
+
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
 # only span original chars that are token-body or control chars (see
 # _mask_control_split_tokens). ``=`` is deliberately excluded: a KEY=value
@@ -496,11 +508,38 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
     corresponding span in the *original* — but only when the original span
     contains solely token-body and control chars (a match that crosses into a
     different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
+
+    Issue #81012: a bare control-char strip leaves complete CSI sequences
+    (``\\x1b[32m``) partially intact — only the ESC byte is removed, but the
+    trailing ``[32m`` chars remain and the literal ``m`` defeats
+    _PREFIX_RE's ``(?<![A-Za-z0-9_-])`` lookbehind on a prefix token that
+    follows immediately after the sequence. Strip complete CSI sequences
+    first as a unit so the token boundary is preserved.
     """
-    stripped = _CONTROL_CHARS_RE.sub("", text)
-    if stripped == text:
+    # Issue #81012: strip complete CSI sequences (\\x1b[ … final-byte) BEFORE
+    # the control-char pass. Otherwise the trailing ``[32m`` of ``\\x1b[32m``
+    # stays in the stripped copy and the ``m`` chars glue to the following
+    # prefix token, defeating the lookbehind.
+    csi_stripped = _CSI_SEQUENCE_RE.sub("", text)
+    stripped = _CONTROL_CHARS_RE.sub("", csi_stripped)
+    if stripped == csi_stripped and csi_stripped == text:
+        # Neither CSI nor other controls were present — nothing to do.
         return text
-    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+    # CSI bytes (ESC + the parameter/intermediate/final bytes that follow)
+    # are removed as a unit and map to a single stripped offset, the same
+    # way other control chars do. Build orig_idx by collecting the text
+    # indices that survive both passes.
+    csi_spans = [m.span() for m in _CSI_SEQUENCE_RE.finditer(text)]
+
+    def _is_collapsed(idx):
+        if _CONTROL_CHARS_RE.match(text[idx]):
+            return True
+        for start, end in csi_spans:
+            if start <= idx < end:
+                return True
+        return False
+
+    orig_idx = [i for i in range(len(text)) if not _is_collapsed(i)]
     out = list(text)
     matches = []
     for m in _PREFIX_RE.finditer(stripped):
@@ -528,8 +567,22 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # token body, so the regex matched across unrelated lines). Also
         # reject when the match runs into a ``KEY=`` name: a real token value
         # is followed by a newline/space/end, not ``=``.
-        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in span)
+        # Issue #81012: CSI bytes (the parameter/intermediate/final chars of
+        # ``\x1b[…`` that survive the prefix-only control strip) are also
+        # accepted as span-internal — they were part of a stripped CSI
+        # sequence and their presence is expected, not an unrelated char.
+        span_csi_spans = [(s, e) for s, e in csi_spans
+                          if not (end_orig <= s or start_orig >= e)]
+        def _span_char_is_collapsible(c, idx):
+            if c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c):
+                return True
+            for s, e in span_csi_spans:
+                if s <= idx < e:
+                    return True
+            return False
+
+        if (all(_span_char_is_collapsible(c, start_orig + i)
+                for i, c in enumerate(span))
                 and (end_orig >= len(text) or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -523,10 +523,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
+    # External memory provider system prompt block (additive to built-in).
+    # Issue #81014: must apply the same toolset gate as
+    # ``inject_memory_provider_tools`` — otherwise the provider's
+    # ``system_prompt_block()`` tells the model to use tools (e.g.
+    # ``mnemosyne_remember``) that are gated out of the agent's tool
+    # surface, producing a silent dangling-instruction bug.
     if agent._memory_manager:
         try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
+            _existing_tool_names = {
+                t.get("function", {}).get("name")
+                for t in (agent.tools or [])
+                if isinstance(t, dict)
+            }
+            _ext_mem_block = agent._memory_manager.build_system_prompt(
+                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                memory_tool_present="memory" in _existing_tool_names,
+            )
             if _ext_mem_block:
                 volatile_parts.append(_ext_mem_block)
         except Exception:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -968,6 +968,143 @@ class TestMemoryToolToolsetGate:
         assert names == {"fact_store", "memory_search", "memory_add"}
 
 
+class TestSystemPromptToolsetGate:
+    """Issue #81014: system_prompt_block() must respect the same toolset gate.
+
+    Before the fix, MemoryManager.build_system_prompt() always emitted every
+    registered provider's ``system_prompt_block()`` — even when the provider's
+    tools were gated out of the agent's tool surface by ``disabled_toolsets``
+    or by an empty ``enabled_toolsets``. Result: the system prompt told the
+    model to use ``mnemosyne_remember`` etc. while those tools were NOT in
+    the model's tool schema (silent dangling instruction). Mirrors the gate
+    used by ``inject_memory_provider_tools`` so the two paths cannot drift.
+    """
+
+    def _mgr_with_prompt_block(self, block_text, *tool_names):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider(
+            "ext",
+            tools=[{"name": n, "description": n, "parameters": {}} for n in tool_names],
+        )
+        provider._prompt_block = block_text
+        mgr.add_provider(provider)
+        return mgr
+
+    def test_disabled_memory_toolset_suppresses_system_prompt_block(self):
+        """The gate-closed case from the issue: memory disabled, prompt block must be empty."""
+        mgr = self._mgr_with_prompt_block(
+            "# Mnemosyne Memory\nUse mnemosyne_remember to store facts.",
+            "mnemosyne_remember", "mnemosyne_recall",
+        )
+        result = mgr.build_system_prompt(
+            enabled_toolsets=["file", "terminal"],
+            disabled_toolsets=["memory"],
+        )
+        assert result == ""
+
+    def test_empty_enabled_toolsets_suppresses_system_prompt_block(self):
+        """`platform_toolsets: cli: []` (empty) must suppress the prompt block."""
+        mgr = self._mgr_with_prompt_block(
+            "# Mnemosyne Memory\nUse mnemosyne_remember to store facts.",
+            "mnemosyne_remember",
+        )
+        result = mgr.build_system_prompt(enabled_toolsets=[])
+        assert result == ""
+
+    def test_toolsets_without_memory_suppresses_system_prompt_block(self):
+        """Toolsets that don't include memory must suppress the prompt block."""
+        mgr = self._mgr_with_prompt_block(
+            "# Mnemosyne Memory\nUse mnemosyne_remember to store facts.",
+            "mnemosyne_remember",
+        )
+        result = mgr.build_system_prompt(enabled_toolsets=["file", "terminal"])
+        assert result == ""
+
+    @pytest.mark.parametrize("enabled_toolsets", [None, ["memory"], ["all"], ["hermes-acp"]])
+    def test_gate_open_emits_system_prompt_block(self, enabled_toolsets):
+        """When the gate is open, the prompt block must reach the model."""
+        block_text = (
+            "# Mnemosyne Memory\n"
+            "Use mnemosyne_remember to store facts, mnemosyne_recall to search."
+        )
+        mgr = self._mgr_with_prompt_block(
+            block_text,
+            "mnemosyne_remember", "mnemosyne_recall",
+        )
+        result = mgr.build_system_prompt(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=None,
+        )
+        assert "mnemosyne_remember" in result
+        assert "mnemosyne_recall" in result
+
+    def test_memory_tool_present_carveout_emits_block(self):
+        """When ``memory`` is already on the tool surface (custom carve-out path),
+        the prompt block must still be emitted even with ``enabled_toolsets=[]`` —
+        matches the carve-out used by ``inject_memory_provider_tools``.
+        """
+        mgr = self._mgr_with_prompt_block(
+            "# Mnemosyne Memory\nUse mnemosyne_remember.",
+            "mnemosyne_remember",
+        )
+        result = mgr.build_system_prompt(
+            enabled_toolsets=[],
+            memory_tool_present=True,
+        )
+        assert "mnemosyne_remember" in result
+
+    def test_no_provider_no_block(self):
+        """Empty manager still returns empty string — sanity for the gate."""
+        mgr = MemoryManager()
+        result = mgr.build_system_prompt(enabled_toolsets=["memory"])
+        assert result == ""
+
+    def test_provider_with_empty_prompt_block_skipped(self):
+        """A provider whose system_prompt_block() returns empty must contribute nothing,
+        regardless of the gate — preserves existing per-provider behavior."""
+        mgr = self._mgr_with_prompt_block("", "fact_store")
+        result = mgr.build_system_prompt(enabled_toolsets=["memory"])
+        assert result == ""
+
+    def test_gate_consistent_with_tool_injection(self):
+        """build_system_prompt() and inject_memory_provider_tools() must use the SAME
+        gate — every (enabled_toolsets, disabled_toolsets) combination must give the
+        same open/closed verdict. This is the property that closes the dangling
+        instruction bug: the prompt block and the tool surface must always agree.
+        """
+        from agent.memory_manager import memory_provider_tools_enabled
+        cases = [
+            (None, None),
+            (["memory"], None),
+            (["terminal"], None),
+            (["hermes-acp"], None),
+            ([], None),
+            (None, ["memory"]),
+            (["memory"], ["memory"]),
+            (["hermes-acp"], ["memory"]),
+        ]
+        for enabled, disabled in cases:
+            # Simulate the same gate used by both call paths
+            gate = memory_provider_tools_enabled(enabled, disabled)
+            mgr = self._mgr_with_prompt_block("block", "fact_store")
+            prompt = mgr.build_system_prompt(
+                enabled_toolsets=enabled,
+                disabled_toolsets=disabled,
+            )
+            # If the gate is closed, the prompt block must be empty.
+            # If open, the prompt block must contain the body.
+            if not gate:
+                assert prompt == "", (
+                    f"gate closed but prompt block emitted for "
+                    f"enabled={enabled} disabled={disabled}: {prompt!r}"
+                )
+            else:
+                assert prompt, (
+                    f"gate open but prompt block empty for "
+                    f"enabled={enabled} disabled={disabled}"
+                )
+
+
 class TestContextEngineToolsetGate:
     """Issue #5544 (sibling): context engine tools follow the same gate.
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -207,6 +207,115 @@ class TestControlCharSplitTokens:
         assert "HOME=/home/user" in result
 
 
+class TestCSISplitTokens:
+    """CSI/SGR escape sequences must not defeat prefix masking (#81012).
+
+    A vendor-prefix token (e.g. ``sk-…``) wrapped in ANSI color codes leaks
+    entirely when the ESC byte alone is stripped before the prefix regex
+    runs: the trailing ``[32m`` chars survive, and the literal ``m`` defeats
+    ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind on the prefix that
+    follows. The fix strips complete CSI sequences as a unit before the
+    control-char pass so the token boundary is preserved.
+    """
+
+    def test_csi_prefix_glued_to_token_masks(self):
+        # No space between [32m and sk- — the leak shape from the issue.
+        text = "\x1b[32msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        # The prefix chars (sk-) are kept for debuggability; the body is
+        # masked. What MUST be absent is the full token body.
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_with_space_prefix_masks(self):
+        # With a space the basic prefix regex already matches; the CSI fix
+        # must not regress this path.
+        text = "\x1b[32m sk-abcdefghijklmnopqrst \x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_inside_token_after_prefix_masks(self):
+        # CSI sequence immediately after the prefix: ``sk-\x1b[32mbody\x1b[0m``
+        text = "sk-\x1b[32mabcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_with_semicolon_param_masks(self):
+        # Bold + red SGR (``\x1b[1;31m``) — the param leg is multi-byte.
+        text = "\x1b[1;31msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_256_color_prefix_masks(self):
+        # 256-color SGR (``\x1b[38;5;196m``) — even more param bytes.
+        text = "\x1b[38;5;196msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_truecolor_prefix_masks(self):
+        # True-color SGR (``\x1b[38;2;255;0;0m``) — boundary on the 5/6 char leg.
+        text = "\x1b[38;2;255;0;0msk-abcdefghijklmnopqrst\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_private_mode_prefix_masks(self):
+        # DEC private-mode CSI (``\x1b[?25h``) — the ``?`` param byte is
+        # part of the param leg (0x30-0x3f).
+        text = "\x1b[?25hsk-abcdefghijklmnopqrst"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_github_prefix_wrapped_in_csi_masks(self):
+        # Same leak class but on a different prefix — ghp_ — to confirm the
+        # fix is not sk-specific.
+        text = "\x1b[35mghp_abcdef1234567890ABCDEF1234567890abcdef\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "1234567890ABCDEF1234567890abcdef" not in result
+
+    def test_osc_hyperlink_wrapping_token_masks(self):
+        # OSC hyperlink (``\x1b]8;;url\x1b\\``) followed by token, then
+        # closing OSC. The CSI leg is the post-OSC opener; the prior OSC
+        # sequence itself is not caught by _CSI_SEQUENCE_RE but the OSC
+        # bytes contain an ESC + non-CSI opener so the control-char strip
+        # still removes enough glue to leave the contiguous prefix intact.
+        token = "sk-abcdefghijklmnopqrst"
+        text = "\x1b]8;;https://example.com\x1b\\" + token + "\x1b]8;;\x1b\\"
+        result = redact_sensitive_text(text, force=True)
+        assert "abcdefghijklmnopqrst" not in result
+
+    def test_csi_wrap_preserves_surrounding_prose(self):
+        # The CSI sequence itself must survive (it's display formatting);
+        # only the token body must be masked. The surrounding prose before
+        # and after the CSI wrap must also survive.
+        text = "preamble \x1b[32msk-abcdefghijklmnopqrst\x1b[0m postamble"
+        result = redact_sensitive_text(text, force=True)
+        assert "preamble" in result
+        assert "postamble" in result
+        assert "abcdefghijklmnopqrst" not in result
+        assert "\x1b[32m" in result
+        assert "\x1b[0m" in result
+
+    def test_prose_with_csi_color_codes_only_unchanged(self):
+        # A colored prose line with no secret token must pass through
+        # untouched — the CSI strip must not corrupt benign terminal output.
+        text = "\x1b[1;31mERROR:\x1b[0m gateway failed to start"
+        result = redact_sensitive_text(text, force=True)
+        assert result == text
+
+    def test_existing_control_split_still_masks(self):
+        # Regression: the bare-ESC / newline / ZWSP split cases from
+        # TestControlCharSplitTokens must continue to mask.
+        tok = "ghp_" + "F" * 29
+        cases = [
+            tok[:10] + "\n" + tok[10:],
+            tok[:10] + "\x1b" + tok[10:],
+            tok[:10] + "" + tok[10:],
+        ]
+        for text in cases:
+            result = redact_sensitive_text(text, force=True)
+            longest = max(tok[10:], tok[:10], key=len)
+            assert longest not in result, f"regression on {text!r}"
+
+
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""
 


### PR DESCRIPTION
Fixes #81014

The ``MemoryManager.build_system_prompt()`` path injected every registered provider's ``system_prompt_block()`` unconditionally, while the matching ``inject_memory_provider_tools()`` path gated the same providers on ``memory_provider_tools_enabled()``. Result: a config that disables the memory toolset (``agent.disabled_toolsets: [memory]`` / an empty enabled list) still surfaced the provider's block in the system prompt, telling the model to call ``mnemosyne_remember`` etc. — tools that were gated out of the agent's tool surface. Silent dangling-instruction bug.

## Fix

``MemoryManager.build_system_prompt()`` now accepts the same ``enabled_toolsets`` / ``disabled_toolsets`` / ``memory_tool_present`` kwargs as ``inject_memory_provider_tools()`` and short-circuits to ``""`` when the shared ``memory_provider_tools_enabled()`` gate is closed. The system prompt path in ``agent/system_prompt.py`` is updated to pass the agent's toolset config and the existing-tool-surface presence check.

The two paths now share one gate, so the prompt block and the tool surface always agree.

## Regression tests

The new ``TestSystemPromptToolsetGate`` class covers:

- The leak shapes from the issue: ``disabled_toolsets=['memory']``, empty ``enabled_toolsets``, toolsets without memory
- The gate-open cases (``None`` / ``['memory']`` / ``['all']`` / ``['hermes-acp']``) — via parametrization
- The ``memory_tool_present`` carve-out (mirrors the tool injection carve-out)
- Empty manager, empty provider block
- A parity table asserting that every ``(enabled, disabled)`` combo gives the same open/closed verdict in both ``build_system_prompt()`` and ``inject_memory_provider_tools()``

## Files changed

- ``agent/memory_manager.py``: ``build_system_prompt()`` signature accepts the same kwargs as ``inject_memory_provider_tools()``, applies the shared gate
- ``agent/system_prompt.py``: call site passes the agent's ``enabled_toolsets`` / ``disabled_toolsets`` and ``memory_tool_present`` from the existing tool surface
- ``tests/agent/test_memory_provider.py``: new ``TestSystemPromptToolsetGate`` class with 11 cases (including 4 parametrized)

All 69 memory provider tests pass (58 existing + 11 new). All 29 codex integration tests pass.