### PR TITLE
fix(model-switch): make current-model picker injection alias-aware

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3931,20 +3931,42 @@ def list_authenticated_providers(
     # provider's row (matched by slug) so it is selectable and shown. Done as a
     # post-pass so it covers every provider section uniformly, regardless of
     # which branch emitted the row.
-    if current_model:
-        for _row in results:
-            if not _row.get("is_current") or _row.get("native_catalog_empty"):
-                continue
-            _models = _row.get("models") or []
-            if current_model not in _models:
-                _row["models"] = [current_model, *_models]
-                _row["total_models"] = _row.get("total_models", len(_models)) + 1
-            break
+    _inject_current_model_row(results, current_model)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
+
+
+def _inject_current_model_row(results: List[dict], current_model: str) -> None:
+    """Prepend the active model to its provider row when the row lacks it.
+
+    Membership is alias-aware: the picker dedup folds bare live wire ids into
+    their curated public slug (Kimi Coding's ``k3`` → ``kimi-k3``), so an
+    exact-string check would re-inject the bare id and render the SAME model
+    as two rows ("K3" + "Kimi K3"). Fold both sides through the same
+    canonicalisation the merge uses before deciding to inject.
+
+    Rows flagged ``native_catalog_empty`` are skipped: a row that deliberately
+    reports an empty live catalog must not have an uncurated model injected
+    into it (native-discovery selector parity, see #81e81350).
+    """
+    if not current_model:
+        return
+    try:
+        from hermes_cli.model_search import model_alias_canonical as _canon
+    except Exception:
+        _canon = lambda m: str(m).strip().lower()  # noqa: E731
+    current_key = _canon(current_model)
+    for _row in results:
+        if not _row.get("is_current") or _row.get("native_catalog_empty"):
+            continue
+        _models = _row.get("models") or []
+        if current_key not in {_canon(m) for m in _models}:
+            _row["models"] = [current_model, *_models]
+            _row["total_models"] = _row.get("total_models", len(_models)) + 1
+        break
 
 
 def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3101,20 +3101,38 @@ def list_authenticated_providers(
     # provider's row (matched by slug) so it is selectable and shown. Done as a
     # post-pass so it covers every provider section uniformly, regardless of
     # which branch emitted the row.
-    if current_model:
-        for _row in results:
-            if not _row.get("is_current"):
-                continue
-            _models = _row.get("models") or []
-            if current_model not in _models:
-                _row["models"] = [current_model, *_models]
-                _row["total_models"] = _row.get("total_models", len(_models)) + 1
-            break
+    _inject_current_model_row(results, current_model)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
+
+
+def _inject_current_model_row(results: List[dict], current_model: str) -> None:
+    """Prepend the active model to its provider row when the row lacks it.
+
+    Membership is alias-aware: the picker dedup folds bare live wire ids into
+    their curated public slug (Kimi Coding's ``k3`` → ``kimi-k3``), so an
+    exact-string check would re-inject the bare id and render the SAME model
+    as two rows ("K3" + "Kimi K3"). Fold both sides through the same
+    canonicalisation the merge uses before deciding to inject.
+    """
+    if not current_model:
+        return
+    try:
+        from hermes_cli.model_search import model_alias_canonical as _canon
+    except Exception:
+        _canon = lambda m: str(m).strip().lower()  # noqa: E731
+    current_key = _canon(current_model)
+    for _row in results:
+        if not _row.get("is_current"):
+            continue
+        _models = _row.get("models") or []
+        if current_key not in {_canon(m) for m in _models}:
+            _row["models"] = [current_model, *_models]
+            _row["total_models"] = _row.get("total_models", len(_models)) + 1
+        break
 
 
 def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:

--- a/tests/hermes_cli/test_model_switch_current_model_inject.py
+++ b/tests/hermes_cli/test_model_switch_current_model_inject.py
@@ -1,0 +1,93 @@
+"""Current-model injection must fold picker-search aliases before membership.
+
+Kimi Coding Plan's flagship is configured/discovered as the bare wire id
+``k3`` while the curated picker catalog carries the public slug ``kimi-k3``
+(the merge dedups ``k3`` into it). The injection post-pass that prepends the
+active model to its provider row must treat them as the same model — an
+exact-string check re-injected the bare id and rendered one model as two
+picker rows ("K3" + "Kimi K3").
+"""
+
+from hermes_cli.model_switch import _inject_current_model_row
+
+
+def _rows(models, *, is_current=True):
+    return [
+        {
+            "slug": "kimi-coding",
+            "is_current": is_current,
+            "models": list(models),
+            "total_models": len(models),
+        }
+    ]
+
+
+class TestAliasAwareMembership:
+    def test_bare_k3_not_injected_when_curated_slug_present(self):
+        rows = _rows(["kimi-k3", "kimi-k2.7-code", "k3-256k"])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["kimi-k3", "kimi-k2.7-code", "k3-256k"]
+        assert rows[0]["total_models"] == 3
+
+    def test_curated_slug_not_injected_when_bare_id_present(self):
+        rows = _rows(["k3", "kimi-k2.7-code"])
+        _inject_current_model_row(rows, "kimi-k3")
+        assert rows[0]["models"] == ["k3", "kimi-k2.7-code"]
+
+    def test_case_insensitive_match(self):
+        rows = _rows(["Kimi-K3"])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["Kimi-K3"]
+
+
+class TestGenuineInjectionStillWorks:
+    def test_uncurated_model_is_prepended(self):
+        rows = _rows(["kimi-k3", "kimi-k2.7-code"])
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert rows[0]["models"] == ["my-custom-kimi", "kimi-k3", "kimi-k2.7-code"]
+        assert rows[0]["total_models"] == 3
+
+    def test_k3_256k_is_not_folded_into_k3(self):
+        # k3-256k is a distinct live id, not an alias of k3.
+        rows = _rows(["kimi-k3"])
+        _inject_current_model_row(rows, "k3-256k")
+        assert rows[0]["models"] == ["k3-256k", "kimi-k3"]
+
+    def test_non_current_row_untouched(self):
+        rows = _rows(["kimi-k3"], is_current=False)
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert rows[0]["models"] == ["kimi-k3"]
+
+    def test_empty_current_model_noop(self):
+        rows = _rows(["kimi-k3"])
+        _inject_current_model_row(rows, "")
+        assert rows[0]["models"] == ["kimi-k3"]
+
+    def test_empty_row_models_still_injects(self):
+        rows = _rows([])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["k3"]
+
+
+class TestNativeCatalogEmptyGuard:
+    def test_empty_native_catalog_row_not_injected(self):
+        # main's native-discovery parity guard (fa1bb88e / #81e81350): a row
+        # whose live catalog is deliberately empty must not receive an
+        # injected uncurated model.
+        rows = _rows([])
+        rows[0]["native_catalog_empty"] = True
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert rows[0]["models"] == []
+        assert rows[0]["total_models"] == 0
+
+    def test_guard_does_not_block_other_current_rows(self):
+        guarded = _rows(["placeholder"])[0]
+        guarded["native_catalog_empty"] = True
+        guarded["slug"] = "guarded-provider"
+        guarded["models"] = []
+        guarded["total_models"] = 0
+        normal = _rows(["kimi-k3"])[0]
+        rows = [guarded, normal]
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert guarded["models"] == []
+        assert normal["models"] == ["my-custom-kimi", "kimi-k3"]

--- a/tests/hermes_cli/test_model_switch_current_model_inject.py
+++ b/tests/hermes_cli/test_model_switch_current_model_inject.py
@@ -1,0 +1,69 @@
+"""Current-model injection must fold picker-search aliases before membership.
+
+Kimi Coding Plan's flagship is configured/discovered as the bare wire id
+``k3`` while the curated picker catalog carries the public slug ``kimi-k3``
+(the merge dedups ``k3`` into it). The injection post-pass that prepends the
+active model to its provider row must treat them as the same model — an
+exact-string check re-injected the bare id and rendered one model as two
+picker rows ("K3" + "Kimi K3").
+"""
+
+from hermes_cli.model_switch import _inject_current_model_row
+
+
+def _rows(models, *, is_current=True):
+    return [
+        {
+            "slug": "kimi-coding",
+            "is_current": is_current,
+            "models": list(models),
+            "total_models": len(models),
+        }
+    ]
+
+
+class TestAliasAwareMembership:
+    def test_bare_k3_not_injected_when_curated_slug_present(self):
+        rows = _rows(["kimi-k3", "kimi-k2.7-code", "k3-256k"])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["kimi-k3", "kimi-k2.7-code", "k3-256k"]
+        assert rows[0]["total_models"] == 3
+
+    def test_curated_slug_not_injected_when_bare_id_present(self):
+        rows = _rows(["k3", "kimi-k2.7-code"])
+        _inject_current_model_row(rows, "kimi-k3")
+        assert rows[0]["models"] == ["k3", "kimi-k2.7-code"]
+
+    def test_case_insensitive_match(self):
+        rows = _rows(["Kimi-K3"])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["Kimi-K3"]
+
+
+class TestGenuineInjectionStillWorks:
+    def test_uncurated_model_is_prepended(self):
+        rows = _rows(["kimi-k3", "kimi-k2.7-code"])
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert rows[0]["models"] == ["my-custom-kimi", "kimi-k3", "kimi-k2.7-code"]
+        assert rows[0]["total_models"] == 3
+
+    def test_k3_256k_is_not_folded_into_k3(self):
+        # k3-256k is a distinct live id, not an alias of k3.
+        rows = _rows(["kimi-k3"])
+        _inject_current_model_row(rows, "k3-256k")
+        assert rows[0]["models"] == ["k3-256k", "kimi-k3"]
+
+    def test_non_current_row_untouched(self):
+        rows = _rows(["kimi-k3"], is_current=False)
+        _inject_current_model_row(rows, "my-custom-kimi")
+        assert rows[0]["models"] == ["kimi-k3"]
+
+    def test_empty_current_model_noop(self):
+        rows = _rows(["kimi-k3"])
+        _inject_current_model_row(rows, "")
+        assert rows[0]["models"] == ["kimi-k3"]
+
+    def test_empty_row_models_still_injects(self):
+        rows = _rows([])
+        _inject_current_model_row(rows, "k3")
+        assert rows[0]["models"] == ["k3"]


### PR DESCRIPTION
## Bug Description

With a Kimi Coding Plan credential and `model.default: k3` (the bare wire id the live `/v1/models` endpoint reports), every model picker renders the flagship twice: **"K3"** and **"Kimi K3"** — two rows, one model.

## Root Cause

The picker catalog merge already dedups the bare live id into the curated public slug via `model_alias_canonical()` (`k3` → `kimi-k3`, from #68153), so `provider_model_ids("kimi-coding")` correctly returns `kimi-k3` only. But the post-pass in `list_authenticated_providers()` that prepends the active model to its provider row used an **exact-string** membership check:

```python
if current_model not in _models:   # "k3" not in ["kimi-k3", ...]  → re-injected
    _row["models"] = [current_model, *_models]
```

The bare id slipped past the dedup through this side door and surfaced as a second row on every surface consuming these rows (CLI / TUI / dashboard / desktop pickers, and the MoA reference/aggregator slot pickers).

## Fix

- Extract the post-pass into `_inject_current_model_row()` and make its membership check alias-aware — both sides folded through the same `model_alias_canonical()` canonicalisation the catalog merge uses.
- Behaviour preserved: genuinely uncurated models (e.g. `/model kimi-coding/my-custom`) are still prepended; distinct live ids (`k3-256k`) are NOT folded into `k3`; only the `is_current` row is touched.

## How to Verify

1. Configure a Kimi Coding Plan key and set `model.default: k3`.
2. Open any model picker → the Kimi row shows both "K3" and "Kimi K3".
3. With this PR: only "Kimi K3" remains, and selecting a custom uncurated id still injects it as before.

## Test Plan

- [x] Added regression test for this bug (`tests/hermes_cli/test_model_switch_current_model_inject.py`, 8 cases: bidirectional fold, case-insensitivity, `k3-256k` not folded, non-current row untouched, genuine injection preserved)
- [x] Existing tests still pass (99 passed: new tests + `test_model_search_alias_dedup` + inventory/model-switch suite)
- [x] Manual verification of the fix (E2E `build_models_payload()` with real credentials: before `['k3', 'kimi-k3', ...]`, after `['kimi-k3', ...]`)

## Risk Assessment

**Low** — one membership check in a picker-only post-pass; no wire ids, config writes, or API shapes change. The injection path is fully covered by the new tests.