### PR TITLE
fix(gateway): anchor fallback secret patterns with ASCII word lookarounds

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -451,7 +451,11 @@ _GATEWAY_CONNECTION_ERROR_RE = re.compile(
 # Boundary anchors use ASCII word lookarounds instead of ``\b``: under Python 3's
 # default Unicode semantics ``\b`` treats CJK/fullwidth letters as word
 # characters, so a token glued to one (``xx中sk-...``) is NOT at a boundary and
-# the fallback pass silently leaks it (#81073).
+# the fallback pass silently leaks it (#81073). The Bearer pattern scopes its
+# case-insensitivity to the literal via ``(?i:Bearer)`` — a blanket ``(?i)``
+# would also case-fold the lookarounds, making Python treat the Unicode
+# case-fold characters İ ı ſ K as ASCII word neighbors and leaking a bare
+# ``KBearer <token>`` beside them (#81073).
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"(?<![A-Za-z0-9_])sk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}(?![A-Za-z0-9_])"),
     re.compile(r"(?<![A-Za-z0-9_])gh[pousr]_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])"),
@@ -459,7 +463,7 @@ _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"(?<![A-Za-z0-9_])xox[baprs]-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
     re.compile(r"(?<![A-Za-z0-9_])hf_[A-Za-z0-9]{20,}(?![A-Za-z0-9_])"),
     re.compile(r"(?<![A-Za-z0-9_])glpat-[A-Za-z0-9_\-]{20,}(?![A-Za-z0-9_])"),
-    re.compile(r"(?i)(?<![A-Za-z0-9_])(Bearer\s+)[A-Za-z0-9._\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])((?i:Bearer)\s+)[A-Za-z0-9._\-]{20,}(?![A-Za-z0-9_])"),
 )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -447,14 +447,19 @@ _GATEWAY_CONNECTION_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Belt-and-suspenders credential redaction for user-facing gateway output.
+# Boundary anchors use ASCII word lookarounds instead of ``\b``: under Python 3's
+# default Unicode semantics ``\b`` treats CJK/fullwidth letters as word
+# characters, so a token glued to one (``xx中sk-...``) is NOT at a boundary and
+# the fallback pass silently leaks it (#81073).
 _GATEWAY_SECRET_PATTERNS = (
-    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
-    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
-    re.compile(r"\bxapp-\d+-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
-    re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
+    re.compile(r"(?<![A-Za-z0-9_])sk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])gh[pousr]_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xapp-\d+-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xox[baprs]-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])hf_[A-Za-z0-9]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])glpat-[A-Za-z0-9_\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?i)(?<![A-Za-z0-9_])(Bearer\s+)[A-Za-z0-9._\-]{20,}(?![A-Za-z0-9_])"),
 )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -379,14 +379,19 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Belt-and-suspenders credential redaction for user-facing gateway output.
+# Boundary anchors use ASCII word lookarounds instead of ``\b``: under Python 3's
+# default Unicode semantics ``\b`` treats CJK/fullwidth letters as word
+# characters, so a token glued to one (``xx中sk-...``) is NOT at a boundary and
+# the fallback pass silently leaks it (#81073).
 _GATEWAY_SECRET_PATTERNS = (
-    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
-    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
-    re.compile(r"\bxapp-\d+-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
-    re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
+    re.compile(r"(?<![A-Za-z0-9_])sk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])gh[pousr]_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xapp-\d+-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xox[baprs]-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])hf_[A-Za-z0-9]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])glpat-[A-Za-z0-9_\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?i)(?<![A-Za-z0-9_])(Bearer\s+)[A-Za-z0-9._\-]{20,}(?![A-Za-z0-9_])"),
 )
 
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -21,6 +21,7 @@ import logging
 import queue
 import secrets
 import threading
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
@@ -39,6 +40,47 @@ from gateway.response_filters import (
 )
 
 logger = logging.getLogger("gateway.stream_consumer")
+
+# ── Secret redaction for streamed output ─────────────────────────────
+# Stateful redactor for the streaming path (P1 81097): deltas wired directly
+# to on_delta bypassed _sanitize_gateway_final_response, so a credential like
+# `xx中sk-...` leaked via the stream even though the non-streaming fallback
+# would redact.  The redactor is forced (ignores security.redact_secrets)
+# and preserves token fragments across deltas by holding a small tail that
+# may contain an incomplete credential prefix.
+
+_GATEWAY_STREAM_SECRET_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9_])sk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])gh[pousr]_[A-Za-z0-9_]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xapp-\d+-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])xox[baprs]-[A-Za-z0-9\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])hf_[A-Za-z0-9]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])glpat-[A-Za-z0-9_\-]{20,}(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_])((?i:Bearer)\s+)[A-Za-z0-9._\-]{20,}(?![A-Za-z0-9_])"),
+)
+
+_STREAM_REDACT_TAIL = 40
+
+
+def _redact_stream_text(text: str) -> str:
+    """Forced secret redaction for gateway stream output.
+
+    Mirrors ``gateway.run._redact_gateway_user_facing_secrets`` without
+    importing it (avoids a circular import: run imports this module).
+    Delegates to the authoritative ``agent.redact.redact_sensitive_text``
+    first, then the fallback ASCII-lookaround patterns.
+    """
+    redacted = str(text or "")
+    try:
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(redacted, force=True)
+    except Exception:
+        pass
+    for pattern in _GATEWAY_STREAM_SECRET_PATTERNS:
+        redacted = pattern.sub(lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]", redacted)
+    return redacted
+
 
 # Sentinel to signal the stream is complete
 _DONE = object()
