### PR TITLE
fix: strip full-width punctuation from voice stop-phrase match

### DIFF
--- a/tests/tools/test_voice_stop_phrase.py
+++ b/tests/tools/test_voice_stop_phrase.py
@@ -41,6 +41,18 @@ class TestIsVoiceStopPhrase:
     def test_bare_stop_matches(self, utterance):
         assert is_voice_stop_phrase(utterance, ("stop",)) is True
 
+    @pytest.mark.parametrize("utterance", [
+        "停止", "停止。", "停止！", "停止？", "停止，", "停止…", "“停止”",
+        "『停止』", "（停止）", "停止；",
+    ])
+    def test_cjk_punctuation_stripped(self, utterance):
+        """Whisper transcribes Chinese with full-width marks (停止。); the
+        exact-match gate must strip them or the phrase never fires."""
+        assert is_voice_stop_phrase(utterance, ("停止",)) is True
+
+    def test_cjk_phrase_inside_sentence_still_does_not_match(self):
+        assert is_voice_stop_phrase("停止播放音乐", ("停止",)) is False
+
 
     def test_uses_config_when_phrases_omitted(self):
         with patch("tools.voice_mode._load_voice_stop_phrases", return_value=("halt",)):

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1303,7 +1303,12 @@ def is_voice_stop_phrase(transcript: str, stop_phrases: Optional[tuple] = None) 
     """
     if not transcript:
         return False
-    cleaned = transcript.strip().lower().strip(".,!?;: \t\n\"'")
+    # Strip ASCII AND full-width/CJK punctuation: whisper transcribes
+    # Chinese with full-width marks (停止。 / 停止！ / “停止”), which the
+    # ASCII-only set left behind and silently broke exact-match phrases.
+    cleaned = transcript.strip().lower().strip(
+        ".,!?;: \t\n\"'。，！？；：、…“”‘’()（）「」『』—"
+    )
     if not cleaned:
         return False
     if stop_phrases is None:


### PR DESCRIPTION
## Summary

`is_voice_stop_phrase` stripped only **ASCII** punctuation before the exact-match gate, so a configured phrase like `"停止"` never fired when Whisper transcribed it with full-width marks (`停止。`, `停止！`, `“停止”`) — the transcript with its trailing ideographic full stop never matched.

The strip set now also covers CJK punctuation (`。，！？；：、…“”‘’()（）「」『』—`), so Chinese stop phrases work exactly like the ASCII ones.

## Motivation

User reported the voice stop phrase "停止" not stopping the voice conversation; the real transcript was `停止。`.

## Test Plan

- Parametrized cases for `停止` with every common full-width mark (`。！？，…“”『』（）；`) — all match
- Guard case: `停止播放音乐` still does **not** match (exact-match semantics preserved)
- `tests/tools/test_voice_stop_phrase.py`: **31 passed** (20 pre-existing + 11 new), via `scripts/run_tests.sh`
