### PR TITLE
fix(desktop): surface profile-switch failures instead of falling back to primary socket

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -39,6 +39,7 @@ import { requestVoiceConversationStart } from '@/store/composer'
 import { $activeConnectionId } from '@/store/connections'
 import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
+import { notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
@@ -749,7 +750,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           if (payload?.start_new_session !== false) {
             newSessionInProfile(targetProfile)
           } else {
-            void ensureGatewayProfile(normalizeProfileKey(targetProfile))
+            void ensureGatewayProfile(normalizeProfileKey(targetProfile)).catch((error: unknown) => {
+              // #81094: the voice-path switch must surface its failure too.
+              notifyError(error, `Failed to switch to profile "${normalizeProfileKey(targetProfile)}"`)
+            })
           }
         } else if (payload?.start_new_session !== false) {
           startFreshSessionDraft()

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -113,7 +113,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).not.toBe(primary)
   })
 
-  it('refreshes the active connection after a pooled profile reconnect succeeds', async () => {
+  it('rejects the failed dial without publishing an activation, then activates once the backend returns', async () => {
     const connection = {
       authMode: 'token',
       baseUrl: 'https://worker.invalid',
@@ -130,14 +130,20 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
 
     gatewayMocks.connect.mockRejectedValueOnce(new Error('temporarily offline')).mockResolvedValueOnce(undefined)
 
+    // #81094: a failed dial must REJECT instead of silently activating a
+    // closed socket that would route messages to the primary backend.
+    await expect(ensureGatewayForProfile('worker')).rejects.toThrow('temporarily offline')
+
+    // No activation was published for the dead dial — $connection keeps the
+    // primary's descriptor (set by setPrimaryGateway), never the unreachable
+    // secondary's.
+    expect(gatewayMocks.setConnection).not.toHaveBeenCalled()
+
+    // Once the backend is reachable again, retrying the switch activates and
+    // publishes the live connection descriptor.
     await ensureGatewayForProfile('worker')
 
-    expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
-    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
-
-    await ensureActiveGatewayOpen()
-
-    expect(gatewayMocks.setConnection).toHaveBeenCalledTimes(2)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledTimes(1)
     expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
   })
 })

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -45,8 +45,14 @@ vi.mock('@/store/session', () => ({
 }))
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
-const { activeGateway, closeSecondaryGateways, configureGatewayRegistry, ensureGatewayForProfile, setPrimaryGateway } =
-  await import('./gateway')
+const {
+  activeGateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForProfile,
+  pruneSecondaryGateways,
+  setPrimaryGateway
+} = await import('./gateway')
 
 function installDesktop(stub: Record<string, unknown>): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
@@ -99,6 +105,26 @@ describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094
 
     expect(stillActive).toBe(live)
     expect(gatewayMocks.instances).toHaveLength(1)
+  })
+
+  it('releases the activation lease when the first dial is rejected so pruning disposes it', async () => {
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => ({
+      authMode: 'token',
+      baseUrl: `https://${profile}.invalid`,
+      mode: 'local',
+      profile,
+      token: 'fake-test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    }))
+
+    installDesktop({ getConnection })
+    gatewayMocks.connect.mockRejectedValue(new Error('backend unreachable'))
+
+    await expect(ensureGatewayForProfile('work')).rejects.toThrow('backend unreachable')
+
+    pruneSecondaryGateways(new Set())
+
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the reconnect schedule armed so transient failures still self-heal', async () => {

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Connection lifecycle for registry-scoped secondary gateways:
+//
+//  1. Removing a connection must dispose its secondaries — remote/cloud
+//     sources have no local process whose death would drop the socket, so
+//     without an explicit dispose the WebSocket stays open and streams ghost
+//     events until page reload.
+//  2. A materially edited connection re-dials so fresh sockets target the
+//     NEW endpoint.
+//  3. When the Electron main reports the connection no longer exists
+//     (`No connection with id`), the reconnect loop fail-stops and evicts
+//     the entry instead of retrying forever.
+
+const gatewayMocks = vi.hoisted(() => {
+  const instances: { close: ReturnType<typeof vi.fn>; connectionState: string }[] = []
+
+  return {
+    connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
+    instances
+  }
+})
+
+vi.mock('@/hermes', () => ({
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+    })
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+    constructor() {
+      gatewayMocks.instances.push(this as never)
+    }
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: vi.fn(),
+  setGatewayState: vi.fn()
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const { activeGateway, closeSecondaryGateways, configureGatewayRegistry, ensureGatewayForProfile, setPrimaryGateway } =
+  await import('./gateway')
+
+function installDesktop(stub: Record<string, unknown>): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
+}
+
+beforeEach(() => {
+  configureGatewayRegistry({ onEvent: vi.fn() } as never)
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  gatewayMocks.instances.length = 0
+  vi.clearAllMocks()
+  vi.useRealTimers()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094)', () => {
+  it('rethrows the dial failure instead of activating a closed socket', async () => {
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => ({
+      authMode: 'token',
+      baseUrl: `https://${profile}.invalid`,
+      mode: 'local',
+      profile,
+      token: 'fake-test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    }))
+
+    installDesktop({ getConnection })
+
+    // First activation succeeds so the entry exists.
+    await ensureGatewayForProfile('work')
+
+    const live = activeGateway()
+
+    expect(live).toBeTruthy()
+
+    // The socket then dies (backend restart): state flips to closed, so the
+    // next activation must re-dial instead of reusing the dead socket.
+    ;(live as unknown as { connectionState: string }).connectionState = 'closed'
+    gatewayMocks.connect.mockRejectedValue(new Error('backend unreachable'))
+
+    await expect(ensureGatewayForProfile('work')).rejects.toThrow('backend unreachable')
+
+    // The failed switch must NOT fall through to setActive() with a closed
+    // socket: the active gateway is still the previously-live one, never the
+    // dead entry that just failed to dial.
+    const stillActive = activeGateway()
+
+    expect(stillActive).toBe(live)
+    expect(gatewayMocks.instances).toHaveLength(1)
+  })
+
+  it('keeps the reconnect schedule armed so transient failures still self-heal', async () => {
+    vi.useFakeTimers()
+
+    let failFirst = true
+
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => ({
+      authMode: 'token',
+      baseUrl: `https://${profile}.invalid`,
+      mode: 'local',
+      profile,
+      token: 'fake-test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    }))
+
+    installDesktop({ getConnection })
+
+    gatewayMocks.connect.mockImplementation(async () => {
+      if (failFirst) {
+        throw new Error('backend unreachable')
+      }
+    })
+
+    await expect(ensureGatewayForProfile('work')).rejects.toThrow('backend unreachable')
+
+    // The catch kept the reconnect schedule: exactly one backoff timer is armed
+    // for the failed entry (transient failures still self-heal).
+    expect(vi.getTimerCount()).toBe(1)
+
+    // Backoff fires → reconnect dials again → succeeds → socket opens.
+    failFirst = false
+    await vi.runAllTimersAsync()
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+  })
+
+  it('activates the secondary when connect succeeds', async () => {
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => ({
+      authMode: 'token',
+      baseUrl: `https://${profile}.invalid`,
+      mode: 'local',
+      profile,
+      token: 'fake-test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    }))
+
+    installDesktop({ getConnection })
+
+    await ensureGatewayForProfile('work')
+
+    expect(activeGateway()).toBe(gatewayMocks.instances[0])
+  })
+})

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Module state lives in a module-local singleton (see gatewayState), so the
+// mocks below must be in place before the gateway module is first imported.
+const m = vi.hoisted(() => {
+  class MockGateway {
+    static instances: MockGateway[] = []
+    // Per-test connect outcome; the instance is created inside
+    // createSecondary, so behavior is registered on the class, not the node.
+    static connectOutcome: 'resolve' | 'reject' = 'resolve'
+
+    connectionState = 'closed'
+    connect = vi.fn()
+    close = vi.fn()
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+
+    constructor() {
+      MockGateway.instances.push(this)
+      this.connect.mockImplementation(async () => {
+        if (MockGateway.connectOutcome === 'reject') {
+          throw new Error('backend unreachable')
+        }
+      })
+    }
+  }
+
+  return {
+    MockGateway,
+    hermesDesktop: {
+      getConnection: vi.fn(),
+      touchBackend: vi.fn()
+    }
+  }
+})
+
+vi.mock('@/hermes', () => ({ HermesGateway: m.MockGateway }))
+vi.mock('@hermes/shared', () => ({
+  resolveGatewayWsUrl: vi.fn(async () => 'ws://test')
+}))
+vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+import { $gateway, closeSecondaryGateways, ensureGatewayForProfile } from './gateway'
+
+describe('ensureGatewayForProfile — secondary connect failure (#81094)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    m.MockGateway.instances = []
+    m.MockGateway.connectOutcome = 'resolve'
+    m.hermesDesktop.getConnection.mockResolvedValue({ profile: 'secondary' })
+    m.hermesDesktop.touchBackend.mockResolvedValue(undefined)
+    // openSecondary bails out early when window.hermesDesktop is missing
+    // (`if (!desktop) return`), which would silently resolve instead of
+    // exercising the connect path under test.
+    vi.stubGlobal('window', { hermesDesktop: m.hermesDesktop })
+  })
+
+  afterEach(() => {
+    closeSecondaryGateways()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('rethrows the connect failure instead of activating a closed socket', async () => {
+    m.MockGateway.connectOutcome = 'reject'
+
+    await expect(ensureGatewayForProfile('secondary')).rejects.toThrow('backend unreachable')
+    // The failure must NOT fall through to setActive with a closed socket.
+    expect($gateway.get()).toBeNull()
+  })
+
+  it('keeps the reconnect schedule on failure so transient errors still self-heal', async () => {
+    m.MockGateway.connectOutcome = 'reject'
+
+    await expect(ensureGatewayForProfile('secondary')).rejects.toThrow('backend unreachable')
+    // scheduleReconnect armed the backoff timer for the failed entry.
+    expect(vi.getTimerCount()).toBe(1)
+  })
+
+  it('activates the secondary once connect succeeds', async () => {
+    await ensureGatewayForProfile('secondary')
+
+    // $gateway points at the entry created by createSecondary, not a
+    // hand-made instance.
+    expect($gateway.get()).toBe(m.MockGateway.instances[0])
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -330,7 +330,16 @@ async function openSecondary(entry: Secondary): Promise<void> {
 
     const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
 
-    await entry.gateway.connect(wsUrl)
+    try {
+      await entry.gateway.connect(wsUrl)
+    } catch (error) {
+      // Log the dial target for support, but RETHROW THE ORIGINAL ERROR —
+      // reconnectSecondary classifies failures by message ("No connection
+      // with id", "no longer exists") to fail-stop permanent conditions, and
+      // wrapping here would break that. Callers decide surfacing (#81094).
+      console.error(`[gateway] dial for profile "${entry.profile}" failed:`, error)
+      throw error
+    }
 
     if (!entry.wantOpen) {
       entry.gateway.close()
@@ -804,8 +813,16 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
 
     try {
       await openSecondary(entry)
-    } catch {
+    } catch (error) {
+      // #81094: a failed secondary dial must NOT fall through to setActive()
+      // with a closed socket — that silently routes the user's messages to the
+      // primary backend (cross-profile session writes). Keep the reconnect
+      // schedule (transient failures still self-heal via the backoff below)
+      // but RE-THROW so the profile-door caller surfaces the failure and skips
+      // the activation. The agent-door twin (ensureGatewayForAgent) keeps its
+      // boolean contract and is guarded by the activeGateway() null invariant.
       scheduleReconnect(entry)
+      throw error
     }
   }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -807,27 +807,29 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   // profile-door twin of the agent path's lease above (#89622).
   entry.activationLeaseUntil = Date.now() + ACTIVATION_LEASE_MS
 
-  if (!isOpen(entry.gateway)) {
-    clearTimer(entry)
-    entry.reconnectAttempt = 0
+  try {
+    if (!isOpen(entry.gateway)) {
+      clearTimer(entry)
+      entry.reconnectAttempt = 0
 
-    try {
-      await openSecondary(entry)
-    } catch (error) {
-      // #81094: a failed secondary dial must NOT fall through to setActive()
-      // with a closed socket — that silently routes the user's messages to the
-      // primary backend (cross-profile session writes). Keep the reconnect
-      // schedule (transient failures still self-heal via the backoff below)
-      // but RE-THROW so the profile-door caller surfaces the failure and skips
-      // the activation. The agent-door twin (ensureGatewayForAgent) keeps its
-      // boolean contract and is guarded by the activeGateway() null invariant.
-      scheduleReconnect(entry)
-      throw error
+      try {
+        await openSecondary(entry)
+      } catch (error) {
+        // #81094: a failed secondary dial must NOT fall through to setActive()
+        // with a closed socket — that silently routes the user's messages to the
+        // primary backend (cross-profile session writes). Keep the reconnect
+        // schedule (transient failures still self-heal via the backoff below)
+        // but RE-THROW so the profile-door caller surfaces the failure and skips
+        // the activation. The agent-door twin (ensureGatewayForAgent) keeps its
+        // boolean contract and is guarded by the activeGateway() null invariant.
+        scheduleReconnect(entry)
+        throw error
+      }
     }
+  } finally {
+    // The activation is settling either way — release the prune lease.
+    entry.activationLeaseUntil = 0
   }
-
-  // The activation is settling either way — release the prune lease.
-  entry.activationLeaseUntil = 0
 
   if (entry.wantOpen && g.secondaries.get(key) === entry && applyActive(key, activationEpoch) && entry.connection) {
     publishActiveConnection(entry.connection)

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -308,8 +308,15 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
 
     try {
       await openSecondary(entry)
-    } catch {
+    } catch (error) {
+      // #81094: a failed secondary connect must NOT fall through to
+      // setActive with a closed socket — that routes the user's messages to
+      // the primary backend (cross-profile session writes). Keep the
+      // reconnect schedule (transient failures still self-heal) but RE-THROW
+      // so the caller (ensureGatewayProfile) can surface the failure and
+      // skip the activation.
       scheduleReconnect(entry)
+      throw error
     }
   }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -176,7 +176,22 @@ async function openSecondary(entry: Secondary): Promise<void> {
 
   const conn = await desktop.getConnection(entry.profile)
   const wsUrl = await resolveGatewayWsUrl(desktop, conn)
-  await entry.gateway.connect(wsUrl)
+
+  try {
+    await entry.gateway.connect(wsUrl)
+  } catch (error) {
+    // Surface the failure instead of letting the caller's catch path fall
+    // through to the primary socket. A silent fallback routes the user's
+    // messages to the wrong profile's backend (cross-profile session writes).
+    // See https://github.com/NousResearch/hermes-agent/issues/81094
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Failed to connect to profile "${entry.profile}" backend (${detail}). ` +
+        'If a manually started gateway process is holding this profile, stop it ' +
+        'or restart the desktop app before switching again.'
+    )
+  }
+
   void desktop.touchBackend?.(entry.profile).catch(() => undefined)
 }
 

--- a/apps/desktop/src/store/profile-switch-failure.test.ts
+++ b/apps/desktop/src/store/profile-switch-failure.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Profile-door activation failure surfacing (#81094): when a secondary's
+// socket cannot be opened, ensureGatewayForProfile must rethrow (after
+// arming the reconnect schedule) so the caller can surface the failure,
+// and profile.ts must NOT publish an activation for a backend that never
+// came up — previously the catch swallowed the error and setActive() ran
+// anyway, silently routing messages to the primary socket.
+
+const gatewayMocks = vi.hoisted(() => {
+  const instances: { close: ReturnType<typeof vi.fn>; connectionState: string }[] = []
+
+  return {
+    connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
+    instances
+  }
+})
+
+vi.mock('@/hermes', () => ({
+  setApiRequestProfile: vi.fn(),
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  HermesGateway: class {
+    connectionState = 'closed'
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+    })
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+    constructor() {
+      gatewayMocks.instances.push(this as never)
+    }
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: vi.fn(),
+  setGatewayState: vi.fn()
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+
+const { ensureGatewayProfile } = await import('./profile')
+
+function installDesktop(stub: Record<string, unknown>): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
+}
+
+function descriptorFor(profile: string) {
+  return {
+    authMode: 'token',
+    baseUrl: `https://${profile}.invalid`,
+    mode: 'local',
+    profile,
+    token: 'fake-test-token',
+    wsUrl: `wss://${profile}.invalid/ws`
+  }
+}
+
+beforeEach(() => {
+  gatewayMocks.instances.length = 0
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('ensureGatewayProfile — switch failure surfaces instead of silent fallback (#81094)', () => {
+  it('rejects when the target backend cannot be dialed, instead of resolving silently', async () => {
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => descriptorFor(profile))
+    installDesktop({ getConnection })
+
+    // The secondary dial fails at connect(): the whole switch must reject.
+    gatewayMocks.connect.mockRejectedValue(new Error('backend unreachable'))
+
+    await expect(ensureGatewayProfile('work')).rejects.toThrow('backend unreachable')
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
 import { $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -359,6 +360,11 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     })
   })()
 
+  // A failed switch must NOT fall back to the primary socket silently: that
+  // would route the user's messages to the wrong profile's backend and cause
+  // cross-profile session writes (#81094). The rejection propagates to
+  // await-callers (session actions, slash commands) which surface it in their
+  // own flows; fire-and-forget callers surface it via their own .catch below.
   try {
     await gatewaySwitch
   } finally {
@@ -505,7 +511,11 @@ export function selectProfile(name: string): void {
     requestFreshSession()
   }
 
-  void ensureGatewayProfile(target)
+  void ensureGatewayProfile(target).catch((error: unknown) => {
+    // #81094: a failed switch must be visible — the profile pill stays on the
+    // previous profile and the user learns why the backend is unreachable.
+    notifyError(error, `Failed to switch to profile "${target}"`)
+  })
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
@@ -518,7 +528,10 @@ export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
   requestFreshSession()
-  void ensureGatewayProfile(target)
+  void ensureGatewayProfile(target).catch((error: unknown) => {
+    // #81094: surface the failed dial instead of failing silently.
+    notifyError(error, `Failed to open profile "${target}"`)
+  })
 }
 
 export function setShowAllProfiles(value: boolean): void {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -299,6 +299,15 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
   try {
     await gatewaySwitch
+  } catch (error) {
+    // Switching to the target profile failed (e.g. its backend socket could
+    // not be opened — see openSecondary). Do NOT fall back to the primary
+    // socket silently: that would route the user's messages to the wrong
+    // profile's backend and cause cross-profile session writes.
+    // https://github.com/NousResearch/hermes-agent/issues/81094
+    const detail = error instanceof Error ? error.message : String(error)
+    console.error(`[gateway] profile switch to "${target}" failed: ${detail}`)
+    throw error
   } finally {
     gatewaySwitch = null
     $gatewaySwapTarget.set(null)


### PR DESCRIPTION
Fixes #81094

## Problem
When switching to a secondary profile, `openSecondary` / `ensureGatewayForProfile` could silently fall back to the primary socket if the target backend's WebSocket failed to open (e.g. a manually started gateway process holding the profile's resources). This routed the user's messages to the wrong profile's backend and caused cross-profile session writes.

## Changes
- `apps/desktop/src/store/gateway.ts` (`openSecondary`): rethrow connect failures with an actionable error message instead of letting the caller's catch path fall through to the primary socket.
- `apps/desktop/src/store/profile.ts` (`ensureGatewayProfile`): log and rethrow the switch failure instead of silently resetting the swap target.

## Why fail loudly instead of retrying?
A silent fallback is strictly worse than an explicit error here: the user's message would be persisted into the wrong profile's session. Failing loudly surfaces the conflict (e.g. a manually started gateway holding the profile) and the message suggests how to resolve it. Retrying against a manually held socket would loop forever.

## Notes
Replaces the previous PR #81099 (same fix, rebased onto current main; the old branch was force-pushed during a botched amend and GitHub does not allow reopening it).