### PR TITLE
perf(model): disk-cache custom-provider /v1/models probes (#72762, salvage of #80740)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -114,7 +114,7 @@ def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, st
             is_provider_enabled,
             load_config,
         )
-        from hermes_cli.models import fetch_api_models
+        from hermes_cli.models import cached_fetch_api_models
         from hermes_cli.providers import custom_provider_slug
     except ImportError:
         return []
@@ -176,7 +176,7 @@ def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, st
             discover = discover.lower() not in {"false", "no", "0"}
         if discover and api_key:
             try:
-                live = fetch_api_models(
+                live = cached_fetch_api_models(
                     api_key, base_url, api_mode=entry.get("api_mode")
                 )
             except Exception:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2725,8 +2725,8 @@ def list_authenticated_providers(
             )
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
-                    live_models = fetch_api_models(
+                    from hermes_cli.models import cached_fetch_api_models
+                    live_models = cached_fetch_api_models(
                         api_key,
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
@@ -2795,9 +2795,9 @@ def list_authenticated_providers(
         _models = [current_model] if current_model else []
         if refresh or probe_current_custom_provider:
             try:
-                from hermes_cli.models import fetch_api_models
+                from hermes_cli.models import cached_fetch_api_models
 
-                _live_models = fetch_api_models(
+                _live_models = cached_fetch_api_models(
                     "",
                     str(current_base_url).strip().rstrip("/"),
                     timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
@@ -3039,9 +3039,9 @@ def list_authenticated_providers(
             )
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
+                    from hermes_cli.models import cached_fetch_api_models
 
-                    live_models = fetch_api_models(
+                    live_models = cached_fetch_api_models(
                         api_key,
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -19,7 +19,10 @@ import urllib.error
 import time
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import TypeGuard
 
 from hermes_cli import __version__ as _HERMES_VERSION
 from hermes_cli.urllib_security import open_credentialed_url
@@ -3106,37 +3109,50 @@ _swr_refresh_inflight: set = set()
 _swr_refresh_lock = threading.Lock()
 
 
-def _spawn_swr_refresh(provider: str) -> None:
-    """Kick a background refresh of *provider*'s model-id cache entry.
+def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
+    """Kick a background refresh of *cache_key*'s model-id cache entry.
 
-    Fire-and-forget daemon thread; at most one in flight per provider.
+    Fire-and-forget daemon thread; at most one in flight per cache key.
     Failures are swallowed — the stale entry stays served until a later
     refresh succeeds (same degradation the blocking path already had).
+
+    ``refresh_fn`` (no-args, returns the fresh cache-entry dict or ``None``)
+    lets non-slug keys (``custom:<base_url>`` entries from
+    :func:`cached_fetch_api_models`) reuse the same inflight-dedupe and
+    thread scaffolding. When omitted, *cache_key* is treated as a
+    ``PROVIDER_REGISTRY`` slug and refreshed via :func:`provider_model_ids`
+    (the original behavior).
     """
     with _swr_refresh_lock:
-        if provider in _swr_refresh_inflight:
+        if cache_key in _swr_refresh_inflight:
             return
-        _swr_refresh_inflight.add(provider)
+        _swr_refresh_inflight.add(cache_key)
+
+    def _default_refresh():
+        live = provider_model_ids(cache_key, force_refresh=True)
+        if not live:
+            return None
+        return {
+            "fp": _credential_fingerprint(cache_key),
+            "at": time.time(),
+            "models": list(live),
+        }
 
     def _refresh() -> None:
         try:
-            live = provider_model_ids(provider, force_refresh=True)
-            if live:
+            entry = (refresh_fn or _default_refresh)()
+            if entry:
                 cache = _load_provider_models_cache()
-                cache[provider] = {
-                    "fp": _credential_fingerprint(provider),
-                    "at": time.time(),
-                    "models": list(live),
-                }
+                cache[cache_key] = entry
                 _save_provider_models_cache(cache)
         except Exception:
-            logger.debug("SWR refresh failed for %s", provider, exc_info=True)
+            logger.debug("SWR refresh failed for %s", cache_key, exc_info=True)
         finally:
             with _swr_refresh_lock:
-                _swr_refresh_inflight.discard(provider)
+                _swr_refresh_inflight.discard(cache_key)
 
     threading.Thread(
-        target=_refresh, daemon=True, name=f"model-cache-swr-{provider}"
+        target=_refresh, daemon=True, name=f"model-cache-swr-{cache_key}"
     ).start()
 
 
@@ -4668,6 +4684,23 @@ def _custom_endpoint_fingerprint(
     return hashlib.blake2b(blob, digest_size=8).hexdigest()
 
 
+def _cache_entry_valid(entry: Any, fp: str) -> "TypeGuard[dict[str, Any]]":
+    """True when *entry* is a well-formed cache row for fingerprint *fp*.
+
+    Requires a numeric ``at`` so corrupt disk state (hand-edited JSON with
+    ``"at": "yesterday"`` or ``null``) degrades to a cache miss / live fetch
+    instead of raising out of the wrapper.
+    """
+    return (
+        isinstance(entry, dict)
+        and entry.get("fp") == fp
+        and isinstance(entry.get("models"), list)
+        and bool(entry["models"])
+        and isinstance(entry.get("at"), (int, float))
+        and not isinstance(entry.get("at"), bool)
+    )
+
+
 def cached_fetch_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -4680,29 +4713,23 @@ def cached_fetch_api_models(
 ) -> Optional[list[str]]:
     """Disk-cached wrapper around :func:`fetch_api_models` for custom endpoints.
 
-    Mirrors :func:`cached_provider_model_ids` but keys
-    ``provider_models_cache.json`` off ``custom:<base_url>`` instead of a
-    ``PROVIDER_REGISTRY`` slug, since custom endpoints (named
-    ``custom_providers`` rows, bare ``provider: custom``, and per-endpoint-map
-    entries) have none. Same stale-beats-nothing fallback policy as
-    ``cached_provider_model_ids``: a live-fetch failure serves the last
-    same-fingerprint result rather than an empty list. Always returns
-    whatever :func:`fetch_api_models` would (a list or ``None``), never
-    raises.
+    Mirrors :func:`cached_provider_model_ids` — including its
+    stale-while-revalidate tier — but keys ``provider_models_cache.json``
+    off ``custom:<base_url>`` instead of a ``PROVIDER_REGISTRY`` slug, since
+    custom endpoints (named ``custom_providers`` rows, bare
+    ``provider: custom``, and per-endpoint-map entries) have none. Same
+    stale-beats-nothing fallback policy: a live-fetch failure serves the
+    last same-fingerprint result rather than an empty list. Returns whatever
+    :func:`fetch_api_models` would (a list or ``None``); corrupt cache rows
+    degrade to a live fetch instead of raising.
     """
-    # Only forward api_mode when the caller actually set it — none of the
-    # current probe call sites do, and omitting it (rather than passing
-    # api_mode=None) keeps the live-call signature identical to a direct
-    # fetch_api_models() call.
-    live_kwargs: dict[str, Any] = {"timeout": timeout, "headers": headers}
-    if api_mode is not None:
-        live_kwargs["api_mode"] = api_mode
-
     normalized_url = str(base_url or "").strip().rstrip("/").lower()
     if not normalized_url:
         # No base_url means nothing to key the cache on — fall through to a
         # live call so callers keep getting fetch_api_models' own behavior.
-        return fetch_api_models(api_key, base_url, **live_kwargs)
+        return fetch_api_models(
+            api_key, base_url, timeout=timeout, api_mode=api_mode, headers=headers
+        )
 
     cache_key = f"custom:{normalized_url}"
     fp = _custom_endpoint_fingerprint(api_key, api_mode, headers)
@@ -4710,17 +4737,30 @@ def cached_fetch_api_models(
     entry = cache.get(cache_key)
     now = time.time()
 
-    if (
-        not force_refresh
-        and isinstance(entry, dict)
-        and entry.get("fp") == fp
-        and isinstance(entry.get("models"), list)
-        and entry["models"]
-        and (now - float(entry.get("at", 0))) < ttl_seconds
-    ):
-        return list(entry["models"])
+    if not force_refresh and _cache_entry_valid(entry, fp):
+        age = now - entry["at"]
+        if age < ttl_seconds:
+            return list(entry["models"])
+        if age < _PROVIDER_MODELS_STALE_SERVE_MAX:
+            # Stale-while-revalidate: serve the expired entry immediately so
+            # picker opens never block on a live /v1/models round-trip
+            # (#72762's stall class, which a plain TTL would reintroduce an
+            # hour into the session); refresh off-thread for the next open.
+            def _refresh_custom():
+                live = fetch_api_models(
+                    api_key, base_url,
+                    timeout=timeout, api_mode=api_mode, headers=headers,
+                )
+                if not live:
+                    return None
+                return {"fp": fp, "at": time.time(), "models": list(live)}
 
-    live = fetch_api_models(api_key, base_url, **live_kwargs)
+            _spawn_swr_refresh(cache_key, _refresh_custom)
+            return list(entry["models"])
+
+    live = fetch_api_models(
+        api_key, base_url, timeout=timeout, api_mode=api_mode, headers=headers
+    )
     if live:
         cache[cache_key] = {"fp": fp, "at": now, "models": list(live)}
         _save_provider_models_cache(cache)
@@ -4728,12 +4768,7 @@ def cached_fetch_api_models(
 
     # Live fetch returned nothing (offline endpoint, timeout, auth hiccup).
     # A stale same-fingerprint entry beats an empty result.
-    if (
-        isinstance(entry, dict)
-        and entry.get("fp") == fp
-        and isinstance(entry.get("models"), list)
-        and entry["models"]
-    ):
+    if _cache_entry_valid(entry, fp):
         return list(entry["models"])
     return live
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4643,6 +4643,101 @@ def fetch_api_models(
     ).get("models")
 
 
+def _custom_endpoint_fingerprint(
+    api_key: Optional[str],
+    api_mode: Optional[str],
+    headers: Optional[dict[str, str]],
+) -> str:
+    """Fingerprint the credentials/wire-shape used to probe a custom endpoint.
+
+    Custom OpenAI-compatible endpoints have no ``PROVIDER_REGISTRY`` slug to
+    key off (unlike ``_credential_fingerprint``), so this hashes exactly the
+    values callers pass to :func:`fetch_api_models`: a rotated ``api_key``, a
+    changed ``api_mode``, or an edited ``extra_headers`` block each bust the
+    cache entry on their own.
+    """
+    import hashlib
+
+    blob = "|".join((
+        api_key or "",
+        api_mode or "",
+        json.dumps(headers or {}, sort_keys=True),
+    )).encode("utf-8", errors="replace")
+    # blake2b for cache-key fingerprinting only, same rationale as
+    # _credential_fingerprint (avoids CodeQL's sha256-over-secrets rule).
+    return hashlib.blake2b(blob, digest_size=8).hexdigest()
+
+
+def cached_fetch_api_models(
+    api_key: Optional[str],
+    base_url: Optional[str],
+    *,
+    timeout: float = 5.0,
+    api_mode: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
+    force_refresh: bool = False,
+    ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL,
+) -> Optional[list[str]]:
+    """Disk-cached wrapper around :func:`fetch_api_models` for custom endpoints.
+
+    Mirrors :func:`cached_provider_model_ids` but keys
+    ``provider_models_cache.json`` off ``custom:<base_url>`` instead of a
+    ``PROVIDER_REGISTRY`` slug, since custom endpoints (named
+    ``custom_providers`` rows, bare ``provider: custom``, and per-endpoint-map
+    entries) have none. Same stale-beats-nothing fallback policy as
+    ``cached_provider_model_ids``: a live-fetch failure serves the last
+    same-fingerprint result rather than an empty list. Always returns
+    whatever :func:`fetch_api_models` would (a list or ``None``), never
+    raises.
+    """
+    # Only forward api_mode when the caller actually set it — none of the
+    # current probe call sites do, and omitting it (rather than passing
+    # api_mode=None) keeps the live-call signature identical to a direct
+    # fetch_api_models() call.
+    live_kwargs: dict[str, Any] = {"timeout": timeout, "headers": headers}
+    if api_mode is not None:
+        live_kwargs["api_mode"] = api_mode
+
+    normalized_url = str(base_url or "").strip().rstrip("/").lower()
+    if not normalized_url:
+        # No base_url means nothing to key the cache on — fall through to a
+        # live call so callers keep getting fetch_api_models' own behavior.
+        return fetch_api_models(api_key, base_url, **live_kwargs)
+
+    cache_key = f"custom:{normalized_url}"
+    fp = _custom_endpoint_fingerprint(api_key, api_mode, headers)
+    cache = _load_provider_models_cache()
+    entry = cache.get(cache_key)
+    now = time.time()
+
+    if (
+        not force_refresh
+        and isinstance(entry, dict)
+        and entry.get("fp") == fp
+        and isinstance(entry.get("models"), list)
+        and entry["models"]
+        and (now - float(entry.get("at", 0))) < ttl_seconds
+    ):
+        return list(entry["models"])
+
+    live = fetch_api_models(api_key, base_url, **live_kwargs)
+    if live:
+        cache[cache_key] = {"fp": fp, "at": now, "models": list(live)}
+        _save_provider_models_cache(cache)
+        return list(live)
+
+    # Live fetch returned nothing (offline endpoint, timeout, auth hiccup).
+    # A stale same-fingerprint entry beats an empty result.
+    if (
+        isinstance(entry, dict)
+        and entry.get("fp") == fp
+        and isinstance(entry.get("models"), list)
+        and entry["models"]
+    ):
+        return list(entry["models"])
+    return live
+
+
 # ---------------------------------------------------------------------------
 # Ollama Cloud — merged model discovery with disk cache
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -1,0 +1,207 @@
+"""Cache-contract tests for ``cached_fetch_api_models()``.
+
+Custom OpenAI-compatible endpoints (named ``custom_providers`` rows, bare
+``provider: custom``, and per-endpoint-map entries) previously called
+``fetch_api_models()`` directly with no disk cache, so the current custom
+endpoint's ``/v1/models`` got a live HTTP round-trip on literally every
+``/model`` open (#72762). ``cached_fetch_api_models()`` gives custom
+endpoints the same ``provider_models_cache.json`` TTL cache first-class
+providers already get via ``cached_provider_model_ids()``.
+
+These pin the cache contract directly (hit / stale / rotation / refresh /
+fallback), separate from ``test_model_switch_custom_providers.py``'s
+higher-level picker-shape tests.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+class TestCachedFetchApiModels:
+    def _entry(self, models, age_seconds, fp="fp"):
+        return {"fp": fp, "at": time.time() - age_seconds, "models": list(models)}
+
+    def test_fresh_entry_served_without_live_fetch(self):
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], age_seconds=10)}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out == ["m1", "m2"]
+        live.assert_not_called()
+        save.assert_not_called()
+
+    def test_cache_key_normalizes_trailing_slash_and_case(self):
+        """A saved entry for the lowercased/rstripped URL must be hit even
+        when the caller passes a differently-cased URL with a trailing
+        slash — config.yaml entries are not guaranteed to be normalized."""
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1"], age_seconds=10)}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models("sk-key", "HTTPS://GW.example.com/v1/")
+        assert out == ["m1"]
+        live.assert_not_called()
+
+    def test_expired_entry_triggers_live_fetch_and_is_persisted(self):
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], age_seconds=99999)}
+        saved = {}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache", side_effect=saved.update), \
+             patch.object(mod, "fetch_api_models", return_value=["fresh-a", "fresh-b"]) as live:
+            out = mod.cached_fetch_api_models(
+                "sk-key", "https://gw.example.com/v1", ttl_seconds=3600
+            )
+        assert out == ["fresh-a", "fresh-b"]
+        live.assert_called_once()
+        assert saved["custom:https://gw.example.com/v1"]["models"] == ["fresh-a", "fresh-b"]
+        assert saved["custom:https://gw.example.com/v1"]["fp"] == "fp"
+
+    def test_rotated_api_key_busts_cache_even_when_fresh(self):
+        """A same-age entry with a DIFFERENT fingerprint (key rotated, or
+        extra_headers edited) must not be served — it reflects the old
+        credentials' catalog."""
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["old-key-models"], 10, fp="old-fp")}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="new-fp"), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "fetch_api_models", return_value=["new-key-models"]) as live:
+            out = mod.cached_fetch_api_models("sk-new-key", "https://gw.example.com/v1")
+        assert out == ["new-key-models"]
+        live.assert_called_once()
+
+    def test_force_refresh_bypasses_fresh_cache(self):
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["stale-but-fresh"], age_seconds=5)}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "fetch_api_models", return_value=["forced-live"]) as live:
+            out = mod.cached_fetch_api_models(
+                "sk-key", "https://gw.example.com/v1", force_refresh=True
+            )
+        assert out == ["forced-live"]
+        live.assert_called_once()
+
+    def test_live_failure_falls_back_to_stale_same_fingerprint_entry(self):
+        """Stale data beats no data when the endpoint is flaky (#72762
+        proposed-fix: 'same stale-beats-nothing fallback as
+        cached_provider_model_ids')."""
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["last-known-good"], age_seconds=99999, fp="fp")}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "fetch_api_models", return_value=None):
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out == ["last-known-good"]
+        save.assert_not_called()  # nothing new to persist
+
+    def test_live_failure_with_no_matching_entry_returns_live_value(self):
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache", return_value={}), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "fetch_api_models", return_value=None):
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out is None
+        save.assert_not_called()
+
+    def test_empty_live_result_is_not_persisted(self):
+        """An empty list from a transient error must never pin an empty
+        cache entry over real data on the next open."""
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache", return_value={}), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "fetch_api_models", return_value=[]):
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out == []
+        save.assert_not_called()
+
+    def test_blank_base_url_skips_cache_entirely(self):
+        """No base_url means nothing to key the cache on — call straight
+        through to fetch_api_models rather than caching under an empty key."""
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache") as load, \
+             patch.object(mod, "fetch_api_models", return_value=["x"]) as live:
+            out = mod.cached_fetch_api_models("sk-key", "")
+        assert out == ["x"]
+        live.assert_called_once()
+        load.assert_not_called()
+
+    def test_fingerprint_ignores_timeout_but_reacts_to_headers(self):
+        """Sanity check on the real (non-mocked) fingerprint helper: it must
+        not vary with call-only params like timeout, but must vary with the
+        actual credential/header inputs."""
+        import hermes_cli.models as mod
+
+        fp_a = mod._custom_endpoint_fingerprint("sk-key", None, {"X-Tenant": "a"})
+        fp_b = mod._custom_endpoint_fingerprint("sk-key", None, {"X-Tenant": "b"})
+        fp_a_again = mod._custom_endpoint_fingerprint("sk-key", None, {"X-Tenant": "a"})
+        assert fp_a != fp_b
+        assert fp_a == fp_a_again
+
+
+class TestCachedFetchApiModelsDiskRoundTrip:
+    """End-to-end through the real (per-test-isolated) provider_models_cache.json
+    disk file rather than mocked load/save, so a regression in the on-disk
+    schema (e.g. a key collision with provider-slug entries) would show up
+    here even if the mocked unit tests above stayed green."""
+
+    def test_second_call_within_ttl_hits_disk_cache_no_live_fetch(self, monkeypatch):
+        import hermes_cli.models as mod
+
+        calls = []
+
+        def fake_fetch(api_key, base_url, **kwargs):
+            calls.append((api_key, base_url))
+            return ["disk-cached-model"]
+
+        monkeypatch.setattr(mod, "fetch_api_models", fake_fetch)
+
+        first = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        second = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+
+        assert first == ["disk-cached-model"]
+        assert second == ["disk-cached-model"]
+        assert len(calls) == 1, "second open must be served from disk, not a fresh live fetch"
+
+    def test_custom_key_does_not_collide_with_provider_slug_cache(self, monkeypatch):
+        """A custom endpoint literally named e.g. 'openrouter' in its
+        base_url must not read/write the same cache slot as the first-class
+        'openrouter' provider slug used by cached_provider_model_ids()."""
+        import hermes_cli.models as mod
+
+        monkeypatch.setattr(
+            mod, "fetch_api_models", lambda *a, **k: ["custom-endpoint-model"]
+        )
+        monkeypatch.setattr(
+            mod, "provider_model_ids", lambda *a, **k: ["openrouter-curated-model"]
+        )
+
+        mod.cached_fetch_api_models("sk-key", "https://openrouter.ai/v1")
+        mod.cached_provider_model_ids("openrouter")
+
+        cache = mod._load_provider_models_cache()
+        assert cache["custom:https://openrouter.ai/v1"]["models"] == ["custom-endpoint-model"]
+        assert cache["openrouter"]["models"] == ["openrouter-curated-model"]

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -55,7 +55,11 @@ class TestCachedFetchApiModels:
     def test_expired_entry_triggers_live_fetch_and_is_persisted(self):
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], age_seconds=99999)}
+        # Beyond the stale-serve window, so the wrapper must block on a
+        # live fetch (within the window it stale-serves + refreshes off
+        # thread — covered in TestSalvageFollowups).
+        too_old = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], age_seconds=too_old)}
         saved = {}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
