### PR TITLE
fix(agent): stop the session wedging after the continuation ceiling is exhausted

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -119,6 +119,16 @@ _API_CALL_MODULES = frozenset({
 })
 
 
+def _join_truncated_parts(parts: List[str]) -> str:
+    """Join continuation fragments, adding a newline where two would glue together (#78577)."""
+    joined = ""
+    for part in parts:
+        if joined and not joined[-1].isspace() and part and not part[0].isspace():
+            joined += "\n"
+        joined += part
+    return joined
+
+
 def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text: str) -> None:
     """Append a provider-safe checkpoint and correction to the live turn.
 
@@ -3119,7 +3129,7 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
                             if partial_response:
                                 agent._vprint(
                                     f"{agent.log_prefix}⚠️  Response still truncated "
@@ -6993,7 +7003,7 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    final_response = "".join(truncated_response_parts) + final_response
+                    final_response = _join_truncated_parts([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
                     # The continuation recovered, so the fragments stay in the transcript.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1660,6 +1660,9 @@ def run_conversation(
                 api_msg.pop("finish_reason")
             # Strip internal thinking-prefill marker
             api_msg.pop("_thinking_prefill", None)
+            # Strip length-continuation marks; not every transport drops underscore keys.
+            api_msg.pop("_length_continuation_fragment", None)
+            api_msg.pop("_length_continuation_nudge", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2900,8 +2900,8 @@ def run_conversation(
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
                         agent._vprint(
-                            f"{agent.log_prefix}⚠️  Stream interrupted by network error "
-                            f"(finish_reason='length' on partial-stream-stub)",
+                            f"{agent.log_prefix}⚠️  Response truncated — stream "
+                            f"ended before completion",
                             force=True,
                         )
                     else:
@@ -3028,6 +3028,11 @@ def run_conversation(
                                 # gets a coherent continuation point.
                                 if truncated_response_parts:
                                     messages = agent._get_messages_up_to_last_assistant(messages)
+                                # Unmark survivors: their text left the stitched partial.
+                                for _frag in messages:
+                                    if isinstance(_frag, dict):
+                                        _frag.pop("_length_continuation_fragment", None)
+                                        _frag.pop("_length_continuation_nudge", None)
                                 agent._session_messages = messages
                                 length_continue_retries = 0
                                 truncated_response_parts = []
@@ -3064,6 +3069,8 @@ def run_conversation(
                             )
                             if not _is_empty_partial_stub:
                                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                                # Marked so the ceiling exit can drop the fragment trail.
+                                interim_msg["_length_continuation_fragment"] = True
                                 messages.append(interim_msg)
                                 if assistant_message.content:
                                     truncated_response_parts.append(assistant_message.content)
@@ -3102,6 +3109,7 @@ def run_conversation(
                                 continue_msg = {
                                     "role": "user",
                                     "content": _continue_content,
+                                    "_length_continuation_nudge": True,
                                 }
                                 messages.append(continue_msg)
                                 agent._session_messages = messages
@@ -3109,6 +3117,37 @@ def run_conversation(
                                 break
 
                             partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            if partial_response:
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  Response still truncated "
+                                    f"after 4 continuation attempts — keeping the "
+                                    f"partial response received so far.",
+                                    force=True,
+                                )
+                            # Unanswered continue nudges made every later turn re-truncate.
+                            _turn_start = (
+                                current_turn_user_idx + 1
+                                if isinstance(current_turn_user_idx, int)
+                                and current_turn_user_idx >= 0
+                                else 0
+                            )
+                            messages[_turn_start:] = [
+                                m for m in messages[_turn_start:]
+                                if not (
+                                    isinstance(m, dict)
+                                    and (
+                                        m.get("_length_continuation_fragment")
+                                        or m.get("_length_continuation_nudge")
+                                    )
+                                )
+                            ]
+                            if partial_response:
+                                messages.append({
+                                    "role": "assistant",
+                                    "content": partial_response,
+                                    "finish_reason": "length",
+                                })
+                            agent._session_messages = messages
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -6954,6 +6993,11 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
+                    # The continuation recovered, so the fragments stay in the transcript.
+                    for _frag in messages:
+                        if isinstance(_frag, dict):
+                            _frag.pop("_length_continuation_fragment", None)
+                            _frag.pop("_length_continuation_nudge", None)
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
                 

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -229,3 +229,24 @@ class TestContinuationCeilingWedge:
         )
         assert "second turn partial" in result2["final_response"]
         assert "and the rest." in result2["final_response"]
+
+
+class TestTruncatedPartJoining:
+    """#78577 — parts joined with no separator glued text together."""
+
+    def test_glued_parts_get_a_newline(self):
+        from agent.conversation_loop import _join_truncated_parts
+        assert _join_truncated_parts(
+            ["Edited index.html", "Review the 5 changes"]
+        ) == "Edited index.html\nReview the 5 changes"
+
+    def test_existing_whitespace_is_not_doubled(self):
+        from agent.conversation_loop import _join_truncated_parts
+        assert _join_truncated_parts(["line one\n", "line two"]) == "line one\nline two"
+        assert _join_truncated_parts(["word", " next"]) == "word next"
+
+    def test_degenerate_inputs(self):
+        from agent.conversation_loop import _join_truncated_parts
+        assert _join_truncated_parts([]) == ""
+        assert _join_truncated_parts(["only"]) == "only"
+        assert _join_truncated_parts(["a", "", "b"]) == "a\nb"

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -1,0 +1,168 @@
+"""Regression tests for the post-ceiling session wedge.
+
+A turn that exhausts all 4 length-continuation attempts must leave the
+session usable: the next user message issues a fresh upstream request,
+inherits no continuation counter, and the partial text that WAS received
+is surfaced instead of dropped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _stub(content):
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+    return SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=content),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _run(agent, message, history=None):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(message, conversation_history=history)
+
+
+class TestContinuationCeilingWedge:
+    def _exhaust_ceiling(self, agent):
+        agent.client.chat.completions.create.side_effect = [
+            _stub("part one "), _stub("part two "),
+            _stub("part three "), _stub("part four."),
+        ]
+        return _run(agent, "write me a long report")
+
+    def test_partial_text_surfaced_at_ceiling(self, loop_agent):
+        result = self._exhaust_ceiling(loop_agent)
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "part one" in (result["final_response"] or "")
+        assert "part four" in (result["final_response"] or "")
+
+    def test_new_user_message_issues_fresh_request(self, loop_agent):
+        """Core regression: after the ceiling, a new user turn must reach
+        the provider instead of replaying wedge state."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        result1 = self._exhaust_ceiling(loop_agent)
+        assert "truncated after 4 continuation attempts" in (result1.get("error") or "")
+        calls_after_turn1 = loop_agent.client.chat.completions.create.call_count
+        assert calls_after_turn1 == 4
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="Hello! How can I help?", finish_reason="stop"),
+        ]
+        result2 = _run(loop_agent, "hi", history=result1["messages"])
+
+        assert loop_agent.client.chat.completions.create.call_count == calls_after_turn1 + 1, (
+            "A new user message after the continuation ceiling must issue "
+            "exactly one fresh upstream request."
+        )
+        assert result2["completed"] is True
+        assert result2["final_response"] == "Hello! How can I help?"
+        assert not result2.get("error")
+
+    def test_ceiling_replaces_scaffolding_with_settled_turn(self, loop_agent):
+        """The persisted tail must not keep the continuation scaffolding.
+        Unanswered "continue" nudges make every later turn resume the
+        truncated response and re-exhaust the same ceiling."""
+        result = self._exhaust_ceiling(loop_agent)
+        msgs = result["messages"]
+
+        nudges = [
+            m for m in msgs
+            if m.get("role") == "user"
+            and "Continue exactly where you left off" in (m.get("content") or "")
+        ]
+        assert nudges == [], (
+            "Continuation nudges must not survive the ceiling exit — they "
+            "steer every subsequent turn back into the truncated response."
+        )
+
+        assistants = [m for m in msgs if m.get("role") == "assistant"]
+        assert len(assistants) == 1, (
+            "The fragment trail must collapse into one settled assistant turn."
+        )
+        assert msgs[-1]["role"] == "assistant"
+        content = msgs[-1]["content"] or ""
+        for part in ("part one", "part two", "part three", "part four"):
+            assert part in content, "Stitched partial must keep every fragment."
+
+    def test_ceiling_not_labeled_network_error(self, loop_agent):
+        """A finish_reason='length' stub is a truncation, not a network
+        error — the user-facing message must not blame the network."""
+        printed = []
+        original = loop_agent._vprint
+
+        def _capture(text, **kwargs):
+            printed.append(str(text))
+            return original(text, **kwargs)
+
+        with patch.object(loop_agent, "_vprint", side_effect=_capture):
+            self._exhaust_ceiling(loop_agent)
+
+        network_lines = [line for line in printed if "network error" in line.lower()]
+        assert network_lines == [], (
+            "Truncation must not be reported as a network error: "
+            f"{network_lines!r}"
+        )
+        assert any("truncated" in line.lower() for line in printed), (
+            "The user-facing message must name the truncation."
+        )
+
+    def test_new_turn_does_not_inherit_continuation_counter(self, loop_agent):
+        """A single truncation on the turn AFTER the ceiling must get its
+        own full 4-attempt budget, not the exhausted counter."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        result1 = self._exhaust_ceiling(loop_agent)
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("second turn partial "),
+            _mock_response(content="and the rest.", finish_reason="stop"),
+        ]
+        result2 = _run(loop_agent, "try again", history=result1["messages"])
+
+        assert result2["completed"] is True, (
+            "One truncation on a fresh turn must continue (1/4), not fail "
+            "with an inherited exhausted counter."
+        )
+        assert "second turn partial" in result2["final_response"]
+        assert "and the rest." in result2["final_response"]

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -148,6 +148,69 @@ class TestContinuationCeilingWedge:
             "The user-facing message must name the truncation."
         )
 
+    def test_continuation_requests_carry_no_marks(self, loop_agent):
+        """The scaffolding marks are Hermes bookkeeping. The centrally
+        sanitized api_messages must never carry them — only the
+        chat-completions transport strips underscore keys, so anthropic
+        and bedrock requests would otherwise send them to the provider."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        seen_api_messages = []
+        original = loop_agent._build_api_kwargs
+
+        def _spy(api_messages, tools_for_api=None):
+            seen_api_messages.append([dict(m) for m in api_messages if isinstance(m, dict)])
+            return original(api_messages, tools_for_api=tools_for_api)
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("part one "), _stub("part two "),
+            _mock_response(content="the rest.", finish_reason="stop"),
+        ]
+        with patch.object(loop_agent, "_build_api_kwargs", side_effect=_spy):
+            result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        assert len(seen_api_messages) >= 3, "Expected continuation attempts 2+."
+        marked = [
+            (idx, key)
+            for idx, batch in enumerate(seen_api_messages)
+            for m in batch
+            for key in m
+            if str(key).startswith("_length_continuation")
+        ]
+        assert marked == [], (
+            f"Continuation marks leaked into outgoing api_messages: {marked!r}"
+        )
+
+    def test_prior_turn_marked_message_survives_later_ceiling(self, loop_agent):
+        """A mark that reached disk mid-crash and got reloaded on a PRIOR
+        turn's message must never be deleted by a later turn's ceiling
+        cleanup — the cleanup is scoped to the current turn."""
+        reloaded_history = [
+            {"role": "user", "content": "earlier question"},
+            {
+                "role": "assistant",
+                "content": "earlier answer fragment",
+                "_length_continuation_fragment": True,
+            },
+        ]
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("wedge one "), _stub("wedge two "),
+            _stub("wedge three "), _stub("wedge four."),
+        ]
+        result = _run(loop_agent, "another long report", history=reloaded_history)
+
+        assert "truncated after 4 continuation attempts" in (result.get("error") or "")
+        prior = [
+            m for m in result["messages"]
+            if m.get("role") == "assistant"
+            and "earlier answer fragment" in (m.get("content") or "")
+        ]
+        assert len(prior) == 1, (
+            "The prior turn's reloaded message must survive the later "
+            "turn's ceiling cleanup."
+        )
+
     def test_new_turn_does_not_inherit_continuation_counter(self, loop_agent):
         """A single truncation on the turn AFTER the ceiling must get its
         own full 4-attempt budget, not the exhausted counter."""


