### PR TITLE
fix(config): guard security-policy keys in hermes config set/unset

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -877,11 +877,15 @@ class GatewaySlashCommandsMixin(
         from gateway.slash_access import policy_for_source
         from hermes_cli.approval_mode import run_approval_mode_command
         requested = event.get_command_args().strip() or None
-        # This mutates profile-wide security policy. The central slash gate can allow selected
-        # commands to non-admin users, so enforce admin again at this side-effect boundary.
-        # Unconfigured policies remain unrestricted.
+        # This mutates profile-wide security policy. The central slash gate can
+        # allow selected commands to non-admin users, so enforce admin again at
+        # this side-effect boundary. A *change* additionally requires an
+        # explicit admin policy: with gating disabled (no admin list
+        # configured), policy.is_admin() returns True for everyone, which would
+        # let a non-admin caller persist approvals.mode: off through the
+        # gateway and disable approval checks (#81108). Queries stay open.
         policy = policy_for_source(self.config, event.source)
-        if requested and not policy.is_admin(event.source.user_id):
+        if requested and (not policy.enabled or not policy.is_admin(event.source.user_id)):
             return "Only gateway admins can change the persistent approval mode."
         # Approval checks load config dynamically; do not evict the cached agent or alter its
         # system prompt/tool schema (prompt-cache prefix is sacred).

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -54,12 +54,15 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     # set_config_value is the canonical managed-scope/write-safety chokepoint.
     # It reports managed policy through stderr + SystemExit, so capture that for
     # slash-command output instead of terminating the interactive worker.
+    # force=True is the explicit operator override for the security-policy guard
+    # (#81101): /approvals is the sanctioned way to change approvals.mode, so it
+    # must not be blocked by the same guard that stops a raw `config set`.
     from hermes_cli.config import set_config_value
 
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested)
+            set_config_value("approvals.mode", requested, force=True)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -44,11 +44,14 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     # policy through stderr + SystemExit, and the fail-closed write guard raises RuntimeError on an
     # unparseable config.yaml; capture both for slash-command output instead of terminating the
     # interactive worker.
+    # force=True is the explicit operator override for the security-policy guard
+    # (#81101): /approvals is the sanctioned way to change approvals.mode, so it
+    # must not be blocked by the same guard that stops a raw `config set`.
     from hermes_cli.config import set_config_value
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested)
+            set_config_value("approvals.mode", requested, force=True)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -40,18 +40,19 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     if requested not in VALID_APPROVAL_MODES:
         return ApprovalModeResult(False, current, False, "Usage: /approvals [manual|smart|off]")
 
-    # set_config_value is the canonical managed-scope/write-safety chokepoint. It reports managed
-    # policy through stderr + SystemExit, and the fail-closed write guard raises RuntimeError on an
-    # unparseable config.yaml; capture both for slash-command output instead of terminating the
-    # interactive worker.
-    # force=True is the explicit operator override for the security-policy guard
-    # (#81101): /approvals is the sanctioned way to change approvals.mode, so it
-    # must not be blocked by the same guard that stops a raw `config set`.
+    # set_config_value is the canonical managed-scope/write-safety chokepoint.
+    # It reports managed policy through stderr + SystemExit, and the fail-closed
+    # write guard raises RuntimeError on an unparseable config.yaml; capture both
+    # for slash-command output instead of terminating the interactive worker.
+    # approval_override=True is the dedicated authorization for the sanctioned
+    # /approvals command — deliberately NOT the generic ``force`` escape hatch,
+    # so an alternate CLI entrypoint reaching the writer cannot weaken the
+    # security policy by passing force (#81108).
     from hermes_cli.config import set_config_value
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested, force=True)
+            set_config_value("approvals.mode", requested, approval_override=True)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1172,6 +1172,53 @@ def _is_env_config_key(key: str) -> bool:
     )
 
 
+# Security-sensitive config keys that `hermes config set`/`unset` refuses to
+# mutate without an explicit operator override. ``config.yaml`` IS the security
+# policy (approvals.mode, command_allowlist, security.*), the config cache is
+# mtime-keyed, and a write takes effect mid-session — so the sanctioned CLI
+# path must not let an agent silently weaken the approval gate or redaction
+# the way it could by writing to the file directly. Mirrors the file-tool deny
+# in tools/file_tools.py (_check_sensitive_path). See #81101.
+_SENSITIVE_CONFIG_KEYS = ("approvals.", "security.", "command_allowlist")
+
+
+def _is_sensitive_config_key(key: str) -> bool:
+    """Return whether *key* targets a security-sensitive config section.
+
+    A bare section name (``approvals``) is guarded too, since ``config set
+    approvals off --force`` would replace the whole mapping with a scalar.
+    """
+    normalized = key.strip().lower()
+    return any(
+        normalized == prefix.rstrip(".")
+        or normalized.startswith(prefix)
+        for prefix in _SENSITIVE_CONFIG_KEYS
+    )
+
+
+def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
+    """Print a refusal for a security-sensitive key write and exit non-zero."""
+    print(
+        f"✗ Cannot {hint} '{key}': this key controls security policy "
+        f"(approvals / security / command_allowlist) and cannot be changed "
+        f"without explicit operator confirmation.",
+        file=sys.stderr,
+    )
+    if key == "approvals.mode":
+        print(
+            "  Use `hermes approvals [manual|smart|off]` to change the "
+            "approval mode.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "  Use `hermes config set --force <key> <value>` to override, or "
+            "edit ~/.hermes/config.yaml directly.",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
 def _format_config_get_value(value, *, as_json: bool) -> str:
     """Format a config value for command-line output."""
     if as_json:
@@ -4853,6 +4900,13 @@ def set_config_value(key: str, value: str, force: bool = False):
             file=sys.stderr,
         )
         sys.exit(1)
