### PR TITLE
fix(banner): add TCP preflight check before git fetch to prevent Windows hang

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -238,11 +238,21 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
-            fetch_args,
-            capture_output=True, timeout=10,
-            cwd=str(repo_dir),
-        )
+        # Windows subprocess timeout is unreliable — pre-flight TCP check first.
+        import socket as _socket
+        try:
+            _s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+            _s.settimeout(2)
+            _s.connect(("github.com", 443))
+            _s.close()
+        except Exception:
+            pass  # skip fetch when GitHub is unreachable
+        else:
+            subprocess.run(
+                fetch_args,
+                capture_output=True, timeout=8,
+                cwd=str(repo_dir),
+            )
     except Exception:
         pass  # Offline or timeout — use stale refs, that's fine
 


### PR DESCRIPTION
On Windows, subprocess.run with capture_output=True can hang indefinitely when GitHub is unreachable, even with a timeout set. Add a 2-second TCP socket preflight to github.com:443 before git fetch, skipping the fetch when the host is unreachable.

This prevents `hermes --version` and other update-check commands from hanging on networks where GitHub is blocked.