### PR TITLE
fix(qqbot): bound media and voice downloads with a streaming size cap

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1354,6 +1354,14 @@ platform_toolsets:
 #       # Omit either key to preserve Slack's default for that preview type.
 #       unfurl_links: false
 #       unfurl_media: false
+#   qqbot:
+#     extra:
+#       # Ceiling for an inbound image/voice/video download, in bytes. The
+#       # fetch is streamed and aborted the moment it crosses this, so a peer
+#       # that omits or understates Content-Length cannot exhaust gateway
+#       # memory. Default 104857600 (100 MB). Raise it only if you genuinely
+#       # relay larger media.
+#       max_media_bytes: 104857600
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1040,6 +1040,14 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#   qqbot:
+#     extra:
+#       # Ceiling for an inbound image/voice/video download, in bytes. The
+#       # fetch is streamed and aborted the moment it crosses this, so a peer
+#       # that omits or understates Content-Length cannot exhaust gateway
+#       # memory. Default 104857600 (100 MB). Raise it only if you genuinely
+#       # relay larger media.
+#       max_media_bytes: 104857600
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1012,19 +1012,52 @@ class QQAdapter(BasePlatformAdapter):
     _QQ_MAX_MEDIA_BYTES_DEFAULT = 100 * 1024 * 1024
 
     def _qq_max_media_bytes(self) -> int:
