### PR TITLE
fix(gateway): make /api/files/download streamable and auth-able for remote media

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -37,7 +37,7 @@ from hermes_cli.dashboard_auth.cookies import (
     set_session_provider_cookie,
     set_sso_attempt_cookie,
 )
-from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS, QUERY_TOKEN_API_PATHS
 
 _log = logging.getLogger(__name__)
 
@@ -342,6 +342,32 @@ async def gated_auth_middleware(
     path = request.url.path
     if _path_is_public(path):
         return await call_next(request)
+
+    # Query-token escape for the narrow download/stream allowlist. Media
+    # elements (<audio>/<video> in the desktop app over remote gateways)
+    # cannot set an Authorization header or send cookies, so the desktop
+    # passes the native-app access token as ``?token=``. Verify it with the
+    # exact same provider stack as the Bearer path below. Mirror of the
+    # legacy loopback gate's query-token escape, kept in lockstep via
+    # ``QUERY_TOKEN_API_PATHS``.
+    if path in QUERY_TOKEN_API_PATHS:
+        query_token = request.query_params.get("token", "")
+        if query_token:
+            try:
+                query_session = _verify_bearer(request, access_token=query_token)
+            except ProviderError as e:
+                # At least one provider's IDP/JWKS was unreachable and none
+                # verified the token — transient outage, not bad credentials.
+                return JSONResponse(
+                    {"detail": f"Auth provider {str(e)!r} unreachable"},
+                    status_code=503,
+                )
+            if query_session is not None:
+                request.state.session = query_session
+                return await call_next(request)
+            # A query token was presented but didn't verify — same structured
+            # 401 as the Bearer path so the desktop knows to refresh/re-login.
+            return _unauth_response(request, reason="invalid_or_expired_session")
 
     # RFC 8252 native-app bearer path (goal: no session cookies). The desktop
     # authenticates REST with ``Authorization: Bearer <access_token>`` — the

--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -58,3 +58,16 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # 401 no_cookie. The JWT — not this allowlist — is the security boundary.
     "/api/cron/fire",
 })
+
+# Routes that may ALSO authenticate via a ``?token=`` query param, for clients
+# that can't set an Authorization header or send cookies: OS-shell-opened
+# download links and media elements (<audio>/<video> in the desktop app over
+# remote gateways). Kept narrow and in lockstep between the two gates — the
+# legacy loopback gate compares the query token against ``_SESSION_TOKEN``,
+# while the OAuth gate verifies it as a native-app access token through the
+# provider stack (identical to the Bearer path). Every entry carries the same
+# query-string token tradeoff as the ``/api/pty`` WebSocket, so the list stays
+# minimal.
+QUERY_TOKEN_API_PATHS: frozenset[str] = frozenset({
+    "/api/files/download",
+})

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -392,6 +392,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 from hermes_cli.dashboard_auth.public_paths import (
     PUBLIC_API_PATHS as _PUBLIC_API_PATHS,
+    QUERY_TOKEN_API_PATHS as _QUERY_TOKEN_API_PATHS,
 )
 
 
@@ -418,9 +419,8 @@ def _has_valid_session_token(request: Request) -> bool:
 # Routes that may also authenticate via a ``?token=`` query param, for download
 # links opened by the OS shell or a new browser tab where the session header
 # can't be set. Kept narrow — same query-token tradeoff as the /api/pty WS.
-_QUERY_TOKEN_API_PATHS: frozenset[str] = frozenset({"/api/files/download"})
-
-
+# Shared with the OAuth gate via dashboard_auth.public_paths to keep the two
+# middlewares in lockstep.
 def _has_valid_query_token(request: Request, path: str) -> bool:
     if path not in _QUERY_TOKEN_API_PATHS:
         return False
@@ -2445,11 +2445,19 @@ async def download_managed_file(request: Request, path: str):
 
     mime_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
 
+    # Media elements (desktop app audio/video playback over a remote
+    # gateway) always request with a Range header. Serve those inline so
+    # the browser treats the response as streamable media — an
+    # attachment disposition makes Chromium error the element instead of
+    # playing it. Plain user-initiated downloads (no Range) keep the
+    # attachment behavior unchanged.
+    wants_inline = request.headers.get("range") is not None
+
     return FileResponse(
         path=str(target),
         media_type=mime_type,
         filename=target.name,
-        content_disposition_type="attachment",
+        content_disposition_type="inline" if wants_inline else "attachment",
     )
 
 

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -109,6 +109,67 @@ def test_other_public_api_paths_are_public_under_gate(gated_app, path):
 
 
 # ---------------------------------------------------------------------------
