### PR TITLE
fix(telegram): ignore edited message replays

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8864,13 +8864,23 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, _redact_telegram_error_text(e))
 
     def _effective_update_message(self, update: Update) -> Optional[Message]:
-        """Return the message-like payload for normal messages and channel posts.
+        """Return the payload for new messages and channel posts only.
 
         Telegram exposes channel broadcasts as ``update.channel_post`` rather
-        than ``update.message``.  MessageHandler filters can still dispatch
+        than ``update.message``. MessageHandler filters can still dispatch
         those updates, so handlers must use ``effective_message`` to avoid
         consuming channel posts without ever building a gateway event.
+
+        Edited messages are deliberately ignored. Telegram can emit spurious
+        ``edited_message`` updates for metadata-only changes such as member-tag
+        updates, and replaying their original text could re-run side-effecting
+        commands such as ``/stop`` or ``/restart``.
         """
+        if (
+            getattr(update, "edited_message", None) is not None
+            or getattr(update, "edited_channel_post", None) is not None
+        ):
+            return None
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/gateway/test_telegram_long_command_batching.py
+++ b/tests/gateway/test_telegram_long_command_batching.py
@@ -67,6 +67,31 @@ def _make_update(text):
     return SimpleNamespace(update_id=1, message=_make_message(text), effective_message=None)
 
 
+def _make_edited_update(text, edited_field):
+    message = _make_message(text)
+    return SimpleNamespace(
+        update_id=2,
+        message=None,
+        channel_post=None,
+        edited_message=message if edited_field == "edited_message" else None,
+        edited_channel_post=message if edited_field == "edited_channel_post" else None,
+        effective_message=message,
+    )
+
+
+@pytest.mark.parametrize("edited_field", ("edited_message", "edited_channel_post"))
+@pytest.mark.parametrize("command", ("/restart", "/new", "/stop"))
+@pytest.mark.asyncio
+async def test_edited_command_is_not_dispatched(edited_field, command):
+    adapter = _make_adapter()
+
+    await adapter._handle_command(
+        _make_edited_update(command, edited_field), SimpleNamespace()
+    )
+
+    adapter.handle_message.assert_not_awaited()  # type: ignore[attr-defined]
+
+
 @pytest.mark.asyncio
 async def test_short_command_dispatched_immediately():
     adapter = _make_adapter()


### PR DESCRIPTION
## Bug Description

Telegram can emit `edited_message` updates for metadata-only changes such as a member-tag update. Hermes currently treats `update.effective_message` as fresh input, so the original text of a historical message can be dispatched again. If that text is a side-effecting command such as `/stop` or `/restart`, the command is executed without a new user request.

Telegram tracks the provider behavior here: https://bugs.telegram.org/?type=issues&tag_ids=25&sort=rate

Duplicate search found no existing Hermes issue or PR for edited-message command replay.

## Root Cause

Telegram text, command, and location handlers resolve their payload through `_effective_update_message()`. That helper returned `update.effective_message` without distinguishing new messages from `edited_message` or `edited_channel_post` updates. Telegram assigns a fresh update ID to the edit, so update-ID deduplication cannot identify the original message text as a replay. Media handling already accepts only `update.message`, which is absent for edited updates.

## Fix

- Ignore `edited_message` and `edited_channel_post` in the shared Telegram message extractor.
- Preserve normal messages and new channel posts.
- Add regression coverage proving edited `/restart`, `/new`, and `/stop` commands never reach gateway dispatch.

## How to Verify

1. Run the focused regression test and confirm both edited update types are ignored.
2. Run the Telegram-focused test suite and confirm normal messages, channel posts, polling, webhooks, and reactions remain green.
3. Run Ruff on the modified adapter and test file.

## Test Plan

- [x] Added regression tests for `/restart`, `/new`, and `/stop` across `edited_message` and `edited_channel_post`
- [x] `./scripts/run_tests.sh tests/gateway/test_telegram*.py tests/test_telegram*.py -q` — 523 passed
- [x] `uv run ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_long_command_batching.py`
- [ ] Live candidate verification was intentionally not performed against a production bot

## Risk Assessment

Low — the change is limited to Telegram edit updates at the shared inbound message boundary. New messages, new channel posts, and callback queries keep their existing paths. Users who edit a previously sent message will no longer retrigger agent work from that edit; Hermes has no merged edit-as-branch contract, and replaying historical side effects is unsafe.