+    # Security-policy guard (#81101): approvals.*, security.* and
+    # command_allowlist change the effective security policy mid-session. Only
+    # an explicit --force (an operator typing the override at the CLI) may
+    # mutate them — the canonical operator paths (e.g. `hermes approvals`) pass
+    # force=True.
+    if _is_sensitive_config_key(key) and not force:
+        _refuse_sensitive_config_key(key, hint="set")
     # Check if it's an API key (goes to .env)
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old
@@ -5077,6 +5131,14 @@ def unset_config_value(key: str):
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Security-policy guard (#81101): mirror set_config_value. `config unset`
+    # has no --force escape hatch, so a security-sensitive key is refused
+    # outright — unsetting approvals.mode / security.* / command_allowlist is
+    # always an operator-level action, and editing config.yaml directly (or the
+    # canonical command) is the sanctioned route.
+    if _is_sensitive_config_key(key):
+        _refuse_sensitive_config_key(key, hint="unset")
 
     if _is_env_config_key(key):
         # Unified lifecycle: prune env-seeded credential_pool entries and

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -950,8 +950,8 @@ def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
     )
     if key == "approvals.mode":
         print(
-            "  Use `hermes approvals [manual|smart|off]` to change the "
-            "approval mode.",
+            "  Use the /approvals slash command (manual|smart|off) to change "
+            "the approval mode.",
             file=sys.stderr,
         )
     else:
@@ -3452,11 +3452,13 @@ def _print_unknown_key_notice(key: str, suggestion: Optional[str]) -> None:
         "this notice.)", Colors.DIM))
 
 
-def set_config_value(key: str, value: str, force: bool = False):
+def set_config_value(key: str, value: str, force: bool = False, *, approval_override: bool = False):
     """Set a configuration value at a dotted ``key``; ``value`` is auto-coerced to bool/int/float.
     ``force`` skips the unknown-key warning AND authorizes replacing a mapping section with a
     scalar. Without it, scalar writes over mappings are refused and bare ``model`` is redirected
-    to ``model.default``."""
+    to ``model.default``. ``approval_override`` is the dedicated authorization for the sanctioned
+    /approvals command only (approval_mode.py) — generic ``force`` never authorizes
+    security-policy writes (#81108)."""
     if is_managed():
         managed_error("set configuration values")
         return
@@ -3470,12 +3472,15 @@ def set_config_value(key: str, value: str, force: bool = False):
     _exit_if_key_managed(key, "set")
     # Security-policy guard (#81101): approvals.*, security.* and
     # command_allowlist change the effective security policy mid-session.
-    # force=True is honored ONLY by the in-process user-mediated canonical
-    # path (`hermes approvals` / /approvals → approval_mode.py); the CLI
-    # never forwards --force for sensitive keys (config_command refuses them
-    # at every form), so no agent-reachable invocation can weaken the policy
-    # without an operator in the loop. See review on #81108.
-    if _is_sensitive_config_key(key) and not force:
+    # Mutation authorization is independent of invocation form: generic
+    # ``force`` (``hermes config set --force``) is deliberately NOT
+    # sufficient — only the dedicated approval_override flag, used
+    # exclusively by the user-mediated /approvals command
+    # (hermes_cli/approval_mode.py), may mutate them. The CLI additionally
+    # refuses sensitive keys at every form in config_command, so no
+    # agent-reachable invocation can weaken the policy without an operator
+    # in the loop (#81108).
+    if _is_sensitive_config_key(key) and not approval_override:
         _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old value.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -956,8 +956,13 @@ def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
         )
     else:
         print(
-            "  Use `hermes config set --force <key> <value>` to override, or "
-            "edit ~/.hermes/config.yaml directly.",
+            "  Security-policy keys cannot be changed via `hermes config set` "
+            "(with or without --force).",
+            file=sys.stderr,
+        )
+        print(
+            "  Edit config.yaml directly, or use the dedicated command where "
+            "one exists (e.g. `hermes approvals` for approvals.mode).",
             file=sys.stderr,
         )
     sys.exit(1)
@@ -3464,10 +3469,12 @@ def set_config_value(key: str, value: str, force: bool = False):
             "(leading, trailing, or doubled '.').")
     _exit_if_key_managed(key, "set")
     # Security-policy guard (#81101): approvals.*, security.* and
-    # command_allowlist change the effective security policy mid-session. Only
-    # an explicit --force (an operator typing the override at the CLI) may
-    # mutate them — the canonical operator paths (e.g. `hermes approvals`) pass
-    # force=True.
+    # command_allowlist change the effective security policy mid-session.
+    # force=True is honored ONLY by the in-process user-mediated canonical
+    # path (`hermes approvals` / /approvals → approval_mode.py); the CLI
+    # never forwards --force for sensitive keys (config_command refuses them
+    # at every form), so no agent-reachable invocation can weaken the policy
+    # without an operator in the loop. See review on #81108.
     if _is_sensitive_config_key(key) and not force:
         _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
@@ -3649,6 +3656,18 @@ def _cmd_config_set(args):
     value = getattr(args, 'value', None)
     if not key or value is None:
         _usage_exit(*_USAGE_SET)
