### PR TITLE
feat(telegram): add nested model picker navigation

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5462,3 +5462,78 @@ def validate_requested_model(
             f"If the service isn't down, this model may not be valid."
         ),
     }
+
+
+def categorize_models(model_ids):
+    """Categorize the supplied live model IDs into picker buckets.
+
+    Classification is intentionally derived only from each input ID.  The
+    provider response is the source of truth; the static OpenRouter snapshot
+    must not leak stale models into this picker.
+    """
+    def is_free(model_id):
+        lowered = str(model_id).lower()
+        return lowered.endswith((":free", "-free", "/free"))
+
+    def is_fast(model_id):
+        lowered = str(model_id).lower()
+        return lowered.endswith(":fast") or "fast" in lowered
+
+    free = [model_id for model_id in model_ids if is_free(model_id)]
+    paid = [model_id for model_id in model_ids if not is_free(model_id)]
+    fast = [model_id for model_id in model_ids if is_fast(model_id)]
+    slow = [model_id for model_id in model_ids if not is_fast(model_id)]
+    return {"free": free, "paid": paid, "fast": fast, "slow": slow}
+
+
+
+
+def categorize_models_nested(model_ids, speed_categories_enabled=False):
+    """Partition model IDs by Free/Paid, optionally by Fast/Slow.
+
+    Returns:
+        speed_categories_enabled=False → ``{"free": [...], "paid": [...]}``
+        speed_categories_enabled=True  →
+            ``{"free": {"fast": [...], "slow": [...]}, "paid": {...}}``
+
+    Pure function over the existing :func:`categorize_models` partition.
+    """
+    base = categorize_models(model_ids)
+    if not speed_categories_enabled:
+        return {"free": base["free"], "paid": base["paid"]}
+    return {
+        "free": {
+            "fast": [m for m in base["free"] if m in base["fast"]],
+            "slow": [m for m in base["free"] if m in base["slow"]],
+        },
+        "paid": {
+            "fast": [m for m in base["paid"] if m in base["fast"]],
+            "slow": [m for m in base["paid"] if m in base["slow"]],
+        },
+    }
+
+
+def validate_picker_query(query):
+    """Validate picker search query for the Telegram picker contract.
+
+    Accepts strings of length 1..64 inclusive; everything else is rejected so
+    the caller can render a clear UX response instead of echoing raw input.
+    """
+    if not isinstance(query, str):
+        return False
+    if not (1 <= len(query) <= 64):
+        return False
+    return True
+
+
+def filter_models_by_query(model_ids, query):
+    """Case-insensitive substring filter on model IDs.
+
+    Bounded to 1..64 characters per the picker contract. Empty or oversized
+    queries return an empty list — callers must surface a UX error rather than
+    echoing raw user input.
+    """
+    if not isinstance(query, str) or not (1 <= len(query) <= 64):
+        return []
+    needle = query.lower()
+    return [m for m in model_ids if needle in m.lower()]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -234,7 +234,14 @@ async def _shutdown_abandoned_app(app) -> None:
             logger.debug("Abandoned Telegram request shutdown failed", exc_info=True)
 
 try:
-    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
+    from telegram import (
+        Update,
+        Bot,
+        Message,
+        InlineKeyboardButton,
+        InlineKeyboardMarkup,
+        ForceReply,
+    )
     try:
         from telegram import LinkPreviewOptions
     except ImportError:
@@ -257,6 +264,7 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+    ForceReply = Any
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
@@ -5764,7 +5772,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             # Build provider buttons — folds provider groups (display only).
-            keyboard, provider_page_info = self._build_provider_keyboard(providers, 0)
+            keyboard, provider_page_info = self._build_provider_keyboard(
+                providers, 0, nested=True
+            )
 
             provider_label = get_label(current_provider)
             text = self.format_message(
@@ -5794,15 +5804,29 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             )
 
-            # Store picker state keyed by chat_id
+            # Store picker state keyed by chat_id. Nested fields are additive;
+            # legacy callback states remain valid when they are absent.
             self._model_picker_state[str(chat_id)] = {
                 "msg_id": msg.message_id,
                 "providers": providers,
+                "provider_view": list(providers),
                 "session_key": session_key,
                 "on_model_selected": on_model_selected,
                 "current_model": current_model,
                 "current_provider": current_provider,
                 "provider_page": 0,
+                "nested_picker": True,
+                "nested_stage": "providers",
+                "speed_categories": self._model_picker_speed_categories_enabled(),
+                "selected_provider_idx": None,
+                "selected_category": None,
+                "selected_speed": None,
+                "model_list": [],
+                "model_page": 0,
+                "search_stage": None,
+                "search_prompt_id": None,
+                "search_started_at": None,
+                "model_filter_query": None,
             }
 
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -5934,8 +5958,232 @@ class TelegramAdapter(BasePlatformAdapter):
         self._choice_picker_state.pop(chat_id, None)
 
     _MODEL_PAGE_SIZE = 8
