### PR TITLE
fix(update): write completion receipt directly to the action log

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -719,7 +719,23 @@ def _print_update_completion(message: str) -> None:
     print(message)
     action_id = os.environ.get("HERMES_ACTION_ID", "")
     if len(action_id) == 32 and all(char in "0123456789abcdef" for char in action_id):
-        print(f"=== hermes-update completed {action_id} ===")
+        receipt = f"=== hermes-update completed {action_id} ==="
+        print(receipt)
+        # The Desktop's completion detection tails the *action* log
+        # (hermes-update.log), not update.log. The stdout mirror to the
+        # action log can break mid-run (gateway restart, fd churn), which
+        # leaves the receipt only in update.log — the Desktop then times out
+        # and reports "Backend update failed" even though the update
+        # succeeded. Write the receipt straight to the action log so it is
+        # always matchable after the dashboard restarts (#81116).
+        try:
+            action_log = get_hermes_home() / "logs" / "hermes-update.log"
+            action_log.parent.mkdir(parents=True, exist_ok=True)
+            with open(action_log, "a", encoding="utf-8", errors="replace") as log_fh:
+                log_fh.write(f"\n{receipt}\n")
+        except Exception:
+            # Best-effort only — the mirrored print above is the primary path.
+            pass
 
 
 def _update_via_zip(args):


### PR DESCRIPTION
Fixes #81193

## Problem

The Desktop's completion detection for backend updates tails the **action log** (`~/.hermes/logs/hermes-update.log`) and, after the dashboard restarts mid-update, matches the exact line `=== hermes-update completed <id> ===` in that tail (`completedAfterRestart()` in apps/desktop/src/store/updates.ts). The receipt was only **printed to stdout**, which during `hermes update` is an `_UpdateOutputStream` mirroring to both update.log and the original stream (the action-log fd). The mirror to the original stream can break mid-run (observed: action log ends at `✓ Code updated!` while update.log has the full tail), so the receipt never reaches the file the Desktop reads → 6-minute timeout → **false "Backend update failed"** after a *successful* update.

Observed 2026-08-07: two consecutive successful updates (repo fast-forwarded to origin/main, gateway + dashboard restarted) both reported as failed by the Desktop modal.

## Fix

`_print_update_completion()` now also appends the receipt **directly** to `~/.hermes/logs/hermes-update.log` (best-effort, try/except, parent mkdir). The Desktop can then always match it after restart, regardless of stdout-mirror state.

## Verification

- Unit-style repro with a broken stdout mirror: receipt lands in the action log file; the no-action-id (plain CLI) path is unaffected.
- `python -m py_compile` passes.

## Notes

- The receipt mechanism itself (#47359/#58764) is sound; only its delivery channel was fragile.
- Optionally, `get_action_status()` could also merge the update.log tail for the `hermes-update` action as defense-in-depth — happy to add if maintainers prefer.