+    # Security-policy guard (#81101): refuse sensitive keys at EVERY CLI
+    # form. --force is a non-sensitive-key escape hatch (unknown-key
+    # notice / scalar-over-mapping); it must not become a security-policy
+    # override, or an agent typing `hermes config set --force
+    # approvals.mode off` into the terminal would disable the approval
+    # gate with no operator confirmation (the one-command bypass the
+    # file-tool deny exists to prevent). The in-process user-mediated
+    # path (`hermes approvals` / /approvals) is the only sanctioned way
+    # to change approvals.mode; everything else edits config.yaml
+    # directly. See review on #81108.
+    if _is_sensitive_config_key(key):
+        _refuse_sensitive_config_key(key, hint="set")
     _run_write_command(set_config_value, key, value, bool(getattr(args, 'force', False)))
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -916,6 +916,53 @@ def _is_env_config_key(key: str) -> bool:
         or key_upper.startswith('TERMINAL_SSH'))
 
 
+# Security-sensitive config keys that `hermes config set`/`unset` refuses to
+# mutate without an explicit operator override. ``config.yaml`` IS the security
+# policy (approvals.mode, command_allowlist, security.*), the config cache is
+# mtime-keyed, and a write takes effect mid-session — so the sanctioned CLI
+# path must not let an agent silently weaken the approval gate or redaction
+# the way it could by writing to the file directly. Mirrors the file-tool deny
+# in tools/file_tools.py (_check_sensitive_path). See #81101.
+_SENSITIVE_CONFIG_KEYS = ("approvals.", "security.", "command_allowlist")
+
+
+def _is_sensitive_config_key(key: str) -> bool:
+    """Return whether *key* targets a security-sensitive config section.
+
+    A bare section name (``approvals``) is guarded too, since ``config set
+    approvals off --force`` would replace the whole mapping with a scalar.
+    """
+    normalized = key.strip().lower()
+    return any(
+        normalized == prefix.rstrip(".")
+        or normalized.startswith(prefix)
+        for prefix in _SENSITIVE_CONFIG_KEYS
+    )
+
+
+def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
+    """Print a refusal for a security-sensitive key write and exit non-zero."""
+    print(
+        f"✗ Cannot {hint} '{key}': this key controls security policy "
+        f"(approvals / security / command_allowlist) and cannot be changed "
+        f"without explicit operator confirmation.",
+        file=sys.stderr,
+    )
+    if key == "approvals.mode":
+        print(
+            "  Use `hermes approvals [manual|smart|off]` to change the "
+            "approval mode.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "  Use `hermes config set --force <key> <value>` to override, or "
+            "edit ~/.hermes/config.yaml directly.",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
 def _format_config_get_value(value, *, as_json: bool) -> str:
     """Format a config value for command-line output."""
     if as_json:
@@ -3416,6 +3463,13 @@ def set_config_value(key: str, value: str, force: bool = False):
             f"✗ Invalid config key: {key!r} — contains an empty path segment "
             "(leading, trailing, or doubled '.').")
     _exit_if_key_managed(key, "set")
+    # Security-policy guard (#81101): approvals.*, security.* and
+    # command_allowlist change the effective security policy mid-session. Only
+    # an explicit --force (an operator typing the override at the CLI) may
+    # mutate them — the canonical operator paths (e.g. `hermes approvals`) pass
+    # force=True.
+    if _is_sensitive_config_key(key) and not force:
+        _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old value.
         from hermes_cli.credential_lifecycle import save_provider_env_credential
@@ -3508,6 +3562,14 @@ def unset_config_value(key: str):
         managed_error("unset configuration values")
         return
     _exit_if_key_managed(key, "unset")
+
+    # Security-policy guard (#81101): mirror set_config_value. `config unset`
+    # has no --force escape hatch, so a security-sensitive key is refused
+    # outright — unsetting approvals.mode / security.* / command_allowlist is
+    # always an operator-level action, and editing config.yaml directly (or the
+    # canonical command) is the sanctioned route.
+    if _is_sensitive_config_key(key):
+        _refuse_sensitive_config_key(key, hint="unset")
 
     if _is_env_config_key(key):
         # Unified lifecycle: also prunes env-seeded credential_pool entries and model-cache rows so

--- a/tests/gateway/test_approvals_command.py
+++ b/tests/gateway/test_approvals_command.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+
 import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.platforms.event import MessageEvent
@@ -55,5 +56,57 @@ async def test_gateway_rejects_non_admin_persistent_approval_change():
 
     assert "admin" in output.lower()
     run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_approval_change_without_configured_policy():