@@ -205,3 +209,87 @@ class TestCachedFetchApiModelsDiskRoundTrip:
         cache = mod._load_provider_models_cache()
         assert cache["custom:https://openrouter.ai/v1"]["models"] == ["custom-endpoint-model"]
         assert cache["openrouter"]["models"] == ["openrouter-curated-model"]
+
+
+class TestSalvageFollowups:
+    """Follow-up behaviors added while salvaging PR #80740: SWR stale-serve
+    parity with cached_provider_model_ids, and corrupt-cache degradation."""
+
+    def _entry(self, models, age_seconds, fp="fp"):
+        return {"fp": fp, "at": time.time() - age_seconds, "models": list(models)}
+
+    def test_expired_entry_within_stale_window_is_served_and_refreshed_off_thread(self):
+        """TTL-expired (but < stale-serve max) entries must be served
+        immediately — the picker never blocks on a live round-trip — while a
+        background refresh is spawned for the next open."""
+        import hermes_cli.models as mod
+
+        cache = {"custom:https://gw.example.com/v1": self._entry(["stale-ok"], age_seconds=7200)}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_spawn_swr_refresh") as spawn, \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models(
+                "sk-key", "https://gw.example.com/v1", ttl_seconds=3600
+            )
+        assert out == ["stale-ok"]
+        live.assert_not_called()
+        spawn.assert_called_once()
+        assert spawn.call_args[0][0] == "custom:https://gw.example.com/v1"
+
+    def test_entry_beyond_stale_window_blocks_on_live_fetch(self):
+        import hermes_cli.models as mod
+
+        too_old = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["ancient"], age_seconds=too_old)}
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "_spawn_swr_refresh") as spawn, \
+             patch.object(mod, "fetch_api_models", return_value=["fresh"]) as live:
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out == ["fresh"]
+        live.assert_called_once()
+        spawn.assert_not_called()
+
+    def test_swr_refresh_fn_writes_custom_entry_through_shared_scaffolding(self):
+        """The generalized _spawn_swr_refresh(key, refresh_fn) must persist a
+        custom-endpoint entry via the shared inflight-dedupe machinery."""
+        import threading as _threading
+
+        import hermes_cli.models as mod
+
+        done = _threading.Event()
+        saved = {}
+
+        def fake_save(data):
+            saved.update(data)
+            done.set()
+
+        with patch.object(mod, "_load_provider_models_cache", return_value={}), \
+             patch.object(mod, "_save_provider_models_cache", side_effect=fake_save):
+            mod._spawn_swr_refresh(
+                "custom:https://gw.example.com/v1",
+                lambda: {"fp": "fp", "at": time.time(), "models": ["refreshed"]},
+            )
+            assert done.wait(timeout=5), "background refresh did not complete"
+        assert saved["custom:https://gw.example.com/v1"]["models"] == ["refreshed"]
+        assert "custom:https://gw.example.com/v1" not in mod._swr_refresh_inflight
+
+    def test_corrupt_at_field_degrades_to_live_fetch_instead_of_raising(self):
+        """provider_models_cache.json is user-editable; a corrupted 'at' must
+        be a cache miss (live fetch), never an exception out of the wrapper."""
+        import hermes_cli.models as mod
+
+        cache = {
+            "custom:https://gw.example.com/v1": {
+                "fp": "fp", "at": "yesterday", "models": ["corrupt-row"],
+            }
+        }
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "fetch_api_models", return_value=["live-models"]) as live:
+            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        assert out == ["live-models"]
+        live.assert_called_once()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -640,7 +640,11 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     assert gateway_prov is not None, "Custom provider group not found in results"
     assert calls == [
-        ("sk-gateway-key", "https://gateway.example.com/v1", {"timeout": 5.0, "headers": None})
+        (
+            "sk-gateway-key",
+            "https://gateway.example.com/v1",
+            {"timeout": 5.0, "api_mode": None, "headers": None},
+        )
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",

--- a/tests/hermes_cli/test_picker_prewarm.py
+++ b/tests/hermes_cli/test_picker_prewarm.py
@@ -45,3 +45,98 @@ def test_prewarm_guard_is_once_per_process():
     _reset_guard()
 
 
+def test_prewarm_warms_the_active_custom_endpoint_for_the_next_open(monkeypatch):
+    """End-to-end regression for #72762: the active custom endpoint must be
+    warm by the time the user opens ``/model``, not just first-class
+    ``PROVIDER_REGISTRY`` providers.
+
+    The cache is keyed purely on ``base_url`` (see ``cached_fetch_api_models``
+    in ``hermes_cli/models.py``), so this is not specific to any named
+    provider — the fixture below stands in for any OpenAI-compatible custom
+    endpoint a user might configure (an LLM gateway, Kilo Code, Together AI,
+    a self-hosted vLLM/SGLang server, ...).
+
+    Runs the real ``list_authenticated_providers()`` (not mocked, unlike the
+    two tests above) through the prewarm thread against a fake
+    ``load_picker_context()`` config with one active custom provider, then
+    replays the exact kwargs the plain CLI ``/model`` handler passes twice in
+    a row (``probe_custom_providers=False, probe_current_custom_provider=True``),
+    simulating two ``/model`` opens in one session.
+
+    We deliberately do NOT assert on *which* of (prewarm thread, first
+    foreground open) wins the race to perform the live fetch — that's a
+    thread-scheduling detail, not the contract. What must hold regardless of
+    scheduling: across the warm-up plus two foreground opens, the endpoint is
+    ever probed live at most once, and every open after that first probe is
+    served from the disk cache with zero additional network calls.
+    """
+    import hermes_cli.inventory as inventory_mod
+    import hermes_cli.models as models_mod
+
+    _reset_guard()
+
+    base_url = "https://api.example-gateway.test/v1"
+    ctx = inventory_mod.ConfigContext(
+        current_provider="custom:example-gateway",
+        current_model="",  # avoid the unrelated current-model-always-shown guarantee (line ~3104)
+        current_base_url=base_url,
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "example-gateway",
+                "base_url": base_url,
+                "api_key": "sk-gateway-key",
+            }
+        ],
+        excluded_providers=[],
+    )
+    monkeypatch.setattr(inventory_mod, "load_picker_context", lambda: ctx)
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, url, **kwargs):
+        calls.append((api_key, url))
+        return ["gateway-model-a", "gateway-model-b"]
+
+    monkeypatch.setattr(models_mod, "fetch_api_models", fake_fetch_api_models)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    def open_picker():
+        return ms.list_authenticated_providers(
+            current_provider=ctx.current_provider,
+            current_base_url=ctx.current_base_url,
+            current_model=ctx.current_model,
+            user_providers=ctx.user_providers,
+            custom_providers=ctx.custom_providers,
+            excluded_providers=ctx.excluded_providers,
+            # Exact kwargs cli.py's plain (no-args, no --refresh) /model
+            # handler passes: probe only the active custom endpoint,
+            # everything else from the warm disk cache.
+            probe_custom_providers=False,
+            probe_current_custom_provider=True,
+        )
+
+    t = ms.prewarm_picker_cache_async()
+    assert t is not None
+    t.join(timeout=10)
+
+    first_open = open_picker()
+    assert len(calls) == 1, (
+        "the endpoint must be live-probed at most once across boot prewarm "
+        "plus the first /model open, however the race between them resolves"
+    )
+    row = next(p for p in first_open if p.get("api_url") == base_url)
+    assert row["models"] == ["gateway-model-a", "gateway-model-b"]
+
+    second_open = open_picker()
+    assert len(calls) == 1, (
+        "a second /model open in the same session must be served entirely "
+        "from the disk cache — this is the #72762 regression: previously "
+        "every open re-probed the endpoint live"
+    )
+    row2 = next(p for p in second_open if p.get("api_url") == base_url)
+    assert row2["models"] == ["gateway-model-a", "gateway-model-b"]
+
+    _reset_guard()
+
+

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -158,7 +158,13 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     )
 
     assert user_prov is not None