### PR DESCRIPTION

## Symptom

After a turn exhausts all 4 length-continuation attempts ("Response remained
truncated after 4 continuation attempts"), every later user turn — including a
bare "hi" — fails the same way:

```
⚠️  Stream interrupted by network error (finish_reason='length' on partial-stream-stub)
↻ Stream interrupted — requesting continuation (1/4)...
[repeats]
Error: Response remained truncated after 4 continuation attempts
```

Observed on a custom OpenAI-compatible provider with a reasoning model, in a
long (~19h, ~41K-context) session.

## Evidence

The reporter compared client behavior against the upstream server logs during
the post-wedge failures. The endpoint answered direct completion and streaming
requests cleanly at the same time.

## Root cause

The reporter's hypothesis was that the partial-stream stub or the continuation
counter is stored on the session and replayed. That is not what the code does:
`length_continue_retries`, `truncated_response_parts`, and the stub are all
locals of one `run_conversation` call, and a regression test confirms a new
user message issues a fresh upstream request with a fresh counter even on the
unpatched code.

What does persist is the conversation transcript. Each continuation attempt
appends an interim assistant fragment plus a `[System: ... Continue exactly
where you left off ...]` user nudge, and the ceiling exit persisted all of that
scaffolding as-is. The next user turn therefore replays up to four unanswered
"continue" demands and a fragment trail, so the model resumes the oversized
response, truncates again, and burns its own 4-attempt budget — every turn,
regardless of what the user typed. The continuation state that wedges the
session lives in the persisted messages, not in a counter.

The wedge also mislabeled itself: a `finish_reason='length'` stub was reported
as "Stream interrupted by network error", pointing users at their network
instead of the model's output ceiling.

## Fix

`agent/conversation_loop.py`:

- Mark the interim fragments and continuation nudges as this turn's
  scaffolding. When the 4-attempt ceiling is exhausted, remove them from the
  turn's tail and store one settled assistant turn carrying the stitched
  partial text, then persist. The next user message starts from a clean
  transcript.
- The marks are removed when a continuation succeeds and on the
  content-filter fallback rollback, so a later cleanup can never delete
  fragments whose text was already consumed.
- The marks are popped in the central api_messages sanitization (next to
  `_thinking_prefill` / `_row_id`): only the chat-completions transport
  strips underscore keys, so anthropic and bedrock requests would
  otherwise send them to strict providers.
- The stitched partial text is kept as the turn's response (returned as
  `final_response` and stored in the settled assistant turn) instead of being
  stranded across scaffolding rows.
- Reworded the stub message: "Response truncated — stream ended before
  completion" instead of blaming a network error, plus an explicit notice
  when the ceiling is exhausted and the partial response is kept.

## Tests

`tests/run_agent/test_continuation_ceiling_wedge.py`:

- `test_ceiling_replaces_scaffolding_with_settled_turn` — no continuation
  nudges survive the ceiling; one assistant turn carries all fragments.
  Fails on unpatched main.
- `test_ceiling_not_labeled_network_error` — the truncation is never
  reported as a network error. Fails on unpatched main.
- `test_new_user_message_issues_fresh_request` — a new user message after
  the ceiling issues exactly one fresh upstream request. Passes on unpatched
  main too; pinned as the regression guard for the reported replay behavior.
- `test_new_turn_does_not_inherit_continuation_counter` — a truncation on
  the next turn gets a fresh 4-attempt budget.
- `test_partial_text_surfaced_at_ceiling` — partial text reaches the caller.
- `test_continuation_requests_carry_no_marks` — the centrally sanitized
  api_messages never carry the scaffolding marks on continuation attempts
  2+. Fails without the sanitization pops.
- `test_prior_turn_marked_message_survives_later_ceiling` — a mark that
  reached disk mid-crash and reloads on a prior turn's message is never
  deleted by a later turn's ceiling cleanup (turn-scoped filter).
- `test_glued_parts_get_a_newline`, `test_existing_whitespace_is_not_doubled`,
  `test_degenerate_inputs` — fragment joining (#78577).

`tests/run_agent/` passes at 1414. Seven failures in that directory are
pre-existing on `main` (anthropic stream callbacks, anthropic interrupt, nous
fallback, switch-model reasoning) and are unrelated to this change.

## Related issues

Fixes #78577 — `truncated_response_parts` were joined with `"".join()` at both
the ceiling exit and the success path, so a fragment ending mid-word ran
straight into the next one. A newline is now inserted only when the previous
fragment ends non-whitespace and the next starts non-whitespace, so existing
separators are not doubled. This matters here because the ceiling exit now
keeps the partial text, and it should be readable.

Partially addresses #75801. That report describes the same "4 fake continuations
then Response remained truncated" sequence from a provider that omits
`finish_reason`. This branch fixes the misleading network-error label and stops
the partial answer being discarded, but not the desktop-side half (the
`message.complete` payload in `tui_gateway/server.py` not setting `partial:
true`), which is untouched here.

## Open question

The reporter observed no request arriving at the upstream server during the
post-wedge failures. This diagnosis predicts a request is issued every time, and
every local reproduction did issue one. Either that observation was misread, or
there is a second failure mode this change does not cover. Worth re-checking
upstream logs after this lands.
