### PR TITLE
fix(stt): repair idle-unload watcher lifecycle

### DIFF
--- a/tests/tools/test_stt_idle_unload.py
+++ b/tests/tools/test_stt_idle_unload.py
@@ -24,6 +24,7 @@ Contract under test:
 """
 
 import struct
+import threading
 import time
 import wave
 from unittest.mock import MagicMock, patch
@@ -281,3 +282,137 @@ class TestUnloadDuringTranscriptionRace:
 
         assert result["success"] is True, result.get("error")
         assert result["transcript"] == "hello"
+
+
+# ============================================================================
+# Watcher lifecycle: the slot must always be reclaimable, and a resident model
+# must always end up watched.
+# ============================================================================
+
+
+class TestIdleUnloadWatcherLifecycle:
+
+    @staticmethod
+    def _silent_wav(tmp_path):
+        wav_path = tmp_path / "a.wav"
+        n = 16000
+        with wave.open(str(wav_path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(struct.pack(f"<{n}h", *([0] * n)))
+        return wav_path
+
+    def test_stop_idle_unload_watcher_stops_a_running_watcher(self):
+        """``_idle_unload_stop`` needs a setter — nothing in the codebase set it.
+
+        The event was waited on and cleared on start, but never set, so a live
+        watcher could not be shut down by any code path.
+        """
+        mock_model = MagicMock(name="whisper_model")
+        try:
+            with patch.object(tt, "_local_model", mock_model), \
+                 patch.object(tt, "_local_model_name", "base"), \
+                 patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.5), \
+                 patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 100}}), \
+                 patch.object(tt, "_last_transcription_time", time.monotonic()):
+                _start_idle_unload_watcher(timeout_seconds=100)
+                thread = tt._idle_unload_thread
+                assert thread is not None and thread.is_alive()
+
+                tt._stop_idle_unload_watcher(timeout=5)
+
+                assert not thread.is_alive(), "watcher ignored the stop signal"
+                assert tt._idle_unload_running is False
+                # Stopped, not unloaded — stopping is not an eviction.
+                assert tt._local_model is mock_model
+        finally:
+            tt._idle_unload_stop.clear()
+
+    def test_stale_alive_thread_does_not_block_a_new_watcher(self):
+        """A watcher past its loop but not yet torn down must not wedge the slot.
+
+        Guarding on ``Thread.is_alive()`` dropped the start request during that
+        teardown window, leaving the model resident with nothing watching it.
+        """
+        parked = threading.Event()
+        stale = threading.Thread(target=parked.wait, name="stale-watcher", daemon=True)
+        stale.start()
+        mock_model = MagicMock(name="whisper_model")
+        original_thread = tt._idle_unload_thread
+        original_running = tt._idle_unload_running
+        try:
+            # The previous watcher's thread object is still alive, but the
+            # watcher body has already released its slot.
+            tt._idle_unload_thread = stale
+            tt._idle_unload_running = False
+            with patch.object(tt, "_local_model", mock_model), \
+                 patch.object(tt, "_local_model_name", "base"), \
+                 patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.5), \
+                 patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 100}}), \
+                 patch.object(tt, "_last_transcription_time", time.monotonic()):
+                _start_idle_unload_watcher(timeout_seconds=100)
+
+                assert tt._idle_unload_thread is not stale, \
+                    "a stale-but-alive thread blocked a new watcher"
+                assert tt._idle_unload_thread.is_alive()
+                tt._stop_idle_unload_watcher(timeout=5)
+        finally:
+            parked.set()
+            stale.join(timeout=2)
+            tt._idle_unload_thread = original_thread
+            tt._idle_unload_running = original_running
+            tt._idle_unload_stop.clear()
+
+    def test_watcher_is_armed_when_transcription_fails(self, tmp_path):
+        """A model that loaded and then failed must still end up watched.
+
+        Arming only on the success path left a loaded model resident with no
+        watcher until the next *successful* voice message — which, for a model
+        that keeps failing, never arrives.
+        """
+        wav_path = self._silent_wav(tmp_path)
+        mock_model = MagicMock(name="whisper_model")
+        mock_model.transcribe.side_effect = RuntimeError("decoder exploded")
+        try:
+            with patch.object(tt, "_HAS_FASTER_WHISPER", True), \
+                 patch.object(tt, "_IDLE_UNLOAD_CHECK_INTERVAL", 0.5), \
+                 patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 100}}), \
+                 patch.object(tt, "_local_model", mock_model), \
+                 patch.object(tt, "_local_model_name", "base"):
+                from tools.transcription_tools import _transcribe_local
+
+                result = _transcribe_local(str(wav_path), "base")
+
+                assert result["success"] is False
+                assert tt._idle_unload_running is True, \
+                    "failed transcription left the model resident with no watcher"
+                assert tt._idle_unload_thread is not None
+                assert tt._idle_unload_thread.is_alive()
+        finally:
+            tt._stop_idle_unload_watcher(timeout=5)
+            tt._idle_unload_stop.clear()
+
+    def test_watcher_not_armed_when_no_model_is_resident(self, tmp_path):
+        """No model loaded → nothing to watch → no thread spawned."""
+        wav_path = self._silent_wav(tmp_path)
+        original_running = tt._idle_unload_running
+        try:
+            with patch.object(tt, "_HAS_FASTER_WHISPER", True), \
+                 patch.object(tt, "_load_stt_config",
+                              return_value={"local": {"unload_after_idle_seconds": 100}}), \
+                 patch.object(tt, "_local_model", None), \
+                 patch.object(tt, "_local_model_name", None), \
+                 patch.object(tt, "_load_local_whisper_model", return_value=None):
+                from tools.transcription_tools import _transcribe_local
+
+                result = _transcribe_local(str(wav_path), "base")
+
+                assert result["success"] is False
+                assert tt._idle_unload_running is False
+        finally:
+            tt._idle_unload_running = original_running
+            tt._idle_unload_stop.clear()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -149,8 +149,14 @@ _local_model_lock = threading.Lock()
 _last_transcription_time: float = 0.0
 _idle_unload_thread: Optional[threading.Thread] = None
 _idle_unload_stop = threading.Event()
+# True from the moment a watcher is registered until that watcher's own
+# ``finally`` clears it. ``Thread.is_alive()`` is not a usable substitute: a
+# watcher that has already broken out of its loop keeps reporting alive while
+# the interpreter tears it down, and a start request landing in that window
+# would be dropped — leaving the model resident with nothing watching it.
+_idle_unload_running = False
 # Serializes watcher start checks so two concurrent transcriptions can't
-# both observe "no watcher alive" and spawn duplicates.
+# both observe "no watcher running" and spawn duplicates.
 _idle_unload_mgmt_lock = threading.Lock()
 
 _IDLE_UNLOAD_CHECK_INTERVAL = 30  # seconds between idle checks
@@ -1530,38 +1536,88 @@ def _start_idle_unload_watcher(timeout_seconds: int) -> None:
     ``timeout_seconds`` seeds the first cycle so a just-written config is
     honored even if a concurrent config read would race.
     """