-    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1", {"timeout": 5.0, "headers": None})]
+    assert calls == [
+        (
+            "sk-test",
+            "http://127.0.0.1:3000/api/v1",
+            {"timeout": 5.0, "api_mode": None, "headers": None},
+        )
+    ]
     assert user_prov["models"] == ["old-configured-model", "new-live-model"]
     assert user_prov["total_models"] == 2
 
@@ -497,7 +503,7 @@ def test_section3_probes_no_key_endpoint_without_explicit_models(monkeypatch):
 
     assert probed.get("called") is True, "no-key bare endpoint should be probed"
     assert probed["api_key"] == ""
-    assert probed["kwargs"] == {"timeout": 5.0, "headers": None}
+    assert probed["kwargs"] == {"timeout": 5.0, "api_mode": None, "headers": None}
     row = next(p for p in providers if p["slug"] == "local-llamacpp")
     assert row["models"] == ["live-model-1", "live-model-2", "live-model-3"]
     assert row["total_models"] == 3


### PR DESCRIPTION
## Summary
Custom OpenAI-compatible endpoints get the same disk-cached `/v1/models` discovery first-class providers already have — a plain `/model` open no longer live-probes the active custom endpoint every time, and the boot-time prewarm now actually persists what it fetches.

Salvage of #80740 by @prashantjain25 (cherry-picked, authorship preserved). Closes #80740. Fixes #72762 (custom-endpoint slice; per GottZ's triage and teknium's review of #72810, the credential-pool/Copilot costs remain separate follow-up).

