### PR TITLE
fix(ci): skip pick-releases on forks

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -58,6 +58,11 @@ jobs:
   # by both route matrices, so the two routes cover the same set.
   pick-releases:
     name: Pick release tags
+    # Only run on the upstream repository, not on forks. pick-release-tags.sh
+    # errors on zero release tags, which every fork has. update and installer
+    # both declare `needs: pick-releases`, so they skip automatically once
+    # this job is skipped.
+    if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
---

**Problem:** The `install-e2e` workflow runs on a 12-hourly schedule, but every fork of this repo lacks release tags. The `pick-release-tags.sh` script errors on zero tags, causing every scheduled run on forks to fail. Confirmed: 3/3 failures on `steveonjava/hermes-agent` (GitHub Actions run [31162103635](https://github.com/steveonjava/hermes-agent/actions/runs/31162103635)).

**Fix:** Add the same `if: github.repository == 'NousResearch/hermes-agent'` guard to the `pick-releases` job, matching the house style established by the sibling workflows `skills-index.yml` and `skills-index-freshness.yml` (merged in [#4107](https://github.com/NousResearch/hermes-agent/pull/4107)).

**Diff:** one condition line (+5 insertions, 0 deletions):

```diff
   pick-releases:
     name: Pick release tags
+    if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
```

**Design decisions:**

1. **Guard scope** — `pick-releases` only. Both `update` and `installer` declare `needs: pick-releases`, so they show as `Skipped` automatically once the entry-point job is skipped. This matches the sibling convention (e.g. `skills-index.yml` guards `build-index` explicitly but not downstream `trigger-deploy`, which relies on the `needs:` graph).

2. **`workflow_dispatch` escape hatch** — none. Both sibling guarded workflows block all triggers including manual dispatch on forks (unconditional `if:` check, no OR against `github.event_name`). Consistency over convenience.

**Prior art:** Closed PR [#29397](https://github.com/NousResearch/hermes-agent/pull/29397) attempted the same pattern on a different (now-deleted) file — not a duplicate, just precedent for the convention.

---

Findings for future backlog:
- `osv-scanner.yml` fork-guard status unverified (possible follow-up)
- `pick-release-tags.sh` error message clarity (optional, low-priority)