### PR TITLE
fix(desktop): sync typed model switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -13,11 +13,18 @@ import {
   $busy,
   $connection,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $currentUsage,
   $messages,
   $sessions,
   $terminalBackend,
   $turnStartedAt,
+  getCurrentModelSource,
+  markComposerSelectionManual,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentProvider,
   setCurrentUsage,
   setMessages,
   setSessions
@@ -1037,7 +1044,88 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
   afterEach(() => {
     cleanup()
     $busy.set(false)
+    setCurrentModel('')
+    setCurrentProvider('')
+    setCurrentModelSource('')
     vi.restoreAllMocks()
+  })
+
+  it('reconciles the composer model after a typed /model switch', async () => {
+    setCurrentModel('old-model')
+    setCurrentProvider('old-provider')
+    setCurrentModelSource('manual')
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return { output: '✓ Model switched: new-model' } as never
+      }
+
+      if (method === 'model.options') {
+        return { model: 'new-model', provider: 'new-provider' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/model new-model --provider new-provider')
+
+    expect(requestGateway).toHaveBeenCalledWith('model.options', { session_id: RUNTIME_SESSION_ID })
+    expect($currentModel.get()).toBe('new-model')
+    expect($currentProvider.get()).toBe('new-provider')
+    expect(getCurrentModelSource()).toBe('manual')
+  })
+
+  it('does not overwrite a newer picker selection while typed /model is in flight', async () => {
+    setCurrentModel('old-model')
+    setCurrentProvider('old-provider')
+    setCurrentModelSource('manual')
+
+    let resolveSlashExec: (value: unknown) => void = () => undefined
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return new Promise(resolve => {
+          resolveSlashExec = resolve
+        }) as never
+      }
+
+      if (method === 'model.options') {
+        return { model: 'typed-model', provider: 'typed-provider' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const submitting = handle!.submitText('/model typed-model --provider typed-provider')
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.anything()))
+
+    setCurrentModel('picker-model')
+    setCurrentProvider('picker-provider')
+    markComposerSelectionManual()
+    resolveSlashExec({ output: '✓ Model switched: typed-model' })
+    await submitting
+
+    expect(requestGateway).not.toHaveBeenCalledWith('model.options', expect.anything())
+    expect($currentModel.get()).toBe('picker-model')
+    expect($currentProvider.get()).toBe('picker-provider')
   })
 
   it('executes /approvals against the focused profile session and persists its mode', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -28,8 +28,12 @@ import {
   $connection,
   $sessions,
   $yoloActive,
+  getComposerSelectionGeneration,
+  markComposerSelectionManual,
   resolveComposerSessionKey,
   setActiveSessionId,
+  setCurrentModel,
+  setCurrentProvider,
   setCurrentUsage,
   setModelPickerOpen,
   setSessionPickerOpen,
@@ -46,6 +50,7 @@ import {
   type WakeStatusResponse,
   type WakeStopResponse
 } from '@/store/wake-word'
+import type { ModelOptionsResponse } from '@/types/hermes'
 
 import type {
   BrowserManageResponse,
@@ -245,6 +250,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // path that talks to slash.exec / command.dispatch.
       async function runExec(ctx: SlashActionCtx): Promise<void> {
         const { arg, command, name } = ctx
+
+        const typedModelSelectionGeneration =
+          name === 'model' && arg.trim() ? getComposerSelectionGeneration() : null
+
         const resolved = await withSlashOutput(ctx)
 
         if (!resolved) {
@@ -381,6 +390,42 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // indicator tracks pause/resume/clear immediately.
           if (name === 'goal' && output?.output) {
             applyGoalStatusText(sessionId, output.output)
+          }
+
+          // The typed `/model <name>` path is executed by the slash worker,
+          // then mirrored onto the live session. Its response is text-only,
+          // so reconcile the composer's model pill from the backend's
+          // authoritative session state rather than parsing that display text.
+          // A picker click or session switch that lands while this request is
+          // in flight is newer intent and must win over the delayed response.
+          if (
+            typedModelSelectionGeneration !== null &&
+            activeSessionIdRef.current === sessionId &&
+            getComposerSelectionGeneration() === typedModelSelectionGeneration
+          ) {
+            try {
+              const current = await requestGateway<ModelOptionsResponse>('model.options', { session_id: sessionId })
+
+              if (
+                activeSessionIdRef.current === sessionId &&
+                getComposerSelectionGeneration() === typedModelSelectionGeneration &&
+                (typeof current.model === 'string' || typeof current.provider === 'string')
+              ) {
+                if (typeof current.model === 'string') {
+                  setCurrentModel(current.model)
+                }
+
+                if (typeof current.provider === 'string') {
+                  setCurrentProvider(current.provider)
+                }
+
+                markComposerSelectionManual()
+              }
+            } catch {
+              // The command already succeeded and session.info remains the
+              // fallback reconciliation path; never mask its output because a
+              // follow-up metadata read failed.
+            }
           }
 
           renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)


### PR DESCRIPTION
Fixes #80904

## What changed

- Reconcile the Desktop composer model/provider after a typed `/model <name>` command by reading the existing session-scoped `model.options` RPC.
- Keep the backend authoritative instead of parsing the slash command's display text.
- Preserve newer user intent: a session switch or GUI picker selection made while either RPC is in flight prevents the older typed-command response from repainting the pill.
- Add regression coverage for both the successful sync and the in-flight picker race.

## Root cause

The GUI picker updates the composer nanostores optimistically, but the typed command only rendered `slash.exec` text. Its backend mirror switched the live session correctly while the composer stores remained stale; normal `session.info` handling deliberately avoids overwriting sticky manual selections.

## Verification

- `npm test -- --run src/app/session/hooks/use-prompt-actions/index.test.tsx` (103 passed)
- `npm run typecheck`
- Targeted ESLint (0 errors)
- `git diff --check`