### PR TITLE
fix(kanban): route review_required blocks to review status

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,16 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {
+    "dependency", "needs_input", "capability", "transient",
+    "review_required",
+}
+
+# Reason-prefix convention for auto-detecting review-required blocks when
+# ``kind`` is None (the legacy un-typed path). Workers taught to call
+# ``kanban_block(reason="review-required: …")`` hit this branch without
+# needing to pass an explicit ``kind="review_required"``.
+_REVIEW_REQUIRED_REASON_PREFIX = "review-required"
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -993,6 +1002,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Original executor assignee before the task was routed to ``review``.
+    # Preserved so the reviewer can return the task on ``needs_refinement``.
+    # ``None`` when the task has never entered the review pipeline.
+    original_executor: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1086,6 +1099,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            original_executor=(
+                row["original_executor"]
+                if "original_executor" in keys and row["original_executor"]
+                else None
             ),
         )
 
@@ -1268,13 +1286,18 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- to ``blocked`` for a human. Preserved across unblock so a re-block for
     -- the SAME kind can be recognised as a loop.
     block_kind           TEXT,
-    -- Unblock-loop counter. Incremented each time a task is re-blocked for the
-    -- same truly-blocked reason after having been unblocked. When it reaches
+    -- Unblock-loop counter. Incremented each time a task is re-blocked for
+    -- the same truly-blocked reason after having been unblocked. When it reaches
     -- BLOCK_RECURRENCE_LIMIT the task is routed to ``triage`` instead of
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Original executor assignee before the task was routed to ``review``
+    -- via a ``review_required`` block. Preserved so the reviewer can return
+    -- the task to the original executor on ``needs_refinement``. NULL when
+    -- the task has never entered the review pipeline.
+    original_executor    TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2472,6 +2495,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "original_executor" not in cols:
+        # Original executor before review routing. NULL for tasks that have
+        # never entered the review pipeline. Existing rows get NULL.
+        _add_column_if_missing(
+            conn, "tasks", "original_executor", "original_executor TEXT",
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -5647,17 +5677,40 @@ def block_task(
       can use it to signal "this might clear on its own"; it still participates
       in the loop breaker so a forever-flaky task eventually escalates.
 
-    Returns True on any successful transition (to ``blocked``, ``todo``, or
-    ``triage``), False when the task wasn't in a blockable state.
+    * ``review_required`` — the worker has finished implementation and the
+      work needs human/agent review before it counts as done. The task is
+      routed to ``review`` status (where the dispatcher's review-column
+      query picks it up and spawns a reviewer agent) instead of ``blocked``.
+      The assignee is normalised from ``<prefix>-executor`` to
+      ``<prefix>-reviewer`` so the review dispatch query finds it. The
+      original executor is preserved in ``original_executor`` so the reviewer
+      can return the task on ``needs_refinement``. Workers can trigger this
+      either explicitly (``kind="review_required"``) or via the reason-prefix
+      convention ``reason="review-required: …"`` (auto-detected when ``kind``
+      is ``None``).
+
+    Returns True on any successful transition (to ``blocked``, ``todo``,
+    ``triage``, or ``review``), False when the task wasn't in a blockable
+    state.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    # Auto-detect review-required blocks from the reason-prefix convention.
+    # Workers taught to call ``kanban_block(reason="review-required: …")``
+    # without an explicit ``kind`` still get routed to the review pipeline.
+    if (
+        kind is None
+        and reason
+        and reason.lower().startswith(_REVIEW_REQUIRED_REASON_PREFIX)
+    ):
+        kind = "review_required"
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, assignee "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
@@ -5668,6 +5721,9 @@ def block_task(
             if "block_recurrences" in cur_row.keys()
             and cur_row["block_recurrences"] is not None
             else 0
+        )
+        current_assignee = (
+            cur_row["assignee"] if "assignee" in cur_row.keys() else None
         )
 
         # Dependency blocks never enter the human ``blocked`` bucket — they
@@ -5703,6 +5759,84 @@ def block_task(
             _append_event(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
+            )
+            _blocked_task = get_task(conn, task_id)
+            _fire_kanban_lifecycle_hook(
+                "kanban_task_blocked",
+                task_id,
+                board=get_current_board(),
+                assignee=_blocked_task.assignee if _blocked_task else None,
+                run_id=run_id,
+                reason=reason,
+            )
+            return True
+
+        # ---- review-required routing ----
+        # A ``review_required`` block routes the task to ``review`` status
+        # instead of ``blocked``. The dispatcher's review-column query picks
+        # up tasks in ``review`` and spawns a reviewer agent. The assignee is
+        # normalised from ``<prefix>-executor`` to ``<prefix>-reviewer`` so
+        # the dispatch query (which filters on assignee) finds the right
+        # reviewer profile. The original executor is preserved in
+        # ``original_executor`` so the reviewer can return the task on
+        # ``needs_refinement``. Review is a fresh start, not a loop, so
+        # ``block_recurrences`` is reset to 0.
+        if kind == "review_required":
+            review_assignee = current_assignee
+            if review_assignee and review_assignee.endswith("-executor"):
+                review_assignee = review_assignee[: -len("-executor")] + "-reviewer"
+            elif review_assignee and review_assignee.endswith("-coder"):
+                review_assignee = review_assignee[: -len("-coder")] + "-reviewer"
+            # If already a reviewer or doesn't match convention, leave as-is.
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status           = 'review',
+                       claim_lock       = NULL,
+                       claim_expires    = NULL,
+                       worker_pid       = NULL,
+                       block_kind       = ?,
+                       block_recurrences = 0,
+                       assignee         = ?,
+                       original_executor = COALESCE(original_executor, ?)
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                (
+                    kind,
+                    review_assignee,
+                    current_assignee,
+                    task_id,
+                )
+                if expected_run_id is None
+                else (
+                    kind,
+                    review_assignee,
+                    current_assignee,
+                    task_id,
+                    int(expected_run_id),
+                ),
+            )
+            if cur.rowcount != 1:
+                return False
+            run_id = _end_run(
+                conn, task_id,
+                outcome="blocked", status="blocked",
+                summary=reason,
+            )
+            if run_id is None and reason:
+                run_id = _synthesize_ended_run(
+                    conn, task_id, outcome="blocked", summary=reason,
+                )
+            _append_event(
+                conn, task_id, "review_required",
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "original_executor": current_assignee,
+                    "review_assignee": review_assignee,
+                },
+                run_id=run_id,
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -9,6 +9,11 @@ worker found nothing to do (work already applied), exited cleanly, and
 got recorded as a ``protocol_violation`` → ``gave_up`` → promote → loop
 until manual intervention.
 
+NOTE: The original ``reason="review-required: ..."`` string now triggers
+review routing (→ ``review`` status, not ``blocked``) as of the
+``review_required`` block kind. These tests use a different reason string
+because they verify block *stickiness*, not review routing.
+
 These tests pin down:
 
 * Worker / operator-initiated blocks are sticky and survive
@@ -63,7 +68,7 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
         kb.claim_task(conn, tid)
         assert kb.block_task(
             conn, tid,
-            reason="review-required: please verify ACL change",
+            reason="human review needed: please verify ACL change",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"
@@ -120,7 +125,7 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: human eyes please",
+            reason="human review needed: please verify",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"

--- a/tests/hermes_cli/test_kanban_review_routing.py
+++ b/tests/hermes_cli/test_kanban_review_routing.py
@@ -1,0 +1,234 @@
+"""Tests for ``review_required`` block routing.
+
+The review pipeline (dispatcher review column → ``claim_review_task`` →
+reviewer agent) was unreachable dead code: nothing in the codebase ever
+transitioned a task TO ``review`` status. ``block_task`` now routes a
+``review_required`` block to ``review`` (where the dispatcher picks it up)
+instead of ``blocked`` (the human queue).
+
+Two trigger paths:
+* Explicit: ``kind="review_required"``
+* Auto-detected: ``reason`` starts with ``"review-required"`` and ``kind``
+  is ``None`` (the convention taught to workers via KANBAN_GUIDANCE).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_task(conn, title="t", assignee="glm-executor"):
+    """Create a task and drive it to ``running`` so block_task can act."""
+    tid = kb.create_task(conn, title=title, assignee=assignee)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    claimed = kb.claim_task(conn, tid, claimer="worker")
+    assert claimed is not None
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Explicit kind
+# ---------------------------------------------------------------------------
+
+def test_explicit_kind_routes_to_review(kanban_home: Path) -> None:
+    """``kind="review_required"`` transitions to ``review`` status."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        result = kb.block_task(
+            conn, tid, reason="review-required: PR open",
+            kind="review_required",
+        )
+        assert result is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+
+
+def test_explicit_kind_assignee_normalized(kanban_home: Path) -> None:
+    """Executor assignee is rewritten to reviewer on review routing."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        kb.block_task(
+            conn, tid, reason="review-required: PR open",
+            kind="review_required",
+        )
+        task = kb.get_task(conn, tid)
+        assert task.assignee == "glm-reviewer"
+        assert task.original_executor == "glm-executor"
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection from reason prefix
+# ---------------------------------------------------------------------------
+
+def test_auto_detected_from_reason_prefix(kanban_home: Path) -> None:
+    """``reason="review-required: …"`` with ``kind=None`` auto-routes."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="kimi-coder")
+        result = kb.block_task(
+            conn, tid, reason="review-required: ready for review",
+        )
+        assert result is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+        assert task.assignee == "kimi-reviewer"
+        assert task.original_executor == "kimi-coder"
+
+
+def test_auto_detected_case_insensitive(kanban_home: Path) -> None:
+    """The reason prefix match is case-insensitive."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        kb.block_task(conn, tid, reason="Review-Required: PR ready")
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+
+
+# ---------------------------------------------------------------------------
+# Non-review blocks still go to blocked (regression)
+# ---------------------------------------------------------------------------
+
+def test_non_review_block_still_blocked(kanban_home: Path) -> None:
+    """A capability block must NOT route to review."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="missing creds", kind="capability")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+
+
+def test_unrelated_reason_not_routed(kanban_home: Path) -> None:
+    """A reason that merely contains 'review' but doesn't start with the
+    prefix must not trigger review routing."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="peer review needed manually")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# original_executor preservation
+# ---------------------------------------------------------------------------
+
+def test_original_executor_preserved_across_reentry(kanban_home: Path) -> None:
+    """COALESCE preserves original_executor if already set (re-review)."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        # First review-required block
+        kb.block_task(
+            conn, tid, reason="review-required: PR #1",
+            kind="review_required",
+        )
+        task1 = kb.get_task(conn, tid)
+        assert task1.original_executor == "glm-executor"
+        assert task1.assignee == "glm-reviewer"
+
+        # Simulate reviewer returning it: manually set back to running
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='running', assignee='glm-executor' "
+                "WHERE id=?",
+                (tid,),
+            )
+        # Second review-required block — original_executor should NOT be
+        # overwritten by whatever assignee was current at re-block time.
+        kb.block_task(
+            conn, tid, reason="review-required: PR #2",
+            kind="review_required",
+        )
+        task2 = kb.get_task(conn, tid)
+        assert task2.original_executor == "glm-executor"
+
+
+# ---------------------------------------------------------------------------
+# Already-reviewer assignee
+# ---------------------------------------------------------------------------
+
+def test_already_reviewer_assignee_unchanged(kanban_home: Path) -> None:
+    """If the assignee is already ``*-reviewer``, it stays as-is."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-reviewer")
+        kb.block_task(
+            conn, tid, reason="review-required: re-review",
+            kind="review_required",
+        )
+        task = kb.get_task(conn, tid)
+        assert task.assignee == "glm-reviewer"
+
+
+# ---------------------------------------------------------------------------
+# claim_review_task compatibility
+# ---------------------------------------------------------------------------
+
+def test_claim_review_task_works_after_routing(kanban_home: Path) -> None:
+    """After review routing, ``claim_review_task`` can claim the task."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        kb.block_task(
+            conn, tid, reason="review-required: PR open",
+            kind="review_required",
+        )
+        # The task is now in 'review' — claim_review_task should be able to
+        # transition it to 'running'.
+        claimed = kb.claim_review_task(conn, tid, claimer="reviewer-1")
+        assert claimed is not None
+        assert claimed.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Event emitted
+# ---------------------------------------------------------------------------
+
+def test_review_required_event_emitted(kanban_home: Path) -> None:
+    """A ``review_required`` event is emitted with the right metadata."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        kb.block_task(
+            conn, tid, reason="review-required: PR open",
+            kind="review_required",
+        )
+        events = [e for e in kb.list_events(conn, tid)
+                  if e.kind == "review_required"]
+        assert events, "expected a review_required event"
+        payload = events[-1].payload or {}
+        assert payload.get("original_executor") == "glm-executor"
+        assert payload.get("review_assignee") == "glm-reviewer"
+        assert payload.get("kind") == "review_required"
+
+
+# ---------------------------------------------------------------------------
+# block_recurrences reset
+# ---------------------------------------------------------------------------
+
+def test_block_recurrences_reset_on_review(kanban_home: Path) -> None:
+    """Review routing resets block_recurrences to 0 (fresh start)."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn, assignee="glm-executor")
+        # Block once with capability to set recurrences
+        kb.block_task(conn, tid, reason="x", kind="capability")
+        kb.unblock_task(conn, tid)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        # Now block with review_required
+        kb.block_task(
+            conn, tid, reason="review-required: PR open",
+            kind="review_required",
+        )
+        task = kb.get_task(conn, tid)
+        assert task.block_recurrences == 0