-    global _idle_unload_thread
+    global _idle_unload_thread, _idle_unload_running
     with _idle_unload_mgmt_lock:
-        if _idle_unload_thread is not None and _idle_unload_thread.is_alive():
+        if _idle_unload_running:
             return
 
         def _watch(initial_timeout=timeout_seconds):
+            global _idle_unload_running
             timeout = initial_timeout
-            while not _idle_unload_stop.is_set():
-                if _idle_unload_stop.wait(_IDLE_UNLOAD_CHECK_INTERVAL):
-                    break
-                if _local_model is None:
-                    break
-                # Re-read the timeout each cycle: config edits apply without
-                # waiting for the next voice message.
-                try:
-                    timeout = _get_idle_unload_seconds(
-                        _load_stt_config().get("local") or {}
-                    )
-                except Exception:  # noqa: BLE001 - keep the seed value
-                    timeout = initial_timeout
-                if timeout <= 0:
-                    break  # unload disabled mid-flight — stand down
-                idle_for = time.monotonic() - _last_transcription_time
-                if idle_for >= timeout:
-                    _unload_local_model()
-                    break
+            try:
+                while not _idle_unload_stop.is_set():
+                    if _idle_unload_stop.wait(_IDLE_UNLOAD_CHECK_INTERVAL):
+                        break
+                    if _local_model is None:
+                        break
+                    # Re-read the timeout each cycle: config edits apply without
+                    # waiting for the next voice message.
+                    try:
+                        timeout = _get_idle_unload_seconds(
+                            _load_stt_config().get("local") or {}
+                        )
+                    except Exception:  # noqa: BLE001 - keep the seed value
+                        timeout = initial_timeout
+                    if timeout <= 0:
+                        break  # unload disabled mid-flight — stand down
+                    idle_for = time.monotonic() - _last_transcription_time
+                    if idle_for >= timeout:
+                        _unload_local_model()
+                        break
+            finally:
+                # Release the slot from inside the thread, so the next
+                # transcription can always arm a fresh watcher no matter how
+                # this one exited (unload, stand-down, stop, or exception).
+                with _idle_unload_mgmt_lock:
+                    _idle_unload_running = False
 
         _idle_unload_stop.clear()
