### PR TITLE
fix(gateway): keep auto-TTS output inside safe root (#80386)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -178,8 +178,23 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
+    # The official Docker image sets HERMES_WRITE_SAFE_ROOT=/opt/data.
+    # Keep generated auto-TTS files inside that sandbox when it is active;
+    # otherwise retain the normal system-temp behavior.
+    output_root = Path(tempfile.gettempdir())
+    try:
+        from agent.file_safety import get_safe_write_roots
+
+        safe_roots = get_safe_write_roots()
+        if safe_roots:
+            output_root = Path(sorted(safe_roots)[0])
+    except (ImportError, OSError, ValueError):
+        # Auto-TTS should remain best-effort if the optional safety helper
+        # cannot be loaded in a minimal runtime.
+        pass
+
     audio_path = os.path.join(
-        tempfile.gettempdir(),
+        str(output_root),
         "hermes_voice",
         f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
     )

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -86,6 +86,13 @@ def test_output_path_is_mp3_for_non_opus_platforms(platform):
     assert path.endswith(".mp3"), path
 
 
+def test_output_path_stays_inside_write_safe_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+    path = build_auto_tts_output_path(Platform.DISCORD)
+    assert path.startswith(str(tmp_path / "hermes_voice"))
+    assert path.endswith(".mp3")
+
+
 # ---------------------------------------------------------------------------
 # Base-adapter auto-TTS block: explicit output_path, no contextvar reliance
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Keep gateway auto-TTS temporary files inside the configured HERMES_WRITE_SAFE_ROOT.
- Preserve system temporary output when no safe root is configured.

Closes #80386

## Tests
- pytest -q tests/gateway/test_base_auto_tts_output_format.py
