### PR TITLE
feat(whatsapp): WhatsApp @mention tagging support

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,1 @@
+dhruvkej9

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1638,6 +1638,15 @@ def load_gateway_config() -> GatewayConfig:
                     # (slack, telegram, matrix, dingtalk, whatsapp, feishu …)
                     # instead of re-enabling them on token/SDK presence. #41112.
                     extra["_enabled_explicit"] = True
+                # Preserve the platform's own nested ``extra:`` dict so
+                # per-platform settings (e.g. group_sessions_per_user) survive
+                # the shared-key loop, which only bridges known top-level keys
+                # and silently dropped anything the user placed under
+                # ``<platform>.extra``.  Top-level bridged keys are applied
+                # after, so they keep precedence ("top-level wins").
+                _nested_extra = platform_cfg.get("extra")
+                if isinstance(_nested_extra, dict):
+                    extra.update(_nested_extra)
                 extra.update(bridged)
 
             # Plugin-owned YAML→env config bridges (#24836).  See

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1806,6 +1806,15 @@ def load_gateway_config() -> GatewayConfig:
                     # (slack, telegram, matrix, dingtalk, whatsapp, feishu …)
                     # instead of re-enabling them on token/SDK presence. #41112.
                     extra["_enabled_explicit"] = True
+                # Preserve the platform's own nested ``extra:`` dict so
+                # per-platform settings (e.g. group_sessions_per_user) survive
+                # the shared-key loop, which only bridges known top-level keys
+                # and silently dropped anything the user placed under
+                # ``<platform>.extra``.  Top-level bridged keys are applied
+                # after, so they keep precedence ("top-level wins").
+                _nested_extra = platform_cfg.get("extra")
+                if isinstance(_nested_extra, dict):
+                    extra.update(_nested_extra)
                 extra.update(bridged)
 
             # Plugin-owned YAML→env config bridges (#24836).  See

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6723,10 +6723,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        # Honor per-platform extra overrides (mirrors SessionStore._generate_session_key
+        # and the adapters' text-batching keys) so the fallback path never diverges
+        # from the primary path on group/thread session isolation.
+        _group_sessions_per_user = getattr(config, "group_sessions_per_user", True)
+        _thread_sessions_per_user = getattr(config, "thread_sessions_per_user", False)
+        if config is not None and getattr(source, "platform", None) is not None:
+            _platform_cfg = getattr(config, "platforms", {}).get(source.platform)
+            if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+                _extra = _platform_cfg.extra
+                _group_sessions_per_user = _extra.get(
+                    "group_sessions_per_user", _group_sessions_per_user
+                )
+                _thread_sessions_per_user = _extra.get(
+                    "thread_sessions_per_user", _thread_sessions_per_user
+                )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=_group_sessions_per_user,
+            thread_sessions_per_user=_thread_sessions_per_user,
             profile=_profile,
         )
 
@@ -15999,6 +16014,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ) or ""
         _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
         _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        # Resolve per-platform extra overrides so shared-session attribution
+        # (user_name prefixing) matches the session key that build_session_key
+        # produced for this source (see _session_key_for_source).
+        _platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+            _extra = _platform_cfg.extra
+            _group_sessions_per_user = _extra.get(
+                "group_sessions_per_user", _group_sessions_per_user
+            )
+            _thread_sessions_per_user = _extra.get(
+                "thread_sessions_per_user", _thread_sessions_per_user
+            )
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8376,10 +8376,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        # Honor per-platform extra overrides (mirrors SessionStore._generate_session_key
+        # and the adapters' text-batching keys) so the fallback path never diverges
+        # from the primary path on group/thread session isolation.
+        _group_sessions_per_user = getattr(config, "group_sessions_per_user", True)
+        _thread_sessions_per_user = getattr(config, "thread_sessions_per_user", False)
+        if config is not None and getattr(source, "platform", None) is not None:
+            _platform_cfg = getattr(config, "platforms", {}).get(source.platform)
+            if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+                _extra = _platform_cfg.extra
+                _group_sessions_per_user = _extra.get(
+                    "group_sessions_per_user", _group_sessions_per_user
+                )
+                _thread_sessions_per_user = _extra.get(
+                    "thread_sessions_per_user", _thread_sessions_per_user
+                )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=_group_sessions_per_user,
+            thread_sessions_per_user=_thread_sessions_per_user,
             profile=_profile,
         )
 
@@ -19615,6 +19630,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ) or ""
         _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
         _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        # Resolve per-platform extra overrides so shared-session attribution
