### PR TITLE
fix(desktop/review): diff untracked folder rows, and literalize every pathspec

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,18 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewList } from './git-review-ops'
+import {
+  fileDiffVsHead,
+  gitFor,
+  repoStatus,
+  resolveRenamePath,
+  REVIEW_FILE_CAP,
+  reviewDiff,
+  reviewList,
+  reviewRevert,
+  reviewStage,
+  reviewUnstage
+} from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -116,4 +127,280 @@ test('reviewList caps the file payload returned to the renderer', async () => {
   const result = await reviewList(dir, 'uncommitted', null, 'git')
 
   assert.equal(result.files.length, REVIEW_FILE_CAP)
+})
+
+// ── reviewDiff: the click → bottom-panel payload ─────────────────────────────
+// `reviewList` collapses an untracked directory into one `dir/` row (asserted
+// above). Clicking that row used to hand `dir/` to `git diff --no-index --
+// /dev/null dir/`, which pairs the operands as trees, fails looking for
+// `dir/null`, and prints nothing — so the pane rendered "No diff to show"
+// under a fully populated header.
+
+const uncommittedDiff = (dir: string, filePath: string, staged = false) =>
+  reviewDiff(dir, filePath, 'uncommitted', null, staged, 'git')
+
+test('reviewDiff synthesizes an all-add diff for an untracked file', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'fresh.txt'), 'alpha\nbeta\n')
+
+  const diff = await uncommittedDiff(dir, 'fresh.txt')
+
+  assert.match(diff, /\+alpha/)
+  assert.match(diff, /\+beta/)
+})
+
+test('reviewDiff expands an untracked directory into its files', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'newdir', 'sub'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'newdir', 'one.txt'), 'first\n')
+  fs.writeFileSync(path.join(dir, 'newdir', 'sub', 'two.txt'), 'second\n')
+
+  const diff = await uncommittedDiff(dir, 'newdir/')
+
+  assert.notEqual(diff.trim(), '')
+  assert.match(diff, /\+first/)
+  assert.match(diff, /\+second/)
+  // Every file is named, so the renderer can label a multi-file payload.
+  assert.match(diff, /newdir\/one\.txt/)
+  assert.match(diff, /newdir\/sub\/two\.txt/)
+})
+
+test('reviewDiff expands an untracked directory whose path contains spaces', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'Fallout Vault', '20 Projects'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'Fallout Vault', '20 Projects', 'note.md'), 'vault note\n')
+
+  const diff = await uncommittedDiff(dir, 'Fallout Vault/')
+
+  assert.match(diff, /\+vault note/)
+})
+
+test('reviewDiff skips gitignored files when expanding an untracked directory', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, '.gitignore'), '*.log\n')
+  fs.mkdirSync(path.join(dir, 'logs'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'logs', 'keep.txt'), 'kept\n')
+  fs.writeFileSync(path.join(dir, 'logs', 'noisy.log'), 'ignored\n')
+
+  const diff = await uncommittedDiff(dir, 'logs/')
+
+  assert.match(diff, /\+kept/)
+  assert.doesNotMatch(diff, /\+ignored/)
+})
+
+test('reviewDiff caps a huge untracked directory and says what it dropped', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'generated'), { recursive: true })
+
+  for (let i = 0; i < 60; i++) {
+    fs.writeFileSync(path.join(dir, 'generated', `f-${String(i).padStart(3, '0')}.txt`), `line ${i}\n`)
+  }
+
+  const diff = await uncommittedDiff(dir, 'generated/')
+
+  assert.match(diff, /\+line 0/)
+  // Truncation is never silent.
+  assert.match(diff, /10 more file\(s\) omitted/)
+})
+
+test('reviewDiff returns empty for a nested git repo the outer repo cannot see into', async () => {
+  const dir = makeRepo()
+  const nested = path.join(dir, 'nested_repo')
+
+  fs.mkdirSync(nested, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: nested })
+  fs.writeFileSync(path.join(nested, 'inner.txt'), 'inner\n')
+
+  // Opaque to the outer repo — the pane shows the folder empty-state for this,
+  // not the generic "No diff to show".
+  assert.equal(await uncommittedDiff(dir, 'nested_repo/'), '')
+})
+
+test('reviewDiff shows staged AND unstaged changes for a partially staged file', async () => {
+  const dir = makeRepo()
+  const file = path.join(dir, 'tracked.txt')
+
+  fs.writeFileSync(file, 'tracked\nstaged line\n')
+  execFileSync('git', ['add', 'tracked.txt'], { cwd: dir })
+  fs.writeFileSync(file, 'tracked\nstaged line\nunstaged line\n')
+
+  // `staged: true` is what the row reports once anything is in the index; the
+  // row's +/- counts sum both sides, so the diff has to as well.
+  const diff = await uncommittedDiff(dir, 'tracked.txt', true)
+
+  assert.match(diff, /\+staged line/)
+  assert.match(diff, /\+unstaged line/)
+})
+
+test('reviewDiff falls back to the index diff when the repo has no commits yet', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-status-'))
+
+  tempDirs.push(dir)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'hermes-test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'Hermes Test'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'first.txt'), 'first commit pending\n')
+  execFileSync('git', ['add', 'first.txt'], { cwd: dir })
+
+  // No HEAD to diff against — the `--cached` fallback keeps the panel populated.
+  assert.match(await uncommittedDiff(dir, 'first.txt', true), /\+first commit pending/)
+})
+
+test('fileDiffVsHead expands an untracked directory too', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'preview-dir'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'preview-dir', 'a.txt'), 'preview line\n')
+
+  assert.match(await fileDiffVsHead(dir, 'preview-dir/', 'git'), /\+preview line/)
+})
+
+test('fileDiffVsHead still returns empty for a clean tracked file', async () => {
+  const dir = makeRepo()
+
+  assert.equal(await fileDiffVsHead(dir, 'tracked.txt', 'git'), '')
+})
+
+test('reviewDiff shows the real conflict body for an unmerged file', async () => {
+  const dir = makeRepo()
+  const file = path.join(dir, 'tracked.txt')
+  const base = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: dir }).toString().trim()
+
+  execFileSync('git', ['checkout', '-q', '-b', 'other'], { cwd: dir })
+  fs.writeFileSync(file, 'other side\n')
+  execFileSync('git', ['commit', '-qam', 'other'], { cwd: dir })
+  execFileSync('git', ['checkout', '-q', base], { cwd: dir })
+  fs.writeFileSync(file, 'main side\n')
+  execFileSync('git', ['commit', '-qam', 'main'], { cwd: dir })
+
+  try {
+    execFileSync('git', ['merge', 'other'], { cwd: dir, stdio: 'ignore' })
+  } catch {
+    // Conflicts, by design.
+  }
+
+  // An unmerged path reports `staged: true`. `--cached` answers that with the
+  // bare "* Unmerged path" stub — no hunks, so the panel rendered one useless
+  // line. HEAD..worktree carries the actual conflict.
+  const diff = await uncommittedDiff(dir, 'tracked.txt', true)
+
+  assert.match(diff, /<<<<<<< HEAD/)
+  assert.match(diff, /other side/)
+})
+
+// A filename containing pathspec wildcards is matched as a GLOB by default, so
+// `weird[1].txt` also selects `weird1.txt`. That leaked across every git call in
+// this module: reads showed the wrong file's body, and the mutations changed the
+// wrong file on disk. The decoy here is TRACKED and MODIFIED - the nastiest
+// shape, with a real worktree diff to leak and real edits to destroy.
+function makeGlobRepo() {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'neighbour original\n')
+  execFileSync('git', ['add', 'weird1.txt'], { cwd: dir })
+  execFileSync('git', ['commit', '-qm', 'add neighbour'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'neighbour MODIFIED\n')
+  fs.writeFileSync(path.join(dir, 'weird[1].txt'), 'clicked file\n')
+
+  return dir
+}
+
+test('reviewDiff does not pull in neighbours of a file whose name looks like a glob', async () => {
+  const dir = makeGlobRepo()
+
+  // Without --literal-pathspecs the worktree probe `git diff -- weird[1].txt`
+  // returns the TRACKED neighbour's diff, so the pane renders a file the user
+  // never clicked.
+  const diff = await uncommittedDiff(dir, 'weird[1].txt')
+
+  assert.match(diff, /\+clicked file/)
+  assert.doesNotMatch(diff, /neighbour MODIFIED/)
+  assert.doesNotMatch(diff, /weird1\.txt/)
+})
+
+test('fileDiffVsHead does not pull in glob neighbours either', async () => {
+  const dir = makeGlobRepo()
+  const diff = await fileDiffVsHead(dir, 'weird[1].txt', 'git')
+
+  assert.match(diff, /\+clicked file/)
+  assert.doesNotMatch(diff, /neighbour MODIFIED/)
+})
+
+test('reviewStage stages only the selected file, not its glob neighbours', async () => {
+  const dir = makeGlobRepo()
+
+  await reviewStage(dir, 'weird[1].txt', 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  assert.match(staged, /weird\[1\]\.txt/)
+  assert.doesNotMatch(staged, /^weird1\.txt$/m)
+})
+
+test('reviewUnstage unstages only the selected file, not its glob neighbours', async () => {
+  const dir = makeGlobRepo()
+
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+  await reviewUnstage(dir, 'weird[1].txt', 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  // The neighbour must stay staged; only the clicked file comes back out.
+  assert.match(staged, /^weird1\.txt$/m)
+  assert.doesNotMatch(staged, /weird\[1\]\.txt/)
+})
+
+test('reviewRevert does not discard edits to a glob neighbour', async () => {
+  const dir = makeGlobRepo()
+
+  // The destructive one: `git checkout HEAD -- 'weird[1].txt'` also restored
+  // weird1.txt, silently throwing away the user's uncommitted edits.
+  await reviewRevert(dir, 'weird[1].txt', 'git')
+
+  assert.equal(fs.readFileSync(path.join(dir, 'weird1.txt'), 'utf8'), 'neighbour MODIFIED\n')
+  assert.equal(fs.existsSync(path.join(dir, 'weird[1].txt')), false)
+})
+
+// The `filePath === null` variants take a different argv shape now that
+// LITERAL_PATHSPECS leads every mutation ("stage all" / "unstage all" /
+// "revert all" carry no pathspec at all, or the bare `.`).
+test('reviewStage with no path stages everything', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  fs.writeFileSync(path.join(dir, 'brand-new.txt'), 'new\n')
+  await reviewStage(dir, null, 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  assert.match(staged, /tracked\.txt/)
+  assert.match(staged, /brand-new\.txt/)
+})
+
+test('reviewUnstage with no path unstages everything', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+  await reviewUnstage(dir, null, 'git')
+
+  assert.equal(execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString().trim(), '')
+})
+
+test('reviewRevert with no path restores tracked files and removes untracked ones', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  fs.writeFileSync(path.join(dir, 'brand-new.txt'), 'new\n')
+  await reviewRevert(dir, null, 'git')
+
+  // Checkout re-materializes the file through git's eol filters, so compare
+  // content rather than bytes (core.autocrlf turns this into CRLF on Windows).
+  assert.equal(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8').replace(/\r\n/g, '\n'), 'tracked\n')
+  assert.equal(fs.existsSync(path.join(dir, 'brand-new.txt')), false)
 })

--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -365,3 +365,42 @@ test('reviewRevert does not discard edits to a glob neighbour', async () => {
   assert.equal(fs.readFileSync(path.join(dir, 'weird1.txt'), 'utf8'), 'neighbour MODIFIED\n')
   assert.equal(fs.existsSync(path.join(dir, 'weird[1].txt')), false)
 })
+
+// The `filePath === null` variants take a different argv shape now that
+// LITERAL_PATHSPECS leads every mutation ("stage all" / "unstage all" /
+// "revert all" carry no pathspec at all, or the bare `.`).
+test('reviewStage with no path stages everything', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  fs.writeFileSync(path.join(dir, 'brand-new.txt'), 'new\n')
+  await reviewStage(dir, null, 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  assert.match(staged, /tracked\.txt/)
+  assert.match(staged, /brand-new\.txt/)
+})
+
+test('reviewUnstage with no path unstages everything', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+  await reviewUnstage(dir, null, 'git')
+
+  assert.equal(execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString().trim(), '')
+})
+
+test('reviewRevert with no path restores tracked files and removes untracked ones', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'edited\n')
+  fs.writeFileSync(path.join(dir, 'brand-new.txt'), 'new\n')
+  await reviewRevert(dir, null, 'git')
+
+  // Checkout re-materializes the file through git's eol filters, so compare
+  // content rather than bytes (core.autocrlf turns this into CRLF on Windows).
+  assert.equal(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8').replace(/\r\n/g, '\n'), 'tracked\n')
+  assert.equal(fs.existsSync(path.join(dir, 'brand-new.txt')), false)
+})

