### PR TITLE
fix(config): strip inline comments in load_env() env parsing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3683,6 +3683,15 @@ def load_env() -> Dict[str, str]:
             raw_lines = f.readlines()
         # Normalize line endings without interpreting value contents as syntax.
         lines = _sanitize_env_lines(raw_lines)
+        # Strip dotenv-style inline comments (``KEY=value # comment``) with
+        # the same quote-aware helper the profile secret scope uses
+        # (agent.secret_scope.load_env_file). Without this, load_env() returns
+        # ``KEY=https://x/v4  # comment`` as the value, so get_env_prefer_dotenv()
+        # / credential-pool seeding persist a base URL that contains the
+        # comment text → runtime requests fail with HTTP 404 (encoded spaces).
+        # Lazy import mirrors secret_scope's own lazy import of
+        # _parse_env_value and avoids any import-time cycle.
+        from agent.secret_scope import _strip_inline_comment
         for line in lines:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
@@ -3692,7 +3701,7 @@ def load_env() -> Dict[str, str]:
                 if line.startswith('export '):
                     line = line[7:]
                 key, _, value = line.partition('=')
-                env_vars[key.strip()] = _parse_env_value(value)
+                env_vars[key.strip()] = _parse_env_value(_strip_inline_comment(value))
 
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -323,6 +323,44 @@ class TestSaveEnvValueSecure:
             assert load_env()["TERMINAL_SSH_KEY"] == raw
 
 
+class TestLoadEnvInlineComments:
+    """load_env() must strip dotenv-style inline comments from values.
+
+    Regression: credential-pool seeding read ``KEY=https://x/v4  # comment``
+    as a base URL containing the comment text, producing runtime HTTP 404
+    (URL-encoded spaces). Mirrors agent.secret_scope.load_env_file() semantics.
+    """
+
+    def test_unquoted_value_inline_comment_stripped(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            (tmp_path / ".env").write_text(
+                "GLM_BASE_URL=https://api.z.ai/api/paas/v4  # Override default base URL\n",
+                encoding="utf-8",
+            )
+            assert load_env()["GLM_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_quoted_value_trailing_comment_stripped(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            (tmp_path / ".env").write_text(
+                'QUOTED="https://x/v1"  # trailing comment\n',
+                encoding="utf-8",
+            )
+            assert load_env()["QUOTED"] == "https://x/v1"
+
+    def test_hash_without_preceding_whitespace_is_not_a_comment(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            (tmp_path / ".env").write_text("TOKEN=foo#bar\n", encoding="utf-8")
+            assert load_env()["TOKEN"] == "foo#bar"
+
+    def test_export_prefix_with_inline_comment(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            (tmp_path / ".env").write_text(
+                "export GLM_BASE_URL=https://api.z.ai/api/paas/v4  # comment\n",
+                encoding="utf-8",
+            )
+            assert load_env()["GLM_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):
         env_path = tmp_path / ".env"


### PR DESCRIPTION
## Problem

`hermes_cli.config.load_env()` does not strip dotenv-style inline comments from values, so a `.env` line like:

```
GLM_BASE_URL=https://api.z.ai/api/paas/v4  # Override default base URL
```

resolves `GLM_BASE_URL` to the literal string `https://api.z.ai/api/paas/v4  # Override default base URL`.

`agent/credential_pool.get_env_prefer_dotenv()` reads through `load_env()` (`.env` value wins over the secret scope), and `_seed_from_env()` persists that mangled value into the credential pool (`auth.json`) as the provider base URL. Every subsequent runtime request then hits a URL containing encoded spaces/comment text:

```
HTTP 404: {"path": "/v4%20%20/chat/completions"}
```

This is the second half of the same bug class fixed in `agent/secret_scope.py` (which now applies `_strip_inline_comment()` before `_parse_env_value()`): `secret_scope.load_env_file()` was fixed, but `config.load_env()` — the parser used by credential-pool seeding — was missed. The two Hermes `.env` parsers therefore disagreed: `hermes status` and direct `load_hermes_dotenv()` tests show a clean value while the runtime (via the pool) uses the mangled one.

## Fix

In `load_env()`, strip inline comments with the same quote-aware helper `agent.secret_scope._strip_inline_comment()` (lazy import, mirroring `secret_scope`'s own lazy import of `_parse_env_value`, so there is no import-time cycle):

```python
env_vars[key.strip()] = _parse_env_value(_strip_inline_comment(value))
```

Semantics match python-dotenv:
- `KEY=value # comment` → `value`
- `KEY="has # inside" # trailing` → `has # inside`
- `KEY=foo#bar` → `foo#bar` (no whitespace before `#` → not a comment)

## Tests

Adds `TestLoadEnvInlineComments` in `tests/hermes_cli/test_config.py` covering unquoted inline comments, quoted values with trailing comments, `export` prefix, and hash-without-preceding-whitespace (non-comment) values.

- `tests/hermes_cli/test_config.py`: 78 passed (incl. 4 new)
- `tests/agent/test_secret_scope.py`: 22 passed

## E2E validation

Reproduced on a live install: `GLM_BASE_URL` with an inline comment caused `HTTP 404 path "/v4%20%20/chat/completions"` for `glm-5.2` via the built-in `zai` provider. After the fix (no `.env` changes): `load_env()`, `resolve_runtime_provider()` and the re-seeded credential-pool entry all return the clean URL, and `hermes chat --provider zai -m glm-5.2` completes successfully.
