### PR TITLE
feat(feishu): interactive card buttons for clarify and slash-confirm prompts

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1556,6 +1556,10 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id → {session_key, message_id, chat_id})
+        self._clarify_state: Dict[str, Dict[str, str]] = {}
+        # Slash-confirm button state (confirm_id → {session_key, message_id, chat_id})
+        self._slash_confirm_state: Dict[str, Dict[str, str]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2236,6 +2240,127 @@ class FeishuAdapter(BasePlatformAdapter):
         tmp_path.write_text(answer, encoding="utf-8")
         tmp_path.replace(response_path)
 
+    @staticmethod
+    def _build_clarify_card(
+        *, question: str, choices: Optional[List[str]], clarify_id: str, multi_select: bool = False,
+    ) -> Dict[str, Any]:
+        """Build an interactive card for a clarify prompt.
+
+        Multi-choice mode: one button per choice plus an "Other" button.
+        Open-ended mode (no choices): question only — the next message in
+        the session is captured by the gateway's text-intercept.
+        """
+        elements: List[Dict[str, Any]] = [
+            {"tag": "markdown", "content": question},
+        ]
+
+        if choices:
+            option_lines = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(choices))
+            elements.append({"tag": "markdown", "content": option_lines})
+
+            if multi_select:
+                # Multi-select responses use a JSON-array contract that a
+                # single scalar button click cannot express (a button only
+                # yields one value).  Fall back to the text renderer: render
+                # the numbered list with a clear prompt and let the gateway's
+                # text-intercept path parse "1,3" / "1 3" into the array.
+                elements.append({
+                    "tag": "markdown",
+                    "content": "🖱️ 请直接输入要选择的编号，可多选（用逗号或空格分隔，如 `1,3` 或 `1 3`）。",
+                })
+            else:
+                def _btn(label: str, choice_idx: int) -> dict:
+                    return {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": label},
+                        "type": "default",
+                        "value": {
+                            "hermes_clarify_action": "choice",
+                            "clarify_id": clarify_id,
+                            "choice_idx": choice_idx,
+                        },
+                    }
+
+                actions = [_btn(str(i + 1), i) for i in range(len(choices))]
+                actions.append({
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": "✏️ 其他（输入回答）"},
+                    "type": "default",
+                    "value": {
+                        "hermes_clarify_action": "other",
+                        "clarify_id": clarify_id,
+                    },
+                })
+                elements.append({"tag": "action", "actions": actions})
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ 需要你的输入", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": elements,
+        }
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[List[str]],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive clarify prompt with choice buttons.
+
+        Multi-choice mode (``choices`` non-empty): renders one button per
+        option plus a final "✏️ 其他（输入回答）" button.  Picking "Other"
+        flips the entry into text-capture mode so the next message becomes
+        the response.
+
+        Open-ended mode (``choices`` empty): renders the question as a card
+        with no buttons — the next message in the session is captured by the
+        gateway's text-intercept and resolves the clarify.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            from tools.clarify_gateway import _entries as _clarify_entries
+            entry = _clarify_entries.get(clarify_id)
+            multi_select = bool(entry.multi_select) if entry else False
+        except Exception:
+            multi_select = False
+
+        try:
+            payload = json.dumps(
+                self._build_clarify_card(
+                    question=question, choices=choices,
+                    clarify_id=clarify_id, multi_select=multi_select,
+                ),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_clarify failed")
+            if result.success:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+
     async def send_voice(
         self,
         chat_id: str,
@@ -2734,11 +2859,31 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action:
+            return self._handle_clarify_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if slash_confirm_action:
+            return self._handle_slash_confirm_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2891,6 +3036,143 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule clarify resolution and build the synchronous callback response.
+
+        Two action kinds:
+          * ``choice`` — a numbered option button; resolves immediately with
+            the chosen text.
+          * ``other``  — flips the entry into text-capture mode so the user's
+            next message becomes the answer (gateway text-intercept resolves).
+        """
+        clarify_id = action_value.get("clarify_id")
+        if not clarify_id:
+            logger.debug("[Feishu] Clarify card action missing clarify_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        state = self._clarify_state.get(clarify_id)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Clarify callback chat mismatch for %s (expected=%s, got=%s)",
+                clarify_id, expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        action_kind = str(action_value.get("hermes_clarify_action", "") or "")
+
+        if action_kind == "other":
+            # Flip into text-capture mode; do NOT pop state yet — the entry
+            # must survive until the typed answer arrives (or times out).
+            flipped = False
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                flipped = mark_awaiting_text(clarify_id)
+            except Exception as exc:
+                logger.warning("[Feishu] mark_awaiting_text failed: %s", exc)
+            if not flipped:
+                self._clarify_state.pop(clarify_id, None)
+                resolved_card = self._build_resolved_clarify_card(
+                    label="已过期", template="grey", body="该提问已超时或被取消，请重新发起。",
+                )
+            else:
+                resolved_card = self._build_resolved_clarify_card(
+                    label="等待输入", template="blue",
+                    body=f"✏️ 请在聊天中直接输入回答（由 **{user_name}** 发起）",
+                )
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = resolved_card
+                response.card = card
+            return response
+
+        # Numeric choice → resolve immediately with the chosen text.
+        choice_idx = action_value.get("choice_idx")
+        resolved_text: Optional[str] = None
+        try:
+            idx = int(choice_idx)
+        except (ValueError, TypeError):
+            idx = -1
+        try:
+            from tools.clarify_gateway import _entries as _clarify_entries
+            entry = _clarify_entries.get(clarify_id)
+            if entry and entry.choices and 0 <= idx < len(entry.choices):
+                resolved_text = entry.choices[idx]
+        except Exception:
+            resolved_text = None
+
+        if resolved_text is None:
+            resolved_text = str(idx + 1) if idx >= 0 else ""
+
+        # Pop state now so a second click is a no-op.
+        self._clarify_state.pop(clarify_id, None)
+
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_clarify(clarify_id, resolved_text, user_name),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_clarify_card(
+                label="已回答", template="green",
+                body=f"✅ **{resolved_text}**\n\n回答者：**{user_name}**",
+            )
+            response.card = card
+        return response
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, label: str, template: str, body: str) -> Dict[str, Any]:
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"❓ {label}", "tag": "plain_text"},
+                "template": template,
+            },
+            "elements": [{"tag": "markdown", "content": body}],
+        }
+
+    async def _resolve_clarify(self, clarify_id: str, response: str, user_name: str) -> None:
+        """Unblock the agent thread waiting on ``clarify_id``."""
+        try:
+            from tools.clarify_gateway import resolve_gateway_clarify
+            ok = resolve_gateway_clarify(clarify_id, response)
+            if ok:
+                logger.info(
+                    "Feishu clarify button resolved %s (response=%r, user=%s)",
+                    clarify_id, response, user_name,
+                )
+            else:
+                logger.debug("[Feishu] Clarify %s already resolved or expired", clarify_id)
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu clarify: %s", exc)
+
+    # =========================================================================
+    # Slash-command confirmation (destructive /new, /reset, /undo)
+    # =========================================================================
+
     async def _resolve_approval(
         self,
         approval_id: Any,
@@ -2985,6 +3267,194 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+
+    @staticmethod
+    def _build_slash_confirm_card(*, title: str, message: str, confirm_id: str) -> Dict[str, Any]:
+        """Build an interactive card with Approve / Always / Cancel buttons."""
+        def _btn(label: str, choice: str, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_slash_confirm_action": choice,
+                    "confirm_id": confirm_id,
+                },
+            }
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"⚠️ {title}", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": [
+                {"tag": "markdown", "content": message},
+                {
+                    "tag": "action",
+                    "actions": [
+                        _btn("✅ 仅本次批准", "once", "primary"),
+                        _btn("🔒 始终批准", "always"),
+                        _btn("❌ 取消", "cancel", "danger"),
+                    ],
+                },
+            ],
+        }
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a three-button slash-command confirmation card."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            payload = json.dumps(
+                self._build_slash_confirm_card(
+                    title=title, message=message, confirm_id=confirm_id,
+                ),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                self._slash_confirm_state[confirm_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _handle_slash_confirm_card_action(
+        self, *, event: Any, action_value: Dict[str, Any], loop: Any,
+    ) -> Any:
+        """Resolve a slash-confirm button click and rebuild the card inline."""
+        confirm_id = action_value.get("confirm_id")
+        if not confirm_id:
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        state = self._slash_confirm_state.get(confirm_id)
+        if not state:
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized slash-confirm click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Slash-confirm callback chat mismatch (expected=%s, got=%s)",
+                expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = str(action_value.get("hermes_slash_confirm_action", "") or "")
+
+        # Fail closed on malformed callback data: only the three documented
+        # choices are valid.  The destructive slash handler executes every
+        # value other than "cancel", so an unexpected value must NEVER reach
+        # it.  Validate against the whitelist BEFORE popping state.
+        _SLASH_CONFIRM_CHOICES = frozenset({"once", "always", "cancel"})
+        if choice not in _SLASH_CONFIRM_CHOICES:
+            logger.warning(
+                "[Feishu] Rejecting malformed slash-confirm choice %r for %s",
+                choice, confirm_id,
+            )
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = {
+                    "config": {"wide_screen_mode": True},
+                    "header": {
+                        "title": {"content": "❌ 无效操作", "tag": "plain_text"},
+                        "template": "grey",
+                    },
+                    "elements": [
+                        {"tag": "markdown", "content": "该确认按钮数据无效，已忽略。请重新发起操作。"},
+                    ],
+                }
+                response.card = card
+            return response
+
+        session_key = state["session_key"]
+        chat_id = state["chat_id"]
+
+        # Pop state so a second click is a no-op.
+        self._slash_confirm_state.pop(confirm_id, None)
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        label_map = {
+            "once": "✅ 已批准（仅本次）",
+            "always": "🔒 已始终批准",
+            "cancel": "❌ 已取消",
+        }
+        label = label_map.get(choice, "已处理")
+
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_slash_confirm(session_key, confirm_id, choice, chat_id, user_name),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            template = "grey" if choice == "cancel" else "green"
+            card.data = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": label, "tag": "plain_text"},
+                    "template": template,
+                },
+                "elements": [
+                    {"tag": "markdown", "content": f"操作者：**{user_name}**"},
+                ],
+            }
+            response.card = card
+        return response
+
+    async def _resolve_slash_confirm(
+        self, session_key: str, confirm_id: str, choice: str, chat_id: str, user_name: str,
+    ) -> None:
+        """Run the registered slash-confirm handler and post its result."""
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            result_text = await _slash_confirm_mod.resolve(session_key, confirm_id, choice)
+            logger.info(
+                "Feishu slash-confirm resolved %s (choice=%r, user=%s)",
+                confirm_id, choice, user_name,
+            )
+            if result_text:
+                await self.send(chat_id=chat_id, content=str(result_text))
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu slash-confirm: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -80,6 +80,53 @@ def _close_submitted_coro(coro, _loop):
     return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
 
 
+class _RunCoroFuture:
+    """A fake Future that runs the coroutine synchronously on creation.
+
+    Used where a test must verify that the coroutine passed to
+    ``_submit_on_loop`` actually drove a downstream call (e.g. that
+    ``tools.slash_confirm.resolve`` ran with the chosen value).
+    """
+
+    def __init__(self, coro, _loop):
+        self._coro = coro
+        self._done_callbacks = []
+
+    def add_done_callback(self, fn):
+        self._done_callbacks.append(fn)
+        return self
+
+    def done(self):
+        return True
+
+    def result(self, timeout=None):
+        return None
+
+
+def _run_submitted_coro(coro, _loop, **_kwargs):
+    """Schedule a coroutine synchronously (run it to completion inline).
+
+    Mirrors what ``_submit_on_loop`` does via
+    ``agent.async_utils.safe_schedule_threadsafe``, but executes the coroutine
+    immediately so downstream async calls (e.g. ``tools.slash_confirm.resolve``)
+    actually run and can be asserted.  ``safe_schedule_threadsafe`` also accepts
+    ``logger``/``log_message``/``log_level`` kwargs, which are ignored here.
+    """
+    try:
+        import asyncio
+
+        async def _runner():
+            await coro
+
+        try:
+            asyncio.get_running_loop().run_until_complete(_runner())
+        except RuntimeError:
+            asyncio.run(_runner())
+    except Exception:
+        pass
+    return _RunCoroFuture(coro, _loop)
+
+
 # ===========================================================================
 # send_exec_approval — interactive card with buttons
 # ===========================================================================
@@ -445,5 +492,356 @@ class TestResolveUpdatePrompt:
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
+
+
+# ===========================================================================
+# Clarify — send_clarify interactive card + multi_select text fallback
+# ===========================================================================
+
+class TestFeishuClarifyCard:
+    """Test send_clarify renders an interactive card with choice buttons."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card_with_buttons(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clar_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="Which server to deploy?",
+                choices=["staging", "prod"],
+                clarify_id="clar_001",
+                session_key="agent:main:feishu:group:oc_12345",
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_clar_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "blue"
+        assert "Which server to deploy?" in card["elements"][0]["content"]
+        # Buttons for each choice + "Other"
+        actions = card["elements"][-1]["actions"]
+        assert len(actions) == 3
+        action_values = [a["value"] for a in actions]
+        assert action_values[0] == {
+            "hermes_clarify_action": "choice",
+            "clarify_id": "clar_001",
+            "choice_idx": 0,
+        }
+        assert action_values[-1] == {
+            "hermes_clarify_action": "other",
+            "clarify_id": "clar_001",
+        }
+
+    @pytest.mark.asyncio
+    async def test_multi_select_falls_back_to_text_renderer(self):
+        """multi_select must NOT render scalar choice buttons (JSON-array
+        contract can't be expressed by a single button click). It renders a
+        text prompt instead, which the gateway text-intercept resolves."""
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clar_ms_001"),
+        )
+        entries = {
+            "clar_ms_1": SimpleNamespace(multi_select=True),
+        }
+        with (
+            patch.object(
+                adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_send,
+            patch(
+                "plugins.platforms.feishu.adapter._clarify_entries", entries,
+            ) if False else patch("tools.clarify_gateway._entries", entries),
+        ):
+            result = await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="Pick all environments",
+                choices=["staging", "prod", "dev"],
+                clarify_id="clar_ms_1",
+                session_key="sess-ms-1",
+            )
+
+        assert result.success is True
+        card = json.loads(mock_send.call_args[1]["payload"])
+        # No action buttons — only markdown elements (question, list, prompt)
+        assert not any(e.get("tag") == "action" for e in card["elements"])
+        # The multi-select hint is present
+        assert any("多选" in e.get("content", "") for e in card["elements"])
+
+    @pytest.mark.asyncio
+    async def test_stores_clarify_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clar_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="Confirm?",
+                choices=["yes", "no"],
+                clarify_id="clar_002",
+                session_key="sess-2",
+            )
+
+        state = adapter._clarify_state["clar_002"]
+        assert state["session_key"] == "sess-2"
+        assert state["message_id"] == "msg_clar_002"
+        assert state["chat_id"] == "oc_12345"
+
+
+class TestClarifyCardAction:
+    """Test _handle_clarify_card_action resolves a choice via gateway."""
+
+    def test_choice_button_resolves(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._clarify_state["clar_1"] = {
+            "session_key": "sess-1",
+            "message_id": "msg-1",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_clarify_action": "choice",
+                "clarify_id": "clar_1",
+                "choice_idx": 1,
+            },
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        entries = {
+            "clar_1": SimpleNamespace(choices=["staging", "prod"]),
+        }
+        with (
+            patch("tools.clarify_gateway._entries", entries),
+            patch(
+                "agent.async_utils.safe_schedule_threadsafe",
+                side_effect=_run_submitted_coro,
+            ),
+        ):
+            response = adapter._handle_clarify_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "prod" in card["elements"][0]["content"]
+        assert "clar_1" not in adapter._clarify_state
+
+
+# ===========================================================================
+# Slash-confirm — card + whitelist validation (fail closed)
+# ===========================================================================
+
+class TestFeishuSlashConfirmCard:
+    """Test send_slash_confirm renders a three-button confirmation card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_three_button_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Reload MCP?",
+                message="This invalidates the provider prompt cache.",
+                session_key="sess-sc-1",
+                confirm_id="sc_001",
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "orange"
+        actions = card["elements"][-1]["actions"]
+        assert [a["value"]["hermes_slash_confirm_action"] for a in actions] == [
+            "once", "always", "cancel",
+        ]
+        assert all(a["value"]["confirm_id"] == "sc_001" for a in actions)
+
+    @pytest.mark.asyncio
+    async def test_stores_slash_confirm_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm?",
+                message="Do it?",
+                session_key="sess-sc-2",
+                confirm_id="sc_002",
+            )
+
+        state = adapter._slash_confirm_state["sc_002"]
+        assert state["session_key"] == "sess-sc-2"
+        assert state["chat_id"] == "oc_12345"
+
+
+class TestSlashConfirmCardAction:
+    """Test _handle_slash_confirm_card_action resolves valid choices and
+    fails closed on malformed callback data."""
+
+    def _make_ready_adapter(self, confirm_id="sc_1"):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state[confirm_id] = {
+            "session_key": "sess-sc-1",
+            "message_id": "msg-sc-1",
+            "chat_id": "oc_12345",
+        }
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        return adapter
+
+    def test_valid_once_resolves(self, _patch_callback_card_types):
+        adapter = self._make_ready_adapter()
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "sc_1"},
+            open_id="ou_bob",
+        )
+
+        with (
+            patch(
+                "tools.slash_confirm.resolve",
+                new_callable=AsyncMock, return_value="done",
+            ) as mock_resolve,
+            patch(
+                "agent.async_utils.safe_schedule_threadsafe",
+                side_effect=_run_submitted_coro,
+            ),
+        ):
+            response = adapter._handle_slash_confirm_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data["header"]["title"]["content"] == "✅ 已批准（仅本次）"
+        assert "sc_1" not in adapter._slash_confirm_state
+        mock_resolve.assert_called_once_with("sess-sc-1", "sc_1", "once")
+
+    def test_malformed_choice_fails_closed(self, _patch_callback_card_types):
+        """A callback with an unexpected choice value must NEVER reach the
+        destructive handler. It is rejected, state is NOT popped, and no
+        resolve runs."""
+        adapter = self._make_ready_adapter()
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "rm_rf_everything", "confirm_id": "sc_1"},
+            open_id="ou_bob",
+        )
+
+        with (
+            patch(
+                "tools.slash_confirm.resolve",
+                new_callable=AsyncMock, return_value="done",
+            ) as mock_resolve,
+            patch("asyncio.run_coroutine_threadsafe") as mock_submit,
+        ):
+            response = adapter._handle_slash_confirm_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data["header"]["title"]["content"] == "❌ 无效操作"
+        # State preserved so a legitimate retry isn't blocked, and the
+        # destructive handler was never invoked.
+        assert "sc_1" in adapter._slash_confirm_state
+        mock_resolve.assert_not_called()
+        mock_submit.assert_not_called()
+
+    def test_cancel_is_valid(self, _patch_callback_card_types):
+        adapter = self._make_ready_adapter()
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "cancel", "confirm_id": "sc_1"},
+            open_id="ou_bob",
+        )
+
+        with (
+            patch(
+                "tools.slash_confirm.resolve",
+                new_callable=AsyncMock, return_value="cancelled",
+            ) as mock_resolve,
+            patch(
+                "agent.async_utils.safe_schedule_threadsafe",
+                side_effect=_run_submitted_coro,
+            ),
+        ):
+            response = adapter._handle_slash_confirm_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+
+        assert response is not None
+        assert response.card.data["header"]["title"]["content"] == "❌ 已取消"
+        assert response.card.data["header"]["template"] == "grey"
+        mock_resolve.assert_called_once_with("sess-sc-1", "sc_1", "cancel")
+
+    def test_unauthorized_click_does_not_resolve(self, _patch_callback_card_types):
+        adapter = self._make_ready_adapter()
+        adapter._allowed_group_users = {"ou_other"}
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "sc_1"},
+            open_id="ou_intruder",
+        )
+
+        with (
+            patch(
+                "tools.slash_confirm.resolve",
+                new_callable=AsyncMock, return_value="done",
+            ) as mock_resolve,
+            patch("asyncio.run_coroutine_threadsafe") as mock_submit,
+        ):
+            response = adapter._handle_slash_confirm_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+
+        assert response is not None
+        assert response.card is None
+        assert "sc_1" in adapter._slash_confirm_state
+        mock_resolve.assert_not_called()
+        mock_submit.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

The Feishu (Lark) adapter lacks "send_clarify" and "send_slash_confirm" methods. The gateway falls back to plain-text numbered lists for clarify prompts and text instructions ("reply /approve") for destructive slash-command confirmations (/new, /reset, /undo). Telegram, Discord, and Slack all render native buttons for these flows.

## Solution

Two interactive card implementations following the existing "send_update_prompt" / "_build_update_prompt_card" pattern:

### send_clarify
Renders one button per choice plus an "Other (input)" button. Picking a choice resolves immediately; "Other" flips the entry into text-capture mode.

### send_slash_confirm
Renders Approve Once / Always Approve / Cancel buttons.

## Review fixes (round 2)

Addressed feedback from the first review round:

1. **Fail closed on malformed slash-confirm values** — validate against the once/always/cancel whitelist BEFORE popping state, so destructive handlers are never invoked with unexpected callback data.
2. **multi_select clarify support** — single scalar button clicks cannot express the JSON-array multi-select contract, so multi-select clarifies fall back to the text renderer with a numbered prompt ("1,3" / "1 3") parsed by the gateway's multi-select text interception.
3. **Tests** — added coverage for send_clarify / send_slash_confirm cards, state tracking, authorization, choice resolution, whitelist validation (fail-closed), and multi-select text fallback.

## Files changed

- plugins/platforms/feishu/adapter.py
- tests/gateway/test_feishu_approval_buttons.py