--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,15 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewList } from './git-review-ops'
+import {
+  fileDiffVsHead,
+  gitFor,
+  repoStatus,
+  resolveRenamePath,
+  REVIEW_FILE_CAP,
+  reviewDiff,
+  reviewList
+} from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -116,4 +124,181 @@ test('reviewList caps the file payload returned to the renderer', async () => {
   const result = await reviewList(dir, 'uncommitted', null, 'git')
 
   assert.equal(result.files.length, REVIEW_FILE_CAP)
+})
+
+// ── reviewDiff: the click → bottom-panel payload ─────────────────────────────
+// `reviewList` collapses an untracked directory into one `dir/` row (asserted
+// above). Clicking that row used to hand `dir/` to `git diff --no-index --
+// /dev/null dir/`, which pairs the operands as trees, fails looking for
+// `dir/null`, and prints nothing — so the pane rendered "No diff to show"
+// under a fully populated header.
+
+const uncommittedDiff = (dir: string, filePath: string, staged = false) =>
+  reviewDiff(dir, filePath, 'uncommitted', null, staged, 'git')
+
+test('reviewDiff synthesizes an all-add diff for an untracked file', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'fresh.txt'), 'alpha\nbeta\n')
+
+  const diff = await uncommittedDiff(dir, 'fresh.txt')
+
+  assert.match(diff, /\+alpha/)
+  assert.match(diff, /\+beta/)
+})
+
+test('reviewDiff expands an untracked directory into its files', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'newdir', 'sub'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'newdir', 'one.txt'), 'first\n')
+  fs.writeFileSync(path.join(dir, 'newdir', 'sub', 'two.txt'), 'second\n')
+
+  const diff = await uncommittedDiff(dir, 'newdir/')
+
+  assert.notEqual(diff.trim(), '')
+  assert.match(diff, /\+first/)
+  assert.match(diff, /\+second/)
+  // Every file is named, so the renderer can label a multi-file payload.
+  assert.match(diff, /newdir\/one\.txt/)
+  assert.match(diff, /newdir\/sub\/two\.txt/)
+})
+
+test('reviewDiff expands an untracked directory whose path contains spaces', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'Fallout Vault', '20 Projects'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'Fallout Vault', '20 Projects', 'note.md'), 'vault note\n')
+
+  const diff = await uncommittedDiff(dir, 'Fallout Vault/')
+
+  assert.match(diff, /\+vault note/)
+})
+
+test('reviewDiff skips gitignored files when expanding an untracked directory', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, '.gitignore'), '*.log\n')
+  fs.mkdirSync(path.join(dir, 'logs'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'logs', 'keep.txt'), 'kept\n')
+  fs.writeFileSync(path.join(dir, 'logs', 'noisy.log'), 'ignored\n')
+
+  const diff = await uncommittedDiff(dir, 'logs/')
+
+  assert.match(diff, /\+kept/)
+  assert.doesNotMatch(diff, /\+ignored/)
+})
+
+test('reviewDiff caps a huge untracked directory and says what it dropped', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'generated'), { recursive: true })
+
+  for (let i = 0; i < 60; i++) {
+    fs.writeFileSync(path.join(dir, 'generated', `f-${String(i).padStart(3, '0')}.txt`), `line ${i}\n`)
+  }
+
+  const diff = await uncommittedDiff(dir, 'generated/')
+
+  assert.match(diff, /\+line 0/)
+  // Truncation is never silent.
+  assert.match(diff, /10 more file\(s\) omitted/)
+})
+
+test('reviewDiff returns empty for a nested git repo the outer repo cannot see into', async () => {
+  const dir = makeRepo()
+  const nested = path.join(dir, 'nested_repo')
+
+  fs.mkdirSync(nested, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: nested })
+  fs.writeFileSync(path.join(nested, 'inner.txt'), 'inner\n')
+
+  // Opaque to the outer repo — the pane shows the folder empty-state for this,
+  // not the generic "No diff to show".
+  assert.equal(await uncommittedDiff(dir, 'nested_repo/'), '')
+})
+
+test('reviewDiff shows staged AND unstaged changes for a partially staged file', async () => {
+  const dir = makeRepo()
+  const file = path.join(dir, 'tracked.txt')
+
+  fs.writeFileSync(file, 'tracked\nstaged line\n')
+  execFileSync('git', ['add', 'tracked.txt'], { cwd: dir })
+  fs.writeFileSync(file, 'tracked\nstaged line\nunstaged line\n')
+
+  // `staged: true` is what the row reports once anything is in the index; the
+  // row's +/- counts sum both sides, so the diff has to as well.
+  const diff = await uncommittedDiff(dir, 'tracked.txt', true)
+
+  assert.match(diff, /\+staged line/)
+  assert.match(diff, /\+unstaged line/)
+})
+
+test('reviewDiff falls back to the index diff when the repo has no commits yet', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-status-'))
+
+  tempDirs.push(dir)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'hermes-test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'Hermes Test'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'first.txt'), 'first commit pending\n')
+  execFileSync('git', ['add', 'first.txt'], { cwd: dir })
+
+  // No HEAD to diff against — the `--cached` fallback keeps the panel populated.
+  assert.match(await uncommittedDiff(dir, 'first.txt', true), /\+first commit pending/)
+})
+
+test('fileDiffVsHead expands an untracked directory too', async () => {
+  const dir = makeRepo()
+
+  fs.mkdirSync(path.join(dir, 'preview-dir'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'preview-dir', 'a.txt'), 'preview line\n')
+
+  assert.match(await fileDiffVsHead(dir, 'preview-dir/', 'git'), /\+preview line/)
+})
+
+test('fileDiffVsHead still returns empty for a clean tracked file', async () => {
+  const dir = makeRepo()
+
+  assert.equal(await fileDiffVsHead(dir, 'tracked.txt', 'git'), '')
+})
+
+test('reviewDiff shows the real conflict body for an unmerged file', async () => {
+  const dir = makeRepo()
+  const file = path.join(dir, 'tracked.txt')
+  const base = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: dir }).toString().trim()
+
+  execFileSync('git', ['checkout', '-q', '-b', 'other'], { cwd: dir })
+  fs.writeFileSync(file, 'other side\n')
+  execFileSync('git', ['commit', '-qam', 'other'], { cwd: dir })
+  execFileSync('git', ['checkout', '-q', base], { cwd: dir })
+  fs.writeFileSync(file, 'main side\n')
+  execFileSync('git', ['commit', '-qam', 'main'], { cwd: dir })
+
+  try {
+    execFileSync('git', ['merge', 'other'], { cwd: dir, stdio: 'ignore' })
+  } catch {
+    // Conflicts, by design.
+  }
+
+  // An unmerged path reports `staged: true`. `--cached` answers that with the
+  // bare "* Unmerged path" stub — no hunks, so the panel rendered one useless
+  // line. HEAD..worktree carries the actual conflict.
+  const diff = await uncommittedDiff(dir, 'tracked.txt', true)
+
+  assert.match(diff, /<<<<<<< HEAD/)
+  assert.match(diff, /other side/)
+})
+
+test('reviewDiff does not pull in neighbours of a file whose name looks like a glob', async () => {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'weird[1].txt'), 'clicked file\n')
+  // Matches the GLOB `weird[1].txt`, so a non-literal pathspec would sweep it in.
+  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'DECOY neighbour\n')
+
+  const diff = await uncommittedDiff(dir, 'weird[1].txt')
+
+  assert.match(diff, /\+clicked file/)
+  assert.doesNotMatch(diff, /DECOY neighbour/)
 })

--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -13,7 +13,10 @@ import {
   resolveRenamePath,
   REVIEW_FILE_CAP,
   reviewDiff,
-  reviewList
+  reviewList,
+  reviewRevert,
+  reviewStage,
+  reviewUnstage
 } from './git-review-ops'
 
 const tempDirs: string[] = []
@@ -290,15 +293,75 @@ test('reviewDiff shows the real conflict body for an unmerged file', async () =>
   assert.match(diff, /other side/)
 })
 
