### PR TITLE
fix(memory): bound per-turn memory mutations to stop destructive loops

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -244,6 +244,106 @@ class TestMemoryConsolidationGracefulDegrade:
         assert "continue with your reply" not in r["error"]
 
 
+class TestMemoryMutationBudget:
+    """Issue #81120: a model can loop SUCCESSFUL memory writes (each with
+    different parameters, each returning done=true) to bypass the consecutive-
+    failure cap and rewrite/delete unrelated facts indefinitely —
+    _success_response resets _consolidation_failures on every success. The
+    per-turn mutation budget counts ALL attempts (success AND failure alike)
+    and stops the loop within a bounded number of calls, leaving the last
+    known-good store state intact."""
+
+    def test_loop_of_distinct_successful_writes_is_bounded(self, store):
+        # Seed an unrelated fact plus near-full usage so the maintenance
+        # situation from the issue (an overflow add) triggers.
+        store.add("memory", "keep me: unrelated fact")
+        fill = "a" * 468
+        store.add("memory", fill)
+        r = store.add("memory", "brand new fact")  # overflow
+        assert r["success"] is False
+        assert "exceed" in r["error"].lower()
+
+        cap = store._MAX_MUTATIONS_PER_TURN
+        used = store._mutations_this_turn  # 2 seeds + 1 overflow attempt
+        assert used == 3
+        remaining = cap - used
+
+        # Every replacement SUCCEEDS and is DISTINCT, so the old consecutive-
+        # failure cap never fires (each success resets it via _success_response).
+        # Only the cumulative mutation budget can stop this sequence.
+        current = fill
+        for i in range(remaining):
+            nxt = f"v{i}" + "x" * (len(fill) - len(f"v{i}"))
+            r = store.replace("memory", current, nxt)
+            assert r["success"] is True, f"replace {i} should succeed"
+            assert r["done"] is True
+            current = nxt
+
+        # The next attempt is rejected: terminal, and NOTHING changed — the
+        # budget is checked before any mutation is applied.
+        before = list(store.memory_entries)
+        r = store.replace("memory", "keep me", "clobbered")
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "budget" in r["error"]
+        assert store.memory_entries == before
+        # The unrelated persistent entry survived the whole sequence.
+        assert "keep me: unrelated fact" in store.memory_entries
+        assert "clobbered" not in store.memory_entries
+
+    def test_normal_single_writes_still_work(self, store):
+        store.add("memory", "first fact")
+        store.replace("memory", "first", "first updated")
+        store.remove("memory", "first updated")
+        store.add("user", "Name: Alice")
+        assert "first updated" not in store.memory_entries
+        assert "Name: Alice" in store.user_entries
+        assert store._mutations_this_turn == 4
+
+    def test_terminated_turn_resumes_after_boundary(self, store):
+        cap = store._MAX_MUTATIONS_PER_TURN
+        for i in range(cap):
+            r = store.add("memory", f"filler {i}")
+            assert r["success"] is True
+        # Budget exhausted: next call is terminal (done=true), store unchanged —
+        # the terminal semantics do not break the model's ability to reply.
+        before = list(store.memory_entries)
+        r = store.add("memory", "extra")
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "budget" in r["error"]
+        assert store.memory_entries == before
+        # A new turn boundary resets the budget — normal writes resume.
+        store.reset_consolidation_failures()
+        r = store.add("memory", "fresh after reset")
+        assert r["success"] is True
+        assert "fresh after reset" in store.memory_entries
+        assert store._mutations_this_turn == 1
+
+    def test_batch_counts_as_single_mutation(self, store):
+        store.add("memory", "stale A")
+        store.add("memory", "stale B")
+        before = store._mutations_this_turn
+        r = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "stale A"},
+            {"action": "remove", "old_text": "stale B"},
+            {"action": "add", "content": "fresh fact"},
+        ])
+        assert r["success"] is True
+        assert "fresh fact" in store.memory_entries
+        assert store._mutations_this_turn == before + 1
+
+    def test_over_budget_batch_is_rejected_before_mutation(self, store):
+        cap = store._MAX_MUTATIONS_PER_TURN
+        for i in range(cap):
+            store.add("memory", f"filler {i}")
+        r = store.apply_batch("memory", [{"action": "remove", "old_text": "filler 0"}])
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "budget" in r["error"]
+        assert "filler 0" in store.memory_entries  # nothing was removed
+
+
 class TestMemoryStorePersistence:
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -173,6 +173,19 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
+    # Per-turn budget on TOTAL memory mutation attempts (add / replace / remove
+    # / apply_batch calls — successful AND failed alike). This is independent
+    # of whether each individual write succeeds: _consolidation_failures only
+    # caps CONSECUTIVE failures, and a successful write resets it, so a model
+    # that keeps issuing DIFFERENT successful replace/remove calls could loop
+    # forever, rewriting or deleting unrelated facts until the user interrupts
+    # (issue #81120). This counter bounds the whole memory-maintenance effort
+    # per turn — generous enough for normal multi-write turns (a couple of
+    # single adds/replaces, or one atomic operations= batch) while stopping a
+    # pathological loop within a handful of calls. When it is hit, the model is
+    # told to stop mutating memory and reply to the user.
+    _MAX_MUTATIONS_PER_TURN = 8
+
     def __init__(
         self,
         memory_char_limit: int = 2200,
@@ -192,14 +205,21 @@ class MemoryStore:
         # Per-turn counter of failed at-capacity consolidation attempts; reset
         # at each turn boundary by reset_consolidation_failures() (#42405).
         self._consolidation_failures = 0
+        # Per-turn counter of TOTAL mutation attempts (successes + failures);
+        # reset at each turn boundary by reset_consolidation_failures()
+        # (#81120). Independent of _consolidation_failures: a successful write
+        # does NOT reset this, so a loop of distinct successful writes is still
+        # bounded.
+        self._mutations_this_turn = 0
 
     def target_enabled(self, target: str) -> bool:
         """Return whether this session's selected built-in store is writable."""
         return self.user_profile_enabled if target == "user" else self.memory_enabled
 
     def reset_consolidation_failures(self) -> None:
-        """Reset the per-turn consolidation-failure counter (call at turn start)."""
+        """Reset the per-turn consolidation-failure and mutation counters (call at turn start)."""
         self._consolidation_failures = 0
+        self._mutations_this_turn = 0
 
     def _consolidation_failure(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Count an at-capacity consolidation failure and degrade gracefully.
@@ -221,6 +241,32 @@ class MemoryStore:
                 "this turn. Stop retrying memory calls — leave memory unchanged for "
                 "now and continue with your reply to the user. The fact can be saved "
                 "in a later turn."
+            ),
+        }
+
+    def _mutation_budget_exceeded(self) -> Dict[str, Any]:
+        """Terminal response when the per-turn mutation budget is exhausted.
+
+        The budget counts EVERY mutation attempt (success and failure alike),
+        so a model that loops successful replace/remove calls with different
+        parameters can no longer bypass the guard by resetting the
+        consecutive-failure counter via _success_response (issue #81120).
+        Returning a TERMINAL result tells the model to stop issuing memory
+        calls and continue with its reply to the user.
+
+        The store keeps its last-known-good state: the budget is checked
+        BEFORE any mutation is applied, so the over-budget call changes
+        nothing — unrelated persistent entries are never touched.
+        """
+        return {
+            "success": False,
+            "done": True,
+            "error": (
+                f"Memory mutations reached the per-turn budget of "
+                f"{self._MAX_MUTATIONS_PER_TURN} attempts. Stop making memory "
+                "changes for now and continue with your reply to the user. "
+                "Unrelated memory entries were left untouched. New memory can "
+                "be saved in a later turn."
             ),
         }
 
