### PR TITLE
fix(desktop): wait for backend child exit before quitting

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2616,6 +2616,7 @@ let isQuittingForHandoff = false
 // (the app.quit() that follows re-enters before-quit and must pass through).
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
+let backendQuitTeardownDone = false
 
 // Resolve the staged updater binary the desktop may hand an update to. On
 // Windows that binary owns ALL repo mutation — running `hermes update` +
@@ -8322,6 +8323,20 @@ function stopAllPoolBackends() {
   }
 }
 
+// Quit-path variant of stopAllPoolBackends(): waits for every pool backend to
+// actually exit (SIGKILL escalation after 5s each, via teardownPoolBackendAndWait)
+// instead of firing SIGTERM and returning immediately. Used only from
+// before-quit, where the fire-and-forget original could let Electron's own
+// process exit before the child did, orphaning it to launchd. The Windows
+// lock-release path (releaseBackendLock) keeps calling the original
+// stopAllPoolBackends() — it already tree-kills aggressively right after, so
+// waiting there would just duplicate work for no benefit.
+async function stopAllPoolBackendsAndWait() {
+  await Promise.all(
+    [...backendPool.keys()].map(profile => teardownPoolBackendAndWait(profile))
+  )
+}
+
 // Returns the profile name whose backend was torn down, or null when the
 // request is not a profile-delete.  The caller uses this to skip ensureBackend
 // for the just-torn-down profile — otherwise ensureBackend respawns a pool
@@ -12021,8 +12036,24 @@ app.on('before-quit', event => {
     disposeTerminalSession(id)
   }
 
-  stopBackendChild(backendConnectionState.getProcess())
-  stopAllPoolBackends()
+  // Wait for the primary + pool backend children to actually exit before
+  // letting the app finish quitting. A bare SIGTERM-and-return (the previous
+  // behavior) could let Electron's own process exit first, orphaning the
+  // `hermes serve` child to launchd (PPID 1) — it stops listening but keeps
+  // ~/.hermes/state.db open indefinitely. teardownPrimaryBackendAndWait /
+  // teardownPoolBackendAndWait already implement the wait+SIGKILL-escalation
+  // (5s) this needs; the outer 6s race is just a hard ceiling so a stuck
+  // backend can never hang the quit entirely.
+  if (!backendQuitTeardownDone) {
+    event.preventDefault()
+
+    const pending = Promise.allSettled([teardownPrimaryBackendAndWait(), stopAllPoolBackendsAndWait()])
+
+    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 6_000))]).then(() => {
+      backendQuitTeardownDone = true
+      app.quit()
+    })
+  }
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Bug

Quitting the desktop app leaked its `hermes_cli.main serve` (or pool-backend) child process to `launchd` instead of terminating it. Reproduced 3/3 times on macOS: quit the app, then `ps aux | grep hermes_cli.main serve` still shows the process alive (`PPID=1`), no longer listening on its port but still holding `~/.hermes/state.db` open indefinitely.

## Root cause

`before-quit` in `apps/desktop/electron/main.ts` called `stopBackendChild(...)` / `stopAllPoolBackends()`, which only send `SIGTERM` and return immediately — nothing waits for the child to actually exit before Electron's own process finishes quitting. If the backend's graceful shutdown (uvicorn, WS teardown, etc.) takes any real time, the child gets orphaned instead of dying with its parent.

The wait+escalate primitive already existed in the file (`teardownPrimaryBackendAndWait` / `teardownPoolBackendAndWait`, used by profile/connection-switch flows) — it just wasn't wired into the quit path.

## Fix

- Added `stopAllPoolBackendsAndWait()`, an awaited variant of `stopAllPoolBackends()` built on the existing `teardownPoolBackendAndWait`.
- `before-quit` now holds the quit open (`event.preventDefault()` + a `backendQuitTeardownDone` latch, mirroring the existing SSH-teardown block earlier in the same handler) while it awaits `teardownPrimaryBackendAndWait()` + `stopAllPoolBackendsAndWait()`, then calls `app.quit()`. A 6s outer race caps worst-case quit latency if a backend ever hangs (each backend already escalates to SIGKILL after 5s internally).
- The Windows-only `releaseBackendLock` lock-release path is untouched — it already tree-kills aggressively right after calling `stopAllPoolBackends()`, so switching it to the waiting variant would just duplicate work.

## Verification

- `npm run typecheck` — clean.
- `npm run test:desktop:platforms` — 938 passed, 2 pre-existing skips, unchanged.
- Manual repro/fix verification: built the branch (`npm run pack`), launched an isolated instance (separate `HERMES_HOME`/`--user-data-dir`/`HERMES_DESKTOP_APP_NAME` to dodge the single-instance lock against a real running Hermes), captured the spawned backend's PID, sent `SIGTERM` to the Electron main process (simulating Cmd+Q / `app.quit()`), and confirmed the backend PID no longer exists afterward. Repeated 3/3 clean — zero orphans, the exact inverse of the original repro.