## Context
Before: every `/model` open ran a live HTTP round-trip to the current custom endpoint's `/v1/models` (three call sites in `model_switch.py`), regardless of how recently it had been probed — the #72762 stall. After: probes go through `cached_fetch_api_models()`, a TTL disk cache keyed `custom:<base_url>` and fingerprinted on api_key/api_mode/headers, with the same stale-beats-nothing fallback as `cached_provider_model_ids()`.

## Changes
- **Contributor commit (verbatim cherry-pick):** `cached_fetch_api_models()` + `_custom_endpoint_fingerprint()` in `hermes_cli/models.py`; 3 probe call sites in `hermes_cli/model_switch.py` routed through it; cache-contract tests + prewarm E2E test.
- **Follow-up commit (review findings, ours):**
  - Stale-while-revalidate parity: TTL-expired entries within the 7d window are served instantly + refreshed off-thread, matching `cached_provider_model_ids` — without it, every open an hour into the session re-blocked on the live probe (the docstring claimed "mirrors" but omitted SWR).
  - `_spawn_swr_refresh(cache_key, refresh_fn)` generalization (slug default preserved; inflight-dedupe shared).
  - Missed sibling: `acp_adapter/server.py` `_named_custom_provider_catalogs()` live-probed every `custom_providers` row per ACP catalog build — same bug class, now cached.
  - `_cache_entry_valid()` helper (predicate existed 4×) + numeric-`at` validation so corrupt/hand-edited cache JSON degrades to a live fetch instead of raising through the picker's blanket except.
  - Dead `api_mode` conditional flattened (`fetch_api_models` declares `api_mode=None`; the branch was inert).

## Validation
| Check | Result |
|---|---|
| PR-scoped suites (cached_fetch, prewarm, custom-providers, SWR) | 65/65 pass |
| tests/acp_adapter/ | 14/14 pass |
| E2E probe (real disk I/O, isolated HERMES_HOME): hit / rotation-bust / stale-fallback / no slug collision / atomic write path | all pass |
| Mutation checks: stale-serve branch disabled → guard test fails; `at` validation removed → guard test fails | both confirmed |
| ruff on touched files | clean |

Provenance of kept/dropped parts: contributor's design kept intact (key scheme, fingerprint, fallback policy, all tests); review findings applied on top as a separate commit. Nothing dropped.