+    """An unconfigured slash policy (gating disabled) must NOT authorize a
+    persistent approval-mode change: with ``enabled=False``,
+    ``policy.is_admin`` returns True for everyone, which would let any caller
+    persist ``approvals.mode: off`` and disable approval checks (#81108)."""
+    runner = _runner()  # platforms={} → policy_for_source returns disabled policy
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        output = await runner._handle_approvals_command(_event("/approvals off"))
+
+    assert "admin" in output.lower()
+    run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_allows_query_without_configured_policy():
+    """Reading the current approval mode stays open even with no policy."""
+    runner = _runner()
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        run.return_value = SimpleNamespace(message="Approval mode: manual")
+        output = await runner._handle_approvals_command(_event("/approvals"))
+
+    assert output == "Approval mode: manual"
+    run.assert_called_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_gateway_allows_admin_change_with_configured_policy():
+    runner = _runner()
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(
+                extra={
+                    "allow_admin_from": ["admin-1"],
+                    "user_allowed_commands": ["approvals"],
+                }
+            )
+        }
+    )
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        run.return_value = SimpleNamespace(message="Approval mode: off")
+        event = _event("/approvals off")
+        event.source.user_id = "admin-1"
+        output = await runner._handle_approvals_command(event)
+
+    assert output == "Approval mode: off"
+    run.assert_called_once_with("off")
 
 

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -75,6 +75,10 @@ class TestMalformedKey:
 class TestStringTypedGuardPreserved:
     def test_enum_off_stays_string(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        cfg.set_config_value("approvals.mode", "off")
+        # approvals.mode is a security-policy key (#81101): plain config set
+        # refuses it, so go through the dedicated approval_override channel —
+        # the string-coercion invariant under test is unchanged ("off" must
+        # survive the round-trip as a string, not YAML bool False).
+        cfg.set_config_value("approvals.mode", "off", approval_override=True)
         v = _read(tmp_path, "approvals", "mode")
         assert v == "off" and isinstance(v, str)  # not bool False

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -112,7 +112,7 @@ def test_string_typed_key_bracket_value_stays_string(user_home):
     even when the value looks like a list literal."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "[off]")
+    set_config_value("approvals.mode", "[off]", approval_override=True)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "[off]"
     assert isinstance(raw["approvals"]["mode"], str)
@@ -122,7 +122,7 @@ def test_string_typed_key_negative_number_stays_string(user_home):
     """'-5' for a string-typed key must remain the string '-5'."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "-5")
+    set_config_value("approvals.mode", "-5", approval_override=True)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "-5"
 

--- a/tests/hermes_cli/test_console_engine_config_guard.py
+++ b/tests/hermes_cli/test_console_engine_config_guard.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+Test that the console_engine _config_set path (alternate CLI entrypoint)
+also refuses security-sensitive keys — the guard lives inside
+set_config_value itself, not just in config_command's pre-check.
+
+This pins the finding from review on #81108: an alternate supported
+entrypoint (console_engine's `config set`) reaches set_config_value
+without going through config_command's CLI-level sensitive-key check.
+The in-set_config_value guard (#81101) must independently refuse.
+"""
+import sys
+import io
+import pytest
+
+
+class TestConsoleEngineSensitiveKeyGuard:
+    """Pin that the console_engine path (which calls set_config_value
+    directly without config_command's pre-check) is still guarded."""
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals",
+        "security.foo",
+        "security",
+        "command_allowlist",
+    ])
+    def test_console_engine_refuses_sensitive_keys(self, key, monkeypatch):
+        """set_config_value(key, value) without approval_override must
+        refuse security-sensitive keys regardless of entrypoint."""
+        from hermes_cli.config import set_config_value
+
+        err = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", err)
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value(key, "off")
+
+        assert exc_info.value.code == 1
+        assert "security policy" in err.getvalue()
+
+    def test_non_sensitive_keys_not_refused(self):
+        """Non-sensitive keys are classified correctly."""
+        from hermes_cli.config import _is_sensitive_config_key
+
+        assert not _is_sensitive_config_key("model.default")
+        assert not _is_sensitive_config_key("provider.openai.api_key")
+        assert not _is_sensitive_config_key("ui.theme")
+
+    def test_approval_override_skips_guard(self, monkeypatch):
+        """approval_override=True (sanctioned /approvals command) must
+        NOT trigger the sensitive-key refusal — it proceeds past the guard."""
+        import hermes_cli.config as cfg
+
+        refuse_called = False
+
+        def spy_refuse(*args, **kwargs):
+            nonlocal refuse_called
+            refuse_called = True
+            raise SystemExit(1)
+
+        monkeypatch.setattr(cfg, "_refuse_sensitive_config_key", spy_refuse)
+        # Short-circuit after the guard: is_managed exits before any write
+        monkeypatch.setattr(cfg, "is_managed", lambda: True)
+
+        err = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", err)
+
+        try:
+            cfg.set_config_value("approvals.mode", "off", approval_override=True)
+        except SystemExit:
+            pass  # is_managed exits — that's AFTER the guard, which is what we test
+
+        assert not refuse_called, \
+            "approval_override=True must NOT trigger the sensitive-key refusal"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -351,7 +351,9 @@ class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        set_config_value("approvals.mode", value)
+        # approvals.mode is security-sensitive; force=True is the explicit
+        # operator override (the canonical path is `hermes approvals`).
+        set_config_value("approvals.mode", value, force=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -365,7 +367,8 @@ class TestStringTypedConfigValues:
     def test_non_string_defaults_keep_existing_coercion(
         self, _isolated_hermes_home, key, value, expected
     ):
-        set_config_value(key, value)
+        force = key == "approvals.timeout"  # security-sensitive key
+        set_config_value(key, value, force=force)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -723,3 +726,97 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Security-policy guard (#81101)
+# ---------------------------------------------------------------------------
+
+class TestSensitiveConfigKeyGuard:
+    """`hermes config set` must refuse security-policy keys without --force.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*); the config cache is mtime-keyed so a write takes effect
+    mid-session. The file tools already hard-deny agent writes to config.yaml
+    (tools/file_tools.py), so the sanctioned CLI must not be the one-command
+    bypass for an agent to disable the approval gate.
+    """
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "approvals.deny",
+        "approvals",
+        "security.redact_secrets",
+        "security.tirith_enabled",
+        "security",
+        "command_allowlist",
+    ])
+    def test_sensitive_key_refused_without_force(self, _isolated_hermes_home, capsys, key):
+        from hermes_cli.config import unset_config_value
+
+        with pytest.raises(SystemExit):
+            set_config_value(key, "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+        assert key in captured.err
+
+        # Nothing was written to config.yaml.
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
+    @pytest.mark.parametrize("key, expected", [
+        ("approvals.mode", "off"),          # string-typed default → stays string
+        ("approvals.cron_mode", "off"),     # string-typed default → stays string
+        ("security.redact_secrets", False),  # bool default → "off" coerces to False
+        ("command_allowlist", "git push --force"),  # list default → literal string
+    ])
+    def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
+        """--force is the explicit operator override for security keys."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        node = saved
+        for part in key.split("."):
+            node = node[part]
+        assert node == expected
+
+    def test_approvals_mode_refusal_mentions_canonical_command(self, _isolated_hermes_home, capsys):
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "hermes approvals" in captured.err
+
+    def test_non_sensitive_keys_still_work(self, _isolated_hermes_home):
+        """Ordinary config keys are unaffected by the guard."""
+        set_config_value("terminal.backend", "docker")
+        set_config_value("display.skin", "mono")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["backend"] == "docker"
+        assert saved["display"]["skin"] == "mono"
+
+    def test_unset_sensitive_key_refused(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import unset_config_value
+
+        with pytest.raises(SystemExit):
+            unset_config_value("approvals.mode")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+    def test_sensitive_guard_runs_before_yaml_parse(self, _isolated_hermes_home, capsys):
+        """Even a broken config.yaml must not block the security refusal."""
+        ( _isolated_hermes_home / "config.yaml").write_text("model: gpt-4o\n  broken: [oops")
+
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -865,13 +865,16 @@ class TestLiteralDotKeyEscaping:
 # ---------------------------------------------------------------------------
 
 class TestSensitiveConfigKeyGuard:
-    """`hermes config set` must refuse security-policy keys without --force.
+    """`hermes config set` must refuse security-policy keys at every CLI form.
 
     config.yaml IS the security policy (approvals.mode, command_allowlist,
     security.*); the config cache is mtime-keyed so a write takes effect
     mid-session. The file tools already hard-deny agent writes to config.yaml
     (tools/file_tools.py), so the sanctioned CLI must not be the one-command
-    bypass for an agent to disable the approval gate.
+    bypass for an agent to disable the approval gate — with or without
+    --force. The writer honors force=True only for the in-process
+    user-mediated canonical path (`hermes approvals` / /approvals); the CLI
+    never forwards it for sensitive keys. See review on #81108.
     """
 
     @pytest.mark.parametrize("key", [
@@ -907,7 +910,13 @@ class TestSensitiveConfigKeyGuard:
         ("command_allowlist", "git push --force"),  # list default → literal string
     ])
     def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
-        """--force is the explicit operator override for security keys."""
+        """Writer-level force=True stays honored for the /approvals contract.
+
+        This is the in-process user-mediated canonical path
+        (approval_mode.py → set_config_value(..., force=True)); the CLI never
+        forwards --force for sensitive keys (see
+        test_cli_set_refuses_sensitive_key_even_with_force below).
+        """
         set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
 
         import yaml
@@ -916,6 +925,52 @@ class TestSensitiveConfigKeyGuard:
         for part in key.split("."):
             node = node[part]
         assert node == expected
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "approvals",
+        "security.redact_secrets",
+        "security",
+        "command_allowlist",
+    ])
+    def test_cli_set_refuses_sensitive_key_even_with_force(
+        self, _isolated_hermes_home, capsys, key
+    ):
+        """`hermes config set --force <sensitive-key>` is still refused.
+
+        --force is a non-sensitive-key escape hatch (unknown-key notice /
+        scalar-over-mapping). If it also bypassed the security guard, an
+        agent typing the command into the terminal could persist
+        ``approvals.mode: off`` and disable approval checks — the alternate
+        entrypoint reported in the #81108 review. The refusal must fire at
+        the CLI layer regardless of the flag.
+        """
+        from types import SimpleNamespace
+
+        args = SimpleNamespace(config_command="set", key=key, value="off", force=True)
+        with pytest.raises(SystemExit):
+            config_command(args)
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+        # Nothing was written to config.yaml.
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
+    def test_cli_set_force_still_works_for_non_sensitive_key(self, _isolated_hermes_home):
+        """--force keeps its documented meaning for non-sensitive keys."""
+        from types import SimpleNamespace
+
+        args = SimpleNamespace(config_command="set", key="model", value="gpt-5.6-sol", force=True)
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["model"] == "gpt-5.6-sol"
 
     def test_approvals_mode_refusal_mentions_canonical_command(self, _isolated_hermes_home, capsys):
         with pytest.raises(SystemExit):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -357,9 +357,9 @@ class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        # approvals.mode is security-sensitive; force=True is the explicit
