### PR TITLE
fix(email): answer mail that arrived while the gateway was down

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -47,6 +47,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from plugins.platforms.email.uid_cursor import EmailUidCursor
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -190,6 +191,35 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
         )
     except Exception as e:  # noqa: BLE001 — best-effort, never fatal
         logger.debug("[Email] IMAP ID command not accepted: %s", e)
+
+
+def _uid_int(uid: Any) -> int:
+    """Numeric value of an IMAP UID token, or 0 when it is not a number."""
+    try:
+        return int(uid)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_uidvalidity(imap: "imaplib.IMAP4") -> str:
+    """UIDVALIDITY of the selected mailbox, or '' when the server sent none.
+
+    SELECT already carries UIDVALIDITY in an untagged response that imaplib
+    buffers, so reading it here costs no extra round trip.  STATUS would cost
+    one, and RFC 3501 discourages STATUS against the mailbox that is currently
+    selected.
+    """
+    try:
+        _typ, data = imap.response("UIDVALIDITY")
+    except Exception as e:  # noqa: BLE001 — best-effort; '' just re-baselines
+        logger.debug("[Email] Could not read UIDVALIDITY: %s", e)
+        return ""
+    if not data or not data[0]:
+        return ""
+    value = data[0]
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("ascii", errors="replace")
+    return str(value).strip()
 
 
 def _is_automated_sender(address: str, headers: dict) -> bool:
@@ -526,6 +556,24 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
+        # Resume the INBOX where the last run stopped instead of re-baselining
+        # against the whole mailbox on every start, so mail that arrived while
+        # the gateway was down still gets answered (#80925). Opt in via
+        # config.yaml:
+        #   platforms:
+        #     email:
+        #       resume_after_downtime: true
+        # Default off: an existing install keeps today's behavior exactly, and
+        # nothing is read from or written to disk. See uid_cursor.py for what is
+        # persisted and why it is one integer rather than a set of UIDs.
+        # The cursor exists only when the option is on, so `is not None` is the
+        # single test for "resume mode" everywhere below.
+        self._uid_cursor: Optional[EmailUidCursor] = (
+            EmailUidCursor(self._address)
+            if bool(extra.get("resume_after_downtime", False))
+            else None
+        )
+
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
@@ -550,6 +598,49 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _establish_resume_point(
+        self, imap: "imaplib.IMAP4", cursor: EmailUidCursor
+    ) -> None:
+        """Decide which UID this run resumes after. INBOX must be selected.
+
+        A cursor stored in the same UIDVALIDITY generation is resumed from:
+        everything above it is mail that arrived while the gateway was down, and
+        the ordinary poll loop dispatches it on its first tick — there is no
+        separate catch-up path.
+
+        With no usable cursor — first opted-in start, an unreadable file, or a
+        mailbox whose UIDVALIDITY changed — we baseline at the highest UID
+        present. That is exactly the default path's promise that mail already in
+        the INBOX is never answered.
+        """
+        uidvalidity = _read_uidvalidity(imap)
+        if not uidvalidity:
+            logger.warning(
+                "[Email] Mailbox reported no UIDVALIDITY — resume_after_downtime "
+                "cannot store a resume point and behaves as if it were off."
+            )
+
+        resume = cursor.resume_from(uidvalidity)
+        if resume is not None:
+            logger.info(
+                "[Email] IMAP connection test passed. Resuming after UID %d — "
+                "mail that arrived since then will be answered.",
+                resume,
+            )
+            return
+
+        highest = 0
+        status, data = imap.uid("search", None, "ALL")
+        if status == "OK" and data and data[0]:
+            for uid in data[0].split():
+                highest = max(highest, _uid_int(uid))
+        cursor.baseline(uidvalidity, highest)
+        logger.info(
+            "[Email] IMAP connection test passed. No usable resume point — "
+            "baselined at UID %d; mail already in the INBOX is not answered.",
+            highest,
+        )
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -630,16 +721,20 @@ class EmailAdapter(BasePlatformAdapter):
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
-            # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
+            cursor = self._uid_cursor
+            if cursor is not None:
+                self._establish_resume_point(imap, cursor)
+            else:
+                # Mark all existing messages as seen so we only process new ones
+                status, data = imap.uid("search", None, "ALL")
+                if status == "OK" and data and data[0]:
+                    for uid in data[0].split():
+                        self._seen_uids.add(uid)
+                # Keep only the most recent UIDs to prevent unbounded growth
+                self._trim_seen_uids()
+                logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
             imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             return False
@@ -695,6 +790,7 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        cursor = self._uid_cursor
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
@@ -702,17 +798,43 @@ class EmailAdapter(BasePlatformAdapter):
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
-                status, data = imap.uid("search", None, "UNSEEN")
+                if cursor is not None:
+                    # The persisted cursor is the queue, not the server-side
+                    # \Seen flag: a human opening the mailbox in a mail client
+                    # sets \Seen without the agent having answered anything,
+                    # which would hide that mail from an UNSEEN search forever.
+                    status, data = imap.uid(
+                        "search", None, "UID", f"{cursor.uid + 1}:*"
+                    )
+                else:
+                    status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:
                     return results
 
+                # Snapshot the cursor: it advances inside the loop, and filtering
+                # against a moving value would drop a lower UID if the server
+                # returned the batch out of order.
+                resume_after = cursor.uid if cursor is not None else 0
+
                 for uid in data[0].split():
-                    if uid in self._seen_uids:
-                        continue
-                    self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
+                    if cursor is not None:
+                        # RFC 3501: a UID range ending in '*' always includes the
+                        # last message in the mailbox, even when the range starts
+                        # above it — so filter what the server hands back.
+                        if _uid_int(uid) <= resume_after:
+                            continue
+                        # Commit here, before the FETCH that sets \Seen, which is
+                        # exactly where the in-memory skip set commits on the
+                        # default path. The cursor therefore means precisely what
+                        # that set already means, and this path is never worse.
+                        cursor.advance(_uid_int(uid))
+                    else:
+                        if uid in self._seen_uids:
+                            continue
+                        self._seen_uids.add(uid)
+                        # Trim periodically to prevent unbounded memory growth
+                        if len(self._seen_uids) > self._seen_uids_max:
+                            self._trim_seen_uids()
 
                     status, msg_data = imap.uid("fetch", uid, "(RFC822)")
                     if status != "OK":
@@ -786,6 +908,10 @@ class EmailAdapter(BasePlatformAdapter):
                     imap.logout()
                 except Exception:
                     pass
+                # One write per poll that moved the cursor, including the polls
+                # that returned early above.
+                if cursor is not None:
+                    cursor.flush()
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -613,6 +613,12 @@ class EmailAdapter(BasePlatformAdapter):
         mailbox whose UIDVALIDITY changed — we baseline at the highest UID
         present. That is exactly the default path's promise that mail already in
         the INBOX is never answered.
