### PR TITLE
fix(gateway): keep provider failures out of chat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -645,23 +645,13 @@ def _format_exec_approval_fallback(
 
 
 def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
-    if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
-    if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
-        )
-    if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
-    )
+    """Return one provider-agnostic failure message for human chat surfaces.
+
+    Provider names, account state, billing guidance, model names, and raw HTTP
+    details belong in logs only. Keeping one stable sentence also prevents
+    retry/status paths from revealing progressively more detail.
+    """
+    return "⚠️ I couldn’t complete that request. Please try again shortly."
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
@@ -672,6 +662,19 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"|rate\s+limited\s+after\s+\d+\s+retries"
     r"|error\s+code\s*:"
     r"|http\s*\d{3}\b"
+    r"|incorrect\s+api\s+key"
+    r"|invalid\s+api\s+key"
+    r")",
+    re.IGNORECASE,
+)
+
+_GATEWAY_STRONG_PROVIDER_ERROR_SHAPE_RE = re.compile(
+    r"^\s*(\W*\s*)?("
+    r"api\s+(?:call\s+)?failed"
+    r"|provider\s+authentication\s+failed"
+    r"|non-retryable\s+error"
+    r"|rate\s+limited\s+after\s+\d+\s+retries"
+    r"|error\s+code\s*:"
     r"|incorrect\s+api\s+key"
     r"|invalid\s+api\s+key"
     r")",
@@ -695,8 +698,13 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     if not text:
         return False
     body = str(text).strip()
-    # Provider failure envelopes are short. Assistant answers that happen
-    # to mention HTTP status codes ("HTTP 404 means...") tend to be longer.
+    # Strong provider envelopes remain errors even when an SDK appends a long
+    # JSON payload, request id, account guidance, or retry diagnostics. The old
+    # 400-character ceiling leaked exactly those expanded failures.
+    if _GATEWAY_STRONG_PROVIDER_ERROR_SHAPE_RE.search(body):
+        return True
+    # Bare "HTTP NNN" is ambiguous (an assistant may be explaining HTTP), so
+    # retain the conservative short-envelope heuristic for that shape alone.
     if len(body) > 400 or body.count("\n") > 4:
         return False
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
@@ -754,7 +762,9 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text)
+        # Retry/status callbacks are diagnostics, not a first chat reply. The
+        # final-result path emits the single safe failure sentence.
+        return None
     return text
 
 
@@ -5601,7 +5611,15 @@ class TurnRunner:
             )
             final_response = _sanitize_gateway_final_response(ctx.source.platform, final_response)
             if not final_response:
