### PR TITLE
fix(desktop): support RTL session titles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -238,7 +238,10 @@ function SidebarSessionRowImpl({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+          <SidebarRowLabel
+            className="flex-1 text-start font-normal [unicode-bidi:plaintext] group-hover:text-foreground group-data-[working=true]:text-foreground/90"
+            dir="auto"
+          >
             {title}
           </SidebarRowLabel>
           {showProfile && <ProfileTag profile={session.profile} />}


### PR DESCRIPTION
## Summary

Fix RTL and mixed-direction session titles in the Desktop sidebar.

Session titles can contain Persian, Arabic, Hebrew, or mixed RTL/LTR text. They were previously rendered with LTR-oriented alignment and bidi behavior.

This change:

- adds `dir=auto` so the browser determines the title's base direction
- uses `text-start` instead of fixed left alignment
- uses `unicode-bidi: plaintext` for more reliable mixed RTL/LTR rendering

The change is intentionally scoped to session-title directionality. It does not introduce language-specific fonts or global typography changes.

## Testing

- TypeScript typecheck: passed
- ESLint: passed with 0 errors
- Manually verified on Windows with Persian and mixed Persian/English session titles
- Full UI suite was not clean in the local environment: 3519/3525 tests passed; the full suite was not rerun after rebasing