@@ -497,7 +539,7 @@ class GatewayStreamConsumer:
         if self._turn_split_delivery and self._stream_ledger:
             source = self._stream_ledger
         self._delivered_final_text = ensure_closed_code_fences(
-            self._clean_for_display(source)
+            self._sanitized_for_display(source)
         ).strip()
 
     def delivered_final_matches(self, final_text: str) -> Optional[bool]:
@@ -520,7 +562,7 @@ class GatewayStreamConsumer:
           dedup is not regressed.
         """
         target = ensure_closed_code_fences(
-            self._clean_for_display(final_text or "")
+            self._sanitized_for_display(final_text or "")
         ).strip()
         if not target:
             return None
@@ -539,7 +581,7 @@ class GatewayStreamConsumer:
 
     def has_delivered_text(self, text: str) -> bool:
         """Return True if *text* was already delivered as visible chat content."""
-        target = self._clean_for_display(text or "").strip()
+        target = self._sanitized_for_display(text or "").strip()
         if not target:
             return False
         visible_prefix = self._visible_prefix().strip()
@@ -616,7 +658,7 @@ class GatewayStreamConsumer:
         # clearing ``_last_sent_text``, so ``has_delivered_text`` can still
         # match it after a segment break. (#65919 review)
         if self._last_sent_text:
-            finalized = self._clean_for_display(self._last_sent_text).strip()
+            finalized = self._sanitized_for_display(self._last_sent_text).strip()
             if finalized:
                 self._delivered_segment_texts.append(finalized)
         self._message_id = None
@@ -1177,29 +1219,51 @@ class GatewayStreamConsumer:
                         # multi-message delivery (#71643 record semantics).
                         self._turn_split_delivery = True
 
-                    display_text = self._accumulated
-                    if not got_done and not got_segment_break and commentary_text is None:
-                        display_text += self.cfg.cursor
-
-                    # Segment break: finalize the current message so platforms
-                    # that need explicit closure (e.g. DingTalk AI Cards) don't
-                    # leave the previous segment stuck in a loading state when
-                    # the next segment (tool progress, next chunk) creates a
-                    # new message below it.  got_done has its own finalize
-                    # path below so we don't finalize here for it.
-                    draft_final_fresh_send = (
-                        got_done
-                        and self._use_draft_streaming
-                        and self._message_id is None
-                    )
-                    current_update_visible = await self._send_or_edit(
-                        display_text,
-                        finalize=(got_done or got_segment_break),
-                        # A segment-break finalize closes a preamble, not the
-                        # turn-final answer — only got_done marks delivered (#29346).
-                        is_turn_final=got_done,
-                    )
-                    self._last_edit_time = time.monotonic()
+                    # Stateful secret redaction with fragment-aware tail hold-back.
+                    # Non-final streaming previews hold the last
+                    # _STREAM_REDACT_TAIL chars so a credential split across
+                    # deltas cannot leak before the next delta completes the
+                    # pattern.  Final/segment/commentary paths force the full
+                    # buffer to be sanitized.
+                    _is_streaming_preview = not got_done and not got_segment_break and commentary_text is None
+                    if _is_streaming_preview:
+                        _redacted = self._redacted_accumulated(is_final=False)
+                        if not _redacted.strip():
+                            display_text = ""
+                            current_update_visible = False
+                        else:
+                            display_text = _redacted + self.cfg.cursor
+                            current_update_visible = await self._send_or_edit(
+                                display_text,
+                                finalize=False,
+                                is_turn_final=False,
+                            )
+                            self._last_edit_time = time.monotonic()
+                        # Streaming preview handled; skip the outer send block
+                        # and fall through to got_done/commentary handling.
+                        # (draft_final_fresh_send keeps its loop-init False:
+                        # a preview tick is never the draft-final fresh send.)
+                    else:
+                        display_text = self._sanitized_for_display(self._accumulated)
+                        # Segment break: finalize the current message so platforms
+                        # that need explicit closure (e.g. DingTalk AI Cards) don't
+                        # leave the previous segment stuck in a loading state when
+                        # the next segment (tool progress, next chunk) creates a
+                        # new message below it.  got_done has its own finalize
+                        # path below so we don't finalize here for it.
+                        draft_final_fresh_send = (
+                            got_done
+                            and self._use_draft_streaming
+                            and self._message_id is None
+                        )
+                        current_update_visible = await self._send_or_edit(
+                            display_text,
+                            finalize=(got_done or got_segment_break),
+                            # A segment-break finalize closes a preamble, not the
+                            # turn-final answer — only got_done marks delivered (#29346).
+                            is_turn_final=got_done,
+                        )
+                        self._last_edit_time = time.monotonic()
 
                 if got_done:
                     if self._accumulated or self._message_id is not None or self._already_sent:
@@ -1441,6 +1505,77 @@ class GatewayStreamConsumer:
         """
         return _BasePlatformAdapter.strip_media_directives_for_display(text)
 
