### PR TITLE
fix: support Chinese spoken stop commands in desktop voice chat

### DIFF
--- a/apps/desktop/src/lib/voice-stop-word.test.ts
+++ b/apps/desktop/src/lib/voice-stop-word.test.ts
@@ -59,6 +59,29 @@ describe('isVoiceStopCommand', () => {
       expect(isVoiceStopCommand(phrase)).toBe(false)
     }
   })
+
+  it('matches Chinese stop commands with and without full-width punctuation', () => {
+    for (const phrase of [
+      '停止', '停止。', '停止！', '停止？', '停止…', '“停止”', '『停止』',
+      '结束对话', '结束对话。', '再见', '再见。', '取消', '取消！'
+    ]) {
+      expect(isVoiceStopCommand(phrase)).toBe(true)
+    }
+  })
+
+  it('matches Chinese stop commands addressed to 小雨 without spaces', () => {
+    for (const phrase of [
+      '你好小雨停止', '你好小雨,停止', '小雨停止', '小雨,停止', '小雨 停止'
+    ]) {
+      expect(isVoiceStopCommand(phrase)).toBe(true)
+    }
+  })
+
+  it('does NOT match Chinese requests that merely contain 停止', () => {
+    for (const phrase of ['停止播放音乐', '怎么停止这个任务', '小雨今天天气怎么样']) {
+      expect(isVoiceStopCommand(phrase)).toBe(false)
+    }
+  })
 })
 
 describe('interceptsTypedVoiceStop', () => {

--- a/apps/desktop/src/lib/voice-stop-word.ts
+++ b/apps/desktop/src/lib/voice-stop-word.ts
@@ -76,8 +76,10 @@ function stripAddress(text: string): string {
     if (text === prefix) {
       continue
     }
+
     if (text.startsWith(prefix)) {
       const rest = text.slice(prefix.length).trim()
+
       if (rest) {
         return rest
       }

--- a/apps/desktop/src/lib/voice-stop-word.ts
+++ b/apps/desktop/src/lib/voice-stop-word.ts
@@ -30,20 +30,32 @@ const STOP_PHRASES: readonly string[] = [
   'goodbye',
   'good bye',
   'bye',
-  'cancel'
+  'cancel',
+  // Chinese equivalents — whisper transcribes these with full-width marks
+  // (停止。 / 停止！) which normalize() below also strips.
+  '停止',
+  '结束对话',
+  '再见',
+  '取消'
 ]
 
 // Optional address prefixes so "hermes stop" / "ok stop" / "hey hermes, stop"
 // still count. Stripped before matching the core phrase.
 const ADDRESS_PREFIXES: readonly string[] = ['hey hermes', 'hey hermes,', 'hermes', 'hermes,', 'ok', 'okay', 'hey']
 
+// Chinese address prefixes are stripped without requiring a trailing space:
+// STT output for Chinese rarely contains spaces (你好小雨停止). ASCII prefixes
+// keep the space requirement so "okay stop" can't be mis-stripped by "ok".
+const CJK_ADDRESS_PREFIXES: readonly string[] = ['你好小雨', '小雨']
+
 // Normalise: lowercase, strip surrounding punctuation/whitespace, collapse
-// internal runs of spaces. Trailing punctuation (".", "!", "…") is common in
-// STT output and must not defeat the match.
+// internal runs of spaces. Trailing punctuation (".", "!", "…", and the
+// full-width 。！？， forms whisper emits for Chinese) is common in STT output
+// and must not defeat the match.
 function normalize(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[.,!?;:…]+/g, ' ')
+    .replace(/[.,!?;:…。，！？；：、”“‘’「」『』（）]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -57,6 +69,18 @@ function stripAddress(text: string): string {
 
     if (text.startsWith(`${prefix} `)) {
       return text.slice(prefix.length + 1).trim()
+    }
+  }
+
+  for (const prefix of CJK_ADDRESS_PREFIXES) {
+    if (text === prefix) {
+      continue
+    }
+    if (text.startsWith(prefix)) {
+      const rest = text.slice(prefix.length).trim()
+      if (rest) {
+        return rest
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

The desktop voice-conversation stop-word matcher (`voice-stop-word.ts`) hardcoded English phrases and only stripped ASCII punctuation. A Chinese "停止" (transcribed by whisper as `停止。`) was therefore submitted as a normal turn and the conversation never ended.

Changes:
- Add Chinese stop phrases: `停止` / `结束对话` / `再见` / `取消`
- Strip full-width punctuation (`。，！？；：、”“‘’「」『』（）`) in `normalize()` — ASCII quotes stay, so contractions like `that's all` still match
- Strip Chinese address prefixes (`你好小雨` / `小雨`) without requiring a trailing space, matching space-less CJK STT output

## Motivation

User with a Chinese wake word ("你好小雨") could not end hands-free voice conversations by voice: every spoken "停止" came back as `停止。` and was sent to the agent as a regular turn.

## Test Plan

- New cases in `voice-stop-word.test.ts`: Chinese stop commands with/without every common full-width mark; space-less addressed forms (`你好小雨停止`, `小雨,停止`); negative cases (`停止播放音乐`, `小雨今天天气怎么样`)
- `vitest run src/lib/voice-stop-word.test.ts`: **13 passed** (10 pre-existing + 3 new groups)
- ESLint on both files: **0 problems**
