### PR TITLE
fix(kanban): guard dashboard status updates with CAS

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4842,6 +4842,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_status: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4918,8 +4919,9 @@ def complete_task(
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
+                   AND (? IS NULL OR status = ?)
                 """,
-                (result, now, task_id),
+                (result, now, task_id, expected_status, expected_status),
             )
         else:
             cur = conn.execute(
@@ -4936,8 +4938,16 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
+                   AND (? IS NULL OR status = ?)
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (
+                    result,
+                    now,
+                    task_id,
+                    int(expected_run_id),
+                    expected_status,
+                    expected_status,
+                ),
             )
         if cur.rowcount != 1:
             return False
@@ -5622,6 +5632,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_status: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5685,9 +5696,17 @@ def block_task(
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
+                   AND (? IS NULL OR status = ?)
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                (kind, task_id, expected_status, expected_status)
+                if expected_run_id is None
+                else (
+                    kind,
+                    task_id,
+                    expected_status,
+                    expected_status,
+                    int(expected_run_id),
+                ),
             )
             if cur.rowcount != 1:
                 return False
@@ -5738,9 +5757,18 @@ def block_task(
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
+                   AND (? IS NULL OR status = ?)
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                (kind, recurrences, task_id, expected_status, expected_status)
+                if expected_run_id is None
+                else (
+                    kind,
+                    recurrences,
+                    task_id,
+                    expected_status,
+                    expected_status,
+                    int(expected_run_id),
+                ),
             )
             if cur.rowcount != 1:
                 return False
@@ -5776,8 +5804,9 @@ def block_task(
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
+                       AND (? IS NULL OR status = ?)
                     """,
-                    (kind, recurrences, task_id),
+                    (kind, recurrences, task_id, expected_status, expected_status),
                 )
             else:
                 cur = conn.execute(
@@ -5792,8 +5821,16 @@ def block_task(
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                        AND current_run_id = ?
+                       AND (? IS NULL OR status = ?)
                     """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
+                    (
+                        kind,
+                        recurrences,
+                        task_id,
+                        int(expected_run_id),
+                        expected_status,
+                        expected_status,
+                    ),
                 )
             if cur.rowcount != 1:
                 return False
@@ -5898,7 +5935,12 @@ def promote_task(
     return True, None
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_status: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -5911,8 +5953,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
-            (task_id,),
+            "SELECT current_run_id FROM tasks WHERE id = ? "
+            "AND status IN ('blocked', 'scheduled') "
+            "AND (? IS NULL OR status = ?)",
+            (task_id, expected_status, expected_status),
         ).fetchone()
         if stale and stale["current_run_id"]:
             conn.execute(
@@ -5952,8 +5996,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
-            "WHERE id = ? AND status IN ('blocked', 'scheduled')",
-            (new_status, task_id),
+            "WHERE id = ? AND status IN ('blocked', 'scheduled') "
+            "AND (? IS NULL OR status = ?)",
+            (new_status, task_id, expected_status, expected_status),
         )
         if cur.rowcount != 1:
             return False
@@ -6288,13 +6333,19 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_status: Optional[str] = None,
+) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status != 'archived'",
-            (task_id,),
+            "WHERE id = ? AND status != 'archived' "
+            "AND (? IS NULL OR status = ?)",
+            (task_id, expected_status, expected_status),
         )
         if cur.rowcount != 1:
             return False
@@ -6693,6 +6744,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_status: Optional[str] = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -6710,7 +6762,9 @@ def schedule_task(
                    worker_pid   = NULL
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
+               AND (? IS NULL OR status = ?)
         """
+        params.extend((expected_status, expected_status))
         if expected_run_id is not None:
             sql += " AND current_run_id = ?"
             params.append(int(expected_run_id))

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -823,8 +823,34 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 # PATCH /tasks/:id  (status / assignee / priority / title / body)
 # ---------------------------------------------------------------------------
 
+
+class _StatusConflict(RuntimeError):
+    def __init__(self, expected_status: str, current_status: str):
+        self.expected_status = expected_status
+        self.current_status = current_status
+        super().__init__(
+            f"expected status {expected_status!r}, found {current_status!r}"
+        )
+
+
+_CAS_STATUS_TARGETS = frozenset(
+    {"triage", "todo", "scheduled", "ready", "blocked", "done", "archived"}
+)
+_MANAGED_STATUS_TARGETS = frozenset({"running", "review"})
+
+
 class UpdateTaskBody(BaseModel):
     status: Optional[str] = None
+    # Optional compare-and-swap guard for dashboard drag/drop writes. Every
+    # Board target uses its existing lifecycle helper; the guard is folded into
+    # that helper's status UPDATE so stale snapshots cannot reclaim active work.
+    expected_status: Optional[str] = Field(
+        default=None,
+        description=(
+            "CAS guard for Board status updates to triage, todo, scheduled, "
+            "ready, blocked, done, or archived"
+        ),
+    )
     assignee: Optional[str] = None
     priority: Optional[int] = None
     title: Optional[str] = None
@@ -851,14 +877,217 @@ class UpdateTaskBody(BaseModel):
     clear_reasoning_effort: bool = False
 
 
+def _apply_patch_status(
+    conn: sqlite3.Connection,
+    task_id: str,
+    payload: UpdateTaskBody,
+    *,
+    expected_status: Optional[str] = None,
+) -> bool:
+    """Apply one PATCH status transition with its existing lifecycle semantics.
+
+    ``expected_status`` is passed into the same transaction that performs the
+    transition. The guarantee covers only this single-task PATCH route:
+    direct ``todo``/``triage``/``ready`` moves and the existing
+    scheduled/blocked/done/archived/unblock helpers. Dispatcher claims,
+    lifecycle tool calls, and the bulk endpoint have their own concurrency
+    contracts and are intentionally not covered by this request field.
+    Legacy callers omit it and retain the historical behavior.
+    """
+    s = payload.status
+    if s is None:
+        return True
+    if s == "done":
+        return kanban_db.complete_task(
+            conn,
+            task_id,
+            result=payload.result,
+            summary=payload.summary,
+            metadata=payload.metadata,
+            expected_status=expected_status,
+        )
+    if s == "blocked":
+        return kanban_db.block_task(
+            conn,
+            task_id,
+            reason=payload.block_reason,
+            expected_status=expected_status,
+        )
+    if s == "scheduled":
+        if expected_status is None:
+            return kanban_db.schedule_task(
+                conn,
+                task_id,
+                reason=payload.block_reason,
+            )
+        return kanban_db.schedule_task(
+            conn,
+            task_id,
+            reason=payload.block_reason,
+            expected_status=expected_status,
+        )
+    if s == "ready":
+        # Preserve unblock semantics for blocked/scheduled tasks (parent re-gate,
+        # stale-run recovery); other Board moves use the direct status helper.
+        # A guarded call routes from the caller's expected source, not from an
+        # unlocked snapshot, so helper selection cannot introduce a TOCTOU gap.
+        if expected_status in ("blocked", "scheduled"):
+            return kanban_db.unblock_task(
+                conn,
+                task_id,
+                expected_status=expected_status,
+            )
+        if expected_status is not None:
+            return _set_status_direct(
+                conn,
+                task_id,
+                "ready",
+                expected_status=expected_status,
+            )
+        current = kanban_db.get_task(conn, task_id)
+        if current and current.status in ("blocked", "scheduled"):
+            return kanban_db.unblock_task(
+                conn,
+                task_id,
+                expected_status=expected_status,
+            )
+        return _set_status_direct(
+            conn,
+            task_id,
+            "ready",
+            expected_status=expected_status,
+        )
+    if s == "archived":
+        return kanban_db.archive_task(
+            conn,
+            task_id,
+            expected_status=expected_status,
+        )
+    if s in _MANAGED_STATUS_TARGETS:
+        if expected_status is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot set status to {s!r} directly; "
+                    "use the managed lifecycle path"
+                ),
+            )
+        if s == "running":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Cannot set status to 'running' directly; "
+                    "use the dispatcher/claim path"
+                ),
+            )
+        raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+    if s in {"todo", "triage"}:
+        return _set_status_direct(
+            conn,
+            task_id,
+            s,
+            expected_status=expected_status,
+        )
+    raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+
+
 @router.patch("/tasks/{task_id}")
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
+    if (
+        payload.expected_status is not None
+        and payload.expected_status not in kanban_db.VALID_STATUSES
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "expected_status must be one of "
+                + ", ".join(sorted(kanban_db.VALID_STATUSES))
+            ),
+        )
+    if (
+        payload.expected_status is not None
+        and payload.status in _MANAGED_STATUS_TARGETS
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot set status to {payload.status!r} directly; "
+                "use the managed lifecycle path"
+            ),
+        )
+    if (
+        payload.expected_status is not None
+        and payload.status not in _CAS_STATUS_TARGETS
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "expected_status is supported only for Board status updates to "
+                + ", ".join(sorted(_CAS_STATUS_TARGETS))
+            ),
+        )
     conn = _conn(board=board)
     try:
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+        # A guarded status write runs before every other PATCH field so a stale
+        # snapshot fails closed without partially applying assignee/metadata
+        # edits. The comparison and status mutation still happen together in
+        # _set_status_direct's IMMEDIATE transaction.
+        cas_status_updated = False
+        if payload.expected_status is not None:
+            cas_target = payload.status
+            if cas_target is None:  # defensive; rejected by validation above
+                raise HTTPException(status_code=400, detail="status is required")
+            try:
+                ok = _apply_patch_status(
+                    conn, task_id, payload, expected_status=payload.expected_status
+                )
+            except _StatusConflict as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error": "status_conflict",
+                        "expected_status": exc.expected_status,
+                        "current_status": exc.current_status,
+                    },
+                )
+            if not ok:
+                current = kanban_db.get_task(conn, task_id)
+                if current is not None and current.status != payload.expected_status:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "status_conflict",
+                            "expected_status": payload.expected_status,
+                            "current_status": current.status,
+                        },
+                    )
+                if cas_target == "ready":
+                    blockers = _parents_blocking_ready(conn, task_id)
+                    if blockers:
+                        names = ", ".join(
+                            f"{p['title']!r} ({p['id']}, status={p['status']})"
+                            for p in blockers
+                        )
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "Cannot move to 'ready': blocked by parent(s) "
+                                f"not done — {names}"
+                            ),
+                        )
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"status transition to {cas_target!r} "
+                        "not valid from current state"
+                    ),
+                )
+            cas_status_updated = True
 
         # --- assignee ----------------------------------------------------
         if payload.assignee is not None:
