### PR TITLE
feat(gateway): configurable Discord thread auto-archive duration

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1949,6 +1949,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "thread_auto_archive_duration": 1440,  # Auto-archive minutes for threads Hermes creates (60/1440/4320/10080)
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1094,6 +1094,12 @@ class DiscordAdapter(BasePlatformAdapter):
             "websocket_max_latency_seconds",
             30.0,
         )
+        # Auto-archive duration (minutes) for threads Hermes creates (auto-
+        # threads, /thread slash, handoffs). Discord only accepts 60/1440/4320/
+        # 10080; any other config value falls back to the default 1440.
+        self._thread_auto_archive_duration = self._config_int("thread_auto_archive_duration", 1440)
+        if self._thread_auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
+            self._thread_auto_archive_duration = 1440
         self._liveness_task: Optional[asyncio.Task] = None
         self._liveness_notification_task: Optional[asyncio.Task] = None
         # True while disconnect() is intentionally closing discord.py. The
@@ -5590,7 +5596,7 @@ class DiscordAdapter(BasePlatformAdapter):
             interaction: discord.Interaction,
             name: str,
             message: str = "",
-            auto_archive_duration: int = 1440,
+            auto_archive_duration: Optional[int] = None,
         ):
             # defer() is performed inside the handler *after* the auth gate
             # so a rejected invoker can receive an ephemeral rejection.
@@ -6036,11 +6042,16 @@ class DiscordAdapter(BasePlatformAdapter):
         interaction: discord.Interaction,
         name: str,
         message: str = "",
-        auto_archive_duration: int = 1440,
+        auto_archive_duration: Optional[int] = None,
     ) -> None:
         """Create a Discord thread from a slash command and start a session in it."""
         if not await self._check_slash_authorization(interaction, "/thread"):
             return
+        effective_duration = (
+            auto_archive_duration
+            if auto_archive_duration is not None
+            else self._thread_auto_archive_duration
+        )
         deferred_response = False
         try:
             await interaction.response.defer(ephemeral=True)
@@ -6056,7 +6067,7 @@ class DiscordAdapter(BasePlatformAdapter):
             interaction,
             name=name,
             message=message,
-            auto_archive_duration=auto_archive_duration,
+            auto_archive_duration=effective_duration,
         )
 
         if not result.get("success"):
@@ -6728,7 +6739,7 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         name: str,
         message: str = "",
-        auto_archive_duration: int = 1440,
+        auto_archive_duration: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Create a thread in the current Discord channel.
 
@@ -6740,7 +6751,12 @@ class DiscordAdapter(BasePlatformAdapter):
         if not name:
             return {"error": "Thread name is required."}
 
-        if auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
+        effective_duration = (
+            auto_archive_duration
+            if auto_archive_duration is not None
+            else self._thread_auto_archive_duration
+        )
+        if effective_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
             allowed = ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES))
             return {"error": f"auto_archive_duration must be one of: {allowed}."}
 
@@ -6761,7 +6777,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             thread = await parent_channel.create_thread(
                 name=name,
-                auto_archive_duration=auto_archive_duration,
+                auto_archive_duration=effective_duration,
                 reason=reason,
             )
             if starter_message:
@@ -6777,7 +6793,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 seed_msg = await parent_channel.send(seed_content)
                 thread = await seed_msg.create_thread(
                     name=name,
-                    auto_archive_duration=auto_archive_duration,
+                    auto_archive_duration=effective_duration,
                     reason=reason,
                 )
                 return {
@@ -6835,7 +6851,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         for attempt in range(2):
             try:
-                thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+                thread = await message.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=self._thread_auto_archive_duration,
+                )
                 try:
                     setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
                 except Exception:
@@ -6849,7 +6868,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     thread = await seed_msg.create_thread(
                         name=thread_name,
-                        auto_archive_duration=1440,
+                        auto_archive_duration=self._thread_auto_archive_duration,
                         reason=reason,
                     )
                     try:
@@ -6984,7 +7003,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if create is not None:
                 thread = await create(
                     name=thread_name,
-                    auto_archive_duration=1440,
+                    auto_archive_duration=self._thread_auto_archive_duration,
                     reason=reason,
                 )
                 return str(thread.id)
@@ -7002,7 +7021,7 @@ class DiscordAdapter(BasePlatformAdapter):
             seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
             thread = await seed_msg.create_thread(
                 name=thread_name,
-                auto_archive_duration=1440,
+                auto_archive_duration=self._thread_auto_archive_duration,
                 reason=reason,
             )
             return str(thread.id)

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -141,6 +141,48 @@ async def test_registers_native_thread_slash_command(adapter):
     adapter._handle_thread_create_slash.assert_awaited_once_with(interaction, "Planning", "", 1440)
 
 
