### PR TITLE
fix(video): read analyze inputs through the terminal backend (#58242 salvage)

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -1,7 +1,9 @@
 """Tests for video_analyze tool in tools/vision_tools.py."""
 
 import asyncio
+import base64
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -204,6 +206,47 @@ class TestVideoAnalyzeTool:
         assert content[1]["type"] == "video_url"
         assert "video_url" in content[1]
         assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+    def test_non_local_backend_reads_video_from_terminal_backend(self, tmp_path, monkeypatch):
+        """Non-local terminal backends must not read local host video paths."""
+        host_video = tmp_path / "clip.mp4"
+        host_video.write_bytes(b"HOST-VIDEO")
+        remote_bytes = b"REMOTE-SANDBOX-VIDEO"
+        remote_b64 = base64.b64encode(remote_bytes).decode("ascii")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        class FakeFileOps:
+            def _exec(self, command, timeout=None):
+                assert str(host_video) in command
+                assert timeout == 300
+                return SimpleNamespace(stdout=remote_b64, exit_code=0)
+
+        captured_kwargs = {}
+
+        async def capture_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "sandbox video"
+            return mock_response
+
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=FakeFileOps()) as get_ops,
+            patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value="sandbox video"),
+        ):
+            result = self._run(
+                video_analyze_tool(str(host_video), "Describe this", task_id="task-123")
+            )
+
+        data = json.loads(result)
+        assert data["success"] is True
+        get_ops.assert_called_once_with("task-123")
+        video_url = captured_kwargs["messages"][0]["content"][1]["video_url"]["url"]
+        uploaded_bytes = base64.b64decode(video_url.split(",", 1)[1])
+        assert uploaded_bytes == remote_bytes
+        assert uploaded_bytes != host_video.read_bytes()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -208,7 +208,13 @@ class TestVideoAnalyzeTool:
         assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
 
     def test_non_local_backend_reads_video_from_terminal_backend(self, tmp_path, monkeypatch):
-        """Non-local terminal backends must not read local host video paths."""
+        """Non-local terminal backends must not read local host video paths.
+
+        The read routes through the shared media resolver
+        (tools.image_source, ``permitted=("video",)``) which exec-reads the
+        bytes inside the sandbox — so the analyzed video is the container's
+        file, never the host's.
+        """
         host_video = tmp_path / "clip.mp4"
         host_video.write_bytes(b"HOST-VIDEO")
         remote_bytes = b"REMOTE-SANDBOX-VIDEO"
@@ -216,11 +222,19 @@ class TestVideoAnalyzeTool:
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
 
-        class FakeFileOps:
-            def _exec(self, command, timeout=None):
-                assert str(host_video) in command
-                assert timeout == 300
-                return SimpleNamespace(stdout=remote_b64, exit_code=0)
+        import tools.image_source as isrc
+        import tools.terminal_tool as tt
+
+        env_lookups = []
+
+        def fake_get_active(task_id):
+            env_lookups.append(task_id)
+            return SimpleNamespace(
+                execute=lambda cmd, **kw: {"returncode": 0, "output": remote_b64}
+            )
+
+        monkeypatch.setattr(tt, "ensure_task_env", lambda *a, **k: None)
+        monkeypatch.setattr(isrc, "_get_active_env", fake_get_active)
 
         captured_kwargs = {}
 
@@ -232,7 +246,6 @@ class TestVideoAnalyzeTool:
             return mock_response
 
         with (
-            patch("tools.file_tools._get_file_ops", return_value=FakeFileOps()) as get_ops,
             patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
             patch("tools.vision_tools.extract_content_or_reasoning", return_value="sandbox video"),
         ):
@@ -242,7 +255,7 @@ class TestVideoAnalyzeTool:
 
         data = json.loads(result)
         assert data["success"] is True
-        get_ops.assert_called_once_with("task-123")
+        assert env_lookups == ["task-123"]
         video_url = captured_kwargs["messages"][0]["content"][1]["video_url"]["url"]
         uploaded_bytes = base64.b64decode(video_url.split(",", 1)[1])
         assert uploaded_bytes == remote_bytes

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,6 +35,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
+import shlex
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -1751,6 +1752,60 @@ def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None)
     return f"data:{mime};base64,{encoded}"
 
 