-test('reviewDiff does not pull in neighbours of a file whose name looks like a glob', async () => {
+// A filename containing pathspec wildcards is matched as a GLOB by default, so
+// `weird[1].txt` also selects `weird1.txt`. That leaked across every git call in
+// this module: reads showed the wrong file's body, and the mutations changed the
+// wrong file on disk. The decoy here is TRACKED and MODIFIED - the nastiest
+// shape, with a real worktree diff to leak and real edits to destroy.
+function makeGlobRepo() {
   const dir = makeRepo()
 
+  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'neighbour original\n')
+  execFileSync('git', ['add', 'weird1.txt'], { cwd: dir })
+  execFileSync('git', ['commit', '-qm', 'add neighbour'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'neighbour MODIFIED\n')
   fs.writeFileSync(path.join(dir, 'weird[1].txt'), 'clicked file\n')
-  // Matches the GLOB `weird[1].txt`, so a non-literal pathspec would sweep it in.
-  fs.writeFileSync(path.join(dir, 'weird1.txt'), 'DECOY neighbour\n')
 
+  return dir
+}
+
+test('reviewDiff does not pull in neighbours of a file whose name looks like a glob', async () => {
+  const dir = makeGlobRepo()
+
+  // Without --literal-pathspecs the worktree probe `git diff -- weird[1].txt`
+  // returns the TRACKED neighbour's diff, so the pane renders a file the user
+  // never clicked.
   const diff = await uncommittedDiff(dir, 'weird[1].txt')
 
   assert.match(diff, /\+clicked file/)
-  assert.doesNotMatch(diff, /DECOY neighbour/)
+  assert.doesNotMatch(diff, /neighbour MODIFIED/)
+  assert.doesNotMatch(diff, /weird1\.txt/)
+})
+
+test('fileDiffVsHead does not pull in glob neighbours either', async () => {
+  const dir = makeGlobRepo()
+  const diff = await fileDiffVsHead(dir, 'weird[1].txt', 'git')
+
+  assert.match(diff, /\+clicked file/)
+  assert.doesNotMatch(diff, /neighbour MODIFIED/)
+})
+
+test('reviewStage stages only the selected file, not its glob neighbours', async () => {
+  const dir = makeGlobRepo()
+
+  await reviewStage(dir, 'weird[1].txt', 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  assert.match(staged, /weird\[1\]\.txt/)
+  assert.doesNotMatch(staged, /^weird1\.txt$/m)
+})
+
+test('reviewUnstage unstages only the selected file, not its glob neighbours', async () => {
+  const dir = makeGlobRepo()
+
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+  await reviewUnstage(dir, 'weird[1].txt', 'git')
+
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir }).toString()
+
+  // The neighbour must stay staged; only the clicked file comes back out.
+  assert.match(staged, /^weird1\.txt$/m)
+  assert.doesNotMatch(staged, /weird\[1\]\.txt/)
+})
+
+test('reviewRevert does not discard edits to a glob neighbour', async () => {
+  const dir = makeGlobRepo()
+
+  // The destructive one: `git checkout HEAD -- 'weird[1].txt'` also restored
+  // weird1.txt, silently throwing away the user's uncommitted edits.
+  await reviewRevert(dir, 'weird[1].txt', 'git')
+
+  assert.equal(fs.readFileSync(path.join(dir, 'weird1.txt'), 'utf8'), 'neighbour MODIFIED\n')
+  assert.equal(fs.existsSync(path.join(dir, 'weird[1].txt')), false)
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -17,6 +17,25 @@ const COMMIT_CONTEXT_UNTRACKED_MAX = 80
 const REVIEW_FILE_CAP = 2_000
 const UNTRACKED_LINE_COUNT_CONCURRENCY = 16
 const UNTRACKED_LINE_COUNT_MAX_BYTES = 1024 * 1024
+// An untracked directory arrives as ONE row, so opening it can mean diffing an
+// unbounded subtree (a build output, a browser profile). Cap the expansion.
+const UNTRACKED_DIR_FILE_CAP = 50
+const UNTRACKED_LIST_MAX_BYTES = 4 * 1024 * 1024
+
+// EVERY pathspec this module hands git is a literal path that came out of
+// `git status` — never a glob the user typed. Without this flag a real filename
+// containing pathspec wildcards (`weird[1].txt`) also matches its neighbours
+// (`weird1.txt`), so the pane showed a different file's diff and — far worse —
+// `add` / `reset` / `checkout` / `clean` mutated files the user never selected
+// (`checkout HEAD -- 'weird[1].txt'` silently discarded edits to `weird1.txt`).
+//
+// It has to LEAD the argv: git rejects `--literal-pathspecs` after the
+// subcommand, which is why the pathspec-taking reads go through `raw()` rather
+// than simple-git's typed `.diff()`. It deliberately is NOT set via simple-git's
+// `.env()` either: that REPLACES the child environment instead of merging it,
+// which would strip the PATH this file works hard to keep alive for
+// GUI-launched Electron (plus HOME, and with it the user's gitconfig).
+const LITERAL_PATHSPECS = '--literal-pathspecs'
 
 // GUI-launched Electron apps on macOS inherit only a minimal PATH (no
 // /opt/homebrew/bin or /usr/local/bin), so `gh` — and the `git` gh shells out
@@ -325,7 +344,93 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
   }
 }
 
-async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
+// All-add diff for ONE untracked file. `--no-index` exits non-zero by design
+// when the two sides differ, so go around simple-git's reject-on-nonzero with a
+// raw execFile and read stdout.
+function synthesizeAddDiff(cwd, gitBin, filePath): Promise<string> {
+  return new Promise(resolve => {
+    execFile(
+      gitBin || 'git',
+      ['diff', '--no-index', '--', '/dev/null', filePath],
+      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
+      (_err, stdout) => resolve(String(stdout || ''))
+    )
+  })
+}
+
+// The untracked paths git reports under `pathspec`. Resolved through git rather
+// than a filesystem walk so .gitignore is honored and the enumeration can never
+// escape the repo. An untracked FILE resolves to itself; an untracked DIRECTORY
+// resolves to its descendants; a nested git repo stays opaque and resolves to
+// the `dir/` row itself (nothing to expand).
+//
+// Bounded by maxBuffer rather than buffered whole: the point of listing with
+// `--untracked-files=normal` is that an untracked tree can be a browser profile
+// with hundreds of thousands of entries, and expanding one on click shouldn't
+// re-introduce that cost. On overflow node kills git and hands back truncated
+// stdout, which still fills the capped preview.
+function untrackedPathsUnder(cwd, gitBin, pathspec): Promise<string[]> {
+  return new Promise(resolve => {
+    execFile(
+      gitBin || 'git',
+      [LITERAL_PATHSPECS, 'ls-files', '--others', '--exclude-standard', '-z', '--', pathspec],
+      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: UNTRACKED_LIST_MAX_BYTES },
+      (_err, stdout) => {
+        const parts = String(stdout || '').split('\0')
+
+        // Entries are NUL-TERMINATED, so the tail is either '' (complete run)
+        // or a half-written path (truncated run). Neither is a usable entry.
+        parts.pop()
+
+        resolve(parts.filter(Boolean))
+      }
+    )
+  })
+}
+
+// All-add diff for an untracked row, which may be a file OR a directory.
+// `git status --untracked-files=normal` deliberately collapses an untracked
+// directory into a single `dir/` row (keeping generated trees from flooding the
+// pane), but `git diff --no-index -- /dev/null dir/` can't diff that: it pairs
+// the operands as trees and fails looking for `dir/null`, printing nothing to
+// stdout. That left the pane rendering "No diff to show" under a fully
+// populated header. Expand the row to the files git actually sees underneath
+// and concatenate their all-add diffs into one multi-file payload.
+async function untrackedDiff(cwd, gitBin, filePath): Promise<string> {
+  const entries = await untrackedPathsUnder(cwd, gitBin, filePath)
+
+  // A plain untracked file resolves to itself — the common case, one diff.
+  if (entries.length === 1 && entries[0] === filePath) {
+    return synthesizeAddDiff(cwd, gitBin, filePath)
+  }
+
+  // Entries that keep a trailing slash are opaque to this repo (a nested git
+  // repo); there is no file to synthesize a diff from.
+  const files = entries.filter(entry => !entry.endsWith('/'))
+
+  if (files.length === 0) {
+    return ''
+  }
+
+  const visible = files.slice(0, UNTRACKED_DIR_FILE_CAP)
+  const diffs = []
+
+  for (let i = 0; i < visible.length; i += UNTRACKED_LINE_COUNT_CONCURRENCY) {
+    diffs.push(
+      ...(await Promise.all(
+        visible.slice(i, i + UNTRACKED_LINE_COUNT_CONCURRENCY).map(entry => synthesizeAddDiff(cwd, gitBin, entry))
+      ))
+    )
+  }
+
+  const omitted = files.length - visible.length
+  const body = diffs.filter(Boolean).join('')
+
+  // Never truncate silently — the reader has to know the view is partial.
+  return omitted > 0 ? `${body}# ${omitted} more file(s) omitted\n` : body
+}
+
+async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin): Promise<string> {
   let cwd
 
   try {
@@ -335,7 +440,8 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
   }
 
   const git = gitFor(cwd, gitBin)
-  const safe = args => git.diff(args).catch(() => '')
+  // `raw` rather than `.diff()` so LITERAL_PATHSPECS can lead the argv.
+  const safe = args => git.raw([LITERAL_PATHSPECS, 'diff', ...args]).catch(() => '')
 
   if (scope === 'branch') {
     const base = await branchBase(git)
@@ -348,6 +454,17 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
   }
 
   if (staged) {
+    // The row's +/- sums the staged AND unstaged churn for this path, so the
+    // diff has to cover both: HEAD..worktree is the whole story. `--cached`
+    // alone silently dropped the unstaged half of a partially-staged file.
+    // Fall back to the index-only diff in a repo with no commits yet, where
+    // there is no HEAD to diff against.
+    const combined = await safe(['HEAD', '--', filePath])
+
+    if (combined.trim()) {
+      return combined
+    }
+
     return safe(['--cached', '--', filePath])
   }
 
@@ -357,24 +474,14 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
     return worktree
   }
 
-  // Untracked file: no worktree diff exists, so synthesize an all-add diff via
-  // --no-index (exits non-zero by design when files differ, so go around
-  // simple-git's reject-on-nonzero with a raw execFile).
-  return new Promise(resolve => {
-    execFile(
-      gitBin || 'git',
-      ['diff', '--no-index', '--', '/dev/null', filePath],
-      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
-      (_err, stdout) => resolve(String(stdout || ''))
-    )
-  })
+  return untrackedDiff(cwd, gitBin, filePath)
 }
 
 // Working-tree-vs-HEAD diff for ONE file — the "what changed since the last
 // commit" view used by the file preview. Unlike reviewDiff this never synthesizes
 // a full-add for a clean tracked file (so a pristine file shows no diff); it only
 // all-adds a genuinely untracked file.
-async function fileDiffVsHead(repoPath, filePath, gitBin) {
+async function fileDiffVsHead(repoPath, filePath, gitBin): Promise<string> {
   let cwd
 
   try {
@@ -384,7 +491,7 @@ async function fileDiffVsHead(repoPath, filePath, gitBin) {
   }
 
   const git = gitFor(cwd, gitBin)
-  const head = await git.diff(['HEAD', '--', filePath]).catch(() => '')
+  const head = await git.raw([LITERAL_PATHSPECS, 'diff', 'HEAD', '--', filePath]).catch(() => '')
 
   if (head.trim()) {
     return head
@@ -392,26 +499,21 @@ async function fileDiffVsHead(repoPath, filePath, gitBin) {
 
   // No tracked changes vs HEAD. Only synthesize an all-add diff for a file git
   // doesn't know yet; a clean tracked file must return empty.
-  const status = await git.raw(['status', '--porcelain', '--', filePath]).catch(() => '')
+  const status = await git.raw([LITERAL_PATHSPECS, 'status', '--porcelain', '--', filePath]).catch(() => '')
 
   if (!status.trim().startsWith('??')) {
     return ''
   }
 
-  return new Promise(resolve => {
-    execFile(
-      gitBin || 'git',
-      ['diff', '--no-index', '--', '/dev/null', filePath],
-      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
-      (_err, stdout) => resolve(String(stdout || ''))
-    )
-  })
+  // Same directory caveat as reviewDiff: an untracked row can be a collapsed
+  // directory, which --no-index cannot diff against /dev/null.
+  return untrackedDiff(cwd, gitBin, filePath)
 }
 
 async function reviewStage(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review stage' })
 
-  await gitFor(cwd, gitBin).raw(filePath ? ['add', '--', filePath] : ['add', '-A'])
+  await gitFor(cwd, gitBin).raw([LITERAL_PATHSPECS, 'add', ...(filePath ? ['--', filePath] : ['-A'])])
 
   return { ok: true }
 }
@@ -419,7 +521,7 @@ async function reviewStage(repoPath, filePath, gitBin) {
 async function reviewUnstage(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review unstage' })
 
-  await gitFor(cwd, gitBin).raw(filePath ? ['reset', '-q', 'HEAD', '--', filePath] : ['reset', '-q', 'HEAD'])
+  await gitFor(cwd, gitBin).raw([LITERAL_PATHSPECS, 'reset', '-q', 'HEAD', ...(filePath ? ['--', filePath] : [])])
 
   return { ok: true }
 }
@@ -431,11 +533,11 @@ async function reviewRevert(repoPath, filePath, gitBin) {
   const git = gitFor(cwd, gitBin)
 
   if (filePath) {
-    await git.raw(['checkout', 'HEAD', '--', filePath]).catch(() => undefined)
-    await git.raw(['clean', '-fd', '--', filePath]).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'checkout', 'HEAD', '--', filePath]).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'clean', '-fd', '--', filePath]).catch(() => undefined)
   } else {
-    await git.raw(['checkout', 'HEAD', '--', '.']).catch(() => undefined)
-    await git.raw(['clean', '-fd']).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'checkout', 'HEAD', '--', '.']).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'clean', '-fd']).catch(() => undefined)
   }
 
   return { ok: true }

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -17,6 +17,9 @@ const COMMIT_CONTEXT_UNTRACKED_MAX = 80
 const REVIEW_FILE_CAP = 2_000
 const UNTRACKED_LINE_COUNT_CONCURRENCY = 16
 const UNTRACKED_LINE_COUNT_MAX_BYTES = 1024 * 1024
+// An untracked directory arrives as ONE row, so opening it can mean diffing an
+// unbounded subtree (a build output, a browser profile). Cap the expansion.
+const UNTRACKED_DIR_FILE_CAP = 50
 
 // GUI-launched Electron apps on macOS inherit only a minimal PATH (no
 // /opt/homebrew/bin or /usr/local/bin), so `gh` — and the `git` gh shells out
@@ -325,7 +328,82 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
   }
 }
 