+# ------------------------------------------------------------------
+# thread_auto_archive_duration — config resolution and slash default
+# ------------------------------------------------------------------
+
+
+def test_thread_auto_archive_duration_defaults_to_1440():
+    """With no config value, threads use Discord's default 1440-minute archive."""
+    config = PlatformConfig(enabled=True, token="***")
+    adapter = DiscordAdapter(config)
+    assert adapter._thread_auto_archive_duration == 1440
+
+
+def test_thread_auto_archive_duration_reads_valid_config_value():
+    """A valid configured duration is honored."""
+    config = PlatformConfig(enabled=True, token="***", extra={"thread_auto_archive_duration": 4320})
+    adapter = DiscordAdapter(config)
+    assert adapter._thread_auto_archive_duration == 4320
+
+
+def test_thread_auto_archive_duration_invalid_config_falls_back_to_1440():
+    """Discord only accepts 60/1440/4320/10080; an invalid config value falls back to 1440."""
+    config = PlatformConfig(enabled=True, token="***", extra={"thread_auto_archive_duration": 9999})
+    adapter = DiscordAdapter(config)
+    assert adapter._thread_auto_archive_duration == 1440
+
+
+@pytest.mark.asyncio
+async def test_thread_slash_omitted_param_forwards_none(adapter):
+    """Omitting auto_archive_duration in /thread forwards None so the config default is used."""
+    adapter._handle_thread_create_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["thread"]
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+    )
+
+    await command(interaction, name="Planning", message="")
+
+    adapter._handle_thread_create_slash.assert_awaited_once_with(interaction, "Planning", "", None)
+
+
 @pytest.mark.asyncio
 async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter):
     class UnknownInteraction(Exception):
@@ -346,6 +388,68 @@ async def test_handle_thread_create_slash_falls_back_to_seed_message(adapter):
     interaction.followup.send.assert_awaited()
 
 
+@pytest.mark.asyncio
+async def test_handle_thread_create_slash_none_uses_config_duration(adapter):
+    """auto_archive_duration=None resolves to the configured value."""
+    adapter._thread_auto_archive_duration = 10080
+    created_thread = SimpleNamespace(id=555, name="Planning", send=AsyncMock())
+    parent_channel = SimpleNamespace(create_thread=AsyncMock(return_value=created_thread), send=AsyncMock())
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(parent=parent_channel),
+        channel_id=123,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        guild=SimpleNamespace(name="TestGuild"),
+        followup=SimpleNamespace(send=AsyncMock()),
+        response=SimpleNamespace(defer=AsyncMock()),
+    )
+
+    await adapter._handle_thread_create_slash(interaction, "Planning", "Kickoff")
+
+    parent_channel.create_thread.assert_awaited_once_with(
+        name="Planning",
+        auto_archive_duration=10080,
+        reason="Requested by Jezza via /thread",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_thread_create_slash_explicit_param_wins(adapter):
+    """An explicit valid auto_archive_duration beats the config value."""
+    adapter._thread_auto_archive_duration = 10080
+    created_thread = SimpleNamespace(id=555, name="Planning", send=AsyncMock())
+    parent_channel = SimpleNamespace(create_thread=AsyncMock(return_value=created_thread), send=AsyncMock())
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(parent=parent_channel),
+        channel_id=123,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        guild=SimpleNamespace(name="TestGuild"),
+        followup=SimpleNamespace(send=AsyncMock()),
+        response=SimpleNamespace(defer=AsyncMock()),
+    )
+
+    await adapter._handle_thread_create_slash(interaction, "Planning", "Kickoff", 4320)
+
+    parent_channel.create_thread.assert_awaited_once_with(
+        name="Planning",
+        auto_archive_duration=4320,
+        reason="Requested by Jezza via /thread",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_rejects_invalid_explicit_duration(adapter):
+    """Explicit invalid durations are still rejected even when the config default is valid."""
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="general"),
+        user=SimpleNamespace(display_name="Jezza", id=42),
+    )
+
+    result = await adapter._create_thread(interaction, name="Planning", auto_archive_duration=9999)
+
+    assert not result.get("success")
+    assert "auto_archive_duration must be one of" in result["error"]
+
+
 # ------------------------------------------------------------------
 # _dispatch_thread_session — builds correct event and routes it
 # ------------------------------------------------------------------
@@ -425,6 +529,43 @@ async def test_auto_create_thread_strips_mention_syntax_from_name(adapter):
     assert "<@" not in name, f"role/user mention leaked: {name!r}"
     assert "<#" not in name, f"channel mention leaked: {name!r}"
     assert name == "please help"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_uses_config_archive_duration(adapter):
