### PR TITLE
fix: keep listening after stopping a voice-conversation reply

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -203,9 +203,10 @@ describe('useVoiceConversation playback rearm', () => {
       mocks.continueStreamStart()
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    // The reply is silenced, but the conversation stays live and re-listens.
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
     expect(mocks.stopVoicePlayback).toHaveBeenCalledTimes(2)
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    expect(hook.result.current.status).toBe('listening')
   })
 
   it('does not start fallback playback after Stop during stream discovery', async () => {
@@ -221,24 +222,28 @@ describe('useVoiceConversation playback rearm', () => {
       mocks.continueStreamStart()
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    // No fallback playback, but the loop re-arms the mic instead of wedging.
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
     expect(mocks.playSpeechText).not.toHaveBeenCalled()
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    expect(hook.result.current.status).toBe('listening')
   })
 
-  it('does not re-arm after an external Stop during streaming playback', async () => {
+  it('re-arms the microphone after an external Stop during streaming playback', async () => {
     const hook = renderRearmConversation('reply-stopped', 'Playing now')
 
     await beginReply(hook)
     await waitFor(() => expect(mocks.startSpeechStream).toHaveBeenCalled())
 
+    // Regression: stopping the reply (playback Stop button) used to wedge the
+    // conversation into idle with the mic never reopening — the user could no
+    // longer speak. An active conversation must keep listening after a stop.
     mocks.stopVoicePlayback()
     await act(async () => {
       mocks.finishSpeech('done')
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
+    expect(hook.result.current.status).toBe('listening')
   })
 
   it('re-arms the microphone after normal fallback playback completes', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -262,7 +262,7 @@ export function useVoiceConversation({
   }, [handle, handleTurn, onFatalError, voiceCopy.couldNotStartSession, voiceCopy.microphoneFailed])
 
   const settleAfterSpeech = useCallback(
-    (barged: boolean, stoppedDuringSetup = false) => {
+    (barged: boolean) => {
       if (barged || !awaitingSpokenResponseRef.current) {
         awaitingSpokenResponseRef.current = false
         consumePendingResponse()
@@ -282,16 +282,15 @@ export function useVoiceConversation({
 
       dropSpeechSession()
 
-      // If stopVoicePlayback() was called externally (Stop button, end), the
-      // voice-playback sequence has advanced past what we captured at speech
-      // start — don't auto-start the next sentence, the user chose to stop.
-      const stoppedByUser =
-        stoppedDuringSetup ||
-        (speechStartSequenceRef.current > 0 && $voicePlayback.get().sequence > speechStartSequenceRef.current)
-
+      // An external stopVoicePlayback() (the playback Stop button) silences
+      // the current reply. The conversation loop must keep listening — the
+      // user pressed stop to speak, not to leave; ending the conversation is
+      // end()'s job (it clears pendingStartRef itself). Without the re-arm,
+      // a mid-reply Stop wedged the loop into idle with the mic never
+      // reopening, and the user could not continue speaking.
       speechStartSequenceRef.current = 0
 
-      if (enabledRef.current && !stoppedByUser) {
+      if (enabledRef.current) {
         pendingStartRef.current = true
       }
 
@@ -517,7 +516,7 @@ export function useVoiceConversation({
           // live attempt into fresh fallback playback.
           if ($voicePlayback.get().sequence > sequenceBeforeStart) {
             awaitingSpokenResponseRef.current = false
-            settleAfterSpeech(false, true)
+            settleAfterSpeech(false)
 
             return
           }
@@ -542,7 +541,7 @@ export function useVoiceConversation({
         if (stoppedDuringStart) {
           stopVoicePlayback()
           awaitingSpokenResponseRef.current = false
-          settleAfterSpeech(false, true)
+          settleAfterSpeech(false)
 
           return
         }


### PR DESCRIPTION
## Summary

Stopping playback mid-reply (the playback **Stop** button) suppressed the next listen cycle: `settleAfterSpeech` treated any external `stopVoicePlayback()` as "user chose to stop" and left `pendingStartRef` false — wedging an **active** voice conversation into idle with the mic never reopening. The user could not continue speaking until manually restarting the conversation.

An active conversation must stay live after a Stop: the button silences the current reply, and `end()` (which clears `pendingStartRef` itself) is the only path that should end the loop. The `stoppedByUser` sequence heuristic is removed; the loop re-arms unconditionally when enabled.

## Motivation

Reported by a user: in a voice conversation, stopping the spoken reply mid-output made voice input dead — the loop never re-listened.

## Test Plan

- Updated `use-voice-conversation-rearm.test.tsx`:
  - `re-arms the microphone after an external Stop during streaming playback` (regression test — previously asserted the wedge)
  - Stop while preparing / during stream discovery now asserts the mic re-arms (`handle.start` ×2, status `listening`) while playback stays silenced (`stopVoicePlayback` still fired, no fallback `playSpeechText`)
- `vitest run` on both conversation hook test files: **11 passed**
- ESLint: 0 problems
