### PR TITLE
fix(honcho): honor saveMessages=false in shutdown() flush (salvages #67559)

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -215,7 +215,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
-| `saveMessages` | bool | `true` | Persist messages to Honcho API |
+| `saveMessages` | bool | `true` | Persist messages to Honcho API. When `false`, all automatic writes are skipped — raw turns (`sync_turn`), conclusion mirroring (`on_memory_write`), and session-end/shutdown flushes — while read and tools paths stay fully functional. |
 
 ### Session Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1319,8 +1319,13 @@ class HonchoMemoryProvider(MemoryProvider):
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
+
+        Honors saveMessages: false — the provider then never persists raw
+        turns to Honcho (read/tools paths stay fully functional).
         """
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return
@@ -1368,6 +1373,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         if self._cron_skipped:
             return
+        if not getattr(self._config, "save_messages", True):
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1386,6 +1393,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if not self._manager:
             return

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1538,7 +1538,12 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush any remaining messages. Honors saveMessages: false — skip
+        # persistence, but the worker-thread joins above still run (cleanup
+        # is independent of persistence; placing the guard here rather than
+        # at the top avoids leaking _prefetch_thread/_sync_thread).
+        if not getattr(self._config, "save_messages", True):
+            return
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:
                 self._manager.flush_all()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -1,0 +1,65 @@
+"""Tests for the saveMessages knob: when false, the provider never writes to Honcho.
+
+The knob has always been parsed by HonchoClientConfig but was not consumed by
+the write paths (sync_turn / on_memory_write / on_session_end). These tests pin
+the contract: saveMessages=false disables all automatic persistence while read
+and tools paths remain untouched.
+"""
+
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+def _provider(save_messages: bool) -> HonchoMemoryProvider:
+    p = HonchoMemoryProvider()
+    p._config = HonchoClientConfig(save_messages=save_messages)
+    p._manager = MagicMock()
+    p._session_key = 'test-session'
+    p._session_initialized = True
+    return p
+
+
+class TestSyncTurn:
+    def test_disabled_writes_nothing(self):
+        p = _provider(save_messages=False)
+        p.sync_turn('user says', 'assistant says')
+        p._manager.get_or_create.assert_not_called()
+        p._manager._flush_session.assert_not_called()
+
+    def test_enabled_writes(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+
+
+class TestOnMemoryWrite:
+    def test_disabled_skips_conclusion_mirror(self):
+        p = _provider(save_messages=False)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        p._manager.create_conclusion.assert_not_called()
+
+    def test_enabled_mirrors(self):
+        import time
+
+        p = _provider(save_messages=True)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        deadline = time.time() + 5
+        while time.time() < deadline and not p._manager.create_conclusion.called:
+            time.sleep(0.05)
+        p._manager.create_conclusion.assert_called_once()
+
+
+class TestOnSessionEnd:
+    def test_disabled_skips_flush(self):
+        p = _provider(save_messages=False)
+        p.on_session_end([])
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = _provider(save_messages=True)
+        p.on_session_end([])
+        p._manager.flush_all.assert_called_once()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -63,3 +63,27 @@ class TestOnSessionEnd:
         p = _provider(save_messages=True)
         p.on_session_end([])
         p._manager.flush_all.assert_called_once()
+
+
+class TestShutdown:
+    """shutdown() joins worker threads then flushes; saveMessages=false must
+    skip the flush (persistence) while still running the joins (cleanup)."""
+
+    def _provider_for_shutdown(self, save_messages: bool) -> HonchoMemoryProvider:
+        p = _provider(save_messages=save_messages)
+        # shutdown() iterates these thread handles; if no turn/session-end ran
+        # they may be unset, so default to None (= "no thread started").
+        p._init_thread = None
+        p._prefetch_thread = None
+        p._sync_thread = None
+        return p
+
+    def test_disabled_skips_flush(self):
+        p = self._provider_for_shutdown(save_messages=False)
+        p.shutdown()
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = self._provider_for_shutdown(save_messages=True)
+        p.shutdown()
+        p._manager.flush_all.assert_called_once()


### PR DESCRIPTION
Salvages #67559 (original by @Matroskin86, inactive 3+ weeks).

## The gap

#67559 gated `sync_turn` / `on_memory_write` / `on_session_end` behind `saveMessages: false`, but `HonchoMemoryProvider.shutdown()` still called `flush_all()` unconditionally — so a provider configured **not** to persist would still flush on exit. The hermes-sweeper review (salvageability=high) flagged this as the single remaining gap.

## Changes

- **`plugins/memory/honcho/__init__.py`** — original 3 guards (cherry-picked, credit @Matroskin86) + a 4th guard in `shutdown()`. Placed **after** the worker-thread joins, not at the top of the method: `saveMessages` controls persistence, not cleanup, and a top-of-method return would leak `_prefetch_thread` / `_sync_thread`.
- **`tests/honcho_plugin/test_save_messages.py`** — original 6 tests (cherry-picked) + `TestShutdown` (disabled skips flush / enabled flushes).
- **`README.md`** — clarifies the `saveMessages: false` row (sweeper-suggested change).

## Verification

- `pytest tests/honcho_plugin/` → **224 passed, 12 skipped** (full suite, no regressions)
- `pytest tests/honcho_plugin/test_save_messages.py` → **8 passed**

Cherry-pick preserves the original author credit (`eapwrk` / @Matroskin86).