### PR TITLE
fix: support zh-en sherpa KWS models for Chinese wake phrases

### DIFF
--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -335,8 +335,16 @@ def _install_fake_sherpa(monkeypatch, tmp_path):
         def reset_stream(self, stream):
             pass
 
-    def _fake_text2token(phrases, tokens, tokens_type, bpe_model):
-        calls["text2token"].append(list(phrases))
+    def _fake_text2token(phrases, tokens, tokens_type, bpe_model=None, lexicon=None):
+        calls["text2token"].append(
+            {
+                "phrases": list(phrases),
+                "tokens": str(tokens),
+                "tokens_type": tokens_type,
+                "bpe_model": str(bpe_model) if bpe_model else None,
+                "lexicon": str(lexicon) if lexicon else None,
+            }
+        )
         return [p.split() for p in phrases]
 
     sherpa = types.ModuleType("sherpa_onnx")
@@ -358,6 +366,50 @@ def _install_fake_sherpa(monkeypatch, tmp_path):
         np_stub.asarray = lambda x, dtype=None: _FakeArr(x)
         monkeypatch.setitem(sys.modules, "numpy", np_stub)
     return calls, model_dir
+
+
+def _sherpa_engine_config(model_dir, phrase="你好小雨") -> dict:
+    return {
+        "provider": "sherpa",
+        "phrase": phrase,
+        "sherpa": {"model_dir": str(model_dir)},
+    }
+
+
+def test_sherpa_engine_bpe_model_keeps_bpe_tokenization(monkeypatch, tmp_path):
+    """A BPE model (bpe.model present) must keep the original bpe path."""
+    calls, model_dir = _install_fake_sherpa(monkeypatch, tmp_path)
+    eng = ww._SherpaKwsEngine(_sherpa_engine_config(model_dir, phrase="hello world"))
+    assert calls["text2token"][0]["tokens_type"] == "bpe"
+    assert calls["text2token"][0]["bpe_model"].endswith("bpe.model")
+    assert calls["text2token"][0]["lexicon"] is None
+    with open(eng._keywords_file, encoding="utf-8") as f:
+        assert "HELLO WORLD @HELLO_WORLD" in f.read()
+
+
+def test_sherpa_engine_zh_en_model_uses_phone_ppinyin(monkeypatch, tmp_path):
+    """A zh-en model (en.phone, no bpe.model) must tokenize via
+    phone+ppinyin with the lexicon instead of crashing on the missing
+    bpe.model — this is what enables Chinese wake phrases like 你好小雨."""
+    calls, model_dir = _install_fake_sherpa(monkeypatch, tmp_path)
+    (model_dir / "bpe.model").unlink()
+    (model_dir / "en.phone").write_bytes(b"x")
+
+    eng = ww._SherpaKwsEngine(_sherpa_engine_config(model_dir))
+    assert calls["text2token"][0]["tokens_type"] == "phone+ppinyin"
+    assert calls["text2token"][0]["lexicon"].endswith("en.phone")
+    assert calls["text2token"][0]["bpe_model"] is None
+    with open(eng._keywords_file, encoding="utf-8") as f:
+        assert "你好小雨 @你好小雨" in f.read()
+
+
+def test_sherpa_engine_rejects_unsupported_model_dir(monkeypatch, tmp_path):
+    """A model dir with neither bpe.model nor en.phone is rejected with a
+    message naming the missing files (no silent fallback to a broken path)."""
+    calls, model_dir = _install_fake_sherpa(monkeypatch, tmp_path)
+    (model_dir / "bpe.model").unlink()
+    with pytest.raises(RuntimeError, match="not supported"):
+        ww._SherpaKwsEngine(_sherpa_engine_config(model_dir))
 
 
 # ── Multi-profile phrase routing ─────────────────────────────────────────

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -661,12 +661,30 @@ class _SherpaKwsEngine(_Engine):
 
         phrases = list(phrase_map)
         # Runtime tokenization of the arbitrary phrases — the open-vocab core.
-        tokens = text2token(
-            [p.upper() for p in phrases],
-            tokens=str(d / "tokens.txt"),
-            tokens_type="bpe",
-            bpe_model=str(d / "bpe.model"),
-        )
+        # Auto-detect the model family: BPE models (English gigaspeech) carry
+        # bpe.model; zh-en models carry en.phone and tokenize Chinese via
+        # pinyin (initials+finals) and English via CMU-style phonemes
+        # (tokens_type="phone+ppinyin").
+        if (d / "bpe.model").exists():
+            tokens = text2token(
+                [p.upper() for p in phrases],
+                tokens=str(d / "tokens.txt"),
+                tokens_type="bpe",
+                bpe_model=str(d / "bpe.model"),
+            )
+        elif (d / "en.phone").exists():
+            tokens = text2token(
+                [p.upper() for p in phrases],
+                tokens=str(d / "tokens.txt"),
+                tokens_type="phone+ppinyin",
+                lexicon=str(d / "en.phone"),
+            )
+        else:
+            raise RuntimeError(
+                f"sherpa KWS model at {d} is not supported: expected "
+                "bpe.model (English BPE) or en.phone (zh-en) in the "
+                "model directory"
+            )
         import tempfile
 
         # sherpa keyword entries reject spaces in the @display-name; underscore


### PR DESCRIPTION
## Summary

The sherpa wake-word engine hardcoded BPE tokenization (`tokens_type="bpe"` + `bpe.model`), which made **Chinese wake phrases impossible**: the zh-en KWS models (e.g. `sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20`) ship `en.phone` with pinyin/phoneme tokens and **no `bpe.model`**, so engine init crashed with a missing-file error.

The engine now auto-detects the model family by its marker file:

- `bpe.model` present → original BPE path (unchanged behavior)
- `en.phone` present → `tokens_type="phone+ppinyin"` with the lexicon (Chinese → pinyin initials+finals, English → CMU phonemes)
- neither → clear `RuntimeError` naming the missing marker

## Motivation

A user on a China-region network wanted a Chinese wake word ("你好小雨"). The bundled English gigaspeech BPE model cannot tokenize Chinese at all; the zh-en model supports arbitrary Chinese phrases but Hermes could not load it.

## Test Plan

- **New unit tests** in `tests/tools/test_wake_word.py`:
  - BPE model dir keeps `tokens_type="bpe"` (regression guard for the original path)
  - zh-en model dir (no `bpe.model`, has `en.phone`) → `tokens_type="phone+ppinyin"` + lexicon, keywords file written with the phrase
  - dir with neither marker → `RuntimeError` with a helpful message
- `tests/tools/test_wake_word.py`: **29 passed** (26 pre-existing + 3 new), via `scripts/run_tests.sh`
- **Real-model check**: engine init against the actual `zh-en-3M-2025-12-20` model tokenizes 你好小雨 → `n ǐ h ǎo x iǎo y ǔ` and constructs the `KeywordSpotter` successfully.
