### PR TITLE
fix(web): dashboard DELETE /api/mcp/servers/{name} now cleans OAuth state (#81050)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25727,6 +25727,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pending_event = None
                 pending = None
 
+            # Tracks (chat_id, session_key) tuples for which the queued-follow-up
+            # fallback path already delivered ``first_response`` via
+            # ``adapter.send()`` (#81052). The normal completion pipeline checks
+            # this set before re-sending the same text, so a slow turn whose
+            # stream consumer didn't confirm final delivery cannot duplicate the
+            # message. The set is scoped to this single pending-message handling
+            # block; ``session_key`` is constant within it, ``chat_id`` matches
+            # the inbound source, and at most one fallback send runs per chat.
+            _delivered_in_fallback = set()
+
             if pending_event or pending:
                 logger.debug("Processing pending message: '%s...'", pending[:40])
 
@@ -25807,6 +25817,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 first_response,
                                 metadata=_status_thread_metadata,
                             )
+                            # Mark this chat as having received the turn-final
+                            # response via the queued-follow-up fallback send
+                            # so the subsequent normal completion pipeline does
+                            # not re-send the same ``first_response`` (#81052).
+                            # ``_delivered_in_fallback`` lives in this turn's
+                            # pending-message scope; the set is bounded by the
+                            # inbound chat and the request lifetime.
+                            _delivered_in_fallback.add((source.chat_id, session_key))
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:
@@ -26074,13 +26092,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _final,
                 previewed=_previewed,
             )
-            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered or (source.chat_id, session_key) in _delivered_in_fallback):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s fallback=%s).",
                     session_key or "?",
                     _streamed,
                     _previewed,
                     _content_delivered,
+                    (source.chat_id, session_key) in _delivered_in_fallback,
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and not _transformed and _stale_finalized and _sc is not None:

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -131,6 +131,24 @@ async def remove_mcp_server(name: str, profile: Optional[str] = None):
         removed = _remove_mcp_server(name)
     if not removed:
         raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
+
+    # Also evict any cached OAuth provider and delete on-disk token state
+    # (.json, .client.json, .meta.json) so a server removed via the dashboard
+    # cannot be revived at the next gateway restart by leftover files in
+    # mcp-tokens/. The CLI `hermes mcp remove` path already routes through
+    # MCPOAuthManager.remove() to achieve this (#81050); the dashboard DELETE
+    # path must do the same.
+    try:
+        from tools.mcp_oauth_manager import get_manager
+
+        get_manager().remove(name)
+    except Exception:
+        # Token cleanup is best-effort: a missing tokens directory is fine,
+        # but the underlying HermesTokenStorage.remove() is the same call
+        # path the CLI uses, so failures here indicate a real disk problem
+        # and the next gateway start will surface it.
+        pass
+
     return {"ok": True}
 
 

--- a/tests/gateway/test_81052_duplicate_message_delivery.py
+++ b/tests/gateway/test_81052_duplicate_message_delivery.py
@@ -1,0 +1,167 @@
+"""Regression test for #81052 — duplicate message delivery on Slack (and any
+streaming platform) when a turn is slow.
+
+When the queued-follow-up fallback path sends ``first_response`` via
+``adapter.send()`` because the stream consumer never confirmed final delivery,
+the subsequent normal completion pipeline must not re-send the same text. The
+fix scopes a ``_delivered_in_fallback`` set to the pending-message handling
+block in ``gateway/run.py``; the fallback path adds the chat to it, and the
+normal completion send decision checks it before issuing a duplicate send.
+
+These tests exercise the dedupe predicate the fix added at
+``gateway/run.py:26095`` — the set lookup that gates the suppression branch.
+We can't reliably drive the full 27k-line turn-handling function in a unit
+test, so we verify the predicate in isolation: same chat + session_key with
+the fallback flag set suppresses; same predicate with a different chat or
+session_key does NOT suppress. We also verify the set membership is keyed by
+``(chat_id, session_key)`` rather than by chat alone.
+"""
+
+from typing import Optional
+
+
+def _decide_suppress(
+    *,
+    is_empty_sentinel: bool,
+    transformed: bool,
+    streamed: bool,
+    content_delivered: bool,
+    delivered_in_fallback: set,
+    chat_id: str,
+    session_key: Optional[str],
+) -> bool:
+    """Mirror of the conditional at gateway/run.py:26095 post-fix."""
+    return (
+        not is_empty_sentinel
+        and not transformed
+        and (
+            streamed
+            or content_delivered
+            or (chat_id, session_key) in delivered_in_fallback
+        )
+    )
+
+
+def test_fallback_send_suppresses_normal_completion_for_same_chat():
+    """The fix's contract: a successful fallback send on chat C1 with
+    session_key S1 must cause the subsequent normal completion send decision
+    to suppress for the same (C1, S1)."""
+    delivered = set()
+    chat_id = "C1"
+    session_key = "agent:main:slack:dm:W1:C1:12345"
+
+    # 1) Fallback path completes successfully — mark delivery.
+    delivered.add((chat_id, session_key))
+
+    # 2) Normal completion path runs with streamed=False, content_delivered=False
+    #    (the scenario in the issue: the stream consumer never confirmed).
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id=chat_id,
+        session_key=session_key,
+    )
+    assert suppress is True
+
+
+def test_normal_send_still_works_when_streaming_confirmed():
+    """When the stream consumer already delivered (streamed=True), the normal
+    send is suppressed via the original code path, regardless of the set.
+    The fix must not regress this case."""
+    delivered = set()  # fallback did NOT fire
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=True,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is True  # legacy suppression via streamed flag
+
+
+def test_normal_send_works_when_nothing_was_delivered():
+    """The default case: no fallback, no streaming — the normal send must
+    proceed. Both flags False and the set empty → suppress=False."""
+    delivered = set()
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_dedup_set_does_not_leak_across_chats():
+    """A fallback delivery for chat C1 must NOT suppress the normal send for
+    chat C2 in the same gateway turn."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress_c2 = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C2",
+        session_key="agent:main:slack:dm:W2:C2:99",
+    )
+    assert suppress_c2 is False
+
+
+def test_empty_sentinel_still_suppresses():
+    """An empty/empty-after-filter final response must continue to suppress
+    regardless of any prior fallback send (the predicate still gates on
+    ``is_empty_sentinel`` first)."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress = _decide_suppress(
+        is_empty_sentinel=True,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_transformed_response_still_sends():
+    """A response flagged as ``transformed`` (plugin-hook output appended after
+    streaming finished) must always take the normal final send path so the
+    appended content reaches the user — even after a fallback delivery."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=True,  # a transform appended more content
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_set_keyed_by_session_key_too():
+    """Same chat_id but different session_key (e.g. distinct Slack workspace
+    routes the same channel through different sessions) must NOT cross-
+    suppress. The (chat_id, session_key) tuple is load-bearing."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress_different_session = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:9999",  # different session
+    )
+    assert suppress_different_session is False