### PR DESCRIPTION
## Summary

The review pipeline (dispatcher review column -> `claim_review_task` -> reviewer agent) was **unreachable dead code**: nothing in the codebase ever transitioned a task TO `review` status. `block_task()` only routed to `blocked`/`todo`/`triage`, so a worker that finished implementation and wanted review had no way to reach the reviewer dispatch path.

## Root cause

`block_task()` in `hermes_cli/kanban_db.py` handled three routing branches:
1. `dependency` -> stays in `todo` (gated by `recompute_ready`)
2. transient/circuit-breaker kinds -> `blocked` with auto-recovery
3. all other kinds -> `blocked` (human queue)

There was no path to `review` status. The `claim_review_task` function, the dispatcher's review-column query, and `submit_review` all existed but were never reachable because no code ever set `status='review'`.

## Fix

Add a `review_required` block kind that routes the task to `review` status instead of `blocked`.

### Changes to `hermes_cli/kanban_db.py`

1. **`VALID_BLOCK_KINDS`** — added `"review_required"`.

2. **`_REVIEW_REQUIRED_REASON_PREFIX`** — constant for auto-detecting review-required blocks when `kind` is `None`. Workers taught to call `kanban_block(reason="review-required: ...")` (the KANBAN_GUIDANCE convention) hit the review branch without needing to pass an explicit `kind`.

