### PR TITLE
fix(weixin): exempt slash commands from content-fingerprint dedup

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1446,10 +1446,16 @@ class WeixinAdapter(BasePlatformAdapter):
         if message_id and self._dedup.is_duplicate(message_id):
             return
 
-        # Secondary content-fingerprint dedup for text messages
+        # Secondary content-fingerprint dedup for text messages. Slash
+        # commands (e.g. "/approve") are exempt: two separate, legitimate
+        # command invocations can carry identical text — most notably the
+        # user replying "/approve" to two distinct approval prompts issued
+        # in the same agent run (#81026) — and message_id dedup above
+        # already protects against a true upstream retransmit of the same
+        # command.
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
-        if text:
+        if text and not text.lstrip().startswith("/"):
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -546,6 +546,134 @@ class TestWeixinContentDedup:
         assert event.text == "hello world"
 
 
+class TestWeixinApproveCommandDedup:
+    """Regression tests for Issue #81026 — the ``/approve`` (and other slash
+    command) text was silently swallowed by the content-fingerprint dedup
+    and/or the text-batch debounce, causing a legitimate second approval
+    from the same sender to be dropped and the command to time out.
+    """
+
+    def test_two_distinct_approve_messages_both_reach_handle_message(self):
+        # Two separate agent turns each prompt the user with "/approve";
+        # WeChat assigns each a different message_id. Content-fingerprint
+        # dedup must not treat these as duplicates — each is a distinct,
+        # legitimate approval request that the user is responding to.
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "cmd-msg-1"})
+            await asyncio.sleep(0.2)
+            await adapter._process_message({**base_msg, "message_id": "cmd-msg-2"})
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 2
+        for call in adapter.handle_message.await_args_list:
+            assert call[0][0].text == "/approve"
+
+    def test_true_resend_same_message_id_is_still_deduped(self):
+        # A genuine transport-level redelivery (same message_id) of a
+        # command must still be dropped by message_id dedup — this is the
+        # one case where suppressing a repeat "/approve" is correct,
+        # because re-running it would double-approve the same request.
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        msg = {
+            "from_user_id": "wxid_user1",
+            "message_id": "same-id",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+
+        async def _drive():
+            await adapter._process_message(msg)
+            await adapter._process_message(msg)
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 1
+
+    def test_plain_text_repeat_is_still_content_deduped(self):
+        # Non-command text must keep the existing content-fingerprint dedup
+        # behavior (Issue #16182) — this guards against regressing that fix
+        # while fixing the command-specific case above.
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "hello world"}}],
+        }
+
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "msg-1"})
+            await adapter._process_message({**base_msg, "message_id": "msg-2"})
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 1
+
+    def test_command_after_plain_text_dispatches_independently_without_merging(self):
+        # A slash command arriving while a plain-text batch is pending must
+        # not be absorbed into that batch, and must not itself sit through
+        # the full debounce delay — it dispatches on its own, promptly.
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        # A long delay would make the test slow (and flaky under load) if
+        # the command were forced to wait out the plain-text debounce
+        # window instead of flushing immediately.
+        adapter._text_batch_delay_seconds = 5.0
+        adapter._text_batch_split_delay_seconds = 5.0
+
+        text_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "hello there"}}],
+        }
+        approve_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+
+        async def _drive():
+            await adapter._process_message({**text_msg, "message_id": "t1"})
+            await asyncio.sleep(0.1)
+            await adapter._process_message({**approve_msg, "message_id": "c1"})
+            # The command must have dispatched well before the 5s plain-text
+            # debounce window would otherwise elapse.
+            await asyncio.sleep(0.5)
+            assert adapter.handle_message.await_count == 1
+            first_event = adapter.handle_message.await_args_list[0][0][0]
+            assert first_event.text == "/approve"
+            assert first_event.message_type == MessageType.COMMAND
+            # The still-pending plain text batch flushes later on its own.
+            await asyncio.sleep(5.0)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 2
+        second_event = adapter.handle_message.await_args_list[1][0][0]
+        assert second_event.text == "hello there"
+
+
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).
 


### PR DESCRIPTION
## Summary

- In the Weixin adapter, two distinct inbound messages with identical slash-command text (for example, two `/approve` replies for sequential approvals) were treated as duplicate content for 300 seconds and the second message was dropped before a MessageEvent reached gateway routing.
- Exempt slash-command-shaped text from the adapter content-fingerprint deduplication. Message-ID deduplication remains unchanged, so genuine platform retransmits cannot resolve an additional approval.
- Keep ordinary repeated text under the existing content-dedup behavior.

## Relation to #81026

Part of #81026; complements #81088. #81088 improves gateway-side recognition of approval replies that reach the busy handler. This PR fixes the Weixin adapter-side path where a second, distinct-message-id `/approve` never reaches the gateway at all.

## Tests

- Two distinct message IDs carrying `/approve` both reach `handle_message`.
- A retransmit using the same message ID remains deduplicated.
- Duplicate plain text remains content-deduplicated.
- A slash command after ordinary text is dispatched independently rather than merged into the text batch.

`pytest tests/gateway/test_weixin.py -q -k "ApproveCommandDedup or ContentDedup"` → 5 passed.