+def _terminal_backend_is_local() -> bool:
+    backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    return backend in ("", "local")
+
+
+def _is_path_like_video_source(value: str) -> bool:
+    lowered = (value or "").strip().lower()
+    if not lowered:
+        return False
+    return not lowered.startswith(("http://", "https://", "data:"))
+
+
+def _materialize_video_from_terminal_backend(video_source: str, task_id: Optional[str]) -> Path:
+    """Read a path from the active terminal backend into a local temp video file."""
+    from tools.file_tools import _get_file_ops
+
+    source = video_source
+    if source.startswith("file://"):
+        source = source[len("file://"):]
+    suffix = Path(source).suffix.lower()
+    if suffix not in _VIDEO_MIME_TYPES:
+        raise ValueError(
+            f"Unsupported video format: '{suffix}'. "
+            f"Supported: {', '.join(sorted(_VIDEO_MIME_TYPES.keys()))}"
+        )
+
+    command = (
+        "python3 -c "
+        + shlex.quote(
+            "import base64, pathlib, sys; "
+            "p = pathlib.Path(sys.argv[1]).expanduser(); "
+            "sys.stdout.write(base64.b64encode(p.read_bytes()).decode('ascii'))"
+        )
+        + f" {shlex.quote(source)}"
+    )
+    file_ops = _get_file_ops(task_id or "default")
+    result = file_ops._exec(command, timeout=300)
+    if result.exit_code != 0:
+        details = result.stdout.strip() or f"exit code {result.exit_code}"
+        raise ValueError(f"Could not read video from terminal backend: {details}")
+
+    encoded = "".join(result.stdout.split())
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise ValueError(f"Terminal backend returned invalid video data: {exc}") from exc
+
+    temp_dir = get_hermes_dir("cache/video", "temp_video_files")
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = temp_dir / f"terminal_video_{uuid.uuid4()}{suffix}"
+    temp_path.write_bytes(data)
+    return temp_path
+
+
 async def _download_video(video_url: str, destination: Path, max_retries: int = 3) -> Path:
     """Download video from URL with SSRF protection and retry."""
     import asyncio
@@ -1815,6 +1870,7 @@ async def video_analyze_tool(
     video_url: str,
     user_prompt: str,
     model: str = None,
+    task_id: Optional[str] = None,
 ) -> str:
     """Analyze a video via multimodal LLM. Returns JSON {success, analysis}."""
     if not isinstance(user_prompt, str):
