### PR TITLE
fix(redact): strip complete ANSI CSI sequences before control-split masking

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shlex
+from bisect import bisect_left
 from urllib.parse import unquote_plus
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
@@ -471,6 +472,16 @@ _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
 )
 
+# Complete CSI (ECMA-48 control sequence introducer) sequences, e.g. the ANSI
+# color codes ``\x1b[32m`` / ``\x1b[0m``. A vendor-prefixed token wrapped in
+# color codes (``\x1b[32msk-…\x1b[0m``) leaks ENTIRELY if only the bare ESC
+# byte is stripped: ``[32m`` stays glued to the token head and the literal
+# ``m`` defeats ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind in both the
+# shadow copy and the original (issue #81012). Stripping the complete SEQUENCE
+# instead of the bare byte restores alignment so the split-join pass fires.
+# Mirrors the CSI branch of tools/ansi_strip.py's _ANSI_ESCAPE_RE.
+_ANSI_CSI_SEQ_RE = re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
+
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
 # only span original chars that are token-body or control chars (see
 # _mask_control_split_tokens). ``=`` is deliberately excluded: a KEY=value
@@ -486,55 +497,112 @@ _PREFIX_RE = re.compile(
 
 
 def _mask_control_split_tokens(text: str, mask_fn) -> str:
-    """Mask tokens whose body is split by control/zero-width characters.
+    """Mask tokens whose body is split across control/zero-width characters.
 
-    A credential like ``sk-abc\\x1bdef456…`` or ``ghp_abc\\n123def…`` has its
+    A credential like ``sk-abc\\x1bdef456…`` or ``ghp_abc\\n123…`` has its
     token body interrupted, so the contiguous _PREFIX_RE cannot match it and
-    the secret leaks verbatim (issue #77484). Strategy: build a copy with all
-    control chars removed (the token is contiguous again, matching even when
-    each fragment alone is too short), match on that, then mask the
-    corresponding span in the *original* — but only when the original span
-    contains solely token-body and control chars (a match that crosses into a
-    different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
+    the secret leaks raw (issue #77484). Strategy: build a shadow copy with
+    all control chars — and complete ANSI CSI sequences — removed (the token
+    is contiguous again, matching even when each fragment alone is too
+    short), match on that, then mask the corresponding span in the *original*
+    — but only when the span contains only token-body and stripped bytes (a
+    new match that crosses into a different line's unrelated text, e.g.
+    ``EXA_API_KEY=*** is rejected).
     """
-    stripped = _CONTROL_CHARS_RE.sub("", text)
-    if stripped == text:
+    # Fast path: no control bytes? Nothing to join.
+    if _CONTROL_CHARS_RE.search(text) is None:
         return text
-    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+
+    cleaned, keep, orig_idx = _strip_shadow(text)
+    if cleaned == text:
+        return text
     out = list(text)
     matches = []
-    for m in _PREFIX_RE.finditer(stripped):
+    n = len(text)
+    for m in _PREFIX_RE.finditer(cleaned):
         body = m.group(1)
-        start_orig = orig_idx[m.start(1)]
-        end_orig = orig_idx[m.end(1) - 1] + 1
-        # If a fragment inside the span already matches _PREFIX_RE on its
-        # own AND the span crosses a LINE boundary (\n / \r), do NOT join.
-        # A complete token at end-of-line followed by a word line
-        # (``ghp_<token>\nbutton [ref=e3]``) joins into one stripped-copy
-        # match and the mask eats ``button``. Line structure is legitimate;
-        # the self-matching fragment is handled by the ordinary prefix pass
-        # (any remainder past the newline is left unmasked — accepted
-        # residual to preserve line structure).
-        # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
-        # when a fragment self-matches: those bytes never legitimately sit
-        # between a token and adjacent prose, and skipping there let the
-        # non-matching remainder of a split token leak
-        # (``sk-<head>\x1b<tail>`` masked only the head).
+        body_start = m.start(1)
+        body_end = m.end(1)
+        start_orig = orig_idx[body_start]
+        end_orig = orig_idx[body_end - 1] + 1
         span = text[start_orig:end_orig]
-        if ("\n" in span or "\r" in span) and _PREFIX_RE.search(span):
-            continue
-        # Reject matches whose original span crosses a non-token char
-        # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
-        # token body, so the regex matched across unrelated lines). Also
-        # reject when the match runs into a ``KEY=`` name: a real token value
-        # is followed by a newline/space/end, not ``=``.
-        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in span)
-                and (end_orig >= len(text) or text[end_orig] != "=")):
+        if "\n" in span or "\r" in span:
+            # The join spans a LINE boundary. Crossing it may pull adjacent
+            # text into the mask (``ghp_<token>\nbutton [ref=e3]``) — only
+            # safe when NO fragment of the span already matches _PREFIX_RE
+            # by itself (a complete token at a line boundary, or a short head
+            # split across a newline). If a fragment self-matches, restrict
+            # the join to the first line segment so an escaped drop on the
+            # SAME line (``sk-<head>\x1b<mid>\n…``) still gets masked
+            # (issue #81012) while later text is left untouched.
+            if _PREFIX_RE.search(span):
+                cuts = []
+                if "\n" in span:
+                    cuts.append(span.index("\n"))
+                if "\r" in span:
+                    cuts.append(span.index("\r"))
+                if cuts:
+                    cutoff = min(cuts)
+                    end_orig = start_orig + cutoff
+                    span = text[start_orig:end_orig]
+                    # Clip the body to the shadow chars that fall inside the
+                    # clipped range so the replacement mask stays in line.
+                    clips = bisect_left(orig_idx, end_orig)
+                    body = body[:clips - body_start]
+                    if not body:
+                        continue
+        if (all(c in _TOKEN_BODY_CHARS or keep[start_orig + k]
+                for k, c in enumerate(span))
+                and (end_orig >= n or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):
         out[start_orig:end_orig] = list(replacement)
     return "".join(out)
+
+
+def _strip_shadow(text: str):
+    """Build the shadow copy used to find control/CSI-split tokens.
+
+    Returns ``(cleaned, keep, orig_idx)``:
+
+    - ``cleaned`` is a copy of ``text`` with every complete ANSI CSI
+      sequence and every bare control/zero-width char removed.
+    - ``keep[i]`` is truthy when ``text[i]`` was stripped noise (a byte
+      belonging to an ANSI CSI sequence or a bare control char).
+    - ``orig_idx`` maps each shadow index back to its index in ``text``.
+
+    Stripping complete CSI sequences — not just the bare ``\\x1b`` byte — is
+    what closes issue #81012: deleting only the ESC from ``\\x1b[32msk-…``
+    leaves ``[32m`` glued to the token head, the literal ``m`` defeats
+    ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind, and the secret leaks
+    verbatim in both the shadow and the original. Removing the whole
+    ``\\x1b[32m`` sequence realigns the token in the shadow so the join pass
+    can fire, and the ``keep`` back-map still validates that the masked orig
+    span contains no live non-token characters.
+    """
+    out_chars = []
+    keep = bytearray(len(text))
+    orig_idx = []
+    rem = _ANSI_CSI_SEQ_RE.search
+    i = 0
+    ctrl = _CONTROL_CHARS_RE.match
+    while i < len(text):
+        if text[i] == "\x1b":
+            m = rem(text, i)
+            if m:
+                for j in range(i, m.end()):
+                    keep[j] = 1
+                i = m.end()
+                continue
+        c = text[i]
+        if ctrl(c):
+            keep[i] = 1
+            i += 1
+            continue
+        out_chars.append(c)
+        orig_idx.append(i)
+        i += 1
+    return "".join(out_chars), bytes(keep), orig_idx
 
 
 # Display-mask strip for mask_secret: EVERY control char incl. \n/\t, C1,

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -553,8 +553,25 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
                     body = body[:clips - body_start]
                     if not body:
                         continue
-        if (all(c in _TOKEN_BODY_CHARS or keep[start_orig + k]
-                for k, c in enumerate(span))
+        # Live chars must be token-body chars, AND stripped regions must be
+        # KIND-UNIFORM: all bare controls, or all complete-CSI bytes. An
+        # orphan ESC followed by a later color sequence leaves live text
+        # between two stripped regions that is not provably part of one
+        # smuggled token — bridging across it deletes arbitrary bytes
+        # (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
+        # NOT_TOKEN_TEXT; review finding on #81012). Kind-uniform spans keep
+        # both smuggling shapes covered: bare-control splits (#77484) bridge
+        # only their own kind, color-glued fragments (#81012) only theirs.
+        kinds = 0  # bit set from keep values: 1 = bare control · 2 = CSI byte
+        clean_join = True
+        for k, c in enumerate(span):
+            kd = keep[start_orig + k]
+            if kd:
+                kinds |= kd
+            elif c not in _TOKEN_BODY_CHARS:
+                clean_join = False
+                break
+        if (clean_join and kinds != 3
                 and (end_orig >= n or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):
@@ -569,8 +586,12 @@ def _strip_shadow(text: str):
 
     - ``cleaned`` is a copy of ``text`` with every complete ANSI CSI
       sequence and every bare control/zero-width char removed.
-    - ``keep[i]`` is truthy when ``text[i]`` was stripped noise (a byte
-      belonging to an ANSI CSI sequence or a bare control char).
+    - ``keep[i]`` classifies ``text[i]``: 0 = live char kept in the shadow,
+      1 = bare control char (stripped individually), 2 = byte belonging to a
+      complete ANSI CSI sequence (stripped as a unit). Any truthy value means
+      strippable noise, preserving the historical contract; the KIND
+      distinction lets the join pass refuse candidate spans whose stripped
+      regions MIX kinds (see the gate in _mask_control_split_tokens).
     - ``orig_idx`` maps each shadow index back to its index in ``text``.
 
     Stripping complete CSI sequences — not just the bare ``\\x1b`` byte — is
@@ -585,7 +606,14 @@ def _strip_shadow(text: str):
     out_chars = []
     keep = bytearray(len(text))
     orig_idx = []
-    rem = _ANSI_CSI_SEQ_RE.search
+    # .match, NOT .search: at an ESC that does NOT begin a CSI sequence,
+    # search(text, i) jumps ahead to a LATER CSI and marks everything from
+    # this ESC through that sequence as strippable noise — blessing arbitrary
+    # live bytes between the two regions and letting the greedy join delete
+    # them (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
+    # NOT_TOKEN_TEXT). With .match a sequence is stripped only when it starts
+    # AT this ESC; otherwise the bare-control path strips just the ESC byte.
+    rem = _ANSI_CSI_SEQ_RE.match
     i = 0
     ctrl = _CONTROL_CHARS_RE.match
     while i < len(text):
@@ -593,7 +621,7 @@ def _strip_shadow(text: str):
             m = rem(text, i)
             if m:
                 for j in range(i, m.end()):
-                    keep[j] = 1
+                    keep[j] = 2
                 i = m.end()
                 continue
         c = text[i]

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -12,6 +12,7 @@ import os
 import re
 import shlex
 import threading
+from bisect import bisect_left
 from urllib.parse import unquote_plus
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
@@ -473,6 +474,16 @@ _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
 )
 
+# Complete CSI (ECMA-48 control sequence introducer) sequences, e.g. the ANSI
+# color codes ``\x1b[32m`` / ``\x1b[0m``. A vendor-prefixed token wrapped in
+# color codes (``\x1b[32msk-…\x1b[0m``) leaks ENTIRELY if only the bare ESC
+# byte is stripped: ``[32m`` stays glued to the token head and the literal
+# ``m`` defeats ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind in both the
+# shadow copy and the original (issue #81012). Stripping the complete SEQUENCE
+# instead of the bare byte restores alignment so the split-join pass fires.
+# Mirrors the CSI branch of tools/ansi_strip.py's _ANSI_ESCAPE_RE.
+_ANSI_CSI_SEQ_RE = re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
+
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
 # only span original chars that are token-body or control chars (see
 # _mask_control_split_tokens). ``=`` is deliberately excluded: a KEY=value
@@ -488,55 +499,112 @@ _PREFIX_RE = re.compile(
 
 
 def _mask_control_split_tokens(text: str, mask_fn) -> str:
-    """Mask tokens whose body is split by control/zero-width characters.
+    """Mask tokens whose body is split across control/zero-width characters.
 
-    A credential like ``sk-abc\\x1bdef456…`` or ``ghp_abc\\n123def…`` has its
+    A credential like ``sk-abc\\x1bdef456…`` or ``ghp_abc\\n123…`` has its
     token body interrupted, so the contiguous _PREFIX_RE cannot match it and
-    the secret leaks verbatim (issue #77484). Strategy: build a copy with all
-    control chars removed (the token is contiguous again, matching even when
-    each fragment alone is too short), match on that, then mask the
-    corresponding span in the *original* — but only when the original span
-    contains solely token-body and control chars (a match that crosses into a
-    different line's unrelated text, e.g. ``EXA_API_KEY=*** is rejected).
+    the secret leaks raw (issue #77484). Strategy: build a shadow copy with
+    all control chars — and complete ANSI CSI sequences — removed (the token
+    is contiguous again, matching even when each fragment alone is too
+    short), match on that, then mask the corresponding span in the *original*
+    — but only when the span contains only token-body and stripped bytes (a
+    new match that crosses into a different line's unrelated text, e.g.
+    ``EXA_API_KEY=*** is rejected).
     """
-    stripped = _CONTROL_CHARS_RE.sub("", text)
-    if stripped == text:
+    # Fast path: no control bytes? Nothing to join.
+    if _CONTROL_CHARS_RE.search(text) is None:
         return text
-    orig_idx = [i for i, c in enumerate(text) if not _CONTROL_CHARS_RE.match(c)]
+
+    cleaned, keep, orig_idx = _strip_shadow(text)
+    if cleaned == text:
+        return text
     out = list(text)
     matches = []
-    for m in _PREFIX_RE.finditer(stripped):
+    n = len(text)
+    for m in _PREFIX_RE.finditer(cleaned):
         body = m.group(1)
-        start_orig = orig_idx[m.start(1)]
-        end_orig = orig_idx[m.end(1) - 1] + 1
-        # If a fragment inside the span already matches _PREFIX_RE on its
-        # own AND the span crosses a LINE boundary (\n / \r), do NOT join.
-        # A complete token at end-of-line followed by a word line
-        # (``ghp_<token>\nbutton [ref=e3]``) joins into one stripped-copy
-        # match and the mask eats ``button``. Line structure is legitimate;
-        # the self-matching fragment is handled by the ordinary prefix pass
-        # (any remainder past the newline is left unmasked — accepted
-        # residual to preserve line structure).
-        # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
-        # when a fragment self-matches: those bytes never legitimately sit
-        # between a token and adjacent prose, and skipping there let the
-        # non-matching remainder of a split token leak
-        # (``sk-<head>\x1b<tail>`` masked only the head).
+        body_start = m.start(1)
+        body_end = m.end(1)
+        start_orig = orig_idx[body_start]
+        end_orig = orig_idx[body_end - 1] + 1
         span = text[start_orig:end_orig]
-        if ("\n" in span or "\r" in span) and _PREFIX_RE.search(span):
-            continue
-        # Reject matches whose original span crosses a non-token char
-        # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
-        # token body, so the regex matched across unrelated lines). Also
-        # reject when the match runs into a ``KEY=`` name: a real token value
-        # is followed by a newline/space/end, not ``=``.
-        if (all(c in _TOKEN_BODY_CHARS or _CONTROL_CHARS_RE.match(c)
-                for c in span)
-                and (end_orig >= len(text) or text[end_orig] != "=")):
+        if "\n" in span or "\r" in span:
+            # The join spans a LINE boundary. Crossing it may pull adjacent
+            # text into the mask (``ghp_<token>\nbutton [ref=e3]``) — only
+            # safe when NO fragment of the span already matches _PREFIX_RE
+            # by itself (a complete token at a line boundary, or a short head
+            # split across a newline). If a fragment self-matches, restrict
+            # the join to the first line segment so an escaped drop on the
+            # SAME line (``sk-<head>\x1b<mid>\n…``) still gets masked
+            # (issue #81012) while later text is left untouched.
+            if _PREFIX_RE.search(span):
+                cuts = []
+                if "\n" in span:
+                    cuts.append(span.index("\n"))
+                if "\r" in span:
+                    cuts.append(span.index("\r"))
+                if cuts:
+                    cutoff = min(cuts)
+                    end_orig = start_orig + cutoff
+                    span = text[start_orig:end_orig]
+                    # Clip the body to the shadow chars that fall inside the
+                    # clipped range so the replacement mask stays in line.
+                    clips = bisect_left(orig_idx, end_orig)
+                    body = body[:clips - body_start]
+                    if not body:
+                        continue
+        if (all(c in _TOKEN_BODY_CHARS or keep[start_orig + k]
+                for k, c in enumerate(span))
+                and (end_orig >= n or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):
         out[start_orig:end_orig] = list(replacement)
     return "".join(out)
+
+
+def _strip_shadow(text: str):
+    """Build the shadow copy used to find control/CSI-split tokens.
+
+    Returns ``(cleaned, keep, orig_idx)``:
+
+    - ``cleaned`` is a copy of ``text`` with every complete ANSI CSI
+      sequence and every bare control/zero-width char removed.
+    - ``keep[i]`` is truthy when ``text[i]`` was stripped noise (a byte
+      belonging to an ANSI CSI sequence or a bare control char).
+    - ``orig_idx`` maps each shadow index back to its index in ``text``.
+
+    Stripping complete CSI sequences — not just the bare ``\\x1b`` byte — is
+    what closes issue #81012: deleting only the ESC from ``\\x1b[32msk-…``
+    leaves ``[32m`` glued to the token head, the literal ``m`` defeats
+    ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind, and the secret leaks
+    verbatim in both the shadow and the original. Removing the whole
+    ``\\x1b[32m`` sequence realigns the token in the shadow so the join pass
+    can fire, and the ``keep`` back-map still validates that the masked orig
+    span contains no live non-token characters.
+    """
+    out_chars = []
+    keep = bytearray(len(text))
+    orig_idx = []
+    rem = _ANSI_CSI_SEQ_RE.search
+    i = 0
+    ctrl = _CONTROL_CHARS_RE.match
+    while i < len(text):
+        if text[i] == "\x1b":
+            m = rem(text, i)
+            if m:
+                for j in range(i, m.end()):
+                    keep[j] = 1
+                i = m.end()
+                continue
+        c = text[i]
+        if ctrl(c):
+            keep[i] = 1
+            i += 1
+            continue
+        out_chars.append(c)
+        orig_idx.append(i)
+        i += 1
+    return "".join(out_chars), bytes(keep), orig_idx
 
 
 # Display-mask strip for mask_secret: EVERY control char incl. \n/\t, C1,

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -553,25 +553,34 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
                     body = body[:clips - body_start]
                     if not body:
                         continue
-        # Live chars must be token-body chars, AND stripped regions must be
-        # KIND-UNIFORM: all bare controls, or all complete-CSI bytes. An
-        # orphan ESC followed by a later color sequence leaves live text
-        # between two stripped regions that is not provably part of one
-        # smuggled token — bridging across it deletes arbitrary bytes
-        # (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
-        # NOT_TOKEN_TEXT; review finding on #81012). Kind-uniform spans keep
-        # both smuggling shapes covered: bare-control splits (#77484) bridge
-        # only their own kind, color-glued fragments (#81012) only theirs.
-        kinds = 0  # bit set from keep values: 1 = bare control · 2 = CSI byte
+        # Live chars must be token-body chars, and a candidate whose stripped
+        # regions contain BOTH an orphan ESC (a bare \x1b that began no CSI)
+        # and a complete CSI sequence is refused: that combination marks
+        # mangled/truncated terminal output, where the live text sitting
+        # between the two regions is not provably part of one smuggled token,
+        # and the greedy shadow match bridges across it deleting arbitrary
+        # bytes (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
+        # NOT_TOKEN_TEXT; review finding on #81012). Each splitter alone stays
+        # bridgeable — bare-control splits are #77484's canonical shape,
+        # complete sequences #81012's — and MIXING non-ESC encodings (one CSI
+        # plus one zero-width/control split) remains fail-closed-masked:
+        # diversity of supported splitting encodings is not evidence that a
+        # candidate is unrelated prose.
+        has_orphan_esc = False
+        has_csi = False
         clean_join = True
         for k, c in enumerate(span):
             kd = keep[start_orig + k]
-            if kd:
-                kinds |= kd
+            if kd == 2:
+                has_csi = True
+            elif kd:
+                if c == "\x1b":
+                    has_orphan_esc = True
             elif c not in _TOKEN_BODY_CHARS:
                 clean_join = False
                 break
-        if (clean_join and kinds != 3
+        if (clean_join
+                and not (has_orphan_esc and has_csi)
                 and (end_orig >= n or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):
@@ -590,8 +599,8 @@ def _strip_shadow(text: str):
       1 = bare control char (stripped individually), 2 = byte belonging to a
       complete ANSI CSI sequence (stripped as a unit). Any truthy value means
       strippable noise, preserving the historical contract; the KIND
-      distinction lets the join pass refuse candidate spans whose stripped
-      regions MIX kinds (see the gate in _mask_control_split_tokens).
+      distinction lets the join pass refuse candidates that mix an ORPHAN ESC
+      with a formed CSI sequence (see the gate in _mask_control_split_tokens).
     - ``orig_idx`` maps each shadow index back to its index in ``text``.
 
     Stripping complete CSI sequences — not just the bare ``\\x1b`` byte — is

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -481,8 +481,10 @@ _CONTROL_CHARS_RE = re.compile(
 # ``m`` defeats ``_PREFIX_RE``'s ``(?<![A-Za-z0-9_-])`` lookbehind in both the
 # shadow copy and the original (issue #81012). Stripping the complete SEQUENCE
 # instead of the bare byte restores alignment so the split-join pass fires.
-# Mirrors the CSI branch of tools/ansi_strip.py's _ANSI_ESCAPE_RE.
-_ANSI_CSI_SEQ_RE = re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
+# Mirrors the CSI branch of tools/ansi_strip.py's _ANSI_ESCAPE_RE, including
+# the 8-bit C1 form (``\x9b``) — a ``\x9b31m``-wrapped token glues its ``m``
+# exactly like the 7-bit shape, so both introducers must strip as a unit.
+_ANSI_CSI_SEQ_RE = re.compile(r"(?:\x1b\[|\x9b)[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
 
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
 # only span original chars that are token-body or control chars (see
@@ -511,8 +513,8 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
     new match that crosses into a different line's unrelated text, e.g.
     ``EXA_API_KEY=*** is rejected).
     """
-    # Fast path: no control bytes? Nothing to join.
-    if _CONTROL_CHARS_RE.search(text) is None:
+    # Fast path: no control bytes and no 8-bit CSI introducer? Nothing to join.
+    if _CONTROL_CHARS_RE.search(text) is None and "\x9b" not in text:
         return text
 
     cleaned, keep, orig_idx = _strip_shadow(text)
@@ -553,34 +555,34 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
                     body = body[:clips - body_start]
                     if not body:
                         continue
-        # Live chars must be token-body chars, and a candidate whose stripped
-        # regions contain BOTH an orphan ESC (a bare \x1b that began no CSI)
-        # and a complete CSI sequence is refused: that combination marks
-        # mangled/truncated terminal output, where the live text sitting
-        # between the two regions is not provably part of one smuggled token,
-        # and the greedy shadow match bridges across it deleting arbitrary
-        # bytes (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
-        # NOT_TOKEN_TEXT; review finding on #81012). Each splitter alone stays
-        # bridgeable — bare-control splits are #77484's canonical shape,
-        # complete sequences #81012's — and MIXING non-ESC encodings (one CSI
-        # plus one zero-width/control split) remains fail-closed-masked:
-        # diversity of supported splitting encodings is not evidence that a
-        # candidate is unrelated prose.
-        has_orphan_esc = False
-        has_csi = False
+        # Live chars must be token-body chars. One combination is refused:
+        # an ORPHAN ESC (a bare \x1b that began no CSI) appearing BEFORE any
+        # complete CSI sequence in the span. That order marks mangled or
+        # truncated terminal output — the live text between the dangling
+        # escape and the next formed sequence is continuation-of-prose, not
+        # provably token material
+        # (``sk-aaaaa\x1bNOT_TOKEN_TEXT\x1b[31mbbbbbbbbbb`` erased
+        # NOT_TOKEN_TEXT; review finding on #81012). Once a formed sequence
+        # has been seen, a later bare ESC reads as an ordinary in-token
+        # split like any other control, so the mirrored layout
+        # (``sk-aaaaa\x1b[31mbbbbb\x1bcccccccccc``) stays fully masked and no
+        # splitter combination can flip a candidate to raw emission: every
+        # non-refused candidate is replaced wholesale.
+        orphan_precedes_csi = False
+        seen_csi = False
         clean_join = True
         for k, c in enumerate(span):
             kd = keep[start_orig + k]
             if kd == 2:
-                has_csi = True
+                seen_csi = True
             elif kd:
-                if c == "\x1b":
-                    has_orphan_esc = True
+                if c == "\x1b" and not seen_csi:
+                    orphan_precedes_csi = True
             elif c not in _TOKEN_BODY_CHARS:
                 clean_join = False
                 break
         if (clean_join
-                and not (has_orphan_esc and has_csi)
+                and not (orphan_precedes_csi and seen_csi)
                 and (end_orig >= n or text[end_orig] != "=")):
             matches.append((start_orig, end_orig, mask_fn(body)))
     for start_orig, end_orig, replacement in reversed(matches):
@@ -599,8 +601,9 @@ def _strip_shadow(text: str):
       1 = bare control char (stripped individually), 2 = byte belonging to a
       complete ANSI CSI sequence (stripped as a unit). Any truthy value means
       strippable noise, preserving the historical contract; the KIND
-      distinction lets the join pass refuse candidates that mix an ORPHAN ESC
-      with a formed CSI sequence (see the gate in _mask_control_split_tokens).
+      distinction lets the join pass refuse candidates whose ORPHAN ESC
+      precedes a formed CSI sequence (see the gate in
+      _mask_control_split_tokens).
     - ``orig_idx`` maps each shadow index back to its index in ``text``.
 
     Stripping complete CSI sequences — not just the bare ``\\x1b`` byte — is
@@ -626,7 +629,7 @@ def _strip_shadow(text: str):
     i = 0
     ctrl = _CONTROL_CHARS_RE.match
     while i < len(text):
-        if text[i] == "\x1b":
+        if text[i] == "\x1b" or text[i] == "\x9b":
             m = rem(text, i)
             if m:
                 for j in range(i, m.end()):

--- a/contributors/emails/Parkerscottfawcett@gmail.com
+++ b/contributors/emails/Parkerscottfawcett@gmail.com
@@ -1,0 +1,2 @@
+Parker-Fawcett
+# PR #81121 (redact: strip complete ANSI CSI sequences before control-split masking)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -183,17 +183,6 @@ class TestControlCharSplitTokens:
         assert "button" in result
         assert "ref=e3" in result
 
-    def test_selfmatching_head_esc_split_tail_masked(self):
-        # A split where the HEAD fragment alone already matches _PREFIX_RE
-        # (>= 10 body chars) but the tail doesn't: the join must still run
-        # for non-newline controls, or the tail leaks in cleartext. Only
-        # LINE-crossing spans skip the join (see the annotation test).
-        head = "sk-" + "a" * 15
-        tail = "b" * 25
-        result = redact_sensitive_text(head + "\x1b" + tail, force=True)
-        assert tail not in result
-        assert "a" * 12 not in result
-
     def test_env_dump_lines_not_joined(self):
         # Control-stripping must not join unrelated env lines into one match
         env_dump = (
@@ -205,6 +194,74 @@ class TestControlCharSplitTokens:
         result = redact_sensitive_text(env_dump, force=True)
         assert "SHELL=/bin/bash" in result
         assert "HOME=/home/user" in result
+
+    def test_selfmatching_head_esc_split_tail_masked(self):
+        # A split where the HEAD fragment alone already matches _PREFIX_RE
+        # (>= 10 body chars) but the tail doesn't: the join must still run
+        # for non-newline controls, or the tail leaks in cleartext. Only
+        # LINE-crossing spans skip the join (see the annotation test).
+        head = "sk-" + "a" * 15
+        tail = "b" * 25
+        result = redact_sensitive_text(head + "\x1b" + tail, force=True)
+        assert tail not in result
+        assert "a" * 12 not in result
+
+    def test_ansi_wrapped_token_not_glued_head(self):
+        # Issue #81012: a vendor-prefixed token wrapped in ANSI color codes
+        # (``\x1b[32msk-…\x1b[0m``). Stripping only the ESC byte glued ``[32m``
+        # to the token head and the literal ``m`` defeated _PREFIX_RE's
+        # lookbehind — the whole secret leaked. The complete CSI sequence must
+        # be stripped from the shadow so the token stays aligned.
+        body = "a" * 25
+        text = f"\x1b[32msk-{body}\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert body not in result
+        assert "sk-" + body not in result
+        # The ANSI codes themselves must survive (terminal color, not noise)
+        assert "\x1b[32m" in result and "\x1b[0m" in result
+
+    def test_ansi_wrapped_token_private_params(self):
+        # CSI with private-mode / extra params (cursor shapes, 256-color
+        # prefixes) must strip just the same.
+        body = "b" * 25
+        text = f"\x1b[38;5;200msk_{body}\x1b[?25h"
+        result = redact_sensitive_text(text, force=True)
+        assert body not in result
+        assert f"sk_{body}" not in result
+
+    def test_ansi_wrapped_zero_width_split_also_masked(self):
+        # ANSI reset gluing is fixed, and a control-split body wrapped in
+        # codes still masks through the raw shadow.
+        body = "ghp_" + "c" * 12 + "\u200b" + "c" * 13
+        text = f"\x1b[31m{body}\x1b[0m"
+        result = redact_sensitive_text(text, force=True)
+        assert "c" * 12 not in result
+        assert "ghp_" + "c" * 12 not in result
+
+    def test_newline_esc_split_remainder_masked(self):
+        # Issue #81012, second gap: a span carrying BOTH a newline and an
+        # ESC split (``sk-<head>\x1b<mid>\n<tail>``) used to skip the join
+        # (line-boundary guard from #80987) and leak every byte after the
+        # self-matching head. The join must now run per line segment, keeping
+        # the escaped MIDDLE masked while leaving the next line untouched.
+        head = "sk-" + "a" * 15
+        mid_tail = "b" * 25
+        text = f"{head}\x1b{mid_tail}\nbutton [ref=e3]"
+        result = redact_sensitive_text(text, force=True)
+        assert mid_tail not in result
+        assert "button" in result
+        assert "ref=e3" in result
+
+    def test_ansi_glued_head_and_tail_both_masked(self):
+        # SGR colors can also split a token from the MIDDLE
+        # (``sk-ab\x1b[31mc…``) — both fragments must be covered, not just the
+        # bare-ESC shadow.
+        a = "a" * 12
+        b = "b" * 12
+        text = f"sk-{a}\x1b[31m{b}"
+        result = redact_sensitive_text(text, force=True)
+        assert a not in result
+        assert b not in result
 
 
 class TestEnvLookupPreserved:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -263,6 +263,16 @@ class TestControlCharSplitTokens:
         assert a not in result
         assert b not in result
 
+    def test_non_csi_esc_before_later_csi_live_text_survives(self):
+        # Review finding on #81012: at an ESC that does NOT begin a CSI
+        # sequence, the shadow builder must strip a CSI only when it starts
+        # AT that ESC. Jumping ahead to a LATER CSI marked the live text
+        # between the two regions as strippable noise, blessed it through
+        # the span validation, and the greedy join deleted it.
+        text = "sk-" + "a" * 5 + "\x1bNOT_TOKEN_TEXT\x1b[31m" + "b" * 10
+        result = redact_sensitive_text(text, force=True)
+        assert "NOT_TOKEN_TEXT" in result
+
 
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -273,6 +273,20 @@ class TestControlCharSplitTokens:
         result = redact_sensitive_text(text, force=True)
         assert "NOT_TOKEN_TEXT" in result
 
+    def test_mixed_csi_and_bare_control_split_masked(self):
+        # Follow-up review finding on #81012: one complete CSI sequence PLUS
+        # one bare/zero-width split inside the SAME credential must still
+        # mask — mixing supported control encodings is not evidence of
+        # unrelated prose. Only an orphan ESC coexisting with a formed CSI
+        # (mangled/truncated terminal output) refuses the join.
+        for sep, tail_ch in (("\u200b", "c"), ("\x00", "d")):
+            text = "sk-" + "a" * 5 + "\x1b[31m" + "b" * 5 + sep + tail_ch * 10
+            result = redact_sensitive_text(text, force=True)
+            assert result != text
+            assert "a" * 5 not in result
+            assert "b" * 5 not in result
+            assert tail_ch * 10 not in result
+
 
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -287,6 +287,31 @@ class TestControlCharSplitTokens:
             assert "b" * 5 not in result
             assert tail_ch * 10 not in result
 
+    def test_orphan_esc_after_csi_still_masks(self):
+        # Follow-up review finding on #81012: adding a trailing orphan ESC to
+        # a mixed-encoding credential must NOT walk it through unmasked. An
+        # orphan ESC only refuses the join when it PRECEDES every complete
+        # CSI in the span; once a formed sequence has been seen, a later bare
+        # ESC is an ordinary in-token split.
+        text = "sk-" + "a" * 5 + "\x1b[31m" + "b" * 5 + "\x1b" + "c" * 10
+        result = redact_sensitive_text(text, force=True)
+        assert result != text
+        assert "a" * 5 not in result
+        assert "b" * 5 not in result
+        assert "c" * 10 not in result
+
+    def test_8bit_csi_wrapped_token_masked(self):
+        # Follow-up review finding on #81012: the ECMA-48 8-bit CSI form
+        # (\x9b … m — recognized by tools/ansi_strip.py) bypassed the shadow
+        # entirely because _CONTROL_CHARS_RE excludes C1 bytes. The glued
+        # terminator defeats the prefix lookbehind exactly like the 7-bit
+        # shape, so both introducers must strip as a unit.
+        body = "a" * 25
+        text = "\x9b31m" + f"sk-{body}" + "\x9b0m"
+        result = redact_sensitive_text(text, force=True)
+        assert body not in result
+        assert f"sk-{body}" not in result
+
 
 class TestEnvLookupPreserved:
     """Programmatic env var lookups must not be corrupted (issue #2852)."""


### PR DESCRIPTION
Fixes #81012

## What & why

`_mask_control_split_tokens` stripped only the bare ESC byte when building
its shadow copy. For a token wrapped in ANSI color codes
(`\x1b[32msk-…\x1b[0m` — no spaces, the real leak shape), the CSI parameter
bytes `[32m` stayed glued to the token head. The literal `m` is alphanumeric,
so it defeats `_PREFIX_RE`'s `(?<![A-Za-z0-9_-])` lookbehind **in both the
shadow copy and the original**, and the whole secret survives redaction
verbatim. The split-join pass never fires because the token is
not-contiguous-but-also-not-`_PREFIX_RE`-matchable.

The fix strips **complete CSI sequences** (mirroring the CSI leg of
`tools/ansi_strip.py`) instead of the bare ESC byte, so the token realigns in
the shadow. A per-index `keep` map marks every stripped byte (CSI member bytes
*and* bare control chars) so the maskable-span check still accepts only
token-body + stripped-noise characters when validating the *original* span.

It also closes the second gap from the issue via per-line-segment clipping: a
span carrying BOTH a line boundary and an escaped body
(`sk-<head>\x1b<mid>\n<…>`) used to skip the join wholesale under the
#80987 line-boundary guard and leak every byte after the self-matching head.
The join now clips `end_orig` and the shadow `body` to the first line segment
(`bisect_left` over the index map), so the escaped **same-line** middle is
masked while later lines stay untouched.

## How to test

```python
from agent.redact import redact_sensitive_text

# ANSI-glued (no spaces) — the primary leak from #81012
print(redact_sensitive_text('\x1b[32msk-' + 'a' * 25 + '\x1b[0m', force=True))

# ESC + newline with a self-matching head — same-line middle must mask:
print(redact_sensitive_text('sk-' + 'a' * 15 + '\x1b' + 'b' * 12 + '\nrest', force=True))
```

New regression tests: `TestControlCharSplitTokens` gains `ansi_wrapped_*`,
`newline_esc_split_remainder_masked`, and `ansi_glued_head_and_tail_both_masked`.

## Platform

Tested on macOS (Python 3.11). Change is pure string/regex logic in
`agent/redact.py`; no OS-touching code, `os.*`, or shell — no Windows
footguns. `tests/agent/test_redact.py` (102 ✓) and
`tests/tools/test_terminal_output_transform_hook.py` (5 ✓) pass via
`scripts/run_tests.sh`.

## Related

Closes #81012. Prior art: #77484 (control-split masking), #80987 (line-boundary
guard), #80465 / #80965 (redaction emission gaps).

Note on overlap: #81060 and #81083 independently addressed the CSI-strip half.
#81083's per-line fallback still leaks the **same-line ESC remainder**
(`sk-<head>\x1b<mid>\n…` → the `\x1b<mid>` stays in cleartext, verified on its
head). This PR's per-line-segment clipping masks that middle for real.
