### PR TITLE
fix(gateway): preserve saved voice mode on Discord /voice join

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19190,9 +19190,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            # Preserve a previously-saved mode ("voice_only", "all", "off")
+            # so /voice join doesn't silently clobber an operator's deliberate
+            # setting — channels with no saved mode default to "all" to keep
+            # today's documented join behavior (#81041).
+            voice_key = self._voice_key(event.source.platform, event.source.chat_id)
+            effective_mode = self._voice_mode.setdefault(voice_key, "all")
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            if effective_mode == "voice_only":
+                return (
+                    f"Joined voice channel **{voice_channel.name}**.\n"
+                    f"I'll listen, and reply in text unless you speak. "
+                    f"Use /voice tts to speak all replies."
+                )
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -574,6 +574,65 @@ class TestVoiceChannelCommands:
 
 
     @pytest.mark.asyncio
+    async def test_join_preserves_saved_voice_only_mode(self, runner):
+        """``/voice join`` must not clobber a previously saved ``voice_only``
+        mode (#81041). Without the fix, ``_handle_voice_channel_join``
+        unconditionally writes ``"all"`` to ``_voice_mode`` and persists it,
+        silently degrading a channel that the operator had deliberately set
+        to ``voice_only`` (text-in/text-out, voice-in/voice-out) so the bot
+        starts speaking every typed reply in the VC.
+        """
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        event = self._make_discord_event()
+        event.source.chat_type = "group"
+        event.source.chat_name = "Hermes Server / #general"
+        runner.adapters[event.source.platform] = mock_adapter
+        runner._voice_mode["discord:123"] = "voice_only"
+
+        result = await runner._handle_voice_channel_join(event)
+
+        # The saved mode is preserved (not clobbered to "all").
+        assert runner._voice_mode["discord:123"] == "voice_only"
+        # The persisted file reflects the preserved mode.
+        persisted = json.loads(runner._VOICE_MODE_PATH.read_text(encoding="utf-8"))
+        assert persisted["discord:123"] == "voice_only"
+        # The join reply acknowledges the voice_only behaviour so the operator
+        # is not told "I'll speak my replies" when the bot won't.
+        assert "joined" in result.lower()
+        assert "General" in result
+        assert "voice_only" in result or "reply in text" in result.lower()
+        assert "I'll speak my replies" not in result
+
+    @pytest.mark.asyncio
+    async def test_join_preserves_saved_all_mode(self, runner):
+        """``/voice join`` with an existing ``"all"`` mode keeps ``"all"``."""
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        event = self._make_discord_event()
+        event.source.chat_type = "group"
+        event.source.chat_name = "Hermes Server / #general"
+        runner.adapters[event.source.platform] = mock_adapter
+        runner._voice_mode["discord:123"] = "all"
+
+        await runner._handle_voice_channel_join(event)
+
+        assert runner._voice_mode["discord:123"] == "all"
+
+
+    @pytest.mark.asyncio
     async def test_join_missing_voice_dependencies(self, runner):
         """Missing PyNaCl/davey should return a user-actionable install hint."""
         mock_channel = MagicMock()


### PR DESCRIPTION
Fixes #81041

The Discord gateway's `_handle_voice_channel_join` (gateway/run.py) unconditionally writes `"all"` to `_voice_mode` and persists it on every successful join, clobbering any previously saved `"voice_only"` mode.

Operators who deliberately set a channel to `voice_only` (`/voice on` — text-in/text-out, voice-in/voice-out) silently lost that setting on every `/voice join`/reconnect, and the bot started speaking every typed reply in the VC. There was no signal to the user beyond the reply text.

## Fix

Use `setdefault(key, "all")` so a previously saved mode is respected. Channels with no prior setting keep today's documented "join and speak my replies" behavior. The canned reply is adjusted when the effective mode is `voice_only` so the operator isn't told "I'll speak my replies" for a channel that won't.

This is the `setdefault` version of the proposed fix in #81041; it leaves the `voice.default_mode` config seeding and the gateway-vs-CLI split called out in the issue for a follow-up.

## Tests

`tests/gateway/test_voice_command.py` gains two regression tests:

- `test_join_preserves_saved_voice_only_mode`: pre-seed `_voice_mode["discord:123"] = "voice_only"`, run `_handle_voice_channel_join`, assert the mode is preserved in memory AND persisted to the on-disk `gateway_voice_mode.json`, and that the reply reflects the voice_only behavior (no "I'll speak my replies" line).
- `test_join_preserves_saved_all_mode`: pre-seed with `"all"`, assert no behavior change.

All 10 tests in `TestVoiceChannelCommands` pass.
