### PR TITLE
fix(memory): gate provider system-prompt block on the toolset gate

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -483,12 +483,36 @@ class MemoryManager:
 
     # -- System prompt -------------------------------------------------------
 
-    def build_system_prompt(self) -> str:
+    def build_system_prompt(
+        self,
+        *,
+        enabled_toolsets: Optional[List[str]] = None,
+        disabled_toolsets: Optional[List[str]] = None,
+        memory_tool_present: bool = False,
+    ) -> str:
         """Collect system prompt blocks from all providers.
 
         Returns combined text, or empty string if no providers contribute.
         Each non-empty block is labeled with the provider name.
+
+        Honors the same ``memory_provider_tools_enabled`` gate as
+        :func:`inject_memory_provider_tools` when ``enabled_toolsets`` /
+        ``disabled_toolsets`` are supplied (#81014). Without this gate, an
+        operator who disables the memory toolset (e.g.
+        ``agent.disabled_toolsets: [memory]``) still sees the provider's
+        "use mnemosyne_remember …" instructions in the system prompt even
+        though the corresponding tools are absent from the model surface —
+        producing a dangling instruction that confuses smaller models and
+        causes failed / hallucinated tool calls.
         """
+        if (enabled_toolsets is not None or disabled_toolsets is not None) and not (
+            memory_provider_tools_enabled(
+                enabled_toolsets,
+                disabled_toolsets,
+                memory_tool_present=memory_tool_present,
+            )
+        ):
+            return ""
         blocks = []
         for provider in self._providers:
             try:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -523,10 +523,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
+    # External memory provider system prompt block (additive to built-in).
+    # Honors the same toolset gate as inject_memory_provider_tools so the
+    # provider's "use mnemosyne_remember …" instructions aren't injected into
+    # the system prompt when the provider's tools are gated out — see #81014.
     if agent._memory_manager:
         try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
+            _existing_tool_names = {
+                tool.get("function", {}).get("name")
+                for tool in (agent.tools or [])
+                if isinstance(tool, dict)
+            }
+            _ext_mem_block = agent._memory_manager.build_system_prompt(
+                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                memory_tool_present="memory" in _existing_tool_names,
+            )
             if _ext_mem_block:
                 volatile_parts.append(_ext_mem_block)
         except Exception:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -18,10 +18,11 @@ from agent.memory_manager import MemoryManager, inject_memory_provider_tools
 class FakeMemoryProvider(MemoryProvider):
     """Minimal concrete provider for testing."""
 
-    def __init__(self, name="fake", available=True, tools=None):
+    def __init__(self, name="fake", available=True, tools=None, prompt_block=""):
         self._name = name
         self._available = available
         self._tools = tools or []
+        self._prompt_block = prompt_block
         self.initialized = False
         self.synced_turns = []
         self.prefetch_queries = []
@@ -32,7 +33,6 @@ class FakeMemoryProvider(MemoryProvider):
         self.memory_writes = []
         self.shutdown_called = False
         self._prefetch_result = ""
-        self._prompt_block = ""
 
     @property
     def name(self) -> str:
@@ -966,6 +966,90 @@ class TestMemoryToolToolsetGate:
         mgr = self._mgr_with_tools("fact_store", "memory_search", "memory_add")
         tools, names = self._run_memory_injection(None, mgr)
         assert names == {"fact_store", "memory_search", "memory_add"}