@@ -1849,7 +1905,11 @@ async def video_analyze_tool(
             resolved_url = resolved_url[len("file://"):]
         local_path = Path(os.path.expanduser(resolved_url))
 
-        if local_path.is_file():
+        if not _terminal_backend_is_local() and _is_path_like_video_source(video_url):
+            logger.info("Reading video source via terminal backend: %s", video_url)
+            temp_video_path = _materialize_video_from_terminal_backend(video_url, task_id)
+            should_cleanup = True
+        elif local_path.is_file():
             from agent.file_safety import raise_if_read_blocked
             raise_if_read_blocked(str(local_path))
             logger.info("Using local video file: %s", video_url)
@@ -2068,7 +2128,7 @@ def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         pass
     if not model:
         model = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip() or os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
-    return video_analyze_tool(video_url, full_prompt, model)
+    return video_analyze_tool(video_url, full_prompt, model, task_id=kw.get("task_id"))
 
 
 registry.register(

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,7 +35,6 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
-import shlex
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -1764,9 +1763,18 @@ def _is_path_like_video_source(value: str) -> bool:
     return not lowered.startswith(("http://", "https://", "data:"))
 
 
-def _materialize_video_from_terminal_backend(video_source: str, task_id: Optional[str]) -> Path:
-    """Read a path from the active terminal backend into a local temp video file."""
-    from tools.file_tools import _get_file_ops
+async def _materialize_video_from_terminal_backend(video_source: str, task_id: Optional[str]) -> Path:
+    """Read a path via the shared media resolver into a local temp video file.
+
+    Routes through :func:`tools.image_source.resolve_image_source` with
+    ``permitted=("video",)`` so terminal-backend video reads get the exact
+    pipeline vision_analyze uses: media-cache host reads (gateway-downloaded
+    videos live on the host, not in the sandbox), bounded in-sandbox exec-read
+    (``head -c`` cap — no unbounded base64 stream, no python3 dependency in
+    the sandbox image), lazy env bring-up (#62825), the credential-read
+    guard, and the 50MB ingest cap.
+    """
+    from tools.image_source import ImageResolutionError, ResolveContext, resolve_image_source
 
     source = video_source
     if source.startswith("file://"):
@@ -1778,31 +1786,17 @@ def _materialize_video_from_terminal_backend(video_source: str, task_id: Optiona
             f"Supported: {', '.join(sorted(_VIDEO_MIME_TYPES.keys()))}"
         )
 
-    command = (
-        "python3 -c "
-        + shlex.quote(
-            "import base64, pathlib, sys; "
-            "p = pathlib.Path(sys.argv[1]).expanduser(); "
-            "sys.stdout.write(base64.b64encode(p.read_bytes()).decode('ascii'))"
-        )
-        + f" {shlex.quote(source)}"
-    )
-    file_ops = _get_file_ops(task_id or "default")
-    result = file_ops._exec(command, timeout=300)
-    if result.exit_code != 0:
-        details = result.stdout.strip() or f"exit code {result.exit_code}"
-        raise ValueError(f"Could not read video from terminal backend: {details}")
-
-    encoded = "".join(result.stdout.split())
     try:
-        data = base64.b64decode(encoded, validate=True)
-    except Exception as exc:
-        raise ValueError(f"Terminal backend returned invalid video data: {exc}") from exc
+        resolved = await resolve_image_source(
+            video_source, ResolveContext(task_id=task_id), permitted=("video",)
+        )
+    except ImageResolutionError as exc:
+        raise ValueError(f"Could not read video from terminal backend: {exc}") from exc
 
     temp_dir = get_hermes_dir("cache/video", "temp_video_files")
     temp_dir.mkdir(parents=True, exist_ok=True)
     temp_path = temp_dir / f"terminal_video_{uuid.uuid4()}{suffix}"
-    temp_path.write_bytes(data)
+    temp_path.write_bytes(resolved.data)
     return temp_path
 
 
@@ -1907,7 +1901,7 @@ async def video_analyze_tool(
 
         if not _terminal_backend_is_local() and _is_path_like_video_source(video_url):
             logger.info("Reading video source via terminal backend: %s", video_url)
-            temp_video_path = _materialize_video_from_terminal_backend(video_url, task_id)
+            temp_video_path = await _materialize_video_from_terminal_backend(video_url, task_id)
             should_cleanup = True
         elif local_path.is_file():
             from agent.file_safety import raise_if_read_blocked


### PR DESCRIPTION
## Summary
`video_analyze` now routes path reads through the terminal backend under non-local backends (ssh/docker/…), closing the sibling of the vision_analyze confinement gap fixed in #80801: it previously read model-supplied paths straight off the host filesystem regardless of backend.

## Changes
- `tools/vision_tools.py`: under a non-local backend, path-like video sources are materialized via the shared media resolver (`tools.image_source.resolve_image_source(permitted=("video",))`) instead of `local_path.is_file()` host reads — inheriting media-cache host reads, the bounded `head -c` in-sandbox exec-read, lazy env bring-up (#62825/#80801), the credential-read guard, and the 50MB ingest cap. `task_id` threaded through the registry handler.
- Follow-up commit (ours): replaced the salvaged commit's hand-rolled `file_ops._exec("python3 -c …")` reader with the shared resolver — no python3 dependency in the sandbox image, no unbounded base64 stream, one confinement chokepoint instead of two.
- `tests/tools/test_video_analyze.py`: non-local backend test asserts the analyzed bytes come from the sandbox exec-read, not the host file.

## Validation
| | Before | After |
|---|---|---|
| video path under ssh/docker | host filesystem read | sandbox exec-read via resolver (E2E) |
| first video call, no prior terminal cmd | — | lazy env bring-up, works (E2E) |
| unsupported extension | — | rejected before any exec |
| local backend | host read | unchanged |

Targeted: `test_video_analyze.py` + `test_image_source.py` — 32/32. Ruff clean. E2E in isolated HERMES_HOME with stubbed SSH backend.

Salvaged from #58242 by @necoweb3 (authorship preserved via cherry-pick). Independent of #58144 (provider routing / yt-dlp — different bug in the same file).

## Infographic

![video_analyze joins the sandbox pipeline](https://v3b.fal.media/files/b/0aa56769/_Qv0WvRP68JgcRumB-PbM_s0GfAVS5.png)
