### PR TITLE
fix(browser): validate params before frame_id SSRF guard (#80846)

### DIFF
--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -426,6 +426,12 @@ def browser_cdp(
     """
     effective_task_id = task_id or "default"
 
+    # --- Validate params before any routing (frame_id path included) ---
+    if params is not None and not isinstance(params, dict):
+        return tool_error(
+            f"'params' must be an object/dict, got {type(params).__name__}"
+        )
+
     # --- Route iframe-scoped calls through the supervisor ---------------
     if frame_id:
         # Same private-page/SSRF boundary as the stateless path below —


### PR DESCRIPTION
## Summary

Validates `params` type **before** the `frame_id` routing branch in `browser_cdp()`, closing a path where malformed `params` could bypass the private-page / SSRF guard.

Fixes #80846

## Root cause

The `frame_id` early-return (line ~430) calls `_browser_cdp_private_guard(params=params or {})` **before** the `isinstance(params, dict)` check that the non-frame_id path enforces (line ~479).

When `params` is a non-dict value (e.g. a string):
1. `_browser_cdp_private_guard` calls `(params or {}).get(...)` which raises `AttributeError`
2. The broad `except Exception` at line 176 catches it and returns `None` (fail-open)
3. The guard is bypassed and the call proceeds into supervisor routing

## Fix

Add `isinstance(params, dict)` validation at the top of `browser_cdp()`, before either routing path. This matches the existing validation contract and ensures malformed params are rejected with a clear error message regardless of whether `frame_id` is set.

## Testing

- Existing `browser_cdp` tests continue to pass
- Non-dict `params` with `frame_id` now returns the same validation error as without `frame_id`