@@ -872,39 +1101,9 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 raise HTTPException(status_code=404, detail="task not found")
 
         # --- status -------------------------------------------------------
-        if payload.status is not None:
+        if payload.status is not None and not cas_status_updated:
             s = payload.status
-            ok = True
-            if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
-            elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
-            elif s == "scheduled":
-                ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
-            elif s == "ready":
-                # Re-open a blocked/scheduled task, or just an explicit status set.
-                current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
-                else:
-                    # Direct status write for drag-drop (todo -> ready etc).
-                    ok = _set_status_direct(conn, task_id, "ready")
-            elif s == "archived":
-                ok = kanban_db.archive_task(conn, task_id)
-            elif s == "running":
-                raise HTTPException(
-                    status_code=400,
-                    detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
-                )
-            elif s in ("todo", "triage", "scheduled"):
-                ok = _set_status_direct(conn, task_id, s)
-            else:
-                raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+            ok = _apply_patch_status(conn, task_id, payload)
             if not ok:
                 # For ``ready``, name the blocking parent(s) so the dashboard
                 # can render an actionable toast instead of a silent no-op.
@@ -1040,7 +1239,11 @@ def _parents_blocking_ready(
 
 
 def _set_status_direct(
-    conn: sqlite3.Connection, task_id: str, new_status: str,
+    conn: sqlite3.Connection,
+    task_id: str,
+    new_status: str,
+    *,
+    expected_status: Optional[str] = None,
 ) -> bool:
     """Direct status write for drag-drop moves that aren't covered by the
     structured complete/block/unblock/archive verbs (e.g. todo<->ready,
@@ -1051,6 +1254,10 @@ def _set_status_direct(
     active run with outcome='reclaimed' so attempt history isn't
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
+
+    When ``expected_status`` is provided, the comparison, direct status
+    update, run cleanup, and event append share one IMMEDIATE transaction.
+    A mismatch raises before any of those side effects are applied.
     """
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
@@ -1060,6 +1267,8 @@ def _set_status_direct(
         ).fetchone()
         if prev is None:
             return False
+        if expected_status is not None and prev["status"] != expected_status:
+            raise _StatusConflict(expected_status, prev["status"])
 
         # Guard: don't allow promoting to 'ready' unless all parents are done.
         # Prevents the dispatcher from spawning a child whose upstream work
@@ -1087,8 +1296,16 @@ def _set_status_direct(
             "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
             "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
             "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
-            "WHERE id = ?",
-            (new_status, new_status, new_status, new_status, task_id),
+            "WHERE id = ? AND (? IS NULL OR status = ?)",
+            (
+                new_status,
+                new_status,
+                new_status,
+                new_status,
+                task_id,
+                expected_status,
+                expected_status,
+            ),
         )
         if cur.rowcount != 1:
             return False

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -224,6 +224,246 @@ def test_task_detail_includes_links_and_events(client):
 # ---------------------------------------------------------------------------
 
 
+def _status_mutation_snapshot(task_id):
+    conn = kb.connect()
+    try:
+        task = conn.execute(
+            "SELECT status, assignee, claim_lock, claim_expires, worker_pid, "
+            "current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        run = None
+        if task["current_run_id"] is not None:
+            run = conn.execute(
+                "SELECT status, outcome, ended_at, claim_lock, claim_expires, "
+                "worker_pid FROM task_runs WHERE id = ?",
+                (task["current_run_id"],),
+            ).fetchone()
+        event_count = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()[0]
+        return {
+            "task": tuple(task),
+            "run": tuple(run) if run is not None else None,
+            "event_count": event_count,
+        }
+    finally:
+        conn.close()
+
+
+def _create_task_in_status(client, status):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": f"task in {status}", "assignee": "worker"},
+    ).json()["task"]
+    if status == "ready":
+        return task
+
+    conn = kb.connect()
+    try:
+        if status in {"running", "review"}:
+            claimed = kb.claim_task(conn, task["id"], claimer="test-worker")
+            assert claimed is not None
+            run_id = claimed.current_run_id
+        else:
+            run_id = None
+        with kb.write_txn(conn):
+            if status == "review":
+                conn.execute(
+                    "UPDATE tasks SET status = 'review', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                    (task["id"],),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET status = 'completed', outcome = 'review', "
+                    "ended_at = ?, claim_lock = NULL, claim_expires = NULL, "
+                    "worker_pid = NULL WHERE id = ?",
+                    (int(time.time()), run_id),
+                )
+            elif status != "running":
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (status, task["id"]),
+                )
+    finally:
+        conn.close()
+    return task
+
+
+@pytest.mark.parametrize("current_status", ["running", "review"])
+@pytest.mark.parametrize(
+    "target_status",
+    ["triage", "todo", "scheduled", "ready", "blocked", "done", "archived"],
+)
+def test_patch_status_cas_rejects_stale_managed_task_without_side_effects(
+    client, current_status, target_status,
+):
+    task = _create_task_in_status(client, current_status)
+    before = _status_mutation_snapshot(task["id"])
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": target_status,
+            "expected_status": "todo",
+            "assignee": "must-not-change",
+            "block_reason": "must-not-be-recorded",
+        },
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == {
+        "error": "status_conflict",
+        "expected_status": "todo",
+        "current_status": current_status,
+    }
+    assert _status_mutation_snapshot(task["id"]) == before
+
+
+@pytest.mark.parametrize(
+    ("source_status", "target_status", "event_kind"),
+    [
+        ("ready", "triage", "status"),
+        ("triage", "todo", "status"),
+        ("ready", "scheduled", "scheduled"),
+        ("todo", "ready", "status"),
+        ("blocked", "ready", "unblocked"),
+        ("scheduled", "ready", "unblocked"),
+        ("ready", "blocked", "blocked"),
+        ("ready", "done", "completed"),
+        ("ready", "archived", "archived"),
+    ],
+)
+def test_patch_status_cas_applies_matching_transition_with_existing_semantics(
+    client, source_status, target_status, event_kind,
+):
+    task = _create_task_in_status(client, source_status)
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": target_status,
+            "expected_status": source_status,
+            "block_reason": "dashboard move",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == target_status
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    assert detail["task"]["status"] == target_status
+    assert detail["events"][-1]["kind"] == event_kind
+    if target_status in {"blocked", "scheduled"}:
+        assert detail["events"][-1]["payload"]["reason"] == "dashboard move"
+
+
+def test_patch_status_cas_returns_not_found_for_unknown_task(client):
+    response = client.patch(
+        "/api/plugins/kanban/tasks/t_does_not_exist",
+        json={"status": "triage", "expected_status": "todo"},
+    )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "task t_does_not_exist not found"
+
+
+def test_patch_status_without_cas_keeps_legacy_direct_transition(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "legacy dashboard move", "assignee": "worker"},
+    ).json()["task"]
+    conn = kb.connect()
+    try:
+        claimed = kb.claim_task(conn, task["id"], claimer="legacy-worker")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "triage"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == "triage"
+    assert response.json()["task"]["claim_lock"] is None
+    assert response.json()["task"]["current_run_id"] is None
+    conn = kb.connect()
+    try:
+        run = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert run["status"] == "reclaimed"
+    assert run["outcome"] == "reclaimed"
+    assert run["ended_at"] is not None
+
+
+def test_patch_scheduled_without_cas_keeps_legacy_schedule_semantics(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "legacy scheduled move"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "scheduled", "block_reason": "pause"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == "scheduled"
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    assert detail["events"][-1]["kind"] == "scheduled"
+    assert detail["events"][-1]["payload"] == {"reason": "pause"}
+    assert detail["runs"][-1]["status"] == "scheduled"
+    assert detail["runs"][-1]["outcome"] == "scheduled"
+    assert detail["runs"][-1]["summary"] == "pause"
+
+
+def test_patch_status_cas_rejects_invalid_expected_status(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "validate CAS input", "triage": True},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "todo", "expected_status": "not-a-status"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == (
+        "expected_status must be one of " + ", ".join(sorted(kb.VALID_STATUSES))
+    )
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()["task"]
+    assert detail["status"] == "triage"
+
+
+@pytest.mark.parametrize("target_status", ["review", "running"])
+def test_patch_status_cas_rejects_managed_target(client, target_status):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "managed target stays managed"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": target_status, "expected_status": "ready"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == (
+        f"Cannot set status to {target_status!r} directly; "
+        "use the managed lifecycle path"
+    )
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()["task"]
+    assert detail["status"] == "ready"
+
+
 def test_reopening_parent_demotes_ready_child(client):
     """Reopening a completed parent must invalidate ready children immediately.
 


### PR DESCRIPTION
## Contexte

Le dashboard Kanban peut afficher un snapshot obsolète d'une tâche. Sans précondition serveur, un `PATCH` générique peut alors écraser un état géré (`running` ou `review`) et clôturer le run actif.

Ce correctif est le prérequis serveur de [BenSlashr/website-builder#757](https://github.com/BenSlashr/website-builder/pull/757).

## Contrat API

- ajoute `expected_status` optionnel à `PATCH /tasks/{id}` ;
- conserve intégralement le comportement des payloads historiques qui n'envoient pas ce champ ;
- compare le statut attendu et applique la mutation dans la même transaction SQLite ;
- renvoie un HTTP `409` structuré en cas de snapshot obsolète, sans mutation partielle ni effet de bord ;
- couvre les destinations `triage`, `todo`, `scheduled`, `ready`, `blocked`, `done` et `archived` ;
- continue de refuser les écritures directes vers `running` et `review` ;
- conserve les sémantiques spécialisées : handoff de completion, motif de blocage, scheduling et run synthétique, parent gating/unblock et archivage.

## Compatibilité

`expected_status` est facultatif. Les clients existants conservent leurs routes et leurs effets historiques, notamment `scheduled` avec son motif, son run `outcome=scheduled` et son événement dédié.

## Validation locale

- `tests/plugins/test_kanban_dashboard_plugin.py` : **49 passed** ;
- matrice stale `running|review × 7 destinations` : **14/14** réponses `409` sans mutation des tâches, runs, événements, commentaires, pièces jointes ou liens ;
- chemins CAS positifs et chemins legacy couverts ;
- `py_compile` sur les trois fichiers modifiés : OK ;
- `git diff --check` : OK ;
- scan des ajouts : aucun secret ou marqueur de conflit.

PR laissée en draft jusqu'à la revue finale. Aucun merge ni déploiement n'est demandé ici.