+        _idle_unload_running = True
         _idle_unload_thread = threading.Thread(
             target=_watch, name="hermes-stt-idle-unload", daemon=True
         )
         _idle_unload_thread.start()
+
+
+def _stop_idle_unload_watcher(timeout: float = 5.0) -> None:
+    """Signal the idle-unload watcher to exit and wait for it.
+
+    ``_idle_unload_stop`` previously had no setter anywhere in the codebase:
+    the event was waited on and cleared on start, but nothing ever set it, so a
+    running watcher could not be shut down. This is that missing half — used by
+    orderly shutdown paths and by tests that must not leak a live thread into
+    the next test.
+
+    Safe to call from the watcher thread itself (skips the self-join) and safe
+    to call when no watcher is running.
+    """
+    _idle_unload_stop.set()
+    with _idle_unload_mgmt_lock:
+        thread = _idle_unload_thread
+    if (
+        thread is not None
+        and thread.is_alive()
+        and thread is not threading.current_thread()
+    ):
+        thread.join(timeout=timeout)
+
+
+def _arm_idle_unload_watcher() -> None:
+    """Start the idle-unload watcher if a model is resident and unload is on.
+
+    Called on *every* exit path of :func:`_transcribe_local`. Arming only on
+    success left a model that loaded and then failed to transcribe sitting in
+    RAM/VRAM with nothing watching it until the next *successful* voice
+    message — which, for a persistently failing model, never comes.
+    """
+    if _local_model is None:
+        return
+    try:
+        idle_timeout = _get_idle_unload_seconds(_load_stt_config().get("local") or {})
+    except Exception:  # noqa: BLE001 - never let cleanup mask the real result
+        return
+    if idle_timeout > 0:
+        _start_idle_unload_watcher(idle_timeout)
 
 
 def _touch_transcription_time() -> None:
@@ -1817,15 +1873,17 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         )
 
         _touch_transcription_time()
