### PR TITLE
fix(tools): improve MCP discovery diagnostics (#80938)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6231,7 +6231,14 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         List of all currently registered MCP tool names.
     """
     if not _MCP_AVAILABLE:
-        logger.debug("MCP SDK not available -- skipping explicit MCP registration")
+        if servers:
+            logger.warning(
+                "MCP SDK not available but %d server(s) provided "
+                "-- skipping explicit MCP registration",
+                len(servers),
+            )
+        else:
+            logger.debug("MCP SDK not available -- skipping explicit MCP registration")
         return []
 
     servers = _filter_suspicious_mcp_servers(servers)
@@ -6427,6 +6434,11 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         summary = f"MCP: registered {new_tool_count} tool(s) from {connected_count} server(s)"
         if failed:
             summary += f" ({failed} failed)"
+            with _lock:
+                error_snapshot = dict(_server_connect_errors)
+            for name in new_servers:
+                if name not in connected and name in error_snapshot:
+                    summary += f"\n  - {name}: {error_snapshot[name]}"
         logger.info(summary)
 
     return _existing_tool_names()
@@ -6445,7 +6457,18 @@ def discover_mcp_tools() -> List[str]:
         List of all registered MCP tool names.
     """
     if not _MCP_AVAILABLE:
-        logger.debug("MCP SDK not available -- skipping MCP tool discovery")
+        # Only warn if the user has MCP servers configured — otherwise
+        # an absent SDK is expected and harmless.
+        _cfg = _load_mcp_config()
+        if _cfg:
+            logger.warning(
+                "MCP SDK not available but %d server(s) configured "
+                "-- skipping MCP tool discovery. Install the 'mcp' "
+                "package to enable MCP tools.",
+                len(_cfg),
+            )
+        else:
+            logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
 
     servers = _load_mcp_config()
@@ -6508,6 +6531,10 @@ def discover_mcp_tools() -> List[str]:
             summary = f"  MCP: {new_tool_count} tool(s) from {len(connected_server_names)} server(s)"
             if failed_count:
                 summary += f" ({failed_count} failed)"
+                error_snapshot = dict(_server_connect_errors)
+                for name in new_server_names:
+                    if name not in connected_server_names and name in error_snapshot:
+                        summary += f"\n    - {name}: {error_snapshot[name]}"
             logger.info(summary)
 
         return tool_names


### PR DESCRIPTION
## Summary

Improves MCP discovery diagnostics in two ways:

1. **SDK unavailable with configured servers**: When the MCP SDK is not installed but servers are configured, `discover_mcp_tools()` now logs at `WARNING` instead of `DEBUG`, making the misconfiguration visible without requiring debug log inspection.

2. **Per-server failure causes in summary**: When discovery completes with failed servers, the log summary now includes each failed server's name and error cause from `_server_connect_errors`, instead of only showing the aggregate count.

Fixes #80938

## Changes

- `tools/mcp_tool.py`:
  - `register_mcp_servers()`: SDK check warns when servers are provided, stays DEBUG when no servers
  - `discover_mcp_tools()`: SDK check loads config first to detect configured servers, warns at WARNING level when SDK is missing with configured servers
  - Both `register_mcp_servers()` and `discover_mcp_tools()`: summary logs include per-server error details from `_server_connect_errors` when failures occur

## Testing

- Existing MCP tests continue to pass
- SDK-missing path now emits WARNING when servers exist
- Per-server errors appear in summary log lines
