### PR TITLE
fix(gateway): preserve voice_mode on Discord /voice join

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19190,13 +19190,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            # Respect any previously-saved voice mode for this chat —
+            # only seed the "all" default on first-ever join (#81041).
+            voice_key = self._voice_key(
+                event.source.platform, event.source.chat_id
+            )
+            effective_mode = self._voice_mode.setdefault(voice_key, "all")
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
-            return (
-                f"Joined voice channel **{voice_channel.name}**.\n"
-                f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
-            )
+            if effective_mode == "voice_only":
+                reply = (
+                    f"Joined voice channel **{voice_channel.name}**.\n"
+                    "I'll listen in voice and stay text-only for typed messages "
+                    "(mode: voice_only). Use /voice leave to disconnect."
+                )
+            else:
+                reply = (
+                    f"Joined voice channel **{voice_channel.name}**.\n"
+                    f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
+                )
+            return reply
         # Join failed — clear callback
         adapter._voice_input_callback = None
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -184,6 +184,67 @@ class TestHandleVoiceCommand:
         assert runner._voice_mode["slack:999"] == "off"
 
 
+class TestVoiceJoinPreservesExistingMode:
+    """Issue #81041: ``/voice join`` must NOT clobber a saved mode."""
+
+    def _make_runner(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        # Pre-existing saved mode for this Discord channel: voice_only
+        runner._voice_mode["discord:777"] = "voice_only"
+        # Stub adapter lookup + adapter API surface the join handler uses.
+        from types import SimpleNamespace
+        adapter = SimpleNamespace(
+            join_voice_channel=AsyncMock(return_value=True),
+            get_user_voice_channel=AsyncMock(
+                return_value=SimpleNamespace(name="general", id=42)
+            ),
+            _voice_text_channels={},
+            _voice_sources={},
+            _auto_tts_enabled_chats=set(),
+        )
+        runner.adapters = {"discord": adapter}
+        runner._adapter_for_source = lambda source: adapter
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_join_preserves_voice_only(self, tmp_path):
+        """Regression for issue #81041.
+
+        ``/voice join`` previously set ``_voice_mode[key] = "all"``
+        unconditionally, silently overwriting a previously-saved
+        ``voice_only``. The user then had to re-run ``/voice on`` after
+        every join/rejoin or the bot would speak every typed reply into
+        the VC.
+        """
+        from gateway.config import Platform
+        runner = self._make_runner(tmp_path)
+
+        event = _make_event("/voice join", chat_id="777")
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+
+        await runner._handle_voice_channel_join(event)
+
+        assert runner._voice_mode["discord:777"] == "voice_only"
+
+    @pytest.mark.asyncio
+    async def test_join_seeds_default_when_no_saved_mode(self, tmp_path):
+        """Channels with no saved mode keep the documented ``"all"`` default
+        on first join (unchanged behaviour for everyone else, #81041)."""
+        from gateway.config import Platform
+        runner = self._make_runner(tmp_path)
+        # No pre-existing entry for chat_id=888
+        runner._voice_mode.pop("discord:888", None)
+
+        event = _make_event("/voice join", chat_id="888")
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+
+        await runner._handle_voice_channel_join(event)
+
+        assert runner._voice_mode["discord:888"] == "all"
+
+
 # =====================================================================
 # Auto voice reply decision logic
 # =====================================================================


### PR DESCRIPTION
Fixes #81041

`/voice join` (and `/voice channel`) unconditionally wrote `_voice_mode[key] = "all"` on every successful join, silently clobbering any previously-saved `voice_only`. Operators had to re-run `/voice on` after every join/rejoin or the bot would start speaking every typed reply into the VC.

Fix: `setdefault("all")` so the default seeds only on first-ever join. Existing modes (`voice_only`, `off`) survive a join/rejoin unchanged. The canned join reply also reflects the effective mode when it isn't `all`.

Regression tests cover both branches:
- a saved voice_only survives a join
- a chat with no prior entry still seeds "all" on first join.