+    @staticmethod
+    def _sanitized_for_display(text: str) -> str:
+        """Strip media directives and apply forced secret redaction.
+
+        Used for every adapter send and for the delivery bookkeeping that
+        the gateway compares against the sanitized final response.  The
+        forced redaction mirrors ``gateway.run._redact_gateway_user_facing_secrets``
+        without importing it (circular).  Idempotent: text already containing
+        ``[REDACTED]`` passes through unchanged.
+        """
+        cleaned = _BasePlatformAdapter.strip_media_directives_for_display(text or "")
+        return _redact_stream_text(cleaned)
+
+    def _redacted_accumulated(self, *, is_final: bool) -> str:
+        """Return the sanitized form of ``_accumulated`` for display.
+
+        When ``is_final`` is False the method holds back the last
+        ``_STREAM_REDACT_TAIL`` characters so a credential split across two
+        deltas (e.g. ``sk-`` at the boundary) cannot leak as visible text
+        before the next delta completes the pattern.  The tail is not discarded:
+        it will be part of the next call's ``safe`` prefix once more text
+        arrives, or of the final call where ``is_final=True`` forces the full
+        buffer to be redacted.  ``is_final`` is True for segment-breaks,
+        commentary boundaries, and the got_done finalize path.
+
+        To avoid delaying ordinary prose, the tail is only held when the
+        recent window contains a possible secret prefix (``sk-``, ``ghp_``,
+        ``Bearer ``, …).  Text without such a prefix is sent immediately.
+        """
+        raw = self._accumulated or ""
+        if is_final:
+            return _redact_stream_text(self._clean_for_display(raw))
+        # Fast path: no possible secret in recent window → send full
+        # immediately.  Look at the last 2*tail chars so a secret that starts
+        # just before the tail is still detected.
+        window = raw[-_STREAM_REDACT_TAIL * 2 :] if len(raw) > _STREAM_REDACT_TAIL * 2 else raw
+        lower_window = window.lower()
+        # Substrings that can start a gateway fallback secret or a common
+        # agent.redact prefix.  Kept short (prefix only) so we hold as soon
+        # as the model begins emitting a credential, not after it is complete.
+        _SECRET_HINTS = (
+            "sk-",
+            "ghp_",
+            "gho_",
+            "ghu_",
+            "ghs_",
+            "ghr_",
+            "xapp-",
+            "xox",
+            "hf_",
+            "glpat-",
+            "bearer ",
+            # A few high-value agent.redact prefixes that are not in the
+            # gateway fallback set but still must not leak via streaming.
+            "apikey",
+            "api_key",
+            "AIza",
+            "pplx-",
+            "fal_",
+            "hf_",
+            "gsk_",
+            "xai-",
+        )
+        has_hint = any(hint in lower_window for hint in _SECRET_HINTS)
+        if not has_hint:
+            return _redact_stream_text(self._clean_for_display(raw))
+        if len(raw) > _STREAM_REDACT_TAIL:
+            safe = raw[:-_STREAM_REDACT_TAIL]
+            return _redact_stream_text(self._clean_for_display(safe))
+        return ""
+
     async def _send_new_chunk(
         self,
         text: str,
@@ -1452,7 +1587,7 @@ class GatewayStreamConsumer:
 
         Returns the message_id so callers can thread subsequent chunks.
         """
-        text = self._clean_for_display(text)
+        text = self._sanitized_for_display(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -1486,7 +1621,9 @@ class GatewayStreamConsumer:
         prefix = self._last_sent_text or ""
         if self.cfg.cursor and prefix.endswith(self.cfg.cursor):
             prefix = prefix[:-len(self.cfg.cursor)]
-        return self._clean_for_display(prefix)
+        # _last_sent_text is already sanitized; _sanitized_for_display is
+        # idempotent, so this also covers legacy callers that stored raw.
+        return self._sanitized_for_display(prefix)
 
     def _continuation_text(self, final_text: str) -> str:
         """Return only the part of final_text the user has not already seen."""
@@ -1565,7 +1702,7 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
-        final_text = self._clean_for_display(text)
+        final_text = self._sanitized_for_display(text)
         # Ensure balanced code fences before computing continuation,
         # so the closing fence reaches the user even when the fallback
         # only delivers the tail after mid-stream edits failed.
@@ -1998,7 +2135,7 @@ class GatewayStreamConsumer:
                 _md.setdefault("reply_to_message_id", self._initial_reply_to_id)
             await self.adapter.abandon_open_draft(
                 self.chat_id,
-                self._last_sent_text or self._clean_for_display(self._accumulated),
+                self._last_sent_text or self._sanitized_for_display(self._accumulated),
                 metadata=_md or None,
             )
         except Exception as e:
@@ -2023,7 +2160,7 @@ class GatewayStreamConsumer:
         tail = self._accumulated
         if visible and tail.startswith(visible):
             tail = tail[len(visible):].lstrip()
-        tail = self._clean_for_display(tail)
+        tail = self._sanitized_for_display(tail)
         if not tail.strip():
             return
         try:
@@ -2065,7 +2202,7 @@ class GatewayStreamConsumer:
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
-        text = self._clean_for_display(text)
+        text = self._sanitized_for_display(text)
         if not text.strip():
             return False
         try:
@@ -2338,10 +2475,13 @@ class GatewayStreamConsumer:
         ``finalize`` is True when this is the last edit in a streaming
         sequence.
         """
-        # Strip MEDIA: directives so they don't appear as visible text.
+        # Strip MEDIA: directives and apply forced secret redaction so
+        # streamed/interim text never reaches the adapter unredacted (P1).
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
-        text = self._clean_for_display(text)
+        # Use the sanitized helper so every send/edit path is covered even
+        # when callers pass raw ``_accumulated``.
+        text = self._sanitized_for_display(text)
         # Preserve the pre-fence-closed form for stream-is-the-message draft
         # frames: appending a closing ``` to a mid-code-block frame makes
         # frame N not a prefix of frame N+1, so the connector's append-only

--- a/tests/gateway/test_gateway_secret_patterns_cjk.py
+++ b/tests/gateway/test_gateway_secret_patterns_cjk.py
@@ -114,3 +114,157 @@ def test_prose_without_tokens_unchanged():
     """Ordinary prose must pass through untouched."""
     text = "Hello, world. Nothing secret here."
     assert _pattern_pass(text) == text
+
+
+# ── Streamed / interim redaction (P1 81097) ─────────────────────────────
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.run import _sanitize_gateway_final_response
+
+
+class TestStreamedSecretRedaction:
+    """Streamed deltas and interim commentary must be redacted before reaching the adapter.
+
+    The non-streaming fallback (``_sanitize_gateway_final_response``) already
+    redacts, but deltas wired directly to ``GatewayStreamConsumer.on_delta``
+    bypassed it.  The consumer now applies the same forced redaction with a
+    small tail hold-back so a token split across deltas (e.g. ``sk-`` in one
+    delta and the body in the next) does not leak.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cjk_glued_token_split_across_deltas_is_redacted(self):
+        """A CJK-glued token split across two deltas must not leak.
+
+        Example from the review: ``xx中sk-...`` was visible in human chat when
+        ``sk-`` and the body arrived in separate deltas, even though the
+        non-streaming fallback would redact.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1))
+        # Split the credential across deltas to exercise the stateful tail.
+        token = "sk-" + "a" * 20
+        # Use a longer prefix so the first delta alone exceeds the tail window
+        # and would be sent as a preview before the second delta arrives.
+        # Without the fix the first preview would leak ``sk-``.
+        prefix = "Hello world, this is a long preamble that exceeds the tail window. xx中"
+        consumer.on_delta(prefix + "sk-")
+        # Give the run loop a chance to send the first preview
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("a" * 20)
+        consumer.finish()
+        await task
+
+        all_texts = []
+        for call in adapter.send.call_args_list:
+            all_texts.append(call[1].get("content", ""))
+        for call in adapter.edit_message.call_args_list:
+            all_texts.append(call[1].get("content", ""))
+        combined = "\n".join(all_texts)
+        assert token not in combined, f"stream leaked raw token: {combined!r}"
+        # Redacted form may be [REDACTED] (fallback) or masked sk-... (agent redactor)
+        assert "[REDACTED]" in combined or "..." in combined
+
+    @pytest.mark.asyncio
+    async def test_bearer_split_across_deltas_is_redacted(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1))
+        prefix = "Long preamble to exceed tail window for bearer test. "
+        consumer.on_delta(prefix + "Bearer ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("g" * 20)
+        consumer.finish()
+        await task
+
+        all_texts = [c[1].get("content", "") for c in adapter.send.call_args_list] + [
+            c[1].get("content", "") for c in adapter.edit_message.call_args_list
+        ]
+        combined = "\n".join(all_texts)
+        assert "Bearer g" not in combined
+        assert "[REDACTED]" in combined
+        # Prefix preserved (group 1)
+        assert "Bearer " in combined
+
+    @pytest.mark.asyncio
+    async def test_interim_commentary_is_redacted(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1))
+        consumer.on_commentary("interim note Bearer " + "z" * 20 + " end")
+        consumer.finish()
+        await consumer.run()
+
+        sent = [c[1].get("content", "") for c in adapter.send.call_args_list]
+        assert sent, "commentary not sent"
+        assert "Bearer z" not in sent[0]
+        assert "[REDACTED]" in sent[0]
+
+    @pytest.mark.asyncio
+    async def test_sanitized_streamed_final_suppresses_duplicate_final(self):
+        """Only suppress the final send when sanitized payloads match.
+
+        The gateway records the streamed payload sanitized the same way as
+        ``_sanitize_gateway_final_response``.  A raw streamed ``sk-...`` that was
+        redacted to ``[REDACTED]`` must reconcile as matching the sanitized
+        final ``[REDACTED]``, not as a mismatch that would cause a duplicate.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1))
+        token = "sk-" + "a" * 20
+        raw_final = "answer " + token + " done"
+        sanitized_final = _sanitize_gateway_final_response("telegram", raw_final)
+        assert token not in sanitized_final, f"raw token leaked in sanitized: {sanitized_final!r}"
+        assert sanitized_final != raw_final
+
+        # Simulate streaming the raw final (as the model would)
+        consumer.on_delta(raw_final)
+        consumer.finish()
+        await consumer.run()
+
+        # The consumer's recorded payload is sanitized, so it should match the
+        # sanitized final.
+        assert consumer.delivered_final_matches(sanitized_final) is True
+        # And also match the raw final (since has_delivered normalizes via sanitized)
+        assert consumer.delivered_final_matches(raw_final) is True
+        # A different final should be a mismatch
+        assert consumer.delivered_final_matches("different answer") is False
+
+    @pytest.mark.asyncio
+    async def test_normal_prose_still_streams_without_delay(self):
+        """Non-secret prose must not be held back by the tail window."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1))
+        consumer.on_delta("Hello world, no secrets here.")
+        consumer.finish()
+        await consumer.run()
+
+        all_texts = [c[1].get("content", "") for c in adapter.send.call_args_list] + [
+            c[1].get("content", "") for c in adapter.edit_message.call_args_list
+        ]
+        combined = "\n".join(all_texts)
+        assert "Hello world" in combined