-async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
+// All-add diff for ONE untracked file. `--no-index` exits non-zero by design
+// when the two sides differ, so go around simple-git's reject-on-nonzero with a
+// raw execFile and read stdout.
+function synthesizeAddDiff(cwd, gitBin, filePath): Promise<string> {
+  return new Promise(resolve => {
+    execFile(
+      gitBin || 'git',
+      ['diff', '--no-index', '--', '/dev/null', filePath],
+      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
+      (_err, stdout) => resolve(String(stdout || ''))
+    )
+  })
+}
+
+// The untracked paths git reports under `pathspec`. Resolved through git rather
+// than a filesystem walk so .gitignore is honored and the enumeration can never
+// escape the repo. An untracked FILE resolves to itself; an untracked DIRECTORY
+// resolves to its descendants; a nested git repo stays opaque and resolves to
+// the `dir/` row itself (nothing to expand).
+// `--literal-pathspecs` because these paths come from `git status`, not from a
+// user typing a glob: without it a real filename containing pathspec wildcards
+// (`weird[1].txt`) also matches its neighbours (`weird1.txt`), which would pull
+// files the user never clicked into the payload.
+async function untrackedPathsUnder(git, pathspec): Promise<string[]> {
+  const raw = await git
+    .raw(['--literal-pathspecs', 'ls-files', '--others', '--exclude-standard', '-z', '--', pathspec])
+    .catch(() => '')
+
+  return String(raw || '')
+    .split('\0')
+    .filter(Boolean)
+}
+
+// All-add diff for an untracked row, which may be a file OR a directory.
+// `git status --untracked-files=normal` deliberately collapses an untracked
+// directory into a single `dir/` row (keeping generated trees from flooding the
+// pane), but `git diff --no-index -- /dev/null dir/` can't diff that: it pairs
+// the operands as trees and fails looking for `dir/null`, printing nothing to
+// stdout. That left the pane rendering "No diff to show" under a fully
+// populated header. Expand the row to the files git actually sees underneath
+// and concatenate their all-add diffs into one multi-file payload.
+async function untrackedDiff(cwd, git, gitBin, filePath): Promise<string> {
+  const entries = await untrackedPathsUnder(git, filePath)
+
+  // A plain untracked file resolves to itself — the common case, one diff.
+  if (entries.length === 1 && entries[0] === filePath) {
+    return synthesizeAddDiff(cwd, gitBin, filePath)
+  }
+
+  // Entries that keep a trailing slash are opaque to this repo (a nested git
+  // repo); there is no file to synthesize a diff from.
+  const files = entries.filter(entry => !entry.endsWith('/'))
+
+  if (files.length === 0) {
+    return ''
+  }
+
+  const visible = files.slice(0, UNTRACKED_DIR_FILE_CAP)
+  const diffs = []
+
+  for (let i = 0; i < visible.length; i += UNTRACKED_LINE_COUNT_CONCURRENCY) {
+    diffs.push(
+      ...(await Promise.all(
+        visible.slice(i, i + UNTRACKED_LINE_COUNT_CONCURRENCY).map(entry => synthesizeAddDiff(cwd, gitBin, entry))
+      ))
+    )
+  }
+
+  const omitted = files.length - visible.length
+  const body = diffs.filter(Boolean).join('')
+
+  // Never truncate silently — the reader has to know the view is partial.
+  return omitted > 0 ? `${body}# ${omitted} more file(s) omitted\n` : body
+}
+
+async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin): Promise<string> {
   let cwd
 
   try {
@@ -348,6 +426,17 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
   }
 
   if (staged) {
+    // The row's +/- sums the staged AND unstaged churn for this path, so the
+    // diff has to cover both: HEAD..worktree is the whole story. `--cached`
+    // alone silently dropped the unstaged half of a partially-staged file.
+    // Fall back to the index-only diff in a repo with no commits yet, where
+    // there is no HEAD to diff against.
+    const combined = await safe(['HEAD', '--', filePath])
+
+    if (combined.trim()) {
+      return combined
+    }
+
     return safe(['--cached', '--', filePath])
   }
 
@@ -357,24 +446,14 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
     return worktree
   }
 
-  // Untracked file: no worktree diff exists, so synthesize an all-add diff via
-  // --no-index (exits non-zero by design when files differ, so go around
-  // simple-git's reject-on-nonzero with a raw execFile).
-  return new Promise(resolve => {
-    execFile(
-      gitBin || 'git',
-      ['diff', '--no-index', '--', '/dev/null', filePath],
-      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
-      (_err, stdout) => resolve(String(stdout || ''))
-    )
-  })
+  return untrackedDiff(cwd, git, gitBin, filePath)
 }
 
 // Working-tree-vs-HEAD diff for ONE file — the "what changed since the last
 // commit" view used by the file preview. Unlike reviewDiff this never synthesizes
 // a full-add for a clean tracked file (so a pristine file shows no diff); it only
 // all-adds a genuinely untracked file.
