### PR TITLE
fix(desktop): scale native titlebar overlay with page zoom

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -186,7 +186,11 @@ import {
   SshConnection
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
-import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import {
+  nativeOverlayWidth as computeNativeOverlayWidth,
+  macTitleBarOverlayHeight,
+  scaledTitleBarOverlayHeight
+} from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
@@ -802,7 +806,7 @@ function getWindowBackgroundColor() {
 // to GetFrameColor() on some Electron builds; rgba(1,0,0,0) is the escape hatch.
 const TITLEBAR_OVERLAY_COLOR = 'rgba(1, 0, 0, 0)'
 
-function getTitleBarOverlayOptions() {
+function getTitleBarOverlayOptions(zoomFactor = 1) {
   if (IS_MAC) {
     // Tahoe (Darwin 25+) misplaces the traffic lights when the overlay has a
     // nonzero height (electron#49183); 0 there keeps them at the configured
@@ -819,7 +823,10 @@ function getTitleBarOverlayOptions() {
 
   return {
     color: TITLEBAR_OVERLAY_COLOR,
-    height: TITLEBAR_HEIGHT,
+    // Page zoom never touches these OS-painted min/max/close glyphs on its
+    // own (#81086) — scale the overlay height by the same factor so they
+    // stay in proportion with the rest of the zoomed UI.
+    height: scaledTitleBarOverlayHeight({ titlebarHeight: TITLEBAR_HEIGHT, zoomFactor }),
     symbolColor:
       rendererTitleBarTheme && isHexColor(rendererTitleBarTheme.foreground)
         ? rendererTitleBarTheme.foreground
@@ -830,11 +837,17 @@ function getTitleBarOverlayOptions() {
 }
 
 // Push refreshed overlay options to a live window after a theme/appearance
-// change. No-op only on plain (non-WSL) Linux, where getTitleBarOverlayOptions()
-// returns false; the try/catch additionally guards builds where
-// setTitleBarOverlay isn't supported.
+// change or a zoom change (see setAndPersistZoomLevel/restorePersistedZoomLevel
+// below — zoom.ts).  No-op only on plain (non-WSL) Linux, where
+// getTitleBarOverlayOptions() returns false; the try/catch additionally
+// guards builds where setTitleBarOverlay isn't supported.
 function applyTitleBarOverlay(win) {
-  const options = getTitleBarOverlayOptions()
+  const zoomFactor =
+    win && !win.isDestroyed() && win.webContents && !win.webContents.isDestroyed()
+      ? zoomLevelToFactor(win.webContents.getZoomLevel())
+      : 1
+
+  const options = getTitleBarOverlayOptions(zoomFactor)
 
   if (!options || typeof options !== 'object') {
     return
@@ -5535,6 +5548,7 @@ import {
   percentToZoomLevel,
   ZOOM_STEP,
   ZOOM_STORAGE_KEY,
+  zoomLevelToFactor,
   zoomLevelToPercent,
   zoomWiringForWindowKind
 } from './zoom'
@@ -5547,6 +5561,9 @@ function setAndPersistZoomLevel(window, zoomLevel) {
   // Apply + notify in one funnel so the settings UI stays in sync, including
   // changes made via the keyboard shortcuts or the View menu.
   const next = applyZoomLevel(window.webContents, zoomLevel)
+  // Keep the native Windows/Linux titlebar overlay (min/max/close) in
+  // proportion with the newly zoomed page — see getTitleBarOverlayOptions.
+  applyTitleBarOverlay(window)
 
   // Primary store: main-process JSON (survives crash recovery — #56726).
   writeZoomState(next)
@@ -5573,6 +5590,7 @@ function restorePersistedZoomLevel(window) {
 
   if (saved != null) {
     applyZoomLevel(window.webContents, saved)
+    applyTitleBarOverlay(window)
 
     return
   }
@@ -5581,6 +5599,7 @@ function restorePersistedZoomLevel(window) {
   // doesn't flash Chromium 100%, then try localStorage for pre-JSON installs
   // and overwrite if a legacy value is there.
   applyZoomLevel(window.webContents, DEFAULT_ZOOM_LEVEL)
+  applyTitleBarOverlay(window)
 
   window.webContents
     .executeJavaScript(
@@ -5593,6 +5612,7 @@ function restorePersistedZoomLevel(window) {
 
       const level = stored == null ? DEFAULT_ZOOM_LEVEL : Number(stored)
       const applied = applyZoomLevel(window.webContents, level)
+      applyTitleBarOverlay(window)
       writeZoomState(applied)
     })
     .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))

--- a/apps/desktop/electron/titlebar-overlay-width.test.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.test.ts
@@ -6,7 +6,8 @@ import {
   MACOS_TAHOE_DARWIN_MAJOR,
   macTitleBarOverlayHeight,
   nativeOverlayWidth,
-  OVERLAY_FALLBACK_WIDTH
+  OVERLAY_FALLBACK_WIDTH,
+  scaledTitleBarOverlayHeight
 } from './titlebar-overlay-width'
 
 // This static reservation is only the pre-layout FALLBACK. Once laid out the
@@ -52,4 +53,23 @@ test('Tahoe (Darwin 25+) drops the overlay height to 0 to avoid electron#49183',
 
 test('macTitleBarOverlayHeight tolerates missing args (unknown platform → 0)', () => {
   assert.equal(macTitleBarOverlayHeight(), 0)
+})
+
+test('scaledTitleBarOverlayHeight is a no-op at 1x (actual size)', () => {
+  assert.equal(scaledTitleBarOverlayHeight({ titlebarHeight: 34, zoomFactor: 1 }), 34)
+})
+
+test('scaledTitleBarOverlayHeight grows the overlay in proportion with zoom-in (#81086)', () => {
+  // Windows/GNOME/KDE paint the min/max/close glyphs to fill the overlay
+  // height; without scaling this by the page zoom factor, those native
+  // controls stay pinned at the un-zoomed size while the rest of the UI grows.
+  assert.equal(scaledTitleBarOverlayHeight({ titlebarHeight: 34, zoomFactor: 1.5 }), 51)
+})
+
+test('scaledTitleBarOverlayHeight shrinks the overlay in proportion with zoom-out', () => {
+  assert.equal(scaledTitleBarOverlayHeight({ titlebarHeight: 34, zoomFactor: 0.9 }), 31)
+})
+
+test('scaledTitleBarOverlayHeight tolerates missing args', () => {
+  assert.equal(scaledTitleBarOverlayHeight(), 0)
 })

--- a/apps/desktop/electron/titlebar-overlay-width.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.ts
@@ -40,3 +40,18 @@ export const MACOS_TAHOE_DARWIN_MAJOR = 25
 export function macTitleBarOverlayHeight({ darwinMajor = 0, titlebarHeight = 0 } = {}) {
   return darwinMajor >= MACOS_TAHOE_DARWIN_MAJOR ? 0 : titlebarHeight
 }
+
+/**
+ * Height (px) to pass to `titleBarOverlay` on Windows/Linux (WCO). Page zoom
+ * (webContents.setZoomLevel) scales the renderer's own DOM but never the
+ * native min/max/close glyphs the OS paints into the overlay region, so at
+ * higher zoom levels the app's own titlebar content grows while those native
+ * controls stay pinned at the un-zoomed size (#81086). Scaling the overlay
+ * height by the same factor keeps the native buttons in proportion with the
+ * rest of the UI.
+ *
+ * @param {{ titlebarHeight?: number, zoomFactor?: number }} opts
+ */
+export function scaledTitleBarOverlayHeight({ titlebarHeight = 0, zoomFactor = 1 } = {}) {
+  return Math.round(titlebarHeight * zoomFactor)
+}

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -17,6 +17,7 @@ import {
   ZOOM_RESIZE_REASSERT_DELAY_MS,
   ZOOM_STEP,
   ZOOM_STORAGE_KEY,
+  zoomLevelToFactor,
   zoomLevelToPercent,
   zoomReassertWindowEvents,
   zoomWiringForWindowKind
@@ -45,6 +46,20 @@ test('clampZoomLevel rejects garbage and enforces bounds', () => {
 test('level 0 is exactly 100 percent (Chromium actual-size baseline)', () => {
   assert.equal(zoomLevelToPercent(0), 100)
   assert.equal(percentToZoomLevel(100), 0)
+})
+
+test('zoomLevelToFactor matches the percent conversion (both derive from the same factor)', () => {
+  assert.equal(zoomLevelToFactor(0), 1)
+
+  for (const percent of [90, 100, 110, 125, 150, 175]) {
+    const level = percentToZoomLevel(percent)
+    assert.equal(Math.round(zoomLevelToFactor(level) * 100), percent)
+  }
+})
+
+test('zoomLevelToFactor clamps garbage the same way clampZoomLevel does', () => {
+  assert.equal(zoomLevelToFactor(NaN), zoomLevelToFactor(DEFAULT_ZOOM_LEVEL))
+  assert.equal(zoomLevelToFactor(999), zoomLevelToFactor(9))
 })
 
 test('percentToZoomLevel rejects garbage by falling back to the shipped default', () => {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -29,8 +29,15 @@ export function clampZoomLevel(value) {
   return Math.min(Math.max(value, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL)
 }
 
+/** Raw scale factor (1.0 = actual size) a zoom level maps to; the same factor
+ * used to keep the Windows/Linux titlebar overlay's native buttons in
+ * proportion with the zoomed page (see scaledTitleBarOverlayHeight). */
+export function zoomLevelToFactor(level) {
+  return Math.pow(ZOOM_FACTOR_BASE, clampZoomLevel(level))
+}
+
 export function zoomLevelToPercent(level) {
-  return Math.round(Math.pow(ZOOM_FACTOR_BASE, clampZoomLevel(level)) * 100)
+  return Math.round(zoomLevelToFactor(level) * 100)
 }
 
 export function percentToZoomLevel(percent) {


### PR DESCRIPTION
## What does this PR do?

On Windows (and plain Linux KDE/GNOME), the desktop app uses Electron's
Window Controls Overlay (`titleBarStyle: 'hidden'` + `titleBarOverlay`) so
the app can draw its own titlebar chrome around the OS-painted min/max/close
buttons. `getTitleBarOverlayOptions()` in `electron/main.ts` passed a fixed
`height: TITLEBAR_HEIGHT` (34px) to `setTitleBarOverlay`.

Ctrl+zoom / Ctrl+scroll only scales the renderer's own page content
(`webContents.setZoomLevel`) — it has no effect on the native overlay
Electron/Windows paints, since that's OS chrome, not page content. So at
higher zoom levels the app's own UI (including its titlebar drag area/icons)
grows while the native min/max/close buttons stay pinned at their un-zoomed
size, producing the jaggedness/inconsistency described in the issue.

## Related Issue

Fixes #81086

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/titlebar-overlay-width.ts`: add pure helper
  `scaledTitleBarOverlayHeight({ titlebarHeight, zoomFactor })` that scales
  the overlay height by the current zoom factor.
- `apps/desktop/electron/zoom.ts`: extract `zoomLevelToFactor(level)` (the
  raw `1.2^level` scale factor `zoomLevelToPercent` already computed
  internally) so the main process can convert a zoom level to a scale factor
  without duplicating the math.
- `apps/desktop/electron/main.ts`:
  - `getTitleBarOverlayOptions(zoomFactor = 1)` now scales the Windows/Linux
    overlay height via `scaledTitleBarOverlayHeight`.
  - `applyTitleBarOverlay(win)` computes the window's current zoom factor
    from `win.webContents.getZoomLevel()` and passes it through.
  - `applyTitleBarOverlay(window)` is now called from the same funnel every
    zoom change already goes through — `setAndPersistZoomLevel` (user zoom
    in/out/reset) and `restorePersistedZoomLevel` (initial load / crash
    recovery restore) — so the native overlay height always matches the
    currently-applied zoom, not just at first paint.
- Added unit tests for the new pure helpers
  (`titlebar-overlay-width.test.ts`, `zoom.test.ts`).

macOS is untouched — it uses native traffic lights with its own
Tahoe-specific handling (`macTitleBarOverlayHeight`), which this PR does not
touch.

## How to Test

1. On Windows (or Linux with the WCO enabled), launch the desktop app.
2. Press Ctrl+= a few times to zoom in.
3. Before this fix: the app's own titlebar UI grows but the native
   minimize/maximize/close buttons stay the same size, looking mismatched.
4. After this fix: the native buttons scale up proportionally with the rest
   of the UI zoom.

Automated proof (reproduces + fixes at the unit level, since CI has no
Windows GUI to screenshot):

```
$ npx vitest run electron/zoom.test.ts electron/titlebar-overlay-width.test.ts
 Test Files  2 passed (2)
      Tests  31 passed (31)
```

Confirmed the new tests fail without the fix (checked out
`titlebar-overlay-width.ts`/`zoom.ts` from the pre-fix commit while keeping
the new tests):

```
FAIL electron/titlebar-overlay-width.test.ts > scaledTitleBarOverlayHeight ...
TypeError: scaledTitleBarOverlayHeight is not a function
FAIL electron/zoom.test.ts > zoomLevelToFactor ...
TypeError: zoomLevelToFactor is not a function
 Test Files  2 failed (2)
      Tests  6 failed | 25 passed (31)
```

Full electron suite after the fix:

```
$ npx vitest run electron/
 Test Files  74 passed | 1 skipped (75)
      Tests  907 passed | 2 skipped (909)
```

`npm run typecheck` and `npm run lint` both pass clean on the changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — developed/tested on Linux; the Windows
  WCO code path was verified via the extracted pure functions and existing
  `titlebar-overlay-width.test.ts` conventions (no Windows machine available
  in this environment)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## Disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with
human-equivalent verification: reproduced the root cause by reading the
Electron `titleBarOverlay` wiring, made the minimal fix, added tests that
fail on the pre-fix code and pass after, and ran the full lint/typecheck/test
suite before pushing.