@@ -413,6 +459,13 @@ class MemoryStore:
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
+        # Count every mutation attempt (success AND failure) against the
+        # per-turn budget; the budget is checked before any change, so an
+        # over-budget call mutates nothing (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         content = content.strip()
         if not content:
             return {"success": False, "error": "Content cannot be empty."}
@@ -472,6 +525,11 @@ class MemoryStore:
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -543,6 +601,11 @@ class MemoryStore:
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         old_text = old_text.strip()
         if not old_text:
             return {"success": False, "error": "old_text cannot be empty."}
@@ -596,6 +659,11 @@ class MemoryStore:
         the net result would exceed the char limit, NOTHING is written and an
         error is returned describing the first failure plus the live state.
         """
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         if not operations:
             return {"success": False, "error": "operations list is empty."}
 
@@ -725,8 +793,11 @@ class MemoryStore:
 
     def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
         # A successful write means the consolidation loop made progress, so the
-        # per-turn failure budget resets (the cap counts consecutive failures,
-        # not lifetime ones within a turn) (#42405).
+        # per-turn CONSECUTIVE-failure budget resets (the cap counts consecutive
+        # failures, not lifetime ones within a turn) (#42405). The cumulative
+        # per-turn mutation budget (_mutations_this_turn) is NOT reset here — it
+        # bounds the whole maintenance effort regardless of success, so a loop
+        # of distinct successful writes still gets stopped (#81120).
         self._consolidation_failures = 0
         entries = self._entries_for(target)
         current = self._char_count(target)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -162,6 +162,19 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
+    # Per-turn budget on TOTAL memory mutation attempts (add / replace / remove
+    # / apply_batch calls — successful AND failed alike). This is independent
+    # of whether each individual write succeeds: _consolidation_failures only
+    # caps CONSECUTIVE failures, and a successful write resets it, so a model
+    # that keeps issuing DIFFERENT successful replace/remove calls could loop
+    # forever, rewriting or deleting unrelated facts until the user interrupts
+    # (issue #81120). This counter bounds the whole memory-maintenance effort
+    # per turn — generous enough for normal multi-write turns (a couple of
+    # single adds/replaces, or one atomic operations= batch) while stopping a
+    # pathological loop within a handful of calls. When it is hit, the model is
+    # told to stop mutating memory and reply to the user.
+    _MAX_MUTATIONS_PER_TURN = 8
+
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
@@ -172,10 +185,17 @@ class MemoryStore:
         # Per-turn counter of failed at-capacity consolidation attempts; reset
         # at each turn boundary by reset_consolidation_failures() (#42405).
         self._consolidation_failures = 0
+        # Per-turn counter of TOTAL mutation attempts (successes + failures);
+        # reset at each turn boundary by reset_consolidation_failures()
+        # (#81120). Independent of _consolidation_failures: a successful write
+        # does NOT reset this, so a loop of distinct successful writes is still
+        # bounded.
+        self._mutations_this_turn = 0
 
     def reset_consolidation_failures(self) -> None:
-        """Reset the per-turn consolidation-failure counter (call at turn start)."""
+        """Reset the per-turn consolidation-failure and mutation counters (call at turn start)."""
         self._consolidation_failures = 0
+        self._mutations_this_turn = 0
 
     def _consolidation_failure(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Count an at-capacity consolidation failure and degrade gracefully.
@@ -197,6 +217,32 @@ class MemoryStore:
                 "this turn. Stop retrying memory calls — leave memory unchanged for "
                 "now and continue with your reply to the user. The fact can be saved "
                 "in a later turn."
+            ),
+        }
+
+    def _mutation_budget_exceeded(self) -> Dict[str, Any]:
+        """Terminal response when the per-turn mutation budget is exhausted.
+
+        The budget counts EVERY mutation attempt (success and failure alike),
+        so a model that loops successful replace/remove calls with different
+        parameters can no longer bypass the guard by resetting the
+        consecutive-failure counter via _success_response (issue #81120).
+        Returning a TERMINAL result tells the model to stop issuing memory
+        calls and continue with its reply to the user.
+
+        The store keeps its last-known-good state: the budget is checked
+        BEFORE any mutation is applied, so the over-budget call changes
+        nothing — unrelated persistent entries are never touched.
+        """
+        return {
+            "success": False,
+            "done": True,
+            "error": (
+                f"Memory mutations reached the per-turn budget of "
+                f"{self._MAX_MUTATIONS_PER_TURN} attempts. Stop making memory "
+                "changes for now and continue with your reply to the user. "
+                "Unrelated memory entries were left untouched. New memory can "
+                "be saved in a later turn."
             ),
         }
 
@@ -389,6 +435,13 @@ class MemoryStore:
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
+        # Count every mutation attempt (success AND failure) against the
+        # per-turn budget; the budget is checked before any change, so an
+        # over-budget call mutates nothing (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         content = content.strip()
         if not content:
             return {"success": False, "error": "Content cannot be empty."}
@@ -448,6 +501,11 @@ class MemoryStore:
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -519,6 +577,11 @@ class MemoryStore:
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         old_text = old_text.strip()
         if not old_text:
             return {"success": False, "error": "old_text cannot be empty."}
@@ -572,6 +635,11 @@ class MemoryStore:
         the net result would exceed the char limit, NOTHING is written and an
         error is returned describing the first failure plus the live state.
         """
+        # Count every mutation attempt against the per-turn budget (#81120).
+        self._mutations_this_turn += 1
+        if self._mutations_this_turn > self._MAX_MUTATIONS_PER_TURN:
+            return self._mutation_budget_exceeded()
+
         if not operations:
             return {"success": False, "error": "operations list is empty."}
 
@@ -701,8 +769,11 @@ class MemoryStore:
 
     def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
         # A successful write means the consolidation loop made progress, so the
-        # per-turn failure budget resets (the cap counts consecutive failures,
-        # not lifetime ones within a turn) (#42405).
+        # per-turn CONSECUTIVE-failure budget resets (the cap counts consecutive
+        # failures, not lifetime ones within a turn) (#42405). The cumulative
+        # per-turn mutation budget (_mutations_this_turn) is NOT reset here — it
+        # bounds the whole maintenance effort regardless of success, so a loop
+        # of distinct successful writes still gets stopped (#81120).
         self._consolidation_failures = 0
         entries = self._entries_for(target)
         current = self._char_count(target)


### PR DESCRIPTION
Fixes #81120

The memory tool's per-turn consolidation-failure cap only fires on CONSECUTIVE failures and resets on every successful write, so a model can loop replace/remove calls — each with distinct parameters, each returning done=true — and rewrite or delete unrelated facts until the user interrupts. This adds a cumulative per-turn mutation budget that counts every mutation attempt (success AND failure alike) and returns a terminal response once exceeded, preserving the last-known-good store state.

Key points:
- New `_MAX_MUTATIONS_PER_TURN = 8` constant in `MemoryStore`; every add/replace/remove/apply_batch call (success or failure) increments `_mutations_this_turn`.
- Budget is checked BEFORE any mutation, so an over-budget call never touches disk — unrelated entries are guaranteed to survive.
- `reset_consolidation_failures` (called at each turn boundary via `agent/turn_context.py:484`) now also resets `_mutations_this_turn`. No change to turn_context itself.
- Existing `_MAX_CONSOLIDATION_FAILURES_PER_TURN` consecutive-failure degradation logic is unchanged.
- Budget cap of 8 accommodates normal multi-write turns (a couple of single adds/replaces, or one atomic operations= batch) while bounding pathological loops to a handful of destructive calls per turn.
- Regression tests cover: bounded loop of distinct successful writes with unrelated entry preserved; terminal after budget; resume on turn boundary; batch counts as one mutation; over-budget batch rejected before mutation; normal single writes still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)