+        # (user_name prefixing) matches the session key that build_session_key
+        # produced for this source (see _session_key_for_source).
+        _platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if _platform_cfg and isinstance(getattr(_platform_cfg, "extra", None), dict):
+            _extra = _platform_cfg.extra
+            _group_sessions_per_user = _extra.get(
+                "group_sessions_per_user", _group_sessions_per_user
+            )
+            _thread_sessions_per_user = _extra.get(
+                "thread_sessions_per_user", _thread_sessions_per_user
+            )
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2009,12 +2009,37 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_sessions_per_user, thread_sessions_per_user = self._resolve_session_isolation(
+            source
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
             profile=self._resolve_profile_for_key(source),
         )
+
+    def _resolve_session_isolation(
+        self, source: SessionSource
+    ) -> tuple[bool, bool]:
+        """Resolve group/thread session isolation for a source.
+
+        Per-platform ``extra.group_sessions_per_user`` /
+        ``extra.thread_sessions_per_user`` overrides win when present,
+        falling back to the global gateway config. This mirrors the
+        resolution the adapters use for text-batching keys so the main
+        dispatch path and the adapter's batching key never diverge.
+        """
+        default_group = getattr(self.config, "group_sessions_per_user", True)
+        default_thread = getattr(self.config, "thread_sessions_per_user", False)
+        platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if platform_cfg and isinstance(getattr(platform_cfg, "extra", None), dict):
+            extra = platform_cfg.extra
+            return (
+                extra.get("group_sessions_per_user", default_group),
+                extra.get("thread_sessions_per_user", default_thread),
+            )
+        return default_group, default_thread
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1732,12 +1732,37 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_sessions_per_user, thread_sessions_per_user = self._resolve_session_isolation(
+            source
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
             profile=self._resolve_profile_for_key(source),
         )
+
+    def _resolve_session_isolation(
+        self, source: SessionSource
+    ) -> tuple[bool, bool]:
+        """Resolve group/thread session isolation for a source.
+
+        Per-platform ``extra.group_sessions_per_user`` /
+        ``extra.thread_sessions_per_user`` overrides win when present,
+        falling back to the global gateway config. This mirrors the
+        resolution the adapters use for text-batching keys so the main
+        dispatch path and the adapter's batching key never diverge.
+        """
+        default_group = getattr(self.config, "group_sessions_per_user", True)
+        default_thread = getattr(self.config, "thread_sessions_per_user", False)
+        platform_cfg = getattr(self.config, "platforms", {}).get(source.platform)
+        if platform_cfg and isinstance(getattr(platform_cfg, "extra", None), dict):
+            extra = platform_cfg.extra
+            return (
+                extra.get("group_sessions_per_user", default_group),
+                extra.get("thread_sessions_per_user", default_thread),
+            )
+        return default_group, default_thread
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -25,7 +25,7 @@ import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 from hermes_constants import (
@@ -932,12 +932,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        mentions: Optional[List[str]] = None,
     ) -> SendResult:
         """Send a message via the WhatsApp bridge.
 
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
+        ``mentions`` (list of WhatsApp JIDs) @-tags those users on the first
+        chunk; the bridge also auto-tags the author of the replied-to message
+        in a group.
         """
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
@@ -968,6 +972,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Only reply-to on the first text chunk, even if the bridge
                     # response omits a parseable message id.
                     payload["replyTo"] = reply_to
