### PR TITLE
fix(gateway): route approval/denial replies before busy handler (#81026)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8874,6 +8874,97 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    async def _route_pending_approval_response(
+        self, event: MessageEvent, session_key: str
+    ) -> Optional[str]:
+        """Route an approval/denial reply to the canonical handler.
+
+        When a dangerous command is blocked waiting for approval, the user's
+        response may arrive in several shapes: bare ``yes``/``approve``,
+        ``/approve [all|session|always]``, a platform display-prefixed
+        ``!approve``, or a quoted/forwarded message where the slash command is
+        on the last line. If a blocking approval exists for the session and
+        the message matches one of those forms, synthesize a canonical
+        ``/approve <args>``/``/deny <args>`` command, update ``event.text``,
+        and return the handler's reply. Otherwise return ``None`` so the
+        caller can fall through to normal busy handling.
+        """
+        try:
+            from tools.approval import has_blocking_approval
+            if not has_blocking_approval(session_key):
+                return None
+        except Exception:
+            return None
+
+        full_text = (event.text or "").strip()
+        if not full_text:
+            return None
+
+        # Check the full text first; if that is not an approval reply but the
+        # message is multi-line, look at the last non-empty line. Messaging
+        # platforms often quote the previous bot message, leaving the user's
+        # actual response on the final line.
+        candidates: list[str] = [full_text.strip().lower()]
+        for line in reversed(full_text.splitlines()):
+            stripped = line.strip()
+            if stripped:
+                candidates.append(stripped.lower())
+                break
+
+        _approve_commands = {
+            "approve", "yes", "ok", "okay", "confirm", "y", "always", "session",
+        }
+        _deny_commands = {"deny", "no", "reject", "cancel", "n"}
+
+        handler: Optional[Callable[[MessageEvent], Awaitable[Any]]] = None
+        args = ""
+        for _lower in candidates:
+            # Emoji reactions are exact matches only.
+            if _lower == "👍":
+                handler = self._handle_approve_command
+                args = ""
+                break
+            if _lower == "👎":
+                handler = self._handle_deny_command
+                args = ""
+                break
+
+            # Strip display prefixes (! on Slack/Matrix). A leading slash is
+            # removed before parsing the command and any modifiers.
+            _cmd_text = _lower.lstrip("!").strip()
+            if _cmd_text.startswith("/"):
+                _cmd_text = _cmd_text[1:].lstrip()
+            _parts = _cmd_text.split(maxsplit=1)
+            _cmd = _parts[0] if _parts else ""
+            _arg = _parts[1] if len(_parts) > 1 else ""
+
+            if _cmd in _approve_commands:
+                handler = self._handle_approve_command
+                if _cmd in {"always", "session"} and not _arg:
+                    # Single-word scope shorthand.
+                    args = _cmd
+                else:
+                    args = _arg
+                break
+            if _cmd in _deny_commands:
+                handler = self._handle_deny_command
+                args = _arg
+                break
+
+        if handler is None:
+            return None
+
+        _verb = "approve" if handler is self._handle_approve_command else "deny"
+        _synth = f"/{_verb}"
+        if args:
+            _synth = f"{_synth} {args}"
+        event.text = _synth
+        logger.info(
+            "Approval response routed: session=%s verb=%s args=%r original=%r",
+            session_key, _verb, args, full_text,
+        )
+        return await handler(event)
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -8919,77 +9010,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True
 
-        # --- Approval response routing (#46866) ---
+        # --- Approval response routing (#46866, #81026) ---
         # When the agent is blocked waiting for a dangerous-command approval,
-        # plain-text responses like "yes" or "approve" must be routed to the
-        # approval handler instead of being steered/queued/interrupted.
-        # Otherwise approval via messaging platforms never succeeds — the
+        # user responses ("yes", "/approve", "!approve", quoted replies with
+        # the slash on the last line, etc.) must be routed to the approval
+        # handler instead of being steered/queued/interrupted. Otherwise the
         # reply is queued behind a turn that can't start until the approval
         # resolves, so the approval times out and auto-denies (a deadlock).
-        #
-        # Slash forms (/approve, /deny) already bypass to the runner at the
-        # base-adapter guard.  This handles the bare-word forms (Signal/SMS
-        # users naturally type "yes" rather than "/approve").  Gating on
-        # has_blocking_approval(session_key) is the disambiguator that keeps
-        # a conversational "yes" from triggering a dangerous command when no
-        # approval is actually pending (design intent — see run.py "Pending
-        # exec approvals are handled by /approve and /deny" note).
-        #
-        # We reuse the canonical /approve and /deny handlers rather than
-        # re-deriving the resolution + i18n messaging: they resolve the
-        # waiting thread, resume typing, AND return a localized confirmation
-        # string.  The busy-handler path does not auto-send that return, so
-        # we deliver it ourselves (mirroring the draining-case send above).
         try:
-            from tools.approval import has_blocking_approval
-            if has_blocking_approval(session_key):
-                _raw_text = (event.text or "").strip().lower()
-                _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
-                _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
-                _approval_handler = None
-                _normalized_args = ""
-                if _raw_text in _approve_words:
-                    _approval_handler = self._handle_approve_command
-                elif _raw_text in _deny_words:
-                    _approval_handler = self._handle_deny_command
-                elif _raw_text in {"always", "approve always", "always approve"}:
-                    _approval_handler = self._handle_approve_command
-                    _normalized_args = "always"
-                elif _raw_text in {"session", "approve session", "session approve"}:
-                    _approval_handler = self._handle_approve_command
-                    _normalized_args = "session"
-                if _approval_handler is not None:
-                    # Synthesize the canonical "/approve [args]" / "/deny"
-                    # command text so the slash handlers parse modifiers via
-                    # event.get_command_args().  Always use a literal "/" —
-                    # MessageEvent.is_command()/get_command_args() only
-                    # recognize the "/" prefix, not the per-platform display
-                    # prefix ("!" on Slack/Matrix).
-                    _verb = "approve" if _approval_handler is self._handle_approve_command else "deny"
-                    _synth = f"/{_verb}"
-                    if _normalized_args:
-                        _synth = f"{_synth} {_normalized_args}"
-                    event.text = _synth
-                    _reply = await _approval_handler(event)
-                    logger.info(
-                        "Approval response via plain text: session=%s verb=%s args=%r",
-                        session_key, _verb, _normalized_args,
-                    )
-                    _adapter = self._adapter_for_source(event.source)
-                    if _adapter and _reply:
-                        _text, _eph_ttl = _adapter._unwrap_ephemeral(_reply)
-                        if _text:
-                            _anchor = self._reply_anchor_for_event(event)
-                            await _adapter._send_with_retry(
-                                chat_id=event.source.chat_id,
-                                content=_text,
-                                reply_to=_anchor,
-                                metadata=self._thread_metadata_for_source(event.source, _anchor),
-                            )
-                    return True
+            _reply = await self._route_pending_approval_response(event, session_key)
+            if _reply is not None:
+                _adapter = self._adapter_for_source(event.source)
+                if _adapter and _reply:
+                    _text, _eph_ttl = _adapter._unwrap_ephemeral(_reply)
+                    if _text:
+                        _anchor = self._reply_anchor_for_event(event)
+                        await _adapter._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=_text,
+                            reply_to=_anchor,
+                            metadata=self._thread_metadata_for_source(event.source, _anchor),
+                        )
+                return True
         except Exception:
             logger.warning(
-                "Plain-text approval routing failed for session %s; "
+                "Approval response routing failed for session %s; "
                 "falling through to busy handling",
                 session_key, exc_info=True,
             )
@@ -15034,6 +15079,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return await self._dispatch_busy_slash_command(
                     event, _cmd_def_inner, _quick_key, source,
                 )
+
+            # If the message looks like an approval/denial reply but did not
+            # resolve as a recognized slash command (e.g. a quoted reply where
+            # the command is on the last line), route it before the busy
+            # queue/steer/interrupt logic consumes it.
+            _approval_reply = await self._route_pending_approval_response(event, _quick_key)
+            if _approval_reply is not None:
+                return _approval_reply
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8938,6 +8938,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cmd = _parts[0] if _parts else ""
             _arg = _parts[1] if len(_parts) > 1 else ""
 