--- a/tests/gateway/test_gateway_secret_patterns_cjk.py
+++ b/tests/gateway/test_gateway_secret_patterns_cjk.py
@@ -78,6 +78,38 @@ def test_bearer_prefix_is_preserved():
     assert "Bearer zzz" not in redacted
 
 
+# Unicode case-fold characters that Python's IGNORECASE maps onto ASCII
+# letters: U+0130 İ, U+0131 ı, U+017F ſ, U+212A K. With the blanket ``(?i)``
+# these folded into the ASCII word lookarounds, so a token glued beside one
+# was NOT redacted (the boundary assertion failed). The fix scopes
+# case-insensitivity to the Bearer literal via ``(?i:Bearer)`` (#81073).
+_CASE_FOLD_NEIGHBORS = ("İ", "ı", "ſ", "K")
+
+
+@pytest.mark.parametrize("neighbor", _CASE_FOLD_NEIGHBORS)
+def test_bearer_redacted_beside_unicode_case_fold_left(neighbor):
+    """A bare Bearer token glued after a case-fold character must redact."""
+    redacted = _pattern_pass("xx" + neighbor + "Bearer " + "g" * 20)
+    assert "[REDACTED]" in redacted, f"left {neighbor!r} leaked: {redacted!r}"
+    assert "Bearer g" not in redacted, f"left {neighbor!r} leaked: {redacted!r}"
+
+
+@pytest.mark.parametrize("neighbor", _CASE_FOLD_NEIGHBORS)
+def test_bearer_redacted_beside_unicode_case_fold_right(neighbor):
+    """A bare Bearer token followed by a case-fold character must redact."""
+    redacted = _pattern_pass("Bearer " + "g" * 20 + neighbor)
+    assert "[REDACTED]" in redacted, f"right {neighbor!r} leaked: {redacted!r}"
+    assert "Bearer g" not in redacted, f"right {neighbor!r} leaked: {redacted!r}"
+
+
+@pytest.mark.parametrize("prefix", ["Bearer", "BEARER", "bearer", "BeArEr"])
+def test_bearer_literal_case_variants_still_redact(prefix):
+    """Case-insensitivity of the Bearer literal is preserved (scoped flag)."""
+    redacted = _pattern_pass("Authorization: " + prefix + " " + "z" * 20)
+    assert "[REDACTED]" in redacted
+    assert prefix + " zzz" not in redacted
+
+
 def test_prose_without_tokens_unchanged():
     """Ordinary prose must pass through untouched."""
     text = "Hello, world. Nothing secret here."

