### PR TITLE
fix(gateway): honor per-platform group/thread session isolation in session keys

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,1 @@
+dhruvkej9

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1638,6 +1638,15 @@ def load_gateway_config() -> GatewayConfig:
                     # (slack, telegram, matrix, dingtalk, whatsapp, feishu …)
                     # instead of re-enabling them on token/SDK presence. #41112.
                     extra["_enabled_explicit"] = True
+                # Preserve the platform's own nested ``extra:`` dict so
+                # per-platform settings (e.g. group_sessions_per_user) survive
+                # the shared-key loop, which only bridges known top-level keys
+                # and silently dropped anything the user placed under
+                # ``<platform>.extra``.  Top-level bridged keys are applied
+                # after, so they keep precedence ("top-level wins").
+                _nested_extra = platform_cfg.get("extra")
+                if isinstance(_nested_extra, dict):
+                    extra.update(_nested_extra)
                 extra.update(bridged)
 
             # Plugin-owned YAML→env config bridges (#24836).  See

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6723,10 +6723,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        # Honor per-platform extra overrides (mirrors SessionStore._generate_session_key
+        # and the adapters' text-batching keys) so the fallback path never diverges
+        # from the primary path on group/thread session isolation.
+        _group_sessions_per_user = getattr(config, "group_sessions_per_user", True)
+        _thread_sessions_per_user = getattr(config, "thread_sessions_per_user", False)
+        if config is not None and getattr(source, "platform", None) is not None:
+            _platform_cfg = getattr(config, "platforms", {}).get(source.platform)
+            if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+                _extra = _platform_cfg.extra
+                _group_sessions_per_user = _extra.get(
+                    "group_sessions_per_user", _group_sessions_per_user
+                )
+                _thread_sessions_per_user = _extra.get(
+                    "thread_sessions_per_user", _thread_sessions_per_user
+                )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=_group_sessions_per_user,
+            thread_sessions_per_user=_thread_sessions_per_user,
             profile=_profile,
         )
 
@@ -15999,6 +16014,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ) or ""
         _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
         _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        # Resolve per-platform extra overrides so shared-session attribution
+        # (user_name prefixing) matches the session key that build_session_key
+        # produced for this source (see _session_key_for_source).
+        _platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+            _extra = _platform_cfg.extra
+            _group_sessions_per_user = _extra.get(
+                "group_sessions_per_user", _group_sessions_per_user
+            )
+            _thread_sessions_per_user = _extra.get(
+                "thread_sessions_per_user", _thread_sessions_per_user
+            )
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1732,12 +1732,37 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_sessions_per_user, thread_sessions_per_user = self._resolve_session_isolation(
+            source
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
             profile=self._resolve_profile_for_key(source),
         )
+
+    def _resolve_session_isolation(
+        self, source: SessionSource
+    ) -> tuple[bool, bool]:
+        """Resolve group/thread session isolation for a source.
+
+        Per-platform ``extra.group_sessions_per_user`` /
+        ``extra.thread_sessions_per_user`` overrides win when present,
+        falling back to the global gateway config. This mirrors the
+        resolution the adapters use for text-batching keys so the main
+        dispatch path and the adapter's batching key never diverge.
+        """
+        default_group = getattr(self.config, "group_sessions_per_user", True)
+        default_thread = getattr(self.config, "thread_sessions_per_user", False)
+        platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if platform_cfg and isinstance(getattr(platform_cfg, "extra", None), dict):
+            extra = platform_cfg.extra
+            return (
+                extra.get("group_sessions_per_user", default_group),
+                extra.get("thread_sessions_per_user", default_thread),
+            )
+        return default_group, default_thread
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -257,6 +257,40 @@ class TestGatewayConfigRoundtrip:
         assert restored.unauthorized_dm_behavior == "ignore"
         assert restored.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_top_level_platform_nested_extra_preserved(self, tmp_path, monkeypatch):