-                final_response = f"⚠️ {result['error']}" if result.get("error") else ""
+                raw_error = result.get("error")
+                final_response = (
+                    _sanitize_gateway_final_response(
+                        ctx.source.platform,
+                        f"API call failed: {raw_error}",
+                    )
+                    if raw_error
+                    else ""
+                )
             return {
                 "final_response": final_response,
                 "messages": result.get("messages", []),
@@ -19794,9 +19812,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             result = await self._run_in_executor_with_context(run_sync)
 
-            response = result.get("final_response", "") if result else ""
-            if not response and result and result.get("error"):
-                response = f"Error: {result['error']}"
+            response = result.get("final_response", "") if isinstance(result, dict) else ""
+            if not response and isinstance(result, dict) and result.get("error"):
+                raw_error = result.get("error")
+                response = _sanitize_gateway_final_response(
+                    source.platform,
+                    f"API call failed: {raw_error}",
+                )
 
             # Extract media files from the response
             if response:
@@ -19883,7 +19905,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
+                    content=_sanitize_gateway_final_response(
+                        source.platform,
+                        f"API call failed: {e}",
+                    ),
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -681,6 +681,14 @@ _GATEWAY_STRONG_PROVIDER_ERROR_SHAPE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_PROVIDER_ERROR_PREFIX_RE = re.compile(
+    r"^\s*(?:\W+\s*)?(?:"
+    r"the\s+request\s+failed\s*:"
+    r"|(?:[A-Za-z_]\w*\.)*[A-Za-z_]\w*(?:Error|Exception)\s*:"
+    r")\s*",
+    re.IGNORECASE,
+)
+
 
 def _looks_like_gateway_provider_error(text: str) -> bool:
     """True when text is infrastructure/provider failure, not normal content.
@@ -698,10 +706,20 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     if not text:
         return False
     body = str(text).strip()
+    # Normalization and provider SDKs can prepend a small chain of envelopes,
+    # e.g. ``The request failed: AuthenticationError: Incorrect API key``.
+    # Peel only those anchored prefixes so markers buried in assistant prose
+    # remain ineligible for the provider-error rewrite.
+    strong_candidate = body
+    for _ in range(4):
+        prefix = _GATEWAY_PROVIDER_ERROR_PREFIX_RE.match(strong_candidate)
+        if not prefix:
+            break
+        strong_candidate = strong_candidate[prefix.end():]
     # Strong provider envelopes remain errors even when an SDK appends a long
     # JSON payload, request id, account guidance, or retry diagnostics. The old
     # 400-character ceiling leaked exactly those expanded failures.
-    if _GATEWAY_STRONG_PROVIDER_ERROR_SHAPE_RE.search(body):
+    if _GATEWAY_STRONG_PROVIDER_ERROR_SHAPE_RE.search(strong_candidate):
         return True
     # Bare "HTTP NNN" is ambiguous (an assistant may be explaining HTTP), so
     # retain the conservative short-envelope heuristic for that shape alone.

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -195,8 +195,8 @@ def test_chat_gateways_redact_secret_in_provider_error(platform):
     assert "sk-ABCDEF0123456789abcdef0123" not in sanitized
     assert "sk-ABCDEF" not in sanitized
     assert "HTTP 401" not in sanitized
-    # The user gets the safe provider-error category instead of the raw body.
-    assert "provider" in sanitized.lower()
+    # The user gets one provider-agnostic sentence instead of the raw body.
+    assert sanitized == "⚠️ I couldn’t complete that request. Please try again shortly."
 
 
 @pytest.mark.parametrize("platform", ["slack", "matrix"])
@@ -255,8 +255,8 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
-def test_telegram_status_sanitizes_raw_provider_security_errors():
-    """Provider policy/security bodies should be replaced before chat delivery."""
+def test_telegram_status_suppresses_raw_provider_security_errors():
+    """Provider retry/status diagnostics must not create a first chat reply."""
     raw = (
         "❌ API failed after 3 retries — HTTP 400: request blocked because "
         "Operation contains cybersecurity risk. request_id=req_123"
@@ -264,11 +264,7 @@ def test_telegram_status_sanitizes_raw_provider_security_errors():
 
     sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw)
 
-    assert sanitized is not None
-    assert "provider rejected" in sanitized.lower()
-    assert "cybersecurity risk" not in sanitized.lower()
-    assert "HTTP 400" not in sanitized
-    assert "req_123" not in sanitized
+    assert sanitized is None
 
 
 def test_telegram_final_response_sanitizes_raw_provider_errors():
@@ -280,14 +276,14 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
 
     sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
 
-    assert "provider rejected" in sanitized.lower()
+    assert sanitized == "⚠️ I couldn’t complete that request. Please try again shortly."
     assert "cybersecurity risk" not in sanitized.lower()
     assert "HTTP 400" not in sanitized
     assert "req_abc" not in sanitized
 
 
-def test_telegram_final_response_redacts_auth_secrets():
-    """Authentication errors should be useful without leaking key material."""
+def test_telegram_final_response_hides_auth_and_account_details():
+    """Authentication/account errors use the same provider-agnostic copy."""
     raw = (
         "⚠️ Provider authentication failed: Incorrect API key provided: "
         "sk-live_abcdefghijklmnopqrstuvwxyz1234567890"
@@ -295,9 +291,34 @@ def test_telegram_final_response_redacts_auth_secrets():
 
     sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
 
-    assert "authentication failed" in sanitized.lower()
-    assert "check the configured credentials" in sanitized.lower()
+    assert sanitized == "⚠️ I couldn’t complete that request. Please try again shortly."
     assert "sk-live" not in sanitized
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_long_expanded_provider_failure_is_one_safe_reply(platform):
+    """Expanded SDK payloads over 400 chars must never bypass sanitization."""
+    raw = (
+        "API call failed after 3 retries. Error code: 400 - "
+        "{'type':'error','error':{'type':'invalid_request_error','message':"
+        "'Third-party apps now draw from your extra usage, not your plan limits. "
+        "Add more at vendor.example/settings/usage and keep going.'},"
+        "'request_id':'req_internal_123'} | provider=vendor model=secret-model "
+        + "diagnostic-padding-" * 20
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert sanitized == "⚠️ I couldn’t complete that request. Please try again shortly."
+    for forbidden in (
+        "provider",
+        "model",
+        "usage",
+        "request_id",
+        "HTTP",
+        "settings/usage",
+    ):
+        assert forbidden.lower() not in sanitized.lower()
 
 
 def test_telegram_final_response_keeps_normal_answers():

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -8,6 +8,7 @@ from agent.conversation_compression import (
 )
 from gateway.config import Platform
 from gateway.run import (
+    _normalize_empty_agent_response,
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
@@ -319,6 +320,49 @@ def test_long_expanded_provider_failure_is_one_safe_reply(platform):
         "settings/usage",
     ):
         assert forbidden.lower() not in sanitized.lower()
+
+
+def test_discord_normalized_sdk_auth_failure_is_one_safe_reply():
+    """Failed-turn normalization must not hide an SDK provider envelope."""
+    raw = (
+        "AuthenticationError: Incorrect API key provided: "
+        + "sk-"
+        + "test-not-real; account billing status=inactive; HTTP 401; "
+        "request_id=req_internal"
+    )
+    normalized = _normalize_empty_agent_response(
+        {"failed": True, "error": raw}, "", history_len=0
+    )
+
+    assert _sanitize_gateway_final_response("discord", normalized) == (
+        "⚠️ I couldn’t complete that request. Please try again shortly."
+    )
+
+
+def test_prefixed_long_sdk_provider_failure_is_one_safe_reply():
+    """Gateway and SDK prefixes must not expose expanded provider details."""
+    raw = (
+        "The request failed: openai.RateLimitError: Error code: 429 - "
+        "account billing status=inactive; request_id=req_internal; "
+        + "diagnostic-padding-" * 30
+    )
+
+    assert _sanitize_gateway_final_response("discord", raw) == (
+        "⚠️ I couldn’t complete that request. Please try again shortly."
+    )
+
+
+def test_long_http_explanation_after_ordinary_prose_is_preserved():
+    """An HTTP marker buried in normal assistant prose is not an envelope."""
+    answer = (
+        "Here is a detailed explanation for your application. HTTP 401 means "
+        "the request lacks valid authentication credentials; check how your "
+        "client constructs its Authorization header, confirm the token scope, "
+        "and retry only after correcting the credentials. "
+        + "Additional troubleshooting context. " * 20
+    )
+
+    assert _sanitize_gateway_final_response("discord", answer) == answer
 
 
 def test_telegram_final_response_keeps_normal_answers():


### PR DESCRIPTION
## Summary
- replace human-facing provider/auth/billing failures with one provider-agnostic retry message
- suppress intermediate provider retry/status notices so chat receives one final failure reply
- sanitize empty-result and background-task fallback paths instead of sending raw exceptions
- recognize expanded SDK error envelopes longer than 400 characters

## Tests
- `python -m pytest tests/gateway/test_telegram_noise_filter.py -q` (136 passed)
- `python -m pytest tests/test_lazy_session_regressions.py::TestGatewaySurfacesNullResponse -q` (3 passed)
- `python -m ruff check gateway/run.py tests/gateway/test_telegram_noise_filter.py`
- `python -m py_compile gateway/run.py`
- `git diff --check`