### PR TITLE
fix(desktop): make in-page markdown TOC links scroll to headings (#81055)

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -33,6 +33,7 @@ import {
 import { Check, Pencil, X } from '@/lib/icons'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
+import { findHeadingByHash, rehypeHeadingIds } from '@/lib/markdown-heading-ids'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
@@ -391,7 +392,35 @@ function MarkdownImage({ alt, src, ...rest }: ComponentProps<'img'>) {
   )
 }
 
-function MarkdownLink({ children, className, href, ...rest }: ComponentProps<'a'>) {
+// Custom anchor for the file preview pane (#81055): Streamdown renders links
+// as `<button>` with no `href`, and the default rehype chain strips the `id`
+// we stamp on headings. Fragment links route to the matching heading inside
+// this preview body; every other link keeps the regular external-link
+// treatment. `#preview/...` cross-file references are not handled here (the
+// file preview pane has its own tab switcher that doesn't operate-open
+// another preview from inside markdown).
+function MarkdownAnchor({ children, className, href, ...rest }: ComponentProps<'a'>) {
+  if (href?.startsWith('#')) {
+    return (
+      <a
+        className={cn('text-foreground underline underline-offset-2', className)}
+        href={href}
+        onClick={(event) => {
+          event.preventDefault()
+          // Scope the lookup to this preview body: several previews can be
+          // mounted at once (tabs, tiles) and ids repeat across notes, so a
+          // document-wide match could scroll a different pane.
+          const body = (event.currentTarget as HTMLElement).closest('.preview-markdown') ?? document
+          const heading = findHeadingByHash(body, href)
+          heading?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }}
+        {...rest}
+      >
+        {children}
+      </a>
+    )
+  }
+
   const isExternal = /^https?:\/\//i.test(href || '')
 
   return (
@@ -425,11 +454,15 @@ const MARKDOWN_COMPONENTS = {
   td: tagged('td'),
   thead: tagged('thead'),
   img: MarkdownImage,
-  a: MarkdownLink
+  a: MarkdownAnchor
 }
 
 export function MarkdownPreview({ text }: { text: string }) {
   const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
+  // Heading ids must be stamped AFTER Streamdown's own rehype chain (raw →
+  // sanitize → harden): `id` is not on rehype-sanitize's default allow-list,
+  // so an id added earlier is stripped before it reaches the DOM (#81055).
+  const rehypePlugins = useMemo(() => [rehypeHeadingIds()], [])
 
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
@@ -439,6 +472,7 @@ export function MarkdownPreview({ text }: { text: string }) {
         mode="static"
         parseIncompleteMarkdown={false}
         plugins={{ math: previewMathPlugin }}
+        rehypePlugins={rehypePlugins}
       >
         {mathText}
       </Streamdown>

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -31,8 +31,8 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
-import { findHeadingByHash, rehypeHeadingIds } from '@/lib/markdown-heading-ids'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
+import { findHeadingByHash, rehypeHeadingIds } from '@/lib/markdown-heading-ids'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -31,6 +31,7 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
+import { findHeadingByHash, rehypeHeadingIds } from '@/lib/markdown-heading-ids'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
@@ -355,6 +356,47 @@ function MarkdownCode({ className, children, ...props }: ComponentProps<'code'>)
   return <RichCodeBlock code={code} fallback={highlighted} language={language} />
 }
 
+// Custom anchor for the file preview pane (#81055): Streamdown renders links
+// as `<button>` with no `href`, and the default rehype chain strips the `id`
+// we stamp on headings. This override routes `#fragment` clicks to the
+// matching heading inside this preview body. `#preview/...` cross-file
+// references are not handled here (the file preview pane has its own tab
+// switcher that doesn't operate-open another preview from inside markdown).
+function MarkdownAnchor({ children, href, ...props }: ComponentProps<'a'>) {
+  if (href?.startsWith('#')) {
+    return (
+      <a
+        className="font-semibold text-foreground underline underline-offset-4 decoration-current/30"
+        href={href}
+        onClick={(event) => {
+          event.preventDefault()
+          // Scope the lookup to this preview body: several previews can be
+          // mounted at once (tabs, tiles) and ids repeat across notes, so a
+          // document-wide match could scroll a different pane.
+          const body = (event.currentTarget as HTMLElement).closest('.preview-markdown') ?? document
+          const heading = findHeadingByHash(body, href)
+          heading?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }}
+        {...props}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <a
+      className="font-semibold text-foreground underline underline-offset-4 decoration-current/30"
+      href={href}
+      rel="noopener noreferrer"
+      target="_blank"
+      {...props}
+    >
+      {children}
+    </a>
+  )
+}
+
 const MARKDOWN_COMPONENTS = {
   h1: tagged('h1'),
   h2: tagged('h2'),
@@ -366,13 +408,24 @@ const MARKDOWN_COMPONENTS = {
   li: tagged('li'),
   blockquote: tagged('blockquote'),
   pre: tagged('pre'),
-  code: MarkdownCode
+  code: MarkdownCode,
+  a: MarkdownAnchor
 }
 
 function MarkdownPreview({ text }: { text: string }) {
+  // Heading ids must be stamped AFTER Streamdown's own rehype chain (raw →
+  // sanitize → harden): `id` is not on rehype-sanitize's default allow-list,
+  // so an id added earlier is stripped before it reaches the DOM (#81055).
+  const rehypePlugins = useMemo(() => [rehypeHeadingIds()], [])
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
-      <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
+      <Streamdown
+        components={MARKDOWN_COMPONENTS}
+        controls={false}
+        mode="static"
+        parseIncompleteMarkdown={false}
+        rehypePlugins={rehypePlugins}
+      >
         {text}
       </Streamdown>
     </div>

--- a/apps/desktop/src/lib/markdown-heading-ids.test.ts
+++ b/apps/desktop/src/lib/markdown-heading-ids.test.ts
@@ -71,6 +71,19 @@ describe('rehypeHeadingIds', () => {
     expect(tree.children?.[0].properties?.id).toBe('managed-tiered-kv-cache')
   })
 
+  it('tolerates undefined holes in children lists (math-plugin pipelines)', () => {
+    // When the KaTeX math plugin runs alongside us, intermediate hast
+    // children arrays can carry undefined holes; the walker must skip
+    // them rather than crash the render (#81055 follow-up).
+    const stamped = heading('h2', 'Still Slugged')
+    const tree: HastNode = {
+      type: 'root',
+      children: [undefined as unknown as HastNode, stamped, undefined as unknown as HastNode],
+    }
+    expect(() => rehypeHeadingIds()(tree)).not.toThrow()
+    expect(stamped.properties?.id).toBe('still-slugged')
+  })
+
   it('disambiguates duplicate slugs with -1 / -2 suffixes', () => {
     const tree = wrap(
       heading('h2', 'Intro'),

--- a/apps/desktop/src/lib/markdown-heading-ids.test.ts
+++ b/apps/desktop/src/lib/markdown-heading-ids.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findHeadingByHash,
+  githubSlug,
+  hashFragment,
+  rehypeHeadingIds
+} from './markdown-heading-ids'
+
+interface HastNode {
+  children?: HastNode[]
+  properties?: Record<string, unknown>
+  tagName?: string
+  type?: string
+  value?: string
+}
+
+function heading(tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', text: string): HastNode {
+  return {
+    type: 'element',
+    tagName: tag,
+    properties: {},
+    children: [{ type: 'text', value: text }],
+  }
+}
+
+function wrap(...children: HastNode[]): HastNode {
+  return { type: 'root', children }
+}
+
+describe('githubSlug', () => {
+  it('lowercases and joins words with single dashes', () => {
+    expect(githubSlug('Managed Tiered KV Cache')).toBe('managed-tiered-kv-cache')
+  })
+
+  it('strips punctuation but keeps unicode letters and digits', () => {
+    expect(githubSlug('Hello, world! 123')).toBe('hello-world-123')
+  })
+
+  it('keeps combining marks and dashes', () => {
+    expect(githubSlug('café — naïve')).toContain('caf')
+    expect(githubSlug('café — naïve')).toContain('na')
+  })
+})
+
+describe('hashFragment', () => {
+  it('strips the leading hash', () => {
+    expect(hashFragment('#foo')).toBe('foo')
+  })
+
+  it('decodes percent-escapes', () => {
+    expect(hashFragment('#hello%20world')).toBe('hello world')
+  })
+
+  it('returns the raw value when decoding fails', () => {
+    // %ZZ is not a valid escape; decodeURIComponent throws — the helper
+    // returns the raw fragment so a malformed href doesn't crash the
+    // preview.
+    expect(hashFragment('#bad%ZZescape')).toBe('bad%ZZescape')
+  })
+
+  it('returns empty string for "#"', () => {
+    expect(hashFragment('#')).toBe('')
+  })
+})
+
+describe('rehypeHeadingIds', () => {
+  it('stamps ids matching github-slugger', () => {
+    const tree = wrap(heading('h2', 'Managed Tiered KV Cache'))
+    rehypeHeadingIds()(tree)
+    expect(tree.children?.[0].properties?.id).toBe('managed-tiered-kv-cache')
+  })
+
+  it('disambiguates duplicate slugs with -1 / -2 suffixes', () => {
+    const tree = wrap(
+      heading('h2', 'Intro'),
+      heading('h2', 'Intro'),
+      heading('h2', 'Intro')
+    )
+    rehypeHeadingIds()(tree)
+    const ids = tree.children!.map((c) => c.properties?.id)
+    expect(ids).toEqual(['intro', 'intro-1', 'intro-2'])
+  })
+
+  it('overwrites pre-existing ids so harden-rewritten user-content-* ids are replaced', () => {
+    const node = heading('h2', 'Real Heading')
+    node.properties = { id: 'user-content-real-heading' }
+    const tree = wrap(node)
+    rehypeHeadingIds()(tree)
+    expect(tree.children?.[0].properties?.id).toBe('real-heading')
+  })
+
+  it('does not stamp non-heading elements', () => {
+    const tree = wrap({
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [{ type: 'text', value: 'not a heading' }],
+    })
+    rehypeHeadingIds()(tree)
+    expect(tree.children?.[0].properties?.id).toBeUndefined()
+  })
+})
+
+describe('findHeadingByHash', () => {
+  function renderToContainer(markup: string): HTMLElement {
+    const container = document.createElement('div')
+    container.innerHTML = markup
+    document.body.appendChild(container)
+    return container
+  }
+
+  it('returns null when the fragment is empty', () => {
+    const c = renderToContainer('<h2 id="foo">Foo</h2>')
+    expect(findHeadingByHash(c, '#')).toBeNull()
+  })
+
+  it('matches an exact id', () => {
+    const c = renderToContainer(
+      '<h2 id="managed-tiered-kv-cache">Managed Tiered KV Cache</h2>'
+    )
+    const heading = findHeadingByHash(c, '#managed-tiered-kv-cache')
+    expect(heading).not.toBeNull()
+    expect(heading?.textContent).toBe('Managed Tiered KV Cache')
+  })
+
+  it('falls back to a decoration-insensitive match', () => {
+    const c = renderToContainer(
+      '<h2 id="section-1-introduction">Section 1 — Introduction</h2>'
+    )
+    // Author wrote the href without the decoration: #section1introduction
+    const heading = findHeadingByHash(c, '#section1introduction')
+    expect(heading?.textContent).toBe('Section 1 — Introduction')
+  })
+
+  it('falls back to a leading-section-number-stripped match', () => {
+    const c = renderToContainer('<h2 id="problem">## Problem</h2>')
+    const heading = findHeadingByHash(c, '#3-problem')
+    expect(heading?.textContent).toBe('## Problem')
+  })
+
+  it('returns null when nothing plausibly matches', () => {
+    const c = renderToContainer('<h2 id="real">Real</h2>')
+    expect(findHeadingByHash(c, '#ghost-heading')).toBeNull()
+  })
+
+  it('does not crash on malformed percent-escapes (#81055)', () => {
+    const c = renderToContainer('<h2 id="real">Real</h2>')
+    // decodeURIComponent would throw — the helper returns the raw string.
+    expect(() => findHeadingByHash(c, '#bad%ZZescape')).not.toThrow()
+  })
+})

--- a/apps/desktop/src/lib/markdown-heading-ids.ts
+++ b/apps/desktop/src/lib/markdown-heading-ids.ts
@@ -1,0 +1,147 @@
+/**
+ * Heading-id stamping + in-page anchor resolution for the Desktop
+ * markdown preview pane (#81055).
+ *
+ * Streamdown does not ship a heading slugger: `<h2>` reaches the DOM
+ * without an `id`, so a same-document `#fragment` link — which Streamdown
+ * also renders as a `<button>` with no `href` — has no anchor target and
+ * no navigation affordance. We stamp the `id` ourselves via a rehype
+ * plugin (after Streamdown's raw → sanitize → harden chain so `id` is not
+ * stripped by rehype-sanitize's default attribute allow-list) and resolve
+ * `#hash` clicks against the rendered headings.
+ *
+ * Slug shape follows github-slugger so the resulting anchors match
+ * GitHub / Obsidian / any rehype-slug-based renderer. Duplicate slugs are
+ * disambiguated the same way (`slug`, `slug-1`, `slug-2`).
+ */
+
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
+
+/** GitHub-style slug: lowercase, strip non-letter/digit/mark/dash/underscore/space. */
+export function githubSlug(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\p{M}\-_\s]/gu, '')
+    .replace(/\s/g, '-')
+}
+
+/** Decoration-insensitive key for tolerant matching only. */
+function looseKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\p{No}/gu, '')
+    .replace(/[^\p{L}\p{N}]/gu, '')
+}
+
+/** Drop a leading section number (`3-`, `1.2)`, `§4 `) from a slug. */
+function withoutLeadingNumber(value: string): string {
+  return value.replace(/^[\s§#]*\d+(?:[.\-)]\d+)*[.\-)\s]*/, '')
+}
+
+interface HastNode {
+  children?: HastNode[]
+  properties?: Record<string, unknown>
+  tagName?: string
+  type?: string
+  value?: string
+}
+
+function nodeText(node: HastNode): string {
+  if (node.type === 'text') {
+    return node.value || ''
+  }
+  // `<br>` in a heading is a line break, not a word-boundary remover.
+  if (node.tagName === 'br') {
+    return ' '
+  }
+  return (node.children || []).map(nodeText).join('')
+}
+
+/**
+ * rehype plugin: stamp an `id` on every heading from its text, deduplicating
+ * collisions the way github-slugger does (`slug`, `slug-1`, `slug-2`).
+ *
+ * Any existing id is replaced on purpose: this runs after rehype-harden,
+ * which has already rewritten author-supplied raw-HTML ids to
+ * `user-content-*` — an address no generated TOC uses.
+ */
+export function rehypeHeadingIds() {
+  return (tree: HastNode) => {
+    const counts = new Map<string, number>()
+    const visit = (node: HastNode) => {
+      if (node.type === 'element' && /^h[1-6]$/.test(node.tagName || '')) {
+        const base = githubSlug(nodeText(node))
+        if (base) {
+          const seen = counts.get(base) ?? 0
+          counts.set(base, seen + 1)
+          node.properties = {
+            ...(node.properties || {}),
+            id: seen === 0 ? base : `${base}-${seen}`,
+          }
+        }
+      }
+      for (const child of node.children || []) {
+        visit(child)
+      }
+    }
+    visit(tree)
+  }
+}
+
+/** Decode a raw `#...` href into the bare fragment it addresses. */
+export function hashFragment(href: string): string {
+  const raw = href.replace(/^#/, '')
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
+}
+
+/**
+ * Resolve a `#hash` against the headings rendered in `container`: exact id
+ * first, then decoration-insensitive, then with a leading section number
+ * stripped. Returns null when nothing plausibly matches — a dead anchor
+ * should stay dead rather than scroll somewhere arbitrary.
+ */
+export function findHeadingByHash(
+  container: ParentNode,
+  href: string
+): HTMLElement | null {
+  const fragment = hashFragment(href)
+  if (!fragment) {
+    return null
+  }
+  const headings = Array.from(
+    container.querySelectorAll<HTMLElement>(HEADING_SELECTOR)
+  )
+  const idOf = (element: HTMLElement) => element.getAttribute('id') || ''
+
+  const exact = headings.find((element) => idOf(element) === fragment)
+  if (exact) {
+    return exact
+  }
+
+  const target = looseKey(fragment)
+  if (!target) {
+    return null
+  }
+  const loose = headings.find((element) => looseKey(idOf(element)) === target)
+  if (loose) {
+    return loose
+  }
+
+  const stripped = looseKey(withoutLeadingNumber(fragment))
+  if (!stripped) {
+    return null
+  }
+  return (
+    headings.find(
+      (element) =>
+        looseKey(withoutLeadingNumber(idOf(element))) === stripped
+    ) ||
+    headings.find((element) => looseKey(idOf(element)) === stripped) ||
+    null
+  )
+}

--- a/apps/desktop/src/lib/markdown-heading-ids.ts
+++ b/apps/desktop/src/lib/markdown-heading-ids.ts
@@ -48,6 +48,9 @@ interface HastNode {
 }
 
 function nodeText(node: HastNode): string {
+  if (!node) {
+    return ''
+  }
   if (node.type === 'text') {
     return node.value || ''
   }
@@ -55,7 +58,7 @@ function nodeText(node: HastNode): string {
   if (node.tagName === 'br') {
     return ' '
   }
-  return (node.children || []).map(nodeText).join('')
+  return (node.children || []).filter(Boolean).map(nodeText).join('')
 }
 
 /**
@@ -70,6 +73,13 @@ export function rehypeHeadingIds() {
   return (tree: HastNode) => {
     const counts = new Map<string, number>()
     const visit = (node: HastNode) => {
+      // Tolerate sparse trees: when other rehype plugins run alongside us
+      // (the preview pane pairs this with the memoized KaTeX math plugin),
+      // intermediate node lists can carry undefined holes — skipping them
+      // keeps id stamping working instead of crashing the render.
+      if (!node) {
+        return
+      }
       if (node.type === 'element' && /^h[1-6]$/.test(node.tagName || '')) {
         const base = githubSlug(nodeText(node))
         if (base) {
@@ -82,7 +92,9 @@ export function rehypeHeadingIds() {
         }
       }
       for (const child of node.children || []) {
-        visit(child)
+        if (child) {
+          visit(child)
+        }
       }
     }
     visit(tree)


### PR DESCRIPTION
Fixes #81055 — A note's own table-of-contents links do nothing in the Desktop markdown preview (no heading ids, no href on #fragment links).