### PR TITLE
fix(plugins): register platform-plugin client tools during deferred discovery (#81163)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4432,6 +4432,15 @@ class PluginManager:
         platform. Until then we record a lightweight ``LoadedPlugin`` so
         ``hermes plugins list`` still shows the platform as available, and we
         hand the registry a loader that runs the normal eager-load path.
+
+        If the plugin's ``__init__`` module exposes a top-level
+        ``register_tools(ctx)`` callable, we invoke it eagerly here so the
+        plugin's outbound client/agent tools (e.g. ``a2a``'s ``a2a_call``,
+        ``a2a_discover``) reach the tool catalog during ``discover_plugins()``
+        rather than waiting for the deferred adapter load. The plugin module
+        itself is a thin re-export of ``register`` (per the bundled-platform
+        convention), so this import stays cheap — adapter SDKs remain lazy.
+        See issue #81163.
         """
         lookup_key = manifest.key or manifest.name
         platform_name = self._platform_name_from_manifest(manifest)
@@ -4442,6 +4451,42 @@ class PluginManager:
         loaded = LoadedPlugin(manifest=manifest, enabled=True)
         loaded.deferred = True
         self._plugins[lookup_key] = loaded
+
+        # Eagerly register any client/agent tools the plugin exposes, without
+        # running the full register(ctx) (which would double-register the
+        # platform adapter against platform_registry). Tolerate failure so a
+        # broken or absent register_tools hook never blocks platform loading.
+        try:
+            if manifest.source in {"user", "project", "bundled"}:
+                module = self._load_directory_module(manifest)
+            else:
+                module = self._load_entrypoint_module(manifest)
+            register_tools_fn = getattr(module, "register_tools", None)
+            if callable(register_tools_fn):
+                ctx = PluginContext(manifest, self)
+                # Snapshot registry state BEFORE register_tools() so attribution
+                # in the deferred loader's later _load_plugin() call still
+                # captures *everything* this plugin added, but we ALSO seed
+                # self._plugin_tool_names here so get_plugin_toolsets()
+                # surfaces the toolset on first discovery.
+                _tools_before = set(self._plugin_tool_names)
+                register_tools_fn(ctx)
+                new_tools = [
+                    t for t in self._plugin_tool_names if t not in _tools_before
+                ]
+                if new_tools:
+                    logger.debug(
+                        "Eager-registered %d client tool(s) from deferred platform plugin %s: %s",
+                        len(new_tools),
+                        lookup_key,
+                        ", ".join(sorted(new_tools)),
+                    )
+        except Exception:
+            logger.debug(
+                "Eager register_tools() skipped for deferred platform %s",
+                lookup_key,
+                exc_info=_PLUGINS_DEBUG,
+            )
 
         try:
             from gateway.platform_registry import platform_registry

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1742,6 +1742,15 @@ class PluginManager:
         platform. Until then we record a lightweight ``LoadedPlugin`` so
         ``hermes plugins list`` still shows the platform as available, and we
         hand the registry a loader that runs the normal eager-load path.
+
+        If the plugin's ``__init__`` module exposes a top-level
+        ``register_tools(ctx)`` callable, we invoke it eagerly here so the
+        plugin's outbound client/agent tools (e.g. ``a2a``'s ``a2a_call``,
+        ``a2a_discover``) reach the tool catalog during ``discover_plugins()``
+        rather than waiting for the deferred adapter load. The plugin module
+        itself is a thin re-export of ``register`` (per the bundled-platform
+        convention), so this import stays cheap — adapter SDKs remain lazy.
+        See issue #81163.
         """
         lookup_key = manifest.key or manifest.name
         platform_name = self._platform_name_from_manifest(manifest)
@@ -1752,6 +1761,42 @@ class PluginManager:
         loaded = LoadedPlugin(manifest=manifest, enabled=True)
         loaded.deferred = True
         self._plugins[lookup_key] = loaded
