### PR TITLE
fix(copilot): refresh expired auxiliary IDE tokens

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4417,8 +4417,7 @@ def _refresh_provider_credentials(provider: str) -> bool:
     try:
         if normalized == "copilot":
             from hermes_cli.copilot_auth import (
-                _jwt_cache,
-                _token_fingerprint,
+                evict_cached_exchanged_token,
                 exchange_copilot_token,
                 resolve_copilot_token,
             )
@@ -4426,7 +4425,7 @@ def _refresh_provider_credentials(provider: str) -> bool:
             raw_token, _source = resolve_copilot_token()
             if not str(raw_token or "").strip():
                 return False
-            _jwt_cache.pop(_token_fingerprint(raw_token), None)
+            evict_cached_exchanged_token(raw_token)
             exchange_copilot_token(raw_token)
             _evict_cached_clients(normalized)
             return True
@@ -4516,7 +4515,7 @@ def _auth_refresh_provider_for_route(
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized and normalized != "auto":
         return normalized
-    if base_url_host_matches(client_base_url, "api.githubcopilot.com"):
+    if base_url_host_matches(client_base_url, "githubcopilot.com"):
         return "copilot"
     if base_url_host_matches(client_base_url, "chatgpt.com"):
         return "openai-codex"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2495,6 +2495,77 @@ class _AsyncFailingThenSuccessCompletions:
 
 
 class TestAuxiliaryAuthRefreshRetry:
+    def test_auto_enterprise_copilot_401_refreshes_before_fallback(self):
+        stale_client = MagicMock()
+        stale_client.base_url = "https://api.enterprise.githubcopilot.com"
+        stale_client.chat.completions.create.side_effect = _AuxAuth401(
+            "IDE token expired: unauthorized: token expired"
+        )
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://api.enterprise.githubcopilot.com"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-copilot")
+
+        def _cached_client(provider, model=None, **kwargs):
+            if provider == "copilot":
+                return fresh_client, "gpt-5.6-sol"
+            return stale_client, "gpt-5.6-sol"
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", "gpt-5.6-sol", None, None, None),
+            ),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=_cached_client),
+            patch(
+                "agent.auxiliary_client._refresh_provider_credentials", return_value=True
+            ) as mock_refresh,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_payment_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            response = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert response.choices[0].message.content == "fresh-copilot"
+        mock_refresh.assert_called_once_with("copilot")
+        assert stale_client.chat.completions.create.call_count == 1
+        assert fresh_client.chat.completions.create.call_count == 1
+
+    def test_refresh_provider_credentials_copilot_evicts_exchanged_token(self):
+        with (
+            patch(
+                "hermes_cli.copilot_auth.resolve_copilot_token",
+                return_value=("gho-raw-token", "gh auth token"),
+            ),
+            patch(
+                "hermes_cli.copilot_auth.evict_cached_exchanged_token"
+            ) as mock_evict_token,
+            patch(
+                "hermes_cli.copilot_auth.exchange_copilot_token",
+                return_value=("tid=fresh-token", None, None),
+            ) as mock_exchange,
+            patch("agent.auxiliary_client._evict_cached_clients") as mock_evict_clients,
+        ):
+            from agent.auxiliary_client import _refresh_provider_credentials
+
+            assert _refresh_provider_credentials("copilot") is True
+
+        mock_evict_token.assert_called_once_with("gho-raw-token")
+        mock_exchange.assert_called_once_with("gho-raw-token")
+        mock_evict_clients.assert_called_once_with("copilot")
+
     def test_call_llm_refreshes_codex_on_401_for_vision(self):
         failing_client = MagicMock()
         failing_client.base_url = "https://chatgpt.com/backend-api/codex"


### PR DESCRIPTION
## Problem

A long-lived Copilot gateway can fail context compression after its exchanged IDE token expires:

```text
IDE token expired: unauthorized: token expired
```

For enterprise accounts, the auxiliary client is auto-routed to `api.enterprise.githubcopilot.com`. The auth-refresh route only recognized `api.githubcopilot.com`, so the concrete provider remained `auto`; refresh was skipped, fallbacks were exhausted, and compression aborted into its cooldown.

The Copilot refresh helper also cleared only its in-process JWT cache. A durable or negative exchanged-token cache entry could survive and return the same stale token.

## Fix

- Recognize every validated `*.githubcopilot.com` host as Copilot when resolving an auto-routed auxiliary auth failure.
- Use the canonical `evict_cached_exchanged_token()` helper before re-exchange so in-memory, durable, and negative cache state is cleared together.
- Retry the original auxiliary request with the newly exchanged credential before walking fallbacks.

The hostname check remains parser-based (`base_url_host_matches`), so lookalike domains are not accepted.

## Verification

- New regression tests both fail on the original code:
  - enterprise auto-route 401 refreshes before fallback
  - Copilot refresh evicts canonical exchanged-token cache
- `234 passed` across:
  - `tests/agent/test_auxiliary_client.py`
  - `tests/hermes_cli/test_copilot_token_exchange.py`
  - `tests/run_agent/test_run_agent_codex_responses.py`
- `ruff 0.15.10 check`: passed
- Pyright: zero diagnostics on changed lines (the two legacy files retain their pre-existing baseline diagnostics)
