### PR TITLE
fix(tools): isolate external project environments

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -14,9 +14,11 @@ there is no env-var override. Tests patch ``_load_config`` directly.
 
 import json
 import os
+import subprocess
 import sys
 import unittest
-from contextlib import contextmanager
+import unittest.mock
+from contextlib import contextmanager, ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -36,8 +38,10 @@ from tools.code_execution_tool import (
     EXECUTION_MODES,
     _get_execution_mode,
     _is_usable_python,
+    _python_environment_prefix,
     _resolve_child_cwd,
     _resolve_child_python,
+    _uses_hermes_python_environment,
     build_execute_code_schema,
     execute_code,
 )
@@ -371,6 +375,162 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("execute_code_available: False", result["output"])
         self.assertIn("delegate_task_available: False", result["output"])
+
+
+# ---------------------------------------------------------------------------
+# _python_environment_prefix / _uses_hermes_python_environment
+# ---------------------------------------------------------------------------
+
+class TestPythonEnvironmentPrefix(unittest.TestCase):
+    """Unit tests for the helper that queries sys.prefix of an interpreter."""
+
+    def setUp(self):
+        _python_environment_prefix.cache_clear()
+
+    def tearDown(self):
+        _python_environment_prefix.cache_clear()
+
+    def test_returns_realpath_of_current_interpreter_prefix(self):
+        """Happy path: sys.executable reports its own prefix."""
+        prefix = _python_environment_prefix(sys.executable)
+        self.assertEqual(prefix, os.path.realpath(sys.prefix))
+
+    def test_returns_empty_string_for_nonexistent_path(self):
+        """A path that doesn't exist → OSError → empty string."""
+        result = _python_environment_prefix("/nonexistent/python-does-not-exist")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_when_subprocess_times_out(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=5)):
+            result = _python_environment_prefix("/some/python")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_on_nonzero_exit(self):
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result):
+            result = _python_environment_prefix("/bad/python")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_when_stdout_is_blank(self):
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "   \n"
+        with patch("subprocess.run", return_value=mock_result):
+            result = _python_environment_prefix("/blank/python")
+        self.assertEqual(result, "")
+
+    def test_result_is_cached(self):
+        """Second call returns cached value without spawning another process."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = unittest.mock.MagicMock(
+                returncode=0, stdout="/fake/prefix\n"
+            )
+            _python_environment_prefix("/cached/python")
+            _python_environment_prefix("/cached/python")
+        self.assertEqual(mock_run.call_count, 1)
+
+
+class TestUsesHermesPythonEnvironment(unittest.TestCase):
+    """Unit tests for _uses_hermes_python_environment."""
+
+    def setUp(self):
+        _python_environment_prefix.cache_clear()
+
+    def tearDown(self):
+        _python_environment_prefix.cache_clear()
+
+    def test_true_for_current_interpreter(self):
+        """sys.executable always belongs to the current environment."""
+        self.assertTrue(_uses_hermes_python_environment(sys.executable))
+
+    def test_false_for_different_prefix(self):
+        """An interpreter reporting a different prefix is external."""
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value="/some/other/venv"):
+            self.assertFalse(_uses_hermes_python_environment("/other/python"))
+
+    def test_false_when_prefix_is_empty(self):
+        """If prefix cannot be determined (error path), treat as external."""
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value=""):
+            self.assertFalse(_uses_hermes_python_environment("/bad/python"))
+
+    def test_true_when_prefix_matches_sys_prefix(self):
+        hermes_prefix = os.path.realpath(sys.prefix)
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value=hermes_prefix):
+            self.assertTrue(_uses_hermes_python_environment("/same/env/python"))
+
+
+# ---------------------------------------------------------------------------
+# PYTHONPATH composition — hermes root included only for same-env interpreters
+# ---------------------------------------------------------------------------
+
+class TestPythonPathComposition(unittest.TestCase):
+    """Verify hermes root inclusion in PYTHONPATH depends on env match.
+
+    Patches ``_uses_hermes_python_environment`` directly so these tests are
+    independent of subprocess availability — the unit tests above already
+    cover the detection logic end-to-end.
+    """
+
+    def _capture_pythonpath(self, same_env: bool) -> str:
+        """Return the PYTHONPATH that execute_code would pass to the child."""
+        captured = {}
+
+        def _fake_popen(cmd, **kwargs):
+            env = kwargs.get("env") or {}
+            captured["PYTHONPATH"] = env.get("PYTHONPATH", "")
+            mock_proc = unittest.mock.MagicMock()
+            mock_proc.stdout.read.return_value = b""
+            mock_proc.stderr.read.return_value = b""
+            mock_proc.wait.return_value = 0
+            mock_proc.returncode = 0
+            mock_proc.poll.return_value = 0
+            return mock_proc
+
+        with patch("tools.code_execution_tool._load_config", return_value={"mode": "strict"}), \
+             patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call), \
+             patch("tools.code_execution_tool._uses_hermes_python_environment",
+                   return_value=same_env), \
+             patch("subprocess.Popen", side_effect=_fake_popen):
+            try:
+                execute_code(code="pass", task_id="test-pp", enabled_tools=[])
+            except Exception:
+                pass
+
+        return captured.get("PYTHONPATH", "")
+
+    def _hermes_root(self) -> str:
+        tools_dir = os.path.dirname(os.path.abspath(
+            __import__("tools.code_execution_tool", fromlist=["__file__"]).__file__
+        ))
+        return os.path.dirname(tools_dir)
+
+    def test_hermes_root_included_when_same_env(self):
+        """When interpreter is in the Hermes env, hermes root is in PYTHONPATH."""
+        pythonpath = self._capture_pythonpath(same_env=True)
+        parts = pythonpath.split(os.pathsep)
+        self.assertIn(self._hermes_root(), parts,
+                      "hermes root must be in PYTHONPATH for same-env interpreters")
+
+    def test_hermes_root_excluded_when_external_env(self):
+        """When interpreter is external, hermes root must NOT be in PYTHONPATH."""
+        pythonpath = self._capture_pythonpath(same_env=False)
+        parts = pythonpath.split(os.pathsep)
+        self.assertNotIn(self._hermes_root(), parts,
+                         "hermes root must not leak into an external interpreter's PYTHONPATH")
+
+    def test_staging_dir_always_present(self):
+        """The staging tmpdir must always be the first PYTHONPATH entry."""
+        for same_env in (True, False):
+            with self.subTest(same_env=same_env):
+                pythonpath = self._capture_pythonpath(same_env=same_env)
+                parts = pythonpath.split(os.pathsep)
+                self.assertTrue(parts and parts[0],
+                                "PYTHONPATH must start with the staging tmpdir")
 
 
 if __name__ == "__main__":

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1391,16 +1391,6 @@ def execute_code(
         # with a C/POSIX locale (containers, minimal base images).
         child_env["PYTHONIOENCODING"] = "utf-8"
         child_env["PYTHONUTF8"] = "1"
-        # Ensure the hermes-agent root is importable in the sandbox so
-        # repo-root modules are available to child scripts.  We also prepend
-        # the staging tmpdir so ``from hermes_tools import ...`` resolves even
-        # when the subprocess CWD is not tmpdir (project mode).
-        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        _existing_pp = child_env.get("PYTHONPATH", "")
-        _pp_parts = [tmpdir, _hermes_root]
-        if _existing_pp:
-            _pp_parts.append(_existing_pp)
-        child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
         # Inject user's configured timezone so datetime.now() in sandboxed
         # code reflects the correct wall-clock time.  Only TZ is set —
         # HERMES_TIMEZONE is an internal Hermes setting and must not leak
@@ -1422,6 +1412,22 @@ def execute_code(
         _child_python = _resolve_child_python(_mode)
         _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
         _script_path = os.path.join(tmpdir, "script.py")
+
+        # ``hermes_tools.py`` always lives in the staging directory, so that
+        # directory must be importable even when project mode changes CWD.
+        # Hermes's own package root is useful too, but only when the child
+        # uses the same Python environment. Project mode can select an
+        # external venv; exposing Hermes's site-packages to that interpreter
+        # can mix incompatible compiled extensions (for example, Python 3.12
+        # NumPy with a Python 3.9 project interpreter).
+        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        _existing_pp = child_env.get("PYTHONPATH", "")
+        _pp_parts = [tmpdir]
+        if _uses_hermes_python_environment(_child_python):
+            _pp_parts.append(_hermes_root)
+        if _existing_pp:
+            _pp_parts.append(_existing_pp)
+        child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
 
         proc = subprocess.Popen(
             [_child_python, _script_path],
@@ -1778,6 +1784,33 @@ def _is_usable_python(python_path: str) -> bool:
         return result.returncode == 0
     except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
         return False
+
+
+@functools.lru_cache(maxsize=32)
+def _python_environment_prefix(python_path: str) -> str:
+    """Return the resolved ``sys.prefix`` reported by *python_path*, if any."""
+    try:
+        from agent.delegation_context import delegated_child_subprocess_env
+
+        result = subprocess.run(
+            [python_path, "-c", "import sys; print(sys.prefix)"],
+            timeout=5,
+            capture_output=True,
+            text=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            stdin=subprocess.DEVNULL,
+            env=delegated_child_subprocess_env(),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.realpath(result.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        pass
+    return ""
+
+
+def _uses_hermes_python_environment(python_path: str) -> bool:
+    """Whether *python_path* belongs to Hermes's active Python environment."""
+    return _python_environment_prefix(python_path) == os.path.realpath(sys.prefix)
 
 
 def _resolve_child_python(mode: str) -> str:


### PR DESCRIPTION
## What does this PR do?

When `execute_code` runs in project mode with an external virtualenv (e.g. a Python 3.9 project venv while Hermes itself runs on Python 3.12), the hermes agent root was unconditionally prepended to `PYTHONPATH`. This caused the child interpreter to load Hermes's compiled C extensions built for a different Python ABI resulting in import errors or silent misbehavior (e.g. a Python 3.12 NumPy `.so` loaded by a Python 3.9 interpreter).

The fix adds `_python_environment_prefix` (queries `sys.prefix` of the child interpreter via a subprocess call) and `_uses_hermes_python_environment` ( compares it to `sys.prefix` of the running Hermes process). The hermes root is now added to `PYTHONPATH` only when the child interpreter belongs to the same environment. The staging `tmpdir` which contains `hermes_tools.py` is always included so the tool RPC layer keeps working in both modes.

## Type of Change

- [x] :bug: Bug fix (non-breaking change that fixes an issue)
- [ ] :sparkles: New feature (non-breaking change that adds functionality)
- [ ] :lock: Security fix
- [ ] :pencil: Documentation update
- [x] :white_check_mark: Tests (adding or improving test coverage)
- [ ] :recycle:️ Refactor (no behavior change)
- [ ] :dart: New skill (bundled or hub)

## Changes Made

- `tools/code_execution_tool.py` moved PYTHONPATH assembly after CWD/interpreter resolution; added `_python_environment_prefix` (cached subprocess query for `sys.prefix`) and `_uses_hermes_python_environment` (prefix comparison); gate hermes root inclusion on env match
- `tests/tools/test_code_execution_modes.py` added `TestPythonEnvironmentPrefix` (6 tests: happy path, nonexistent path, timeout, non-zero exit, blank stdout, cache hit), `TestUsesHermesPythonEnvironment` (4 tests), and `TestPythonPathComposition` (3 integration tests: hermes root included for same-env, excluded for external env, staging dir always first)

## How to Test

1. Create an external virtualenv with a different Python version than Hermes: `python3.9 -m venv /tmp/ext-venv VIRTUAL_ENV=/tmp/ext-venv hermes ...`
2. Run `execute_code` with a script that imports a package only available in the external venv (e.g. `import numpy`). Before this fix it would fail with an ABI mismatch; after it should import cleanly.
3. Verify `hermes_tools` is still importable in both project and strict mode: `pytest tests/tools/test_code_execution_modes.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A