+
+
+class TestMemorySystemPromptToolsetGate:
+    """Issue #81014: ``MemoryManager.build_system_prompt`` must honor the same
+    toolset gate as :func:`inject_memory_provider_tools`.
+
+    Without the gate, an operator who disables the memory toolset (e.g.
+    ``agent.disabled_toolsets: [memory]``) still sees the provider's
+    "use mnemosyne_remember …" instructions in the system prompt even
+    though the corresponding tools are absent from the model surface —
+    producing a dangling instruction that confuses smaller models and
+    causes failed / hallucinated tool calls.
+
+    Mirror of :class:`TestMemoryToolToolsetGate` for the prompt path.
+    """
+
+    @staticmethod
+    def _mgr_with_block(block_text):
+        mgr = MemoryManager()
+        mgr.add_provider(FakeMemoryProvider("mnemosyne", prompt_block=block_text))
+        return mgr
+
+    def test_no_gate_args_returns_block_unchanged(self):
+        """Existing call sites that pass no gate args keep today's behavior."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert "mnemosyne_remember" in mgr.build_system_prompt()
+
+    def test_disabled_memory_toolset_suppresses_block(self):
+        """``disabled_toolsets: [memory]`` suppresses the provider's prompt block."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert mgr.build_system_prompt(
+            enabled_toolsets=None,
+            disabled_toolsets=["memory"],
+            memory_tool_present=False,
+        ) == ""
+
+    def test_empty_enabled_toolsets_suppresses_block(self):
+        """``enabled_toolsets: []`` (e.g. ``platform_toolsets.telegram: []``) suppresses the block."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert mgr.build_system_prompt(
+            enabled_toolsets=[],
+            disabled_toolsets=None,
+            memory_tool_present=False,
+        ) == ""
+
+    def test_enabled_toolsets_without_memory_suppresses_block(self):
+        """Toolsets that don't include memory suppress the prompt block."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert mgr.build_system_prompt(
+            enabled_toolsets=["terminal", "web"],
+            disabled_toolsets=None,
+            memory_tool_present=False,
+        ) == ""
+
+    def test_memory_in_enabled_toolsets_keeps_block(self):
+        """An explicit ``memory`` opt-in keeps the block."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert "mnemosyne_remember" in mgr.build_system_prompt(
+            enabled_toolsets=["terminal", "memory"],
+            disabled_toolsets=None,
+            memory_tool_present=False,
+        )
+
+    def test_disabled_memory_wins_over_enabled_memory(self):
+        """An explicit ``disabled_toolsets: [memory]`` overrides enabled include."""
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        assert mgr.build_system_prompt(
+            enabled_toolsets=["memory"],
+            disabled_toolsets=["memory"],
+            memory_tool_present=False,
+        ) == ""
+
+    def test_memory_tool_present_keeps_block(self):
+        """If the built-in ``memory`` tool IS on the surface, the prompt
+        block is kept (matches :func:`memory_provider_tools_enabled`'s
+        ``memory_tool_present`` shortcut for the no-disabled-toolsets path).
+        """
+        mgr = self._mgr_with_block("Use mnemosyne_remember to store facts.")
+        out = mgr.build_system_prompt(
+            enabled_toolsets=["hermes-cli"],  # does NOT include memory
+            disabled_toolsets=None,
+            memory_tool_present=True,
+        )
+        assert "mnemosyne_remember" in out
 
 
 class TestContextEngineToolsetGate:


### PR DESCRIPTION
Fixes #81014

## Problem

`MemoryManager.build_system_prompt()` injected every registered provider's `system_prompt_block()` **unconditionally**, while the provider's tools were gated by `memory_provider_tools_enabled()` (which honors `agent.disabled_toolsets` and `platform_toolsets`).

When the memory toolset was disabled (e.g. `agent.disabled_toolsets: [memory]`) or excluded from the platform's enabled toolsets, the system prompt still told the model to use `mnemosyne_remember` / `mnemosyne_recall`, etc. — tools that were **absent** from its tool surface. This dangling instruction caused confused tool-call attempts and failed memory operations, with no warning logged anywhere.

## Fix

- `MemoryManager.build_system_prompt()` now accepts the same `enabled_toolsets` / `disabled_toolsets` / `memory_tool_present` arguments as the tool-injection path and returns `""` when the gate is closed. Existing call sites that pass no gate args keep today's behavior (backward compatible).
- `agent/system_prompt.py:build_system_prompt_parts` passes the agent's `enabled_toolsets` / `disabled_toolsets` and whether the built-in `memory` tool is present on the surface, so prompt assembly and tool injection can no longer diverge.

## Tests

`tests/agent/test_memory_provider.py` gains `TestMemorySystemPromptToolsetGate` covering:

- no gate args → block returned (backward compat)
- `disabled_toolsets: [memory]` → block suppressed
- `enabled_toolsets: []` → block suppressed
- enabled toolsets without memory → block suppressed
- `memory` in enabled toolsets → block kept
- disabled wins over enabled
- built-in `memory` tool present → block kept

All 65 tests in `test_memory_provider.py` pass, plus the related system-prompt / memory-boundary suites. The only failure in the wider `tests/agent` run is a pre-existing Windows path-separator mismatch in `test_system_prompt.py::test_coding_prompt_preserves_legacy_workspace_order` (confirmed failing on the base commit too).
