### PR TITLE
fix(compression): mark max-iteration nudge as synthetic (#78580)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2322,7 +2322,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         "Please provide a final response summarizing what you've found and accomplished so far, "
         "without calling any more tools."
     )
-    messages.append({"role": "user", "content": summary_request})
+    messages.append({"role": "user", "content": summary_request, "_max_iterations_nudge": True})
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1909,6 +1909,7 @@ _SYNTHETIC_USER_PREFIXES = (
     "[System: Your previous tool call",
     "[Your active task list was preserved across context compression]",
     "[IMPORTANT: Background process ",
+    "You've reached the maximum number of tool-calling iterations allowed.",
 )
 
 
@@ -1931,6 +1932,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_dropped_toolcall_nudge",
+    "_max_iterations_nudge",
 )
 
 


### PR DESCRIPTION
## Summary

`handle_max_iterations()` appends a runtime nudge as `role="user"` message but does not mark it as synthetic. During later context compaction, `_is_real_user_message()` does not recognize this message as runtime scaffolding, so it can be selected as the latest actionable user turn. The real human task is then demoted to historical context or omitted from the compaction summary.

Fixes #78580

## Changes

**`agent/conversation_compression.py`**:
- Add `"You've reached the maximum number of tool-calling iterations allowed."` to `_SYNTHETIC_USER_PREFIXES` — handles existing persisted messages in state.db
- Add `"_max_iterations_nudge"` to `_SYNTHETIC_USER_FLAGS` — handles new messages going forward

**`agent/chat_completion_helpers.py`**:
- Add `"_max_iterations_nudge": True` flag to the nudge message dict in `handle_max_iterations()`

## Testing

- Existing compaction tests continue to pass
- Max-iteration nudge is now correctly filtered as synthetic during compaction
- Both prefix-based and flag-based detection paths cover the marker
