### PR TITLE
fix: show explicit member spend cap message instead of 'no credits'

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -139,6 +139,7 @@ _BILLING_ERROR_CODES = frozenset({
     "no_usable_credits",
     "balance_depleted",
     "model_not_supported_on_free_tier",
+    "member_spend_cap_exceeded",
     _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -939,7 +939,7 @@ def format_auth_error(error: Exception) -> str:
             return _format_nous_entitlement_auth_error(error)
         return "Subscription credits are exhausted. Top up/renew credits, then retry."
 
-    if error.code in {"subscription_expired", "no_usable_credits", "account_missing"}:
+    if error.code in {"subscription_expired", "no_usable_credits", "account_missing", "member_spend_cap_exceeded"}:
         if error.provider == "nous":
             return _format_nous_entitlement_auth_error(error)
 

--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -58,6 +58,10 @@ class NousPaidServiceAccessInfo:
     subscription_credits_remaining: Optional[float] = None
     purchased_credits_remaining: Optional[float] = None
     total_usable_credits: Optional[float] = None
+    member_spend_cap_exceeded: Optional[bool] = None
+    member_spend_cap_usd: Optional[float] = None
+    member_spend_usd: Optional[float] = None
+    member_spend_cap_remaining_usd: Optional[float] = None
 
 
 @dataclass(frozen=True)
@@ -267,6 +271,23 @@ def _no_paid_access_message(
     total_usable = access.total_usable_credits if access else None
     subscription_credits = access.subscription_credits_remaining if access else None
     purchased_credits = access.purchased_credits_remaining if access else None
+
+    if access and access.member_spend_cap_exceeded:
+        cap = access.member_spend_cap_usd
+        spent = access.member_spend_usd
+        credit_detail = _credit_detail(total_usable, subscription_credits, purchased_credits)
+        cap_detail = ""
+        if cap is not None and spent is not None:
+            cap_detail = f" Your organisation's per-member spend cap is ${cap:.2f} and you've spent ${spent:.2f} of it."
+        elif cap is not None:
+            cap_detail = f" Your organisation's per-member spend cap is ${cap:.2f}."
+        return (
+            f"Your Nous Portal access is paused because you've exceeded the"
+            f" per-member spend cap set by your organisation.{cap_detail}"
+            f"{credit_detail} Ask your organisation admin to raise the"
+            f" member spend cap at {billing_url}, then run `hermes model`"
+            f" to refresh."
+        )
 
     if has_active_subscription and active_subscription_is_paid:
         credit_detail = _credit_detail(total_usable, subscription_credits, purchased_credits)
@@ -713,6 +734,10 @@ def _paid_service_access_from_payload(value: Any) -> Optional[NousPaidServiceAcc
         subscription_credits_remaining=_coerce_float(value.get("subscription_credits_remaining")),
         purchased_credits_remaining=_coerce_float(value.get("purchased_credits_remaining")),
         total_usable_credits=_coerce_float(value.get("total_usable_credits")),
+        member_spend_cap_exceeded=_coerce_bool(value.get("member_spend_cap_exceeded")),
+        member_spend_cap_usd=_coerce_float(value.get("member_spend_cap_usd")),
+        member_spend_usd=_coerce_float(value.get("member_spend_usd")),
+        member_spend_cap_remaining_usd=_coerce_float(value.get("member_spend_cap_remaining_usd")),
     )
 
 

--- a/tests/hermes_cli/test_nous_account.py
+++ b/tests/hermes_cli/test_nous_account.py
@@ -41,7 +41,38 @@ def _account_payload(
     subscription: dict[str, Any] | None,
     subscription_credits: float,
     purchased_credits: float,
+    member_spend_cap_exceeded: bool | None = None,
+    member_spend_cap_usd: float | str | None = None,
+    member_spend_usd: float | str | None = None,
+    member_spend_cap_remaining_usd: float | str | None = None,
 ) -> dict[str, Any]:
+    psa: dict[str, Any] = {
+        "allowed": allowed,
+        "paid_access": allowed,
+        "reason": "usable_credits" if allowed else "no_usable_credits",
+        "organisation_id": "org_123",
+        "effective_at_ms": 123456789,
+        "has_active_subscription": subscription is not None,
+        "active_subscription_is_paid": bool(
+            subscription and subscription.get("monthly_charge", 0) > 0
+        ),
+        "subscription_tier": subscription.get("tier") if subscription else None,
+        "subscription_monthly_charge": (
+            subscription.get("monthly_charge") if subscription else None
+        ),
+        "subscription_credits_remaining": subscription_credits,
+        "purchased_credits_remaining": purchased_credits,
+        "total_usable_credits": subscription_credits + purchased_credits,
+    }
+    if member_spend_cap_exceeded is not None:
+        psa["member_spend_cap_exceeded"] = member_spend_cap_exceeded
+        psa["reason"] = "member_spend_cap_exceeded"
+    if member_spend_cap_usd is not None:
+        psa["member_spend_cap_usd"] = member_spend_cap_usd
+    if member_spend_usd is not None:
+        psa["member_spend_usd"] = member_spend_usd
+    if member_spend_cap_remaining_usd is not None:
+        psa["member_spend_cap_remaining_usd"] = member_spend_cap_remaining_usd
     return {
         "user": {
             "email": "alice@example.test",
@@ -52,24 +83,7 @@ def _account_payload(
         },
         "subscription": subscription,
         "purchased_credits_remaining": purchased_credits,
-        "paid_service_access": {
-            "allowed": allowed,
-            "paid_access": allowed,
-            "reason": "usable_credits" if allowed else "no_usable_credits",
-            "organisation_id": "org_123",
-            "effective_at_ms": 123456789,
-            "has_active_subscription": subscription is not None,
-            "active_subscription_is_paid": bool(
-                subscription and subscription.get("monthly_charge", 0) > 0
-            ),
-            "subscription_tier": subscription.get("tier") if subscription else None,
-            "subscription_monthly_charge": (
-                subscription.get("monthly_charge") if subscription else None
-            ),
-            "subscription_credits_remaining": subscription_credits,
-            "purchased_credits_remaining": purchased_credits,
-            "total_usable_credits": subscription_credits + purchased_credits,
-        },
+        "paid_service_access": psa,
     }
 
 
@@ -254,6 +268,67 @@ def test_pool_oauth_entry_force_fresh_uses_account_api(monkeypatch):
     assert info.credential_source == "pool:dashboard device_code"
 
 
+# ── member spend cap exceeded ───────────────────────────────────────────────
+
+
+def test_member_spend_cap_exceeded_message(monkeypatch):
+    """When the Portal returns member_spend_cap_exceeded, the entitlement
+    message should explain the cap — not say 'no credits'."""
+    payload = _account_payload(
+        allowed=False,
+        subscription=None,
+        subscription_credits=0,
+        purchased_credits=222990.17,
+        member_spend_cap_exceeded=True,
+        member_spend_cap_usd="500",
+        member_spend_usd="520.51",
+        member_spend_cap_remaining_usd="0",
+    )
+    token = _jwt({"sub": "user_123", "org_id": "org_123", "exp": int(time.time()) + 900})
+    monkeypatch.setattr("hermes_cli.auth.get_provider_auth_state", lambda provider: _state(token))
+    monkeypatch.setattr("hermes_cli.auth.resolve_nous_access_token", lambda: "fresh-token")
+    monkeypatch.setattr("hermes_cli.nous_account._fetch_nous_account_info", lambda *a, **kw: payload)
+
+    info = get_nous_portal_account_info(force_fresh=True)
+
+    assert info.paid_service_access is False
+    assert info.paid_service_access_info is not None
+    assert info.paid_service_access_info.member_spend_cap_exceeded is True
+    assert info.paid_service_access_info.member_spend_cap_usd == 500.0
+    assert info.paid_service_access_info.member_spend_usd == 520.51
+
+    msg = format_nous_portal_entitlement_message(info, capability="Nous model access")
+    assert msg is not None
+    # Must mention spend cap, not "no active subscription or usable credits"
+    assert "spend cap" in msg
+    assert "$500.00" in msg
+    assert "$520.51" in msg
+    # Should NOT say "no active subscription"
+    assert "no active subscription" not in msg
+    # Should still show available credits
+    assert "$222990.17" in msg
+
+
+def test_member_spend_cap_exceeded_without_amounts(monkeypatch):
+    """Even if the Portal doesn't include cap/spend amounts, the message
+    should still mention the spend cap rather than credits."""
+    payload = _account_payload(
+        allowed=False,
+        subscription=None,
+        subscription_credits=0,
+        purchased_credits=100,
+        member_spend_cap_exceeded=True,
+    )
+    token = _jwt({"sub": "user_123", "org_id": "org_123", "exp": int(time.time()) + 900})
+    monkeypatch.setattr("hermes_cli.auth.get_provider_auth_state", lambda provider: _state(token))
+    monkeypatch.setattr("hermes_cli.auth.resolve_nous_access_token", lambda: "fresh-token")
+    monkeypatch.setattr("hermes_cli.nous_account._fetch_nous_account_info", lambda *a, **kw: payload)
+
+    info = get_nous_portal_account_info(force_fresh=True)
+    msg = format_nous_portal_entitlement_message(info, capability="Nous model access")
+    assert msg is not None
+    assert "spend cap" in msg
+    assert "no active subscription" not in msg
 
 
 


### PR DESCRIPTION
## Context

When a Nous Portal user exceeds their organisation's per-member spend cap, the Portal API returns:

```json
{
  "paid_service_access": {
    "allowed": false,
    "reason": "member_spend_cap_exceeded",
    "member_spend_cap_exceeded": true,
    "member_spend_cap_usd": "<cap>",
    "member_spend_usd": "<spent>",
    "member_spend_cap_remaining_usd": "0",
    "total_usable_credits": "<credits>",
    "has_active_subscription": false
  }
}
```

Hermes was falling through to the generic "no active subscription or usable credits" branch, producing this misleading message:

> Your Nous Portal account has no active subscription or usable credits (usable $..., subscription $0.00, purchased $...), so paid Nous models is unavailable.

The user may have ample purchased credits — the real blocker is the org-level per-member spend cap.

## What changed

Added a dedicated `member_spend_cap_exceeded` branch in `_no_paid_access_message()` that fires **before** the generic subscription/credits fall-through. The user now sees:

> Your Nous Portal access is paused because you've exceeded the per-member spend cap set by your organisation. Your organisation's per-member spend cap is $X.XX and you've spent $Y.YY of it. (usable $Z.ZZ, subscription $0.00, purchased $Z.ZZ) Ask your organisation admin to raise the member spend cap at https://portal.nousresearch.com/billing, then run `hermes model` to refresh.

### Files

- **`hermes_cli/nous_account.py`** — Added 4 fields (`member_spend_cap_exceeded`, `member_spend_cap_usd`, `member_spend_usd`, `member_spend_cap_remaining_usd`) to `NousPaidServiceAccessInfo`, parse them in `_paid_service_access_from_payload()`, and added the dedicated message branch in `_no_paid_access_message()`.
- **`agent/error_classifier.py`** — Added `"member_spend_cap_exceeded"` to `_BILLING_ERROR_CODES` so it's treated as a billing error (not a transient retry).
- **`hermes_cli/auth.py`** — Added `"member_spend_cap_exceeded"` to the Nous-specific auth error code set so it routes through `_format_nous_entitlement_auth_error()` for the proper Portal-aware message.
- **`tests/hermes_cli/test_nous_account.py`** — Extended `_account_payload()` test helper + 2 new tests: full message with cap/spend amounts, and graceful degradation when amounts are absent.

## Test plan

- [x] `pytest tests/hermes_cli/test_nous_account.py` — 8 passed
- [x] `pytest tests/agent/test_billing_usage.py tests/agent/test_nous_credits_gauge.py tests/agent/test_nous_credits_snapshot.py tests/tools/test_tool_backend_helpers.py tests/agent/test_credits_view.py tests/agent/test_error_classifier.py` — 125 passed, 0 regressions