--- a/tests/gateway/test_gateway_secret_patterns_cjk.py
+++ b/tests/gateway/test_gateway_secret_patterns_cjk.py
@@ -1,0 +1,84 @@
+"""Regression tests for the gateway fallback secret-redaction patterns.
+
+Issue #81073: ``_GATEWAY_SECRET_PATTERNS`` anchored with ``\\b``, which under
+Python 3's default Unicode semantics treats CJK/fullwidth letters as word
+characters. A token glued to a CJK character (``xx中sk-...``) is therefore NOT
+at a ``\\b`` boundary, so the fallback pattern pass silently left it
+unredacted. The anchors are now ASCII word lookarounds
+(``(?<![A-Za-z0-9_])`` / ``(?![A-Za-z0-9_])``) so Unicode-glued tokens are
+caught the same as ASCII-neighbored ones.
+"""
+
+import pytest
+
+from gateway.run import _GATEWAY_SECRET_PATTERNS
+
+# Each entry is (text with token, expected-absence substring).
+_FAKE_TOKENS = [
+    ("sk-" + "a" * 20, "sk-"),
+    ("ghp_" + "b" * 20, "ghp_"),
+    ("xapp-1-" + "c" * 20, "xapp-"),
+    ("xoxb-" + "d" * 20, "xoxb-"),
+    ("hf_" + "e" * 20, "hf_"),
+    ("glpat-" + "f" * 20, "glpat-"),
+    ("Bearer " + "g" * 20, "Bearer g"),
+]
+
+
+def _pattern_pass(text: str) -> str:
+    """Run exactly the fallback pass ``_redact_gateway_user_facing_secrets``
+    applies after the Tirith-grade redactor."""
+    redacted = text
+    for pattern in _GATEWAY_SECRET_PATTERNS:
+        redacted = pattern.sub(
+            lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]",
+            redacted,
+        )
+    return redacted
+
+
+@pytest.mark.parametrize("token,prefix", _FAKE_TOKENS)
+def test_cjk_glued_tokens_are_redacted(token, prefix):
+    """A token glued directly to a CJK character must be redacted (#81073)."""
+    redacted = _pattern_pass("xx中" + token)
+    assert "[REDACTED]" in redacted
+    assert prefix not in redacted, f"CJK-glued token leaked: {redacted!r}"
+
+
+@pytest.mark.parametrize("token,prefix", _FAKE_TOKENS)
+def test_fullwidth_digit_glued_tokens_are_redacted(token, prefix):
+    """A token glued to a fullwidth digit (Unicode ``\\w``) must be redacted."""
+    redacted = _pattern_pass("xx１" + token)
+    assert "[REDACTED]" in redacted
+    assert prefix not in redacted, f"fullwidth-glued token leaked: {redacted!r}"
+
+
+@pytest.mark.parametrize("token,prefix", _FAKE_TOKENS)
+def test_ascii_neighbor_tokens_still_redacted(token, prefix):
+    """ASCII-neighbored tokens keep redacting (no regression)."""
+    redacted = _pattern_pass("xx " + token)
+    assert "[REDACTED]" in redacted
+    assert prefix not in redacted, f"ASCII-neighbor token leaked: {redacted!r}"
+
+
+@pytest.mark.parametrize("token,prefix", _FAKE_TOKENS)
+def test_embedded_in_ascii_word_not_matched(token, prefix):
+    """A token embedded inside an ASCII identifier must NOT match — same
+    boundary semantics as ``\\b``."""
+    redacted = _pattern_pass("xx" + token + "yy")
+    assert "[REDACTED]" not in redacted, (
+        f"embedded token over-matched: {redacted!r}"
+    )
+
+
+def test_bearer_prefix_is_preserved():
+    """The Bearer prefix survives redaction (group(1) preserved)."""
+    redacted = _pattern_pass("Authorization: Bearer " + "z" * 20)
+    assert "Bearer " in redacted
+    assert "Bearer zzz" not in redacted
+
+
+def test_prose_without_tokens_unchanged():
+    """Ordinary prose must pass through untouched."""
+    text = "Hello, world. Nothing secret here."
+    assert _pattern_pass(text) == text


