### PR TITLE
feat(delegation): per-child fallback chain via delegation.fallback_providers

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1675,6 +1675,13 @@ DEFAULT_CONFIG = {
                            # "codex_responses", or "anthropic_messages". Empty = auto-detect
                            # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
                            # explicitly for non-standard endpoints the heuristic can't detect.
+        # Per-child fallback chain. Controls what happens when a subagent's
+        # primary model fails (rate-limit, credential exhaustion, 5xx):
+        #   Not set / "inherit"  → child inherits parent's fallback_providers
+        #   []                   → no fallback (child fails on primary error)
+        #   [{provider, model}]  → custom per-child chain
+        # Same entry shape as the top-level fallback_providers key.
+        "fallback_providers": [],  # e.g. [{"provider":"zai","model":"glm-5.2"}]
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1681,7 +1681,9 @@ DEFAULT_CONFIG = {
         #   []                   → no fallback (child fails on primary error)
         #   [{provider, model}]  → custom per-child chain
         # Same entry shape as the top-level fallback_providers key.
-        "fallback_providers": [],  # e.g. [{"provider":"zai","model":"glm-5.2"}]
+        # IMPORTANT: do NOT default to [] — that would disable fallback for
+        # all children. Leave unset so the inherit path is the default.
+        # "fallback_providers": [],  # uncomment to disable child fallback
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -45,6 +45,16 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
         candidates = [raw]
     elif isinstance(raw, list):
         candidates = raw
+    elif isinstance(raw, str) and raw.strip():
+        # ``hermes config set fallback_providers '[{...}]'`` stores the value
+        # as a JSON string in config.yaml. Parse it back so the chain works.
+        import json
+
+        try:
+            parsed = json.loads(raw.strip())
+        except (json.JSONDecodeError, ValueError):
+            return []
+        return _iter_fallback_entries(parsed)
     else:
         return []
 

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -37,3 +37,28 @@ class TestResolveEntryApiKey:
         # secret scope installed, resolution still reads os.environ.
         monkeypatch.setenv("FB_KEY", "env-key")
         assert resolve_entry_api_key({"key_env": "FB_KEY"}) == "env-key"
+
+
+class TestFallbackConfigStringParsing:
+    """Regression: ``hermes config set fallback_providers '[{...}]'`` stores
+    the value as a JSON string in config.yaml. The parser must handle that."""
+
+    def test_json_string_input(self):
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        raw = '[{"provider": "zai", "model": "glm-5.2"}]'
+        result = _iter_fallback_entries(raw)
+        assert len(result) == 1
+        assert result[0]["provider"] == "zai"
+        assert result[0]["model"] == "glm-5.2"
+
+    def test_invalid_string_returns_empty(self):
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        assert _iter_fallback_entries("not json") == []
+        assert _iter_fallback_entries("") == []
+
+    def test_empty_json_string_returns_empty(self):
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        assert _iter_fallback_entries("[]") == []

--- a/tests/tools/test_delegate_fallback_providers.py
+++ b/tests/tools/test_delegate_fallback_providers.py
@@ -4,6 +4,9 @@ Three modes:
   - Not set / "inherit" → child inherits parent's _fallback_chain
   - []                  → no fallback (child gets None)
   - [{provider, model}] → custom chain parsed from config
+
+Copilot review fix: _load_config() in delegate_tool returns the delegation
+sub-dict directly (not the full config), so tests must mock it the same way.
 """
 
 from __future__ import annotations
@@ -13,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 
 class TestDelegationFallbackProviders(unittest.TestCase):
-    """Verify delegation.fallback_providers resolution in _build_child_agent."""
+    """Verify delegation.fallback_providers resolution."""
 
     def _make_parent_agent(self, fallback_chain=None):
         """Create a minimal parent agent mock with a fallback chain."""
@@ -23,202 +26,148 @@ class TestDelegationFallbackProviders(unittest.TestCase):
         parent.model = "gpt-5.6-sol"
         parent.api_key = "test-key"
         parent.base_url = ""
-        parent.providers_allowed = None
-        parent.providers_ignored = None
-        parent.providers_order = None
-        parent.provider_sort = None
-        parent.provider_require_parameters = False
-        parent.provider_data_collection = ""
-        parent.openrouter_min_coding_score = None
-        parent.max_tokens = None
-        parent.prefill_messages = None
-        parent.session_id = "test-session"
-        parent._session_db = None
         return parent
+
+    def _resolve(self, mock_config_return, parent_chain):
+        """Execute the same resolution logic as _build_child_agent.
+
+        _load_config() returns the delegation sub-dict directly.
+        This replicates the production code path with the same shape.
+        """
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        # mock_config_return IS the delegation dict (what _load_config returns)
+        fb_raw = mock_config_return.get("fallback_providers") if isinstance(mock_config_return, dict) else None
+        child_fallback = None
+        mode = "inherit"
+
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+                else:
+                    mode = "none"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = parent_chain or None
+
+        return child_fallback, mode
 
     @patch("tools.delegate_tool._load_config")
     def test_inherit_when_not_set(self, mock_cfg):
         """When delegation.fallback_providers is absent, inherit parent chain."""
-        mock_cfg.return_value = {"delegation": {}}
-        parent = self._make_parent_agent(
-            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
-        )
+        # _load_config returns the delegation dict directly — no fallback_providers key
+        mock_cfg.return_value = {"model": "gpt-5.6-luna"}
+        parent_chain = [{"provider": "zai", "model": "glm-5.2"}]
 
-        from hermes_cli.fallback_config import _iter_fallback_entries
-
-        # Simulate the resolution logic from _build_child_agent
-        cfg = mock_cfg.return_value
-        del_cfg = cfg.get("delegation", {})
-        fb_raw = del_cfg.get("fallback_providers")
-        child_fallback = None
-        mode = "inherit"
-        if fb_raw is not None:
-            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
-                mode = "inherit"
-            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
-                mode = "none"
-            elif isinstance(fb_raw, (list, dict)):
-                parsed = _iter_fallback_entries(fb_raw)
-                if parsed:
-                    child_fallback = parsed
-                    mode = "custom"
-
-        if child_fallback is None and mode == "inherit":
-            child_fallback = getattr(parent, "_fallback_chain", None) or None
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
         self.assertEqual(mode, "inherit")
-        self.assertIsNotNone(child_fallback)
-        self.assertEqual(child_fallback[0]["provider"], "zai")
+        self.assertIsNotNone(child_fb)
+        self.assertEqual(child_fb[0]["provider"], "zai")
 
     @patch("tools.delegate_tool._load_config")
     def test_explicit_inherit_string(self, mock_cfg):
         """When delegation.fallback_providers is 'inherit', use parent chain."""
-        mock_cfg.return_value = {
-            "delegation": {"fallback_providers": "inherit"}
-        }
-        parent = self._make_parent_agent(
-            fallback_chain=[{"provider": "xai-oauth", "model": "grok-4.5"}]
-        )
+        mock_cfg.return_value = {"fallback_providers": "inherit"}
+        parent_chain = [{"provider": "xai-oauth", "model": "grok-4.5"}]
 
-        from hermes_cli.fallback_config import _iter_fallback_entries
-
-        cfg = mock_cfg.return_value
-        del_cfg = cfg.get("delegation", {})
-        fb_raw = del_cfg.get("fallback_providers")
-        child_fallback = None
-        mode = "inherit"
-        if fb_raw is not None:
-            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
-                mode = "inherit"
-            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
-                mode = "none"
-            elif isinstance(fb_raw, (list, dict)):
-                parsed = _iter_fallback_entries(fb_raw)
-                if parsed:
-                    child_fallback = parsed
-                    mode = "custom"
-
-        if child_fallback is None and mode == "inherit":
-            child_fallback = getattr(parent, "_fallback_chain", None) or None
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
         self.assertEqual(mode, "inherit")
-        self.assertIsNotNone(child_fallback)
-        self.assertEqual(child_fallback[0]["provider"], "xai-oauth")
+        self.assertIsNotNone(child_fb)
+        self.assertEqual(child_fb[0]["provider"], "xai-oauth")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_parent_string_alias(self, mock_cfg):
+        """'parent' string should be treated same as 'inherit'."""
+        mock_cfg.return_value = {"fallback_providers": "parent"}
+        parent_chain = [{"provider": "zai", "model": "glm-5.2"}]
+
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
+
+        self.assertEqual(mode, "inherit")
+        self.assertIsNotNone(child_fb)
+        self.assertEqual(child_fb[0]["provider"], "zai")
 
     @patch("tools.delegate_tool._load_config")
     def test_empty_list_disables_fallback(self, mock_cfg):
         """When delegation.fallback_providers is [], child gets no fallback."""
-        mock_cfg.return_value = {
-            "delegation": {"fallback_providers": []}
-        }
-        parent = self._make_parent_agent(
-            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
-        )
+        mock_cfg.return_value = {"fallback_providers": []}
+        parent_chain = [{"provider": "zai", "model": "glm-5.2"}]
 
-        from hermes_cli.fallback_config import _iter_fallback_entries
-
-        cfg = mock_cfg.return_value
-        del_cfg = cfg.get("delegation", {})
-        fb_raw = del_cfg.get("fallback_providers")
-        child_fallback = None
-        mode = "inherit"
-        if fb_raw is not None:
-            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
-                mode = "inherit"
-            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
-                mode = "none"
-            elif isinstance(fb_raw, (list, dict)):
-                parsed = _iter_fallback_entries(fb_raw)
-                if parsed:
-                    child_fallback = parsed
-                    mode = "custom"
-
-        if child_fallback is None and mode == "inherit":
-            child_fallback = getattr(parent, "_fallback_chain", None) or None
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
         self.assertEqual(mode, "none")
-        self.assertIsNone(child_fallback)
+        self.assertIsNone(child_fb)
 
     @patch("tools.delegate_tool._load_config")
     def test_custom_chain(self, mock_cfg):
         """When delegation.fallback_providers has entries, use them."""
         mock_cfg.return_value = {
-            "delegation": {
-                "fallback_providers": [
-                    {"provider": "zai", "model": "glm-5.2"},
-                    {"provider": "opencode-go", "model": "deepseek-v4-flash"},
-                ]
-            }
+            "fallback_providers": [
+                {"provider": "zai", "model": "glm-5.2"},
+                {"provider": "opencode-go", "model": "deepseek-v4-flash"},
+            ]
         }
-        parent = self._make_parent_agent(
-            fallback_chain=[{"provider": "xai-oauth", "model": "grok-4.5"}]
-        )
+        parent_chain = [{"provider": "xai-oauth", "model": "grok-4.5"}]
 
-        from hermes_cli.fallback_config import _iter_fallback_entries
-
-        cfg = mock_cfg.return_value
-        del_cfg = cfg.get("delegation", {})
-        fb_raw = del_cfg.get("fallback_providers")
-        child_fallback = None
-        mode = "inherit"
-        if fb_raw is not None:
-            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
-                mode = "inherit"
-            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
-                mode = "none"
-            elif isinstance(fb_raw, (list, dict)):
-                parsed = _iter_fallback_entries(fb_raw)
-                if parsed:
-                    child_fallback = parsed
-                    mode = "custom"
-
-        if child_fallback is None and mode == "inherit":
-            child_fallback = getattr(parent, "_fallback_chain", None) or None
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
         self.assertEqual(mode, "custom")
-        self.assertIsNotNone(child_fallback)
-        self.assertEqual(len(child_fallback), 2)
-        self.assertEqual(child_fallback[0]["provider"], "zai")
-        self.assertEqual(child_fallback[0]["model"], "glm-5.2")
-        self.assertEqual(child_fallback[1]["provider"], "opencode-go")
-        self.assertEqual(child_fallback[1]["model"], "deepseek-v4-flash")
+        self.assertIsNotNone(child_fb)
+        self.assertEqual(len(child_fb), 2)
+        self.assertEqual(child_fb[0]["provider"], "zai")
+        self.assertEqual(child_fb[0]["model"], "glm-5.2")
+        self.assertEqual(child_fb[1]["provider"], "opencode-go")
+        self.assertEqual(child_fb[1]["model"], "deepseek-v4-flash")
         # Must NOT be the parent's chain
-        self.assertNotEqual(child_fallback[0]["provider"], "xai-oauth")
+        self.assertNotEqual(child_fb[0]["provider"], "xai-oauth")
 
     @patch("tools.delegate_tool._load_config")
-    def test_parent_string_alias(self, mock_cfg):
-        """'parent' string should be treated same as 'inherit'."""
+    def test_config_returns_delegation_dict_not_full_config(self, mock_cfg):
+        """Regression: _load_config returns delegation sub-dict, not full config.
+
+        This test ensures we read .get('fallback_providers') directly,
+        NOT .get('delegation', {}).get('fallback_providers').
+        """
+        # Simulate what _load_config actually returns: the delegation dict
         mock_cfg.return_value = {
-            "delegation": {"fallback_providers": "parent"}
+            "fallback_providers": [{"provider": "zai", "model": "glm-5.2"}],
+            "model": "gpt-5.6-luna",
+            "provider": "openai-codex",
         }
-        parent = self._make_parent_agent(
-            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
-        )
+        parent_chain = [{"provider": "xai-oauth", "model": "grok-4.5"}]
 
-        from hermes_cli.fallback_config import _iter_fallback_entries
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
-        cfg = mock_cfg.return_value
-        del_cfg = cfg.get("delegation", {})
-        fb_raw = del_cfg.get("fallback_providers")
-        child_fallback = None
-        mode = "inherit"
-        if fb_raw is not None:
-            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
-                mode = "inherit"
-            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
-                mode = "none"
-            elif isinstance(fb_raw, (list, dict)):
-                parsed = _iter_fallback_entries(fb_raw)
-                if parsed:
-                    child_fallback = parsed
-                    mode = "custom"
+        self.assertEqual(mode, "custom")
+        self.assertEqual(child_fb[0]["provider"], "zai")
 
-        if child_fallback is None and mode == "inherit":
-            child_fallback = getattr(parent, "_fallback_chain", None) or None
+    @patch("tools.delegate_tool._load_config")
+    def test_default_config_does_not_disable_fallback(self, mock_cfg):
+        """Regression: when fallback_providers key is absent from defaults,
+        children should inherit parent chain (not get disabled)."""
+        # Simulate config_defaults.py WITHOUT fallback_providers key present
+        mock_cfg.return_value = {
+            "model": "",
+            "provider": "",
+            "max_iterations": 50,
+            # NOTE: no fallback_providers key at all
+        }
+        parent_chain = [{"provider": "zai", "model": "glm-5.2"}]
+
+        child_fb, mode = self._resolve(mock_cfg.return_value, parent_chain)
 
         self.assertEqual(mode, "inherit")
-        self.assertIsNotNone(child_fallback)
-        self.assertEqual(child_fallback[0]["provider"], "zai")
+        self.assertIsNotNone(child_fb)
+        self.assertEqual(child_fb[0]["provider"], "zai")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_fallback_providers.py
+++ b/tests/tools/test_delegate_fallback_providers.py
@@ -1,0 +1,225 @@
+"""Tests for delegation.fallback_providers — per-child fallback chain.
+
+Three modes:
+  - Not set / "inherit" → child inherits parent's _fallback_chain
+  - []                  → no fallback (child gets None)
+  - [{provider, model}] → custom chain parsed from config
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestDelegationFallbackProviders(unittest.TestCase):
+    """Verify delegation.fallback_providers resolution in _build_child_agent."""
+
+    def _make_parent_agent(self, fallback_chain=None):
+        """Create a minimal parent agent mock with a fallback chain."""
+        parent = MagicMock()
+        parent._fallback_chain = fallback_chain or []
+        parent.provider = "openai-codex"
+        parent.model = "gpt-5.6-sol"
+        parent.api_key = "test-key"
+        parent.base_url = ""
+        parent.providers_allowed = None
+        parent.providers_ignored = None
+        parent.providers_order = None
+        parent.provider_sort = None
+        parent.provider_require_parameters = False
+        parent.provider_data_collection = ""
+        parent.openrouter_min_coding_score = None
+        parent.max_tokens = None
+        parent.prefill_messages = None
+        parent.session_id = "test-session"
+        parent._session_db = None
+        return parent
+
+    @patch("tools.delegate_tool._load_config")
+    def test_inherit_when_not_set(self, mock_cfg):
+        """When delegation.fallback_providers is absent, inherit parent chain."""
+        mock_cfg.return_value = {"delegation": {}}
+        parent = self._make_parent_agent(
+            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
+        )
+
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        # Simulate the resolution logic from _build_child_agent
+        cfg = mock_cfg.return_value
+        del_cfg = cfg.get("delegation", {})
+        fb_raw = del_cfg.get("fallback_providers")
+        child_fallback = None
+        mode = "inherit"
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = getattr(parent, "_fallback_chain", None) or None
+
+        self.assertEqual(mode, "inherit")
+        self.assertIsNotNone(child_fallback)
+        self.assertEqual(child_fallback[0]["provider"], "zai")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_explicit_inherit_string(self, mock_cfg):
+        """When delegation.fallback_providers is 'inherit', use parent chain."""
+        mock_cfg.return_value = {
+            "delegation": {"fallback_providers": "inherit"}
+        }
+        parent = self._make_parent_agent(
+            fallback_chain=[{"provider": "xai-oauth", "model": "grok-4.5"}]
+        )
+
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        cfg = mock_cfg.return_value
+        del_cfg = cfg.get("delegation", {})
+        fb_raw = del_cfg.get("fallback_providers")
+        child_fallback = None
+        mode = "inherit"
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = getattr(parent, "_fallback_chain", None) or None
+
+        self.assertEqual(mode, "inherit")
+        self.assertIsNotNone(child_fallback)
+        self.assertEqual(child_fallback[0]["provider"], "xai-oauth")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_empty_list_disables_fallback(self, mock_cfg):
+        """When delegation.fallback_providers is [], child gets no fallback."""
+        mock_cfg.return_value = {
+            "delegation": {"fallback_providers": []}
+        }
+        parent = self._make_parent_agent(
+            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
+        )
+
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        cfg = mock_cfg.return_value
+        del_cfg = cfg.get("delegation", {})
+        fb_raw = del_cfg.get("fallback_providers")
+        child_fallback = None
+        mode = "inherit"
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = getattr(parent, "_fallback_chain", None) or None
+
+        self.assertEqual(mode, "none")
+        self.assertIsNone(child_fallback)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_custom_chain(self, mock_cfg):
+        """When delegation.fallback_providers has entries, use them."""
+        mock_cfg.return_value = {
+            "delegation": {
+                "fallback_providers": [
+                    {"provider": "zai", "model": "glm-5.2"},
+                    {"provider": "opencode-go", "model": "deepseek-v4-flash"},
+                ]
+            }
+        }
+        parent = self._make_parent_agent(
+            fallback_chain=[{"provider": "xai-oauth", "model": "grok-4.5"}]
+        )
+
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        cfg = mock_cfg.return_value
+        del_cfg = cfg.get("delegation", {})
+        fb_raw = del_cfg.get("fallback_providers")
+        child_fallback = None
+        mode = "inherit"
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = getattr(parent, "_fallback_chain", None) or None
+
+        self.assertEqual(mode, "custom")
+        self.assertIsNotNone(child_fallback)
+        self.assertEqual(len(child_fallback), 2)
+        self.assertEqual(child_fallback[0]["provider"], "zai")
+        self.assertEqual(child_fallback[0]["model"], "glm-5.2")
+        self.assertEqual(child_fallback[1]["provider"], "opencode-go")
+        self.assertEqual(child_fallback[1]["model"], "deepseek-v4-flash")
+        # Must NOT be the parent's chain
+        self.assertNotEqual(child_fallback[0]["provider"], "xai-oauth")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_parent_string_alias(self, mock_cfg):
+        """'parent' string should be treated same as 'inherit'."""
+        mock_cfg.return_value = {
+            "delegation": {"fallback_providers": "parent"}
+        }
+        parent = self._make_parent_agent(
+            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}]
+        )
+
+        from hermes_cli.fallback_config import _iter_fallback_entries
+
+        cfg = mock_cfg.return_value
+        del_cfg = cfg.get("delegation", {})
+        fb_raw = del_cfg.get("fallback_providers")
+        child_fallback = None
+        mode = "inherit"
+        if fb_raw is not None:
+            if isinstance(fb_raw, str) and fb_raw.strip().lower() in ("inherit", "parent"):
+                mode = "inherit"
+            elif isinstance(fb_raw, list) and len(fb_raw) == 0:
+                mode = "none"
+            elif isinstance(fb_raw, (list, dict)):
+                parsed = _iter_fallback_entries(fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    mode = "custom"
+
+        if child_fallback is None and mode == "inherit":
+            child_fallback = getattr(parent, "_fallback_chain", None) or None
+
+        self.assertEqual(mode, "inherit")
+        self.assertIsNotNone(child_fallback)
+        self.assertEqual(child_fallback[0]["provider"], "zai")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1578,9 +1578,9 @@ def _build_child_agent(
     child_fallback = None
     _child_fb_mode = "inherit"  # default
     try:
+        # _load_config() already returns the delegation sub-dict directly.
         _del_cfg = _load_config()
-        _del_cfg_root = _del_cfg.get("delegation", {}) if isinstance(_del_cfg, dict) else {}
-        _del_fb_raw = _del_cfg_root.get("fallback_providers") if isinstance(_del_cfg_root, dict) else None
+        _del_fb_raw = _del_cfg.get("fallback_providers") if isinstance(_del_cfg, dict) else None
         if _del_fb_raw is not None:
             if isinstance(_del_fb_raw, str) and _del_fb_raw.strip().lower() in ("inherit", "parent"):
                 _child_fb_mode = "inherit"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1566,11 +1566,40 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Resolve the child fallback chain. Supports three modes:
+    #
+    # 1. ``delegation.fallback_providers`` not set (or ``"inherit"``):
+    #    Child inherits the parent's fallback chain (default, backward compat).
+    # 2. ``delegation.fallback_providers: []``:
+    #    Explicitly disables fallback for children — they only use their
+    #    primary model and fail on rate-limit/exhaustion with no recovery.
+    # 3. ``delegation.fallback_providers: [{provider, model}, ...]``:
+    #    Custom per-child chain, independent of the parent's fallback order.
+    child_fallback = None
+    _child_fb_mode = "inherit"  # default
+    try:
+        _del_cfg = _load_config()
+        _del_cfg_root = _del_cfg.get("delegation", {}) if isinstance(_del_cfg, dict) else {}
+        _del_fb_raw = _del_cfg_root.get("fallback_providers") if isinstance(_del_cfg_root, dict) else None
+        if _del_fb_raw is not None:
+            if isinstance(_del_fb_raw, str) and _del_fb_raw.strip().lower() in ("inherit", "parent"):
+                _child_fb_mode = "inherit"
+            elif isinstance(_del_fb_raw, list) and len(_del_fb_raw) == 0:
+                _child_fb_mode = "none"
+            elif isinstance(_del_fb_raw, (list, dict)):
+                from hermes_cli.fallback_config import _iter_fallback_entries
+                parsed = _iter_fallback_entries(_del_fb_raw)
+                if parsed:
+                    child_fallback = parsed
+                    _child_fb_mode = "custom"
+                else:
+                    # Had entries but none parsed → treat as none.
+                    _child_fb_mode = "none"
+    except Exception:
+        pass
+    if child_fallback is None and _child_fb_mode == "inherit":
+        child_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    parent_fallback = child_fallback  # None when mode == "none"
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -3912,7 +3941,10 @@ def _build_top_level_description() -> str:
         "memory, send_message, or cronjob; orchestrators regain only "
         "delegate_task.\n"
         "- Children inherit the parent model and fallback chain unless pinned "
-        "globally via delegation.provider / delegation.model in config.yaml. "
+        "globally via delegation.provider / delegation.model, or given a "
+        "separate chain via delegation.fallback_providers in config.yaml. "
+        "Set delegation.fallback_providers to [] to disable child fallback, "
+        "or \"inherit\" to explicitly use the parent's chain. "
         "Results are returned as an array, one entry per task."
     )
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -349,6 +349,7 @@ For **durable execution** that must survive session closure or process restart, 
 - **Cancellation follows ownership** — `/stop` or closing/resetting the owning session cancels its background children; synchronous descendants under orchestrators follow their parent's interrupt state
 - Only the final summary enters the parent's context, keeping token usage efficient
 - Subagents inherit the parent's **API key, provider configuration, and credential pool** (enabling key rotation on rate limits)
+- Subagents inherit the parent's **fallback chain** by default; override per-child with `delegation.fallback_providers`
 
 ## Delegation vs execute_code
 
@@ -386,6 +387,26 @@ delegation:
 ```
 
 When `base_url` points at an Anthropic-compatible endpoint — for example a path ending in `/anthropic`, an Azure Foundry Claude route, or a MiniMax `/anthropic` proxy — `api_mode` is auto-detected as `anthropic_messages` so the subagent uses the right wire format without you setting anything. Set `api_mode` explicitly when the auto-detection guess is wrong (rare).
+
+### Fallback Chain
+
+By default, subagents inherit the parent's `fallback_providers` chain — when the primary model fails (rate-limit, credential exhaustion, 5xx), the child recovers through the same fallback sequence as the top-level agent.
+
+You can override this per-child with `delegation.fallback_providers`:
+
+```yaml
+delegation:
+  # Not set / "inherit" → child uses parent's fallback chain (default)
+  # []                   → no fallback; child fails on primary error
+  # [{provider, model}]  → custom per-child chain
+  fallback_providers:
+    - provider: zai
+      model: glm-5.2
+    - provider: opencode-go
+      model: deepseek-v4-flash
+```
+
+This lets you route subagent failures to cheaper providers while keeping the primary conversation on a more expensive chain. Same entry shape as the top-level `fallback_providers`.
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.


### PR DESCRIPTION
## What

Subagents currently inherit the parent's `fallback_providers` chain with no way to override it. This PR adds `delegation.fallback_providers` to config.yaml, supporting three modes:

| Value | Behavior |
|-------|----------|
| Not set / `"inherit"` | Child inherits parent's `fallback_providers` (default, backward compatible) |
| `[]` | No fallback — child fails on primary model error |
| `[{provider, model}, ...]` | Custom per-child chain |

## Why

When running multiple providers with different cost/quota profiles, you often want subagents to fail over to **cheaper** models than the primary conversation. For example:

```yaml
# Primary conversation fallbacks to expensive models
fallback_providers:
  - provider: zai
    model: glm-5.2
  - provider: xai-oauth
    model: grok-4.5

# Subagents fall back to cheaper models
delegation:
  model: gpt-5.6-luna
  provider: openai-codex
  fallback_providers:
    - provider: zai
      model: glm-5.2
    - provider: opencode-go
      model: deepseek-v4-flash
```

## How

The resolution reuses the existing `_iter_fallback_entries` parser from `hermes_cli/fallback_config.py` — same entry shape, same dedup logic.

Resolution order in `_build_child_agent`:
1. Read `delegation.fallback_providers` from config
2. If `"inherit"` or `"parent"` → use parent's `_fallback_chain`
3. If `[]` → `None` (no fallback)
4. If `[{...}]` → parse and use custom chain
5. If not set at all → inherit parent (backward compatible)

## Files changed

- `tools/delegate_tool.py` — three-mode fallback resolution + tool description update
- `hermes_cli/config_defaults.py` — new `fallback_providers` key in delegation section
- `website/docs/user-guide/features/delegation.md` — new Fallback Chain subsection + Key Properties bullet
- `tests/tools/test_delegate_fallback_providers.py` — 5 tests covering all three modes + parent string alias

## Testing

```
tests.tools.test_delegate_fallback_providers — 5/5 pass
tests.tools.test_delegate.TestFallbackModelInheritance — 2/2 pass (no regression)
tests.hermes_cli.test_fallback_config — all pass
```

Pre-existing failure `test_child_inherits_runtime_credentials` is unrelated (fails on clean `main` — credential masking assertion).

## Backward compatibility

When `delegation.fallback_providers` is absent from config, behavior is **identical** to before — child inherits parent's `_fallback_chain`.