+        """A per-platform setting under ``<platform>.extra`` must survive the
+        shared-key loop in ``load_gateway_config()``.
+
+        Regression: the shared-key loop only bridged known top-level keys
+        (dm_policy, group_policy, …) and silently dropped the platform's own
+        nested ``extra:`` dict. So ``whatsapp.extra.group_sessions_per_user:
+        false`` never reached ``PlatformConfig.extra``, and the session-key
+        paths (which honor per-platform extra) fell back to the global
+        default — every group member kept a separate context even though the
+        config asked for a shared group session.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "whatsapp:\n"
+            "  enabled: true\n"
+            "  extra:\n"
+            "    group_sessions_per_user: false\n"
+            "    bridge_port: 3000\n"
+            "  group_policy: allowlist\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        wa = config.platforms[Platform.WHATSAPP]
+        # Nested extra survives the shared-key loop
+        assert wa.extra.get("group_sessions_per_user") is False
+        assert wa.extra.get("bridge_port") == 3000
+        # Bridged top-level keys still land in extra
+        assert wa.extra.get("group_policy") == "allowlist"
+
     def test_email_defaults_to_ignore_for_unauthorized_dm_behavior(self):
         config = GatewayConfig(
             platforms={Platform.EMAIL: PlatformConfig(enabled=True)},

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -687,6 +687,73 @@ class TestWhatsAppSessionKeyConsistency:
         assert second_entry.session_key == "agent:main:discord:group:guild-123"
         assert first_entry.session_id == second_entry.session_id
 
+    def test_store_honors_per_platform_group_sessions_override(self, store):
+        """Per-platform extra.group_sessions_per_user must win over the global
+        config in the main session-key path (mirrors the adapters' text-batching
+        keys). WhatsApp groups with the override set to False share one session
+        even though the global default is True."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True  # global default: isolated
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(
+            enabled=True,
+            extra={"group_sessions_per_user": False},
+        )
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Shared group session — no per-user suffix, both resolve to the same key.
+        expected = "agent:main:whatsapp:group:120363000000000000@g.us"
+        assert alice_entry.session_key == expected
+        assert bob_entry.session_key == expected
+        assert alice_entry.session_id == bob_entry.session_id
+
+    def test_store_keeps_global_isolation_when_no_platform_override(self, store):
+        """Without a per-platform override, the global default (isolated
+        per-user group sessions) must be preserved."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Isolated per-user sessions (global default) — distinct keys.
+        assert alice_entry.session_key != bob_entry.session_key
+        assert alice_entry.session_id != bob_entry.session_id
+
     def test_telegram_dm_includes_chat_id(self):
         """Non-WhatsApp DMs should also include chat_id to separate users."""
         source = SessionSource(


### PR DESCRIPTION
## Problem

`SessionStore._generate_session_key` and the run.py fallback/write paths read `group_sessions_per_user` / `thread_sessions_per_user` **only from the global gateway config**, while the platform adapters' text-batching keys resolve **per-platform `extra.*` overrides**.

This divergence means a WhatsApp group with `extra.group_sessions_per_user: false` still gets **per-user session keys** on the main dispatch path — so every group member carries a separate context even though the adapter's batching key says they share one. The user-facing symptom: each user in a WhatsApp group gets their own isolated context, which is surprising when the platform config explicitly asks for a shared group session.

## Fix

**1. Session keys honor per-platform overrides** — resolve the per-platform `extra.group_sessions_per_user` / `extra.thread_sessions_per_user` overrides in the **same three places** the session key is built:

- `SessionStore._generate_session_key` (primary dispatch path)
- `GatewayRunner._session_key_for_source` (fallback path)
- `GatewayRunner` shared-session attribution write path (so the `user_name` prefixing matches the key that `build_session_key` produced)

All three now mirror the resolution the adapters already use for text-batching keys, so dispatch, fallback, and shared-session attribution can never diverge from the adapter's batching key.

**2. Config loader preserves nested `<platform>.extra`** — `load_gateway_config()`'s shared-key loop was silently dropping the nested `extra` dict when bridging top-level keys, so a value like `whatsapp.extra.group_sessions_per_user: false` never reached `PlatformConfig.extra` and the session-key fix above had nothing to read. The loader now preserves the nested dict, with a regression test proving the round-trip.

## Tests

- `test_store_honors_per_platform_group_sessions_override` — per-platform override wins over global default (shared group session).
- `test_store_keeps_global_isolation_when_no_platform_override` — global default preserved when no override present.
- `test_top_level_platform_nested_extra_preserved` — config round-trip keeps nested `<platform>.extra`.

`tests/gateway/test_config.py` + `test_session.py` + `test_shared_group_sender_prefix.py` + `test_whatsapp_group_gating.py`: **119 passed**.