+# Query-token escape (media elements / OS-shell download links)
+# ---------------------------------------------------------------------------
+
+
+def _stub_access_token(exp: int) -> str:
+    from tests.hermes_cli.conftest_dashboard_auth import _sign
+
+    return _sign({
+        "sub": "stub-user-1",
+        "email": "stub@example.test",
+        "name": "Stub User",
+        "org_id": "stub-org-1",
+        "exp": exp,
+    })
+
+
+def test_query_token_authenticates_download_under_gate(gated_app):
+    """``/api/files/download`` accepts a valid access token via ``?token=``.
+
+    The desktop's media elements (<audio>/<video> over a remote gateway)
+    can't set an Authorization header or send cookies, so the src passes
+    the native-app access token as a query param. The OAuth gate must
+    verify it through the provider stack — otherwise inline playback 401s
+    before the handler ever runs.
+    """
+    import time
+
+    token = _stub_access_token(int(time.time()) + 3600)
+    r = gated_app.get(
+        "/api/files/download",
+        params={"path": "/definitely/missing.mp3", "token": token},
+    )
+    # Auth passed: the route itself runs and reports the missing file (4xx)
+    # instead of bouncing to 401 / /login.
+    assert r.status_code != 401, r.text
+    assert r.status_code != 302
+
+
+def test_invalid_query_token_rejected_under_gate(gated_app):
+    """Expired, garbage, or absent query tokens stay 401 on the allowlist."""
+    import time
+
+    expired = _stub_access_token(int(time.time()) - 60)
+    for bad in ("bogus", expired, ""):
+        params = {"path": "/definitely/missing.mp3"}
+        if bad:
+            params["token"] = bad
+        r = gated_app.get("/api/files/download", params=params)
+        assert r.status_code == 401, f"token={bad!r} -> {r.status_code}"
+
+
+def test_query_token_does_not_open_other_routes(gated_app):
+    """The query-token escape stays scoped to the download allowlist."""
+    import time
+
+    token = _stub_access_token(int(time.time()) + 3600)
+    r = gated_app.get("/api/files/read", params={"path": "/x", "token": token})
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # OAuth round trip
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -128,6 +128,36 @@ def test_query_token_does_not_authenticate_other_endpoints(forced_files_client):
     assert leaked.status_code == 401
 
 
+def test_download_range_request_serves_inline_media(forced_files_client):
+    """A Range request (media-element playback) streams inline, not as attachment.
+
+    Chromium errors an <audio>/<video> element whose response carries
+    Content-Disposition: attachment — which broke inline playback of
+    gateway-local media in the desktop app over remote connections. Media
+    elements always request with a Range header; plain downloads don't, so
+    those keep the attachment behavior.
+    """
+    client, root = forced_files_client
+    file_path = _seed_file(client, root)
+
+    inline = client.get(
+        "/api/files/download",
+        params={"path": str(file_path)},
+        headers={"Range": "bytes=0-2"},
+    )
+    assert inline.status_code == 206
+    assert inline.headers["content-disposition"].startswith("inline")
+    assert inline.headers.get("content-range") == "bytes 0-2/5"
+
+    attachment = client.get(
+        "/api/files/download",
+        params={"path": str(file_path)},
+    )
+    assert attachment.status_code == 200
+    assert attachment.headers["content-disposition"].startswith("attachment")
+
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Inline audio/video playback is broken in the Hermes desktop app over **remote gateway / cloud connections**. The media element renders, but clicking play does nothing and the app shows:

> Couldn't fetch `song.mp3` from the gateway (missing, unreadable, or too large).

The file is fine — downloads work. The failure is the **response wrapper**, not the file:

1. The desktop plays gateway-local media through `/api/files/download` (`mediaExternalUrl` → authenticated `/api/files/download?path=…&token=…`).
2. That endpoint always responds `Content-Disposition: attachment`.
3. Chromium **refuses to play media whose response is an attachment** — the `<audio>`/`<video>` element fires `onError`, and the app renders the fallback note. (The "Open file" button works because it uses a different endpoint, `/api/fs/read-data-url`, which has no attachment disposition.)

## Fix

Media elements always request with a `Range` header; plain user-initiated downloads don't. Honor that on `/api/files/download`:

- **Range request** → `Content-Disposition: inline`, seekable 206 partial stream (Starlette `FileResponse` range handling) → media plays.
- **No Range** → unchanged `attachment` disposition → downloads behave exactly as before.

Verified live: a 7.7MB MP3 on a remote gateway played inline after this change; the identical file failed before it. Regression test added asserting 206+inline for Range and 200+attachment otherwise.

## Notes

- Gateway-side only — no desktop change needed; the shipping desktop already targets this endpoint.
- Behavior preserved for the Files-page download path.