### PR TITLE
fix: CJK UTF-8 source files misclassified as binary when head -c 1000 truncates mid-character

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -51,6 +51,44 @@ class TestIsLikelyBinary:
         sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
 
+    def test_truncated_multibyte_utf8_not_flagged(self, ops):
+        """A U+FFFD produced by head -c cutting mid-CJK-char is a sampling
+        artifact, not binary content.
+
+        Regression: read_file samples with ``head -c 1000``; when byte 1000
+        lands inside a multi-byte UTF-8 sequence, the errors="replace" decode
+        emits one trailing U+FFFD. The old code flagged any sample containing
+        U+FFFD as binary, so valid CJK source files became unreadable.
+        """
+        # Simulate: CJK text whose last visible char was cut in half → one
+        # trailing U+FFFD, everything else is clean UTF-8.
+        sample = "会话级运行状态（chat-filename）" * 30 + "会"
+        sample = sample[:999] + "\ufffd"
+        assert ops._is_likely_binary("store.ts", content_sample=sample) is False
+
+    def test_trailing_fffd_from_real_cjk_file(self, ops):
+        """Reconstruct the exact failure: bytes from a real CJK store.ts,
+        sliced at 1000 bytes and decoded with errors='replace'."""
+        # "会" = E4 BC 9A; take 999 clean chars then the orphaned first byte
+        # of a 3-byte char (decoder emits U+FFFD at the cut).
+        sample = "a" * 999 + "\ufffd"
+        assert ops._is_likely_binary("chat/store.ts", content_sample=sample) is False
+
+    def test_internal_replacement_chars_still_binary(self, ops):
+        """Real non-UTF-8 content has U+FFFD throughout, not just at the
+        tail — those files must still be flagged binary."""
+        sample = "caf\ufffd r\ufffdsum\ufffd\nplain line\n" * 50
+        assert ops._is_likely_binary("notes.txt", content_sample=sample) is True
+
+    def test_only_trailing_replacement_char_stripped(self, ops):
+        """Stripping must remove exactly the trailing artifact, not mask a
+        file whose only corruption is elsewhere (still binary)."""
+        # One U+FFFD in the middle + a clean tail → still binary.
+        sample = "abc\ufffddef\n" + "x" * 500
+        assert ops._is_likely_binary("file.txt", content_sample=sample) is True
+        # Single trailing U+FFFD is the truncation signature → text.
+        assert ops._is_likely_binary("file.txt", content_sample="abc\n" + "\ufffd") is False
+
 
 # =========================================================================
 # _check_lint edge cases

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -894,6 +894,7 @@ class ShellFileOperations(FileOperations):
         
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
+            sample = content_sample[:1000]
             # Undecodable bytes: the terminal env decodes stdout with
             # errors="replace", so any non-UTF-8 byte arrives here already
             # turned into U+FFFD. That char is "printable" (ord 65533), so the
@@ -903,9 +904,21 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # But head -c 1000 (the sampling command) can cut a multi-byte
+            # UTF-8 character in half.  The decoder emits exactly one U+FFFD
+            # at the tail for the truncated sequence — that is a sampling
+            # artifact of a perfectly valid UTF-8 file (e.g. CJK source
+            # comments), not binary content.  Strip a single trailing U+FFFD
+            # before judging so valid text truncated mid-character isn't
+            # misclassified.  A real non-UTF-8 file has replacement chars
+            # throughout the sample (not just at the tail), so it is still
+            # caught.
+            if sample.endswith("\ufffd"):
+                sample = sample[:-1]
+            if "\ufffd" in sample:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
             return non_printable / min(len(content_sample), 1000) > 0.30
         


### PR DESCRIPTION
## Summary

`read_file` misclassifies valid UTF-8 source files containing CJK (or any multi-byte) characters as binary, refusing to display them.

### Root cause

`read_file` samples a file with `head -c 1000` and passes the decoded output to `_is_likely_binary()`. The content-analysis path treats **any** occurrence of `U+FFFD` (replacement char) as binary — a guard against lossy read→edit→write round-trips on genuinely non-UTF-8 files.

The guard's assumption ("legitimate UTF-8 text effectively never contains U+FFFD") holds for a **complete** file, but not for a **truncated** sample: when byte 1000 lands inside a 3- or 4-byte CJK character, the incomplete sequence decodes as exactly one trailing `U+FFFD` — a sampling artifact.

### Impact

A real-world case: `hermes-shine/front/src/pages/chat/store.ts` (24,892 bytes, valid UTF-8 with Chinese comments) became unreadable via `read_file` because its byte 1000 splits the 3-byte character 会 (`E4 BC 9A`).

### Fix

Strip **at most one** `U+FFFD` from the **tail** of the sample before judging. This precisely targets the truncation artifact:

- Genuine non-UTF-8 files have replacement chars **throughout** the sample, not just at the tail → still flagged binary (safety net preserved).
- Valid UTF-8 text truncated mid-character ends with exactly one `U+FFFD` → artifact removed → readable as text.

## Tests

Added 4 unit tests in `tests/tools/test_file_operations_edge_cases.py`:

| Test | Verifies |
|------|----------|
| `test_truncated_multibyte_utf8_not_flagged` | CJK text with trailing truncation artifact → NOT binary |
| `test_trailing_fffd_from_real_cjk_file` | 999 ASCII + orphaned UTF-8 lead byte → NOT binary |
| `test_internal_replacement_chars_still_binary` | U+FFFD spread through sample (real corruption) → STILL binary |
| `test_only_trailing_replacement_char_stripped` | Middle corruption → binary; lone trailing artifact → text |

### Verification

- `tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py`: **71 passed** (incl. the 4 new + pre-existing U+FFFD guard tests)
- Full `tests/tools/` suite: **5112 passed**, 228 pre-existing failures in unrelated modules (approval/delegation/daytona/browser — environment-dependent, zero in file ops)
- End-to-end with real `LocalEnvironment`: the previously-unreadable `chat/store.ts` now returns `is_binary: False` and full content