### PR TITLE
fix(accounting): forward resolved api_key to /models metadata probe (#75479)

### DIFF
--- a/agent/aux_accounting.py
+++ b/agent/aux_accounting.py
@@ -74,6 +74,7 @@ def record_aux_usage(
     *,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> None:
     """Record an auxiliary response's token usage against the ambient session.
 
@@ -88,6 +89,13 @@ def record_aux_usage(
     The model is read from ``response.model`` (accurate even after the aux
     client's provider-fallback chains); *provider*/*base_url* reflect the
     originally-resolved route and are best-effort.
+
+    Issue #75479: *api_key* must be propagated through to
+    ``estimate_usage_cost`` so the ``/models`` metadata probe on auth-gated
+    providers (LiteLLM proxy and similar) succeeds. Without it, the probe
+    returns 401 and the cost falls back to the no-pricing path even though
+    inference works. The caller — ``_validate_llm_response`` — has access
+    to the resolved ``api_key`` from the auxiliary-client route resolver.
     """
     try:
         if not task or task in _EXCLUDED_TASKS:
@@ -114,7 +122,7 @@ def record_aux_usage(
         estimated_cost = None
         try:
             cost = estimate_usage_cost(
-                model, usage, provider=provider, base_url=base_url
+                model, usage, provider=provider, base_url=base_url, api_key=api_key,
             )
             if cost.amount_usd is not None:
                 estimated_cost = float(cost.amount_usd)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8115,6 +8115,7 @@ def _validate_llm_response(
     task: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> Any:
     """Validate that an LLM response has the expected .choices[0].message shape.
 
@@ -8131,13 +8132,21 @@ def _validate_llm_response(
     best-effort and never affects validation. *provider*/*base_url* are
     optional accounting hints — fallback-path calls omit them and the row
     keeps the model (read from the response itself) with an empty route.
+
+    Issue #75479: *api_key* is forwarded from the resolved auxiliary-client
+    route so the ``/models`` metadata probe used for pricing can authenticate
+    against providers that gate ``/models`` behind auth (LiteLLM proxy and
+    similar). Without it, the probe returns 401 and the cost falls back to
+    the no-pricing path even though inference works.
     """
     if response is None:
         raise RuntimeError(
             f"Auxiliary {task or 'call'}: LLM returned None response"
         )
     from agent.aux_accounting import record_aux_usage
-    record_aux_usage(response, task, provider=provider, base_url=base_url)
+    record_aux_usage(
+        response, task, provider=provider, base_url=base_url, api_key=api_key,
+    )
     # Allow SimpleNamespace responses from adapters (CodexAuxiliaryClient,
     # AnthropicAuxiliaryClient) — they have .choices[0].message.
     try:
@@ -9646,7 +9655,8 @@ async def _async_call_llm_impl(
                     create=_acreate,
                 ),
                 task,
-                provider=request_provider, base_url=_client_base)
+                provider=request_provider, base_url=_client_base,
+                api_key=resolved_api_key)
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -42,6 +42,7 @@ def _estimate_cost(
     cache_write_tokens: int = 0,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> tuple[float, str]:
     """Estimate the USD cost for a session row or a model/token tuple."""
     if isinstance(session_or_model, dict):
@@ -68,6 +69,7 @@ def _estimate_cost(
         usage,
         provider=provider,
         base_url=base_url,
+        api_key=api_key,
     )
     return float(result.amount_usd or 0.0), result.status
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1172,6 +1172,58 @@ def _pricing_entry_from_metadata(
     )
 
 
+def _configured_endpoint_api_key(
+    provider: Optional[str],
+    base_url: Optional[str],
+) -> str:
+    """Resolve a configured route's key without crossing endpoint boundaries.
+
+    Salved from #75510 (andyst-dev): pricing is also recomputed outside live
+    inference (for example by ``hermes insights``), where callers only retain
+    provider/base URL metadata. Resolve the current profile's credential only
+    when its configured endpoint is exactly the route being probed. This
+    prevents a stale or attacker-chosen billing URL from receiving a
+    credential for another provider, and complements the live-path api_key
+    forwarding from the auxiliary client (#75479).
+    """
+    if not base_url:
+        return ""
+    try:
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            get_env_value_prefer_dotenv,
+            load_config,
+        )
+        from hermes_cli.providers import resolve_provider_full
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        config = load_config()
+        if not isinstance(config, dict) or not provider:
+            return ""
+        user_providers = config.get("providers")
+        if not isinstance(user_providers, dict):
+            user_providers = {}
+        resolved = resolve_provider_full(
+            provider,
+            user_providers=user_providers,
+            custom_providers=get_compatible_custom_providers(config),
+        )
+        if resolved is None or (
+            normalize_route_base_url(resolved.base_url)
+            != normalize_route_base_url(base_url)
+        ):
+            return ""
+        for env_name in resolved.api_key_env_vars:
+            secret = str(get_env_value_prefer_dotenv(env_name) or "").strip()
+            if secret:
+                return secret
+    except Exception:
+        # Pricing lookup is best-effort and must never break the agent or
+        # insights generation because config/credential resolution failed.
+        return ""
+    return ""
+
+
 def get_pricing_entry(
     model_name: str,
     provider: Optional[str] = None,
@@ -1191,8 +1243,12 @@ def get_pricing_entry(
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
     if route.base_url:
+        endpoint_api_key = api_key or _configured_endpoint_api_key(
+            provider or route.provider,
+            route.base_url,
+        )
         entry = _pricing_entry_from_metadata(
-            fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
+            fetch_endpoint_model_metadata(route.base_url, api_key=endpoint_api_key),
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -293,6 +293,65 @@ class TestAuxApiKeyForwarding:
         )
         assert sig.parameters["api_key"].default is None
 
+    def test_get_pricing_entry_falls_back_to_configured_endpoint_key(self, monkeypatch):
+        """Offline path (no api_key forwarded — e.g. ``hermes insights``):
+        get_pricing_entry must resolve the configured route's credential via
+        route identity and pass it to the /models probe.
+
+        Salvaged from #75510 (andyst-dev): the route-identity guard means the
+        configured key is only used when the profile's resolved endpoint IS
+        the probed route — a stale or attacker-chosen billing URL never
+        receives another provider's credential.
+        """
+        from unittest.mock import MagicMock
+
+        from agent import usage_pricing as up
+
+        captured = {}
+
+        def _fake_resolve(provider, *, user_providers=None, custom_providers=None):
+            return SimpleNamespace(
+                base_url="https://litellm.example/v1",
+                api_key_env_vars=("LITELLM_API_KEY",),
+            )
+
+        def _fake_env(name):
+            return "sk-configured-route-key" if name == "LITELLM_API_KEY" else None
+
+        def _fake_fetch(base_url, api_key=""):
+            captured["base_url"] = base_url
+            captured["api_key"] = api_key
+            return MagicMock()
+
+        monkeypatch.setattr(up, "fetch_endpoint_model_metadata", _fake_fetch)
+        monkeypatch.setattr(
+            "hermes_cli.providers.resolve_provider_full", _fake_resolve
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.get_env_value_prefer_dotenv", _fake_env
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"providers": {}})
+
+        # No api_key forwarded (offline path): the config route-identity
+        # fallback must supply the credential to the probe.
+        up.get_pricing_entry(
+            "litellm/gpt-4o",
+            provider="litellm-proxy",
+            base_url="https://litellm.example/v1",
+        )
+        assert captured.get("api_key") == "sk-configured-route-key"
+        assert captured.get("base_url") == "https://litellm.example/v1"
+
+        # A forwarded api_key (live path) wins over the config fallback.
+        captured.clear()
+        up.get_pricing_entry(
+            "litellm/gpt-4o",
+            provider="litellm-proxy",
+            base_url="https://litellm.example/v1",
+            api_key="sk-live-forwarded",
+        )
+        assert captured.get("api_key") == "sk-live-forwarded"
+
 
 class TestInsightsApiKeyForwarding:
     """Issue #75479 (sibling): agent/insights.py _estimate_cost must also

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -155,6 +155,190 @@ class TestSchemaMigrationV22:
         db2.close()
 
 
+class TestAuxApiKeyForwarding:
+    """Issue #75479: api_key must reach estimate_usage_cost() so the /models
+    metadata probe on auth-gated providers (LiteLLM proxy and similar) succeeds.
+    Before the fix, ``record_aux_usage`` accepted ``provider``/``base_url`` but
+    not ``api_key`` — so the resolved auxiliary-client api_key never reached
+    the pricing path, and the probe returned 401, silently downgrading the
+    cost to ``status="unknown"``.
+    """
+
+    def test_record_aux_usage_forwards_api_key(self, monkeypatch, db):
+        """The api_key kwarg on record_aux_usage must reach
+        estimate_usage_cost verbatim — no silent None, no empty-string default
+        (empty string was the previous behavior on the hot path because the
+        caller didn't pass any key at all).
+        """
+        captured = {}
+        # estimate_usage_cost is imported lazily inside record_aux_usage, so
+        # patch the source module rather than aux_accounting's namespace.
+        from agent import usage_pricing as up
+
+        def _spy_estimate(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = dict(kwargs)
+            return up.CostResult(
+                amount_usd=None, status="unknown", source="none", label="n/a",
+            )
+
+        monkeypatch.setattr(up, "estimate_usage_cost", _spy_estimate)
+
+        db.create_session("s1", source="cli")
+        from agent.aux_accounting import (
+            record_aux_usage,
+            reset_accounting_context,
+            set_accounting_context,
+        )
+        token = set_accounting_context(db, "s1")
+        try:
+            record_aux_usage(
+                _mk_response(model="aux-m"),
+                "vision",
+                provider="litellm-proxy",
+                base_url="https://litellm.example/v1",
+                api_key="sk-litellm-test-key",
+            )
+        finally:
+            reset_accounting_context(token)
+
+        assert captured["kwargs"]["api_key"] == "sk-litellm-test-key"
+        assert captured["kwargs"]["provider"] == "litellm-proxy"
+        assert captured["kwargs"]["base_url"] == "https://litellm.example/v1"
+
+    def test_record_aux_usage_omitted_api_key_stays_none(self, monkeypatch, db):
+        """Backward-compat: callers that don't pass api_key (the aux fallback
+        path) must still work — api_key=None propagates as None.
+        """
+        captured = {}
+        from agent import usage_pricing as up
+
+        def _spy_estimate(*args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            return up.CostResult(
+                amount_usd=None, status="unknown", source="none", label="n/a",
+            )
+
+        monkeypatch.setattr(up, "estimate_usage_cost", _spy_estimate)
+
+        db.create_session("s1", source="cli")
+        from agent.aux_accounting import (
+            record_aux_usage,
+            reset_accounting_context,
+            set_accounting_context,
+        )
+        token = set_accounting_context(db, "s1")
+        try:
+            record_aux_usage(_mk_response(model="aux-m"), "vision", provider="gemini")
+        finally:
+            reset_accounting_context(token)
+
+        # api_key default is None — must NOT be silently coerced to ""
+        assert captured["kwargs"].get("api_key") is None
+
+    def test_validate_llm_response_accepts_and_forwards_api_key(self, monkeypatch):
+        """_validate_llm_response must accept the api_key kwarg and forward it
+        through record_aux_usage. This is the gate that fixes the leak: the
+        caller (auxiliary_client) has resolved_api_key in scope but the
+        previous signature dropped it on the floor.
+        """
+        from agent.auxiliary_client import _validate_llm_response
+
+        captured_args = []
+        captured_kwargs = {}
+
+        def _spy_record(*args, **kwargs):
+            captured_args.append(args)
+            captured_kwargs.update(kwargs)
+            return None
+
+        monkeypatch.setattr("agent.aux_accounting.record_aux_usage", _spy_record)
+
+        resp = _mk_response(model="aux-m", prompt=10, completion=5)
+        result = _validate_llm_response(
+            resp, "vision",
+            provider="litellm-proxy",
+            base_url="https://litellm.example/v1",
+            api_key="sk-litellm-test-key",
+        )
+
+        assert captured_kwargs["api_key"] == "sk-litellm-test-key"
+        assert captured_kwargs["provider"] == "litellm-proxy"
+        assert captured_kwargs["base_url"] == "https://litellm.example/v1"
+        assert captured_args[0][1] == "vision"  # task is the 2nd positional arg
+        # The original response must still be returned for downstream validation
+        assert result is resp
+
+    def test_validate_llm_response_signature_includes_api_key(self):
+        """Static check: _validate_llm_response must expose api_key as a
+        keyword parameter so the resolved route's credentials can be passed.
+        """
+        import inspect
+        from agent.auxiliary_client import _validate_llm_response
+        sig = inspect.signature(_validate_llm_response)
+        assert "api_key" in sig.parameters, (
+            f"_validate_llm_response missing api_key param; signature is {sig}"
+        )
+        assert sig.parameters["api_key"].default is None
+
+    def test_record_aux_usage_signature_includes_api_key(self):
+        """Static check: record_aux_usage must expose api_key as a keyword
+        parameter so _validate_llm_response can forward it.
+        """
+        import inspect
+        from agent.aux_accounting import record_aux_usage
+        sig = inspect.signature(record_aux_usage)
+        assert "api_key" in sig.parameters, (
+            f"record_aux_usage missing api_key param; signature is {sig}"
+        )
+        assert sig.parameters["api_key"].default is None
+
+
+class TestInsightsApiKeyForwarding:
+    """Issue #75479 (sibling): agent/insights.py _estimate_cost must also
+    accept and forward api_key. The insights path operates over persisted
+    session rows (no live credentials), so the caller may not always have a
+    key — but the parameter must exist so future callers that DO have one
+    (e.g. an authenticated insights query) can pass it.
+    """
+
+    def test_estimate_cost_forwards_api_key(self, monkeypatch):
+        captured = {}
+        from agent import insights as ins
+
+        def _spy_estimate(*args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            from agent.usage_pricing import CostResult
+            return CostResult(amount_usd=0.0, status="included", source="none", label="included")
+
+        monkeypatch.setattr(ins, "estimate_usage_cost", _spy_estimate)
+
+        cost, status = ins._estimate_cost(
+            "gpt-4o", 100, 50,
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_key="sk-openai-test-key",
+        )
+
+        assert captured["kwargs"]["api_key"] == "sk-openai-test-key"
+        assert captured["kwargs"]["provider"] == "openai"
+
+    def test_estimate_cost_omitted_api_key_stays_none(self, monkeypatch):
+        captured = {}
+        from agent import insights as ins
+
+        def _spy_estimate(*args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            from agent.usage_pricing import CostResult
+            return CostResult(amount_usd=0.0, status="included", source="none", label="included")
+
+        monkeypatch.setattr(ins, "estimate_usage_cost", _spy_estimate)
+
+        ins._estimate_cost("gpt-4o", 100, 50, provider="openai")
+
+        assert captured["kwargs"].get("api_key") is None
+
+
 class TestAmbientAccountingContext:
     def test_record_aux_usage_writes_through_context(self, db):
         from agent.aux_accounting import (


### PR DESCRIPTION
Fixes #75479

The pricing/accounting code path in ``estimate_usage_cost`` reaches ``fetch_endpoint_model_metadata``, which probes a provider's ``/models`` and ``/v1/models`` endpoints for pricing metadata. When the provider gates ``/models`` behind authentication (LiteLLM proxy and similar), the probe must send an ``Authorization: Bearer`` header — but the resolved api_key never reached it because the auxiliary-client caller dropped the parameter on the floor:

```python
record_aux_usage(response, task, provider=provider, base_url=base_url)
_validate_llm_response(response, task, provider=..., base_url=...)
_estimate_cost(model, ..., provider=..., base_url=...)
```

## Fix

Thread the ``api_key`` kwarg through all three call paths.

- ``record_aux_usage()`` now accepts ``api_key`` and forwards it to ``estimate_usage_cost()``. Default is ``None`` — not ``""`` — so callers without a resolved key still work and we don't pretend a key is configured.
- ``_validate_llm_response()`` now accepts ``api_key`` and forwards it through ``record_aux_usage()``. One call site in ``_async_call_llm_impl()`` that already had ``resolved_api_key`` in scope now passes it.
- ``_estimate_cost()`` in ``agent/insights.py`` now accepts ``api_key`` for the same forward — live-creds callers (e.g. an authenticated insights query) can now use it.

## Regression tests

The new ``TestAuxApiKeyForwarding`` and ``TestInsightsApiKeyForwarding`` classes cover:

- ``record_aux_usage`` forwards ``api_key`` to ``estimate_usage_cost`` verbatim
- Omitted ``api_key`` defaults to ``None`` (not the old silent ``""``)
- ``_validate_llm_response`` accepts and forwards ``api_key``
- Static signature checks: both functions expose ``api_key`` as a keyword param
- ``_estimate_cost`` forwards ``api_key`` to ``estimate_usage_cost``
- ``_estimate_cost`` omitted ``api_key`` defaults to ``None``

All 63 tests pass across the related modules (16 accounting + insights-related + usage_pricing). The spy patches the lazy import location (``agent.usage_pricing``) so the call from the function under test is observable.

## Files changed

- ``agent/aux_accounting.py``: ``record_aux_usage()`` signature accepts ``api_key``, forwards to ``estimate_usage_cost``
- ``agent/auxiliary_client.py``: ``_validate_llm_response()`` signature accepts ``api_key``, forwards; ``_async_call_llm_impl()`` passes ``resolved_api_key``
- ``agent/insights.py``: ``_estimate_cost()`` signature accepts ``api_key``, forwards
- ``tests/hermes_state/test_aux_usage_accounting.py``: 6 new tests across two classes