-        idle_timeout = _get_idle_unload_seconds(local_cfg)
-        if idle_timeout > 0:
-            _start_idle_unload_watcher(idle_timeout)
 
         return {"success": True, "transcript": transcript, "provider": "local"}
 
     except Exception as e:
         logger.error("Local transcription failed: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+    finally:
+        # Arm on every exit path, not just success: the early "model failed to
+        # load" return and any mid-transcribe exception both leave a loaded
+        # model behind that still needs watching.
+        _arm_idle_unload_watcher()
 
 
 def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
## What does this PR do?

Fixes three lifecycle defects in the STT idle-unload watcher added by 7b006ea6 /
72c63aa5. Each one ends the same way: the whisper model stays resident in RAM/VRAM
with nothing watching it, which is exactly the leak the feature was built to close.

**1. The stop event has no setter.** `_idle_unload_stop` is waited on
(`transcription_tools.py:1546`, `:1547`) and cleared on start (`:1571`), but
`.set()` appears **nowhere in the codebase** — the only caller is a test doing its
own cleanup. The kill-switch was wired up but never connected, so no code path
could shut a running watcher down. Adds `_stop_idle_unload_watcher()`.

**2. `Thread.is_alive()` is the wrong readiness signal.** The start guard was
`if _idle_unload_thread is not None and _idle_unload_thread.is_alive(): return`.
A watcher that has already `break`ed out of its loop keeps reporting alive while
the interpreter tears it down. A start request landing in that window is silently
dropped — model resident, no watcher. Replaced with an explicit
`_idle_unload_running` flag that the watcher clears in its **own `finally`**, so
the slot is released no matter how the thread exits (unload, stand-down, stop, or
exception).

**3. The watcher is only armed on the success path.** `_start_idle_unload_watcher`
was called after the final `logger.info` in `_transcribe_local`. A transcription
that loads the model and *then* raises — CUDA blowing up mid-decode, corrupt
audio — returns through `except` and never arms anything. For a model that keeps
failing, the next *successful* voice message never comes, so the model is pinned
until the process restarts. Moved to a `finally` via `_arm_idle_unload_watcher()`,
which no-ops when no model is resident.

## Related Issue

No existing issue — found by auditing 72c63aa5 after it merged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py` — added `_idle_unload_running`, guarded on it
  instead of `is_alive()`, and cleared it from the watcher's own `finally`.
- `tools/transcription_tools.py` — new `_stop_idle_unload_watcher()`; sets the
  event and joins, skipping a self-join if called from the watcher thread.
- `tools/transcription_tools.py` — new `_arm_idle_unload_watcher()`, called from
  a `finally` in `_transcribe_local` so every exit path arms the watcher.
- `tests/tools/test_stt_idle_unload.py` — new `TestIdleUnloadWatcherLifecycle`
  with four regression tests.

## How to Test

1. `./scripts/run_tests.sh tests/tools/test_stt_idle_unload.py` → 21 passed.
2. Restore the pre-fix `tools/transcription_tools.py` and re-run → **17 passed,
   4 failed**: all four new tests fail, and every pre-existing test still passes.
   The tests pin the fix, not the implementation.
3. Wider check: `tests/tools/test_stt_idle_unload.py`,
   `tests/tools/test_transcription_tools.py`,
   `tests/agent/test_transcription_registry.py`, and five `tests/gateway/` STT
   files → **173 passed, 0 failed**.

### Note on unrelated failures in `tests/tools/`

45 tests across 16 files fail on this machine (`test_daytona_environment.py`,
`test_computer_use.py`, `test_image_generation.py`, six `test_mcp_*.py`, and
others). They are pre-existing and unrelated — verified by running the same files
against an unmodified `tools/transcription_tools.py` and getting identical counts.
They appear to need optional SDKs that aren't installed here.

`test_transcription_tools.py::TestRunCommandSttIdleTimeout::test_stderr_progress_extends_beyond_timeout`
is separately flaky under heavy parallelism — it fails intermittently in a
24-worker run and passes in isolation, on both patched and unpatched trees.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the STT suites; see the note above re: pre-existing failures
      elsewhere in `tests/tools/` that are unaffected by this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8.0-84-generic)

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] N/A — no config keys changed (`stt.local.unload_after_idle_seconds` is
      unchanged and still honored mid-flight)
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: pure threading/control-flow change, no platform-specific behavior
- [x] N/A — no tool description/schema change