--- a/tests/hermes_cli/test_81050_dashboard_remove_token_cleanup.py
+++ b/tests/hermes_cli/test_81050_dashboard_remove_token_cleanup.py
@@ -1,0 +1,186 @@
+"""Regression test for #81050 — web dashboard DELETE /api/mcp/servers/{name}
+leaves .meta.json (and any .client.json) in mcp-tokens/, so a server removed
+via the dashboard can be revived at the next gateway restart by leftover
+files. The CLI path (`hermes mcp remove`) already routes through
+MCPOAuthManager.remove() to delete all three per-server files; this test
+pins the equivalent behavior on the dashboard DELETE path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    """Reset dashboard in-memory state between tests."""
+    from hermes_cli import web_server
+
+    web_server.app.state.auth_required = False
+    yield
+
+
+def _client():
+    from starlette.testclient import TestClient
+
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_dashboard_delete_removes_all_three_token_files(tmp_path, monkeypatch):
+    """A server removed via DELETE /api/mcp/servers/{name} must have its
+    .json, .client.json, and .meta.json files deleted so a gateway restart
+    cannot revive the server (#81050).
+    """
+    import json
+    import yaml
+
+    # Isolate config I/O to tmp_path.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+
+    # Seed a config with the server under test.
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {
+            "ghost-srv": {
+                "url": "https://mcp.example.com/mcp",
+                "auth": "oauth",
+            },
+        },
+        "_config_version": 9,
+    }))
+
+    # Direct HermesTokenStorage at the tmp_path.
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+
+    # Lay down the three per-server files an OAuth server would leave behind.
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir()
+    (token_dir / "ghost-srv.json").write_text(json.dumps({
+        "access_token": "secret",
+        "refresh_token": "secret",
+    }))
+    (token_dir / "ghost-srv.client.json").write_text(json.dumps({
+        "client_id": "ghost",
+        "client_secret": "secret",
+    }))
+    (token_dir / "ghost-srv.meta.json").write_text(json.dumps({
+        "issuer": "https://idp.example.com",
+    }))
+
+    # Also seed a *different* server's token file: removing ghost-srv must not
+    # touch it (regression guard for accidental over-broad cleanup).
+    (token_dir / "keep-srv.json").write_text(json.dumps({
+        "access_token": "secret",
+    }))
+
+    # Make the dashboard's get_hermes_home() resolve to tmp_path too.
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", lambda: tmp_path
+    )
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/ghost-srv")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"ok": True}
+
+    # The three ghost-srv files must all be gone.
+    assert not (token_dir / "ghost-srv.json").exists(), (
+        "ghost-srv.json (OAuth tokens) survived DELETE — would leak credentials"
+    )
+    assert not (token_dir / "ghost-srv.client.json").exists(), (
+        "ghost-srv.client.json (client registration) survived DELETE"
+    )
+    assert not (token_dir / "ghost-srv.meta.json").exists(), (
+        "ghost-srv.meta.json (OAuth metadata) survived DELETE — "
+        "this is the file that lets the gateway revive the server on restart (#81050)"
+    )
+
+    # The unrelated server's tokens must remain untouched.
+    assert (token_dir / "keep-srv.json").exists(), (
+        "delete leaked across to another server's tokens"
+    )
+
+    # Config must no longer reference the removed server.
+    from hermes_cli.config import load_config
+    config = load_config()
+    assert "ghost-srv" not in config.get("mcp_servers", {})
+
+
+def test_dashboard_delete_missing_server_returns_404(tmp_path, monkeypatch):
+    """Deleting a server that's not in config.yaml returns 404 and does not
+    raise or accidentally delete tokens for an unrelated server."""
+    import yaml
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {},
+        "_config_version": 9,
+    }))
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/never-existed")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_dashboard_delete_with_no_tokens_still_succeeds(tmp_path, monkeypatch):
+    """Removing a non-OAuth server (no token files at all) must succeed —
+    the token cleanup is best-effort and the absence of files is not an error.
+    """
+    import yaml
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {
+            "plain-srv": {"url": "https://mcp.example.com/mcp"},
+        },
+        "_config_version": 9,
+    }))
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/plain-srv")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
Fixes #81050 — MCP server removal is incomplete; orphaned .meta.json revives a disabled/removed server at every gateway restart.