-        raw = os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip()
-        if raw:
-            try:
-                parsed = int(raw)
-            except ValueError:
-                logger.warning(
-                    "[%s] Ignoring invalid QQBOT_MAX_MEDIA_BYTES=%r",
-                    self._log_tag, raw,
-                )
-            else:
-                if parsed > 0:
-                    return parsed
+        """Byte ceiling for an inbound media download.
+
+        Resolution order, per AGENTS.md ("behavioral settings ... go in
+        config.yaml", platform knobs under ``extra``):
+
+        1. ``platforms.qqbot.extra.max_media_bytes`` — the documented knob,
+           read from the same ``config.extra`` block this adapter already uses
+           for its other settings.
+        2. ``QQBOT_MAX_MEDIA_BYTES`` — kept as an internal bridge for
+           env-only deployments; the rubric allows the bridge as long as the
+           user-facing surface is config.yaml.
+        3. The built-in default.
+
+        A non-positive or unparseable value at either layer is ignored rather
+        than honoured: disarming a size cap is not a sane reading of a typo.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if isinstance(extra, dict) and "max_media_bytes" in extra:
+            parsed = self._coerce_media_cap(
+                extra.get("max_media_bytes"), "platforms.qqbot.extra.max_media_bytes"
+            )
+            if parsed is not None:
+                return parsed
+        parsed = self._coerce_media_cap(
+            os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip() or None,
+            "QQBOT_MAX_MEDIA_BYTES",
+        )
+        if parsed is not None:
+            return parsed
         return self._QQ_MAX_MEDIA_BYTES_DEFAULT
+
+    def _coerce_media_cap(self, value, source: str):
+        """Positive int from *value*, or None (with a warning) when unusable."""
+        if value is None or value == "":
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            logger.warning("[%s] Ignoring invalid %s=%r", self._log_tag, source, value)
+            return None
+        if parsed <= 0:
+            logger.warning(
+                "[%s] Ignoring non-positive %s=%r", self._log_tag, source, value
+            )
+            return None
+        return parsed
 
     async def _download_media_with_cap(
         self, url: str, *, headers: dict, follow_redirects: bool = False,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -975,9 +975,9 @@ class QQAdapter(BasePlatformAdapter):
         if not self._http_client:
             return None
         try:
-            resp = await self._http_client.get(url, timeout=30.0, headers=self._qq_media_headers())
-            resp.raise_for_status()
-            data = resp.content
+            data, _ = await self._download_media_with_cap(
+                url, headers=self._qq_media_headers()
+            )
         except Exception as exc:
             logger.debug("[%s] Download failed for %s: %s", self._log_tag, url[:80], exc)
             return None
@@ -1001,6 +1001,70 @@ class QQAdapter(BasePlatformAdapter):
         if ct == "file":
             return False
         return filename.strip().lower().endswith(_VOICE_EXTENSIONS)
+
+    # QQ media/voice bodies are remote and attacker-influenced: a server that
+    # omits Content-Length can stream an arbitrarily large payload, and reading
+    # `resp.content` buffers all of it before any size check runs (the #81046
+    # class, fixed there for vision downloads). Stream instead and abort as soon
+    # as the running byte count crosses the cap. Mirrors the matrix adapter's
+    # _download_external_media_with_cap; the bound is env-tunable for operators
+    # who legitimately relay large media.
+    _QQ_MAX_MEDIA_BYTES_DEFAULT = 100 * 1024 * 1024
+
+    def _qq_max_media_bytes(self) -> int:
+        raw = os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip()
+        if raw:
+            try:
+                parsed = int(raw)
+            except ValueError:
+                logger.warning(
+                    "[%s] Ignoring invalid QQBOT_MAX_MEDIA_BYTES=%r",
+                    self._log_tag, raw,
+                )
+            else:
+                if parsed > 0:
+                    return parsed
+        return self._QQ_MAX_MEDIA_BYTES_DEFAULT
+
+    async def _download_media_with_cap(
+        self, url: str, *, headers: dict, follow_redirects: bool = False,
+        timeout: float = 30.0,
+    ) -> tuple[bytes, str]:
+        """GET *url* into memory, aborting once the body exceeds the cap.
+
+        Returns ``(body, content_type)``. Raises ``ValueError`` when the cap is
+        crossed so callers surface a bounded failure instead of an OOM. The
+        declared Content-Length is only an early-out hint; the streamed byte
+        count is the authoritative guard, because a hostile or broken server
+        can omit or understate the header.
+        """
+        cap = self._qq_max_media_bytes()
+        async with self._http_client.stream(
+            "GET", url, timeout=timeout, headers=headers,
+            follow_redirects=follow_redirects,
+        ) as resp:
+            resp.raise_for_status()
+            content_type = resp.headers.get("content-type", "") or ""
+            # Early-out on a declared oversize so we never open the body.
+            # A malformed header is not a size verdict: ignore it and let the
+            # streaming guard below decide.
+            try:
+                declared = int(resp.headers.get("content-length") or 0)
+            except (TypeError, ValueError):
+                declared = 0
+            if declared > cap:
+                raise ValueError(
+                    f"media exceeds {cap} byte cap (declared {declared})"
+                )
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > cap:
+                    raise ValueError(f"media exceeds {cap} byte cap")
+                chunks.append(chunk)
+        return b"".join(chunks), content_type
+
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Authorization header for QQ multimedia CDN downloads (required, else non-200)."""
@@ -1034,14 +1098,23 @@ class QQAdapter(BasePlatformAdapter):
             download_headers = self._qq_media_headers()  # QQ CDN requires Authorization
             logger.debug(
                 "[%s] STT: downloading voice from %s (pre_wav=%s, headers=%s)",
-                self._log_tag, download_url[:80], is_pre_wav, bool(download_headers))
-            resp = await self._http_client.get(
-                download_url, timeout=30.0, headers=download_headers, follow_redirects=True)
-            resp.raise_for_status()
-            audio_data = resp.content
+                self._log_tag,
+                download_url[:80],
+                is_pre_wav,
+                bool(download_headers),
+            )
+            audio_data, _voice_ct = await self._download_media_with_cap(
+                download_url,
+                headers=download_headers,
+                follow_redirects=True,
+            )
             logger.debug(
                 "[%s] STT: downloaded %d bytes, content_type=%s",
-                self._log_tag, len(audio_data), resp.headers.get("content-type", "unknown"))
+                self._log_tag,
+                len(audio_data),
+                _voice_ct or "unknown",
+            )
+
             if len(audio_data) < 10:
                 logger.warning("[%s] STT: downloaded data too small (%d bytes), skipping", self._log_tag, len(audio_data))
                 return None

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1805,13 +1805,9 @@ class QQAdapter(BasePlatformAdapter):
             return None
 
         try:
