### PR TITLE
fix(gateway): canonicalize MEDIA dedup keys so spaced/slash-mixed paths upload once (#78383)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4516,6 +4516,18 @@ class BasePlatformAdapter(ABC):
         # referenced twice in one response — e.g. a MEDIA tag inline AND in a
         # summary footer — is uploaded once, not twice (#29131).
         seen_paths: set = set()
+
+        def _seen_key(p: str) -> str:
+            # Windows is case-insensitive and treats '/' and '\\' as
+            # interchangeable separators, so the same file can be spelled
+            # several ways (D:/a/b, D:\\a\\b, d:\\a\\b). Canonicalize before
+            # deduping so one file referenced with mixed spellings uploads
+            # once, not twice (#78383).
+            try:
+                return os.path.normcase(os.path.normpath(p))
+            except (OSError, RuntimeError, ValueError):
+                return p
+
         for match in media_pattern.finditer(scan_content):
             path = _normalize_media_tag_path(match.group("path"))
             if path:
@@ -4534,8 +4546,8 @@ class BasePlatformAdapter(ABC):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.
                     continue
-                if expanded not in seen_paths:
-                    seen_paths.add(expanded)
+                if _seen_key(expanded) not in seen_paths:
+                    seen_paths.add(_seen_key(expanded))
                     media.append((expanded, is_voice))
 
         for match in MEDIA_EXTENSIONLESS_TAG_RE.finditer(scan_content):
@@ -4546,10 +4558,10 @@ class BasePlatformAdapter(ABC):
             if resolved is None:
                 continue
             safe = resolved[0]
-            if safe not in seen_paths:
+            if _seen_key(safe) not in seen_paths:
                 _safe_ext = os.path.splitext(safe)[1].lower()
                 media.append((safe, has_voice_tag and _safe_ext in _AUDIO_EXTS))
-                seen_paths.add(safe)
+                seen_paths.add(_seen_key(safe))
 
         # Remove the delivered MEDIA tags from the user-visible text. Mask a
         # length-equal copy of ``cleaned`` (same union of protected regions) to

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1667,17 +1667,26 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     paths: set = set()
     tool_name_by_call_id: Dict[str, str] = {}
 
+    def _norm_media_path(p: str) -> str:
+        # Canonicalize so spellings that differ only by case/separator
+        # (D:/a/b vs D:\\a\\b vs d:\\a\\b) dedupe to one entry, matching the
+        # extract_media seen-key logic (#78383).
+        try:
+            return os.path.normcase(os.path.normpath(p))
+        except (OSError, RuntimeError, ValueError):
+            return p
+
     def _add_text_media_paths(content: str) -> None:
         for match in _TOOL_MEDIA_RE.finditer(content):
             path = match.group(1).strip().rstrip('",}')
             if path:
-                paths.add(path)
+                paths.add(_norm_media_path(path))
         # The regex alone misses quoted and spaced paths that the delivery
         # pipeline's extract_media grammar accepts — collect through the same
         # extractor so the dedup set sees every path that could actually have
         # been delivered.
         media_files, _ = BasePlatformAdapter.extract_media(content)
-        paths.update(path for path, _is_voice in media_files)
+        paths.update(_norm_media_path(path) for path, _is_voice in media_files)
 
     for msg in agent_history:
         if msg.get("role") == "assistant":


### PR DESCRIPTION
Fixes #78383

## Problem
`extract_media` dedupes MEDIA attachment paths against a `seen_paths` set using **raw path strings**. On Windows, the same file can be spelled multiple ways (D:/a/b, D:\a\b, d:\a\b), so a spaced path picked up by both the main parser and the extensionless fallback parser escapes dedup and is **delivered twice**.

## Fix
Canonicalize with `os.path.normcase(os.path.normpath(p))` before comparing/adding to the dedup set:
- `gateway/platforms/base.py` — `extract_media` seen_keys (3 sites)
- `gateway/run.py` — `_collect_history_media_paths` history dedup (2 sites)

Because `extract_media` is defined once on `BasePlatformAdapter` and inherited by every platform adapter (no overrides), the fix applies to **all messaging platforms** (feishu, weixin, qqbot, telegram, discord, etc.) at both the per-message and cross-turn dedup layers.

## Verification
- Spaced-path MEDIA tag now extracts to **1** path (was 2)
- Mixed spellings (forward slash / backslash / lowercase) dedupe to 1
- Distinct files unaffected (still 2)
- Live send test: feishu + weixin deliver a single attachment for a spaced-path file