+
+        # Eagerly register any client/agent tools the plugin exposes, without
+        # running the full register(ctx) (which would double-register the
+        # platform adapter against platform_registry). Tolerate failure so a
+        # broken or absent register_tools hook never blocks platform loading.
+        try:
+            if manifest.source in {"user", "project", "bundled"}:
+                module = self._load_directory_module(manifest)
+            else:
+                module = self._load_entrypoint_module(manifest)
+            register_tools_fn = getattr(module, "register_tools", None)
+            if callable(register_tools_fn):
+                ctx = PluginContext(manifest, self)
+                # Snapshot registry state BEFORE register_tools() so attribution
+                # in the deferred loader's later _load_plugin() call still
+                # captures *everything* this plugin added, but we ALSO seed
+                # self._plugin_tool_names here so get_plugin_toolsets()
+                # surfaces the toolset on first discovery.
+                _tools_before = set(self._plugin_tool_names)
+                register_tools_fn(ctx)
+                new_tools = [
+                    t for t in self._plugin_tool_names if t not in _tools_before
+                ]
+                if new_tools:
+                    logger.debug(
+                        "Eager-registered %d client tool(s) from deferred platform plugin %s: %s",
+                        len(new_tools),
+                        lookup_key,
+                        ", ".join(sorted(new_tools)),
+                    )
+        except Exception:
+            logger.debug(
+                "Eager register_tools() skipped for deferred platform %s",
+                lookup_key,
+                exc_info=_PLUGINS_DEBUG,
+            )
 
         def _loader(_manifest: PluginManifest = manifest) -> None:
             self._load_plugin(_manifest)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2292,18 +2292,22 @@ def _get_platform_tools(
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
+    # Plugin-provided toolsets are first-class on a platform-toolsets list —
+    # explicit config like ``[hermes-cli, a2a]`` must survive filtering just
+    # like a built-in configurable toolset would. See issue #81163.
+    explicit_known_keys = configurable_keys | plugin_ts_keys
 
     # If the saved list contains any configurable keys directly, the user
     # has explicitly configured this platform — use direct membership.
     # This avoids the subset-inference bug where composite toolsets like
     # "hermes-cli" (which include all _HERMES_CORE_TOOLS) cause disabled
     # toolsets to re-appear as enabled.
-    has_explicit_config = any(ts in configurable_keys for ts in toolset_names)
+    has_explicit_config = any(ts in explicit_known_keys for ts in toolset_names)
 
     if has_explicit_config:
         enabled_toolsets = {
             ts for ts in toolset_names
-            if ts in configurable_keys and _toolset_allowed_for_platform(ts, platform)
+            if ts in explicit_known_keys and _toolset_allowed_for_platform(ts, platform)
         }
         # Mixed config: composite toolset alongside configurables (e.g.
         # ``[hermes-cli, spotify]`` after enabling Spotify via ``hermes

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2253,18 +2253,22 @@ def _get_platform_tools(
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
+    # Plugin-provided toolsets are first-class on a platform-toolsets list —
+    # explicit config like ``[hermes-cli, a2a]`` must survive filtering just
+    # like a built-in configurable toolset would. See issue #81163.
+    explicit_known_keys = configurable_keys | plugin_ts_keys
 
     # If the saved list contains any configurable keys directly, the user
     # has explicitly configured this platform — use direct membership.
     # This avoids the subset-inference bug where composite toolsets like
     # "hermes-cli" (which include all _HERMES_CORE_TOOLS) cause disabled
     # toolsets to re-appear as enabled.
-    has_explicit_config = any(ts in configurable_keys for ts in toolset_names)
+    has_explicit_config = any(ts in explicit_known_keys for ts in toolset_names)
 
     if has_explicit_config:
         enabled_toolsets = {
             ts for ts in toolset_names
-            if ts in configurable_keys and _toolset_allowed_for_platform(ts, platform)
+            if ts in explicit_known_keys and _toolset_allowed_for_platform(ts, platform)
         }
         # Mixed config: composite toolset alongside configurables (e.g.
         # ``[hermes-cli, spotify]`` after enabling Spotify via ``hermes

--- a/plugins/platforms/a2a/__init__.py
+++ b/plugins/platforms/a2a/__init__.py
@@ -17,7 +17,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["register"]
+__all__ = ["register", "register_tools"]
 
 
 def check_requirements() -> bool:
@@ -27,6 +27,20 @@ def check_requirements() -> bool:
     to enable by default once the user turns the platform on.
     """
     return True
+
+
+def register_tools(ctx) -> None:
+    """Eager-registration entry point for the outbound client tools.
+
+    The bundled platform loader (``PluginManager._register_deferred_platform``)
+    imports the plugin module to register any ``register_tools(ctx)`` callable
+    at the top level — the inbound adapter (``register`` / adapter module) is
+    still deferred so the heavy SDK imports don't fire on plain ``hermes chat``.
+    See issue #81163 for the reasoning: outbound client tools should be
+    available regardless of whether the inbound platform is enabled.
+    """
+    from .tools import register_tools as _register_tools
+    _register_tools(ctx)
 
 
 def validate_config(config) -> bool:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1949,3 +1949,143 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestDeferredPlatformClientTools:
+    """Regression for #81163: a deferred platform plugin's client tools must
+    reach the plugin toolset catalog during ``discover_plugins()``, not wait
+    until the deferred adapter loader fires (which only happens when the
+    gateway / cron / setup / send_message path asks the platform_registry
+    for the platform by name)."""
+
+    def _make_deferred_platform_plugin(self, plugins_dir, *, name="deferred_plat"):
+        """A platform-style plugin that:
+        - exposes ``register_tools(ctx)`` (the eager-registration entry point)
+        - exposes ``register(ctx)`` that ALSO registers a platform adapter
+          (matching the bundled-platform convention in plugins/platforms/<x>/)
+        - has ``kind: platform`` in its manifest
+        - is opt-out, but we still need to mark it enabled in plugins.enabled so
+          the plugin manager sweeps the bundled plugin through its deferred
+          branch instead of the opt-in branch.
+        """
+        plugin_dir = plugins_dir / name
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({
+            "name": name,
+            "version": "0.1.0",
+            "description": "deferred platform test",
+            "kind": "platform",
+        }))
+        (plugin_dir / "__init__.py").write_text(
+            "from typing import Any\n"
+            "from typing import Callable\n"
+            "_CLIENT_TOOL_SCHEMA = {\n"
+            "    'name': 'dplat_call',\n"
+            "    'description': 'Outbound client tool for the deferred platform.',\n"
+            "    'parameters': {'type': 'object', 'properties': {}},\n"
+            "}\n"
+            "def _handler(args, **kw):\n"
+            "    return 'called'\n"
+            "def register_tools(ctx):\n"
+            "    ctx.register_tool(\n"
+            "        name='dplat_call',\n"
+            "        toolset='dplat_client',\n"
+            "        schema=_CLIENT_TOOL_SCHEMA,\n"
+            "        handler=_handler,\n"
+            "        description='Outbound client tool for the deferred platform.',\n"
+            "    )\n"
+            "def register(ctx):\n"
+            "    from tools.registry import registry\n"
+            "    if not hasattr(registry, 'register_dplat_adapter_calls'):\n"
+            "        registry.register_dplat_adapter_calls = []\n"
+            "    registry.register_dplat_adapter_calls.append(1)\n"
+        )
+
+    def test_eager_register_tools_runs_for_deferred_platform(self, tmp_path, monkeypatch):
+        """After discover_plugins(), the deferred plugin's client toolset must
+        already appear in get_plugin_toolsets() — without firing the full
+        register(ctx) (which would run the adapter registration)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        self._make_deferred_platform_plugin(plugins_dir)
+        hermes_home = tmp_path / "hermes_test"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # Bundled platform plugins register a deferred loader instead of
+        # importing their module. The bundled-plugin branch in the manager
+        # looks at manifest.source == "bundled". We construct a PluginManifest
+        # directly with source="bundled" so the test exercises that branch.
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.plugins import (
+            get_plugin_toolsets,
+            PluginManager,
+            PluginManifest,
+        )
+
+        plugin_dir = plugins_dir / "deferred_plat"
+        manifest = PluginManifest(
+            name="deferred_plat",
+            source="bundled",
+            path=str(plugin_dir),
+            key="deferred_plat",
+            kind="platform",
+        )
+        mgr = PluginManager()
+        # Make get_plugin_toolsets() see THIS manager, not a fresh global.
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        mgr._register_deferred_platform(manifest)
+
+        # The placeholder must be recorded as deferred so list_plugins() still
+        # shows it, and the platform adapter's register() must NOT have run.
+        loaded = mgr._plugins["deferred_plat"]
+        assert loaded.deferred is True
+        assert loaded.enabled is True
+        # The adapter's register() must NOT have run (it stays lazy).
+        from tools import registry as _reg
+        assert not getattr(_reg, "register_dplat_adapter_calls", [])
+
+        # The client toolset must be present in get_plugin_toolsets() WITHOUT
+        # having to fire the deferred loader first.
+        ts_keys = {k for k, _, _ in get_plugin_toolsets()}
+        assert "dplat_client" in ts_keys, (
+            f"client toolset from deferred platform plugin was not eagerly "
+            f"registered (issue #81163); got {sorted(ts_keys)}"
+        )
+        # Sanity: discover_plugins() must remain idempotent.
+        plugins_mod.discover_plugins()
+        assert "dplat_client" in {k for k, _, _ in get_plugin_toolsets()}
+
+        # Cleanup so we don't leak dplat_call into other tests / processes.
+        from tools.registry import registry as _reg2
+        _reg2.deregister("dplat_call")
+
+    def test_deferred_platform_without_register_tools_is_a_noop(self, tmp_path, monkeypatch):
+        """Plugins without a register_tools() symbol must still register their
+        deferred loader cleanly — the new eager-registration path must
+        tolerate missing/None register_tools attributes."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "no_tools_deferred"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({
+            "name": "no_tools_deferred",
+            "kind": "platform",
+        }))
+        # No register_tools symbol — just a stub register() so _load_plugin
+        # would still be valid if anything tried to invoke the loader.
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n")
+
+        from hermes_cli.plugins import PluginManager, PluginManifest
+
+        manifest = PluginManifest(
+            name="no_tools_deferred",
+            source="bundled",
+            path=str(plugin_dir),
+            key="no_tools_deferred",
+            kind="platform",
+        )
+        mgr = PluginManager()
+        # Must not raise even though register_tools is absent.
+        mgr._register_deferred_platform(manifest)
+        loaded = mgr._plugins["no_tools_deferred"]
+        assert loaded.deferred is True
+        assert loaded.enabled is True

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1186,3 +1186,143 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestDeferredPlatformClientTools:
+    """Regression for #81163: a deferred platform plugin's client tools must
+    reach the plugin toolset catalog during ``discover_plugins()``, not wait
+    until the deferred adapter loader fires (which only happens when the
+    gateway / cron / setup / send_message path asks the platform_registry
+    for the platform by name)."""
+
+    def _make_deferred_platform_plugin(self, plugins_dir, *, name="deferred_plat"):
+        """A platform-style plugin that:
+        - exposes ``register_tools(ctx)`` (the eager-registration entry point)
+        - exposes ``register(ctx)`` that ALSO registers a platform adapter
+          (matching the bundled-platform convention in plugins/platforms/<x>/)
+        - has ``kind: platform`` in its manifest
+        - is opt-out, but we still need to mark it enabled in plugins.enabled so
+          the plugin manager sweeps the bundled plugin through its deferred
+          branch instead of the opt-in branch.
+        """
+        plugin_dir = plugins_dir / name
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({
+            "name": name,
+            "version": "0.1.0",
+            "description": "deferred platform test",
+            "kind": "platform",
+        }))
+        (plugin_dir / "__init__.py").write_text(
+            "from typing import Any\n"
+            "from typing import Callable\n"
+            "_CLIENT_TOOL_SCHEMA = {\n"
+            "    'name': 'dplat_call',\n"
+            "    'description': 'Outbound client tool for the deferred platform.',\n"
+            "    'parameters': {'type': 'object', 'properties': {}},\n"
+            "}\n"
+            "def _handler(args, **kw):\n"
+            "    return 'called'\n"
+            "def register_tools(ctx):\n"
+            "    ctx.register_tool(\n"
+            "        name='dplat_call',\n"
+            "        toolset='dplat_client',\n"
+            "        schema=_CLIENT_TOOL_SCHEMA,\n"
+            "        handler=_handler,\n"
+            "        description='Outbound client tool for the deferred platform.',\n"
+            "    )\n"
+            "def register(ctx):\n"
+            "    from tools.registry import registry\n"
+            "    if not hasattr(registry, 'register_dplat_adapter_calls'):\n"
+            "        registry.register_dplat_adapter_calls = []\n"
+            "    registry.register_dplat_adapter_calls.append(1)\n"
+        )
+
+    def test_eager_register_tools_runs_for_deferred_platform(self, tmp_path, monkeypatch):
+        """After discover_plugins(), the deferred plugin's client toolset must
+        already appear in get_plugin_toolsets() — without firing the full
+        register(ctx) (which would run the adapter registration)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        self._make_deferred_platform_plugin(plugins_dir)
+        hermes_home = tmp_path / "hermes_test"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # Bundled platform plugins register a deferred loader instead of
+        # importing their module. The bundled-plugin branch in the manager
+        # looks at manifest.source == "bundled". We construct a PluginManifest
+        # directly with source="bundled" so the test exercises that branch.
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.plugins import (
+            get_plugin_toolsets,
+            PluginManager,
+            PluginManifest,
+        )
+
+        plugin_dir = plugins_dir / "deferred_plat"
+        manifest = PluginManifest(
+            name="deferred_plat",
+            source="bundled",
+            path=str(plugin_dir),
+            key="deferred_plat",
+            kind="platform",
+        )
+        mgr = PluginManager()
+        # Make get_plugin_toolsets() see THIS manager, not a fresh global.
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        mgr._register_deferred_platform(manifest)
+
+        # The placeholder must be recorded as deferred so list_plugins() still
+        # shows it, and the platform adapter's register() must NOT have run.
+        loaded = mgr._plugins["deferred_plat"]
+        assert loaded.deferred is True
+        assert loaded.enabled is True
+        # The adapter's register() must NOT have run (it stays lazy).
+        from tools import registry as _reg
+        assert not getattr(_reg, "register_dplat_adapter_calls", [])
+
+        # The client toolset must be present in get_plugin_toolsets() WITHOUT
+        # having to fire the deferred loader first.
+        ts_keys = {k for k, _, _ in get_plugin_toolsets()}
+        assert "dplat_client" in ts_keys, (
+            f"client toolset from deferred platform plugin was not eagerly "
+            f"registered (issue #81163); got {sorted(ts_keys)}"
+        )
+        # Sanity: discover_plugins() must remain idempotent.
+        plugins_mod.discover_plugins()
+        assert "dplat_client" in {k for k, _, _ in get_plugin_toolsets()}
+
+        # Cleanup so we don't leak dplat_call into other tests / processes.
+        from tools.registry import registry as _reg2
+        _reg2.deregister("dplat_call")
+
+    def test_deferred_platform_without_register_tools_is_a_noop(self, tmp_path, monkeypatch):
+        """Plugins without a register_tools() symbol must still register their
+        deferred loader cleanly — the new eager-registration path must
+        tolerate missing/None register_tools attributes."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "no_tools_deferred"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({
+            "name": "no_tools_deferred",
+            "kind": "platform",
+        }))
+        # No register_tools symbol — just a stub register() so _load_plugin
+        # would still be valid if anything tried to invoke the loader.
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n")
+
+        from hermes_cli.plugins import PluginManager, PluginManifest
+
+        manifest = PluginManifest(
+            name="no_tools_deferred",
+            source="bundled",
+            path=str(plugin_dir),
+            key="no_tools_deferred",
+            kind="platform",
+        )
+        mgr = PluginManager()
+        # Must not raise even though register_tools is absent.
+        mgr._register_deferred_platform(manifest)
+        loaded = mgr._plugins["no_tools_deferred"]
+        assert loaded.deferred is True
+        assert loaded.enabled is True

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -742,3 +742,94 @@ def test_platforms_whose_composite_excludes_it_are_left_narrow():
             include_default_mcp_servers=False,
         )
         assert not (_RECENTLY_SHIPPED_TOOLSETS & enabled), platform
+
+
+# Regression for issue #81163 (Layer 2): an explicitly-listed plugin toolset
+# in ``platform_toolsets.<platform>`` must survive the filter, not be dropped
+# because it isn't a built-in CONFIGURABLE_TOOLSETS entry.
+
+
+def test_explicit_plugin_toolset_admitted_in_platform_toolsets(monkeypatch):
+    """When a plugin toolset key is explicitly listed under
+    ``platform_toolsets.<platform>`` (alongside a composite like
+    ``hermes-cli``), it MUST be admitted as a configurable key instead of
+    being silently dropped by the has_explicit_config filter.
+
+    Reproduces the second half of #81163: even after the eager register_tools
+    fix lands, ``_get_platform_tools`` was filtering against
+    ``CONFIGURABLE_TOOLSETS`` only, so plugin keys in the explicit list were
+    excluded from ``enabled_toolsets``.
+    """
+    # Force a plugin toolset key to be present without depending on the a2a
+    # plugin being installed on disk. _get_plugin_toolset_keys() calls
+    # discover_plugins(); we patch its source so the test is hermetic.
+    import hermes_cli.plugins as _plugins_mod
+    import hermes_cli.tools_config as _tc_mod
+
+    class _StubMgr:
+        _plugin_tool_names = {"dplat_call"}
+
+        def __getattr__(self, _name):
+            return lambda *_a, **_kw: None
+
+    monkeypatch.setattr(
+        _plugins_mod, "get_plugin_toolsets",
+        lambda: [("dplat_client", "Test", "test toolset")],
+    )
+    monkeypatch.setattr(
+        _tc_mod, "_get_plugin_toolset_keys", lambda: {"dplat_client"},
+    )
+    # Discover_plugins must succeed silently under the stub.
+    monkeypatch.setattr(_plugins_mod, "discover_plugins", lambda: None)
+    # Resolve dplat_call inside the dplat_client toolset — _get_platform_tools
+    # ends up calling resolve_toolset() which can fall back to the registry
+    # for plugin-provided names. Patch resolve_toolset for "dplat_client".
+    from toolsets import TOOLSETS as _BASE_TOOLSETS
+    import toolsets as _toolsets_mod
+
+    original_resolve = _toolsets_mod.resolve_toolset
+
+    def _resolve_with_plugin(ts_key, include_registry=True):
+        if ts_key == "dplat_client":
+            return ["dplat_call"]
+        return original_resolve(ts_key, include_registry=include_registry)
+
+    monkeypatch.setattr(_toolsets_mod, "resolve_toolset", _resolve_with_plugin)
+    monkeypatch.setattr(
+        _tc_mod, "resolve_toolset", _resolve_with_plugin,
+        raising=False,
+    )
+
+    # An explicit platform_toolsets list with a plugin key alongside the
+    # standard composite — exactly the "I want hermes-cli AND a2a in my CLI
+    # session" config the issue's user was trying to write.
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "dplat_client"]}}
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "dplat_client" in enabled, (
+        "plugin toolset 'dplat_client' listed in platform_toolsets.cli was "
+        "dropped by _get_platform_tools — Layer 2 of #81163 not fixed"
+    )
+
+
+def test_explicit_plugin_toolset_admitted_against_real_a2a_plugin(monkeypatch):
+    """End-to-end Layer 2 regression: with the bundled a2a plugin enabled and
+    a real config like ``platform_toolsets.cli: [hermes-cli, a2a]``, ``a2a``
+    must appear in the resolved enabled toolset set. Before the fix, the
+    filter dropped all non-CONFIGURABLE keys (a2a included)."""
+    # Discover real plugins so _get_plugin_toolset_keys() sees the a2a key.
+    # If the worktree lacks bundled plugin manifests, skip — this test
+    # exercises real bundled state and is meaningless without it.
+    from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
+    discover_plugins()
+    plugin_ts_keys = {k for k, _, _ in get_plugin_toolsets()}
+    if "a2a" not in plugin_ts_keys:
+        pytest.skip("bundled a2a plugin not discoverable in this worktree")
+
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "a2a"]}}
+    enabled = _get_platform_tools(config, "cli")
+    assert "a2a" in enabled, (
+        f"plugin-provided 'a2a' toolset dropped by _get_platform_tools "
+        f"(Layer 2 of #81163); enabled={sorted(enabled)}"
+    )

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1013,3 +1013,94 @@ def test_platforms_whose_composite_excludes_it_are_left_narrow():
             include_default_mcp_servers=False,
         )
         assert not (_RECENTLY_SHIPPED_TOOLSETS & enabled), platform
+
+
+# Regression for issue #81163 (Layer 2): an explicitly-listed plugin toolset
+# in ``platform_toolsets.<platform>`` must survive the filter, not be dropped
+# because it isn't a built-in CONFIGURABLE_TOOLSETS entry.
+
+
+def test_explicit_plugin_toolset_admitted_in_platform_toolsets(monkeypatch):
+    """When a plugin toolset key is explicitly listed under
+    ``platform_toolsets.<platform>`` (alongside a composite like
+    ``hermes-cli``), it MUST be admitted as a configurable key instead of
+    being silently dropped by the has_explicit_config filter.
+
+    Reproduces the second half of #81163: even after the eager register_tools
+    fix lands, ``_get_platform_tools`` was filtering against
+    ``CONFIGURABLE_TOOLSETS`` only, so plugin keys in the explicit list were
+    excluded from ``enabled_toolsets``.
+    """
+    # Force a plugin toolset key to be present without depending on the a2a
+    # plugin being installed on disk. _get_plugin_toolset_keys() calls
+    # discover_plugins(); we patch its source so the test is hermetic.
+    import hermes_cli.plugins as _plugins_mod
+    import hermes_cli.tools_config as _tc_mod
+
+    class _StubMgr:
+        _plugin_tool_names = {"dplat_call"}
+
+        def __getattr__(self, _name):
+            return lambda *_a, **_kw: None
+
+    monkeypatch.setattr(
+        _plugins_mod, "get_plugin_toolsets",
+        lambda: [("dplat_client", "Test", "test toolset")],
+    )
+    monkeypatch.setattr(
+        _tc_mod, "_get_plugin_toolset_keys", lambda: {"dplat_client"},
+    )
+    # Discover_plugins must succeed silently under the stub.
+    monkeypatch.setattr(_plugins_mod, "discover_plugins", lambda: None)
+    # Resolve dplat_call inside the dplat_client toolset — _get_platform_tools
+    # ends up calling resolve_toolset() which can fall back to the registry
+    # for plugin-provided names. Patch resolve_toolset for "dplat_client".
+    from toolsets import TOOLSETS as _BASE_TOOLSETS
+    import toolsets as _toolsets_mod
+
+    original_resolve = _toolsets_mod.resolve_toolset
+
+    def _resolve_with_plugin(ts_key, include_registry=True):
+        if ts_key == "dplat_client":
+            return ["dplat_call"]
+        return original_resolve(ts_key, include_registry=include_registry)
+
+    monkeypatch.setattr(_toolsets_mod, "resolve_toolset", _resolve_with_plugin)
+    monkeypatch.setattr(
+        _tc_mod, "resolve_toolset", _resolve_with_plugin,
+        raising=False,
+    )
+
+    # An explicit platform_toolsets list with a plugin key alongside the
+    # standard composite — exactly the "I want hermes-cli AND a2a in my CLI
+    # session" config the issue's user was trying to write.
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "dplat_client"]}}
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "dplat_client" in enabled, (
+        "plugin toolset 'dplat_client' listed in platform_toolsets.cli was "
+        "dropped by _get_platform_tools — Layer 2 of #81163 not fixed"
+    )
+
+
+def test_explicit_plugin_toolset_admitted_against_real_a2a_plugin(monkeypatch):
+    """End-to-end Layer 2 regression: with the bundled a2a plugin enabled and
+    a real config like ``platform_toolsets.cli: [hermes-cli, a2a]``, ``a2a``
+    must appear in the resolved enabled toolset set. Before the fix, the
+    filter dropped all non-CONFIGURABLE keys (a2a included)."""
+    # Discover real plugins so _get_plugin_toolset_keys() sees the a2a key.
+    # If the worktree lacks bundled plugin manifests, skip — this test
+    # exercises real bundled state and is meaningless without it.
+    from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
+    discover_plugins()
+    plugin_ts_keys = {k for k, _, _ in get_plugin_toolsets()}
+    if "a2a" not in plugin_ts_keys:
+        pytest.skip("bundled a2a plugin not discoverable in this worktree")
+
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "a2a"]}}
+    enabled = _get_platform_tools(config, "cli")
+    assert "a2a" in enabled, (
+        f"plugin-provided 'a2a' toolset dropped by _get_platform_tools "
+        f"(Layer 2 of #81163); enabled={sorted(enabled)}"
+    )


### PR DESCRIPTION
## Summary

The bundled a2a-platform plugin's five outbound client tools (a2a_call, a2a_discover, a2a_list, a2a_history, a2a_orchestrate) never reach the agent's tool catalog, because they sit inside the plugin's register(ctx) — and register(ctx) itself never fires: PluginManager._register_deferred_platform defers every 'kind: platform' plugin to a lazy loader that only runs when the gateway / cron / setup / send_message path first asks the platform_registry for that platform. The inbound adapter stays deferred (heavy SDKs aren't pulled in for plain hermes chat), but the client-tool registration has no reason to be tied to it.

This commit fixes both layers described in #81163.

## Fix

### Layer 1 — eager client-tool registration in the deferred path

PluginManager._register_deferred_platform now additionally tries to import the plugin module and, if a top-level register_tools(ctx) callable exists, invokes it during discover_plugins(). The plugin's __init__.py is a thin re-export of register (matching the bundled-platform convention), so this import stays cheap — the heavy adapter module remains lazy. The eager call only runs the plugin's client/agent tools registration; the platform adapter's ctx.register_platform(...) is left for the deferred loader, avoiding a duplicate platform_registry.register(...).

The a2a plugin opts into this entry point by exposing its existing tools.register_tools as a top-level symbol on the package. Other bundled platform plugins without client tools are unaffected (no register_tools attribute → no-op).

### Layer 2 — _get_platform_tools admits explicit plugin toolsets

tools_config._get_platform_tools computed plugin_ts_keys = _get_plugin_toolset_keys() but only used CONFIGURABLE_TOOLSETS in the explicit-config filter. A user-listed key like a2a in 'platform_toolsets.cli: [hermes-cli, a2a]' was therefore silently dropped. The filter now unions configurable and plugin toolset keys when evaluating has_explicit_config and when admitting per-key entries, so explicitly-configured plugin toolsets survive.

## Verification

```python
from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
from hermes_cli.tools_config import _get_plugin_toolset_keys
discover_plugins()
sorted({k for k,_,_ in get_plugin_toolsets()})   # ['a2a', 'spotify']
sorted(_get_plugin_toolset_keys())                # ['a2a', 'spotify']
```

a2a is now present (was absent before).

End-to-end Layer 2 check:
```python
from hermes_cli.tools_config import _get_platform_tools
_get_platform_tools({'platform_toolsets': {'cli': ['hermes-cli', 'a2a']}}, 'cli')
# 'a2a' is in the returned enabled-toolsets set
```

## Tests

- tests/hermes_cli/test_plugins.py::TestDeferredPlatformClientTools
  - test_eager_register_tools_runs_for_deferred_platform — registers a synthetic bundled platform plugin with a top-level register_tools and asserts (a) the placeholder is recorded deferred, (b) the adapter's register() did NOT run, (c) the client toolset appears in get_plugin_toolsets() immediately, (d) discover_plugins() is idempotent. Fails before the fix (Layer 1).
  - test_deferred_platform_without_register_tools_is_a_noop — bundled platform plugins without register_tools still register their deferred loader cleanly.
- tests/hermes_cli/test_tools_config.py
  - test_explicit_plugin_toolset_admitted_in_platform_toolsets — hermetic stub of _get_plugin_toolset_keys asserts an explicit plugin key alongside hermes-cli survives the _get_platform_tools filter (Layer 2).
  - test_explicit_plugin_toolset_admitted_against_real_a2a_plugin — end-to-end check: with the real bundled a2a plugin discoverable, a config like 'platform_toolsets.cli: [hermes-cli, a2a]' produces an enabled-toolsets set containing a2a. Fails before the fix (Layer 2).

## Test runs

```
python -m pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_tools_config.py -q
# 70 passed
```

`python -m ruff check hermes_cli/plugins.py hermes_cli/tools_config.py plugins/platforms/a2a/__init__.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_tools_config.py`
# All checks passed!

Fixes #81163