### PR DESCRIPTION
Fixes #81073

## Problem

`_GATEWAY_SECRET_PATTERNS` in `gateway/run.py` anchored every credential pattern with `\b`. Under Python 3's default Unicode semantics, a CJK or fullwidth letter is a `\w` character, so a credential glued directly to one (`xx中sk-...`, `xx１sk-...`) is **not** at a `\b` boundary. On the fallback-only path the token was left unredacted:

```python
PAT = re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b")
assert PAT.search("xx " + TOKEN)          # ASCII neighbor → matches
assert PAT.search("xx中" + TOKEN) is None # CJK-glued → no match
```

## Fix

Replace the `\b` anchors with ASCII word lookarounds `(?<![A-Za-z0-9_])` / `(?![A-Za-z0-9_])` across all seven patterns. Behavior:

- ASCII-neighbored tokens still redact exactly as before (no regression).
- CJK- and fullwidth-glued tokens now redact too.
- A token embedded inside an ASCII identifier (`xxsk-...yy`) is still not matched — same boundary semantics as `\b`.
- The `Bearer` pattern still preserves its prefix via `group(1)`.

## Tests

New `tests/gateway/test_gateway_secret_patterns_cjk.py` parametrizes all seven token shapes across:

- CJK-glued redaction (the reported regression)
- fullwidth-digit-glued redaction
- ASCII-neighbor redaction (no regression)
- embedded-in-ASCII-word non-matching (no over-match)
- Bearer prefix preservation
- prose-without-tokens unchanged

30 new tests pass; `tests/gateway/test_telegram_noise_filter.py` (133 tests) still passes.
