### PR TITLE
fix(desktop): surface wake word start failures

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -1,9 +1,9 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { I18nProvider } from '@/i18n'
-import { applyWakeStartResult, applyWakeStatus, resetWakeWordState } from '@/store/wake-word'
+import { $wakeWord, applyWakeStartResult, applyWakeStatus, resetWakeWordState } from '@/store/wake-word'
 
 import { ComposerControls } from './controls'
 
@@ -89,6 +89,16 @@ describe('wake-word ear visibility', () => {
     renderControls({ busy: true, busyAction: 'stop' })
 
     expect(screen.getByLabelText('Wake word: "hey hermes" — listening')).toBeTruthy()
+  })
+
+  it('shows an accessible spinner while a wake toggle is pending', () => {
+    applyWakeStatus({ available: true, enabled: true, listening: false, phrase: 'hey hermes' })
+    act(() => $wakeWord.set({ ...$wakeWord.get(), pending: true }))
+    renderControls()
+
+    const ear = screen.getByLabelText('Wake word: "hey hermes" — off')
+    expect(ear.getAttribute('aria-busy')).toBe('true')
+    expect(ear.querySelector('.animate-spin')).toBeTruthy()
   })
 
   it('stays mounted (enabled in config) even when a start was refused', () => {

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -339,6 +339,7 @@ function WakeWordButton({ disabled, pausedForVoice = false }: { disabled: boolea
   return (
     <Tip label={tooltip}>
       <Button
+        aria-busy={wake.pending || undefined}
         aria-label={label}
         aria-pressed={wake.listening && !pausedForVoice}
         className={cn(
@@ -355,7 +356,13 @@ function WakeWordButton({ disabled, pausedForVoice = false }: { disabled: boolea
         type="button"
         variant="ghost"
       >
-        {wake.listening && !pausedForVoice ? <Ear className={iconSize.sm} /> : <EarOff className={iconSize.sm} />}
+        {wake.pending ? (
+          <Loader2 className={cn('animate-spin', iconSize.sm)} />
+        ) : wake.listening && !pausedForVoice ? (
+          <Ear className={iconSize.sm} />
+        ) : (
+          <EarOff className={iconSize.sm} />
+        )}
       </Button>
     </Tip>
   )

--- a/apps/desktop/src/store/wake-word.test.ts
+++ b/apps/desktop/src/store/wake-word.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { startClientWakeCapture } from '@/lib/wake-client-capture'
+import { type ClientWakeCaptureHandle, startClientWakeCapture } from '@/lib/wake-client-capture'
 
 import { $notifications, clearNotifications } from './notifications'
 import {
@@ -11,6 +11,7 @@ import {
   armWakeWord,
   resetWakeWordState,
   resumeWakeAfterVoice,
+  stopClientCapture,
   toggleWakeWord,
   type WakeRequester
 } from './wake-word'
@@ -439,5 +440,30 @@ describe('resumeWakeAfterVoice (post-voice reconcile)', () => {
     await resumeWakeAfterVoice(request)
 
     expect($wakeWord.get()).toMatchObject({ available: false, listening: false })
+  })
+})
+
+describe('client capture race safety', () => {
+  it('discards a capture that resolves after wake word stops', async () => {
+    let resolveCapture: (handle: ClientWakeCaptureHandle) => void = () => undefined
+
+    vi.mocked(startClientWakeCapture).mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveCapture = resolve
+      })
+    )
+
+    applyWakeStartResult({ capture: 'client', frame_length: 1280, started: true })
+    await vi.waitFor(() => expect(startClientWakeCapture).toHaveBeenCalledTimes(1))
+
+    applyWakeStopResult({ stopped: true })
+
+    const handle: ClientWakeCaptureHandle = { active: true, stop: vi.fn() }
+    resolveCapture(handle)
+
+    await vi.waitFor(() => expect(handle.stop).toHaveBeenCalledTimes(1))
+
+    stopClientCapture()
+    expect(handle.stop).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/wake-word.test.ts
+++ b/apps/desktop/src/store/wake-word.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { startClientWakeCapture } from '@/lib/wake-client-capture'
+
+import { $notifications, clearNotifications } from './notifications'
 import {
   $wakeWord,
   applyWakeStartResult,
@@ -12,6 +15,8 @@ import {
   type WakeRequester
 } from './wake-word'
 
+vi.mock('@/lib/wake-client-capture', () => ({ startClientWakeCapture: vi.fn() }))
+
 const requester = (impl: (method: string, params?: Record<string, unknown>) => unknown) =>
   vi.fn(async (method: string, params: Record<string, unknown> = {}) =>
     impl(method, params)
@@ -19,6 +24,9 @@ const requester = (impl: (method: string, params?: Record<string, unknown>) => u
 
 beforeEach(() => {
   resetWakeWordState()
+  clearNotifications()
+  vi.mocked(startClientWakeCapture).mockReset()
+  vi.mocked(startClientWakeCapture).mockResolvedValue({ active: true, stop: vi.fn() })
 })
 
 describe('applyWakeStatus', () => {
@@ -81,6 +89,54 @@ describe('toggleWakeWord', () => {
     expect($wakeWord.get()).toMatchObject({ listening: true, notice: '', pending: false })
   })
 
+  it('surfaces an explicit client microphone startup failure', async () => {
+    applyWakeStatus({ available: true, listening: false, phrase: 'hey hermes' })
+    vi.mocked(startClientWakeCapture).mockRejectedValueOnce(new Error('Microphone permission denied'))
+
+    await toggleWakeWord(
+      requester(() => ({ capture: 'client', frame_length: 1280, phrase: 'hey hermes', started: true }))
+    )
+
+    expect($wakeWord.get()).toMatchObject({
+      listening: false,
+      notice: 'Microphone permission denied',
+      pending: false
+    })
+    expect($notifications.get()).toEqual([
+      expect.objectContaining({
+        id: 'wake-word-start-failed',
+        kind: 'warning',
+        message: 'Microphone permission denied'
+      })
+    ])
+  })
+
+  it('keeps the toggle pending until explicit client microphone capture is ready', async () => {
+    applyWakeStatus({ available: true, listening: false, phrase: 'hey hermes' })
+
+    let resolveCapture: (value: { active: boolean; stop: () => void }) => void = () => undefined
+
+    vi.mocked(startClientWakeCapture).mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveCapture = resolve
+      })
+    )
+
+    const request = requester(() => ({ capture: 'client', frame_length: 1280, started: true }))
+    const first = toggleWakeWord(request)
+
+    await vi.waitFor(() => expect(startClientWakeCapture).toHaveBeenCalledTimes(1))
+    expect($wakeWord.get().pending).toBe(true)
+
+    await toggleWakeWord(request)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    resolveCapture({ active: true, stop: vi.fn() })
+    await first
+
+    expect($wakeWord.get()).toMatchObject({ listening: true, pending: false })
+  })
+
   it('stops via wake.stop when listening', async () => {
     applyWakeStatus({ available: true, listening: true, phrase: 'hey hermes' })
 
@@ -116,6 +172,13 @@ describe('toggleWakeWord', () => {
     expect(state.available).toBe(false)
     expect(state.listening).toBe(false)
     expect(state.notice).toBe('Set PORCUPINE_ACCESS_KEY')
+    expect($notifications.get()).toEqual([
+      expect.objectContaining({
+        id: 'wake-word-start-failed',
+        kind: 'warning',
+        message: 'Set PORCUPINE_ACCESS_KEY'
+      })
+    ])
   })
 
   it('stays off and keeps the error as the notice when the RPC throws', async () => {
@@ -132,6 +195,13 @@ describe('toggleWakeWord', () => {
       notice: 'Hermes gateway unavailable',
       pending: false
     })
+    expect($notifications.get()).toEqual([
+      expect.objectContaining({
+        id: 'wake-word-start-failed',
+        kind: 'warning',
+        message: 'Hermes gateway unavailable'
+      })
+    ])
   })
 
   it('ignores clicks while a toggle is already in flight', async () => {

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -37,15 +37,19 @@ export const $wakeWord = atom<WakeWordState>(INITIAL_WAKE_WORD_STATE)
 
 /** Active client mic stream for remote wake (capture: client). */
 let clientCapture: ClientWakeCaptureHandle | null = null
+let captureGeneration = 0
 
 /** Stop client-side PCM capture (also called on wake.detected before voice). */
 export function stopClientCapture(): void {
+  captureGeneration++
   clientCapture?.stop()
   clientCapture = null
 }
 
 async function maybeStartClientCapture(result: WakeStartResponse | null | undefined): Promise<string> {
-  stopClientCapture()
+  const generation = ++captureGeneration
+  clientCapture?.stop()
+  clientCapture = null
 
   if (!result?.started) {
     return ''
@@ -58,13 +62,25 @@ async function maybeStartClientCapture(result: WakeStartResponse | null | undefi
   }
 
   try {
-    clientCapture = await startClientWakeCapture({
+    const handle = await startClientWakeCapture({
       frameLength: result.frame_length,
       request: gatewayRequester
     })
 
+    if (generation !== captureGeneration) {
+      handle.stop()
+
+      return ''
+    }
+
+    clientCapture = handle
+
     return ''
   } catch (error) {
+    if (generation !== captureGeneration) {
+      return ''
+    }
+
     const current = $wakeWord.get()
     const message = error instanceof Error ? error.message : 'Failed to open the client microphone for wake word'
     $wakeWord.set({

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import { type ClientWakeCaptureHandle, startClientWakeCapture } from '@/lib/wake-client-capture'
 import { $gateway } from '@/store/gateway'
+import { notify } from '@/store/notifications'
 
 // "Hey Hermes" wake-word listener state for the composer toggle. The gateway is
 // the single source of truth (the listener lives in the backend and is shared
@@ -43,17 +44,17 @@ export function stopClientCapture(): void {
   clientCapture = null
 }
 
-async function maybeStartClientCapture(result: WakeStartResponse | null | undefined): Promise<void> {
+async function maybeStartClientCapture(result: WakeStartResponse | null | undefined): Promise<string> {
   stopClientCapture()
 
   if (!result?.started) {
-    return
+    return ''
   }
 
   const mode = (result.capture || '').toLowerCase()
 
   if (mode !== 'client' && mode !== 'remote' && mode !== 'external') {
-    return
+    return ''
   }
 
   try {
@@ -61,12 +62,15 @@ async function maybeStartClientCapture(result: WakeStartResponse | null | undefi
       frameLength: result.frame_length,
       request: gatewayRequester
     })
+
+    return ''
   } catch (error) {
     const current = $wakeWord.get()
+    const message = error instanceof Error ? error.message : 'Failed to open the client microphone for wake word'
     $wakeWord.set({
       ...current,
       listening: false,
-      notice: error instanceof Error ? error.message : 'Failed to open the client microphone for wake word',
+      notice: message,
       pending: false
     })
 
@@ -76,6 +80,8 @@ async function maybeStartClientCapture(result: WakeStartResponse | null | undefi
     } catch {
       // ignore
     }
+
+    return message
   }
 }
 
@@ -137,6 +143,7 @@ export type WakeRequester = <T>(method: string, params?: Record<string, unknown>
 // large wheel) — that legitimately takes minutes. The default 30s WS timeout
 // fired mid-install, leaving a dead button that went blue on its own later.
 const WAKE_START_TIMEOUT_MS = 180_000
+const WAKE_START_FAILURE_NOTICE_ID = 'wake-word-start-failed'
 
 const gatewayRequester: WakeRequester = async <T>(method: string, params: Record<string, unknown> = {}) => {
   const gateway = $gateway.get()
@@ -193,7 +200,10 @@ export function applyWakeStatus(status: WakeStatusResponse | null | undefined): 
 
 /** Sync the atom from a `wake.start` response. A `{started:false, reason}`
  *  refusal keeps the toggle off and surfaces the reason as the tooltip. */
-export function applyWakeStartResult(result: WakeStartResponse | null | undefined): void {
+export function applyWakeStartResult(
+  result: WakeStartResponse | null | undefined,
+  options: { keepPending?: boolean; startClientCapture?: boolean } = {}
+): void {
   const current = $wakeWord.get()
 
   if (result?.started) {
@@ -203,10 +213,13 @@ export function applyWakeStartResult(result: WakeStartResponse | null | undefine
       enabled: true,
       listening: true,
       notice: '',
-      pending: false,
+      pending: options.keepPending === true,
       phrase: result.phrase?.trim() || current.phrase
     })
-    void maybeStartClientCapture(result)
+
+    if (options.startClientCapture !== false) {
+      void maybeStartClientCapture(result)
+    }
 
     return
   }
@@ -308,22 +321,44 @@ export async function toggleWakeWord(request: WakeRequester = gatewayRequester):
       // persist: true — a deliberate click is consent, so the backend flips
       // wake_word.enabled in config.yaml (on/off) and the choice sticks for
       // future sessions. Auto-arm (armWakeWord) never passes it.
-      applyWakeStartResult(
-        await request<WakeStartResponse>('wake.start', {
-          persist: true,
-          surface: 'gui',
-          client_capture: true
+      const result = await request<WakeStartResponse>('wake.start', {
+        persist: true,
+        surface: 'gui',
+        client_capture: true
+      })
+
+      applyWakeStartResult(result, {
+        keepPending: Boolean(result?.started),
+        startClientCapture: false
+      })
+
+      const clientCaptureFailure = result?.started ? await maybeStartClientCapture(result) : ''
+
+      if (result?.started && !clientCaptureFailure) {
+        $wakeWord.set({ ...$wakeWord.get(), pending: false })
+      }
+
+      if (!result?.started || clientCaptureFailure) {
+        notify({
+          id: WAKE_START_FAILURE_NOTICE_ID,
+          kind: 'warning',
+          message: clientCaptureFailure || noticeFrom(result) || 'Wake word could not start'
         })
-      )
+      }
     }
   } catch (error) {
     const current = $wakeWord.get()
+    const message = error instanceof Error ? error.message : String(error)
 
     $wakeWord.set({
       ...current,
-      notice: error instanceof Error ? error.message : String(error),
+      notice: message,
       pending: false
     })
+
+    if (!state.listening) {
+      notify({ id: WAKE_START_FAILURE_NOTICE_ID, kind: 'warning', message })
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #81087

## What changed

- Show a spinning wake-word glyph and expose `aria-busy` while an explicit toggle is starting.
- Surface backend refusals, RPC failures, and client-microphone startup failures as deduplicated warning notifications while retaining the tooltip detail.
- Keep the pending guard active through remote/client microphone initialization so a second click cannot stop the backend lease while capture is still attaching.
- Keep passive auto-arm/resume paths quiet.

## Root cause

The renderer stored start progress and failure details, but the button only used `pending` to disable itself and only exposed `notice` on hover. Fast failures returned to the same ear-off glyph with no visible feedback. For remote capture, the backend could also report success before the client microphone failed asynchronously.

## Verification

- `npm test -- --run src/store/wake-word.test.ts src/app/chat/composer/controls.test.tsx` (33 passed)
- `npm run typecheck`
- Targeted ESLint (0 errors)
- `git diff --check`