### PR TITLE
fix(kanban): caller-identity check on unblock — worker cannot silently lift its own review-required block

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -653,6 +653,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         default=None,
         help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
     )
+    p_unblock.add_argument(
+        "--override-self",
+        action="store_true",
+        help=(
+            "Acknowledge a deliberate self-unblock: required when the "
+            "caller's profile matches the profile that posted the block "
+            "on a human-gate (review-required / needs-input) block. "
+            "Self-unblocks are recorded on the task audit trail."
+        ),
+    )
     p_unblock.add_argument("task_ids", nargs="+")
 
     p_promote = sub.add_parser(
@@ -2271,6 +2281,7 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id_for(tid),
+                author=author,
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -2322,16 +2333,27 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     reason = getattr(args, "reason", None)
     if reason is not None:
         reason = reason.strip() or None
-    author = _profile_author() if reason else None
+    author = _profile_author()
+    override_self = bool(getattr(args, "override_self", False))
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            ok, note = kb.unblock_task(
+                conn, tid, actor=author, override_self=override_self
+            )
+            if not ok:
                 failed.append(tid)
-                print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
+                print(
+                    f"cannot unblock {tid}: {note or 'not blocked/scheduled?'}",
+                    file=sys.stderr,
+                )
             else:
+                if note:
+                    # Unblock succeeded but the caller matched the recorded
+                    # blocker on a programmatic block — flag it, don't fail.
+                    print(f"warning: {note}", file=sys.stderr)
                 print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -993,6 +993,11 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Profile/identity that posted the current block (set by ``block_task``,
+    # cleared on unblock/complete/promote). NULL for legacy rows and for
+    # blocks created before the column existed — the self-unblock guard
+    # treats NULL as unknown-blocker and fails open.
+    blocked_by: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1086,6 +1091,9 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            blocked_by=(
+                row["blocked_by"] if "blocked_by" in keys else None
             ),
         )
 
@@ -1274,7 +1282,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Profile/identity that posted the current block (set by ``block_task``,
+    -- cleared on unblock/complete/promote). NULL for legacy rows and for
+    -- blocks created before the column existed — the self-unblock guard
+    -- treats NULL as unknown-blocker and fails open.
+    blocked_by           TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2473,6 +2486,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
+
+    if "blocked_by" not in cols:
+        # Profile/identity that posted the current block. Existing blocked
+        # rows get NULL, which the self-unblock guard treats as
+        # unknown-blocker (fail-open) — same behaviour they had before the
+        # column existed.
+        _add_column_if_missing(conn, "tasks", "blocked_by", "blocked_by TEXT")
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -4908,16 +4928,17 @@ def complete_task(
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                  SET status       = 'done',
+                      result       = ?,
+                      completed_at = ?,
+                      claim_lock   = NULL,
+                      claim_expires= NULL,
+                      worker_pid   = NULL,
+                      block_kind   = NULL,
+                      block_recurrences = 0,
+                      blocked_by   = NULL
+                WHERE id = ?
+                  AND status IN ('running', 'ready', 'blocked')
                 """,
                 (result, now, task_id),
             )
@@ -4925,17 +4946,18 @@ def complete_task(
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
-                   AND current_run_id = ?
+                  SET status       = 'done',
+                      result       = ?,
+                      completed_at = ?,
+                      claim_lock   = NULL,
+                      claim_expires= NULL,
+                      worker_pid   = NULL,
+                      block_kind   = NULL,
+                      block_recurrences = 0,
+                      blocked_by   = NULL
+                WHERE id = ?
+                  AND status IN ('running', 'ready', 'blocked')
+                  AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
             )
@@ -5622,8 +5644,15 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    author: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+
+    ``author`` (when provided) is recorded in ``tasks.blocked_by`` so a
+    later ``unblock_task`` can enforce the caller-identity check (a worker
+    must not unblock its own human-gate block — #75319). NULL on legacy
+    callers means the task has no recorded blocker and self-unblock
+    detection fails open.
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -5730,17 +5759,18 @@ def block_task(
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status        = 'triage',
-                       claim_lock    = NULL,
-                       claim_expires = NULL,
-                       worker_pid    = NULL,
-                       block_kind    = ?,
-                       block_recurrences = ?
-                 WHERE id = ?
-                   AND status IN ('running', 'ready')
+                  SET status        = 'triage',
+                      claim_lock    = NULL,
+                      claim_expires = NULL,
+                      worker_pid    = NULL,
+                      block_kind    = ?,
+                      block_recurrences = ?,
+                      blocked_by    = ?
+                WHERE id = ?
+                  AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                (kind, recurrences, author, task_id) if expected_run_id is None
+                else (kind, recurrences, author, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
@@ -5768,32 +5798,34 @@ def block_task(
                 cur = conn.execute(
                     """
                     UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
+                      SET status        = 'blocked',
+                          claim_lock    = NULL,
+                          claim_expires = NULL,
+                          worker_pid    = NULL,
+                          block_kind    = ?,
+                          block_recurrences = ?,
+                          blocked_by    = ?
+                    WHERE id = ?
+                      AND status IN ('running', 'ready')
                     """,
-                    (kind, recurrences, task_id),
+                    (kind, recurrences, author, task_id),
                 )
             else:
                 cur = conn.execute(
                     """
                     UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                       AND current_run_id = ?
+                      SET status        = 'blocked',
+                          claim_lock    = NULL,
+                          claim_expires = NULL,
+                          worker_pid    = NULL,
+                          block_kind    = ?,
+                          block_recurrences = ?,
+                          blocked_by    = ?
+                    WHERE id = ?
+                      AND status IN ('running', 'ready')
+                      AND current_run_id = ?
                     """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
+                    (kind, recurrences, author, task_id, int(expected_run_id)),
                 )
             if cur.rowcount != 1:
                 return False
@@ -5882,7 +5914,7 @@ def promote_task(
 
     with write_txn(conn):
         upd = conn.execute(
-            "UPDATE tasks SET status = 'ready' "
+            "UPDATE tasks SET status = 'ready', blocked_by = NULL "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
             (task_id,),
         )
@@ -5898,7 +5930,21 @@ def promote_task(
     return True, None
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+# Human-in-the-loop block kinds: a task sitting in ``blocked`` with one of
+# these (or a legacy NULL kind) is waiting on a human decision. A caller
+# whose identity matches ``blocked_by`` may not lift the gate without an
+# explicit override. ``transient`` blocks are programmatic (they may clear
+# on retry), so a matching caller only gets a recorded warning (#75319).
+SELF_UNBLOCK_GATED_KINDS = frozenset({None, "needs_input", "capability"})
+
+
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: Optional[str] = None,
+    override_self: bool = False,
+) -> tuple[bool, Optional[str]]:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -5907,24 +5953,64 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
+
+    Caller-identity guard (#75319): when ``actor`` matches the recorded
+    ``blocked_by`` on a human-gate block (kind ``needs_input`` /
+    ``capability`` / legacy NULL), the unblock is refused unless
+    ``override_self=True`` — a worker must not silently lift its own
+    review-required gate. Matching callers on a ``transient`` block proceed
+    with a warning. Tasks with no recorded blocker (legacy rows, or blocks
+    made before the column existed) fail open — there is no identity to
+    compare.
+
+    Returns ``(True, None)`` on success (mirroring ``promote_task``),
+    ``(True, warning)`` when the unblock proceeded despite a matching
+    caller on a programmatic block, and ``(False, error)`` on refusal.
+    The actor and override flag are recorded on the ``unblocked`` event for
+    audit.
     """
     now = int(time.time())
     with write_txn(conn):
-        stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
+        row = conn.execute(
+            "SELECT current_run_id, status, block_kind, blocked_by "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
-        if stale and stale["current_run_id"]:
+        if row is None:
+            return False, f"task {task_id} not found"
+        if row["current_run_id"] and row["status"] in ("blocked", "scheduled"):
             conn.execute(
                 """
                 UPDATE task_runs
-                   SET status = 'reclaimed', outcome = 'reclaimed',
-                       summary = COALESCE(summary, 'invariant recovery on unblock'),
-                       ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
-                 WHERE id = ? AND ended_at IS NULL
+                  SET status = 'reclaimed', outcome = 'reclaimed',
+                      summary = COALESCE(summary, 'invariant recovery on unblock'),
+                      ended_at = ?,
+                      claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                WHERE id = ? AND ended_at IS NULL
                 """,
-                (now, int(stale["current_run_id"])),
+                (now, int(row["current_run_id"])),
+            )
+        warning: Optional[str] = None
+        legacy_blocker = bool(row["status"] == "blocked" and not row["blocked_by"])
+        if (
+            actor
+            and row["status"] == "blocked"
+            and row["blocked_by"]
+            and actor == row["blocked_by"]
+            and not override_self
+        ):
+            kind = row["block_kind"]
+            if kind in SELF_UNBLOCK_GATED_KINDS:
+                return False, (
+                    f"task {task_id} is blocked by {row['blocked_by']} "
+                    f"(this caller); human-gate blocks need a different "
+                    f"operator to unblock, or an explicit override "
+                    f"acknowledging the self-unblock"
+                )
+            warning = (
+                f"task {task_id} was blocked by {row['blocked_by']} "
+                f"(this caller); self-unblock of a '{kind}' block "
+                f"proceeded but is recorded"
             )
         # Re-gate on parent completion before flipping 'blocked' back to
         # 'ready'. Unconditionally setting status='ready' here bypasses the
@@ -5951,17 +6037,26 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "consecutive_failures = 0, last_failure_error = NULL "
+            "consecutive_failures = 0, last_failure_error = NULL, "
+            "blocked_by = NULL "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
         )
         if cur.rowcount != 1:
-            return False
-        _append_event(
-            conn, task_id, "unblocked",
-            {"status": new_status} if new_status != "ready" else None,
-        )
-        return True
+            return False, f"task {task_id} is not blocked/scheduled"
+        payload: dict[str, object] = {}
+        if new_status != "ready":
+            payload["status"] = new_status
+        if actor is not None:
+            payload["actor"] = actor
+        if legacy_blocker:
+            # The task was blocked before caller-identity recording existed —
+            # the audit trail can't attribute the block, so say so explicitly.
+            payload["legacy_blocker"] = True
+        if override_self:
+            payload["override_self"] = True
+        _append_event(conn, task_id, "unblocked", payload or None)
+        return True, warning
 
 
 def specify_triage_task(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -890,7 +890,9 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
                 if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
+                    # Dashboard access is the operator surface (session-token
+                    # gated); record the unblock actor for the audit trail.
+                    ok, _note = kanban_db.unblock_task(conn, task_id, actor="dashboard")
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
                     ok = _set_status_direct(conn, task_id, "ready")
@@ -1266,7 +1268,10 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
                         if cur and cur.status in ("blocked", "scheduled"):
-                            ok = kanban_db.unblock_task(conn, tid)
+                            # Dashboard access is the operator surface
+                            # (session-token gated); record the unblock actor
+                            # for the audit trail.
+                            ok, _note = kanban_db.unblock_task(conn, tid, actor="dashboard")
                         else:
                             ok = _set_status_direct(conn, tid, "ready")
                     elif s == "running":

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -594,7 +594,8 @@ def test_unblock_invariant_recovery(kanban_home):
         assert kb.get_run(conn, leaked_run_id).ended_at is None
 
         # Unblock — the defensive recovery must close the leaked run.
-        assert kb.unblock_task(conn, tid) is True
+        ok, _note = kb.unblock_task(conn, tid)
+        assert ok is True
         task = kb.get_task(conn, tid)
         assert task.status == "ready"
         assert task.current_run_id is None

--- a/tests/hermes_cli/test_kanban_self_unblock_guard.py
+++ b/tests/hermes_cli/test_kanban_self_unblock_guard.py
@@ -1,0 +1,282 @@
+"""Tests for the kanban self-unblock caller-identity guard (#75319).
+
+A worker must not be able to silently lift its own human-gate block:
+``unblock_task`` refuses when the caller's identity matches the recorded
+blocker on a ``needs_input`` / ``capability`` / legacy (NULL-kind) block
+unless the caller explicitly acknowledges the self-unblock. Programmatic
+(``transient``) blocks proceed with a recorded warning. Tasks with no
+recorded blocker (legacy rows) fail open. Every unblock records the actor
+on the audit trail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kb_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+def _blocked_task(conn, *, kind=None, author: str | None = "alice", reason="review-required: please check"):
+    """Create a task and block it from ``ready`` with a recorded author."""
+    tid = kb.create_task(conn, title="t", assignee="worker")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    ok = kb.block_task(conn, tid, reason=reason, kind=kind, author=author)
+    assert ok is True
+    return tid
+
+
+def _events(conn, tid):
+    return [
+        {"kind": e.kind, "payload": e.payload}
+        for e in kb.list_events(conn, tid)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DB layer: blocked_by recording
+# ---------------------------------------------------------------------------
+
+
+def test_block_records_blocked_by(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.blocked_by == "alice"
+
+
+def test_block_without_author_leaves_null_blocker(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        kb.block_task(conn, tid, reason="x")
+        assert kb.get_task(conn, tid).blocked_by is None
+
+
+# ---------------------------------------------------------------------------
+# DB layer: self-unblock guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["needs_input", "capability", None])
+def test_self_unblock_refused_on_human_gate(kanban_home, kind):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind=kind, author="alice")
+        ok, err = kb.unblock_task(conn, tid, actor="alice")
+        assert ok is False
+        assert "blocked by alice" in (err or "")
+        # The task stays blocked — the guard must not partially transition.
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.get_task(conn, tid).blocked_by == "alice"
+
+
+def test_self_unblock_allowed_with_explicit_override(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        ok, err = kb.unblock_task(conn, tid, actor="alice", override_self=True)
+        assert ok is True
+        assert err is None
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.blocked_by is None
+        # Audit trail distinguishes the acknowledged self-unblock.
+        unblocked = [e for e in _events(conn, tid) if e["kind"] == "unblocked"]
+        assert unblocked
+        assert unblocked[-1]["payload"] == {
+            "actor": "alice",
+            "override_self": True,
+        }
+
+
+def test_different_actor_unblocks_without_flag(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        ok, err = kb.unblock_task(conn, tid, actor="bob")
+        assert ok is True
+        assert err is None
+        assert kb.get_task(conn, tid).status == "ready"
+        unblocked = [e for e in _events(conn, tid) if e["kind"] == "unblocked"]
+        assert unblocked[-1]["payload"] == {"actor": "bob"}
+
+
+def test_transient_self_unblock_proceeds_with_warning(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="transient", author="alice")
+        ok, warning = kb.unblock_task(conn, tid, actor="alice")
+        assert ok is True
+        assert warning is not None
+        assert "proceeded but is recorded" in warning
+        assert kb.get_task(conn, tid).status == "ready"
+        unblocked = [e for e in _events(conn, tid) if e["kind"] == "unblocked"]
+        assert unblocked[-1]["payload"] == {"actor": "alice"}
+
+
+def test_legacy_null_blocker_fails_open(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author=None)
+        assert kb.get_task(conn, tid).blocked_by is None
+        ok, err = kb.unblock_task(conn, tid, actor="alice")
+        assert ok is True
+        assert err is None
+        # The audit trail must say the block predates identity recording.
+        unblocked = [e for e in _events(conn, tid) if e["kind"] == "unblocked"]
+        assert unblocked[-1]["payload"] == {"actor": "alice", "legacy_blocker": True}
+
+
+def test_scheduled_unblock_not_affected_by_guard(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.schedule_task(conn, tid) is True
+        ok, err = kb.unblock_task(conn, tid, actor="alice")
+        assert ok is True
+        assert err is None
+
+
+def test_unblock_clears_blocked_by(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        kb.unblock_task(conn, tid, actor="bob")
+        assert kb.get_task(conn, tid).blocked_by is None
+
+
+def test_complete_clears_blocked_by(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        assert kb.complete_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.blocked_by is None
+
+
+def test_promote_clears_blocked_by(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+        ok, err = kb.promote_task(conn, tid, actor="bob")
+        assert ok is True
+        assert err is None
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.blocked_by is None
+
+
+def test_blocked_event_still_has_no_actor_payload(kanban_home):
+    """The blocked event payload is unchanged; identity lives in blocked_by."""
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="capability", author="alice")
+        blocked = [e for e in _events(conn, tid) if e["kind"] == "blocked"]
+        assert blocked[-1]["payload"] == {
+            "reason": "review-required: please check",
+            "kind": "capability",
+            "recurrences": 1,
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI layer: `hermes kanban unblock` + --override-self
+# ---------------------------------------------------------------------------
+
+
+def _unblock_ns(task_id, *, reason=None, override_self=False):
+    return argparse.Namespace(
+        task_ids=[task_id],
+        reason=reason,
+        override_self=override_self,
+    )
+
+
+def test_cli_self_unblock_refused_without_override(kanban_home, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_PROFILE", "alice")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+    rc = kb_cli._cmd_unblock(_unblock_ns(tid))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "override" in err
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_cli_self_unblock_with_override_succeeds(kanban_home, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_PROFILE", "alice")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+    rc = kb_cli._cmd_unblock(_unblock_ns(tid, override_self=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"Unblocked {tid}" in out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_cli_different_profile_unblocks_without_flag(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE", "bob")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="needs_input", author="alice")
+    rc = kb_cli._cmd_unblock(_unblock_ns(tid))
+    assert rc == 0
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_cli_transient_self_unblock_warns(kanban_home, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_PROFILE", "alice")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="transient", author="alice")
+    rc = kb_cli._cmd_unblock(_unblock_ns(tid))
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "warning" in err
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# Tool layer: kanban_unblock override_self
+# ---------------------------------------------------------------------------
+
+
+def test_tool_self_unblock_refused_without_override(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="capability", author="orchestrator")
+    from tools import kanban_tools as kt
+    out = json.loads(kt._handle_unblock({"task_id": tid}))
+    assert out.get("ok") is not True
+    assert "override" in out.get("error", "")
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_tool_self_unblock_with_override_succeeds(kanban_home, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    with kb.connect() as conn:
+        tid = _blocked_task(conn, kind="capability", author="orchestrator")
+    from tools import kanban_tools as kt
+    out = json.loads(kt._handle_unblock({"task_id": tid, "override_self": True}))
+    assert out["ok"] is True
+    assert out["status"] == "ready"
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "ready"

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -833,7 +833,8 @@ def _(home, kb):
         # complete/block/unblock on archived should all refuse.
         assert kb.complete_task(conn, tid) is False
         assert kb.block_task(conn, tid, reason="no") is False
-        assert kb.unblock_task(conn, tid) is False
+        ok, _note = kb.unblock_task(conn, tid)
+        assert ok is False
         print("  archived task cannot be resurrected via normal APIs")
     finally:
         conn.close()

--- a/tests/stress/test_concurrency_mixed.py
+++ b/tests/stress/test_concurrency_mixed.py
@@ -53,7 +53,7 @@ def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:
                 ).fetchone()
                 if row:
                     try:
-                        ok = kb.unblock_task(conn, row["id"])
+                        ok, _note = kb.unblock_task(conn, row["id"])
                         events.append({"kind": "unblocked" if ok else "unblock_noop",
                                        "task": row["id"], "worker": worker_id})
                     except sqlite3.OperationalError as e:

--- a/tests/stress/test_property_fuzzing.py
+++ b/tests/stress/test_property_fuzzing.py
@@ -194,7 +194,7 @@ def random_op(rng, conn, kb, task_pool):
         ok = kb.block_task(conn, tid, reason=reason)
         return {"op": "block", "tid": tid, "ok": ok}
     if op == "unblock":
-        ok = kb.unblock_task(conn, tid)
+        ok, _note = kb.unblock_task(conn, tid)
         return {"op": "unblock", "tid": tid, "ok": ok}
     if op == "archive":
         ok = kb.archive_task(conn, tid)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -865,6 +865,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                author=os.environ.get("HERMES_PROFILE") or "worker",
             )
             if not ok:
                 return tool_error(
@@ -1489,14 +1490,30 @@ def _handle_unblock(args: dict, **kw) -> str:
     if ownership_err:
         return ownership_err
     board = args.get("board")
+    override_self, bool_err = _parse_bool_arg(args, "override_self", default=False)
+    if bool_err:
+        return tool_error(f"kanban_unblock: {bool_err}")
     try:
         kb, conn = _connect(board=board)
         try:
-            ok = kb.unblock_task(conn, str(tid))
+            ok, note = kb.unblock_task(
+                conn,
+                str(tid),
+                actor=os.environ.get("HERMES_PROFILE") or "worker",
+                override_self=override_self,
+            )
             if not ok:
-                return tool_error(f"could not unblock {tid} (not blocked or unknown)")
+                return tool_error(f"could not unblock {tid}: {note or 'not blocked or unknown'}")
             task = kb.get_task(conn, str(tid))
-            return _ok(task_id=str(tid), status=task.status if task else None)
+            fields: dict[str, Any] = {
+                "task_id": str(tid),
+                "status": task.status if task else None,
+            }
+            if note:
+                # The unblock went through but the caller matched the recorded
+                # blocker (programmatic block kind) — surface the warning.
+                fields["warning"] = note
+            return _ok(**fields)
         finally:
             conn.close()
     except ValueError as e:
@@ -2103,7 +2120,10 @@ KANBAN_UNBLOCK_SCHEMA = {
         "Unblock a Kanban task. It moves to ready when all parents are done, "
         "or todo while any parent remains open. Orchestrator-only — only "
         "profiles with the kanban toolset can unblock routed work; "
-        "dispatcher-spawned task workers never see this tool."
+        "dispatcher-spawned task workers never see this tool. If the caller's "
+        "profile matches the profile that posted the block on a human-gate "
+        "(needs-input / capability) block, the unblock is refused unless "
+        "override_self=true acknowledges a deliberate self-unblock."
     ),
     "parameters": {
         "type": "object",
@@ -2111,6 +2131,15 @@ KANBAN_UNBLOCK_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": "Blocked task id to move to ready or parent-gated todo.",
+            },
+            "override_self": {
+                "type": "boolean",
+                "description": (
+                    "Acknowledge a deliberate self-unblock. Required when this "
+                    "caller's profile matches the profile that posted the block "
+                    "on a human-gate block. Self-unblocks are recorded on the "
+                    "task audit trail."
+                ),
             },
             "board": _board_schema_prop(),
         },

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -284,6 +284,19 @@ parent, missing input, unmet capability) before unblocking, or raise
 `BLOCK_RECURRENCE_LIMIT` if the loop is expected.
 :::
 
+:::note Who may unblock
+`unblock` records the caller's profile on the task audit trail, and the board
+remembers which profile posted the current block (`blocked_by`). When the same
+profile tries to unblock a **human-gate block** (`needs_input`, `capability`,
+or an un-typed legacy block — including the `review-required:` convention),
+the command refuses unless you pass `--override-self` to explicitly
+acknowledge the self-unblock. This stops a worker from silently lifting its
+own review-required gate; the override is recorded in the audit trail
+(`override_self: true` on the `unblocked` event). Programmatic `transient`
+blocks from the same profile proceed with a warning. Tasks blocked before the
+identity column existed have no recorded blocker and unblock normally.
+:::
+
 ## How workers interact with the board
 
 **Workers do not shell out to `hermes kanban`.** When the dispatcher spawns a worker it sets `HERMES_KANBAN_TASK=t_abcd` in the child's env, and that env var flips on a dedicated **kanban toolset** in the model's schema. The same toolset is also available to orchestrator profiles that enable `kanban` in their toolsets config. These tools read and mutate the board directly via the Python `kanban_db` layer, same as the CLI does. A running worker calls these like any other tool; it never sees or needs the `hermes kanban` CLI.
@@ -301,7 +314,7 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_attachments` | List a task's attachments. | — |
 | `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
-| `kanban_unblock` | (Orchestrators) move a blocked task to `ready` when all parents are done, or `todo` while any parent remains open. | `task_id` |
+| `kanban_unblock` | (Orchestrators) move a blocked task to `ready` when all parents are done, or `todo` while any parent remains open. Refuses to lift a human-gate block posted by the same profile unless `override_self=true` acknowledges the self-unblock. | `task_id` |
 
 A typical worker turn looks like:
 


### PR DESCRIPTION
## Summary

Closes #75319.

`hermes kanban unblock` performed no caller-identity check: a worker could
lift its own `review-required` block via the CLI, silently defeating the
documented human-in-the-loop gate, and the audit trail recorded no actor on
either the `blocked` or `unblocked` event, so operator approval was
indistinguishable from self-approval.

This PR makes the gate explicit and auditable:

- **`tasks.blocked_by`** — `block_task` now records the caller's profile
  (new nullable column, additive migration; NULL on legacy rows).
- **Self-unblock guard** — `unblock_task` refuses when the caller's profile
  matches `blocked_by` on a human-gate block (`needs_input`, `capability`,
  or an un-typed legacy block — including the `review-required:` reason
  convention) unless the caller explicitly acknowledges the self-unblock:
  `--override-self` on the CLI, `override_self=true` on the
  `kanban_unblock` tool.
- **Programmatic blocks** (`transient`) from the matching caller proceed
  with a recorded warning.
- **Legacy rows fail open** — tasks blocked before identity recording
  existed have no blocker to compare; the unblock proceeds and the audit
  event marks `legacy_blocker: true`.
- **Audit trail** — the `unblocked` event now carries `actor`,
  `override_self`, and `legacy_blocker`; `blocked_by` is cleared on
  unblock / complete / promote.

### Surfaces

| Surface | Change |
|---|---|
| `hermes kanban block` | passes caller profile as `blocked_by` |
| `hermes kanban unblock` | new `--override-self` flag; records actor |
| `kanban_unblock` tool | new `override_self` boolean param (orchestrator-only tool, unchanged gating) |
| kanban dashboard | unblocks record `actor="dashboard"` (the dashboard's session-token auth is explicitly not multi-user — see plugin header) |

### Migration

Additive, automatic: a new nullable `tasks.blocked_by` column is added via
the existing `_migrate_add_optional_columns` path (no manual steps, no data
rewrite). Existing rows keep `blocked_by = NULL`, which the guard treats as
"unknown blocker" and fails open. New installs get the column from
`SCHEMA_SQL` directly.

### Design decision (issue is labeled `needs-decision`)

The issue suggested either (a) warn/flag on matching identities or
(b) require an explicit override. This PR implements (b) — hard refusal
with an explicit, audit-recorded override — for human-gate blocks, and
(a) — warn + record — for programmatic `transient` blocks. Rationale: a
silent warning is exactly what the reporter's worker ignored; an explicit
flag makes the self-approval visible on the audit trail while keeping the
legitimate stale-block-clearance workflow possible.

### Testing

- New `tests/hermes_cli/test_kanban_self_unblock_guard.py` (19 tests):
  refusal per kind, override path, different-actor zero-friction path,
  transient warning, legacy fail-open + `legacy_blocker` marker, event
  payload assertions, CLI and tool surfaces.
- Existing kanban suites updated for the `(ok, note)` return contract
  (mirrors `promote_task`); all pass.
- End-to-end via the CLI binary: self-unblock refused (exit 1, single
  clear error), `--override-self` succeeds, a different-profile operator
  unblocks with no flag, audit event records the actor.
- Docs: `website/docs/user-guide/features/kanban.md` — "Who may unblock"
  note and `kanban_unblock` tool row updated.

### API contract note

`unblock_task` now returns `(ok, note)` instead of a bare bool — matching
the existing `promote_task` contract. All in-repo callers are migrated; the
`unblocked` event payload additionally carries `actor`, `override_self`,
and `legacy_blocker` fields (ignored by existing consumers, which key on
event `kind`).

### Related

- #28712 / #28903 (dispatcher auto-promotion) — closed, different bug
  class; this PR is about *intentional* self-unblock, not accidental
  promotion.
- #39609 (no-actor auto-promotion on `--initial-status blocked`) — still
  open; related in spirit (actor-less transitions) but not covered here.

## Notes

**Open question:** flag naming. The issue suggested `--i-am-not-the-blocker`
style naming; this PR uses `--override-self` (the flag acknowledges a
deliberate self-unblock — the caller *is* the blocker in this path).
Happy to rename if maintainers prefer a different convention.

**Open question:** severity. Filed as P3; the failure mode silently defeats
a documented authorization gate. Worth re-triaging to P2?
