### PR TITLE
fix(desktop): omit empty model provider flag

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -359,6 +359,27 @@ describe('useModelControls', () => {
     expect(setGlobalModel).not.toHaveBeenCalled()
   })
 
+  it('does not emit an empty provider flag when a live model pick has no provider', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({})
+    let controls!: Controls
+
+    $activeSessionId.set('session-1')
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({
+        model: 'custom:qwen3.6-35b-a3b',
+        provider: ''
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'custom:qwen3.6-35b-a3b --session'
+    })
+  })
+
   it('updates only the active profile new-chat cache', async () => {
     const queryClient = new QueryClient()
     $activeGatewayProfile.set('compass')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -207,10 +207,11 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       }
 
       try {
+        const providerFlag = selection.provider ? ` --provider ${selection.provider}` : ''
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} --session`
+          value: `${selection.model}${providerFlag} --session`
         })
 
         // A pick made DURING a turn is queued by the gateway and applied at the


### PR DESCRIPTION
## What does this PR do?

This PR fixes a Desktop model-switching bug where live-session model changes could include an empty `--provider` flag when the selected model option did not have a provider value.

That broke custom/self-hosted model selections because the gateway model-switch parser could interpret the malformed value as an unknown provider/model combination, producing errors like:

```text
unknown provider custom:qwen3.6-35b-a3b
```

The fix keeps the existing provider flag behavior when a provider is present, but omits `--provider` entirely when the selected model has no provider value. This matches the gateway CLI shape more closely and avoids sending invalid model-switch arguments.

## Related Issue

No issue filed.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/session/hooks/use-model-controls.ts`
  - Builds the live-session model switch value with `--provider <provider>` only when `selection.provider` is non-empty.
  - Preserves the existing `--session` flag behavior.

- Updated `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`
  - Adds regression coverage for a provider-less custom model selection.
  - Verifies Desktop sends:
    ```text
    custom:qwen3.6-35b-a3b --session
    ```
    instead of:
    ```text
    custom:qwen3.6-35b-a3b --provider  --session
    ```

## How to Test

1. Configure/use a custom model option where the selected model does not provide a separate provider value.
2. Open an existing live Desktop session and change the model from the model picker.
3. Verify the model switch succeeds and does not fail with an unknown provider/model error.

Local verification run:

```bash
cd apps/desktop
npm test -- use-model-controls.test.tsx
npm run build
```

Results:

```text
use-model-controls.test.tsx: 20 tests passed
desktop build passed
assert-dist-built: dist/index.html + assets present
```

Also independently reviewed the diff for security and logic issues; no concerns were found.

## Checklist

### Code

- [x] I've read the [Contributing Guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md`)
- [x] My commit messages follow [Conventional Commits](@url:`https://www.conventionalcommits.org/`) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](@url:`https://github.com/NousResearch/hermes-agent/pulls`) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Arch

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility`) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression test:

```text
> hermes@0.17.0 test
> vitest run use-model-controls.test.tsx

✓ ui src/app/session/hooks/use-model-controls.test.tsx (20 tests)

Test Files  1 passed (1)
Tests       20 passed (20)
```

Build:

```text
npm run build
✓ built
✓ assert-dist-built: dist/index.html + assets present
```