+                if mentions and idx == 0:
+                    payload["mentions"] = list(mentions)
 
                 async with self._http_session.post(
                     f"http://127.0.0.1:{self._bridge_port}/send",
@@ -1636,6 +1642,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 metadata["whatsapp_from_owner"] = True
                 if not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
+
+            # Surface who this message @mentions (bridge extracts
+            # contextInfo.mentionedJid) so the agent can see who is being
+            # addressed in a group — e.g. "@user, what do you think?".
+            mentioned_ids = data.get("mentionedIds") or []
+            if mentioned_ids:
+                metadata["whatsapp_mentioned_ids"] = list(mentioned_ids)
 
             return MessageEvent(
                 text=body,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -22,6 +22,7 @@ import platform
 import re
 import signal
 import subprocess
+import time
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -419,6 +420,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             WhatsAppAdapter._DEFAULT_BRIDGE_DIR = resolve_whatsapp_bridge_dir()
         self._bridge_process: Optional[subprocess.Popen] = None
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        # chat_id -> (fetch_ts, roster) for the group-member roster injected
+        # into group message text so the model knows who is in the group.
+        self._roster_cache: Dict[str, tuple] = {}
+        self._roster_ttl = 10 * 60
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
@@ -1445,6 +1450,32 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
+    async def _get_group_roster(self, chat_id: str) -> list:
+        """Return [{id, name}] for a group, cached for ``_roster_ttl`` seconds.
+
+        Falls back to the cached roster on fetch failure so a transient bridge
+        error never blanks out the member list the model has already seen.
+        """
+        now = time.monotonic()
+        cached = self._roster_cache.get(chat_id)
+        if cached and now - cached[0] < self._roster_ttl:
+            return cached[1]
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        return cached[1] if cached else []
+                    data = await resp.json()
+            roster = data.get("participants") or []
+            self._roster_cache[chat_id] = (now, roster)
+            return roster
+        except Exception:
+            return cached[1] if cached else []
+
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
@@ -1635,6 +1666,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             mentioned_ids = data.get("mentionedIds") or []
             if mentioned_ids:
                 metadata["whatsapp_mentioned_ids"] = list(mentioned_ids)
+
+            # Give the model the group roster so it knows who is in the group
+            # and can @tag a member by display name (the bridge resolves
+            # "@Name" -> JID at send time). Compact, cached, group-only.
+            if is_group:
+                roster = await self._get_group_roster(str(data.get("chatId", "")))
+                names = [r.get("name") for r in roster if r.get("name")]
+                if names:
+                    roster_line = "[Group members: " + ", ".join(names) + "]"
+                    if roster_line not in body:
+                        body = f"{roster_line}\n{body}"
 
             return MessageEvent(
                 text=body,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -25,7 +25,7 @@ import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 from hermes_constants import (
@@ -918,12 +918,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        mentions: Optional[List[str]] = None,
     ) -> SendResult:
         """Send a message via the WhatsApp bridge.
 
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
+        ``mentions`` (list of WhatsApp JIDs) @-tags those users on the first
+        chunk; the bridge also auto-tags the author of the replied-to message
+        in a group.
         """
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
@@ -954,6 +958,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Only reply-to on the first text chunk, even if the bridge
                     # response omits a parseable message id.
                     payload["replyTo"] = reply_to
+                if mentions and idx == 0:
+                    payload["mentions"] = list(mentions)
 
                 async with self._http_session.post(
                     f"http://127.0.0.1:{self._bridge_port}/send",
@@ -1622,6 +1628,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 metadata["whatsapp_from_owner"] = True
                 if not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
+
+            # Surface who this message @mentions (bridge extracts
+            # contextInfo.mentionedJid) so the agent can see who is being
+            # addressed in a group — e.g. "@user, what do you think?".
+            mentioned_ids = data.get("mentionedIds") or []
+            if mentioned_ids:
+                metadata["whatsapp_mentioned_ids"] = list(mentioned_ids)
 
             return MessageEvent(
                 text=body,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -22,6 +22,7 @@ import platform
 import re
 import signal
 import subprocess
+import time
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -419,6 +420,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             WhatsAppAdapter._DEFAULT_BRIDGE_DIR = resolve_whatsapp_bridge_dir()
         self._bridge_process: Optional[subprocess.Popen] = None
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        # chat_id -> (fetch_ts, roster) for the group-member roster injected
+        # into group message text so the model knows who is in the group.
+        self._roster_cache: Dict[str, tuple] = {}
+        self._roster_ttl = 10 * 60
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
@@ -1459,6 +1464,32 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
+    async def _get_group_roster(self, chat_id: str) -> list:
+        """Return [{id, name}] for a group, cached for ``_roster_ttl`` seconds.
+
+        Falls back to the cached roster on fetch failure so a transient bridge
+        error never blanks out the member list the model has already seen.
+        """
+        now = time.monotonic()
+        cached = self._roster_cache.get(chat_id)
+        if cached and now - cached[0] < self._roster_ttl:
+            return cached[1]
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        return cached[1] if cached else []
+                    data = await resp.json()
+            roster = data.get("participants") or []
+            self._roster_cache[chat_id] = (now, roster)
+            return roster
+        except Exception:
+            return cached[1] if cached else []
+
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
@@ -1649,6 +1680,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             mentioned_ids = data.get("mentionedIds") or []
             if mentioned_ids:
                 metadata["whatsapp_mentioned_ids"] = list(mentioned_ids)
+
+            # Give the model the group roster so it knows who is in the group
+            # and can @tag a member by display name (the bridge resolves
+            # "@Name" -> JID at send time). Compact, cached, group-only.
+            if is_group:
+                roster = await self._get_group_roster(str(data.get("chatId", "")))
+                names = [r.get("name") for r in roster if r.get("name")]
+                if names:
+                    roster_line = "[Group members: " + ", ".join(names) + "]"
+                    if roster_line not in body:
+                        body = f"{roster_line}\n{body}"
 
             return MessageEvent(
                 text=body,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -825,7 +825,7 @@ app.post('/send', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, message, replyTo } = req.body;
+  const { chatId, message, replyTo, mentions } = req.body;
   if (!chatId || !message) {
     return res.status(400).json({ error: 'chatId and message are required' });
   }
@@ -838,6 +838,7 @@ app.post('/send', async (req, res) => {
         chatId,
         replyTo: i === 0 ? replyTo : undefined,
         messageStore,
+        mentions: Array.isArray(mentions) ? mentions : [],
       });
       const sent = await sendWithTimeout(chatId, payload, options);
       trackSentMessageId(sent);

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -39,6 +39,8 @@ import {
   createVersionResolver,
   buildLocationPayload,
   buildTextSendPayload,
+  buildGroupRoster,
+  resolveAtNameMentions,
   createBoundedMessageStore,
   extractBridgeEvent,
   inboundReadReceiptKeys,
@@ -281,6 +283,26 @@ const MAX_QUEUE_SIZE = 100;
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
 const messageStore = createBoundedMessageStore(512);
+// jid -> WhatsApp display name (pushName), fed from inbound messages so the
+// group roster can show human names instead of bare numbers.
+const nameCache = new Map();
+// chatId -> { roster, ts } for @Name mention resolution; refreshed on demand.
+const rosterCache = new Map();
+const ROSTER_TTL_MS = 5 * 60 * 1000;
+
+async function getGroupRoster(chatId) {
+  if (!chatId.endsWith('@g.us') || !sock) return [];
+  const cached = rosterCache.get(chatId);
+  if (cached && Date.now() - cached.ts < ROSTER_TTL_MS) return cached.roster;
+  try {
+    const metadata = await sock.groupMetadata(chatId);
+    const roster = buildGroupRoster(metadata.participants, nameCache);
+    rosterCache.set(chatId, { roster, ts: Date.now() });
+    return roster;
+  } catch {
+    return cached ? cached.roster : [];
+  }
+}
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
   const selected = [];
@@ -546,6 +568,11 @@ async function startSocket() {
       const senderId = msg.key.participant || chatId;
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
+      // Feed the name cache from pushName so the group roster can show
+      // human names. Skip our own messages (no useful display name).
+      if (msg.pushName && !msg.key.fromMe) {
+        nameCache.set(normalizeWhatsAppId(senderId), msg.pushName);
+      }
       emitDebugEvent({
         stage: 'upsert',
         type,
@@ -831,6 +858,15 @@ app.post('/send', async (req, res) => {
   }
 
   try {
+    // Resolve "@Name" tags in the text against the group roster when the
+    // caller didn't pass explicit mentions, so the model can tag a member by
+    // display name without knowing their JID.
+    let resolvedMentions = Array.isArray(mentions) ? mentions : [];
+    if (!resolvedMentions.length && chatId.endsWith('@g.us')) {
+      const roster = await getGroupRoster(chatId);
+      resolvedMentions = resolveAtNameMentions(message, roster);
+    }
+
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
@@ -838,7 +874,7 @@ app.post('/send', async (req, res) => {
         chatId,
         replyTo: i === 0 ? replyTo : undefined,
         messageStore,
-        mentions: Array.isArray(mentions) ? mentions : [],
+        mentions: resolvedMentions,
       });
       const sent = await sendWithTimeout(chatId, payload, options);
       trackSentMessageId(sent);
@@ -1090,7 +1126,7 @@ app.get('/chat/:id', async (req, res) => {
       return res.json({
         name: metadata.subject,
         isGroup: true,
-        participants: metadata.participants.map(p => p.id),
+        participants: buildGroupRoster(metadata.participants, nameCache),
       });
     } catch {
       // Fall through to default

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -15,6 +15,8 @@ import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
 import {
   buildPollPayload,
   buildTextSendPayload,
+  buildGroupRoster,
+  resolveAtNameMentions,
   createBoundedMessageStore,
   appendMediaFailureNote,
   extractBridgeEvent,
@@ -64,8 +66,7 @@ import {
     messageStore: store,
   });
 
-  // Group reply auto-tags the replied-to author (WhatsApp @ behavior).
-  assert.deepEqual(content, { text: 'reply text', mentions: ['15550001111@s.whatsapp.net'] });
+  assert.deepEqual(content, { text: 'reply text' });
   assert.equal(options.quoted.key.id, 'inbound-1');
   assert.equal(options.quoted.message.conversation, 'original text');
   console.log('  ✓ text replies include Baileys quoted message when resolvable');
@@ -86,65 +87,58 @@ import {
 
 // -- mentions (WhatsApp @ tagging) -------------------------------------
 {
-  // DM reply: no key.participant → no auto-mention
-  const store = createBoundedMessageStore(2);
-  store.remember({
-    key: { id: 'dm-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
-    message: { conversation: 'dm text' },
-  });
-  const { content } = buildTextSendPayload('dm reply', {
-    chatId: '15551234567@s.whatsapp.net',
-    replyTo: 'dm-1',
-    messageStore: store,
-  });
-  assert.deepEqual(content, { text: 'dm reply' });
-  console.log('  ✓ DM replies do not auto-mention (no participant)');
-}
-
-{
-  // Own message: fromMe → no auto-mention
-  const store = createBoundedMessageStore(2);
-  store.remember({
-    key: {
-      id: 'own-1',
-      remoteJid: '15551234567@s.whatsapp.net',
-      participant: '15550001111@s.whatsapp.net',
-      fromMe: true,
-    },
-    message: { conversation: 'own text' },
-  });
-  const { content } = buildTextSendPayload('reply', {
-    chatId: '15551234567@s.whatsapp.net',
-    replyTo: 'own-1',
-    messageStore: store,
-  });
-  assert.deepEqual(content, { text: 'reply' });
-  console.log('  ✓ replies to own messages do not auto-mention');
-}
-
-{
-  // Explicit mentions pass through and merge with auto-mention (dedup)
-  const store = createBoundedMessageStore(2);
-  store.remember({
-    key: {
-      id: 'grp-1',
-      remoteJid: '15551234567@g.us',
-      participant: '15550001111@s.whatsapp.net',
-      fromMe: false,
-    },
-    message: { conversation: 'grp text' },
-  });
+  // Explicit mentions pass through to Baileys content.mentions
   const { content } = buildTextSendPayload('@user reply', {
     chatId: '15551234567@g.us',
-    replyTo: 'grp-1',
-    messageStore: store,
     mentions: ['15550002222@s.whatsapp.net'],
   });
-  assert.deepEqual(content, {
-    text: '@user reply',
-    mentions: ['15550002222@s.whatsapp.net', '15550001111@s.whatsapp.net'],
+  assert.deepEqual(content, { text: '@user reply', mentions: ['15550002222@s.whatsapp.net'] });
+  console.log('  ✓ explicit mentions pass through to Baileys content');
+}
+
+{
+  // No mentions → no mentions key in content
+  const { content } = buildTextSendPayload('plain reply', {
+    chatId: '15551234567@g.us',
   });
-  console.log('  ✓ explicit mentions merge with auto-tagged reply author');
+  assert.deepEqual(content, { text: 'plain reply' });
+  console.log('  ✓ no mentions key when none requested');
+}
+
+// -- group roster + @Name resolution ------------------------------------
+{
+  const roster = buildGroupRoster(
+    [
+      { id: '15550001111@s.whatsapp.net' },
+      { id: '15550002222@s.whatsapp.net', username: 'ankit' },
+      { id: '15550003333@s.whatsapp.net' },
+    ],
+    new Map([
+      ['15550001111@s.whatsapp.net', 'Dhruv'],
+      ['15550003333@s.whatsapp.net', 'Ankit Kumar'],
+    ]),
+  );
+  assert.deepEqual(roster, [
+    { id: '15550001111@s.whatsapp.net', name: 'Dhruv' },
+    { id: '15550002222@s.whatsapp.net', name: 'ankit' },
+    { id: '15550003333@s.whatsapp.net', name: 'Ankit Kumar' },
+  ]);
+  console.log('  ✓ roster prefers pushName, falls back to username/number');
+}
+
+{
+  const roster = [
+    { id: '15550001111@s.whatsapp.net', name: 'Dhruv' },
+    { id: '15550003333@s.whatsapp.net', name: 'Ankit Kumar' },
+  ];
+  // Case-insensitive substring match on either side
+  assert.deepEqual(resolveAtNameMentions('@ankit kya haal', roster), ['15550003333@s.whatsapp.net']);
+  assert.deepEqual(resolveAtNameMentions('sun @ANKIT ko bata', roster), ['15550003333@s.whatsapp.net']);
+  // Unknown name → no mention
+  assert.deepEqual(resolveAtNameMentions('@nobody hi', roster), []);
+  // No @tokens → no mentions
+  assert.deepEqual(resolveAtNameMentions('just text', roster), []);
+  console.log('  ✓ @Name resolves to JID case-insensitively, unknown names ignored');
 }
 
 // -- inbound quote/media/native metadata --------------------------------

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -64,7 +64,8 @@ import {
     messageStore: store,
   });
 
-  assert.deepEqual(content, { text: 'reply text' });
+  // Group reply auto-tags the replied-to author (WhatsApp @ behavior).
+  assert.deepEqual(content, { text: 'reply text', mentions: ['15550001111@s.whatsapp.net'] });
   assert.equal(options.quoted.key.id, 'inbound-1');
   assert.equal(options.quoted.message.conversation, 'original text');
   console.log('  ✓ text replies include Baileys quoted message when resolvable');
@@ -81,6 +82,69 @@ import {
   assert.deepEqual(content, { text: 'plain text' });
   assert.deepEqual(options, {});
   console.log('  ✓ unresolved replyTo falls back to plain text');
+}
+
+// -- mentions (WhatsApp @ tagging) -------------------------------------
+{
+  // DM reply: no key.participant → no auto-mention
+  const store = createBoundedMessageStore(2);
+  store.remember({
+    key: { id: 'dm-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+    message: { conversation: 'dm text' },
+  });
+  const { content } = buildTextSendPayload('dm reply', {
+    chatId: '15551234567@s.whatsapp.net',
+    replyTo: 'dm-1',
+    messageStore: store,
+  });
+  assert.deepEqual(content, { text: 'dm reply' });
+  console.log('  ✓ DM replies do not auto-mention (no participant)');
+}
+
+{
+  // Own message: fromMe → no auto-mention
+  const store = createBoundedMessageStore(2);
+  store.remember({
+    key: {
+      id: 'own-1',
+      remoteJid: '15551234567@s.whatsapp.net',
+      participant: '15550001111@s.whatsapp.net',
+      fromMe: true,
+    },
+    message: { conversation: 'own text' },
+  });
+  const { content } = buildTextSendPayload('reply', {
+    chatId: '15551234567@s.whatsapp.net',
+    replyTo: 'own-1',
+    messageStore: store,
+  });
+  assert.deepEqual(content, { text: 'reply' });
+  console.log('  ✓ replies to own messages do not auto-mention');
+}
+
+{
+  // Explicit mentions pass through and merge with auto-mention (dedup)
+  const store = createBoundedMessageStore(2);
+  store.remember({
+    key: {
+      id: 'grp-1',
+      remoteJid: '15551234567@g.us',
+      participant: '15550001111@s.whatsapp.net',
+      fromMe: false,
+    },
+    message: { conversation: 'grp text' },
+  });
+  const { content } = buildTextSendPayload('@user reply', {
+    chatId: '15551234567@g.us',
+    replyTo: 'grp-1',
+    messageStore: store,
+    mentions: ['15550002222@s.whatsapp.net'],
+  });
+  assert.deepEqual(content, {
+    text: '@user reply',
+    mentions: ['15550002222@s.whatsapp.net', '15550001111@s.whatsapp.net'],
+  });
+  console.log('  ✓ explicit mentions merge with auto-tagged reply author');
 }
 
 // -- inbound quote/media/native metadata --------------------------------

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -157,7 +157,7 @@ export function pollUpdateForAggregation({
   return null;
 }
 
-export function buildTextSendPayload(text, { replyTo, messageStore } = {}) {
+export function buildTextSendPayload(text, { replyTo, messageStore, mentions = [] } = {}) {
   const content = { text };
   const options = {};
   const quoted = messageStore?.get(replyTo);
@@ -166,6 +166,16 @@ export function buildTextSendPayload(text, { replyTo, messageStore } = {}) {
     // message content payload. Keeping this split avoids silently sending a
     // literal/ignored `quoted` field instead of a native WhatsApp reply.
     options.quoted = quoted;
+    // Auto-tag the author of the replied-to message in a group so the user
+    // knows the reply is addressed to them (WhatsApp @ behavior). DM replies
+    // carry no key.participant, and the bot's own messages are skipped.
+    const participant = quoted.key.participant;
+    if (participant && !quoted.key.fromMe && !mentions.includes(participant)) {
+      mentions = [...mentions, participant];
+    }
+  }
+  if (mentions.length) {
+    content.mentions = mentions;
   }
   return { content, options };
 }

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -166,18 +166,46 @@ export function buildTextSendPayload(text, { replyTo, messageStore, mentions = [
     // message content payload. Keeping this split avoids silently sending a
     // literal/ignored `quoted` field instead of a native WhatsApp reply.
     options.quoted = quoted;
-    // Auto-tag the author of the replied-to message in a group so the user
-    // knows the reply is addressed to them (WhatsApp @ behavior). DM replies
-    // carry no key.participant, and the bot's own messages are skipped.
-    const participant = quoted.key.participant;
-    if (participant && !quoted.key.fromMe && !mentions.includes(participant)) {
-      mentions = [...mentions, participant];
-    }
   }
   if (mentions.length) {
     content.mentions = mentions;
   }
   return { content, options };
+}
+
+// Build a human-readable group roster from Baileys participants plus the
+// bridge's pushName cache. Names fall back to the participant username
+// (@handle) and finally the bare number so the list is never empty.
+export function buildGroupRoster(participants, nameCache = new Map()) {
+  const roster = [];
+  for (const p of participants || []) {
+    const id = p?.id;
+    if (!id) continue;
+    const name = nameCache.get(id)
+      || p.username
+      || id.replace(/@.*/, '');
+    roster.push({ id, name });
+  }
+  return roster;
+}
+
+// Resolve "@Name" tokens in outgoing text against a roster to JIDs, so the
+// model can tag a group member by display name without knowing their JID.
+// Matching is case-insensitive and substring-based on either side. Tokens are
+// single words (no spaces) so "@ankit kya haal" resolves "ankit", while
+// multi-word names like "Ankit Kumar" still match via substring.
+export function resolveAtNameMentions(text, roster) {
+  const tokens = [...String(text || '').matchAll(/@([\p{L}\p{N}_.-]+)/gu)].map(m => m[1].trim());
+  const mentions = [];
+  for (const token of tokens) {
+    const t = token.toLowerCase();
+    const match = (roster || []).find(r => {
+      const n = String(r.name || '').toLowerCase();
+      return n && (n.includes(t) || t.includes(n));
+    });
+    if (match && !mentions.includes(match.id)) mentions.push(match.id);
+  }
+  return mentions;
 }
 
 export function buildLocationPayload({ latitude, longitude, name, address } = {}) {

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -257,6 +257,40 @@ class TestGatewayConfigRoundtrip:
         assert restored.unauthorized_dm_behavior == "ignore"
         assert restored.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_top_level_platform_nested_extra_preserved(self, tmp_path, monkeypatch):
+        """A per-platform setting under ``<platform>.extra`` must survive the
+        shared-key loop in ``load_gateway_config()``.
+
+        Regression: the shared-key loop only bridged known top-level keys
+        (dm_policy, group_policy, …) and silently dropped the platform's own
+        nested ``extra:`` dict. So ``whatsapp.extra.group_sessions_per_user:
+        false`` never reached ``PlatformConfig.extra``, and the session-key
+        paths (which honor per-platform extra) fell back to the global
+        default — every group member kept a separate context even though the
+        config asked for a shared group session.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "whatsapp:\n"
+            "  enabled: true\n"
+            "  extra:\n"
+            "    group_sessions_per_user: false\n"
+            "    bridge_port: 3000\n"
+            "  group_policy: allowlist\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        wa = config.platforms[Platform.WHATSAPP]
+        # Nested extra survives the shared-key loop
+        assert wa.extra.get("group_sessions_per_user") is False
+        assert wa.extra.get("bridge_port") == 3000
+        # Bridged top-level keys still land in extra
+        assert wa.extra.get("group_policy") == "allowlist"
+
     def test_email_defaults_to_ignore_for_unauthorized_dm_behavior(self):
         config = GatewayConfig(
             platforms={Platform.EMAIL: PlatformConfig(enabled=True)},

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -700,6 +700,73 @@ class TestWhatsAppSessionKeyConsistency:
         assert second_entry.session_key == "agent:main:discord:group:guild-123"
         assert first_entry.session_id == second_entry.session_id
 
+    def test_store_honors_per_platform_group_sessions_override(self, store):
+        """Per-platform extra.group_sessions_per_user must win over the global
+        config in the main session-key path (mirrors the adapters' text-batching
+        keys). WhatsApp groups with the override set to False share one session
+        even though the global default is True."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True  # global default: isolated
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(
+            enabled=True,
+            extra={"group_sessions_per_user": False},
+        )
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Shared group session — no per-user suffix, both resolve to the same key.
+        expected = "agent:main:whatsapp:group:120363000000000000@g.us"
+        assert alice_entry.session_key == expected
+        assert bob_entry.session_key == expected
+        assert alice_entry.session_id == bob_entry.session_id
+
+    def test_store_keeps_global_isolation_when_no_platform_override(self, store):
+        """Without a per-platform override, the global default (isolated
+        per-user group sessions) must be preserved."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Isolated per-user sessions (global default) — distinct keys.
+        assert alice_entry.session_key != bob_entry.session_key
+        assert alice_entry.session_id != bob_entry.session_id
+
     def test_telegram_dm_includes_chat_id(self):
         """Non-WhatsApp DMs should also include chat_id to separate users."""
         source = SessionSource(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -687,6 +687,73 @@ class TestWhatsAppSessionKeyConsistency:
         assert second_entry.session_key == "agent:main:discord:group:guild-123"
         assert first_entry.session_id == second_entry.session_id
 
+    def test_store_honors_per_platform_group_sessions_override(self, store):
+        """Per-platform extra.group_sessions_per_user must win over the global
+        config in the main session-key path (mirrors the adapters' text-batching
+        keys). WhatsApp groups with the override set to False share one session
+        even though the global default is True."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True  # global default: isolated
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(
+            enabled=True,
+            extra={"group_sessions_per_user": False},
+        )
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Shared group session — no per-user suffix, both resolve to the same key.
+        expected = "agent:main:whatsapp:group:120363000000000000@g.us"
+        assert alice_entry.session_key == expected
+        assert bob_entry.session_key == expected
+        assert alice_entry.session_id == bob_entry.session_id
+
+    def test_store_keeps_global_isolation_when_no_platform_override(self, store):
+        """Without a per-platform override, the global default (isolated
+        per-user group sessions) must be preserved."""
+        from gateway.config import PlatformConfig
+
+        store.config.group_sessions_per_user = True
+        store.config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+
+        alice = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="alice@lid",
+            user_name="Alice",
+        )
+        bob = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="bob@lid",
+            user_name="Bob",
+        )
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        # Isolated per-user sessions (global default) — distinct keys.
+        assert alice_entry.session_key != bob_entry.session_key
+        assert alice_entry.session_id != bob_entry.session_id
+
     def test_telegram_dm_includes_chat_id(self):
         """Non-WhatsApp DMs should also include chat_id to separate users."""
         source = SessionSource(


### PR DESCRIPTION
## Problem

WhatsApp @mention tagging is missing in Hermes, and the model has no idea who is in a group:

- **Inbound:** the bridge already extracts `contextInfo.mentionedJid` into the event's `mentionedIds`, but the adapter silently dropped it — the agent never learns who a group message @mentions.
- **Outbound:** the bridge send path had no mention support at all, so the bot could not @tag anyone.
- **Context:** even with mention support, the model would need to know a member's JID to tag them — it had no group roster, so "tell @Ankit X" was impossible.

## Fix

**Mention pass-through**
- `buildTextSendPayload` accepts `mentions` and emits Baileys-native `content.mentions`
- `/send` accepts a `mentions` array and forwards it
- `adapter.send()` accepts `mentions` and passes them through
- Adapter surfaces inbound `mentionedIds` as `whatsapp_mentioned_ids` in `MessageEvent` metadata

**Group roster + @Name resolution**
- Bridge keeps a `pushName` cache (jid → display name) fed from inbound messages; `/chat/:id` returns participants as `[{id, name}]` (falls back to the @username handle, then the bare number)
- `/send` resolves `@Name` tokens in the text against the cached group roster (5-min TTL) into Baileys mentions — the model writes `@Ankit`, Ankit gets a real tag. Case-insensitive substring match; unknown names stay literal.
- Adapter prepends a compact `[Group members: ...]` line to group messages (cached 10 min) so the model always knows who is in the group

**No auto-tag on reply** — WhatsApp already notifies the replied-to user, so tagging stays the model's explicit choice.

## Tests

`bridge.native.test.mjs`: roster building (pushName → username → number fallback), @Name resolution (case-insensitive, unknown ignored), mention pass-through. All 18 native bridge tests + 20 whatsapp pytest pass.
