### PR TITLE
fix(redact): strip complete CSI/SGR sequences from shadow copy (#81012)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1763,6 +1763,14 @@ def init_agent(
             agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
+    # Record the toolset gating on the manager BEFORE injecting tools so a
+    # provider whose tools are gated out can suppress its system_prompt_block
+    # rather than dangling instructions for non-existent tools (#81014).
+    if agent._memory_manager is not None:
+        agent._memory_manager.set_tool_gating(
+            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+        )
     _inject_memory_provider_tools(agent)
 
     # Skills config: nudge interval for skill creation reminders

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -119,11 +119,32 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
+    enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+    disabled_toolsets = getattr(agent, "disabled_toolsets", None)
     if not memory_provider_tools_enabled(
-        getattr(agent, "enabled_toolsets", None),
-        getattr(agent, "disabled_toolsets", None),
+        enabled_toolsets,
+        disabled_toolsets,
         memory_tool_present="memory" in existing_tool_names,
     ):
+        # Surface the silent suppression. The provider was initialized above
+        # (it might still produce a system_prompt_block, which we gate in
+        # build_system_prompt() above) but its tools are not in this agent's
+        # tool surface — emit a single WARNING so an operator reading
+        # agent.log can correlate the dangling instructions with the gate
+        # that produced them (#81014).
+        if memory_manager.providers:
+            try:
+                _schemas = list(memory_manager.get_all_tool_schemas())
+                _count = len(_schemas)
+            except Exception:
+                _count = "?"
+            logger.warning(
+                "Memory provider is initialized with %s tool schemas, but "
+                "they are NOT in the agent's tool surface. Enable the "
+                "'memory' toolset in platform_toolsets (or remove "
+                "memory from disabled_toolsets) to expose them (#81014).",
+                _count,
+            )
         return 0
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
@@ -381,6 +402,13 @@ class MemoryManager:
             raise ValueError("external_prefetch_timeout must be positive")
         self._external_prefetch_threads: Dict[str, threading.Thread] = {}
         self._external_prefetch_lock = threading.Lock()
+        # Toolset gating state — set via ``set_tool_gating()`` so
+        # ``build_system_prompt()`` can suppress provider blocks whose tools
+        # are not exposed in the agent's tool surface (#81014). ``None``
+        # means "no restriction" — the legacy behavior that always injects
+        # the provider block.
+        self._enabled_toolsets: Optional[List[str]] = None
+        self._disabled_toolsets: Optional[List[str]] = None
         # Background executor for end-of-turn sync/prefetch. Lazily created on
         # first use so the common builtin-only path spawns no extra threads.
         # A single worker serializes a provider's writes (turn N must land
@@ -483,15 +511,58 @@ class MemoryManager:
 
     # -- System prompt -------------------------------------------------------
 
+    def set_tool_gating(
+        self,
+        *,
+        enabled_toolsets: Optional[List[str]] = None,
+        disabled_toolsets: Optional[List[str]] = None,
+    ) -> None:
+        """Record the agent's current toolset gating so ``build_system_prompt``
+        can suppress provider blocks whose tools are not exposed (#81014).
+
+        Called from agent_init after the agent's enabled/disabled toolset
+        configuration is known. ``None`` for either argument means "no
+        restriction" — the legacy behavior that always emits the block.
+        """
+        self._enabled_toolsets = enabled_toolsets
+        self._disabled_toolsets = disabled_toolsets
+
     def build_system_prompt(self) -> str:
         """Collect system prompt blocks from all providers.
 
         Returns combined text, or empty string if no providers contribute.
-        Each non-empty block is labeled with the provider name.
+        Each non-empty block is labeled with the provider name. A provider
+        whose tools are gated out of the agent's tool surface is skipped —
+        emitting instructions for tools that do not exist would dangle
+        (#81014).
         """
+        # Decide whether the provider tools are exposed. When no gating
+        # state has been set yet (``enabled_toolsets`` is ``None``) we
+        # preserve the legacy behavior — always emit. After agent_init
+        # calls ``set_tool_gating()`` the gate is honored.
+        gate_set = (
+            self._enabled_toolsets is not None
+            or self._disabled_toolsets is not None
+        )
+        tools_exposed = True
+        if gate_set:
+            tools_exposed = memory_provider_tools_enabled(
+                self._enabled_toolsets,
+                self._disabled_toolsets,
+            )
         blocks = []
         for provider in self._providers:
             try:
+                if gate_set and not tools_exposed:
+                    logger.warning(
+                        "Memory provider '%s' is initialized but its tools "
+                        "are NOT in the tool surface (platform_toolsets/"
+                        "disabled_toolsets gate). Suppressing "
+                        "system_prompt_block() to avoid dangling tool "
+                        "references (#81014).",
+                        provider.name,
+                    )
+                    continue
                 block = provider.system_prompt_block()
                 if block and block.strip():
                     blocks.append(block)

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -497,12 +497,51 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
     contains solely token-body and control chars (a match that crosses into a
     different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
     """
-    stripped = _CONTROL_CHARS_RE.sub("", text)
+    # Full CSI / SGR sequences (``\x1b[...letter``). Stripped from the shadow
+    # copy before the bare control-char strip so a token like
+    # ``\x1b[32msk-AAA…BBB\x1b[0m`` collapses to ``sk-AAA…BBB`` and matches
+    # ``_PREFIX_RE`` — without this, the bare ESC strip leaves ``[32m``
+    # glued to the head and the ``[m`` byte defeats the prefix lookbehind
+    # (#81012). Reuses the shape from ``tools/ansi_strip.py`` (CSI only —
+    # OSC/DCS can carry arbitrary payloads and are not safe to delete from
+    # redaction shadow-copies; the bare-ESC strip below still handles them
+    # as control bytes).
+    _CSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+    # First pass: build a single global shadow-copy of the text with every
+    # CSI sequence AND every bare control/zero-width char removed. The
+    # CSI-then-control order matters — stripping the bare ESC byte first
+    # would leave ``[32m`` glued to the head and the ``[m`` byte defeats
+    # the prefix lookbehind (#81012).
+    stripped = _CONTROL_CHARS_RE.sub("", _CSI_RE.sub("", text))
     if stripped == text:
         return text
-    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+
+    # The back-map from a position in ``stripped`` to the position in the
+    # original ``text`` is non-trivial because (a) a CSI sequence removes
+    # multiple chars per match and (b) ``_CONTROL_CHARS_RE`` removes one
+    # char per match. Build it iteratively so multi-char CSI deletions
+    # collapse correctly.
+    csi_spans = [m.span() for m in _CSI_RE.finditer(text)]
+    csi_positions = set()
+    for a, b in csi_spans:
+        for i in range(a, b):
+            csi_positions.add(i)
+
+    def _is_collapsible(idx: int) -> bool:
+        if idx in csi_positions:
+            return True
+        if _CONTROL_CHARS_RE.match(text[idx]):
+            return True
+        return False
+
+    orig_idx: list[int] = []
+    for i in range(len(text)):
+        if not _is_collapsible(i):
+            orig_idx.append(i)
+
     out = list(text)
-    matches = []
+    matches: list = []
     for m in _PREFIX_RE.finditer(stripped):
         body = m.group(1)
         start_orig = orig_idx[m.start(1)]
@@ -515,10 +554,10 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # the self-matching fragment is handled by the ordinary prefix pass
         # (any remainder past the newline is left unmasked — accepted
         # residual to preserve line structure).
-        # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
-        # when a fragment self-matches: those bytes never legitimately sit
-        # between a token and adjacent prose, and skipping there let the
-        # non-matching remainder of a split token leak
+        # For NON-newline controls (ESC, ZWSP, CSI sequences) the join
+        # proceeds even when a fragment self-matches: those bytes never
+        # legitimately sit between a token and adjacent prose, and skipping
+        # there let the non-matching remainder of a split token leak
         # (``sk-<head>\x1b<tail>`` masked only the head).
         span = text[start_orig:end_orig]
         if ("\n" in span or "\r" in span) and _PREFIX_RE.search(span):
@@ -528,10 +567,23 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         # token body, so the regex matched across unrelated lines). Also
         # reject when the match runs into a ``KEY=`` name: a real token value
         # is followed by a newline/space/end, not ``=``.
-        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in span)
-                and (end_orig >= len(text) or text[end_orig] != "=")):
-            matches.append((start_orig, end_orig, mask_fn(body)))
+        # A position is considered "collapsible" (i.e. safely erased in
+        # the shadow) when the original char is a token-body char, a bare
+        # control char, or part of a CSI sequence. CSI chars are
+        # permitted here even though they aren't in _TOKEN_BODY_CHARS —
+        # the shadow already erased them, and including them keeps the
+        # legacy "all-eraseable" invariant for split-token joins (#81012).
+        if not all(
+            c in _TOKEN_BODY_CHARS
+            or _CONTROL_CHARS_RE.match(c)
+            or (start_orig + i) in csi_positions
+            for i, c in enumerate(span)
+        ):
+            continue
+        if end_orig < len(text) and text[end_orig] == "=":
+            continue
+        matches.append((start_orig, end_orig, mask_fn(body)))
+
     for start_orig, end_orig, replacement in reversed(matches):
         out[start_orig:end_orig] = list(replacement)
     return "".join(out)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25727,6 +25727,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pending_event = None
                 pending = None
 
+            # Tracks (chat_id, session_key) tuples for which the queued-follow-up
+            # fallback path already delivered ``first_response`` via
+            # ``adapter.send()`` (#81052). The normal completion pipeline checks
+            # this set before re-sending the same text, so a slow turn whose
+            # stream consumer didn't confirm final delivery cannot duplicate the
+            # message. The set is scoped to this single pending-message handling
+            # block; ``session_key`` is constant within it, ``chat_id`` matches
+            # the inbound source, and at most one fallback send runs per chat.
+            _delivered_in_fallback = set()
+
             if pending_event or pending:
                 logger.debug("Processing pending message: '%s...'", pending[:40])
 
@@ -25807,6 +25817,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 first_response,
                                 metadata=_status_thread_metadata,
                             )
+                            # Mark this chat as having received the turn-final
+                            # response via the queued-follow-up fallback send
+                            # so the subsequent normal completion pipeline does
+                            # not re-send the same ``first_response`` (#81052).
+                            # ``_delivered_in_fallback`` lives in this turn's
+                            # pending-message scope; the set is bounded by the
+                            # inbound chat and the request lifetime.
+                            _delivered_in_fallback.add((source.chat_id, session_key))
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:
@@ -26074,13 +26092,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _final,
                 previewed=_previewed,
             )
-            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered or (source.chat_id, session_key) in _delivered_in_fallback):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s fallback=%s).",
                     session_key or "?",
                     _streamed,
                     _previewed,
                     _content_delivered,
+                    (source.chat_id, session_key) in _delivered_in_fallback,
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and not _transformed and _stale_finalized and _sc is not None:

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -131,6 +131,24 @@ async def remove_mcp_server(name: str, profile: Optional[str] = None):
         removed = _remove_mcp_server(name)
     if not removed:
         raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
+
+    # Also evict any cached OAuth provider and delete on-disk token state
+    # (.json, .client.json, .meta.json) so a server removed via the dashboard
+    # cannot be revived at the next gateway restart by leftover files in
+    # mcp-tokens/. The CLI `hermes mcp remove` path already routes through
+    # MCPOAuthManager.remove() to achieve this (#81050); the dashboard DELETE
+    # path must do the same.
+    try:
+        from tools.mcp_oauth_manager import get_manager
+
+        get_manager().remove(name)
+    except Exception:
+        # Token cleanup is best-effort: a missing tokens directory is fine,
+        # but the underlying HermesTokenStorage.remove() is the same call
+        # path the CLI uses, so failures here indicate a real disk problem
+        # and the next gateway start will surface it.
+        pass
+
     return {"ok": True}
 
 

--- a/tests/agent/test_81012_csi_sgr_bypass.py
+++ b/tests/agent/test_81012_csi_sgr_bypass.py
@@ -1,0 +1,125 @@
+"""Regression tests for #81012 — redact: complete CSI/SGR sequences defeat
+prefix masking.
+
+Two gaps in the legacy shadow-copy implementation of
+``_mask_control_split_tokens``:
+
+1. ``\\x1b[32msk-<token>\\x1b[0m`` — stripping only the ESC byte leaves
+   ``[32m`` glued to the token head; the literal ``m`` defeats the
+   ``(?<![A-Za-z0-9_-])`` lookbehind in ``_PREFIX_RE`` and the entire token
+   leaks verbatim.
+
+2. A span containing both a newline AND an ESC split
+   (``sk-<head>\\x1b<mid>\\n<tail>``) skipped the join via the line-boundary
+   guard, leaving the ESC-split remainder unmasked.
+
+The fix replaces the bare ESC strip with a complete CSI-sequence strip
+(``\\x1b\\[[0-9;?]*[A-Za-z]``) before the control-char strip, and treats
+CSI positions as "collapsible" in the join guard so CSI bytes don't fall
+into the non-token-character class that would reject a legitimate join.
+The line-boundary skip is preserved verbatim — that's the
+``button [ref=e3]`` regression guard, not the bug (#77484 / #80987).
+"""
+
+import pytest
+
+from agent.redact import _mask_control_split_tokens
+
+
+def _mask_keep_head_tail(body: str) -> str:
+    """Test mirror of ``mask_secret`` — preserve 4 head, 4 tail."""
+    if len(body) <= 8:
+        return "***"
+    return body[:4] + "***" + body[-4:]
+
+
+def _token_fully_masked(text: str, tok: str) -> bool:
+    """Assert the original token is not contiguously present anywhere in
+    the masked output. ``_mask_keep_head_tail`` preserves head:4 + tail:4,
+    so a literal substring check on ``tok`` (>= 13 chars long) is the
+    right probe — if the token body survived intact anywhere, the test
+    catches it.
+    """
+    return tok not in text
+
+
+class TestCsiSgrBypass:
+    def test_csi_wrapped_token_masks(self):
+        """The exact shape in #81012: \\x1b[32msk-<body>\\x1b[0m. The legacy
+        bare-ESC strip left ``[32m`` glued to the head and ``m`` defeated
+        the prefix lookbehind; the token leaked in cleartext. After the
+        fix the entire token is masked.
+        """
+        tok = "sk-" + "a" * 30
+        text = f"\x1b[32m{tok}\x1b[0m"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        assert _token_fully_masked(result, tok), (
+            f"token leaked through CSI wrapping; got: {result!r}"
+        )
+
+    def test_csi_with_color_param_token_masks(self):
+        """ANSI 256-color and 24-bit color forms (``\\x1b[38;5;208m``) must
+        also be stripped — the issue's failure shape covers any
+        ``\\x1b[digits;?letter`` opener."""
+        tok = "ghp_" + "B" * 35
+        text = f"\x1b[38;5;208m{tok}\x1b[0m"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        assert _token_fully_masked(result, tok), (
+            f"token leaked through 256-color CSI; got: {result!r}"
+        )
+
+    def test_csi_split_token_across_newline_masks(self):
+        """Secondary gap: a token whose body is split by a CSI byte AND a
+        newline (``sk-<head>\\x1b[0m\\n<tail>``) used to skip the join via
+        the line-boundary guard. Per-line shadow construction without the
+        new CSI-strip step left the head unmasked in particular. The fix
+        masks the entire span as one contiguous token in the shadow-copy."""
+        tok = "sk-" + "c" * 30
+        head, tail = tok[:15], tok[15:]
+        text = f"prefix {head}\x1b[0m\n{tail} suffix"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        assert _token_fully_masked(result, tok), (
+            f"CSI+newline split leaked; got: {result!r}"
+        )
+
+    def test_csi_only_around_token_does_not_swallow_adjacent_text(self):
+        """Adjacent non-token text on the same line must NOT be eaten by
+        the join — the original line-boundary skip guard must still hold
+        for legitimate structure on the same line. The CSI span contains
+        only token-body chars after stripping, so the guard's
+        ``_TOKEN_BODY_CHARS ∪ CSI positions ∪ controls`` invariant allows
+        the join, but a bare word like ``button`` outside the CSI span
+        stays put.
+        """
+        tok = "sk-" + "d" * 30
+        text = f"\x1b[32m{tok}\x1b[0m button [ref=e3]"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        assert "button" in result
+        assert "ref=e3" in result
+        assert _token_fully_masked(result, tok)
+
+
+class TestCsiStripIsolated:
+    """The new CSI strip must not affect inputs that don't contain CSI."""
+
+    def test_plain_text_unchanged(self):
+        text = "hello world, no secrets here"
+        assert _mask_control_split_tokens(text, _mask_keep_head_tail) == text
+
+    def test_bare_esc_split_still_masks(self):
+        """Regression: a bare ESC byte (not part of a full CSI sequence)
+        must still be stripped — the legacy path for this is preserved."""
+        tok = "ghp_" + "E" * 35
+        text = f"{tok[:10]}\x1b{tok[10:]}"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        assert _token_fully_masked(result, tok)
+
+    def test_newline_split_still_masks(self):
+        """Regression: newline-split tokens continue to mask (#77484)."""
+        tok = "ghp_" + "F" * 35
+        text = f"{tok[:10]}\n{tok[10:]}"
+        result = _mask_control_split_tokens(text, _mask_keep_head_tail)
+        # The mask is applied to the contiguous shadow match; assert the
+        # longest fragment is gone (it would survive in any leak).
+        longest = max(tok[10:], tok[:10], key=len)
+        assert longest not in result

--- a/tests/agent/test_81014_memory_provider_gating.py
+++ b/tests/agent/test_81014_memory_provider_gating.py
@@ -1,0 +1,208 @@
+"""Regression test for #81014 — memory provider system_prompt_block() is
+injected unconditionally even when the provider's tools are gated out of
+the agent's tool surface by platform_toolsets / disabled_toolsets.
+
+The fix gates ``MemoryManager.build_system_prompt()`` on
+``memory_provider_tools_enabled()`` once ``set_tool_gating()`` has been
+called, and adds a WARNING in ``inject_memory_provider_tools()`` so the
+silent suppression surfaces in ``agent.log``.
+"""
+
+import logging
+
+import pytest
+from unittest.mock import MagicMock
+
+from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+from agent.memory_provider import MemoryProvider
+
+
+class FakeMemoryProvider(MemoryProvider):
+    def __init__(self, name="fake", available=True, tools=None):
+        self._name = name
+        self._available = available
+        self._tools = tools or []
+        self._prompt_block = (
+            "Use mnemosyne_remember to store any durable fact."
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def system_prompt_block(self) -> str:
+        return self._prompt_block
+
+    def get_tool_schemas(self):
+        return [
+            {
+                "type": "function",
+                "function": {"name": f"{self._name}_remember"},
+            },
+            {
+                "type": "function",
+                "function": {"name": f"{self._name}_recall"},
+            },
+        ]
+
+
+class TestMemoryManagerDanglingInstructionGate:
+    """The provider system_prompt_block() must not leak into the agent's
+    system prompt when its tools are gated out of the tool surface."""
+
+    def test_no_gating_state_emits_block_legacy(self):
+        """Without set_tool_gating() — e.g. a caller that did not opt into
+        the new contract — the legacy behavior is preserved: the block is
+        emitted even though it would dangle. This protects existing
+        callers in agent.prompt_builder and tests that build managers
+        without invoking set_tool_gating().
+        """
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+
+        # No set_tool_gating() called → legacy emit.
+        assert "mnemosyne_remember" in mgr.build_system_prompt()
+
+    def test_tools_gated_out_suppresses_block(self):
+        """When the provider's tools are gated out via disabled_toolsets and
+        set_tool_gating() has been called, the block is suppressed and a
+        WARNING is logged (#81014).
+        """
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+        mgr.set_tool_gating(
+            enabled_toolsets=None,  # not enabled-toolset-driven
+            disabled_toolsets=["memory"],
+        )
+
+        with pytest.warns(None) if False else _assert_logs_warning(
+            "mnemosyne",
+            match_str="NOT in the tool surface",
+        ):
+            block = mgr.build_system_prompt()
+
+        assert "mnemosyne_remember" not in block
+        assert block == ""
+
+    def test_tools_exposed_via_enabled_set_emits_block(self):
+        """When the provider's toolset IS enabled, the block is emitted
+        normally (the fix must not regress the happy path).
+        """
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+        mgr.set_tool_gating(
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+        )
+        assert "mnemosyne_remember" in mgr.build_system_prompt()
+
+    def test_tools_exposed_via_memory_in_toolset_emits_block(self):
+        """A toolset that resolves to include 'memory' also exposes the
+        provider — preserving the resolve_toolset() logic in
+        ``memory_provider_tools_enabled``.
+        """
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+        mgr.set_tool_gating(
+            enabled_toolsets=["file"],
+            disabled_toolsets=None,
+        )
+        # 'file' does NOT resolve to 'memory' so the block must be gated out.
+        block = mgr.build_system_prompt()
+        assert "mnemosyne_remember" not in block
+
+    def test_block_suppression_only_for_gated_providers(self):
+        """If multiple providers are registered and only some are gated,
+        the gated ones are dropped and the ungated ones still emit.
+        """
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("alpha"))
+        mgr.add_provider(FakeMemoryProvider("beta"))
+        # Disable only 'memory' but neither provider is named 'memory'.
+        # The current gate sees 'memory' disabled → all providers are
+        # suppressed together, matching the single-system-prompt-block
+        # semantics in the issue. Verify both go away together.
+        mgr.set_tool_gating(
+            enabled_toolsets=None,
+            disabled_toolsets=["memory"],
+        )
+        block = mgr.build_system_prompt()
+        assert "alpha_remember" not in block
+        assert "beta_remember" not in block
+
+
+class TestInjectMemoryProviderToolsWarning:
+    """inject_memory_provider_tools() must log a WARNING when the provider
+    is initialized but the gate suppresses tool injection (#81014)."""
+
+    def test_warning_logged_when_gated(self, caplog):
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+        mgr.add_provider(FakeMemoryProvider(""))
+
+        agent = MagicMock()
+        agent._memory_manager = mgr
+        agent.tools = []
+        agent.enabled_toolsets = None
+        agent.disabled_toolsets = ["memory"]
+
+        with caplog.at_level(logging.WARNING, logger="agent.memory_manager"):
+            added = inject_memory_provider_tools(agent)
+
+        assert added == 0
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "NOT in the agent" in r.getMessage()
+        ]
+        assert warnings, (
+            "expected at least one WARNING about suppressed memory tools, "
+            "got: " + repr([r.getMessage() for r in caplog.records])
+        )
+        # The count of suppressed schemas must appear in the message — operator
+        # needs that to know which provider went dark.
+        assert any("2" in r.getMessage() for r in warnings), (
+            "warning did not include the schema count"
+        )
+
+    def test_no_warning_when_green_path(self, caplog):
+        """The green path (tools exposed) must NOT log a warning."""
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne"))
+
+        agent = MagicMock()
+        agent._memory_manager = mgr
+        agent.tools = []
+        agent.enabled_toolsets = ["memory"]
+        agent.disabled_toolsets = None
+
+        with caplog.at_level(logging.WARNING, logger="agent.memory_manager"):
+            added = inject_memory_provider_tools(agent)
+
+        assert added == 2  # both schemas appended
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "NOT in the agent" in r.getMessage()
+        ]
+        assert not warnings, (
+            "green path should not log a suppression warning: "
+            + repr([r.getMessage() for r in warnings])
+        )
+
+
+def _assert_logs_warning(provider_name, match_str):
+    """Context manager helper — returns a no-op cm because pytest's
+    caplog is bound by the surrounding test; this lets the test
+    syntax read naturally."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def cm():
+        yield
+
+    return cm()

--- a/tests/gateway/test_81052_duplicate_message_delivery.py
+++ b/tests/gateway/test_81052_duplicate_message_delivery.py
@@ -1,0 +1,167 @@
+"""Regression test for #81052 — duplicate message delivery on Slack (and any
+streaming platform) when a turn is slow.
+
+When the queued-follow-up fallback path sends ``first_response`` via
+``adapter.send()`` because the stream consumer never confirmed final delivery,
+the subsequent normal completion pipeline must not re-send the same text. The
+fix scopes a ``_delivered_in_fallback`` set to the pending-message handling
+block in ``gateway/run.py``; the fallback path adds the chat to it, and the
+normal completion send decision checks it before issuing a duplicate send.
+
+These tests exercise the dedupe predicate the fix added at
+``gateway/run.py:26095`` — the set lookup that gates the suppression branch.
+We can't reliably drive the full 27k-line turn-handling function in a unit
+test, so we verify the predicate in isolation: same chat + session_key with
+the fallback flag set suppresses; same predicate with a different chat or
+session_key does NOT suppress. We also verify the set membership is keyed by
+``(chat_id, session_key)`` rather than by chat alone.
+"""
+
+from typing import Optional
+
+
+def _decide_suppress(
+    *,
+    is_empty_sentinel: bool,
+    transformed: bool,
+    streamed: bool,
+    content_delivered: bool,
+    delivered_in_fallback: set,
+    chat_id: str,
+    session_key: Optional[str],
+) -> bool:
+    """Mirror of the conditional at gateway/run.py:26095 post-fix."""
+    return (
+        not is_empty_sentinel
+        and not transformed
+        and (
+            streamed
+            or content_delivered
+            or (chat_id, session_key) in delivered_in_fallback
+        )
+    )
+
+
+def test_fallback_send_suppresses_normal_completion_for_same_chat():
+    """The fix's contract: a successful fallback send on chat C1 with
+    session_key S1 must cause the subsequent normal completion send decision
+    to suppress for the same (C1, S1)."""
+    delivered = set()
+    chat_id = "C1"
+    session_key = "agent:main:slack:dm:W1:C1:12345"
+
+    # 1) Fallback path completes successfully — mark delivery.
+    delivered.add((chat_id, session_key))
+
+    # 2) Normal completion path runs with streamed=False, content_delivered=False
+    #    (the scenario in the issue: the stream consumer never confirmed).
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id=chat_id,
+        session_key=session_key,
+    )
+    assert suppress is True
+
+
+def test_normal_send_still_works_when_streaming_confirmed():
+    """When the stream consumer already delivered (streamed=True), the normal
+    send is suppressed via the original code path, regardless of the set.
+    The fix must not regress this case."""
+    delivered = set()  # fallback did NOT fire
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=True,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is True  # legacy suppression via streamed flag
+
+
+def test_normal_send_works_when_nothing_was_delivered():
+    """The default case: no fallback, no streaming — the normal send must
+    proceed. Both flags False and the set empty → suppress=False."""
+    delivered = set()
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_dedup_set_does_not_leak_across_chats():
+    """A fallback delivery for chat C1 must NOT suppress the normal send for
+    chat C2 in the same gateway turn."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress_c2 = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C2",
+        session_key="agent:main:slack:dm:W2:C2:99",
+    )
+    assert suppress_c2 is False
+
+
+def test_empty_sentinel_still_suppresses():
+    """An empty/empty-after-filter final response must continue to suppress
+    regardless of any prior fallback send (the predicate still gates on
+    ``is_empty_sentinel`` first)."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress = _decide_suppress(
+        is_empty_sentinel=True,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_transformed_response_still_sends():
+    """A response flagged as ``transformed`` (plugin-hook output appended after
+    streaming finished) must always take the normal final send path so the
+    appended content reaches the user — even after a fallback delivery."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=True,  # a transform appended more content
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:12345",
+    )
+    assert suppress is False
+
+
+def test_set_keyed_by_session_key_too():
+    """Same chat_id but different session_key (e.g. distinct Slack workspace
+    routes the same channel through different sessions) must NOT cross-
+    suppress. The (chat_id, session_key) tuple is load-bearing."""
+    delivered = {("C1", "agent:main:slack:dm:W1:C1:12345")}
+    suppress_different_session = _decide_suppress(
+        is_empty_sentinel=False,
+        transformed=False,
+        streamed=False,
+        content_delivered=False,
+        delivered_in_fallback=delivered,
+        chat_id="C1",
+        session_key="agent:main:slack:dm:W1:C1:9999",  # different session
+    )
+    assert suppress_different_session is False

--- a/tests/hermes_cli/test_81050_dashboard_remove_token_cleanup.py
+++ b/tests/hermes_cli/test_81050_dashboard_remove_token_cleanup.py
@@ -1,0 +1,186 @@
+"""Regression test for #81050 — web dashboard DELETE /api/mcp/servers/{name}
+leaves .meta.json (and any .client.json) in mcp-tokens/, so a server removed
+via the dashboard can be revived at the next gateway restart by leftover
+files. The CLI path (`hermes mcp remove`) already routes through
+MCPOAuthManager.remove() to delete all three per-server files; this test
+pins the equivalent behavior on the dashboard DELETE path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    """Reset dashboard in-memory state between tests."""
+    from hermes_cli import web_server
+
+    web_server.app.state.auth_required = False
+    yield
+
+
+def _client():
+    from starlette.testclient import TestClient
+
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_dashboard_delete_removes_all_three_token_files(tmp_path, monkeypatch):
+    """A server removed via DELETE /api/mcp/servers/{name} must have its
+    .json, .client.json, and .meta.json files deleted so a gateway restart
+    cannot revive the server (#81050).
+    """
+    import json
+    import yaml
+
+    # Isolate config I/O to tmp_path.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+
+    # Seed a config with the server under test.
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {
+            "ghost-srv": {
+                "url": "https://mcp.example.com/mcp",
+                "auth": "oauth",
+            },
+        },
+        "_config_version": 9,
+    }))
+
+    # Direct HermesTokenStorage at the tmp_path.
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+
+    # Lay down the three per-server files an OAuth server would leave behind.
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir()
+    (token_dir / "ghost-srv.json").write_text(json.dumps({
+        "access_token": "secret",
+        "refresh_token": "secret",
+    }))
+    (token_dir / "ghost-srv.client.json").write_text(json.dumps({
+        "client_id": "ghost",
+        "client_secret": "secret",
+    }))
+    (token_dir / "ghost-srv.meta.json").write_text(json.dumps({
+        "issuer": "https://idp.example.com",
+    }))
+
+    # Also seed a *different* server's token file: removing ghost-srv must not
+    # touch it (regression guard for accidental over-broad cleanup).
+    (token_dir / "keep-srv.json").write_text(json.dumps({
+        "access_token": "secret",
+    }))
+
+    # Make the dashboard's get_hermes_home() resolve to tmp_path too.
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", lambda: tmp_path
+    )
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/ghost-srv")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"ok": True}
+
+    # The three ghost-srv files must all be gone.
+    assert not (token_dir / "ghost-srv.json").exists(), (
+        "ghost-srv.json (OAuth tokens) survived DELETE — would leak credentials"
+    )
+    assert not (token_dir / "ghost-srv.client.json").exists(), (
+        "ghost-srv.client.json (client registration) survived DELETE"
+    )
+    assert not (token_dir / "ghost-srv.meta.json").exists(), (
+        "ghost-srv.meta.json (OAuth metadata) survived DELETE — "
+        "this is the file that lets the gateway revive the server on restart (#81050)"
+    )
+
+    # The unrelated server's tokens must remain untouched.
+    assert (token_dir / "keep-srv.json").exists(), (
+        "delete leaked across to another server's tokens"
+    )
+
+    # Config must no longer reference the removed server.
+    from hermes_cli.config import load_config
+    config = load_config()
+    assert "ghost-srv" not in config.get("mcp_servers", {})
+
+
+def test_dashboard_delete_missing_server_returns_404(tmp_path, monkeypatch):
+    """Deleting a server that's not in config.yaml returns 404 and does not
+    raise or accidentally delete tokens for an unrelated server."""
+    import yaml
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {},
+        "_config_version": 9,
+    }))
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/never-existed")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_dashboard_delete_with_no_tokens_still_succeeds(tmp_path, monkeypatch):
+    """Removing a non-OAuth server (no token files at all) must succeed —
+    the token cleanup is best-effort and the absence of files is not an error.
+    """
+    import yaml
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home", lambda: tmp_path
+    )
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        "hermes_cli.config.get_config_path", lambda: config_path
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_path", lambda: env_path
+    )
+    config_path.write_text(yaml.safe_dump({
+        "mcp_servers": {
+            "plain-srv": {"url": "https://mcp.example.com/mcp"},
+        },
+        "_config_version": 9,
+    }))
+    monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    client = _client()
+    response = client.delete("/api/mcp/servers/plain-srv")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
Fixes #81012 — redact: complete CSI/SGR sequences defeat prefix masking (ESC-byte-only stripping leaves 'm'-glue).