-async function fileDiffVsHead(repoPath, filePath, gitBin) {
+async function fileDiffVsHead(repoPath, filePath, gitBin): Promise<string> {
   let cwd
 
   try {
@@ -398,14 +477,9 @@ async function fileDiffVsHead(repoPath, filePath, gitBin) {
     return ''
   }
 
-  return new Promise(resolve => {
-    execFile(
-      gitBin || 'git',
-      ['diff', '--no-index', '--', '/dev/null', filePath],
-      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 32 * 1024 * 1024 },
-      (_err, stdout) => resolve(String(stdout || ''))
-    )
-  })
+  // Same directory caveat as reviewDiff: an untracked row can be a collapsed
+  // directory, which --no-index cannot diff against /dev/null.
+  return untrackedDiff(cwd, git, gitBin, filePath)
 }
 
 async function reviewStage(repoPath, filePath, gitBin) {

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -20,6 +20,22 @@ const UNTRACKED_LINE_COUNT_MAX_BYTES = 1024 * 1024
 // An untracked directory arrives as ONE row, so opening it can mean diffing an
 // unbounded subtree (a build output, a browser profile). Cap the expansion.
 const UNTRACKED_DIR_FILE_CAP = 50
+const UNTRACKED_LIST_MAX_BYTES = 4 * 1024 * 1024
+
+// EVERY pathspec this module hands git is a literal path that came out of
+// `git status` — never a glob the user typed. Without this flag a real filename
+// containing pathspec wildcards (`weird[1].txt`) also matches its neighbours
+// (`weird1.txt`), so the pane showed a different file's diff and — far worse —
+// `add` / `reset` / `checkout` / `clean` mutated files the user never selected
+// (`checkout HEAD -- 'weird[1].txt'` silently discarded edits to `weird1.txt`).
+//
+// It has to LEAD the argv: git rejects `--literal-pathspecs` after the
+// subcommand, which is why the pathspec-taking reads go through `raw()` rather
+// than simple-git's typed `.diff()`. It deliberately is NOT set via simple-git's
+// `.env()` either: that REPLACES the child environment instead of merging it,
+// which would strip the PATH this file works hard to keep alive for
+// GUI-launched Electron (plus HOME, and with it the user's gitconfig).
+const LITERAL_PATHSPECS = '--literal-pathspecs'
 
 // GUI-launched Electron apps on macOS inherit only a minimal PATH (no
 // /opt/homebrew/bin or /usr/local/bin), so `gh` — and the `git` gh shells out
@@ -347,18 +363,29 @@ function synthesizeAddDiff(cwd, gitBin, filePath): Promise<string> {
 // escape the repo. An untracked FILE resolves to itself; an untracked DIRECTORY
 // resolves to its descendants; a nested git repo stays opaque and resolves to
 // the `dir/` row itself (nothing to expand).
-// `--literal-pathspecs` because these paths come from `git status`, not from a
-// user typing a glob: without it a real filename containing pathspec wildcards
-// (`weird[1].txt`) also matches its neighbours (`weird1.txt`), which would pull
-// files the user never clicked into the payload.
-async function untrackedPathsUnder(git, pathspec): Promise<string[]> {
-  const raw = await git
-    .raw(['--literal-pathspecs', 'ls-files', '--others', '--exclude-standard', '-z', '--', pathspec])
-    .catch(() => '')
+//
+// Bounded by maxBuffer rather than buffered whole: the point of listing with
+// `--untracked-files=normal` is that an untracked tree can be a browser profile
+// with hundreds of thousands of entries, and expanding one on click shouldn't
+// re-introduce that cost. On overflow node kills git and hands back truncated
+// stdout, which still fills the capped preview.
+function untrackedPathsUnder(cwd, gitBin, pathspec): Promise<string[]> {
+  return new Promise(resolve => {
+    execFile(
+      gitBin || 'git',
+      [LITERAL_PATHSPECS, 'ls-files', '--others', '--exclude-standard', '-z', '--', pathspec],
+      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: UNTRACKED_LIST_MAX_BYTES },
+      (_err, stdout) => {
+        const parts = String(stdout || '').split('\0')
 
-  return String(raw || '')
-    .split('\0')
-    .filter(Boolean)
+        // Entries are NUL-TERMINATED, so the tail is either '' (complete run)
+        // or a half-written path (truncated run). Neither is a usable entry.
+        parts.pop()
+
+        resolve(parts.filter(Boolean))
+      }
+    )
+  })
 }
 
 // All-add diff for an untracked row, which may be a file OR a directory.
@@ -369,8 +396,8 @@ async function untrackedPathsUnder(git, pathspec): Promise<string[]> {
 // stdout. That left the pane rendering "No diff to show" under a fully
 // populated header. Expand the row to the files git actually sees underneath
 // and concatenate their all-add diffs into one multi-file payload.
-async function untrackedDiff(cwd, git, gitBin, filePath): Promise<string> {
-  const entries = await untrackedPathsUnder(git, filePath)
+async function untrackedDiff(cwd, gitBin, filePath): Promise<string> {
+  const entries = await untrackedPathsUnder(cwd, gitBin, filePath)
 
   // A plain untracked file resolves to itself — the common case, one diff.
   if (entries.length === 1 && entries[0] === filePath) {
@@ -413,7 +440,8 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin): P
   }
 
   const git = gitFor(cwd, gitBin)
-  const safe = args => git.diff(args).catch(() => '')
+  // `raw` rather than `.diff()` so LITERAL_PATHSPECS can lead the argv.
+  const safe = args => git.raw([LITERAL_PATHSPECS, 'diff', ...args]).catch(() => '')
 
   if (scope === 'branch') {
     const base = await branchBase(git)
@@ -446,7 +474,7 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin): P
     return worktree
   }
 
-  return untrackedDiff(cwd, git, gitBin, filePath)
+  return untrackedDiff(cwd, gitBin, filePath)
 }
 
 // Working-tree-vs-HEAD diff for ONE file — the "what changed since the last
@@ -463,7 +491,7 @@ async function fileDiffVsHead(repoPath, filePath, gitBin): Promise<string> {
   }
 
   const git = gitFor(cwd, gitBin)
-  const head = await git.diff(['HEAD', '--', filePath]).catch(() => '')
+  const head = await git.raw([LITERAL_PATHSPECS, 'diff', 'HEAD', '--', filePath]).catch(() => '')
 
   if (head.trim()) {
     return head
@@ -471,7 +499,7 @@ async function fileDiffVsHead(repoPath, filePath, gitBin): Promise<string> {
 
   // No tracked changes vs HEAD. Only synthesize an all-add diff for a file git
   // doesn't know yet; a clean tracked file must return empty.
-  const status = await git.raw(['status', '--porcelain', '--', filePath]).catch(() => '')
+  const status = await git.raw([LITERAL_PATHSPECS, 'status', '--porcelain', '--', filePath]).catch(() => '')
 
   if (!status.trim().startsWith('??')) {
     return ''
@@ -479,13 +507,13 @@ async function fileDiffVsHead(repoPath, filePath, gitBin): Promise<string> {
 
   // Same directory caveat as reviewDiff: an untracked row can be a collapsed
   // directory, which --no-index cannot diff against /dev/null.
-  return untrackedDiff(cwd, git, gitBin, filePath)
+  return untrackedDiff(cwd, gitBin, filePath)
 }
 
 async function reviewStage(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review stage' })
 
-  await gitFor(cwd, gitBin).raw(filePath ? ['add', '--', filePath] : ['add', '-A'])
+  await gitFor(cwd, gitBin).raw([LITERAL_PATHSPECS, 'add', ...(filePath ? ['--', filePath] : ['-A'])])
 
   return { ok: true }
 }
@@ -493,7 +521,7 @@ async function reviewStage(repoPath, filePath, gitBin) {
 async function reviewUnstage(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review unstage' })
 
-  await gitFor(cwd, gitBin).raw(filePath ? ['reset', '-q', 'HEAD', '--', filePath] : ['reset', '-q', 'HEAD'])
+  await gitFor(cwd, gitBin).raw([LITERAL_PATHSPECS, 'reset', '-q', 'HEAD', ...(filePath ? ['--', filePath] : [])])
 
   return { ok: true }
 }
@@ -505,11 +533,11 @@ async function reviewRevert(repoPath, filePath, gitBin) {
   const git = gitFor(cwd, gitBin)
 
   if (filePath) {
-    await git.raw(['checkout', 'HEAD', '--', filePath]).catch(() => undefined)
-    await git.raw(['clean', '-fd', '--', filePath]).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'checkout', 'HEAD', '--', filePath]).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'clean', '-fd', '--', filePath]).catch(() => undefined)
   } else {
-    await git.raw(['checkout', 'HEAD', '--', '.']).catch(() => undefined)
-    await git.raw(['clean', '-fd']).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'checkout', 'HEAD', '--', '.']).catch(() => undefined)
+    await git.raw([LITERAL_PATHSPECS, 'clean', '-fd']).catch(() => undefined)
   }
 
   return { ok: true }

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -71,6 +71,10 @@ const STATUS_GLYPH: Record<string, { icon: string; tone: string }> = {
   '?': { icon: 'diff-added', tone: 'text-muted-foreground/60' }
 }
 
+// Untracked directories come through as a single collapsed `dir/` row; they read
+// as folders, not as the new file the '?' glyph implies.
+const DIR_ROW_GLYPH = { icon: 'folder', tone: 'text-(--ui-text-tertiary)' }
+
 // Review paths are repo-relative; the composer drop expects absolute paths, so
 // join against the pane's repo (its pinned scope, else the active session cwd).
 function absolutePath(relative: string): string {
@@ -315,7 +319,11 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
   const selectedPath = useStore($reviewSelectedPath)
   const file = node.file!
   const selected = file.path === selectedPath
-  const glyph = STATUS_GLYPH[file.status] ?? STATUS_GLYPH.M
+  // An untracked directory arrives as one collapsed `dir/` row. It still opens
+  // a diff (of everything git sees underneath), so it stays a leaf row — but it
+  // gets a folder glyph instead of the untracked-file one it used to borrow.
+  const isDirRow = file.path.endsWith('/')
+  const glyph = isDirRow ? DIR_ROW_GLYPH : (STATUS_GLYPH[file.status] ?? STATUS_GLYPH.M)
   const dragPath = absolutePath(file.path)
   // Reactive mirror of reviewRepoCwd(): the pinned scope wins, else the
   // active session's cwd (subscribing to both keeps the row live either way).

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -64,6 +64,10 @@ const STATUS_GLYPH: Record<string, { icon: string; tone: string }> = {
   '?': { icon: 'diff-added', tone: 'text-muted-foreground/60' }
 }
 
+// Untracked directories come through as a single collapsed `dir/` row; they read
+// as folders, not as the new file the '?' glyph implies.
+const DIR_ROW_GLYPH = { icon: 'folder', tone: 'text-(--ui-text-tertiary)' }
+
 // Review paths are repo-relative; the composer drop expects absolute paths, so
 // join against the pane's repo (its pinned scope, else the active session cwd).
 function absolutePath(relative: string): string {
@@ -308,7 +312,11 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
   const selectedPath = useStore($reviewSelectedPath)
   const file = node.file!
   const selected = file.path === selectedPath
-  const glyph = STATUS_GLYPH[file.status] ?? STATUS_GLYPH.M
+  // An untracked directory arrives as one collapsed `dir/` row. It still opens
+  // a diff (of everything git sees underneath), so it stays a leaf row — but it
+  // gets a folder glyph instead of the untracked-file one it used to borrow.
+  const isDirRow = file.path.endsWith('/')
+  const glyph = isDirRow ? DIR_ROW_GLYPH : (STATUS_GLYPH[file.status] ?? STATUS_GLYPH.M)
   const dragPath = absolutePath(file.path)
   // Reactive mirror of reviewRepoCwd(): the pinned scope wins, else the
   // active session's cwd (subscribing to both keeps the row live either way).

--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -201,7 +201,12 @@ export function ReviewPane() {
             ) : diff ? (
               <FileDiffPanel className="mx-0 mb-0 h-full max-h-none" diff={diff} path={selectedFile.path} virtualized />
             ) : (
-              <div className="py-6 text-center text-[0.66rem] text-muted-foreground/60">{c.noDiff}</div>
+              // A folder row with nothing to expand is its own case (an empty
+              // untracked dir, or a nested git repo the outer repo can't see
+              // into) — say which, rather than implying the folder is clean.
+              <div className="py-6 text-center text-[0.66rem] text-muted-foreground/60">
+                {selectedFile.path.endsWith('/') ? c.noDiffFolder : c.noDiff}
+              </div>
             )}
           </div>
         </div>

--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -194,7 +194,12 @@ export function ReviewPane() {
             ) : diff ? (
               <FileDiffPanel className="mx-0 mb-0 h-full max-h-none" diff={diff} path={selectedFile.path} virtualized />
             ) : (
-              <div className="py-6 text-center text-[0.66rem] text-muted-foreground/60">{c.noDiff}</div>
+              // A folder row with nothing to expand is its own case (an empty
+              // untracked dir, or a nested git repo the outer repo can't see
+              // into) — say which, rather than implying the folder is clean.
+              <div className="py-6 text-center text-[0.66rem] text-muted-foreground/60">
+                {selectedFile.path.endsWith('/') ? c.noDiffFolder : c.noDiff}
+              </div>
             )}
           </div>
         </div>

--- a/apps/desktop/src/app/right-sidebar/review/tree-data.ts
+++ b/apps/desktop/src/app/right-sidebar/review/tree-data.ts
@@ -15,6 +15,13 @@ export interface ReviewTreeNode {
   children?: ReviewTreeNode[]
 }
 
+// `git status --untracked-files=normal` collapses an untracked directory into a
+// single `dir/` row. `split('/')` drops that trailing slash, which rendered the
+// row as a file named `dir` — keep it so the row reads as the folder it is.
+// (These stay leaf rows, not `isDir` folder nodes: clicking one opens the diff
+// of everything underneath, which a collapsible folder row can't do.)
+const withDirSuffix = (name: string, filePath: string): string => (filePath.endsWith('/') ? `${name}/` : name)
+
 // Flat changed-file list (VS Code's default SCM "List" view): one row per file,
 // filename + a dimmed parent-dir path, sorted by path. No folder nodes.
 export function buildReviewFlatList(files: HermesReviewFile[]): ReviewTreeNode[] {
@@ -26,7 +33,7 @@ export function buildReviewFlatList(files: HermesReviewFile[]): ReviewTreeNode[]
 
       return {
         id: file.path,
-        name,
+        name: withDirSuffix(name, file.path),
         dir: segments.join('/'),
         isDir: false,
         added: file.added,
@@ -86,7 +93,7 @@ export function buildReviewTree(files: HermesReviewFile[], compact = true): Revi
 
     dir.files.push({
       id: file.path,
-      name: fileName,
+      name: withDirSuffix(fileName, file.path),
       isDir: false,
       added: file.added,
       removed: file.removed,

--- a/apps/desktop/src/components/chat/diff-lines.test.ts
+++ b/apps/desktop/src/components/chat/diff-lines.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { parseDiff, stripDiffFileHeaders } from './diff-lines'
+
+const SINGLE_FILE = [
+  'diff --git a/src/a.ts b/src/a.ts',
+  'index 1111111..2222222 100644',
+  '--- a/src/a.ts',
+  '+++ b/src/a.ts',
+  '@@ -1,2 +1,3 @@',
+  ' keep',
+  '-gone',
+  '+added',
+  '+also added',
+  ''
+].join('\n')
+
+// What reviewDiff now returns for a collapsed `dir/` row: the per-file all-add
+// diffs concatenated, exactly as git prints a multi-file diff.
+const MULTI_FILE = [
+  'diff --git a/newdir/one.txt b/newdir/one.txt',
+  'new file mode 100644',
+  'index 0000000..1111111',
+  '--- /dev/null',
+  '+++ b/newdir/one.txt',
+  '@@ -0,0 +1,2 @@',
+  '+first',
+  '+first again',
+  'diff --git a/newdir/sub/two.txt b/newdir/sub/two.txt',
+  'new file mode 100644',
+  'index 0000000..2222222',
+  '--- /dev/null',
+  '+++ b/newdir/sub/two.txt',
+  '@@ -0,0 +1 @@',
+  '+second',
+  ''
+].join('\n')
+
+test('parseDiff renders a single-file diff without a filename heading', () => {
+  // Git's trailing newline leaves one empty context row; ignore that here.
+  const lines = parseDiff(SINGLE_FILE).filter(line => line.text !== '')
+
+  // The panel header already names the file — no redundant heading row.
+  assert.deepEqual(
+    lines.map(line => [line.kind, line.text]),
+    [
+      ['context', 'keep'],
+      ['remove', 'gone'],
+      ['add', 'added'],
+      ['add', 'also added']
+    ]
+  )
+})
+
+test('parseDiff labels each file in a multi-file diff', () => {
+  const texts = parseDiff(MULTI_FILE).map(line => line.text)
+
+  assert.ok(texts.includes('newdir/one.txt'), 'first file is named')
+  assert.ok(texts.includes('newdir/sub/two.txt'), 'second file is named')
+})
+
+test('parseDiff keeps every file body in a multi-file diff', () => {
+  const adds = parseDiff(MULTI_FILE)
+    .filter(line => line.kind === 'add')
+    .map(line => line.text)
+
+  assert.deepEqual(adds, ['first', 'first again', 'second'])
+})
+
+test('parseDiff drops inter-file header noise instead of showing it as context', () => {
+  const texts = parseDiff(MULTI_FILE).map(line => line.text)
+
+  // These used to leak into the previous file's hunk as context lines, because
+  // the header strip only ran on the leading block.
+  for (const noise of [
+    'diff --git a/newdir/sub/two.txt b/newdir/sub/two.txt',
+    'new file mode 100644',
+    '--- /dev/null'
+  ]) {
+    assert.ok(!texts.includes(noise), `header noise not rendered: ${noise}`)
+  }
+})
+
+test('parseDiff falls back to raw lines for a payload with no hunks', () => {
+  assert.deepEqual(
+    parseDiff('some plain text').map(line => line.text),
+    ['some plain text']
+  )
+})
+
+test('stripDiffFileHeaders still strips the leading header block', () => {
+  assert.equal(stripDiffFileHeaders(SINGLE_FILE).split('\n')[0], '@@ -1,2 +1,3 @@')
+})

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -33,6 +33,8 @@ interface ParsedHunk {
   lines: Array<{ kind: DiffKind; text: string }>
   newStart: number
   oldStart: number
+  /** File this hunk belongs to, when the payload names one (multi-file diffs). */
+  path: null | string
 }
 
 // Tint + 2px gutter accent per change kind. Text color is included for the
@@ -131,11 +133,32 @@ export function stripDiffFileHeaders(diff: string): string {
   return lines.slice(start).join('\n')
 }
 
+// `+++ b/path` (or `--- a/path`, for a deletion) names the file a header block
+// belongs to. `/dev/null` is the empty side of an add/delete, never a name.
+function headerPath(line: string): null | string {
+  const match = /^(?:\+\+\+|---) (?:[ab]\/)?(.*)$/.exec(line)
+  const path = match ? match[1].trim() : ''
+
+  return path && path !== '/dev/null' ? path : null
+}
+
 function parseHunks(diff: string): ParsedHunk[] {
   const hunks: ParsedHunk[] = []
   let active: null | ParsedHunk = null
+  let pendingPath: null | string = null
 
-  for (const line of stripDiffFileHeaders(diff).split('\n')) {
+  // Scanned raw (no pre-strip): a header block is skipped by the `!active`
+  // branch, which also handles the header blocks BETWEEN files in a multi-file
+  // payload. Those used to be absorbed into the previous hunk as context lines.
+  for (const line of diff.split('\n')) {
+    // Opens the next file — close the current hunk so its lines stop here.
+    if (line.startsWith('diff --git')) {
+      active = null
+      pendingPath = null
+
+      continue
+    }
+
     if (line.startsWith('@@')) {
       const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line)
 
@@ -145,13 +168,21 @@ function parseHunks(diff: string): ParsedHunk[] {
         continue
       }
 
-      active = { oldStart: Number(match[1]), newStart: Number(match[2]), lines: [] }
+      active = { lines: [], newStart: Number(match[2]), oldStart: Number(match[1]), path: pendingPath }
+      pendingPath = null
       hunks.push(active)
 
       continue
     }
 
-    if (!active || line.startsWith('\\')) {
+    if (!active) {
+      // Inside a file-header block: remember which file it names.
+      pendingPath = headerPath(line) ?? pendingPath
+
+      continue
+    }
+
+    if (line.startsWith('\\')) {
       continue
     }
 
@@ -165,7 +196,8 @@ function parseHunks(diff: string): ParsedHunk[] {
 // separator kept between hunks), markers stripped, kind recorded. Old/new line
 // numbers are tracked from each `@@ -a,b +c,d @@` header so a caller that wants
 // a gutter (the preview) can render them; the blank separator carries none.
-function parseDiff(diff: string): DiffLine[] {
+/** Exported for tests. */
+export function parseDiff(diff: string): DiffLine[] {
   const hunks = parseHunks(diff)
 
   if (hunks.length === 0) {
@@ -175,10 +207,16 @@ function parseDiff(diff: string): DiffLine[] {
       .map(line => ({ kind: diffKind(line), text: stripDiffMarker(line) }))
   }
 
+  // Multi-file payload (an untracked directory expanded to its files): label
+  // each file so the adds don't read as one anonymous wall. Single-file diffs —
+  // every other caller — render exactly as before; the panel header names those.
+  const multiFile = new Set(hunks.map(hunk => hunk.path).filter(Boolean)).size > 1
+
   const out: DiffLine[] = []
   let emitted = false
   let oldNo = 1
   let newNo = 1
+  let headingPath: null | string = null
 
   for (const hunk of hunks) {
     oldNo = hunk.oldStart
@@ -186,6 +224,12 @@ function parseDiff(diff: string): DiffLine[] {
 
     if (emitted) {
       out.push({ kind: 'context', text: '' })
+    }
+
+    if (multiFile && hunk.path && hunk.path !== headingPath) {
+      headingPath = hunk.path
+      out.push({ kind: 'context', text: hunk.path })
+      emitted = true
     }
 
     for (const line of hunk.lines) {

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -34,6 +34,8 @@ interface ParsedHunk {
   lines: Array<{ kind: DiffKind; text: string }>
   newStart: number
   oldStart: number
+  /** File this hunk belongs to, when the payload names one (multi-file diffs). */
+  path: null | string
 }
 
 // Tint + 2px gutter accent per change kind. Text color is included for the
@@ -132,11 +134,32 @@ export function stripDiffFileHeaders(diff: string): string {
   return lines.slice(start).join('\n')
 }
 
+// `+++ b/path` (or `--- a/path`, for a deletion) names the file a header block
+// belongs to. `/dev/null` is the empty side of an add/delete, never a name.
+function headerPath(line: string): null | string {
+  const match = /^(?:\+\+\+|---) (?:[ab]\/)?(.*)$/.exec(line)
+  const path = match ? match[1].trim() : ''
+
+  return path && path !== '/dev/null' ? path : null
+}
+
 function parseHunks(diff: string): ParsedHunk[] {
   const hunks: ParsedHunk[] = []
   let active: null | ParsedHunk = null
+  let pendingPath: null | string = null
 
-  for (const line of stripDiffFileHeaders(diff).split('\n')) {
+  // Scanned raw (no pre-strip): a header block is skipped by the `!active`
+  // branch, which also handles the header blocks BETWEEN files in a multi-file
+  // payload. Those used to be absorbed into the previous hunk as context lines.
+  for (const line of diff.split('\n')) {
+    // Opens the next file — close the current hunk so its lines stop here.
+    if (line.startsWith('diff --git')) {
+      active = null
+      pendingPath = null
+
+      continue
+    }
+
     if (line.startsWith('@@')) {
       const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line)
 
@@ -146,13 +169,21 @@ function parseHunks(diff: string): ParsedHunk[] {
         continue
       }
 
-      active = { oldStart: Number(match[1]), newStart: Number(match[2]), lines: [] }
+      active = { lines: [], newStart: Number(match[2]), oldStart: Number(match[1]), path: pendingPath }
+      pendingPath = null
       hunks.push(active)
 
       continue
     }
 
-    if (!active || line.startsWith('\\')) {
+    if (!active) {
+      // Inside a file-header block: remember which file it names.
+      pendingPath = headerPath(line) ?? pendingPath
+
+      continue
+    }
+
+    if (line.startsWith('\\')) {
       continue
     }
 
@@ -166,7 +197,8 @@ function parseHunks(diff: string): ParsedHunk[] {
 // separator kept between hunks), markers stripped, kind recorded. Old/new line
 // numbers are tracked from each `@@ -a,b +c,d @@` header so a caller that wants
 // a gutter (the preview) can render them; the blank separator carries none.
-function parseDiff(diff: string): DiffLine[] {
+/** Exported for tests. */
+export function parseDiff(diff: string): DiffLine[] {
   const hunks = parseHunks(diff)
 
   if (hunks.length === 0) {
@@ -176,10 +208,16 @@ function parseDiff(diff: string): DiffLine[] {
       .map(line => ({ kind: diffKind(line), text: stripDiffMarker(line) }))
   }
 
+  // Multi-file payload (an untracked directory expanded to its files): label
+  // each file so the adds don't read as one anonymous wall. Single-file diffs —
+  // every other caller — render exactly as before; the panel header names those.
+  const multiFile = new Set(hunks.map(hunk => hunk.path).filter(Boolean)).size > 1
+
   const out: DiffLine[] = []
   let emitted = false
   let oldNo = 1
   let newNo = 1
+  let headingPath: null | string = null
 
   for (const hunk of hunks) {
     oldNo = hunk.oldStart
@@ -187,6 +225,12 @@ function parseDiff(diff: string): DiffLine[] {
 
     if (emitted) {
       out.push({ kind: 'context', text: '' })
+    }
+
+    if (multiFile && hunk.path && hunk.path !== headingPath) {
+      headingPath = hunk.path
+      out.push({ kind: 'context', text: hunk.path })
+      emitted = true
     }
 
     for (const line of hunk.lines) {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1980,6 +1980,7 @@ export const ar = defineLocale({
       noChanges: 'لا توجد تغييرات',
       notRepo: 'ليس مستودع git',
       noDiff: 'لا يوجد فرق لعرضه',
+      noDiffFolder: 'مجلد فارغ أو مستودع git منفصل',
       scopeUncommitted: 'غير مُودَع',
       scopeBranch: 'فرع',
       scopeLastTurn: 'آخر دور',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1808,6 +1808,7 @@ export const ar = defineLocale({
       noChanges: 'لا توجد تغييرات',
       notRepo: 'ليس مستودع git',
       noDiff: 'لا يوجد فرق لعرضه',
+      noDiffFolder: 'مجلد فارغ أو مستودع git منفصل',
       scopeUncommitted: 'غير مُودَع',
       scopeBranch: 'فرع',
       scopeLastTurn: 'آخر دور',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2697,6 +2697,7 @@ export const en: Translations = {
       noChanges: 'No changes',
       notRepo: 'Not a git repository',
       noDiff: 'No diff to show',
+      noDiffFolder: 'Empty folder, or a separate git repo',
       scopeUncommitted: 'Uncommitted',
       scopeBranch: 'Branch',
       scopeLastTurn: 'Last turn',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2150,6 +2150,7 @@ export const en: Translations = {
       noChanges: 'No changes',
       notRepo: 'Not a git repository',
       noDiff: 'No diff to show',
+      noDiffFolder: 'Empty folder, or a separate git repo',
       scopeUncommitted: 'Uncommitted',
       scopeBranch: 'Branch',
       scopeLastTurn: 'Last turn',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2323,6 +2323,7 @@ export const ja = defineLocale({
       noChanges: '変更なし',
       notRepo: 'Git リポジトリではありません',
       noDiff: '表示する差分がありません',
+      noDiffFolder: '空のフォルダ、または別の git リポジトリです',
       scopeUncommitted: '未コミット',
       scopeBranch: 'ブランチ',
       scopeLastTurn: '前のターン',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1982,6 +1982,7 @@ export const ja = defineLocale({
       noChanges: '変更なし',
       notRepo: 'Git リポジトリではありません',
       noDiff: '表示する差分がありません',
+      noDiffFolder: '空のフォルダ、または別の git リポジトリです',
       scopeUncommitted: '未コミット',
       scopeBranch: 'ブランチ',
       scopeLastTurn: '前のターン',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2293,6 +2293,7 @@ export interface Translations {
       noChanges: string
       notRepo: string
       noDiff: string
+      noDiffFolder: string
       scopeUncommitted: string
       scopeBranch: string
       scopeLastTurn: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1796,6 +1796,7 @@ export interface Translations {
       noChanges: string
       notRepo: string
       noDiff: string
+      noDiffFolder: string
       scopeUncommitted: string
       scopeBranch: string
       scopeLastTurn: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2243,6 +2243,7 @@ export const zhHant = defineLocale({
       noChanges: '沒有變更',
       notRepo: '不是 Git 儲存庫',
       noDiff: '沒有可顯示的差異',
+      noDiffFolder: '空資料夾，或獨立的 git 儲存庫',
       scopeUncommitted: '未提交',
       scopeBranch: '分支',
       scopeLastTurn: '上一輪',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1923,6 +1923,7 @@ export const zhHant = defineLocale({
       noChanges: '沒有變更',
       notRepo: '不是 Git 儲存庫',
       noDiff: '沒有可顯示的差異',
+      noDiffFolder: '空資料夾，或獨立的 git 儲存庫',
       scopeUncommitted: '未提交',
       scopeBranch: '分支',
       scopeLastTurn: '上一輪',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2862,6 +2862,7 @@ export const zh: Translations = {
       noChanges: '没有更改',
       notRepo: '不是 Git 仓库',
       noDiff: '没有可显示的差异',
+      noDiffFolder: '空文件夹，或独立的 git 仓库',
       scopeUncommitted: '未提交',
       scopeBranch: '分支',
       scopeLastTurn: '上一轮',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2343,6 +2343,7 @@ export const zh: Translations = {
       noChanges: '没有更改',
       notRepo: '不是 Git 仓库',
       noDiff: '没有可显示的差异',
+      noDiffFolder: '空文件夹，或独立的 git 仓库',
       scopeUncommitted: '未提交',
       scopeBranch: '分支',
       scopeLastTurn: '上一轮',

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -26,6 +26,9 @@ _GH_TIMEOUT = 30
 _MAX_BUFFER = 32 * 1024 * 1024
 _UNTRACKED_LINE_MAX_BYTES = 1024 * 1024
 _UNTRACKED_SCAN_CAP = 500
+# An untracked directory arrives as ONE row, so opening it can mean diffing an
+# unbounded subtree (a build output, a browser profile). Cap the expansion.
+_UNTRACKED_DIR_FILE_CAP = 50
 _COMMIT_CONTEXT_DIFF_MAX_CHARS = 120_000
 _COMMIT_CONTEXT_UNTRACKED_MAX = 80
 _TRUNK_BRANCHES = ("main", "master")
@@ -39,10 +42,19 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
     calls serve authenticated REST requests from the dashboard/desktop, so a
     credential prompt from ``fetch``/``push``/``pull`` could never be answered
     — it would just hang the request until the timeout. Failing fast surfaces
-    the real auth error in the toast instead."""
+    the real auth error in the toast instead.
+
+    ``--literal-pathspecs`` leads every invocation. Every path this module
+    hands git came out of ``git status`` — never a glob a user typed. Without
+    it a real filename containing pathspec wildcards (``weird[1].txt``) also
+    matches its neighbours (``weird1.txt``), so the review pane rendered a
+    different file's diff and, far worse, ``add`` / ``reset`` / ``checkout`` /
+    ``clean`` acted on files the user never selected — ``review_revert`` on
+    ``weird[1].txt`` silently discarded uncommitted edits to ``weird1.txt``.
+    It must precede the subcommand; git rejects it afterwards."""
     try:
         proc = subprocess.run(
-            ["git", *args],
+            ["git", "--literal-pathspecs", *args],
             cwd=cwd,
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
@@ -315,6 +327,52 @@ def review_list(cwd: str, scope: str, base_ref: str | None) -> dict:
     return {"files": files, "base": None}
 
 
+def _synthesize_add_diff(cwd: str, file_path: str) -> str:
+    """All-add diff for ONE untracked file. ``--no-index`` exits non-zero by
+    design when the two sides differ, so read stdout and ignore the code."""
+    _, out, _ = _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])
+    return out
+
+
+def _untracked_paths_under(cwd: str, pathspec: str) -> list[str]:
+    """The untracked paths git reports under ``pathspec``. Resolved through git
+    rather than a filesystem walk so .gitignore is honored and the enumeration
+    cannot escape the repo. An untracked FILE resolves to itself; an untracked
+    DIRECTORY resolves to its descendants; a nested git repo stays opaque and
+    resolves to the ``dir/`` row itself (nothing to expand)."""
+    out = _git_out(cwd, ["ls-files", "--others", "--exclude-standard", "-z", "--", pathspec])
+    return [entry for entry in out.split("\0") if entry]
+
+
+def _untracked_diff(cwd: str, file_path: str) -> str:
+    """All-add diff for an untracked row, which may be a file OR a directory.
+
+    ``git status`` collapses an untracked directory into a single ``dir/`` row
+    (so a build output or browser profile can't flood the pane), but
+    ``git diff --no-index -- <devnull> dir/`` cannot diff that: it pairs the
+    operands as trees and fails looking for ``dir/nul``, printing nothing. That
+    left the pane rendering "No diff to show" under a populated header. Expand
+    the row to the files git actually sees underneath instead."""
+    entries = _untracked_paths_under(cwd, file_path)
+
+    # A plain untracked file resolves to itself — the common case, one diff.
+    if entries == [file_path]:
+        return _synthesize_add_diff(cwd, file_path)
+
+    # Entries keeping a trailing slash are opaque to this repo (a nested git
+    # repo); there is no file to synthesize a diff from.
+    files = [entry for entry in entries if not entry.endswith("/")]
+    if not files:
+        return ""
+
+    visible = files[:_UNTRACKED_DIR_FILE_CAP]
+    body = "".join(filter(None, (_synthesize_add_diff(cwd, entry) for entry in visible)))
+    omitted = len(files) - len(visible)
+
+    # Never truncate silently — the reader has to know the view is partial.
+    return f"{body}# {omitted} more file(s) omitted\n" if omitted else body
+
+
 def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool) -> str:
     if not _is_dir(cwd):
         return ""
@@ -324,13 +382,19 @@ def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, stag
     if scope == "lastTurn":
         return _git_out(cwd, ["diff", base_ref, "--", file_path]) if base_ref else ""
     if staged:
+        # The row's +/- sums the staged AND unstaged churn for this path, so the
+        # diff has to cover both: HEAD..worktree is the whole story. `--cached`
+        # alone silently dropped the unstaged half of a partially staged file
+        # (and answered an unmerged path with a hunk-less "* Unmerged path"
+        # stub). Fall back to the index-only diff in a repo with no commits yet.
+        combined = _git_out(cwd, ["diff", "HEAD", "--", file_path])
+        if combined.strip():
+            return combined
         return _git_out(cwd, ["diff", "--cached", "--", file_path])
     worktree = _git_out(cwd, ["diff", "--", file_path])
     if worktree.strip():
         return worktree
-    # Untracked: synthesize an all-add diff (exits non-zero by design).
-    _, out, _ = _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])
-    return out
+    return _untracked_diff(cwd, file_path)
 
 
 def file_diff_vs_head(cwd: str, file_path: str) -> str:
@@ -344,8 +408,9 @@ def file_diff_vs_head(cwd: str, file_path: str) -> str:
     status = _git_out(cwd, ["status", "--porcelain", "--", file_path])
     if not status.strip().startswith("??"):
         return ""
-    _, out, _ = _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])
-    return out
+    # Same directory caveat as review_diff: an untracked row can be a collapsed
+    # directory, which --no-index cannot diff against the null device.
+    return _untracked_diff(cwd, file_path)
 
 
 def review_stage(cwd: str, file_path: str | None) -> dict:

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -22,6 +22,9 @@ _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
 _UNTRACKED_LINE_MAX_BYTES = 1024 * 1024
 _UNTRACKED_SCAN_CAP = 500
+# An untracked directory arrives as ONE row, so opening it can mean diffing an
+# unbounded subtree (a build output, a browser profile). Cap the expansion.
+_UNTRACKED_DIR_FILE_CAP = 50
 _COMMIT_CONTEXT_DIFF_MAX_CHARS = 120_000
 _COMMIT_CONTEXT_UNTRACKED_MAX = 80
 _TRUNK_BRANCHES = ("main", "master")
@@ -41,8 +44,17 @@ def _run(argv: list[str], cwd: str, timeout: int, env: dict) -> subprocess.Compl
 
 
 def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int, str, str]:
-    """(returncode, stdout, stderr) of ``git`` in ``cwd``; never raises on non-zero exit."""
-    proc = _run(["git", *harden_git_argv(args)], cwd, timeout, noninteractive_git_env())
+    """(returncode, stdout, stderr) of ``git`` in ``cwd``; never raises on non-zero exit.
+
+    ``--literal-pathspecs`` leads every invocation. Every path this module
+    hands git came out of ``git status`` — never a glob a user typed. Without
+    it a real filename containing pathspec wildcards (``weird[1].txt``) also
+    matches its neighbours (``weird1.txt``), so the review pane rendered a
+    different file's diff and, far worse, ``add`` / ``reset`` / ``checkout`` /
+    ``clean`` acted on files the user never selected — ``review_revert`` on
+    ``weird[1].txt`` silently discarded uncommitted edits to ``weird1.txt``.
+    It must precede the subcommand; git rejects it afterwards."""
+    proc = _run(["git", "--literal-pathspecs", *harden_git_argv(args)], cwd, timeout, noninteractive_git_env())
     if proc is None:
         return 1, "", "git invocation failed"
     return proc.returncode, proc.stdout, proc.stderr
@@ -280,9 +292,50 @@ def review_list(cwd: str, scope: str, base_ref: str | None) -> dict:
     return _review_result(cwd, files, None)
 
 
-def _all_add_diff(cwd: str, file_path: str) -> str:
-    """Synthesized all-add diff for an untracked file (``--no-index`` exits non-zero by design)."""
-    return _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])[1]
+def _synthesize_add_diff(cwd: str, file_path: str) -> str:
+    """All-add diff for ONE untracked file. ``--no-index`` exits non-zero by
+    design when the two sides differ, so read stdout and ignore the code."""
+    _, out, _ = _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])
+    return out
+
+
+def _untracked_paths_under(cwd: str, pathspec: str) -> list[str]:
+    """The untracked paths git reports under ``pathspec``. Resolved through git
+    rather than a filesystem walk so .gitignore is honored and the enumeration
+    cannot escape the repo. An untracked FILE resolves to itself; an untracked
+    DIRECTORY resolves to its descendants; a nested git repo stays opaque and
+    resolves to the ``dir/`` row itself (nothing to expand)."""
+    out = _git_out(cwd, ["ls-files", "--others", "--exclude-standard", "-z", "--", pathspec])
+    return [entry for entry in out.split("\0") if entry]
+
+
+def _untracked_diff(cwd: str, file_path: str) -> str:
+    """All-add diff for an untracked row, which may be a file OR a directory.
+
+    ``git status`` collapses an untracked directory into a single ``dir/`` row
+    (so a build output or browser profile can't flood the pane), but
+    ``git diff --no-index -- <devnull> dir/`` cannot diff that: it pairs the
+    operands as trees and fails looking for ``dir/nul``, printing nothing. That
+    left the pane rendering "No diff to show" under a populated header. Expand
+    the row to the files git actually sees underneath instead."""
+    entries = _untracked_paths_under(cwd, file_path)
+
+    # A plain untracked file resolves to itself — the common case, one diff.
+    if entries == [file_path]:
+        return _synthesize_add_diff(cwd, file_path)
+
+    # Entries keeping a trailing slash are opaque to this repo (a nested git
+    # repo); there is no file to synthesize a diff from.
+    files = [entry for entry in entries if not entry.endswith("/")]
+    if not files:
+        return ""
+
+    visible = files[:_UNTRACKED_DIR_FILE_CAP]
+    body = "".join(filter(None, (_synthesize_add_diff(cwd, entry) for entry in visible)))
+    omitted = len(files) - len(visible)
+
+    # Never truncate silently — the reader has to know the view is partial.
+    return f"{body}# {omitted} more file(s) omitted\n" if omitted else body
 
 
 def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool) -> str:
@@ -294,9 +347,19 @@ def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, stag
     if scope == "lastTurn":
         return _git_out(cwd, ["diff", base_ref, "--", file_path]) if base_ref else ""
     if staged:
+        # The row's +/- sums the staged AND unstaged churn for this path, so the
+        # diff has to cover both: HEAD..worktree is the whole story. `--cached`
+        # alone silently dropped the unstaged half of a partially staged file
+        # (and answered an unmerged path with a hunk-less "* Unmerged path"
+        # stub). Fall back to the index-only diff in a repo with no commits yet.
+        combined = _git_out(cwd, ["diff", "HEAD", "--", file_path])
+        if combined.strip():
+            return combined
         return _git_out(cwd, ["diff", "--cached", "--", file_path])
     worktree = _git_out(cwd, ["diff", "--", file_path])
-    return worktree if worktree.strip() else _all_add_diff(cwd, file_path)
+    if worktree.strip():
+        return worktree
+    return _untracked_diff(cwd, file_path)
 
 
 def file_diff_vs_head(cwd: str, file_path: str) -> str:
@@ -308,7 +371,11 @@ def file_diff_vs_head(cwd: str, file_path: str) -> str:
     if head.strip():
         return head
     status = _git_out(cwd, ["status", "--porcelain", "--", file_path])
-    return _all_add_diff(cwd, file_path) if status.strip().startswith("??") else ""
+    if not status.strip().startswith("??"):
+        return ""
+    # Same directory caveat as review_diff: an untracked row can be a collapsed
+    # directory, which --no-index cannot diff against the null device.
+    return _untracked_diff(cwd, file_path)
 
 
 def review_stage(cwd: str, file_path: str | None) -> dict:

--- a/tests/hermes_cli/test_web_git_review_pathspecs.py
+++ b/tests/hermes_cli/test_web_git_review_pathspecs.py
@@ -1,0 +1,241 @@
+"""Review-pane git ops: untracked-directory expansion and literal pathspecs.
+
+`web_git` backs the `/api/git/review/*` routes — the same Review pane the
+desktop app drives over IPC, served for remote/web sessions. It had two bugs
+that the Electron module also had:
+
+1. `git status` collapses an untracked directory into one `dir/` row, but
+   `git diff --no-index -- <devnull> dir/` cannot diff that (it pairs the
+   operands as trees and fails looking for `dir/nul`), so clicking the row
+   rendered "No diff to show" under a populated header.
+2. Paths were passed as pathspecs, which git treats as globs. A real filename
+   containing wildcards (`weird[1].txt`) also matched its neighbours
+   (`weird1.txt`): reads showed the wrong file, and `add` / `reset` /
+   `checkout` / `clean` acted on files the user never selected.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hermes_cli.web_git import (
+    file_diff_vs_head,
+    review_diff,
+    review_list,
+    review_revert,
+    review_stage,
+    review_unstage,
+)
+
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo with one committed file."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "hermes-test@example.com")
+    _git(tmp_path, "config", "user.name", "Hermes Test")
+    _git(tmp_path, "config", "core.autocrlf", "false")
+    (tmp_path / "tracked.txt").write_text("tracked\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "base")
+    return tmp_path
+
+
+@pytest.fixture
+def glob_repo(repo):
+    """The nastiest shape for the pathspec bug: the decoy is TRACKED and
+    MODIFIED, so it has both a real diff to leak and real edits to destroy."""
+    (repo / "weird1.txt").write_text("neighbour original\n")
+    _git(repo, "add", "weird1.txt")
+    _git(repo, "commit", "-qm", "add neighbour")
+    (repo / "weird1.txt").write_text("neighbour MODIFIED\n")
+    (repo / "weird[1].txt").write_text("clicked file\n")
+    return repo
+
+
+def _uncommitted(repo, path, staged=False):
+    return review_diff(str(repo), path, "uncommitted", None, staged)
+
+
+# ── untracked directory rows ────────────────────────────────────────────────
+
+
+def test_untracked_directory_is_listed_as_one_row(repo):
+    (repo / "newdir").mkdir()
+    (repo / "newdir" / "one.txt").write_text("first\n")
+
+    paths = [f["path"] for f in review_list(str(repo), "uncommitted", None)["files"]]
+
+    # The compact listing is deliberate; the diff path has to cope with it.
+    assert "newdir/" in paths
+
+
+def test_untracked_directory_expands_to_its_files(repo):
+    (repo / "newdir" / "sub").mkdir(parents=True)
+    (repo / "newdir" / "one.txt").write_text("first\n")
+    (repo / "newdir" / "sub" / "two.txt").write_text("second\n")
+
+    diff = _uncommitted(repo, "newdir/")
+
+    assert "+first" in diff
+    assert "+second" in diff
+    # Every file is named so the renderer can label a multi-file payload.
+    assert "newdir/one.txt" in diff
+    assert "newdir/sub/two.txt" in diff
+
+
+def test_untracked_directory_with_spaces_expands(repo):
+    (repo / "Fallout Vault" / "20 Projects").mkdir(parents=True)
+    (repo / "Fallout Vault" / "20 Projects" / "note.md").write_text("vault note\n")
+
+    assert "+vault note" in _uncommitted(repo, "Fallout Vault/")
+
+
+def test_untracked_directory_expansion_honors_gitignore(repo):
+    (repo / ".gitignore").write_text("*.log\n")
+    (repo / "logs").mkdir()
+    (repo / "logs" / "keep.txt").write_text("kept\n")
+    (repo / "logs" / "noisy.log").write_text("ignored\n")
+
+    diff = _uncommitted(repo, "logs/")
+
+    assert "+kept" in diff
+    assert "+ignored" not in diff
+
+
+def test_untracked_directory_expansion_is_capped_and_says_so(repo):
+    (repo / "generated").mkdir()
+    for i in range(60):
+        (repo / "generated" / f"f-{i:03d}.txt").write_text(f"line {i}\n")
+
+    diff = _uncommitted(repo, "generated/")
+
+    assert "+line 0" in diff
+    assert "10 more file(s) omitted" in diff
+
+
+def test_nested_git_repo_is_opaque_not_a_crash(repo):
+    nested = repo / "nested_repo"
+    nested.mkdir()
+    _git(nested, "init", "-q")
+    (nested / "inner.txt").write_text("inner\n")
+
+    # Opaque to the outer repo — the pane shows its folder empty-state for this.
+    assert _uncommitted(repo, "nested_repo/") == ""
+
+
+def test_untracked_single_file_still_synthesizes_an_all_add_diff(repo):
+    (repo / "fresh.txt").write_text("alpha\nbeta\n")
+
+    diff = _uncommitted(repo, "fresh.txt")
+
+    assert "+alpha" in diff
+    assert "+beta" in diff
+
+
+def test_file_diff_vs_head_expands_an_untracked_directory(repo):
+    (repo / "preview-dir").mkdir()
+    (repo / "preview-dir" / "a.txt").write_text("preview line\n")
+
+    assert "+preview line" in file_diff_vs_head(str(repo), "preview-dir/")
+
+
+def test_file_diff_vs_head_still_empty_for_a_clean_tracked_file(repo):
+    assert file_diff_vs_head(str(repo), "tracked.txt") == ""
+
+
+# ── literal pathspecs: reads ────────────────────────────────────────────────
+
+
+def test_review_diff_does_not_leak_a_glob_neighbour(glob_repo):
+    # The worktree probe runs first, so without --literal-pathspecs this
+    # returns the TRACKED neighbour's diff and the pane renders a file the
+    # user never clicked.
+    diff = _uncommitted(glob_repo, "weird[1].txt")
+
+    assert "+clicked file" in diff
+    assert "neighbour MODIFIED" not in diff
+
+
+def test_file_diff_vs_head_does_not_leak_a_glob_neighbour(glob_repo):
+    diff = file_diff_vs_head(str(glob_repo), "weird[1].txt")
+
+    assert "+clicked file" in diff
+    assert "neighbour MODIFIED" not in diff
+
+
+# ── literal pathspecs: mutations (wrong-tree writes) ────────────────────────
+
+
+def _staged_names(repo):
+    out = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.split()
+
+
+def test_review_stage_stages_only_the_selected_file(glob_repo):
+    review_stage(str(glob_repo), "weird[1].txt")
+
+    staged = _staged_names(glob_repo)
+
+    assert "weird[1].txt" in staged
+    assert "weird1.txt" not in staged
+
+
+def test_review_unstage_unstages_only_the_selected_file(glob_repo):
+    _git(glob_repo, "add", "-A")
+    review_unstage(str(glob_repo), "weird[1].txt")
+
+    staged = _staged_names(glob_repo)
+
+    # The neighbour must stay staged; only the clicked file comes back out.
+    assert "weird1.txt" in staged
+    assert "weird[1].txt" not in staged
+
+
+def test_review_revert_does_not_discard_a_glob_neighbours_edits(glob_repo):
+    # The destructive one: `git checkout HEAD -- 'weird[1].txt'` also restored
+    # weird1.txt, silently throwing away the user's uncommitted work.
+    review_revert(str(glob_repo), "weird[1].txt")
+
+    assert (glob_repo / "weird1.txt").read_text() == "neighbour MODIFIED\n"
+    assert not (glob_repo / "weird[1].txt").exists()
+
+
+# ── staged rows show the whole story ────────────────────────────────────────
+
+
+def test_partially_staged_file_shows_staged_and_unstaged(repo):
+    (repo / "tracked.txt").write_text("tracked\nstaged line\n")
+    _git(repo, "add", "tracked.txt")
+    (repo / "tracked.txt").write_text("tracked\nstaged line\nunstaged line\n")
+
+    # The row's +/- counts sum both sides, so the diff has to as well.
+    diff = _uncommitted(repo, "tracked.txt", staged=True)
+
+    assert "+staged line" in diff
+    assert "+unstaged line" in diff
+
+
+def test_staged_file_in_a_repo_with_no_commits_falls_back_to_the_index(tmp_path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "hermes-test@example.com")
+    _git(tmp_path, "config", "user.name", "Hermes Test")
+    (tmp_path / "first.txt").write_text("first commit pending\n")
+    _git(tmp_path, "add", "first.txt")
+
+    # No HEAD to diff against — the --cached fallback keeps the panel populated.
+    assert "+first commit pending" in review_diff(
+        str(tmp_path), "first.txt", "uncommitted", None, True
+    )


### PR DESCRIPTION
Fixes #81160
Fixes #81161

Two independent bugs in the Desktop Review pane's git layer. The second was found while fixing the first.

## #81160 — untracked folder rows rendered an empty diff

`reviewList` **deliberately** collapses an untracked directory into one `dir/` row (`--untracked-files=normal`, asserted by an existing test) so a build output or browser profile can't flood the pane. But clicking that row handed `dir/` to `git diff --no-index -- /dev/null dir/`, which pairs the operands as trees, fails looking for `dir/nul`, and prints nothing. The error was swallowed, the store stored `''`, and the pane rendered "No diff to show" under a fully populated header.

Untracked rows now resolve through `git ls-files --others --exclude-standard`:

- a file resolves to itself → one `--no-index` diff, as before
- a **directory** resolves to its descendants → expand and concatenate
- a nested git repo self-identifies (git returns the `dir/` row itself) → nothing to expand

Going through git rather than an `fs` walk means `.gitignore` is honored for free and the enumeration cannot escape the repo. Expansion is capped at 50 files with an explicit `# N more file(s) omitted` note, and the enumeration is bounded by `maxBuffer` so expanding one folder can't re-introduce the cost the compact listing exists to avoid.

`fileDiffVsHead` (the preview path) carried the identical blind spot and gets the same guard.

## #81161 — pathspec globbing acted on the wrong files

Every git call in the module passed the row path as a pathspec, so `weird[1].txt` also matched `weird1.txt`. Reads showed the wrong file's body; `add`/`reset` mutated the wrong files; and `checkout HEAD -- 'weird[1].txt'` **silently discarded uncommitted edits to `weird1.txt`**.

All pathspec-taking calls — reads *and* mutations — now go through one `LITERAL_PATHSPECS` constant. Two constraints, both found by testing and recorded in a comment at the constant:

- The flag **must lead the argv** (`git diff --literal-pathspecs` is `error: invalid option`), which is why the reads use `raw()` instead of simple-git's typed `.diff()`.
- It is deliberately **not** set via simple-git's `.env()`, which *replaces* the child environment instead of merging it (verified: `git var GIT_EDITOR` returns the inherited value on a plain instance, git's built-in default with `.env()` set). That would strip the `PATH` `gitFor` works to preserve for GUI-launched Electron, plus `HOME` and the user's gitconfig.

## Supporting changes

**Multi-file rendering.** Concatenated diffs needed `parseHunks` to stop pre-stripping only the *leading* header block — it kept the hunk open across file boundaries, so the next file's `diff --git` / `new file mode` / `---` lines were absorbed as context rows. It now closes the hunk at each boundary and captures the filename, and `parseDiff` labels each file **only when the payload holds more than one**, so every existing single-file caller renders unchanged (guarded by a test).

**UI honesty.** Untracked folder rows keep their trailing slash and take a folder glyph instead of borrowing the untracked-*file* one. They stay leaf rows rather than `isDir` nodes — `ReviewDirRow` is a collapse toggle with no click-to-diff, so promoting them would re-break the thing being fixed. Folder rows with nothing to expand get their own empty state rather than the generic "No diff to show".

## Testing

- **28 tests** in `git-review-ops.test.ts`: untracked file; untracked dir; dir with spaces; `.gitignore` respected during expansion; cap + omission note; nested repo; partially staged file showing both halves; no-commits fallback; conflicted file; `fileDiffVsHead` expansion; clean-tracked-file regression guard; the glob decoy across the read and all three mutations; and the no-pathspec "all" variants of each mutation.
- The five glob tests were validated by swapping `LITERAL_PATHSPECS` for an inert `--no-optional-locks`: **all five fail**, then pass when restored — they're real regression tests, not tautologies.
- **6 tests** in a new `diff-lines.test.ts`, including the single-file no-heading guard.
- `typecheck` clean, `eslint` 0 errors on changed files, `prettier --check` clean, 140 renderer tests passing.
- End-to-end: real `reviewDiff` output piped through the real `parseDiff`, producing labelled per-file adds where the pane previously showed "No diff to show".

Rebased onto current `main`, including `a4b235c4b` (virtualize git file-tree). Verified afterwards that both render paths still dispatch on `node.isDir`, that untracked-folder rows remain `isDir: false` and route to `ReviewFileRow` where the glyph applies, and that `flattenReviewRows` only recurses into `node.isDir && node.children`.

## Both backends

The Review pane has two implementations. `apps/desktop/electron/git-review-ops.ts` runs Electron-local git; `hermes_cli/web_git.py` serves the same pane over `/api/git/review/*` for remote and web sessions. **Both carried all of the above**, verified by calling the Python production functions directly:

```
review_list                    -> 'Fallout Vault/'  status=? +0/-0
review_diff('Fallout Vault/')  -> 0 bytes            ("No diff to show")
review_diff('weird[1].txt')    -> renders weird1.txt'''s content
review_revert('weird[1].txt')  -> discards weird1.txt'''s uncommitted edits
```

Fixing only the Electron side would have closed both issues while leaving the identical data-loss bug live for every remote session, so the Python module is fixed here too (16 pytest cases, same fail-without-the-fix validation).

One difference worth noting: `_git` in the Python module builds the argv itself and is the sole git choke point, so `--literal-pathspecs` goes on **once** and covers every read and mutation. simple-git'''s typed `.diff()` gave no such single point on the TS side.

### Audit of the rest of the codebase

`git-worktree-ops.ts` is **clean**  every command it runs takes refs, branches, or directory operands, never a pathspec. `agent/context_references.py` and the rest of `update_cmd.py` pass no pathspecs either. Two low-risk destructive sites remain un-literalized and were left alone: `hermes_cli/update_cmd.py:3442` (`checkout -- *dirty` on lockfile paths) and `hermes_cli/main.py:1894` (`restore -- <fixed dir name>`)  both act on Hermes''' own install tree with paths that will not contain glob characters.

## Notes for review

- `parseHunks` is shared by every diff surface (tool cards, preview, review pane), so it's the highest-blast-radius change here.
- The `.diff()` → `raw()` swap is behaviourally equivalent in testing, but I did not audit simple-git for differences in error surfacing or trimming.
- The `maxBuffer` truncation branch has no test — exercising it needs ~100k files.
- I only audited `git-review-ops.ts` for the pathspec issue; sibling modules may share the pattern (noted in #81161).
- Untracked folder rows still show `+0 −0` while the body shows real additions. Real counts require walking the subtree during `reviewList`, which is exactly what `--untracked-files=normal` exists to avoid — left deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)