-        # operator override (the canonical path is `hermes approvals`).
-        set_config_value("approvals.mode", value, force=True)
+        # approvals.mode is security-sensitive; approval_override is the
+        # dedicated /approvals channel (#81108).
+        set_config_value("approvals.mode", value, approval_override=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -373,8 +373,8 @@ class TestStringTypedConfigValues:
     def test_non_string_defaults_keep_existing_coercion(
         self, _isolated_hermes_home, key, value, expected
     ):
-        force = key == "approvals.timeout"  # security-sensitive key
-        set_config_value(key, value, force=force)
+        approval_override = key == "approvals.timeout"  # security-sensitive key
+        set_config_value(key, value, approval_override=approval_override)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -909,15 +909,9 @@ class TestSensitiveConfigKeyGuard:
         ("security.redact_secrets", False),  # bool default → "off" coerces to False
         ("command_allowlist", "git push --force"),  # list default → literal string
     ])
-    def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
-        """Writer-level force=True stays honored for the /approvals contract.
-
-        This is the in-process user-mediated canonical path
-        (approval_mode.py → set_config_value(..., force=True)); the CLI never
-        forwards --force for sensitive keys (see
-        test_cli_set_refuses_sensitive_key_even_with_force below).
-        """
-        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
+    def test_sensitive_key_allowed_with_approval_override(self, _isolated_hermes_home, key, expected):
+        """approval_override (the dedicated /approvals channel) may write."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", approval_override=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -961,6 +955,28 @@ class TestSensitiveConfigKeyGuard:
         assert "security" not in raw
         assert "command_allowlist" not in raw
 
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "security.redact_secrets",
+        "command_allowlist",
+    ])
+    def test_sensitive_key_refused_with_generic_force(self, _isolated_hermes_home, capsys, key):
+        """Generic ``force=True`` must NOT authorize a security-policy write
+        at the writer layer either: an alternate CLI entrypoint reaching
+        set_config_value with force would otherwise bypass the approval gate
+        (#81108). Only the dedicated approval_override counts."""
+        with pytest.raises(SystemExit):
+            set_config_value(key, "off", force=True)
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
     def test_cli_set_force_still_works_for_non_sensitive_key(self, _isolated_hermes_home):
         """--force keeps its documented meaning for non-sensitive keys."""
         from types import SimpleNamespace
@@ -977,7 +993,7 @@ class TestSensitiveConfigKeyGuard:
             set_config_value("approvals.mode", "off")
 
         captured = capsys.readouterr()
-        assert "hermes approvals" in captured.err
+        assert "/approvals" in captured.err
 
     def test_non_sensitive_keys_still_work(self, _isolated_hermes_home):
         """Ordinary config keys are unaffected by the guard."""

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -357,7 +357,9 @@ class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        set_config_value("approvals.mode", value)
+        # approvals.mode is security-sensitive; force=True is the explicit
+        # operator override (the canonical path is `hermes approvals`).
+        set_config_value("approvals.mode", value, force=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -371,7 +373,8 @@ class TestStringTypedConfigValues:
     def test_non_string_defaults_keep_existing_coercion(
         self, _isolated_hermes_home, key, value, expected
     ):
-        set_config_value(key, value)
+        force = key == "approvals.timeout"  # security-sensitive key
+        set_config_value(key, value, force=force)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -856,3 +859,96 @@ class TestLiteralDotKeyEscaping:
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["terminal"]["backend"] == "docker"
+
+
+# Security-policy guard (#81101)
+# ---------------------------------------------------------------------------
+
+class TestSensitiveConfigKeyGuard:
+    """`hermes config set` must refuse security-policy keys without --force.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*); the config cache is mtime-keyed so a write takes effect
+    mid-session. The file tools already hard-deny agent writes to config.yaml
+    (tools/file_tools.py), so the sanctioned CLI must not be the one-command
+    bypass for an agent to disable the approval gate.
+    """
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "approvals.deny",
+        "approvals",
+        "security.redact_secrets",
+        "security.tirith_enabled",
+        "security",
+        "command_allowlist",
+    ])
+    def test_sensitive_key_refused_without_force(self, _isolated_hermes_home, capsys, key):
+        from hermes_cli.config import unset_config_value
+
+        with pytest.raises(SystemExit):
+            set_config_value(key, "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+        assert key in captured.err
+
+        # Nothing was written to config.yaml.
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
+    @pytest.mark.parametrize("key, expected", [
+        ("approvals.mode", "off"),          # string-typed default → stays string
+        ("approvals.cron_mode", "off"),     # string-typed default → stays string
+        ("security.redact_secrets", False),  # bool default → "off" coerces to False
+        ("command_allowlist", "git push --force"),  # list default → literal string
+    ])
+    def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
+        """--force is the explicit operator override for security keys."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        node = saved
+        for part in key.split("."):
+            node = node[part]
+        assert node == expected
+
+    def test_approvals_mode_refusal_mentions_canonical_command(self, _isolated_hermes_home, capsys):
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "hermes approvals" in captured.err
+
+    def test_non_sensitive_keys_still_work(self, _isolated_hermes_home):
+        """Ordinary config keys are unaffected by the guard."""
+        set_config_value("terminal.backend", "docker")
+        set_config_value("display.skin", "mono")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["backend"] == "docker"
+        assert saved["display"]["skin"] == "mono"
+
+    def test_unset_sensitive_key_refused(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import unset_config_value
+
+        with pytest.raises(SystemExit):
+            unset_config_value("approvals.mode")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+    def test_sensitive_guard_runs_before_yaml_parse(self, _isolated_hermes_home, capsys):
+        """Even a broken config.yaml must not block the security refusal."""
+        ( _isolated_hermes_home / "config.yaml").write_text("model: gpt-4o\n  broken: [oops")
+
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -850,6 +850,39 @@ class TestLaunchctlGatewayLifecycle:
             assert dangerous is False, cmd
 
 
+class TestConfigSetSecurityPolicy:
+    """`hermes config set` on a security-policy key must require approval.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*) and the config cache is mtime-keyed, so a write takes effect
+    mid-session. The CLI refuses these keys without --force (config.py #81101);
+    this terminal-side pattern gates even the explicit --force variant so the
+    operator is always surfaced for approval — the same treatment sed/tee on
+    config.yaml already get.
+    """
+
+    def test_security_policy_keys_detected(self):
+        for cmd in (
+            "hermes config set approvals.mode off",
+            "hermes config set --force approvals.mode off",
+            "hermes config set approvals.cron_mode deny",
+            "hermes config set security.redact_secrets false",
+            "hermes -p ade config set command_allowlist git",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
+    def test_benign_config_set_not_flagged(self):
+        for cmd in (
+            "hermes config set terminal.backend docker",
+            "hermes config set model gpt-4o",
+            "hermes config set display.skin mono",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy
     work and rewrite shared history. Not covered by rm/chmod patterns.

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -873,6 +873,19 @@ class TestConfigSetSecurityPolicy:
             assert dangerous is True, cmd
             assert "security-policy" in desc, cmd
 
+    def test_quoted_security_policy_keys_detected(self):
+        # The shell strips quotes before the CLI sees the key, so quoting the
+        # key must not bypass the terminal gate either (triage finding).
+        for cmd in (
+            'hermes config set "approvals.mode" off',
+            'hermes config set --force "approvals.mode" off',
+            "hermes config set 'security.redact_secrets' false",
+            'hermes -p ade config set --force "command_allowlist" git',
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
     def test_benign_config_set_not_flagged(self):
         for cmd in (
             "hermes config set terminal.backend docker",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1055,10 +1055,11 @@ class TestConfigSetSecurityPolicy:
 
     config.yaml IS the security policy (approvals.mode, command_allowlist,
     security.*) and the config cache is mtime-keyed, so a write takes effect
-    mid-session. The CLI refuses these keys without --force (config.py #81101);
-    this terminal-side pattern gates even the explicit --force variant so the
-    operator is always surfaced for approval — the same treatment sed/tee on
-    config.yaml already get.
+    mid-session. The CLI refuses these keys through the config API (config.py
+    #81101); this terminal-side pattern gates the terminal path the same way
+    sed/tee on config.yaml are gated, so the operator is always surfaced for
+    approval — including alternate entrypoints like ``python -m
+    hermes_cli.main`` (#81108).
     """
 
     def test_security_policy_keys_detected(self):
@@ -1085,6 +1086,27 @@ class TestConfigSetSecurityPolicy:
             dangerous, _, desc = detect_dangerous_command(cmd)
             assert dangerous is True, cmd
             assert "security-policy" in desc, cmd
+
+    def test_python_dash_m_entrypoint_detected(self):
+        """``python -m hermes_cli.main`` is an alternate supported CLI
+        entrypoint reaching the same config writer (main.py exposes
+        ``if __name__ == "__main__"``); it must hit the same gate (#81108)."""
+        for cmd in (
+            "python -m hermes_cli.main config set --force approvals.mode off",
+            "python3 -m hermes_cli.main config set approvals.mode off",
+            "python3.12 -m hermes_cli.main -p ade config set --force security.redact_secrets false",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
+    def test_benign_python_dash_m_not_flagged(self):
+        for cmd in (
+            "python -m hermes_cli.main config set terminal.backend docker",
+            "python -m hermes_cli.main config show",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
 
     def test_benign_config_set_not_flagged(self):
         for cmd in (

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1073,6 +1073,19 @@ class TestConfigSetSecurityPolicy:
             assert dangerous is True, cmd
             assert "security-policy" in desc, cmd
 
+    def test_quoted_security_policy_keys_detected(self):
+        # The shell strips quotes before the CLI sees the key, so quoting the
+        # key must not bypass the terminal gate either (triage finding).
+        for cmd in (
+            'hermes config set "approvals.mode" off',
+            'hermes config set --force "approvals.mode" off',
+            "hermes config set 'security.redact_secrets' false",
+            'hermes -p ade config set --force "command_allowlist" git',
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
     def test_benign_config_set_not_flagged(self):
         for cmd in (
             "hermes config set terminal.backend docker",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1050,6 +1050,39 @@ class TestLaunchctlGatewayLifecycle:
         assert "launchd" in desc.lower()
 
 
+class TestConfigSetSecurityPolicy:
+    """`hermes config set` on a security-policy key must require approval.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*) and the config cache is mtime-keyed, so a write takes effect
+    mid-session. The CLI refuses these keys without --force (config.py #81101);
+    this terminal-side pattern gates even the explicit --force variant so the
+    operator is always surfaced for approval — the same treatment sed/tee on
+    config.yaml already get.
+    """
+
+    def test_security_policy_keys_detected(self):
+        for cmd in (
+            "hermes config set approvals.mode off",
+            "hermes config set --force approvals.mode off",
+            "hermes config set approvals.cron_mode deny",
+            "hermes config set security.redact_secrets false",
+            "hermes -p ade config set command_allowlist git",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
+    def test_benign_config_set_not_flagged(self):
+        for cmd in (
+            "hermes config set terminal.backend docker",
+            "hermes config set model gpt-4o",
+            "hermes config set display.skin mono",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy
     work and rewrite shared history. Not covered by rm/chmod patterns.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -796,7 +796,9 @@ DANGEROUS_PATTERNS = [
     # these keys without --force (config.py #81101); this pattern additionally
     # gates the terminal path the same way sed/tee on config.yaml are gated, so
     # even an explicit --force variant is surfaced to the operator for approval.
-    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?(?:approvals|security|command_allowlist)\b',
+    # ``["']?`` covers the quoted key form the shell strips before the CLI sees
+    # it (``--force "approvals.mode" off``), so quoting cannot slip past the gate.
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
      "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -790,6 +790,14 @@ DANGEROUS_PATTERNS = [
     # profile flag can't slip the agent past the guard.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # `hermes config set` on a security-policy key. config.yaml IS the security
+    # policy (approvals.mode, command_allowlist, security.*), and the config
+    # cache is mtime-keyed so a write takes effect mid-session. The CLI refuses
+    # these keys without --force (config.py #81101); this pattern additionally
+    # gates the terminal path the same way sed/tee on config.yaml are gated, so
+    # even an explicit --force variant is surfaced to the operator for approval.
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?(?:approvals|security|command_allowlist)\b',
+     "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill
     # containers without approval.  These are agent-initiated lifecycle operations

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -308,13 +308,19 @@ DANGEROUS_PATTERNS = [
     # `hermes config set` on a security-policy key. config.yaml IS the security
     # policy (approvals.mode, command_allowlist, security.*), and the config
     # cache is mtime-keyed so a write takes effect mid-session. The CLI refuses
-    # these keys without --force (config.py #81101); this pattern additionally
-    # gates the terminal path the same way sed/tee on config.yaml are gated, so
-    # even an explicit --force variant is surfaced to the operator for approval.
+    # these keys through the config API (config.py #81101); this pattern
+    # additionally gates the terminal path the same way sed/tee on config.yaml
+    # are gated, so even an explicit --force variant is surfaced to the
+    # operator for approval.
     # ``["']?`` covers the quoted key form the shell strips before the CLI sees
     # it (``--force "approvals.mode" off``), so quoting cannot slip past the gate.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
      "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
+    # Alternate supported entrypoint: ``python -m hermes_cli.main`` reaches the
+    # same config CLI as ``hermes`` (main.py exposes ``if __name__ ==
+    # "__main__"``), so an agent typing the module form must hit the same gate.
+    (r'\bpython(?:3|3\.\d+)?\s+-m\s+hermes_cli\.main\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
+     "python -m hermes_cli.main config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -311,7 +311,9 @@ DANGEROUS_PATTERNS = [
     # these keys without --force (config.py #81101); this pattern additionally
     # gates the terminal path the same way sed/tee on config.yaml are gated, so
     # even an explicit --force variant is surfaced to the operator for approval.
-    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?(?:approvals|security|command_allowlist)\b',
+    # ``["']?`` covers the quoted key form the shell strips before the CLI sees
+    # it (``--force "approvals.mode" off``), so quoting cannot slip past the gate.
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
      "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -305,6 +305,14 @@ DANGEROUS_PATTERNS = [
     # between `hermes` and `gateway` (`hermes -p ade gateway restart`) are allowed so a profile flag can't slip past.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # `hermes config set` on a security-policy key. config.yaml IS the security
+    # policy (approvals.mode, command_allowlist, security.*), and the config
+    # cache is mtime-keyed so a write takes effect mid-session. The CLI refuses
+    # these keys without --force (config.py #81101); this pattern additionally
+    # gates the terminal path the same way sed/tee on config.yaml are gated, so
+    # even an explicit --force variant is surfaced to the operator for approval.
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?(?:approvals|security|command_allowlist)\b',
+     "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context


### PR DESCRIPTION
Fixes #81101

## Problem

`set_config_value()` / `unset_config_value()` accepted ANY key, including security-policy keys (`approvals.*`, `security.*`, `command_allowlist`). An agent could run `hermes config set approvals.mode off` to disable the approval gate mid-session with no operator confirmation — the config cache is mtime-keyed, so the write takes effect immediately.

The file tools already hard-deny agent writes to `config.yaml` (`tools/file_tools.py`), so the sanctioned CLI was a one-command bypass of the exact protection the file-tool deny exists to provide.

## Fix

1. **`hermes_cli/config.py`** — `set_config_value()` now refuses security-policy keys unless `--force` is passed (the explicit operator override typed at the CLI). `unset_config_value()` refuses them outright (no `--force` on that subcommand). A clear message points to `hermes approvals` or `--force`/direct edit.
2. **`hermes_cli/approval_mode.py`** — the canonical operator path (`hermes approvals` / `/approvals`) passes `force=True`, so it keeps working (it's the sanctioned way to change `approvals.mode`).
3. **`tools/approval.py`** — new `DANGEROUS_PATTERNS` entry so the terminal approval gate flags `hermes config set (approvals|security|command_allowlist)` — including the `--force` variant — the same way `sed`/`tee` on `config.yaml` are gated.

## Tests

- `tests/hermes_cli/test_set_config_value.py::TestSensitiveConfigKeyGuard` — refusal without force (parametrized over `approvals.*`/`security.*`/`command_allowlist`), allow with force, unset refusal, benign keys unaffected, refusal fires before YAML parse, `approvals.mode` message points to `hermes approvals`.
- `tests/tools/test_approval.py::TestConfigSetSecurityPolicy` — dangerous detection (incl. `--force` and `-p <profile>` variants) + benign `config set` not flagged.

101 targeted tests pass. (Two unrelated pre-existing failures in `tests/tools/test_approval.py` are Windows-only symlink/rm-tmp issues, confirmed failing on the base commit.)