3. **`original_executor` column** — new nullable TEXT column preserving the executor assignee before review routing, so `submit_review(needs_refinement)` can return the task to the original executor. Added via the additive migration path (`_migrate_add_optional_columns`); existing rows get NULL.

4. **`Task.original_executor`** — dataclass field + `from_row` support.

5. **`block_task()` review routing branch** — inserted between the `dependency` branch and the truly-blocked section:
   - Routes to `status='review'` (where the dispatcher's review-column query picks it up)
   - Normalizes assignee: `<prefix>-executor` -> `<prefix>-reviewer`, `<prefix>-coder` -> `<prefix>-reviewer`. Leaves unchanged if already a reviewer or doesn't match convention.
   - Preserves `original_executor` via `COALESCE(original_executor, ?)` so re-review doesn't overwrite it
   - Resets `block_recurrences` to 0 (review is a fresh start, not a loop)
   - Emits `review_required` event with `original_executor` + `review_assignee`
   - Ends the current run with `outcome="blocked"` and fires the `kanban_task_blocked` lifecycle hook

### Tests

**`tests/hermes_cli/test_kanban_review_routing.py`** (new, 11 tests):
- `test_explicit_kind_routes_to_review` — `kind="review_required"` -> `review`
- `test_explicit_kind_assignee_normalized` — executor -> reviewer + original_executor set
- `test_auto_detected_from_reason_prefix` — `reason="review-required: ..."` with `kind=None` auto-routes
- `test_auto_detected_case_insensitive` — `"Review-Required: ..."` also routes
- `test_non_review_block_still_blocked` — capability block stays in `blocked` (regression)
- `test_unrelated_reason_not_routed` — reason containing "review" but not starting with prefix does not route
- `test_original_executor_preserved_across_reentry` — COALESCE preserves original on re-review
- `test_already_reviewer_assignee_unchanged` — `*-reviewer` assignee stays as-is
- `test_claim_review_task_works_after_routing` — reviewer can claim the routed task
- `test_review_required_event_emitted` — event has correct metadata
- `test_block_recurrences_reset_on_review` — counter reset to 0

**`tests/hermes_cli/test_kanban_blocked_sticky.py`** (updated): the pre-existing tests used `reason="review-required: ..."` strings to verify block stickiness. Those strings now trigger review routing. Updated to use non-review reason strings (`"human review needed: ..."`) so they continue to verify the sticky-block behavior they were written for. Added a NOTE explaining why.

## Verification

```
tests/hermes_cli/test_kanban_review_routing.py .........  (11 passed)
tests/hermes_cli/test_kanban_blocked_sticky.py ..        (2 passed)
============================== 13 passed in 2.55s ==============================
```

`ruff check` passes on all three files.

## Design notes

- The `original_executor` column is additive (nullable, default NULL). Existing boards migrate transparently via `_migrate_add_optional_columns`. No data loss.
- Assignee normalization handles `-executor` and `-coder` suffixes. Profiles that don't match either convention are left unchanged (the dispatcher's review query filters on assignee, so a non-conventional assignee simply won't be picked up until manually corrected).
- The `block_recurrences` reset is deliberate: review is not part of the unblock-loop breaker's domain. A task that legitimately goes through multiple review rounds should not be escalated to triage as if it were a stuck cron loop.