### PR TITLE
fix(daemon_pool): support Python 3.14 WorkerContext API

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,9 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.8–3.14) with two changes:
         # daemon=True and no _threads_queues registration.
+        # CPython 3.14 replaced _initializer/_initargs with WorkerContext.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +50,28 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_initializer"):
+                # CPython 3.8–3.13
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            else:
+                # CPython 3.14+: initializer/initargs folded into WorkerContext.
+                # The daemon pool never passes a custom initializer, so None/().
+                from concurrent.futures.thread import WorkerContext
+                create_ctx, _resolve = WorkerContext.prepare(None, ())
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    create_ctx(),
+                    self._work_queue,
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
CPython 3.14 removed `ThreadPoolExecutor._initializer` / `_initargs` and replaced them with a `WorkerContext` pattern, and `_worker()` changed from 5 args to 3. This breaks `DaemonThreadPoolExecutor` on any system running Python 3.14 (Fedora 44, etc.) with:

    AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'

This manifests in the CLI as intermittent tool-call failures during parallel operations (skill_view, web_search, search_files, and any other concurrent tool dispatch).

The fix detects the available API at runtime via `hasattr(self, '_initializer')` and branches accordingly — old path for 3.8–3.13, new WorkerContext path for 3.14+. Verified on both Python 3.11 and 3.14.

The daemon pool never passes a custom initializer, so `None/()` is the correct equivalent in the 3.14 path.