+    _MODEL_PICKER_CALLBACK_MAX_BYTES = 64
+    _MODEL_PICKER_QUERY_MAX_CHARS = 64
+    _MODEL_PICKER_SEARCH_TTL_SECONDS = 300
 
-    def _build_provider_keyboard(self, providers: list, page: int = 0) -> tuple:
+    def _model_picker_speed_categories_enabled(self) -> bool:
+        """Return the opt-in Fast/Slow layer flag from Telegram extras."""
+        extra = getattr(self.config, "extra", {}) or {}
+        nested = extra.get("model_picker", {})
+        value = nested.get("speed_categories") if isinstance(nested, dict) else None
+        if value is None:
+            value = extra.get("model_picker.speed_categories", False)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    @classmethod
+    def _model_picker_callback(cls, data: str) -> str:
+        if len(data.encode("utf-8")) > cls._MODEL_PICKER_CALLBACK_MAX_BYTES:
+            raise ValueError("model picker callback exceeds Telegram's 64-byte limit")
+        return data
+
+    @staticmethod
+    def _model_picker_categories(model_ids: list, speed_categories: bool) -> dict:
+        from hermes_cli.models import categorize_models_nested
+
+        return categorize_models_nested(
+            model_ids, speed_categories_enabled=speed_categories
+        )
+
+    @staticmethod
+    def _model_picker_filter(model_ids: list, query: str) -> list:
+        from hermes_cli.models import filter_models_by_query
+
+        return filter_models_by_query(model_ids, query)
+
+    def _model_picker_provider(self, state: dict, index: int):
+        providers = state.get("provider_view")
+        if providers is None:
+            providers = state.get("providers") or []
+        return providers[index] if isinstance(index, int) and 0 <= index < len(providers) else None
+
+    def _model_picker_category_models(self, state: dict, category: str, speed: Optional[str] = None) -> list:
+        provider = self._model_picker_provider(state, state.get("selected_provider_idx"))
+        if not provider or category not in {"free", "paid"}:
+            return []
+        categories = self._model_picker_categories(
+            list(provider.get("models", [])), bool(state.get("speed_categories"))
+        )
+        bucket = categories.get(category, [])
+        if speed is not None:
+            models = list(bucket.get(speed, [])) if isinstance(bucket, dict) and speed in {"fast", "slow"} else []
+        else:
+            models = list(bucket) if isinstance(bucket, list) else []
+        query = state.get("model_filter_query")
+        return self._model_picker_filter(models, query) if query else models
+
+    def _model_picker_nested_keyboard(self, state: dict):
+        stage = state.get("nested_stage", "providers")
+        if stage == "providers":
+            providers = state.get("provider_view")
+            if providers is None:
+                providers = state.get("providers") or []
+            keyboard, _ = self._build_provider_keyboard(
+                providers, state.get("provider_page", 0), nested=True
+            )
+            return keyboard
+
+        if stage == "categories":
+            provider = self._model_picker_provider(state, state.get("selected_provider_idx"))
+            models = list(provider.get("models", [])) if provider else []
+            query = state.get("model_filter_query")
+            if query:
+                models = self._model_picker_filter(models, query)
+            categories = self._model_picker_categories(models, bool(state.get("speed_categories")))
+            def _count(bucket):
+                return len(bucket) if isinstance(bucket, list) else sum(len(v) for v in bucket.values())
+            rows = [[
+                InlineKeyboardButton(f"Free ({_count(categories['free'])})", callback_data=self._model_picker_callback(f"mp:cat:{state['selected_provider_idx']}:free")),
+                InlineKeyboardButton(f"Paid ({_count(categories['paid'])})", callback_data=self._model_picker_callback(f"mp:cat:{state['selected_provider_idx']}:paid")),
+            ]]
+            rows.append([InlineKeyboardButton("🔎 Search", callback_data="mp:q:c")])
+            rows.append([InlineKeyboardButton("◀ Back", callback_data="mp:b:p"), InlineKeyboardButton("✗ Cancel", callback_data="mx")])
+            return InlineKeyboardMarkup(rows)
+
+        if stage == "speeds":
+            category = state.get("selected_category")
+            fast = self._model_picker_category_models(state, category, "fast")
+            slow = self._model_picker_category_models(state, category, "slow")
+            rows = [[
+                InlineKeyboardButton(f"Fast ({len(fast)})", callback_data=self._model_picker_callback(f"mp:cat2:{state['selected_provider_idx']}:{category}:fast")),
+                InlineKeyboardButton(f"Slow ({len(slow)})", callback_data=self._model_picker_callback(f"mp:cat2:{state['selected_provider_idx']}:{category}:slow")),
+            ]]
+            rows.append([InlineKeyboardButton("🔎 Search", callback_data="mp:q:s")])
+            rows.append([InlineKeyboardButton("◀ Back", callback_data="mp:b:c"), InlineKeyboardButton("✗ Cancel", callback_data="mx")])
+            return InlineKeyboardMarkup(rows)
+
+        models = state.get("model_list", [])
+        keyboard, _ = self._build_model_keyboard(
+            models,
+            state.get("model_page", 0),
+            nested=True,
+            back_callback="mp:b:s" if state.get("speed_categories") else "mp:b:c",
+        )
+        return keyboard
+
+    def _model_picker_nested_text(self, state: dict) -> str:
+        stage = state.get("nested_stage", "providers")
+        if stage == "providers":
+            return "⚙ *Model Configuration*\n\nSelect a provider:"
+        provider = self._model_picker_provider(state, state.get("selected_provider_idx")) or {}
+        name = provider.get("name", provider.get("slug", ""))
+        if stage == "categories":
+            return f"⚙ *Model Configuration*\n\nProvider: *{name}*\n\nSelect Free or Paid:"
+        if stage == "speeds":
+            return f"⚙ *Model Configuration*\n\nProvider: *{name}*\nCategory: *{state.get('selected_category', '')}*\n\nSelect Fast or Slow:"
+        return f"⚙ *Model Configuration*\n\nProvider: *{name}*\n\nSelect a model:"
+
+    async def _model_picker_render_nested(self, query, state: dict) -> None:
+        await query.edit_message_text(
+            text=self.format_message(self._model_picker_nested_text(state)),
+            parse_mode=ParseMode.MARKDOWN_V2,
+            reply_markup=self._model_picker_nested_keyboard(state),
+        )
+        await query.answer()
+
+    async def _model_picker_render_nested_message(self, state: dict, chat_id: str) -> None:
+        """Render the active nested picker after a ForceReply search response."""
+        if not self._bot or not state.get("msg_id"):
+            return
+        await self._bot.edit_message_text(
+            chat_id=normalize_telegram_chat_id(chat_id),
+            message_id=state["msg_id"],
+            text=self.format_message(self._model_picker_nested_text(state)),
+            parse_mode=ParseMode.MARKDOWN_V2,
+            reply_markup=self._model_picker_nested_keyboard(state),
+        )
+
+    async def _model_picker_begin_search(self, query, state: dict, stage: str) -> None:
+        """Start a bounded, reply-scoped search prompt."""
+        state["search_stage"] = stage
+        state["search_started_at"] = time.monotonic()
+        prompt_message = getattr(query, "message", None)
+        prompt = None
+        reply_text = getattr(prompt_message, "reply_text", None)
+        if callable(reply_text):
+            prompt = await reply_text(
+                "Type a search term (1–64 characters).",
+                reply_markup=ForceReply(selective=True),
+            )
+        state["search_prompt_id"] = getattr(prompt, "message_id", None)
+        await query.answer()
+
+    async def _send_model_picker_search_feedback(self, message, text: str) -> None:
+        reply_text = getattr(message, "reply_text", None)
+        if callable(reply_text):
+            await reply_text(text)
+
+    async def _handle_model_picker_search_message(self, message) -> bool:
+        """Consume only a reply to the currently active picker search prompt."""
+        chat = getattr(message, "chat", None)
+        chat_id = getattr(message, "chat_id", None) or getattr(chat, "id", None)
+        if chat_id is None:
+            return False
+        picker_state = getattr(self, "_model_picker_state", None)
+        if not isinstance(picker_state, dict):
+            return False
+        state = picker_state.get(str(chat_id))
+        if not state or not state.get("search_stage"):
+            return False
+        reply_to = getattr(message, "reply_to_message", None)
+        if getattr(reply_to, "message_id", None) != state.get("search_prompt_id"):
+            return False
+        started = state.get("search_started_at")
+        if started and time.monotonic() - started > self._MODEL_PICKER_SEARCH_TTL_SECONDS:
+            state["search_stage"] = None
+            state["search_prompt_id"] = None
+            state["search_started_at"] = None
+            await self._send_model_picker_search_feedback(
+                message, "Search prompt expired — use Search again."
+            )
+            return True
+
+        query = str(getattr(message, "text", "") or "").strip()
+        if not (1 <= len(query) <= self._MODEL_PICKER_QUERY_MAX_CHARS):
+            await self._send_model_picker_search_feedback(
+                message, "Search must be between 1 and 64 characters."
+            )
+            return True
+
+        stage = state["search_stage"]
+        state["search_stage"] = None
+        state["search_prompt_id"] = None
+        state["search_started_at"] = None
+        if stage == "providers":
+            needle = query.casefold()
+            state["provider_view"] = [
+                provider for provider in state.get("providers", [])
+                if needle in str(provider.get("slug", "")).casefold()
+                or needle in str(provider.get("name", "")).casefold()
+            ]
+            state["provider_page"] = 0
+            state["nested_stage"] = "providers"
+        elif stage in {"category", "speeds"}:
+            state["model_filter_query"] = query
+            state["nested_stage"] = "categories" if stage == "category" else "speeds"
+        elif stage == "models":
+            state["model_filter_query"] = query
+            state["model_list"] = self._model_picker_category_models(
+                state,
+                state.get("selected_category") or "",
+                state.get("selected_speed") if state.get("speed_categories") else None,
+            )
+            state["model_page"] = 0
+            state["nested_stage"] = "models"
+        else:
+            return True
+        try:
+            await self._model_picker_render_nested_message(state, str(chat_id))
+        except Exception as exc:
+            logger.warning("[%s] nested picker search render failed: %s", self.name, _redact_telegram_error_text(exc))
+        return True
+
+
+    def _build_provider_keyboard(
+        self, providers: list, page: int = 0, *, nested: bool = False
+    ) -> tuple:
         """Build the paginated top-level provider keyboard, folding groups.
 
         Provider families (Kimi/Moonshot, MiniMax, xAI Grok, ...) collapse to
@@ -5960,7 +6208,19 @@ class TelegramAdapter(BasePlatformAdapter):
             return InlineKeyboardButton(label, callback_data=f"mp:{p['slug']}")
 
         buttons: list = []
-        if group_providers is not None:
+        if nested:
+            for index, provider in enumerate(providers):
+                count = provider.get("total_models", len(provider.get("models", [])))
+                label = f"{provider.get('name', provider.get('slug', 'provider'))} ({count})"
+                if provider.get("is_current"):
+                    label = f"✓ {label}"
+                buttons.append(
+                    InlineKeyboardButton(
+                        label,
+                        callback_data=self._model_picker_callback(f"mp:p:{index}"),
+                    )
+                )
+        elif group_providers is not None:
             for row in group_providers([p.get("slug") for p in providers]):
                 if row["kind"] == "group":
                     members = [by_slug[m] for m in row["members"] if m in by_slug]
@@ -5998,11 +6258,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 nav.append(InlineKeyboardButton("Next ▶", callback_data=f"mpv:{page + 1}"))
             rows.append(nav)
 
+        if nested:
+            rows.append([InlineKeyboardButton("🔎 Search", callback_data="mp:q:p")])
         rows.append([InlineKeyboardButton("✗ Cancel", callback_data="mx")])
 
         return InlineKeyboardMarkup(rows), page_meta["page_info"]
 
-    def _build_model_keyboard(self, models: list, page: int) -> tuple:
+    def _build_model_keyboard(
+        self,
+        models: list,
+        page: int,
+        *,
+        nested: bool = False,
+        back_callback: str = "mb",
+    ) -> tuple:
         """Build paginated model buttons. Returns (keyboard, page_info_text)."""
         page_models, page_meta = self._format_choice_page(
             models, page, self._MODEL_PAGE_SIZE
@@ -6033,8 +6302,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 nav.append(InlineKeyboardButton("Next ▶", callback_data=f"mg:{page + 1}"))
             rows.append(nav)
 
+        if nested:
+            rows.append([InlineKeyboardButton("🔎 Search", callback_data="mp:q:m")])
         rows.append([
-            InlineKeyboardButton("◀ Back", callback_data="mb"),
+            InlineKeyboardButton("◀ Back", callback_data=back_callback if nested else "mb"),
             InlineKeyboardButton("✗ Cancel", callback_data="mx"),
         ])
 
@@ -6054,6 +6325,86 @@ class TelegramAdapter(BasePlatformAdapter):
         except ImportError:
             def get_label(slug):
                 return slug
+
+        if state.get("nested_picker") and data.startswith("mp:"):
+            if data.startswith("mp:p:"):
+                try:
+                    index = int(data[5:])
+                except ValueError:
+                    await query.answer(text="Invalid provider.")
+                    return
+                provider = self._model_picker_provider(state, index)
+                if provider is None:
+                    await query.answer(text="Provider not found.")
+                    return
+                state["selected_provider_idx"] = index
+                state["selected_provider"] = provider.get("slug", "")
+                state["selected_provider_name"] = provider.get("name", provider.get("slug", ""))
+                state["nested_stage"] = "categories"
+                state["model_filter_query"] = None
+                await self._model_picker_render_nested(query, state)
+                return
+            if data.startswith("mp:cat2:"):
+                parts = data.split(":")
+                if len(parts) != 5 or parts[3] not in {"free", "paid"} or parts[4] not in {"fast", "slow"}:
+                    await query.answer(text="Invalid category.")
+                    return
+                try:
+                    state["selected_provider_idx"] = int(parts[2])
+                except ValueError:
+                    await query.answer(text="Invalid provider.")
+                    return
+                state["selected_category"] = parts[3]
+                state["selected_speed"] = parts[4]
+                state["model_list"] = self._model_picker_category_models(state, parts[3], parts[4])
+                state["model_page"] = 0
+                state["nested_stage"] = "models"
+                await self._model_picker_render_nested(query, state)
+                return
+            if data.startswith("mp:cat:"):
+                parts = data.split(":")
+                if len(parts) != 4 or parts[3] not in {"free", "paid"}:
+                    await query.answer(text="Invalid category.")
+                    return
+                try:
+                    state["selected_provider_idx"] = int(parts[2])
+                except ValueError:
+                    await query.answer(text="Invalid provider.")
+                    return
+                state["selected_category"] = parts[3]
+                if state.get("speed_categories"):
+                    state["nested_stage"] = "speeds"
+                else:
+                    state["model_list"] = self._model_picker_category_models(state, parts[3])
+                    state["model_page"] = 0
+                    state["nested_stage"] = "models"
+                await self._model_picker_render_nested(query, state)
+                return
+            if data in {"mp:q:p", "mp:q:c", "mp:q:s", "mp:q:m"}:
+                stage = {
+                    "mp:q:p": "providers",
+                    "mp:q:c": "category",
+                    "mp:q:s": "speeds",
+                    "mp:q:m": "models",
+                }[data]
+                await self._model_picker_begin_search(query, state, stage)
+                return
+            if data == "mp:b:p":
+                state["nested_stage"] = "providers"
+                await self._model_picker_render_nested(query, state)
+                return
+            if data == "mp:b:c":
+                state["nested_stage"] = "categories"
+                await self._model_picker_render_nested(query, state)
+                return
+            if data == "mp:b:s":
+                state["nested_stage"] = "speeds"
+                await self._model_picker_render_nested(query, state)
+                return
+            if data == "mp:b:m":
+                state["nested_stage"] = "models"
+                await self._model_picker_render_nested(query, state)
+                return
 
         if data.startswith("mp:"):
             # --- Provider selected: show model buttons (page 0) ---
@@ -6102,6 +6453,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             models = state.get("model_list", [])
             state["model_page"] = page
+            if state.get("nested_picker"):
+                state["nested_stage"] = "models"
+                await self._model_picker_render_nested(query, state)
+                return
 
             keyboard, page_info = self._build_model_keyboard(models, page)
 
@@ -6137,6 +6492,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             state["provider_page"] = page
+            if state.get("nested_picker"):
+                if state.get("provider_view") is None:
+                    state["provider_view"] = state["providers"]
+                state["nested_stage"] = "providers"
+                await self._model_picker_render_nested(query, state)
+                return
             keyboard, provider_page_info = self._build_provider_keyboard(
                 state["providers"], page
             )
@@ -6243,10 +6604,11 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 warning = None
             if warning is not None:
+                back_callback = "mp:b:m" if state.get("nested_picker") else "mb"
                 keyboard = InlineKeyboardMarkup([
                     [InlineKeyboardButton("Switch anyway", callback_data=f"mc:{idx}")],
                     [
-                        InlineKeyboardButton("◀ Back", callback_data="mb"),
+                        InlineKeyboardButton("◀ Back", callback_data=back_callback),
                         InlineKeyboardButton("✗ Cancel", callback_data="mx"),
                     ],
                 ])
@@ -8882,6 +9244,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
+            return
+        if await self._handle_model_picker_search_message(msg):
             return
         # Early user-level auth check: reject unauthorized users before any
         # text batching, observe-buffer persistence, event building, or response

--- a/tests/gateway/test_telegram_model_picker_nested.py
+++ b/tests/gateway/test_telegram_model_picker_nested.py
@@ -1,0 +1,205 @@
+"""
+Unit tests for the nested Telegram ``/model`` picker enhancement.
+
+Covers:
+  * Free/Paid and Fast/Slow partitioning via ``categorize_models`` /
+    ``categorize_models_nested``.
+  * ``filter_models_by_query`` and ``validate_picker_query`` behavior,
+    including empty / oversize rejection.
+  * Callback-data byte budget (≤64 ASCII bytes) for the new prefixes.
+  * Backward-compat — the legacy ``mp:`` / ``mpg:`` / ``mpv:`` / ``mm:`` /
+    ``mc:`` / ``mb`` / ``mx`` / ``mg:`` prefixes are not removed.
+  * Config-flag behavior of ``model_picker.speed_categories`` (default off).
+
+These tests focus on the catalog helpers and callback-encoding contracts.
+They intentionally do NOT require a live Telegram bot — they cover the pure
+parts of the contract; the adapter-level wiring is exercised in
+``test_telegram_model_picker.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.models import (
+    categorize_models,
+    categorize_models_nested,
+    filter_models_by_query,
+    validate_picker_query,
+)
+
+
+# ---------------------------------------------------------------------------
+# Categorization
+# ---------------------------------------------------------------------------
+
+
+def test_categorize_models_basic_partition():
+    ids = ["openai/gpt-3.5:free", "openai/gpt-4", "hf/llama:fast", "other:slow"]
+    base = categorize_models(ids)
+    assert set(base.keys()) == {"free", "paid", "fast", "slow"}
+    for v in base.values():
+        assert isinstance(v, list)
+    # Free/Paid partition is disjoint and exhaustive over the input.
+    assert set(base["free"]) | set(base["paid"]) == set(ids)
+    assert not (set(base["free"]) & set(base["paid"]))
+
+
+def test_categorize_models_nested_default_is_flat():
+    ids = ["openai/gpt-3.5:free", "openai/gpt-4", "hf/llama:fast"]
+    nested = categorize_models_nested(ids, speed_categories_enabled=False)
+    assert "free" in nested and "paid" in nested
+    # Speed-categories disabled: values stay flat lists (not nested dicts).
+    assert isinstance(nested["free"], list)
+    assert isinstance(nested["paid"], list)
+    assert "fast" not in nested["free"]  # no third tier when flag is off
+
+
+def test_categorize_models_nested_with_speed_categories():
+    ids = ["a:free", "a:fast", "b:paid", "b:slow"]
+    nested = categorize_models_nested(ids, speed_categories_enabled=True)
+    # When enabled, each Free/Paid bucket is itself a dict with fast/slow keys.
+    assert isinstance(nested["free"], dict)
+    assert isinstance(nested["paid"], dict)
+    assert set(nested["free"].keys()) == {"fast", "slow"}
+    assert set(nested["paid"].keys()) == {"fast", "slow"}
+
+
+def test_categorize_models_nested_empty_input():
+    base = categorize_models_nested([], speed_categories_enabled=False)
+    assert base == {"free": [], "paid": []}
+    nested = categorize_models_nested([], speed_categories_enabled=True)
+    assert nested == {
+        "free": {"fast": [], "slow": []},
+        "paid": {"fast": [], "slow": []},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Search / query validation
+# ---------------------------------------------------------------------------
+
+
+def test_filter_models_by_query_case_insensitive():
+    ids = ["gpt-4", "claude-3-opus", "Gemini-Pro"]
+    out = filter_models_by_query(ids, "gpt")
+    assert out == ["gpt-4"]
+    out2 = filter_models_by_query(ids, "GEM")
+    assert out2 == ["Gemini-Pro"]
+
+
+def test_filter_models_by_query_rejects_empty_and_overlong():
+    ids = ["x", "y", "z"]
+    assert filter_models_by_query(ids, "") == []
+    assert filter_models_by_query(ids, "q" * 65) == []
+
+
+def test_filter_models_by_query_at_boundary():
+    # Build a corpus that contains a 64-char string and prove the inclusive
+    # upper bound is honored (filter passes through to substring match).
+    corpus = ["a" * 64, "beta"]
+    assert filter_models_by_query(corpus, "a" * 64) == ["a" * 64]
+    # And the 65-char case is rejected:
+    assert filter_models_by_query(corpus, "a" * 65) == []
+
+
+def test_validate_picker_query_bounds():
+    assert validate_picker_query("") is False
+    assert validate_picker_query("q" * 65) is False
+    assert validate_picker_query(None) is False
+    assert validate_picker_query(123) is False
+    assert validate_picker_query("ok") is True
+    assert validate_picker_query("q" * 64) is True
+    assert validate_picker_query("a") is True
+
+
+# ---------------------------------------------------------------------------
+# Callback-data byte budget (Telegram enforces ≤64 ASCII bytes)
+# ---------------------------------------------------------------------------
+
+
+def test_callback_encodings_within_64_bytes():
+    # Provider idx up to 999, fp/fs are short tokens; lengths are tiny.
+    for provider_idx in range(0, 1000):
+        for fp in ("free", "paid"):
+            data = f"mp:cat:{provider_idx}:{fp}"
+            assert len(data.encode("ascii")) <= 64, data
+            for fs in ("fast", "slow"):
+                data2 = f"mp:cat2:{provider_idx}:{fp}:{fs}"
+                assert len(data2.encode("ascii")) <= 64, data2
+
+
+def test_callback_search_action_short_token():
+    # Search prompts are passed through the adapter's text/force-reply flow,
+    # not callback data. Even if a short action key leaks into a callback,
+    # the canonical action token is well under the byte budget.
+    for token in ("search", "q", "go", "back", "next"):
+        data = f"mp:{token}"
+        assert len(data.encode("ascii")) <= 64
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility of legacy prefixes
+# ---------------------------------------------------------------------------
+
+
+LEGACY_PREFIXES = {"mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:"}
+NEW_PREFIXES = {"mp:cat:", "mp:cat2:", "mp:search"}
+
+
+def test_backward_compatibility_legacy_prefixes_preserved():
+    # Each new prefix must start with a legacy prefix and then add a
+    # distinguishing token — they MUST NOT collide with any legacy prefix.
+    for new in NEW_PREFIXES:
+        assert not new in LEGACY_PREFIXES, f"{new} collides with legacy"
+        # New prefixes must remain distinct from the bare ``mp:`` so the
+        # legacy branch can keep parsing them as ``mp:<slug>``.
+        assert new != "mp:"
+        # All new prefixes are non-empty extensions of ``mp:``.
+        assert new.startswith("mp:")
+
+
+def test_legacy_mp_slug_callback_still_well_formed():
+    # Sample legacy provider-slug callback remains <=64 bytes.
+    slug = "openai/gpt-4o-mini"
+    data = f"mp:{slug}"
+    assert len(data.encode("ascii")) <= 64
+    # And the new category callback for the same provider is even shorter.
+    cat = f"mp:cat:0:paid"
+    assert len(cat.encode("ascii")) <= 64
+
+
+# ---------------------------------------------------------------------------
+# Config flag default behavior
+# ---------------------------------------------------------------------------
+
+
+def test_speed_categories_flag_default_is_false_in_contract():
+    """``model_picker.speed_categories`` must default to False.
+
+    The catalog helper treats ``False`` as the default — re-asserting the
+    contract here so a future refactor that flips the default to ``True``
+    is caught by tests.
+    """
+    ids = ["a:free", "a:fast", "b:paid"]
+    # speed_categories_enabled omitted → defaults to False → flat partition.
+    default = categorize_models_nested(ids)
+    assert isinstance(default["free"], list)
+    # Explicitly False → identical result.
+    explicit = categorize_models_nested(ids, speed_categories_enabled=False)
+    assert explicit == default
+
+
+# ---------------------------------------------------------------------------
+# Parametric sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("query", ["", " " * 65, "x" * 64 + "y", None, 42, [], {}])
+def test_validate_picker_query_rejects_bad_inputs(query):
+    assert validate_picker_query(query) is False
+
+
+@pytest.mark.parametrize("query", ["a", "ab", "GPT-4", "中", "q" * 64])
+def test_validate_picker_query_accepts_good_inputs(query):
+    assert validate_picker_query(query) is True

--- a/tests/gateway/test_telegram_model_picker_nested_callbacks.py
+++ b/tests/gateway/test_telegram_model_picker_nested_callbacks.py
@@ -1,0 +1,217 @@
+"""Async regression tests for the nested Telegram /model picker callback flows.
+
+These tests exercise the adapter-level state machine without a live bot.
+They cover:
+
+* Nested provider pagination (`mpv:`) stays inside the nested renderer
+  rather than falling into the legacy provider layout.
+* Nested model pagination (`mg:`) preserves the nested renderer.
+* "Back" routes (`mp:b:p`, `mp:b:c`, `mp:b:s`, `mp:b:m`) return to the
+  correct prior stage for both speed-categories enabled and disabled.
+* Expensive-model warning uses the correct Back callback when in nested mode.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock() -> None:
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    mod.ForceReply = type("ForceReply", (), {"__init__": lambda self, **_kw: None})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+CHAT_ID = "99999"
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    bot = MagicMock()
+    bot.edit_message_text = AsyncMock()
+    bot.send_message = AsyncMock()
+    bot.delete_message = AsyncMock()
+    adapter._bot = bot
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _query(data: str):
+    q = AsyncMock()
+    q.data = data
+    q.message = MagicMock()
+    q.message.chat_id = int(CHAT_ID)
+    q.message.message_thread_id = None
+    q.message.chat = MagicMock()
+    q.message.chat.type = "private"
+    q.from_user = MagicMock()
+    q.from_user.id = 1
+    q.from_user.first_name = "Shiko"
+    q.answer = AsyncMock()
+    q.edit_message_text = AsyncMock()
+    return q
+
+
+def _seed_state(adapter: TelegramAdapter, *, speed_categories: bool = False) -> None:
+    providers = [
+        {
+            "slug": "provider_one",
+            "name": "Provider One",
+            "total_models": 12,
+            "is_current": True,
+            "models": [f"provider_one/model_{i}" for i in range(12)],
+        },
+        {
+            "slug": "provider_two",
+            "name": "Provider Two",
+            "total_models": 0,
+            "is_current": False,
+            "models": [],
+        },
+    ]
+    adapter._model_picker_state[CHAT_ID] = {
+        "msg_id": 42,
+        "providers": providers,
+        "provider_view": providers,
+        "session_key": "s",
+        "on_model_selected": AsyncMock(),
+        "current_model": "provider_one/model_0",
+        "current_provider": "provider_one",
+        "provider_page": 0,
+        "nested_picker": True,
+        "nested_stage": "models",
+        "speed_categories": speed_categories,
+        "selected_provider_idx": 0,
+        "selected_provider": "provider_one",
+        "selected_provider_name": "Provider One",
+        "selected_category": "paid",
+        "selected_speed": "slow" if speed_categories else None,
+        "model_list": providers[0]["models"],
+        "model_page": 0,
+        "search_stage": None,
+        "search_prompt_id": None,
+        "search_started_at": None,
+        "model_filter_query": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_nested_model_pagination_routes_through_nested_renderer():
+    adapter = _make_adapter()
+    _seed_state(adapter)
+
+    query = _query("mg:0")
+    await adapter._handle_model_picker_callback(query, "mg:0", CHAT_ID)
+
+    state = adapter._model_picker_state[CHAT_ID]
+    assert state["nested_stage"] == "models"
+    state["model_page"] = 0
+    # The legacy renderer would have called _build_model_keyboard directly;
+    # the nested renderer routes through edit_message_text via the
+    # nested renderer pipeline.
+    args, kwargs = query.edit_message_text.call_args
+    payload = str(kwargs.get("text") or (args[1] if len(args) > 1 else args[0] if args else ""))
+    assert "Model Configuration" in payload
+    assert "Provider One" in payload
+
+
+@pytest.mark.asyncio
+async def test_nested_provider_pagination_routes_through_nested_renderer():
+    adapter = _make_adapter()
+    _seed_state(adapter)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "providers"
+
+    query = _query("mpv:1")
+    await adapter._handle_model_picker_callback(query, "mpv:1", CHAT_ID)
+
+    state = adapter._model_picker_state[CHAT_ID]
+    assert state["provider_page"] == 1
+    assert state["nested_stage"] == "providers"
+    query.edit_message_text.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_back_to_providers_from_categories():
+    adapter = _make_adapter()
+    _seed_state(adapter)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "categories"
+
+    await adapter._handle_model_picker_callback(_query("mp:b:p"), "mp:b:p", CHAT_ID)
+
+    assert state["nested_stage"] == "providers"
+
+
+@pytest.mark.asyncio
+async def test_back_to_categories_from_speeds():
+    adapter = _make_adapter()
+    _seed_state(adapter, speed_categories=True)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "speeds"
+
+    await adapter._handle_model_picker_callback(_query("mp:b:c"), "mp:b:c", CHAT_ID)
+
+    assert state["nested_stage"] == "categories"
+
+
+@pytest.mark.asyncio
+async def test_back_to_speeds_from_models_with_speed_categories():
+    adapter = _make_adapter()
+    _seed_state(adapter, speed_categories=True)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "models"
+
+    await adapter._handle_model_picker_callback(_query("mp:b:s"), "mp:b:s", CHAT_ID)
+
+    assert state["nested_stage"] == "speeds"
+
+
+@pytest.mark.asyncio
+async def test_back_to_categories_from_models_without_speed_categories():
+    adapter = _make_adapter()
+    _seed_state(adapter, speed_categories=False)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "models"
+
+    await adapter._handle_model_picker_callback(_query("mp:b:c"), "mp:b:c", CHAT_ID)
+
+    assert state["nested_stage"] == "categories"
+
+
+@pytest.mark.asyncio
+async def test_back_to_models_from_warning_nested():
+    adapter = _make_adapter()
+    _seed_state(adapter)
+    state = adapter._model_picker_state[CHAT_ID]
+    state["nested_stage"] = "models"
+    # Confirm the model-list Back callback used in the warning screen
+    # routes through the nested renderer when the picker is nested.
+    await adapter._handle_model_picker_callback(_query("mp:b:m"), "mp:b:m", CHAT_ID)
+    assert state["nested_stage"] == "models"


### PR DESCRIPTION
## Summary
- add nested provider/category/speed/model navigation for Telegram /model
- preserve legacy picker routing and fail-closed search behavior
- add async callback coverage

## Verification
- `python3 -m pytest -q tests/gateway/test_telegram_model_picker.py tests/gateway/test_telegram_model_picker_nested.py tests/gateway/test_telegram_model_picker_nested_callbacks.py`
- 34 passed
- `python3 -m py_compile ...`
- `git diff --check`

Review target: `afa67724e253506091fb156865e9e8bc200bbc04`.