+    """Auto-created threads honor the configured auto-archive duration."""
+    adapter._thread_auto_archive_duration = 10080
+    thread = SimpleNamespace(id=999, name="help")
+    message = SimpleNamespace(
+        content="please help",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    await adapter._auto_create_thread(message)
+
+    message.create_thread.assert_awaited_once()
+    assert message.create_thread.await_args.kwargs["auto_archive_duration"] == 10080
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_fallback_uses_config_archive_duration(adapter):
+    """The seed-message fallback also honors the configured auto-archive duration."""
+    adapter._thread_auto_archive_duration = 60
+    thread = SimpleNamespace(id=999, name="help")
+    seed_msg = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+    message = SimpleNamespace(
+        content="please help",
+        create_thread=AsyncMock(side_effect=RuntimeError("direct failed")),
+        channel=SimpleNamespace(send=AsyncMock(return_value=seed_msg)),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    await adapter._auto_create_thread(message)
+
+    seed_msg.create_thread.assert_awaited_once()
+    assert seed_msg.create_thread.await_args.kwargs["auto_archive_duration"] == 60
 
 
 @pytest.mark.asyncio
@@ -599,6 +740,31 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
     assert len(payload) < 500, (
         f"Flat /skill command payload is ~{len(payload)} bytes — the whole "
         f"point of this design is that it stays small regardless of skill count"
+    )
+
+
+# ------------------------------------------------------------------
+# create_handoff_thread — config-driven auto-archive duration
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handoff_thread_uses_config_archive_duration(adapter):
+    """Handoff threads honor the configured auto-archive duration."""
+    adapter._thread_auto_archive_duration = 60
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(return_value=SimpleNamespace(id=777)),
+        send=AsyncMock(),
+    )
+    adapter._client.get_channel = lambda _id: parent
+
+    thread_id = await adapter.create_handoff_thread("123", "handoff test")
+
+    assert thread_id == "777"
+    parent.create_thread.assert_awaited_once_with(
+        name="handoff test",
+        auto_archive_duration=60,
+        reason="Hermes session handoff",
     )
 
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -336,6 +336,7 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
+  thread_auto_archive_duration: 1440  # Auto-archive minutes for threads Hermes creates (60/1440/4320/10080)
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
@@ -409,6 +410,19 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+
+#### `discord.thread_auto_archive_duration`
+
+**Type:** integer — **Default:** `1440`
+
+Auto-archive duration in minutes for threads Hermes creates: mention auto-threads, `/thread` slash-command sessions, and session handoff threads. Discord only accepts `60` (1 hour), `1440` (24 hours), `4320` (3 days), or `10080` (7 days); anything else falls back to the default `1440`.
+
+```yaml
+discord:
+  thread_auto_archive_duration: 4320   # archive threads Hermes creates after 3 days
+```
+
+Passing `auto_archive_duration` to the `/thread` slash command overrides this setting for that thread. Invalid values (config or slash parameter) are rejected or fall back to `1440` rather than being sent to Discord.
 
 #### `discord.reactions`
 


### PR DESCRIPTION
Adds a `discord.thread_auto_archive_duration` config option so the auto-archive window of threads Hermes creates is configurable instead of hardcoded to 24 hours.

Closes #81136

**What changes**

- `hermes_cli/config_defaults.py` — new `discord.thread_auto_archive_duration` key, default `1440` (Discord's valid values: 60 / 1440 / 4320 / 10080 minutes).
- `plugins/platforms/discord/adapter.py` — all gateway thread-creation paths now read the config value instead of a hardcoded 1440:
  - `/thread` slash command (`slash_thread` → `_handle_thread_create_slash` → `_create_thread`): the `auto_archive_duration` parameter stays optional and, when omitted, resolves to the config value. An explicitly passed value still wins and is still validated against the allowed set.
  - Mention auto-threads (`_auto_create_thread`).
  - Session handoff threads.
  - Invalid config values (anything outside 60/1440/4320/10080) fall back to 1440, so a bad YAML value can't make thread creation fail.
- Tests — covers omitted-param-uses-config, invalid-config-falls-back, and explicit-param-wins.
- Docs — the Discord config section now lists the new key.

**Design notes**

The adapter already resolves flat keys from `self.config.extra` via `_config_value` / `_config_int` (used by the websocket liveness settings), so this follows the existing pattern rather than introducing a new mechanism. The model tool in `tools/discord_tool.py` has no config access today and keeps its own 1440 default; the slash command is the user-facing surface, so this change targets the gateway paths.