+            # Reversed scope shorthand: "always approve" / "session approve"
+            # (and the same with yes/ok/deny/...) are equivalent to the
+            # canonical "/approve always" / "/approve session" form.
+            if _cmd in {"always", "session"} and _arg and (
+                _arg in _approve_commands or _arg in _deny_commands
+            ):
+                if _arg in _approve_commands:
+                    handler = self._handle_approve_command
+                else:
+                    handler = self._handle_deny_command
+                args = _cmd
+                break
+
             if _cmd in _approve_commands:
                 handler = self._handle_approve_command
                 if _cmd in {"always", "session"} and not _arg:

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -110,6 +110,45 @@ def test_plaintext_yes_resolves_approval(reply):
     _clear_approval_state()
 
 
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "/approve",          # direct slash
+        "/approve all",      # resolve all
+        "/approve session",  # session scope
+        "/approve always",   # permanent scope
+        "> previous prompt\n/approve",          # quoted reply
+        "> quoted\n/approve all",               # quoted /approve all
+        "> quoted\n/approve session",           # quoted /approve session
+        "!approve",          # Slack/Matrix display prefix
+        "/yes",              # alias slash
+        "> quoted\n/yes",    # quoted alias
+    ],
+)
+def test_approval_routing_handles_slash_and_quoted_replies(reply):
+    """A quoted /approve (or last-line slash) must resolve, not be queued.
+
+    Regression for #81026: the second (and subsequent) /approve in a session
+    can be delivered as a quoted reply or with a display prefix. The busy
+    handler previously only matched bare words and exact slash forms that
+    bypassed the active-session guard, so the approval was queued/interrupted
+    and the command timed out.
+    """
+    _clear_approval_state()
+    runner, adapter = _make_runner()
+    session_key, entry = _register_blocking_approval(runner)
+
+    handled = asyncio.run(
+        runner._handle_active_session_busy_message(_make_event(reply), session_key)
+    )
+
+    assert handled is True
+    assert entry.event.is_set()
+    assert entry.result in {"once", "session", "always"}
+    adapter._send_with_retry.assert_awaited()
+    _clear_approval_state()
+
+
 def test_no_pending_approval_does_not_consume_conversational_yes():
     """A bare 'yes' with NO blocking approval must NOT be treated as an
     approval — it falls through to normal busy handling (design intent:

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -149,6 +149,38 @@ def test_approval_routing_handles_slash_and_quoted_replies(reply):
     _clear_approval_state()
 
 
+@pytest.mark.parametrize(
+    "reply,expected",
+    [
+        ("always approve", "always"),
+        ("approve always", "always"),
+        ("session approve", "session"),
+        ("approve session", "session"),
+        ("always yes", "always"),
+        ("session y", "session"),
+    ],
+)
+def test_approval_scope_word_order(reply, expected):
+    """Reversed scope shorthand ("always approve" etc.) resolves correctly.
+
+    Regression from maintainer review on #81088: the helper previously
+    synthesized "/approve approve" for "always approve", losing the scope.
+    """
+    _clear_approval_state()
+    runner, adapter = _make_runner()
+    session_key, entry = _register_blocking_approval(runner)
+
+    handled = asyncio.run(
+        runner._handle_active_session_busy_message(_make_event(reply), session_key)
+    )
+
+    assert handled is True
+    assert entry.event.is_set()
+    assert entry.result == expected
+    adapter._send_with_retry.assert_awaited()
+    _clear_approval_state()
+
+
 def test_no_pending_approval_does_not_consume_conversational_yes():
     """A bare 'yes' with NO blocking approval must NOT be treated as an
     approval — it falls through to normal busy handling (design intent:


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway busy handler so that approval/denial replies are routed to the canonical `/approve`/`/deny` handlers before the generic queue/steer/interrupt busy logic can consume them.

The second (and subsequent) pending dangerous-command approval in the same agent run could be missed when the user's reply reached the busy handler in a form that wasn't matched by the previous bare-word-only approval routing: slash commands inside quoted/forwarded messages, display-prefixed commands (`!approve` on Slack/Matrix), or multi-line replies where the command is on the last line.

## Related Issue

Fixes #81026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`:
  - Added `_route_pending_approval_response()`, a shared helper that detects approval/denial replies in multiple forms (slash, bare-word, `!`/`/` display prefixes, quoted last-line, aliases like `yes`/`no`) and only activates when `has_blocking_approval(session_key)` is true.
  - Replaced the bare-word-only approval routing in `_handle_active_session_busy_message()` with the new helper.
  - Added the same guard at the start of the busy queue/steer/interrupt path in `_handle_message()` so un-recognized slash-shaped replies (e.g. quoted commands) are not queued or steered when an approval is pending.
- `tests/gateway/test_plaintext_approval_routing.py`:
  - Added a parametrized regression test covering `/approve`, `/approve all`, `/approve session`, `/approve always`, quoted replies, `!approve`, and the `yes` alias.

## How to Test

1. `uv run python -m pytest tests/gateway/test_plaintext_approval_routing.py -q -o 'addopts='`
2. `uv run python -m pytest tests/gateway/test_approve_deny_commands.py tests/gateway/test_priority_path_compression_demotion_56391.py tests/gateway/test_subagent_protection_30170.py -q -o 'addopts='`
3. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/81026`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS