### PR TITLE
fix(gateway): route kanban notices by transport owner

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -178,12 +178,30 @@ class GatewayAuthorizationMixin:
         return None
 
     def _adapter_profile_for_source(self, source: SessionSource) -> Optional[str]:
-        """Resolve the transport-owning profile for adapter policy lookups."""
-        adapter = self._registered_transport_adapter(source)
-        platform = getattr(source, "platform", None)
+        """Resolve the transport-owning profile for policy and delivery.
+
+        The primary adapter registry belongs to the active gateway profile,
+        even when ``source.profile`` names a different routed runtime. Returning
+        that owner explicitly lets notification subscriptions distinguish a
+        shared credential from a real secondary-profile bot.
+        """
+        via_relay = getattr(source, "delivered_via_upstream_relay", False) is True
+        adapter = (
+            self._adapter_for_source(source)
+            if via_relay
+            else self._registered_transport_adapter(source)
+        )
+        platform = Platform.RELAY if via_relay else getattr(source, "platform", None)
         if adapter is not None:
             if adapter is (getattr(self, "adapters", None) or {}).get(platform):
-                return None
+                active_profile_fn = getattr(self, "_active_profile_name", None)
+                if callable(active_profile_fn):
+                    try:
+                        active_profile = str(active_profile_fn() or "").strip()
+                        return active_profile or "default"
+                    except Exception:
+                        pass
+                return "default"
             for profile, profile_adapters in (
                 getattr(self, "_profile_adapters", None) or {}
             ).items():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21513,9 +21513,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # (api_server) declare supports_async_delivery=False. Use getattr so
         # bare runners built via object.__new__ (tests) without self.adapters
         # don't blow up — they simply default to supported.
-        _adapters = getattr(self, "adapters", None) or {}
-        _adapter = _adapters.get(context.source.platform)
+        _adapter = self._adapter_for_source(context.source)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _transport_profile = self._adapter_profile_for_source(context.source) or ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -21529,6 +21529,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            transport_profile=_transport_profile,
             async_delivery=_async_delivery,
             cron_session="",
         )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -94,6 +94,12 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+# Profile that owns the live transport adapter which received this turn. This
+# can differ from _SESSION_PROFILE when one shared bot routes a chat to another
+# runtime namespace (for example default's Telegram bot -> daily).
+_SESSION_TRANSPORT_PROFILE: ContextVar = ContextVar(
+    "HERMES_SESSION_TRANSPORT_PROFILE", default=_UNSET
+)
 
 # Per-session cron marker. Unlike the process-global legacy env var, this is
 # scoped to one cron job / inbound session. _UNSET preserves the legacy env
@@ -141,6 +147,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_SESSION_TRANSPORT_PROFILE": _SESSION_TRANSPORT_PROFILE,
     "HERMES_CRON_SESSION": _CRON_SESSION,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
@@ -220,6 +227,7 @@ def set_session_vars(
     async_delivery: bool = True,
     ui_session_id: str = "",
     cron_session: Any = _UNSET,
+    transport_profile: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -259,6 +267,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _SESSION_TRANSPORT_PROFILE.set(transport_profile),
         _CRON_SESSION.set(cron_session),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
@@ -296,6 +305,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _SESSION_TRANSPORT_PROFILE,
         _CRON_SESSION,
     ):
         var.set("")

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,6 +2,7 @@ import asyncio
 import sqlite3
 from pathlib import Path
 
+import pytest
 
 from gateway.config import Platform
 from gateway.kanban_watchers import (
@@ -214,6 +215,54 @@ def test_non_dispatch_gateway_claims_only_its_profile_subscriptions(
     assert len(_unseen_terminal_events_for(foreign_tid, "default-chat")) == 1
 
 
+@pytest.mark.parametrize("terminal_kind", ["completed", "blocked"])
+def test_routed_runtime_auto_subscription_uses_receiving_transport_profile(
+    tmp_path, monkeypatch, terminal_kind,
+):
+    """A shared bot delivers routed-runtime terminal events back to topic 2."""
+    db_path = tmp_path / f"routed-{terminal_kind}.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import kanban_tools
+
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title=terminal_kind, assignee="worker")
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="shared-bot-chat",
+            chat_type="group",
+            thread_id="2",
+            profile="daily",
+            transport_profile="default",
+        )
+        try:
+            assert kanban_tools._maybe_auto_subscribe(conn, task_id) is True
+        finally:
+            clear_session_vars(tokens)
+
+        [subscription] = kb.list_notify_subs(conn, task_id)
+        assert subscription["notifier_profile"] == "default"
+        assert subscription["thread_id"] == "2"
+        if terminal_kind == "completed":
+            kb.complete_task(conn, task_id, summary="done through shared bot")
+        else:
+            kb.block_task(conn, task_id, reason="review needed", kind="needs_input")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._kanban_notifier_profile = "default"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [delivery["chat_id"] for delivery in adapter.sent] == ["shared-bot-chat"]
+    assert adapter.sent[0]["metadata"]["thread_id"] == "2"
+    assert terminal_kind in adapter.sent[0]["text"]
+
+
 def test_legacy_subscription_requires_confirmed_dispatcher_lock_owner(
     tmp_path, monkeypatch,
 ):
@@ -289,6 +338,80 @@ class ReportedFailureAdapter:
         self.attempts += 1
         from gateway.platforms.base import SendResult
         return SendResult(success=False, error="Not connected")
+
+
+class RetryThenSuccessAdapter:
+    """Report one transport failure, then accept the retry."""
+
+    def __init__(self):
+        self.attempts = []
+
+    async def send(self, chat_id, text, metadata=None):
+        from gateway.platforms.base import SendResult
+
+        self.attempts.append({
+            "chat_id": chat_id,
+            "text": text,
+            "metadata": metadata or {},
+        })
+        if len(self.attempts) == 1:
+            return SendResult(success=False, error="temporary Telegram failure")
+        return SendResult(success=True, message_id="telegram-message-1")
+
+
+def test_notifier_retries_reported_failure_then_succeeds_in_topic(
+    tmp_path, monkeypatch,
+):
+    """A failed topic delivery stays retryable until Telegram accepts it."""
+    db_path = tmp_path / "reported-failure-retry.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="retry topic", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="-100123",
+            thread_id="2",
+        )
+        kb.complete_task(conn, tid, summary="done after retry")
+    finally:
+        conn.close()
+
+    adapter = RetryThenSuccessAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.attempts) == 1
+    assert adapter.attempts[0]["metadata"] == {"thread_id": "2"}
+    conn = kb.connect()
+    try:
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="-100123",
+            thread_id="2",
+            kinds=["completed", "blocked"],
+        )
+        assert [event.kind for event in events] == ["completed"]
+    finally:
+        conn.close()
+
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.attempts) == 2
+    assert adapter.attempts[1]["metadata"] == {"thread_id": "2"}
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
 
 
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -74,6 +74,71 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_session_context_records_primary_transport_owner_for_routed_runtime(monkeypatch):
+    """A runtime route must not relabel the bot that will send notifications."""
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "default"
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="routed-chat",
+        chat_type="dm",
+        profile="daily",
+    )
+    setattr(source, "_transport_adapter_ref", lambda: default_adapter)
+
+    assert runner._adapter_for_source(source) is default_adapter
+    assert runner._adapter_profile_for_source(source) == "default"
+
+    from gateway.session_context import clear_session_vars, get_session_env
+
+    tokens = runner._set_session_env(
+        SimpleNamespace(source=source, session_key="daily-routed-session")
+    )  # type: ignore[arg-type]
+    try:
+        assert get_session_env("HERMES_SESSION_PROFILE") == "daily"
+        assert get_session_env("HERMES_SESSION_TRANSPORT_PROFILE") == "default"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_transport_owner_keeps_distinct_secondary_adapter_isolated(monkeypatch):
+    runner, default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "default"
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="coder-chat",
+        chat_type="dm",
+        profile="coder",
+    )
+    setattr(source, "_transport_adapter_ref", lambda: secondary_adapter)
+
+    assert runner._adapter_profile_for_source(source) == "coder"
+    assert runner._adapter_for_source(source) is secondary_adapter
+    assert runner._adapter_for_source(source) is not default_adapter
+
+
+def test_transport_owner_uses_active_profile_for_routed_relay(monkeypatch):
+    """The shared Relay socket belongs to the active gateway, not the runtime route."""
+    runner, _default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "default"
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters[Platform.RELAY] = relay_adapter  # type: ignore[assignment]
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="relay-chat",
+        chat_type="dm",
+        profile="daily",
+        delivered_via_upstream_relay=True,
+    )
+    setattr(source, "_transport_adapter_ref", lambda: relay_adapter)
+
+    assert runner._adapter_for_source(source) is relay_adapter
+    assert runner._adapter_profile_for_source(source) == "default"
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1430,7 +1430,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
         message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "") or ""
         notifier_profile = (
-            get_session_env("HERMES_SESSION_PROFILE", "")
+            get_session_env("HERMES_SESSION_TRANSPORT_PROFILE", "")
+            or get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
         )
         if not notifier_profile:


### PR DESCRIPTION
## Summary
- preserve the profile that owns the inbound transport separately from the routed runtime profile
- stamp Kanban auto-subscriptions with that transport owner, including shared Relay delivery
- cover routed done/blocked topic notifications and reported-send failure retry semantics

## Verification
- `scripts/run_tests.sh tests/gateway/test_session_context_inheritance.py tests/tools/test_kanban_tools.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_kanban_notifier.py -q` (48 passed)
- independent staged-diff review passed with no security or logic findings
- live gateway restarted on this commit; controlled Telegram topic-2 canary completed and its subscription was acknowledged
- replayed the missed blocked event for `t_ba8b0002`; notifier advanced the cursor and woke the subscribed topic

Fixes local Kanban task `t_1c390707`.