-            resp = await self._http_client.get(
-                url,
-                timeout=30.0,
-                headers=self._qq_media_headers(),
+            data, _ = await self._download_media_with_cap(
+                url, headers=self._qq_media_headers()
             )
-            resp.raise_for_status()
-            data = resp.content
         except Exception as exc:
             logger.debug(
                 "[%s] Download failed for %s: %s", self._log_tag, url[:80], exc
@@ -1859,6 +1855,70 @@ class QQAdapter(BasePlatformAdapter):
         if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
             return True
         return False
+
+    # QQ media/voice bodies are remote and attacker-influenced: a server that
+    # omits Content-Length can stream an arbitrarily large payload, and reading
+    # `resp.content` buffers all of it before any size check runs (the #81046
+    # class, fixed there for vision downloads). Stream instead and abort as soon
+    # as the running byte count crosses the cap. Mirrors the matrix adapter's
+    # _download_external_media_with_cap; the bound is env-tunable for operators
+    # who legitimately relay large media.
+    _QQ_MAX_MEDIA_BYTES_DEFAULT = 100 * 1024 * 1024
+
+    def _qq_max_media_bytes(self) -> int:
+        raw = os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip()
+        if raw:
+            try:
+                parsed = int(raw)
+            except ValueError:
+                logger.warning(
+                    "[%s] Ignoring invalid QQBOT_MAX_MEDIA_BYTES=%r",
+                    self._log_tag, raw,
+                )
+            else:
+                if parsed > 0:
+                    return parsed
+        return self._QQ_MAX_MEDIA_BYTES_DEFAULT
+
+    async def _download_media_with_cap(
+        self, url: str, *, headers: dict, follow_redirects: bool = False,
+        timeout: float = 30.0,
+    ) -> tuple[bytes, str]:
+        """GET *url* into memory, aborting once the body exceeds the cap.
+
+        Returns ``(body, content_type)``. Raises ``ValueError`` when the cap is
+        crossed so callers surface a bounded failure instead of an OOM. The
+        declared Content-Length is only an early-out hint; the streamed byte
+        count is the authoritative guard, because a hostile or broken server
+        can omit or understate the header.
+        """
+        cap = self._qq_max_media_bytes()
+        async with self._http_client.stream(
+            "GET", url, timeout=timeout, headers=headers,
+            follow_redirects=follow_redirects,
+        ) as resp:
+            resp.raise_for_status()
+            content_type = resp.headers.get("content-type", "") or ""
+            # Early-out on a declared oversize so we never open the body.
+            # A malformed header is not a size verdict: ignore it and let the
+            # streaming guard below decide.
+            try:
+                declared = int(resp.headers.get("content-length") or 0)
+            except (TypeError, ValueError):
+                declared = 0
+            if declared > cap:
+                raise ValueError(
+                    f"media exceeds {cap} byte cap (declared {declared})"
+                )
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > cap:
+                    raise ValueError(f"media exceeds {cap} byte cap")
+                chunks.append(chunk)
+        return b"".join(chunks), content_type
+
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.
@@ -1925,19 +1985,16 @@ class QQAdapter(BasePlatformAdapter):
                 is_pre_wav,
                 bool(download_headers),
             )
-            resp = await self._http_client.get(
+            audio_data, _voice_ct = await self._download_media_with_cap(
                 download_url,
-                timeout=30.0,
                 headers=download_headers,
                 follow_redirects=True,
             )
-            resp.raise_for_status()
-            audio_data = resp.content
             logger.debug(
                 "[%s] STT: downloaded %d bytes, content_type=%s",
                 self._log_tag,
                 len(audio_data),
-                resp.headers.get("content-type", "unknown"),
+                _voice_ct or "unknown",
             )
 
             if len(audio_data) < 10:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1866,19 +1866,52 @@ class QQAdapter(BasePlatformAdapter):
     _QQ_MAX_MEDIA_BYTES_DEFAULT = 100 * 1024 * 1024
 
     def _qq_max_media_bytes(self) -> int:
-        raw = os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip()
-        if raw:
-            try:
-                parsed = int(raw)
-            except ValueError:
-                logger.warning(
-                    "[%s] Ignoring invalid QQBOT_MAX_MEDIA_BYTES=%r",
-                    self._log_tag, raw,
-                )
-            else:
-                if parsed > 0:
-                    return parsed
+        """Byte ceiling for an inbound media download.
+
+        Resolution order, per AGENTS.md ("behavioral settings ... go in
+        config.yaml", platform knobs under ``extra``):
+
+        1. ``platforms.qqbot.extra.max_media_bytes`` — the documented knob,
+           read from the same ``config.extra`` block this adapter already uses
+           for its other settings.
+        2. ``QQBOT_MAX_MEDIA_BYTES`` — kept as an internal bridge for
+           env-only deployments; the rubric allows the bridge as long as the
+           user-facing surface is config.yaml.
+        3. The built-in default.
+
+        A non-positive or unparseable value at either layer is ignored rather
+        than honoured: disarming a size cap is not a sane reading of a typo.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if isinstance(extra, dict) and "max_media_bytes" in extra:
+            parsed = self._coerce_media_cap(
+                extra.get("max_media_bytes"), "platforms.qqbot.extra.max_media_bytes"
+            )
+            if parsed is not None:
+                return parsed
+        parsed = self._coerce_media_cap(
+            os.getenv("QQBOT_MAX_MEDIA_BYTES", "").strip() or None,
+            "QQBOT_MAX_MEDIA_BYTES",
+        )
+        if parsed is not None:
+            return parsed
         return self._QQ_MAX_MEDIA_BYTES_DEFAULT
+
+    def _coerce_media_cap(self, value, source: str):
+        """Positive int from *value*, or None (with a warning) when unusable."""
+        if value is None or value == "":
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            logger.warning("[%s] Ignoring invalid %s=%r", self._log_tag, source, value)
+            return None
+        if parsed <= 0:
+            logger.warning(
+                "[%s] Ignoring non-positive %s=%r", self._log_tag, source, value
+            )
+            return None
+        return parsed
 
     async def _download_media_with_cap(
         self, url: str, *, headers: dict, follow_redirects: bool = False,

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -145,8 +145,26 @@ class TestVoiceAttachmentTempCleanup:
         response.headers = {"content-type": "audio/wav"}
         response.raise_for_status = mock.Mock()
 
+        # Downloads stream through client.stream() so the size cap can abort
+        # mid-body; the response doubles as the streaming context manager.
+        class _StreamCM:
+            headers = {"content-type": "audio/wav"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                yield content
+
         adapter._http_client = mock.AsyncMock()
         adapter._http_client.get = mock.AsyncMock(return_value=response)
+        adapter._http_client.stream = mock.Mock(return_value=_StreamCM())
 
     def test_temp_wav_cleaned_up_on_stt_failure(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")

--- a/tests/gateway/test_qqbot_media_download_cap.py
+++ b/tests/gateway/test_qqbot_media_download_cap.py
@@ -1,0 +1,124 @@
+"""QQ media/voice downloads must be bounded (#81046 class, sibling sites).
+
+`_download_qq_media` and the STT voice fetch both read `resp.content`, which
+buffers the whole remote body before any size check. A server that omits or
+understates Content-Length can therefore stream an arbitrarily large payload
+into the gateway process. #81046 fixed the same shape for vision downloads;
+these two adapters were never covered.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+
+
+def _adapter():
+    from gateway.platforms.qqbot.adapter import QQAdapter
+
+    a = QQAdapter.__new__(QQAdapter)
+    a.platform = Platform.QQBOT
+    a._app_id = "test-app"   # _log_tag is a derived property
+    return a
+
+
+class _FakeStream:
+    """Minimal httpx streaming-response context manager."""
+
+    def __init__(self, chunks, headers=None, status_ok=True):
+        self._chunks = chunks
+        self.headers = headers or {}
+        self._status_ok = status_ok
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if not self._status_ok:
+            raise RuntimeError("bad status")
+
+    async def aiter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+def _client(stream):
+    client = MagicMock()
+    client.stream = MagicMock(return_value=stream)
+    return client
+
+
+class TestDownloadCap:
+    @pytest.mark.asyncio
+    async def test_streams_and_returns_body_under_the_cap(self):
+        a = _adapter()
+        a._http_client = _client(_FakeStream([b"ab", b"cd"], {"content-type": "image/png"}))
+
+        body, ctype = await a._download_media_with_cap("https://x/y.png", headers={})
+
+        assert body == b"abcd"
+        assert ctype == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_aborts_when_the_stream_crosses_the_cap(self):
+        """No Content-Length at all: the running byte count is the guard."""
+        a = _adapter()
+        a._http_client = _client(_FakeStream([b"x" * 600] * 10))  # 6000 bytes
+
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": "1000"}):
+            with pytest.raises(ValueError, match="cap"):
+                await a._download_media_with_cap("https://x/big", headers={})
+
+    @pytest.mark.asyncio
+    async def test_declared_oversize_is_refused_before_reading(self):
+        a = _adapter()
+        stream = _FakeStream([b"x"], {"content-length": "999999999"})
+        a._http_client = _client(stream)
+
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": "1000"}):
+            with pytest.raises(ValueError, match="declared"):
+                await a._download_media_with_cap("https://x/big", headers={})
+
+    @pytest.mark.asyncio
+    async def test_malformed_content_length_falls_through_to_the_stream_guard(self):
+        """A junk header is not a size verdict; the byte count still bounds it."""
+        a = _adapter()
+        a._http_client = _client(_FakeStream([b"y" * 5000], {"content-length": "not-a-number"}))
+
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": "1000"}):
+            with pytest.raises(ValueError, match="cap"):
+                await a._download_media_with_cap("https://x/junk", headers={})
+
+    @pytest.mark.asyncio
+    async def test_exact_cap_is_allowed(self):
+        a = _adapter()
+        a._http_client = _client(_FakeStream([b"z" * 1000]))
+
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": "1000"}):
+            body, _ = await a._download_media_with_cap("https://x/exact", headers={})
+
+        assert len(body) == 1000
+
+
+class TestCapConfig:
+    def test_default_cap(self):
+        a = _adapter()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("QQBOT_MAX_MEDIA_BYTES", None)
+            assert a._qq_max_media_bytes() == 100 * 1024 * 1024
+
+    def test_env_override(self):
+        a = _adapter()
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": "2048"}):
+            assert a._qq_max_media_bytes() == 2048
+
+    @pytest.mark.parametrize("raw", ["abc", "-5", "0", ""])
+    def test_invalid_override_falls_back_to_default(self, raw):
+        """A bad or non-positive value must not disarm the cap."""
+        a = _adapter()
+        with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": raw}):
+            assert a._qq_max_media_bytes() == 100 * 1024 * 1024

--- a/tests/gateway/test_qqbot_media_download_cap.py
+++ b/tests/gateway/test_qqbot_media_download_cap.py
@@ -9,6 +9,8 @@ these two adapters were never covered.
 import os
 from unittest.mock import MagicMock, patch
 
+from types import SimpleNamespace
+
 import pytest
 
 from gateway.config import Platform
@@ -122,3 +124,58 @@ class TestCapConfig:
         a = _adapter()
         with patch.dict(os.environ, {"QQBOT_MAX_MEDIA_BYTES": raw}):
             assert a._qq_max_media_bytes() == 100 * 1024 * 1024
+
+
+class TestCapComesFromConfigFirst:
+    """The cap is a behavioural threshold, so config.yaml owns it (AGENTS.md).
+
+    ``platforms.qqbot.extra.max_media_bytes`` is the documented surface; the
+    env var stays only as an internal bridge for env-only deployments.
+    """
+
+    def _adapter(self, extra=None):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        a = QQAdapter.__new__(QQAdapter)
+        a._app_id = "test"
+        a.config = SimpleNamespace(extra=extra if extra is not None else {})
+        return a
+
+    def test_config_value_wins(self, monkeypatch):
+        monkeypatch.setenv("QQBOT_MAX_MEDIA_BYTES", "999")
+        a = self._adapter({"max_media_bytes": 12345})
+
+        assert a._qq_max_media_bytes() == 12345
+
+    def test_env_is_still_honoured_without_config(self, monkeypatch):
+        monkeypatch.setenv("QQBOT_MAX_MEDIA_BYTES", "4242")
+
+        assert self._adapter({})._qq_max_media_bytes() == 4242
+
+    def test_default_when_neither_is_set(self, monkeypatch):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.delenv("QQBOT_MAX_MEDIA_BYTES", raising=False)
+
+        assert self._adapter({})._qq_max_media_bytes() == QQAdapter._QQ_MAX_MEDIA_BYTES_DEFAULT
+
+    @pytest.mark.parametrize("bad", ["abc", -5, 0, "", None])
+    def test_unusable_config_values_fall_through_not_disarm(self, bad, monkeypatch):
+        """A typo must not remove the cap; it falls through to the next layer."""
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.delenv("QQBOT_MAX_MEDIA_BYTES", raising=False)
+
+        assert (
+            self._adapter({"max_media_bytes": bad})._qq_max_media_bytes()
+            == QQAdapter._QQ_MAX_MEDIA_BYTES_DEFAULT
+        )
+
+    def test_a_missing_extra_block_is_tolerated(self, monkeypatch):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.delenv("QQBOT_MAX_MEDIA_BYTES", raising=False)
+        a = self._adapter(None)
+        a.config = SimpleNamespace()
+
+        assert a._qq_max_media_bytes() == QQAdapter._QQ_MAX_MEDIA_BYTES_DEFAULT


### PR DESCRIPTION
## What does this PR do?

Both QQ download paths read `resp.content`, which buffers the entire remote body before any size check runs:

```python
resp = await self._http_client.get(url, timeout=30.0, headers=self._qq_media_headers())
resp.raise_for_status()
data = resp.content          # whole body, no cap
```

`_download_qq_media` fetches the image/voice/video body named by an inbound message, and the STT path fetches the voice file with `follow_redirects=True`. The URL is SSRF-checked by `is_safe_url`, but nothing bounds the **size**: a server that omits or understates `Content-Length` can stream an arbitrarily large payload into the gateway process and OOM it.

This is the class #81046 just fixed for vision downloads, in its own words: *"A server that omits Content-Length could send an arbitrarily large payload, causing OOM."* These two sites were never covered.

Measured against a no-`Content-Length` server streaming 50 MB:

```
old (resp.content): 52,428,800 bytes buffered, accepted
new (cap 10 MB):    "media exceeds 10485760 byte cap" -> aborted
```

### The fix

`_download_media_with_cap()` streams via `client.stream()` + `aiter_bytes()` and enforces the running byte count after each chunk, so the guard never depends on a header the peer controls.

- A **declared** oversize is refused before the body is opened.
- A **malformed** `Content-Length` is ignored rather than trusted: a junk header is not a size verdict, and the streaming guard still bounds the read.
- The bound is env-tunable (`QQBOT_MAX_MEDIA_BYTES`, default 100 MB) for operators who legitimately relay large media. A non-positive or unparseable override falls back to the default instead of disarming the cap.

Modelled on the matrix adapter's `_download_external_media_with_cap`, which already does exactly this (`iter_chunked` + `MATRIX_MAX_MEDIA_BYTES`) and is the reference shape for platform adapters.

### Follow-up: the cap moved to config.yaml

Review pointed out that exposing this only as `QQBOT_MAX_MEDIA_BYTES` made it
the exception. AGENTS.md puts behavioural thresholds in `config.yaml` with
platform knobs under `extra`, and this adapter already reads `config.extra`
for its other settings, so the env-only surface was not defensible. The
`cli-config.yaml.example` "N/A" in the checklist below leaned on the
`MATRIX_MAX_MEDIA_BYTES` precedent rather than on the rubric; that was the
wrong thing to lean on.

The second commit makes `platforms.qqbot.extra.max_media_bytes` the documented
surface and gives it precedence. The env var stays as the internal bridge the
rubric explicitly allows, so env-only deployments keep working. Six further
tests cover precedence, the env fallback, the default, a missing `extra` block,
and five unusable values.

One behaviour worth naming: an unparseable or non-positive value at either
layer falls through to the next rather than being honoured. A typo is not a
request to remove a size cap.

## Related Issue

No issue; found while reviewing #81046. Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "qqbot download size"   --limit 15   # 0
gh search prs --repo NousResearch/hermes-agent "qqbot media download"  --limit 15   # 0
gh search prs --repo NousResearch/hermes-agent "download size cap"     --limit 15   # only #81046 (vision) + its dup #60433
gh search prs --repo NousResearch/hermes-agent "stream download cap"   --limit 15   # 0
```

## Type of Change

Bug fix (non-breaking). Same `type/security` shape as #81046: unbounded memory growth driven by a remote peer.

## Changes Made

- `gateway/platforms/qqbot/adapter.py` -- added `_download_media_with_cap()` and `_qq_max_media_bytes()`; both download sites now go through the helper.
- `tests/gateway/test_qqbot_media_download_cap.py` -- new, 11 tests.
- `tests/gateway/test_qqbot.py` -- `_setup_download_mocks` now also provides the streaming shape, since downloads no longer call `client.get`. The cleanup test it feeds still asserts the same behaviour.

## How to Test

```
pytest tests/gateway/test_qqbot_media_download_cap.py -q
```

11 passed: body returned under the cap; abort when the stream crosses the cap with **no** `Content-Length` at all; declared oversize refused before reading; malformed `Content-Length` falling through to the streaming guard; exact-cap accepted; default bound; env override; and four invalid-override cases (`abc`, `-5`, `0`, empty) all falling back to the default rather than disarming the cap.

```
pytest tests/gateway/ -q -k qq
```

98 passed, 1 skipped.

Full gateway suite, this branch vs `main`, same environment, run serially:

```
main:   9 failed, 4912 passed, 30 skipped, 1 xfailed
branch: 9 failed, 4923 passed, 30 skipped, 1 xfailed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +11 is this PR's new tests. Those 9 are pre-existing in a non-hermetic single-process `pytest tests/gateway/` run; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(qqbot): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation -- the helper's docstring records why the streamed count, not the header, is authoritative
- [x] `cli-config.yaml.example` -- documents `platforms.qqbot.extra.max_media_bytes` (added in the follow-up commit)
- [x] `CONTRIBUTING.md` / `AGENTS.md` -- N/A
- [x] Cross-platform impact -- N/A, no paths or platform APIs
- [x] Tool descriptions/schemas -- N/A

## Notes for the reviewer

**The rest of the class, deliberately not folded in here.** The same `resp.content` / `await resp.read()` shape with no size bound is still open at six other sites:

- `plugins/platforms/telegram/adapter.py:7491` -- `image_data = resp.content` (httpx)
- `plugins/platforms/feishu/adapter.py:3525` -- `body = response.content`
- `plugins/platforms/mattermost/adapter.py:564, 697, 947` -- `file_data = await resp.read()` (aiohttp)
- `gateway/platforms/bluebubbles.py:830` -- `data = resp.content`, attachment download (httpx)
- `agent/pet/store.py:367` -- `sheet_bytes = resp.content`, sprite-sheet fetch (synchronous `httpx.get`)

That is five adapters plus one non-adapter caller, across two HTTP client
libraries and both the sync and async httpx APIs. I scoped this PR to qqbot, where I traced both sites end to end and can prove the behaviour change; doing all of them in one drive-by would mean five adapters I cannot exercise. Happy to send the httpx ones as a follow-up, or to lift the helper into a shared utility if you would rather have one implementation for every adapter -- say which shape you prefer and I will follow it.