+
+        A failed baseline search is not an empty mailbox: the 0 it leaves
+        behind is indistinguishable from one, and recording it would make the
+        first poll search UID 1:* and answer the whole INBOX. The run drops
+        the cursor and behaves as if the option were off instead; the next
+        start tries the baseline again.
         """
         uidvalidity = _read_uidvalidity(imap)
         if not uidvalidity:
@@ -630,9 +636,17 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return
 
-        highest = 0
         status, data = imap.uid("search", None, "ALL")
-        if status == "OK" and data and data[0]:
+        if status != "OK":
+            logger.warning(
+                "[Email] Baseline UID search failed (%s) — no resume point "
+                "this run; behaving as if resume_after_downtime were off.",
+                status,
+            )
+            self._uid_cursor = None
+            return
+        highest = 0
+        if data and data[0]:
             for uid in data[0].split():
                 highest = max(highest, _uid_int(uid))
         cursor.baseline(uidvalidity, highest)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -27,6 +27,7 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.config import Platform, PlatformConfig
+from plugins.platforms.email.uid_cursor import EmailUidCursor
 from utils import is_truthy_value
 from gateway.platforms._shared import get_scoped_secret as _get_secret, coerce_port
 
@@ -165,6 +166,35 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
                          '"vendor" "NousResearch" "support-email" "noreply@nousresearch.com")')
     except Exception as e:  # noqa: BLE001 — best-effort, never fatal
         logger.debug("[Email] IMAP ID command not accepted: %s", e)
+
+
+def _uid_int(uid: Any) -> int:
+    """Numeric value of an IMAP UID token, or 0 when it is not a number."""
+    try:
+        return int(uid)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_uidvalidity(imap: "imaplib.IMAP4") -> str:
+    """UIDVALIDITY of the selected mailbox, or '' when the server sent none.
+
+    SELECT already carries UIDVALIDITY in an untagged response that imaplib
+    buffers, so reading it here costs no extra round trip.  STATUS would cost
+    one, and RFC 3501 discourages STATUS against the mailbox that is currently
+    selected.
+    """
+    try:
+        _typ, data = imap.response("UIDVALIDITY")
+    except Exception as e:  # noqa: BLE001 — best-effort; '' just re-baselines
+        logger.debug("[Email] Could not read UIDVALIDITY: %s", e)
+        return ""
+    if not data or not data[0]:
+        return ""
+    value = data[0]
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("ascii", errors="replace")
+    return str(value).strip()
 
 
 def _is_automated_sender(address: str, headers: dict) -> bool:
@@ -364,6 +394,18 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
         self._last_fetch_failed, self._last_fetch_error = False, ""  # "checked, nothing new" vs "the check itself failed"
+        # Resume the INBOX where the last run stopped instead of re-baselining against the whole mailbox on
+        # every start, so mail that arrived while the gateway was down still gets answered (#80925). Opt in
+        # via config.yaml:
+        #   platforms:
+        #     email:
+        #       resume_after_downtime: true
+        # Default off: an existing install keeps today's behavior exactly, and nothing is read from or written
+        # to disk. See uid_cursor.py for what is persisted and why it is one integer rather than a set of UIDs.
+        # The cursor exists only when the option is on, so `is not None` is the single test for "resume mode".
+        self._uid_cursor: Optional[EmailUidCursor] = (
+            EmailUidCursor(self._address) if bool(extra.get("resume_after_downtime", False)) else None
+        )
         # chat_id (sender email) -> last subject + message-id for threading
         # Track the last IMAP fetch attempt so the poll loop can distinguish "checked, nothing new" from
         # "the check itself failed" (#80016).
@@ -411,6 +453,44 @@ class EmailAdapter(BasePlatformAdapter):
         finally:
             _close_imap(imap)
 
+    def _establish_resume_point(self, imap: "imaplib.IMAP4", cursor: EmailUidCursor) -> None:
+        """Decide which UID this run resumes after. INBOX must be selected.
+
+        A cursor stored in the same UIDVALIDITY generation is resumed from: everything above it is mail that
+        arrived while the gateway was down, and the ordinary poll loop dispatches it on its first tick —
+        there is no separate catch-up path.
+
+        With no usable cursor — first opted-in start, an unreadable file, or a mailbox whose UIDVALIDITY
+        changed — we baseline at the highest UID present. That is exactly the default path's promise that
+        mail already in the INBOX is never answered.
+
+        A failed baseline search is not an empty mailbox: the 0 it leaves behind is indistinguishable from
+        one, and recording it would make the first poll search UID 1:* and answer the whole INBOX. The run
+        drops the cursor and behaves as if the option were off instead; the next start tries again.
+        """
+        uidvalidity = _read_uidvalidity(imap)
+        if not uidvalidity:
+            logger.warning("[Email] Mailbox reported no UIDVALIDITY — resume_after_downtime cannot store a "
+                           "resume point and behaves as if it were off.")
+        resume = cursor.resume_from(uidvalidity)
+        if resume is not None:
+            logger.info("[Email] IMAP connection test passed. Resuming after UID %d — mail that arrived "
+                        "since then will be answered.", resume)
+            return
+        status, data = imap.uid("search", None, "ALL")
+        if status != "OK":
+            logger.warning("[Email] Baseline UID search failed (%s) — no resume point this run; behaving as "
+                           "if resume_after_downtime were off.", status)
+            self._uid_cursor = None
+            return
+        highest = 0
+        if data and data[0]:
+            for uid in data[0].split():
+                highest = max(highest, _uid_int(uid))
+        cursor.baseline(uidvalidity, highest)
+        logger.info("[Email] IMAP connection test passed. No usable resume point — baselined at UID %d; "
+                    "mail already in the INBOX is not answered.", highest)
+
     def _connect_smtp(self) -> smtplib.SMTP:
         """SMTP connection with TLS established (callers go straight to ``login()``). An unreachable IPv6 address can
         hang until the socket timeout, so connection-level failures retry through an IPv4-only socket path (no global
@@ -433,6 +513,11 @@ class EmailAdapter(BasePlatformAdapter):
         """Connection test + seen-UID baseline. Sets a fatal error and returns False on failure."""
         try:
             with self._inbox() as imap:
+                cursor = self._uid_cursor
+                if cursor is not None:
+                    # Resume mode replaces the seen set entirely: the persisted cursor is the baseline.
+                    self._establish_resume_point(imap, cursor)
+                    return True
                 snapshot = self._seen_uids_snapshot.get(self._address)
                 if is_reconnect and snapshot is not None:
                     # Same-process reconnect: restore the previous adapter's baseline so mail that
@@ -528,11 +613,26 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        cursor = self._uid_cursor
         try:
             with self._inbox() as imap:
-                status, data = imap.uid("search", None, "UNSEEN")
+                if cursor is not None:
+                    # The persisted cursor is the queue, not the server-side \Seen flag: a human opening the
+                    # mailbox in a mail client sets \Seen without the agent having answered anything, which
+                    # would hide that mail from an UNSEEN search forever.
+                    status, data = imap.uid("search", None, "UID", f"{cursor.uid + 1}:*")
+                else:
+                    status, data = imap.uid("search", None, "UNSEEN")
+                # Snapshot the cursor: it advances inside the loop, and filtering against a moving value
+                # would drop a lower UID if the server returned the batch out of order.
+                resume_after = cursor.uid if cursor is not None else 0
                 for uid in (data[0].split() if status == "OK" and data and data[0] else []):
-                    if uid in self._seen_uids:
+                    if cursor is not None:
+                        # RFC 3501: a UID range ending in '*' always includes the last message in the
+                        # mailbox, even when the range starts above it — so filter what the server returns.
+                        if _uid_int(uid) <= resume_after:
+                            continue
+                    elif uid in self._seen_uids:
                         continue
                     status, msg_data = imap.uid("fetch", uid, "(RFC822)")
                     if status != "OK":
@@ -541,8 +641,11 @@ class EmailAdapter(BasePlatformAdapter):
                     # but NOT before the fetch: a connection failure must leave the rest of the batch eligible for the next poll.
                     # IMAP fetch can return unexpected structures (e.g. a single bytes item instead of a
                     # list of tuples). See #80032.
-                    self._seen_uids.add(uid)
-                    self._trim_seen_uids()
+                    if cursor is not None:
+                        cursor.advance(_uid_int(uid))
+                    else:
+                        self._seen_uids.add(uid)
+                        self._trim_seen_uids()
                     try:
                         raw_email = msg_data[0][1]
                     except (IndexError, TypeError):
@@ -565,6 +668,10 @@ class EmailAdapter(BasePlatformAdapter):
             # connection (#79889).
             logger.error("[Email] IMAP fetch error: %s", e)
             self._last_fetch_failed, self._last_fetch_error = True, str(e)
+        finally:
+            # One write per poll that moved the cursor, including the polls that found nothing.
+            if cursor is not None:
+                cursor.flush()
         # Keep the reconnect snapshot current so a mid-outage adapter recreation does not re-dispatch messages already processed.
         self._seen_uids_snapshot[self._address] = set(self._seen_uids)
         return results

--- a/plugins/platforms/email/uid_cursor.py
+++ b/plugins/platforms/email/uid_cursor.py
@@ -1,0 +1,126 @@
+"""Persistent INBOX resume point for the email adapter.
+
+``EmailAdapter._seen_uids`` lives only in memory, so every start re-baselines
+against whatever happens to be in the mailbox at that moment: ``connect()``
+marks every existing UID as already seen, and mail that arrived while the
+gateway was down is swallowed into that skip set and never dispatched (#80925).
+
+What this module persists is one integer per mailbox — the highest UID the
+adapter has committed to — plus the UIDVALIDITY generation it was measured in.
+IMAP UIDs are strictly ascending within a generation (RFC 3501 2.3.1.1), so
+``uid > cursor`` is a complete test for "not handled yet".  A persisted *set* of
+UIDs would carry the same information plus a trimming policy, and trimming a set
+is exactly what makes old mail replay (#60637).  A cursor cannot forget.
+
+The cursor records that the adapter took responsibility for a UID, not that a
+reply was delivered: ``BasePlatformAdapter.handle_message`` is documented
+fire-and-forget, so there is no delivery signal to wait for.  That is precisely
+what the in-memory skip set already means, which is what keeps the opt-in path
+from ever being worse than the default one.
+
+Reads and writes are best-effort, in the style of ``gateway/dead_targets.py``:
+a corrupt or unwritable file degrades to establishing a fresh baseline from the
+mailbox, logs at debug, and never raises on the polling path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+def cursor_path(address: str) -> Path:
+    """Profile-scoped, per-mailbox path of the cursor file.
+
+    ``get_hermes_home()`` is already per-profile.  The address goes into the
+    filename as well because profile multiplexing (#50094) can run two email
+    adapters whose homes resolve to the same directory; a single shared file
+    would make each mailbox invalidate the other's cursor on every connect and
+    silently re-baseline, which is the failure this module exists to prevent.
+    """
+    safe = re.sub(r"[^a-z0-9._-]", "_", (address or "").strip().lower())
+    return get_hermes_home() / "gateway" / f"email_uid_cursor_{safe or 'default'}.json"
+
+
+class EmailUidCursor:
+    """Highest committed INBOX UID for one mailbox, persisted as small JSON."""
+
+    def __init__(self, address: str, path: Optional[Path] = None) -> None:
+        self._address = (address or "").strip().lower()
+        self._path = path or cursor_path(self._address)
+        self.uidvalidity: str = ""
+        self.uid: int = 0
+        self._written_uid: Optional[int] = None
+        self._load()
+
+    def _load(self) -> None:
+        """Read the stored cursor.  Anything unreadable means "no cursor"."""
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            self.uidvalidity = str(raw["uidvalidity"])
+            self.uid = int(raw["uid"])
+            self._written_uid = self.uid
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.debug("[Email] No usable UID cursor at %s (%s)", self._path, exc)
+            self.uidvalidity = ""
+            self.uid = 0
+            self._written_uid = None
+
+    def resume_from(self, uidvalidity: str) -> Optional[int]:
+        """Return the UID to resume after, or None when a baseline is needed.
+
+        A cursor is only meaningful inside the UIDVALIDITY generation it was
+        measured in.  A different (or unreadable) generation returns None so the
+        caller re-baselines instead of comparing UIDs across namespaces.
+
+        A stored 0 is a real resume point — the mailbox was empty when the
+        baseline was taken — not "no cursor": treating it as absent would
+        re-baseline past mail that arrived during the outage.
+        """
+        if uidvalidity and self.uidvalidity == uidvalidity:
+            return self.uid
+        return None
+
+    def baseline(self, uidvalidity: str, uid: int) -> None:
+        """Adopt a fresh starting point and persist it immediately."""
+        self.uidvalidity = uidvalidity
+        self.uid = int(uid)
+        self._written_uid = None
+        self.flush()
+
+    def advance(self, uid: int) -> None:
+        """Record *uid* as committed.  Monotonic; older UIDs are ignored."""
+        if uid > self.uid:
+            self.uid = uid
+
+    def flush(self) -> None:
+        """Persist the cursor if it moved.  Never raises on the polling path."""
+        if self.uid == self._written_uid:
+            return
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps(
+                    {
+                        "address": self._address,
+                        "uidvalidity": self.uidvalidity,
+                        "uid": self.uid,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            tmp.replace(self._path)
+            self._written_uid = self.uid
+        except OSError as exc:
+            logger.debug(
+                "[Email] Could not persist UID cursor to %s (%s)", self._path, exc
+            )

--- a/plugins/platforms/email/uid_cursor.py
+++ b/plugins/platforms/email/uid_cursor.py
@@ -1,0 +1,122 @@
+"""Persistent INBOX resume point for the email adapter.
+
+``EmailAdapter._seen_uids`` lives only in memory, so every start re-baselines
+against whatever happens to be in the mailbox at that moment: ``connect()``
+marks every existing UID as already seen, and mail that arrived while the
+gateway was down is swallowed into that skip set and never dispatched (#80925).
+
+What this module persists is one integer per mailbox — the highest UID the
+adapter has committed to — plus the UIDVALIDITY generation it was measured in.
+IMAP UIDs are strictly ascending within a generation (RFC 3501 2.3.1.1), so
+``uid > cursor`` is a complete test for "not handled yet".  A persisted *set* of
+UIDs would carry the same information plus a trimming policy, and trimming a set
+is exactly what makes old mail replay (#60637).  A cursor cannot forget.
+
+The cursor records that the adapter took responsibility for a UID, not that a
+reply was delivered: ``BasePlatformAdapter.handle_message`` is documented
+fire-and-forget, so there is no delivery signal to wait for.  That is precisely
+what the in-memory skip set already means, which is what keeps the opt-in path
+from ever being worse than the default one.
+
+Reads and writes are best-effort, in the style of ``gateway/dead_targets.py``:
+a corrupt or unwritable file degrades to establishing a fresh baseline from the
+mailbox, logs at debug, and never raises on the polling path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+def cursor_path(address: str) -> Path:
+    """Profile-scoped, per-mailbox path of the cursor file.
+
+    ``get_hermes_home()`` is already per-profile.  The address goes into the
+    filename as well because profile multiplexing (#50094) can run two email
+    adapters whose homes resolve to the same directory; a single shared file
+    would make each mailbox invalidate the other's cursor on every connect and
+    silently re-baseline, which is the failure this module exists to prevent.
+    """
+    safe = re.sub(r"[^a-z0-9._-]", "_", (address or "").strip().lower())
+    return get_hermes_home() / "gateway" / f"email_uid_cursor_{safe or 'default'}.json"
+
+
+class EmailUidCursor:
+    """Highest committed INBOX UID for one mailbox, persisted as small JSON."""
+
+    def __init__(self, address: str, path: Optional[Path] = None) -> None:
+        self._address = (address or "").strip().lower()
+        self._path = path or cursor_path(self._address)
+        self.uidvalidity: str = ""
+        self.uid: int = 0
+        self._written_uid: Optional[int] = None
+        self._load()
+
+    def _load(self) -> None:
+        """Read the stored cursor.  Anything unreadable means "no cursor"."""
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            self.uidvalidity = str(raw["uidvalidity"])
+            self.uid = int(raw["uid"])
+            self._written_uid = self.uid
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.debug("[Email] No usable UID cursor at %s (%s)", self._path, exc)
+            self.uidvalidity = ""
+            self.uid = 0
+            self._written_uid = None
+
+    def resume_from(self, uidvalidity: str) -> Optional[int]:
+        """Return the UID to resume after, or None when a baseline is needed.
+
+        A cursor is only meaningful inside the UIDVALIDITY generation it was
+        measured in.  A different (or unreadable) generation returns None so the
+        caller re-baselines instead of comparing UIDs across namespaces.
+        """
+        if uidvalidity and self.uidvalidity == uidvalidity and self.uid > 0:
+            return self.uid
+        return None
+
+    def baseline(self, uidvalidity: str, uid: int) -> None:
+        """Adopt a fresh starting point and persist it immediately."""
+        self.uidvalidity = uidvalidity
+        self.uid = int(uid)
+        self._written_uid = None
+        self.flush()
+
+    def advance(self, uid: int) -> None:
+        """Record *uid* as committed.  Monotonic; older UIDs are ignored."""
+        if uid > self.uid:
+            self.uid = uid
+
+    def flush(self) -> None:
+        """Persist the cursor if it moved.  Never raises on the polling path."""
+        if self.uid == self._written_uid:
+            return
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps(
+                    {
+                        "address": self._address,
+                        "uidvalidity": self.uidvalidity,
+                        "uid": self.uid,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            tmp.replace(self._path)
+            self._written_uid = self.uid
+        except OSError as exc:
+            logger.debug(
+                "[Email] Could not persist UID cursor to %s (%s)", self._path, exc
+            )

--- a/plugins/platforms/email/uid_cursor.py
+++ b/plugins/platforms/email/uid_cursor.py
@@ -79,8 +79,12 @@ class EmailUidCursor:
         A cursor is only meaningful inside the UIDVALIDITY generation it was
         measured in.  A different (or unreadable) generation returns None so the
         caller re-baselines instead of comparing UIDs across namespaces.
+
+        A stored 0 is a real resume point — the mailbox was empty when the
+        baseline was taken — not "no cursor": treating it as absent would
+        re-baseline past mail that arrived during the outage.
         """
-        if uidvalidity and self.uidvalidity == uidvalidity and self.uid > 0:
+        if uidvalidity and self.uidvalidity == uidvalidity:
             return self.uid
         return None
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -907,5 +907,330 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestUidCursorFile(unittest.TestCase):
+    """The persisted resume point itself (plugins/platforms/email/uid_cursor.py)."""
+
+    def _path(self, tmp):
+        from pathlib import Path
+        return Path(tmp) / "email_uid_cursor_hermes_test.com.json"
+
+    def _cursor(self, tmp):
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        return EmailUidCursor("hermes@test.com", path=self._path(tmp))
+
+    def test_missing_file_means_no_resume_point(self):
+        """A mailbox that was never tracked must re-baseline, not resume from 0."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            cursor = self._cursor(tmp)
+            self.assertIsNone(cursor.resume_from("42"))
+            self.assertEqual(cursor.uid, 0)
+
+    def test_baseline_round_trips_across_instances(self):
+        """A restart reads back the UID the previous run stopped at."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 40)
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 40)
+
+    def test_other_uidvalidity_generation_is_not_resumed(self):
+        """UIDs are only comparable inside one UIDVALIDITY generation."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 40)
+            self.assertIsNone(self._cursor(tmp).resume_from("99"))
+
+    def test_advance_is_monotonic(self):
+        """An out-of-order UID must never drag the cursor backwards."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            cursor = self._cursor(tmp)
+            cursor.baseline("42", 40)
+            cursor.advance(50)
+            cursor.advance(20)
+            cursor.flush()
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 50)
+
+    def test_corrupt_file_degrades_to_no_resume_point(self):
+        """A truncated write must re-baseline rather than raise on startup."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._path(tmp).write_text("{not json", encoding="utf-8")
+            self.assertIsNone(self._cursor(tmp).resume_from("42"))
+
+    def test_unwritable_path_does_not_raise(self):
+        """Persistence is best-effort: polling must not break on a bad path."""
+        import tempfile
+        from pathlib import Path
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = Path(tmp) / "blocker"
+            blocker.write_text("not a directory", encoding="utf-8")
+            cursor = EmailUidCursor("hermes@test.com", path=blocker / "cursor.json")
+            cursor.baseline("42", 40)          # must not raise
+            cursor.advance(41)
+            cursor.flush()                     # must not raise
+            self.assertEqual(cursor.uid, 41)
+
+    def test_path_is_per_mailbox_address(self):
+        """Two addresses under one profile must not share a cursor file.
+
+        Profile multiplexing can resolve two email adapters to the same home; a
+        shared file would make each mailbox invalidate the other's cursor on
+        every connect and silently re-baseline.
+        """
+        import tempfile
+        from pathlib import Path
+        from plugins.platforms.email.uid_cursor import cursor_path
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"HERMES_HOME": tmp}):
+                one = cursor_path("one@test.com")
+                two = cursor_path("two@test.com")
+            self.assertNotEqual(one, two)
+            self.assertEqual(one.parent, Path(tmp) / "gateway")
+
+
+class TestResumeAfterDowntime(unittest.TestCase):
+    """platforms.email.resume_after_downtime — the #80925 downtime backlog."""
+
+    ADDRESS = "hermes@test.com"
+
+    def _make_adapter(self, home, resume=True):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": self.ADDRESS,
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "HERMES_HOME": home,
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            extra = {"resume_after_downtime": True} if resume else {}
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    def _cursor_path(self, home):
+        from plugins.platforms.email.uid_cursor import cursor_path
+        with patch.dict(os.environ, {"HERMES_HOME": home}):
+            return cursor_path(self.ADDRESS)
+
+    def _seed_cursor(self, home, uidvalidity, uid):
+        """Write the cursor a previous run would have left behind."""
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        path = self._cursor_path(home)
+        EmailUidCursor(self.ADDRESS, path=path).baseline(uidvalidity, uid)
+        return path
+
+    def _email(self, subject):
+        msg = MIMEText("body", "plain", "utf-8")
+        msg["From"] = "user@test.com"
+        msg["Subject"] = subject
+        msg["Message-ID"] = f"<{subject}@test.com>"
+        return msg
+
+    def _mock_imap(self, uidvalidity=b"42", search=b"", messages=None):
+        messages = messages or {}
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [uidvalidity])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [search])
+            if command == "fetch":
+                uid = args[0]
+                if uid in messages:
+                    return ("OK", [(uid, messages[uid].as_bytes())])
+                return ("NO", [])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        return mock_imap
+
+    def _connect(self, adapter, mock_imap):
+        """Run connect() against a mocked IMAP/SMTP and stop the poll task."""
+        import asyncio
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP", return_value=MagicMock()):
+            result = asyncio.run(adapter.connect())
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+        return result
+
+    def _search_args(self, mock_imap):
+        """Arguments of the IMAP UID SEARCH the adapter issued."""
+        for call in mock_imap.uid.call_args_list:
+            if call.args and call.args[0] == "search":
+                return call.args
+        return ()
+
+    def test_first_enable_baselines_and_answers_nothing(self):
+        """Turning the option on must not answer mail already in the INBOX."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 3)
+            # The startup skip set is what swallowed downtime mail; the resume
+            # path must not populate it at all.
+            self.assertEqual(adapter._seen_uids, set())
+            stored = json.loads(self._cursor_path(home).read_text(encoding="utf-8"))
+            self.assertEqual(stored["uid"], 3)
+            self.assertEqual(stored["uidvalidity"], "42")
+
+    def test_downtime_mail_is_answered_after_restart(self):
+        """The reported bug: mail that arrived while down is dispatched."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"4 5",
+                messages={b"4": self._email("Downtime one"),
+                          b"5": self._email("Downtime two")},
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual([r["subject"] for r in results],
+                             ["Downtime one", "Downtime two"])
+            # Searched the UID range above the cursor, not UNSEEN.
+            self.assertEqual(self._search_args(mock_imap),
+                             ("search", None, "UID", "4:*"))
+            self.assertEqual(
+                json.loads(path.read_text(encoding="utf-8"))["uid"], 5
+            )
+
+    def test_answered_mail_is_not_reanswered_after_restart(self):
+        """A UID at or below the cursor must never be dispatched again.
+
+        RFC 3501 makes an ``n:*`` range always include the mailbox's highest UID
+        even when n is above it, so the server hands back already-answered mail
+        on every poll; the cursor filter is what stops the reply loop.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 5)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"5", messages={b"5": self._email("Already answered")}
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(results, [])
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+
+    def test_mail_a_human_already_read_is_still_answered(self):
+        """The server-side \\Seen flag must not act as the queue.
+
+        A person opening the mailbox in a mail client sets \\Seen without the
+        agent having answered anything, which hides that mail from an UNSEEN
+        search forever. The resume path must not ask for UNSEEN.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"4", messages={b"4": self._email("Read on a phone")}
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 1)
+            self.assertNotIn("UNSEEN", self._search_args(mock_imap))
+
+    def test_uidvalidity_change_rebaselines_without_replay(self):
+        """A recreated mailbox must not be answered from UID 1."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(uidvalidity=b"99", search=b"1 2 3 4 5")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["uidvalidity"], "99")
+            self.assertEqual(stored["uid"], 5)
+
+    def test_corrupt_cursor_file_rebaselines_without_replay(self):
+        """An unreadable cursor must degrade to today's behavior, not crash."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            path.write_text("{ truncated", encoding="utf-8")
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3 4")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 4)
+
+    def test_missing_uidvalidity_does_not_resume(self):
+        """Without a generation to pin UIDs to, re-baseline rather than guess."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3 4 5")
+            mock_imap.response.return_value = ("UIDVALIDITY", [None])
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+
+    def test_default_keeps_todays_behavior(self):
+        """With the option off nothing changes and no state file is written."""
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home, resume=False)
+            self.assertIsNone(adapter._uid_cursor)
+
+            mock_imap = self._mock_imap(search=b"1 2 3")
+            self.assertTrue(self._connect(adapter, mock_imap))
+            self.assertEqual(len(adapter._seen_uids), 3)
+
+            fetch_imap = self._mock_imap(search=b"")
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                adapter._fetch_new_messages()
+            self.assertEqual(self._search_args(fetch_imap),
+                             ("search", None, "UNSEEN"))
+            self.assertFalse((Path(home) / "gateway").exists())
+
+    def test_default_path_still_swallows_mail_present_at_startup(self):
+        """The #80925 behavior itself, pinned on the default path.
+
+        Mail sitting in the INBOX at connect() is marked seen and never
+        dispatched, however unread it is. This is the bug the opt-in path fixes
+        — see test_downtime_mail_is_answered_after_restart for the contrast —
+        and it must stay exactly this way when the option is off.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home, resume=False)
+            self._connect(adapter, self._mock_imap(search=b"1 2 3"))
+
+            # UID 3 arrived while the gateway was down and is still UNSEEN.
+            fetch_imap = self._mock_imap(
+                search=b"3", messages={b"3": self._email("Sent during downtime")}
+            )
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(results, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1238,6 +1238,37 @@ class TestResumeAfterDowntime(unittest.TestCase):
 
             self.assertEqual(adapter._uid_cursor.uid, 5)
 
+    def test_failed_baseline_search_disables_resume_for_the_run(self):
+        """A non-OK baseline search must not record baseline 0.
+
+        Baseline 0 also means "empty mailbox", so recording it would make the
+        first poll search UID 1:* and answer the whole INBOX. The run must
+        degrade to the option-off UNSEEN path and write no cursor file.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"")
+            ok_handler = mock_imap.uid.side_effect
+
+            def uid_handler(command, *args):
+                if command == "search" and args == (None, "ALL"):
+                    return ("NO", [])
+                return ok_handler(command, *args)
+
+            mock_imap.uid.side_effect = uid_handler
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertIsNone(adapter._uid_cursor)
+            self.assertFalse(self._cursor_path(home).exists())
+
+            fetch_imap = self._mock_imap(search=b"")
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                adapter._fetch_new_messages()
+            self.assertEqual(self._search_args(fetch_imap),
+                             ("search", None, "UNSEEN"))
+
     def test_default_keeps_todays_behavior(self):
         """With the option off nothing changes and no state file is written."""
         import tempfile

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -958,6 +958,17 @@ class TestUidCursorFile(unittest.TestCase):
             self._path(tmp).write_text("{not json", encoding="utf-8")
             self.assertIsNone(self._cursor(tmp).resume_from("42"))
 
+    def test_baseline_at_zero_is_a_resume_point(self):
+        """An empty mailbox baselines at UID 0; that cursor must still resume.
+
+        Treating a stored 0 as "no cursor" would re-baseline past mail that
+        arrived during the next outage — the #80925 hole again.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 0)
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 0)
+
     def test_unwritable_path_does_not_raise(self):
         """Persistence is best-effort: polling must not break on a bad path."""
         import tempfile
@@ -1046,10 +1057,18 @@ class TestResumeAfterDowntime(unittest.TestCase):
         return mock_imap
 
     def _connect(self, adapter, mock_imap):
-        """Run connect() against a mocked IMAP/SMTP and stop the poll task."""
+        """Run connect() against a mocked IMAP/SMTP, with the poll loop stubbed.
+
+        connect() starts the poll task, and asyncio.run() gives it one step
+        during shutdown cancellation — enough for run_in_executor to submit a
+        real _fetch_new_messages to a thread. That thread outlives the patch
+        context (racing the assertions, or worse, dialing the real IMAP host),
+        so the loop itself is stubbed out instead of cancelled after the fact.
+        """
         import asyncio
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
-             patch("smtplib.SMTP", return_value=MagicMock()):
+             patch("smtplib.SMTP", return_value=MagicMock()), \
+             patch.object(type(adapter), "_poll_loop", new=AsyncMock()):
             result = asyncio.run(adapter.connect())
         adapter._running = False
         if adapter._poll_task:
@@ -1126,6 +1145,35 @@ class TestResumeAfterDowntime(unittest.TestCase):
 
             self.assertEqual(results, [])
             self.assertEqual(adapter._uid_cursor.uid, 5)
+
+    def test_empty_mailbox_baseline_still_resumes(self):
+        """A stored cursor of UID 0 must resume, not trigger a re-baseline.
+
+        The baseline of a mailbox that was empty when the option kicked in is
+        0. Re-baselining on the next start would set the cursor past mail that
+        arrived during the outage — the #80925 hole again.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 0)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"1 2",
+                messages={b"1": self._email("Outage one"),
+                          b"2": self._email("Outage two")},
+            )
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+            # Resumed at 0; a re-baseline here would move the cursor to 2 and
+            # swallow both waiting messages.
+            self.assertEqual(adapter._uid_cursor.uid, 0)
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual(self._search_args(mock_imap),
+                             ("search", None, "UID", "1:*"))
 
     def test_mail_a_human_already_read_is_still_answered(self):
         """The server-side \\Seen flag must not act as the queue.

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1123,5 +1123,409 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestUidCursorFile(unittest.TestCase):
+    """The persisted resume point itself (plugins/platforms/email/uid_cursor.py)."""
+
+    def _path(self, tmp):
+        from pathlib import Path
+        return Path(tmp) / "email_uid_cursor_hermes_test.com.json"
+
+    def _cursor(self, tmp):
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        return EmailUidCursor("hermes@test.com", path=self._path(tmp))
+
+    def test_missing_file_means_no_resume_point(self):
+        """A mailbox that was never tracked must re-baseline, not resume from 0."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            cursor = self._cursor(tmp)
+            self.assertIsNone(cursor.resume_from("42"))
+            self.assertEqual(cursor.uid, 0)
+
+    def test_baseline_round_trips_across_instances(self):
+        """A restart reads back the UID the previous run stopped at."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 40)
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 40)
+
+    def test_other_uidvalidity_generation_is_not_resumed(self):
+        """UIDs are only comparable inside one UIDVALIDITY generation."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 40)
+            self.assertIsNone(self._cursor(tmp).resume_from("99"))
+
+    def test_advance_is_monotonic(self):
+        """An out-of-order UID must never drag the cursor backwards."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            cursor = self._cursor(tmp)
+            cursor.baseline("42", 40)
+            cursor.advance(50)
+            cursor.advance(20)
+            cursor.flush()
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 50)
+
+    def test_corrupt_file_degrades_to_no_resume_point(self):
+        """A truncated write must re-baseline rather than raise on startup."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._path(tmp).write_text("{not json", encoding="utf-8")
+            self.assertIsNone(self._cursor(tmp).resume_from("42"))
+
+    def test_baseline_at_zero_is_a_resume_point(self):
+        """An empty mailbox baselines at UID 0; that cursor must still resume.
+
+        Treating a stored 0 as "no cursor" would re-baseline past mail that
+        arrived during the next outage — the #80925 hole again.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cursor(tmp).baseline("42", 0)
+            self.assertEqual(self._cursor(tmp).resume_from("42"), 0)
+
+    def test_unwritable_path_does_not_raise(self):
+        """Persistence is best-effort: polling must not break on a bad path."""
+        import tempfile
+        from pathlib import Path
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = Path(tmp) / "blocker"
+            blocker.write_text("not a directory", encoding="utf-8")
+            cursor = EmailUidCursor("hermes@test.com", path=blocker / "cursor.json")
+            cursor.baseline("42", 40)          # must not raise
+            cursor.advance(41)
+            cursor.flush()                     # must not raise
+            self.assertEqual(cursor.uid, 41)
+
+    def test_path_is_per_mailbox_address(self):
+        """Two addresses under one profile must not share a cursor file.
+
+        Profile multiplexing can resolve two email adapters to the same home; a
+        shared file would make each mailbox invalidate the other's cursor on
+        every connect and silently re-baseline.
+        """
+        import tempfile
+        from pathlib import Path
+        from plugins.platforms.email.uid_cursor import cursor_path
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"HERMES_HOME": tmp}):
+                one = cursor_path("one@test.com")
+                two = cursor_path("two@test.com")
+            self.assertNotEqual(one, two)
+            self.assertEqual(one.parent, Path(tmp) / "gateway")
+
+
+class TestResumeAfterDowntime(unittest.TestCase):
+    """platforms.email.resume_after_downtime — the #80925 downtime backlog."""
+
+    ADDRESS = "hermes@test.com"
+
+    def _make_adapter(self, home, resume=True):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": self.ADDRESS,
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "HERMES_HOME": home,
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            extra = {"resume_after_downtime": True} if resume else {}
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    def _cursor_path(self, home):
+        from plugins.platforms.email.uid_cursor import cursor_path
+        with patch.dict(os.environ, {"HERMES_HOME": home}):
+            return cursor_path(self.ADDRESS)
+
+    def _seed_cursor(self, home, uidvalidity, uid):
+        """Write the cursor a previous run would have left behind."""
+        from plugins.platforms.email.uid_cursor import EmailUidCursor
+        path = self._cursor_path(home)
+        EmailUidCursor(self.ADDRESS, path=path).baseline(uidvalidity, uid)
+        return path
+
+    def _email(self, subject):
+        msg = MIMEText("body", "plain", "utf-8")
+        msg["From"] = "user@test.com"
+        msg["Subject"] = subject
+        msg["Message-ID"] = f"<{subject}@test.com>"
+        return msg
+
+    def _mock_imap(self, uidvalidity=b"42", search=b"", messages=None):
+        messages = messages or {}
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [uidvalidity])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [search])
+            if command == "fetch":
+                uid = args[0]
+                if uid in messages:
+                    return ("OK", [(uid, messages[uid].as_bytes())])
+                return ("NO", [])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        return mock_imap
+
+    def _connect(self, adapter, mock_imap):
+        """Run connect() against a mocked IMAP/SMTP, with the poll loop stubbed.
+
+        connect() starts the poll task, and asyncio.run() gives it one step
+        during shutdown cancellation — enough for run_in_executor to submit a
+        real _fetch_new_messages to a thread. That thread outlives the patch
+        context (racing the assertions, or worse, dialing the real IMAP host),
+        so the loop itself is stubbed out instead of cancelled after the fact.
+        """
+        import asyncio
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP", return_value=MagicMock()), \
+             patch.object(type(adapter), "_poll_loop", new=AsyncMock()):
+            result = asyncio.run(adapter.connect())
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+        return result
+
+    def _search_args(self, mock_imap):
+        """Arguments of the IMAP UID SEARCH the adapter issued."""
+        for call in mock_imap.uid.call_args_list:
+            if call.args and call.args[0] == "search":
+                return call.args
+        return ()
+
+    def test_first_enable_baselines_and_answers_nothing(self):
+        """Turning the option on must not answer mail already in the INBOX."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 3)
+            # The startup skip set is what swallowed downtime mail; the resume
+            # path must not populate it at all.
+            self.assertEqual(adapter._seen_uids, set())
+            stored = json.loads(self._cursor_path(home).read_text(encoding="utf-8"))
+            self.assertEqual(stored["uid"], 3)
+            self.assertEqual(stored["uidvalidity"], "42")
+
+    def test_downtime_mail_is_answered_after_restart(self):
+        """The reported bug: mail that arrived while down is dispatched."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"4 5",
+                messages={b"4": self._email("Downtime one"),
+                          b"5": self._email("Downtime two")},
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual([r["subject"] for r in results],
+                             ["Downtime one", "Downtime two"])
+            # Searched the UID range above the cursor, not UNSEEN.
+            self.assertEqual(self._search_args(mock_imap),
+                             ("search", None, "UID", "4:*"))
+            self.assertEqual(
+                json.loads(path.read_text(encoding="utf-8"))["uid"], 5
+            )
+
+    def test_answered_mail_is_not_reanswered_after_restart(self):
+        """A UID at or below the cursor must never be dispatched again.
+
+        RFC 3501 makes an ``n:*`` range always include the mailbox's highest UID
+        even when n is above it, so the server hands back already-answered mail
+        on every poll; the cursor filter is what stops the reply loop.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 5)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"5", messages={b"5": self._email("Already answered")}
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(results, [])
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+
+    def test_empty_mailbox_baseline_still_resumes(self):
+        """A stored cursor of UID 0 must resume, not trigger a re-baseline.
+
+        The baseline of a mailbox that was empty when the option kicked in is
+        0. Re-baselining on the next start would set the cursor past mail that
+        arrived during the outage — the #80925 hole again.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 0)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"1 2",
+                messages={b"1": self._email("Outage one"),
+                          b"2": self._email("Outage two")},
+            )
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+            # Resumed at 0; a re-baseline here would move the cursor to 2 and
+            # swallow both waiting messages.
+            self.assertEqual(adapter._uid_cursor.uid, 0)
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual(self._search_args(mock_imap),
+                             ("search", None, "UID", "1:*"))
+
+    def test_mail_a_human_already_read_is_still_answered(self):
+        """The server-side \\Seen flag must not act as the queue.
+
+        A person opening the mailbox in a mail client sets \\Seen without the
+        agent having answered anything, which hides that mail from an UNSEEN
+        search forever. The resume path must not ask for UNSEEN.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(
+                search=b"4", messages={b"4": self._email("Read on a phone")}
+            )
+
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 1)
+            self.assertNotIn("UNSEEN", self._search_args(mock_imap))
+
+    def test_uidvalidity_change_rebaselines_without_replay(self):
+        """A recreated mailbox must not be answered from UID 1."""
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(uidvalidity=b"99", search=b"1 2 3 4 5")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["uidvalidity"], "99")
+            self.assertEqual(stored["uid"], 5)
+
+    def test_corrupt_cursor_file_rebaselines_without_replay(self):
+        """An unreadable cursor must degrade to today's behavior, not crash."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            path = self._seed_cursor(home, "42", 3)
+            path.write_text("{ truncated", encoding="utf-8")
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3 4")
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 4)
+
+    def test_missing_uidvalidity_does_not_resume(self):
+        """Without a generation to pin UIDs to, re-baseline rather than guess."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            self._seed_cursor(home, "42", 3)
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"1 2 3 4 5")
+            mock_imap.response.return_value = ("UIDVALIDITY", [None])
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertEqual(adapter._uid_cursor.uid, 5)
+
+    def test_failed_baseline_search_disables_resume_for_the_run(self):
+        """A non-OK baseline search must not record baseline 0.
+
+        Baseline 0 also means "empty mailbox", so recording it would make the
+        first poll search UID 1:* and answer the whole INBOX. The run must
+        degrade to the option-off UNSEEN path and write no cursor file.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home)
+            mock_imap = self._mock_imap(search=b"")
+            ok_handler = mock_imap.uid.side_effect
+
+            def uid_handler(command, *args):
+                if command == "search" and args == (None, "ALL"):
+                    return ("NO", [])
+                return ok_handler(command, *args)
+
+            mock_imap.uid.side_effect = uid_handler
+
+            self.assertTrue(self._connect(adapter, mock_imap))
+
+            self.assertIsNone(adapter._uid_cursor)
+            self.assertFalse(self._cursor_path(home).exists())
+
+            fetch_imap = self._mock_imap(search=b"")
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                adapter._fetch_new_messages()
+            self.assertEqual(self._search_args(fetch_imap),
+                             ("search", None, "UNSEEN"))
+
+    def test_default_keeps_todays_behavior(self):
+        """With the option off nothing changes and no state file is written."""
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home, resume=False)
+            self.assertIsNone(adapter._uid_cursor)
+
+            mock_imap = self._mock_imap(search=b"1 2 3")
+            self.assertTrue(self._connect(adapter, mock_imap))
+            self.assertEqual(len(adapter._seen_uids), 3)
+
+            fetch_imap = self._mock_imap(search=b"")
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                adapter._fetch_new_messages()
+            self.assertEqual(self._search_args(fetch_imap),
+                             ("search", None, "UNSEEN"))
+            self.assertFalse((Path(home) / "gateway").exists())
+
+    def test_default_path_still_swallows_mail_present_at_startup(self):
+        """The #80925 behavior itself, pinned on the default path.
+
+        Mail sitting in the INBOX at connect() is marked seen and never
+        dispatched, however unread it is. This is the bug the opt-in path fixes
+        — see test_downtime_mail_is_answered_after_restart for the contrast —
+        and it must stay exactly this way when the option is off.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as home:
+            adapter = self._make_adapter(home, resume=False)
+            self._connect(adapter, self._mock_imap(search=b"1 2 3"))
+
+            # UID 3 arrived while the gateway was down and is still UNSEEN.
+            fetch_imap = self._mock_imap(
+                search=b"3", messages={b"3": self._email("Sent during downtime")}
+            )
+            with patch("imaplib.IMAP4_SSL", return_value=fetch_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(results, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -138,6 +138,27 @@ platforms:
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
 
+### Answering Mail That Arrived While the Gateway Was Down
+
+By default the adapter marks everything already in the INBOX as seen when it starts, so mail that arrived while the gateway was down is never answered — on that start or any later one. To resume where the previous run stopped instead, add to your `config.yaml`:
+
+```yaml
+platforms:
+  email:
+    resume_after_downtime: true
+```
+
+Hermes then records the highest INBOX UID it has handled in `~/.hermes/gateway/email_uid_cursor_<address>.json` and, on the next start, processes everything above it.
+
+Turning the option on does not answer mail that is already sitting in the INBOX. The first start after enabling it records a baseline, and only mail arriving after that point is answered — so there is no burst of replies to old threads.
+
+Two consequences worth knowing:
+
+- The stored UID is the queue, not the `\Seen` flag. Mail you have already opened in a mail client is still answered, because a human reading a message is not the agent handling it.
+- If the mailbox's UIDVALIDITY changes — it was recreated, migrated, or restored from backup — the stored UID no longer refers to the same messages. Hermes records a fresh baseline and does not answer the existing mail.
+
+The record means the adapter accepted a message for processing, not that a reply was delivered. If the agent dies while composing an answer, that message is not retried.
+
 ---
 
 ## Access Control

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -163,6 +163,27 @@ platforms:
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
 
+### Answering Mail That Arrived While the Gateway Was Down
+
+By default the adapter marks everything already in the INBOX as seen when it starts, so mail that arrived while the gateway was down is never answered — on that start or any later one. To resume where the previous run stopped instead, add to your `config.yaml`:
+
+```yaml
+platforms:
+  email:
+    resume_after_downtime: true
+```
+
+Hermes then records the highest INBOX UID it has handled in `~/.hermes/gateway/email_uid_cursor_<address>.json` and, on the next start, processes everything above it.
+
+Turning the option on does not answer mail that is already sitting in the INBOX. The first start after enabling it records a baseline, and only mail arriving after that point is answered — so there is no burst of replies to old threads.
+
+Two consequences worth knowing:
+
+- The stored UID is the queue, not the `\Seen` flag. Mail you have already opened in a mail client is still answered, because a human reading a message is not the agent handling it.
+- If the mailbox's UIDVALIDITY changes — it was recreated, migrated, or restored from backup — the stored UID no longer refers to the same messages. Hermes records a fresh baseline and does not answer the existing mail.
+
+The record means the adapter accepted a message for processing, not that a reply was delivered. If the agent dies while composing an answer, that message is not retried.
+
 ---
 
 ## Access Control


### PR DESCRIPTION
## What does this PR do?

`EmailAdapter.connect()` seeds an in-memory `_seen_uids` set from `UID SEARCH ALL`, marking everything already in the INBOX as processed. Mail that arrived while the gateway was down is therefore skipped on that start — and because the set never survives the process, on every later start too. Nothing records what the adapter actually handled, so handled and unhandled mail are indistinguishable.

This adds an opt-in `platforms.email.resume_after_downtime`. When it is on, the adapter persists one integer per mailbox — the highest UID it has committed to — alongside the UIDVALIDITY generation that UID was measured in, and resumes from it instead of re-baselining against the mailbox. Everything above the cursor is exactly the mail that arrived during the outage, and the ordinary poll loop dispatches it on its first tick, so there is no separate catch-up path.

A cursor rather than a persisted set of UIDs: IMAP UIDs ascend strictly within a UIDVALIDITY generation (RFC 3501 2.3.1.1), so `uid > cursor` is a complete test for "not handled yet". A set would carry the same information plus a trimming policy, and trimming is what makes old mail replay (#60637). A cursor cannot forget, and its size is constant.

On the resume path the poll search changes from `UNSEEN` to a UID range. The server-side `\Seen` flag cannot be the queue: a person opening the mailbox in a mail client sets `\Seen` without the agent having answered anything, which would hide that mail from an `UNSEEN` search forever — the exact case this fix exists for. The default path keeps `UNSEEN` untouched.

Default off. With the key absent the receive path is byte-for-byte today's, and nothing is read from or written to disk.

## Related Issue

Related: #80925

How this sits next to nearby work:

- #80858 (archive messages after processing) proposes making the INBOX itself the visible queue. Same reporter, complementary rather than competing: this PR records the processed boundary, that one would make it visible in the mailbox. No code overlap.
- #60637 / #60652 / #60677 address a different bug on the default path: trimming `_seen_uids` can replay old unread mail. #60677's own description scopes downtime and offline delivery out, noting it "requires persisted state across adapter instances" — that persisted state is what this PR adds. This PR changes neither `_seen_uids` nor `_trim_seen_uids` semantics. If #60677 lands first I will rebase onto it: the overlap is the `connect()` seeding block and the poll search line, and this PR's edits at both places are a branch wrapped around the existing code, so its `_startup_seen_uid_cutoff` becomes the in-memory half of the same boundary.
- #42738 also proposed persisting seen UIDs, but against `gateway/platforms/email.py`, a path that no longer exists on main, and it persists the trimmed set, which carries #60637's replay bug into the state file.
- #28699 and #12600 make startup process the pre-existing unread backlog. Different intent: this PR never answers mail that was already in the INBOX when the option was switched on.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/email/uid_cursor.py` (new): `EmailUidCursor`, a per-mailbox `{address, uidvalidity, uid}` JSON file under `get_hermes_home() / "gateway"`, atomic tmp + replace write, best-effort reads. Factored beside the adapter the way `plugins/platforms/discord/recovery.py` is, which keeps the hot adapter file small.
- `plugins/platforms/email/uid_cursor.py`: a stored cursor of UID 0 — the mailbox was empty when its baseline was taken — is a real resume point, not "no cursor"; re-baselining there would move the cursor past mail that arrived during the outage.
- `plugins/platforms/email/adapter.py`: read `resume_after_downtime` from `PlatformConfig.extra`. The cursor object exists only when the option is on, so `is not None` is the single test for resume mode.
- `plugins/platforms/email/adapter.py`: `_establish_resume_point()` resumes from a cursor of the same UIDVALIDITY generation; with no usable cursor it baselines at the highest existing UID, which is the default path's promise that mail already in the INBOX is never answered.
- `plugins/platforms/email/adapter.py`: the poll searches `UID <cursor+1>:*` on the resume path, with a post-search filter because RFC 3501 makes an `n:*` range always include the mailbox's highest UID even when `n` is above it.
- `plugins/platforms/email/adapter.py`: the cursor advances at the point where `_seen_uids.add(uid)` already commits, and is written once per poll that moved it.
- `plugins/platforms/email/adapter.py`: `_read_uidvalidity()` reads the value `SELECT` already buffered, so it costs no extra round trip and avoids `STATUS` against the selected mailbox.
- `tests/gateway/test_email.py`: 18 tests, listed below. The shared connect helper stubs the poll loop: `asyncio.run()` gives the freshly created poll task one step during shutdown cancellation, which submitted a real `_fetch_new_messages` to an executor thread that outlived the patch context.
- `website/docs/user-guide/messaging/email.md`: documents the key, the first-enable baseline, and the two consequences of turning it on.

### What the cursor means

It records that the adapter took responsibility for a UID, not that a reply was delivered. `BasePlatformAdapter.handle_message` is documented fire-and-forget, so there is no delivery signal to wait on. That is precisely what the in-memory skip set already means today, which is what keeps the opt-in path from ever being worse than the default one.

### Known limits, stated rather than hidden

- A crash between the fetch and the reply loses that message. That is today's behavior, not a new hole: the `FETCH` has already set `\Seen` and the in-memory set dies with the process.
- UIDVALIDITY is checked at connect. A mailbox recreated while the process keeps running is not noticed until the next start.
- Enabling the option after a long outage answers that whole backlog on the first poll. There is deliberately no per-poll cap: switching the option on never answers mail already in the INBOX, so a backlog can only exist for downtime that happened while the option was already on, and the operator knows they were down.

## How to Test

Reproduction of the reported behavior: with the option off, mail sitting in the INBOX at startup is never dispatched, however unread it is. `TestResumeAfterDowntime.test_default_path_still_swallows_mail_present_at_startup` pins that, and passes both before and after this change — it is the contrast case for the fix.

1. The new tests fail on the base commit (feature absent):
   `scripts/run_tests.sh tests/gateway/test_email.py`
   - 33 passed, 17 failed. The one new test that passes on base is the contrast case above.
2. Green with the change:
   `scripts/run_tests.sh tests/gateway/test_email.py`
   - 50 passed (32 pre-existing, 18 new).
3. Wider suite, `scripts/run_tests.sh tests/gateway/ -j 6`:
   - 3 files fail — `test_shutdown_forensics.py`, `test_systemd_notify.py`, `test_wecom_callback.py`. All three fail identically with `plugins/platforms/email/` reverted to base on this same machine (macOS), none of them reference the email adapter, so they are pre-existing and unrelated.
4. Cross-platform and lint:
   - `.venv/bin/python scripts/check-windows-footguns.py plugins/platforms/email/adapter.py plugins/platforms/email/uid_cursor.py tests/gateway/test_email.py` — No Windows footguns found
   - `.venv/bin/ruff check` on the same files — All checks passed
   - `.venv/bin/ty check` on the changed modules — 13 diagnostics vs 11 on base; the 2 new hits are the pre-existing `imap.uid(…, None, …)` charset pattern that base already carries twice (typeshed types the args as `str`), no new diagnostic kinds
   - `git diff --check` — clean

What the new tests cover:

- Downtime mail is answered after a restart, and the poll issues `UID 4:*` rather than `UNSEEN`.
- Answered mail is not re-answered after a restart, including the RFC 3501 `n:*` tail that hands back the highest UID on every poll.
- Mail a human already opened (so `\Seen` is set) is still answered.
- First enable baselines at the highest existing UID, writes the cursor, and answers nothing.
- A baseline of UID 0 — the mailbox was empty when the option kicked in — still resumes, so mail that arrived during the outage is answered instead of re-baselined past.
- A UIDVALIDITY change re-baselines without replaying the mailbox.
- A corrupt cursor file, and a mailbox that reports no UIDVALIDITY, both re-baseline instead of raising.
- With the option off: `connect()` still seeds the skip set, the poll still searches `UNSEEN`, and no state file is written.
- The cursor file itself: round trip across instances, monotonic advance, generation mismatch, corrupt file, unwritable path, and per-address paths so two mailboxes under one profile cannot invalidate each other.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/gateway/` instead; see the note in How to Test about three pre-existing macOS failures unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, it has no `platforms:` section; email keys are documented in `website/docs/user-guide/messaging/email.md`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not applicable; this is an IMAP receive-path change covered by unit tests.

