### PR TITLE
feat(feishu): add single editable turn status lifecycle

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -58,6 +58,9 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Feishu can opt into one persistent per-turn status message that tool
+    # progress edits in place and the delivery lifecycle finalizes.
+    "turn_status_message": False,
     # Live working-state status on platforms whose typing indicator renders
     # text (Slack's assistant status line). Values:
     #   "full" / true  -> verb + argument preview ("is running pytest…")
@@ -148,7 +151,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     },
     "mattermost":      _TIER_MEDIUM,
     "matrix":          _TIER_MEDIUM,
-    "feishu":          _TIER_MEDIUM,
+    "feishu":          {
+        **_TIER_MEDIUM,
+        "turn_status_message": True,
+        "interim_assistant_messages": False,
+    },
 
     # Tier 3 — no edit support, progress messages are permanent
     "signal":          _TIER_LOW,
@@ -274,6 +281,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "busy_ack_detail",
         "busy_steer_ack_enabled",
         "thinking_progress",
+        "turn_status_message",
     }:
         if isinstance(value, str):
             val = value.strip().lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3749,6 +3749,12 @@ class TurnRunner:
         if not ctx.progress_queue or not ctx._run_still_current():
             return
 
+        # Feishu's status counter is driven by the completion event itself.
+        # Queue it before the onboarding-hint branch, which intentionally
+        # returns for the first completed tool.
+        if event_type == "tool.completed" and ctx.turn_status_enabled:
+            ctx.progress_queue.put(("__status_completed__",))
+
         # First-touch onboarding: the first time a tool takes longer than
         # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
         # (progress_mode == "all"), append a one-time hint suggesting
@@ -3793,11 +3799,12 @@ class TurnRunner:
             return
 
         # If tool_progress is off, only _thinking passes through (above).
-        # Regular tool calls are suppressed.
-        if not ctx.tool_progress_enabled:
+        # Regular tool calls are suppressed unless Feishu's single status
+        # message needs lifecycle events to keep its counters accurate.
+        if not ctx.tool_progress_enabled and not ctx.turn_status_enabled:
             return
 
-        # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+        # Only tool.started produces a visible history row.
         if event_type not in {"tool.started",}:
             return
 
@@ -3973,7 +3980,11 @@ class TurnRunner:
         if not ctx.progress_queue:
             return
 
-        adapter = self._runner._adapter_for_source(ctx.source)
+        adapter = (
+            ctx._turn_status_adapter
+            if ctx.turn_status_enabled and ctx._turn_status_adapter is not None
+            else self._runner._adapter_for_source(ctx.source)
+        )
         if not adapter:
             return
 
@@ -3993,8 +4004,9 @@ class TurnRunner:
             return
 
         progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
-        progress_msg_id = None   # ID of the current progress message to edit
-        can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+        progress_msg_id = ctx.status_message_id  # Feishu may pre-create the one turn-status bubble
+        turn_completed_count = 0
+        can_edit = ctx.turn_status_enabled or ctx.progress_grouping != "separate"  # Feishu status always stays singular
         _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
         _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
@@ -4054,6 +4066,17 @@ class TurnRunner:
             return await adapter.edit_message(**kwargs)
 
         def _progress_text(lines: list) -> str:
+            if ctx.turn_status_enabled:
+                recent = lines[-5:]
+                current = str(recent[-1]) if recent else "處理中"
+                history = "\n".join(f"• {line}" for line in recent)
+                text = (
+                    f"處理中\n目前：{current}\n"
+                    f"已完成：{turn_completed_count} 個工具操作"
+                )
+                if history:
+                    text += f"\n\n最近：\n{history}"
+                return text
             return "\n".join(str(line) for line in lines)
 
         def _split_progress_groups(lines: list) -> list[list]:
@@ -4097,8 +4120,8 @@ class TurnRunner:
                 intact for a later retry.  In either case the caller should skip
                 the normal send/edit path for this tick.
                 """
-            nonlocal progress_msg_id, progress_lines, can_edit
-            if not progress_lines or not can_edit:
+            nonlocal progress_msg_id, progress_lines, can_edit, turn_completed_count
+            if ctx.turn_status_enabled or not progress_lines or not can_edit:
                 return False
             groups = _split_progress_groups(progress_lines)
             if len(groups) <= 1:
@@ -4161,8 +4184,13 @@ class TurnRunner:
                 except Exception:
                     pass
 
+                # Completion markers update the count without adding a second
+                # history row for the same tool call.
+                if isinstance(raw, tuple) and raw and raw[0] == "__status_completed__":
+                    turn_completed_count += 1
+                    msg = progress_lines[-1] if progress_lines else "處理中"
                 # Handle dedup messages: update last line with repeat counter
-                if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
                     if progress_lines:
                         progress_lines[-1] = f"{base_msg} (×{count + 1})"
@@ -4176,14 +4204,24 @@ class TurnRunner:
                     # order. Mirrors GatewayStreamConsumer.on_segment_break
                     # on the content side. (Issue: tool + content
                     # linearization regression after PR #7885.)
-                    progress_msg_id = None
-                    progress_lines = []
-                    ctx.last_progress_msg[0] = None
-                    ctx.repeat_count[0] = 0
+                    if not ctx.turn_status_enabled:
+                        progress_msg_id = None
+                        progress_lines = []
+                        ctx.last_progress_msg[0] = None
+                        ctx.repeat_count[0] = 0
                     continue
                 else:
-                    msg = raw
+                    msg = str(raw)
                     progress_lines.append(msg)
+
+                if ctx.turn_status_enabled and ctx.event_message_id:
+                    update_status = getattr(adapter, "update_turn_status_progress", None)
+                    if callable(update_status):
+                        update_status(
+                            ctx.status_lifecycle_id or ctx.event_message_id,
+                            tool_count=turn_completed_count,
+                            current_stage=str(msg),
+                        )
 
                 if await _roll_progress_overflow_if_needed():
                     _last_edit_ts = time.monotonic()
@@ -4210,7 +4248,7 @@ class TurnRunner:
 
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
+                    full_text = _progress_text(progress_lines)
                     result = await _edit_progress_message(progress_msg_id, full_text)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
@@ -4235,6 +4273,10 @@ class TurnRunner:
                             _last_edit_ts = time.monotonic()
                         else:
                             can_edit = False
+                        if ctx.turn_status_enabled:
+                            # Feishu's status contract is one message or none:
+                            # never degrade an edit failure into extra bubbles.
+                            continue
                         _flood_result = await adapter.send(
                             chat_id=ctx.source.chat_id,
                             content=msg,
@@ -4248,6 +4290,11 @@ class TurnRunner:
                         ):
                             ctx._cleanup_msg_ids.append(str(_flood_result.message_id))
                 else:
+                    if ctx.turn_status_enabled:
+                        # A permanent edit failure disables status updates for
+                        # the rest of the turn; never fall back to extra Feishu
+                        # progress bubbles.
+                        continue
                     if can_edit:
                         # First tool: send all accumulated text as new message
                         full_text = "\n".join(progress_lines)
@@ -4284,7 +4331,9 @@ class TurnRunner:
                 while not ctx.progress_queue.empty():
                     try:
                         raw = ctx.progress_queue.get_nowait()
-                        if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                        if isinstance(raw, tuple) and raw and raw[0] == "__status_completed__":
+                            turn_completed_count += 1
+                        elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                             _, base_msg, count = raw
                             if progress_lines:
                                 progress_lines[-1] = f"{base_msg} (×{count + 1})"
@@ -4300,16 +4349,25 @@ class TurnRunner:
                                     await _edit_progress_message(progress_msg_id, _pending_text)
                                 except Exception:
                                     pass
-                            progress_msg_id = None
-                            progress_lines = []
-                            ctx.last_progress_msg[0] = None
-                            ctx.repeat_count[0] = 0
+                            if not ctx.turn_status_enabled:
+                                progress_msg_id = None
+                                progress_lines = []
+                                ctx.last_progress_msg[0] = None
+                                ctx.repeat_count[0] = 0
                         else:
-                            progress_lines.append(raw)
+                            progress_lines.append(str(raw))
                             await _roll_progress_overflow_if_needed()
                     except Exception:
                         break
                 # Final edit with all remaining tools (only if editing works)
+                if ctx.turn_status_enabled and ctx.event_message_id and progress_lines:
+                    update_status = getattr(adapter, "update_turn_status_progress", None)
+                    if callable(update_status):
+                        update_status(
+                            ctx.status_lifecycle_id or ctx.event_message_id,
+                            tool_count=turn_completed_count,
+                            current_stage=str(progress_lines[-1]),
+                        )
                 if can_edit and progress_lines and progress_msg_id:
                     await _roll_progress_overflow_if_needed()
                 if can_edit and progress_lines and progress_msg_id:
@@ -24839,6 +24897,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source.platform != Platform.WEBHOOK
             and interim_assistant_messages_mode != "off"
         )
+        turn_status_enabled = (
+            source.platform == Platform.FEISHU
+            and is_truthy_value(
+                resolve_display_setting(
+                    user_config, platform_key, "turn_status_message"
+                ),
+                default=False,
+            )
+            and bool(event_message_id)
+        )
+        _turn_status_adapter = (
+            self._adapter_for_source(source) if turn_status_enabled else None
+        )
+        status_lifecycle_id = (
+            f"{event_message_id}:{run_generation}:{time.monotonic_ns()}"
+            if turn_status_enabled and event_message_id
+            else None
+        )
         # thinking_progress is independent — if enabled, we need the progress
         # queue even when tool_progress is off (thinking relay uses same infra).
         # Mattermost requires a per-platform opt-in: global scratch-text display
@@ -24849,7 +24925,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             require_platform_override_for={Platform.MATTERMOST},
         )
         _thinking_enabled = _thinking_mode != "off"
-        needs_progress_queue = tool_progress_enabled or _thinking_enabled
+        needs_progress_queue = (
+            tool_progress_enabled or _thinking_enabled or turn_status_enabled
+        )
 
 
         # Queue for progress messages (thread-safe)
@@ -24941,6 +25019,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             log_mode_enabled=log_mode_enabled,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
             needs_progress_queue=needs_progress_queue,
+            turn_status_enabled=turn_status_enabled,
+            status_lifecycle_id=status_lifecycle_id,
+            _turn_status_adapter=_turn_status_adapter,
             _voice_ack_fired=_voice_ack_fired,
             _voice_ack_guild=_voice_ack_guild,
             _voice_ack_loop=_voice_ack_loop,
@@ -25110,6 +25191,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         turn_ctx._progress_metadata = _progress_metadata
         turn_ctx._progress_reply_to = _progress_reply_to
         send_progress_messages = turn_runner.send_progress_messages
+
+        # Feishu's turn UI is one pre-created editable status message.  Tool
+        # callbacks only edit this ID; final delivery later drives the adapter's
+        # reaction/text lifecycle for both the inbound and status messages.
+        if turn_status_enabled:
+            # Bind terminal status cleanup to the adapter that creates this
+            # turn's status. The inbound adapter may be replaced by reconnect
+            # before final delivery, so a fresh registry lookup is not stable.
+            setattr(source, "_feishu_turn_status_adapter", _turn_status_adapter)
+            setattr(
+                source,
+                "_feishu_turn_status_lifecycle_id",
+                status_lifecycle_id,
+            )
+            try:
+                _status_result = await _turn_status_adapter.send(
+                    chat_id=source.chat_id,
+                    content="處理中",
+                    reply_to=_progress_reply_to,
+                    metadata=_progress_metadata,
+                )
+                if getattr(_status_result, "success", False) and getattr(
+                    _status_result, "message_id", None
+                ):
+                    turn_ctx.status_message_id = str(_status_result.message_id)
+                    _register_status = getattr(
+                        _turn_status_adapter, "register_turn_status_message", None
+                    )
+                    if callable(_register_status):
+                        _register_status(
+                            trigger_message_id=str(event_message_id),
+                            chat_id=str(source.chat_id),
+                            status_message_id=turn_ctx.status_message_id,
+                            lifecycle_id=status_lifecycle_id,
+                        )
+                    _start_status_reaction = getattr(
+                        _turn_status_adapter, "start_processing_reaction", None
+                    )
+                    if callable(_start_status_reaction):
+                        await _start_status_reaction(turn_ctx.status_message_id)
+                else:
+                    logger.warning(
+                        "[feishu] Could not create turn status message: %s",
+                        getattr(_status_result, "error", None) or "send failed",
+                    )
+            except Exception:
+                logger.warning(
+                    "[feishu] Could not create turn status message",
+                    exc_info=True,
+                )
         
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -64,6 +64,12 @@ class TurnContext:
     #     send_progress_messages is scheduled) ----------------------------
     _progress_metadata: Optional[dict] = None
     _progress_reply_to: Optional[Any] = None
+    # Feishu-only single editable status bubble for this turn.  It is created
+    # before agent execution and finalized by the adapter after final delivery.
+    turn_status_enabled: bool = False
+    status_message_id: Optional[str] = None
+    status_lifecycle_id: Optional[str] = None
+    _turn_status_adapter: Any = None
 
     # ------------------------------------------------------------------
     # run_sync extraction (second wave of the seam): the closed-over locals

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -271,16 +271,13 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
-# Feishu reactions render as prominent badges, unlike Discord/Telegram's
-# small footer emoji — a success badge on every message would add noise, so
-# we only mark start (Typing) and failure (CrossMark); the reply itself is
-# the success signal.
+# Feishu reactions render as prominent badges.  The unified turn lifecycle
+# deliberately mirrors start and terminal state on both participating messages.
 _FEISHU_REACTION_IN_PROGRESS = "Typing"
+_FEISHU_REACTION_SUCCESS = "CheckMark"
 _FEISHU_REACTION_FAILURE = "CrossMark"
-# Bound on the (message_id → reaction_id) handle cache. Happy-path entries
-# drain on completion; the cap is a safeguard against unbounded growth from
-# delete-failures, not a capacity plan.
-_FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_FEISHU_REACTION_REMOVE_ATTEMPTS = 3
+_FEISHU_REACTION_REMOVE_RETRY_DELAY = 0.25
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
 
 # QR onboarding constants
@@ -1559,6 +1556,10 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        # Trigger-message id -> per-turn editable status message.  Kept on the
+        # adapter because the final delivery lifecycle runs here, after the
+        # gateway has proved whether the answer actually reached Feishu.
+        self._turn_status_messages: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
         self._load_seen_message_ids()
 
     @staticmethod
@@ -3232,42 +3233,165 @@ class FeishuAdapter(BasePlatformAdapter):
         cache = self._pending_processing_reactions
         cache[message_id] = reaction_id
         cache.move_to_end(message_id)
-        while len(cache) > _FEISHU_PROCESSING_REACTION_CACHE_SIZE:
-            cache.popitem(last=False)
+        # Every entry is an in-flight lifecycle handle, not historical cache.
+        # Completion owns removal; evicting an active handle can strand Typing.
 
     def _pop_processing_reaction(self, message_id: str) -> Optional[str]:
         return self._pending_processing_reactions.pop(message_id, None)
 
-    async def on_processing_start(self, event: MessageEvent) -> None:
-        if not self._reactions_enabled():
+    async def start_processing_reaction(self, message_id: str) -> None:
+        """Attach Typing to any message participating in a turn lifecycle."""
+        if not self._reactions_enabled() or not message_id:
             return
-        message_id = event.message_id
-        if not message_id or message_id in self._pending_processing_reactions:
+        if message_id in self._pending_processing_reactions:
             return
-        reaction_id = await self._add_reaction(message_id, _FEISHU_REACTION_IN_PROGRESS)
+        reaction_id = await self._add_reaction(
+            message_id, _FEISHU_REACTION_IN_PROGRESS
+        )
         if reaction_id:
             self._remember_processing_reaction(message_id, reaction_id)
+
+    async def complete_processing_reaction(
+        self, message_id: str, outcome: ProcessingOutcome
+    ) -> None:
+        """Replace Typing with the terminal reaction for one message."""
+        if not self._reactions_enabled() or not message_id:
+            return
+        start_reaction_id = self._pending_processing_reactions.get(message_id)
+        if start_reaction_id:
+            removed = False
+            for attempt in range(_FEISHU_REACTION_REMOVE_ATTEMPTS):
+                if await self._remove_reaction(message_id, start_reaction_id):
+                    removed = True
+                    break
+                if attempt + 1 < _FEISHU_REACTION_REMOVE_ATTEMPTS:
+                    await asyncio.sleep(
+                        _FEISHU_REACTION_REMOVE_RETRY_DELAY * (2**attempt)
+                    )
+            # Release only the handle this completion attempt owned. A newer
+            # lifecycle registration for the same message must not be popped.
+            if (
+                self._pending_processing_reactions.get(message_id)
+                == start_reaction_id
+            ):
+                self._pop_processing_reaction(message_id)
+            if not removed:
+                logger.warning(
+                    "[Feishu] Giving up reaction cleanup on %s after %d attempts",
+                    message_id,
+                    _FEISHU_REACTION_REMOVE_ATTEMPTS,
+                )
+                return
+
+        terminal_reaction = None
+        if outcome is ProcessingOutcome.SUCCESS:
+            terminal_reaction = _FEISHU_REACTION_SUCCESS
+        elif outcome is ProcessingOutcome.FAILURE:
+            terminal_reaction = _FEISHU_REACTION_FAILURE
+        if terminal_reaction:
+            await self._add_reaction(message_id, terminal_reaction)
+
+    def register_turn_status_message(
+        self,
+        *,
+        trigger_message_id: str,
+        chat_id: str,
+        status_message_id: str,
+        lifecycle_id: Optional[str] = None,
+    ) -> None:
+        """Bind the one editable Feishu status message to its inbound turn."""
+        if not trigger_message_id or not chat_id or not status_message_id:
+            return
+        cache = self._turn_status_messages
+        status_key = lifecycle_id or trigger_message_id
+        cache[status_key] = {
+            "trigger_message_id": trigger_message_id,
+            "chat_id": chat_id,
+            "message_id": status_message_id,
+            "tool_count": 0,
+            "current_stage": "處理中",
+        }
+        cache.move_to_end(status_key)
+        # These records represent active turns, not historical cache entries.
+        # Never evict an in-flight turn: on_processing_complete owns removal
+        # and must always be able to clear the status message's Typing reaction.
+
+    def update_turn_status_progress(
+        self, status_key: str, *, tool_count: int, current_stage: str
+    ) -> None:
+        record = self._turn_status_messages.get(status_key)
+        if record is None:
+            return
+        record["tool_count"] = max(0, int(tool_count))
+        record["current_stage"] = str(current_stage or "處理中")
+
+    @staticmethod
+    def _terminal_turn_status_text(record: Dict[str, Any], outcome: ProcessingOutcome) -> str:
+        count = max(0, int(record.get("tool_count", 0) or 0))
+        if outcome is ProcessingOutcome.SUCCESS:
+            return f"已完成\n共執行 {count} 個工具操作"
+        if outcome is ProcessingOutcome.CANCELLED:
+            return "已停止"
+        stage = str(record.get("current_stage") or "處理最終結果")
+        return f"處理失敗\n階段：{stage}\n原因：處理或傳送未成功"
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        await self.start_processing_reaction(event.message_id)
 
     async def on_processing_complete(
         self, event: MessageEvent, outcome: ProcessingOutcome
     ) -> None:
-        if not self._reactions_enabled():
-            return
         message_id = event.message_id
         if not message_id:
             return
+        # The inbound reaction belongs to the adapter that received the event.
+        # Status ownership may live on a replacement adapter after reconnect.
+        await self.complete_processing_reaction(message_id, outcome)
 
-        start_reaction_id = self._pending_processing_reactions.get(message_id)
-        if start_reaction_id:
-            if not await self._remove_reaction(message_id, start_reaction_id):
-                # Don't stack a second badge on top of a Typing we couldn't
-                # remove — UI would read as both "working" and "done/failed"
-                # simultaneously. Keep the handle so LRU eventually evicts it.
-                return
-            self._pop_processing_reaction(message_id)
+        source = getattr(event, "source", None)
+        status_owner = getattr(
+            source, "_feishu_turn_status_adapter", None
+        ) if source is not None else None
+        if not isinstance(status_owner, type(self)):
+            status_owner = self
+        status_key = getattr(
+            source, "_feishu_turn_status_lifecycle_id", None
+        ) if source is not None else None
+        if not isinstance(status_key, str) or not status_key:
+            status_key = message_id
+        await status_owner._finalize_turn_status(status_key, outcome)
 
-        if outcome is ProcessingOutcome.FAILURE:
-            await self._add_reaction(message_id, _FEISHU_REACTION_FAILURE)
+    async def _finalize_turn_status(
+        self, status_key: str, outcome: ProcessingOutcome
+    ) -> None:
+        """Finalize the status record owned by this adapter instance."""
+        status = self._turn_status_messages.pop(status_key, None)
+        if status is None:
+            return
+
+        status_message_id = str(status["message_id"])
+        try:
+            result = await self.edit_message(
+                chat_id=str(status["chat_id"]),
+                message_id=status_message_id,
+                content=self._terminal_turn_status_text(status, outcome),
+            )
+            if not getattr(result, "success", False):
+                logger.warning(
+                    "[Feishu] Turn status edit rejected for %s: %s",
+                    status_message_id,
+                    getattr(result, "error", None) or "unknown error",
+                )
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] Failed to finalize turn status message %s: %s",
+                status_message_id,
+                exc,
+            )
+        finally:
+            # Reaction cleanup is independent of text-edit success.  A failed
+            # edit must never strand Typing on the status message.
+            await self.complete_processing_reaction(status_message_id, outcome)
 
     # =========================================================================
     # Webhook server and security

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -131,6 +131,13 @@ class TestPlatformDefaults:
         # Discord: pure tier_high.
         assert resolve_display_setting({}, "discord", "tool_progress") == "all"
 
+    def test_feishu_defaults_to_single_turn_status_message(self):
+        """Feishu pre-creates one editable status message without extra config."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "feishu", "turn_status_message") is True
+        assert resolve_display_setting({}, "feishu", "interim_assistant_messages") is False
+
 
     def test_low_tier_platforms(self):
         """Signal, BlueBubbles, etc. default to 'off' tool progress."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from gateway.platforms.base import ProcessingOutcome
 
@@ -458,7 +458,7 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter = FeishuAdapter(PlatformConfig())
         adapter._loop = object()
 
-        for emoji in ("Typing", "CrossMark"):
+        for emoji in ("Typing", "CheckMark", "CrossMark"):
             event = SimpleNamespace(
                 message_id="om_msg",
                 operator_type="bot",
@@ -1784,8 +1784,7 @@ class TestBotNameResolution(unittest.TestCase):
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestProcessingReactions(unittest.TestCase):
-    """Typing on start → removed on SUCCESS, swapped for CrossMark on FAILURE,
-    removed (no replacement) on CANCELLED."""
+    """Typing on start → CheckMark/CrossMark terminal reactions."""
 
     @staticmethod
     def _run(coro):
@@ -1861,16 +1860,191 @@ class TestProcessingReactions(unittest.TestCase):
 
     # --------------------------------------------------------------- complete
     @patch.dict(os.environ, {}, clear=True)
-    def test_success_removes_typing_and_adds_nothing(self):
+    def test_success_removes_typing_then_adds_check_mark(self):
         adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
         with self._patch_to_thread():
             self._run(adapter.on_processing_start(self._event()))
             self._run(
                 adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
             )
-        self.assertEqual(tracker.create_calls, ["Typing"])
+        self.assertEqual(tracker.create_calls, ["Typing", "CheckMark"])
         self.assertEqual(tracker.delete_calls, ["r_typing"])
         self.assertNotIn("om_msg", adapter._pending_processing_reactions)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_registered_status_message_receives_same_success_lifecycle(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        adapter.update_turn_status_progress(
+            "om_msg", tool_count=3, current_stage="檢查資料庫"
+        )
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("om_status"))
+            self._run(adapter.on_processing_start(self._event()))
+            self._run(
+                adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
+            )
+
+        self.assertEqual(
+            tracker.create_calls,
+            ["Typing", "Typing", "CheckMark", "CheckMark"],
+        )
+        self.assertEqual(tracker.delete_calls, ["r_typing", "r_typing"])
+        adapter.edit_message.assert_awaited_once_with(
+            chat_id="oc_chat",
+            message_id="om_status",
+            content="已完成\n共執行 3 個工具操作",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_registered_status_message_receives_failure_text_and_cross_mark(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        adapter.update_turn_status_progress(
+            "om_msg", tool_count=2, current_stage="驗證 Slug"
+        )
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("om_status"))
+            self._run(adapter.on_processing_start(self._event()))
+            self._run(
+                adapter.on_processing_complete(self._event(), ProcessingOutcome.FAILURE)
+            )
+
+        self.assertEqual(
+            tracker.create_calls,
+            ["Typing", "Typing", "CrossMark", "CrossMark"],
+        )
+        adapter.edit_message.assert_awaited_once_with(
+            chat_id="oc_chat",
+            message_id="om_status",
+            content="處理失敗\n階段：驗證 Slug\n原因：處理或傳送未成功",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_registered_status_message_cancellation_has_no_terminal_reaction(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("om_status"))
+            self._run(adapter.on_processing_start(self._event()))
+            self._run(
+                adapter.on_processing_complete(self._event(), ProcessingOutcome.CANCELLED)
+            )
+
+        self.assertEqual(tracker.create_calls, ["Typing", "Typing"])
+        self.assertEqual(tracker.delete_calls, ["r_typing", "r_typing"])
+        adapter.edit_message.assert_awaited_once_with(
+            chat_id="oc_chat",
+            message_id="om_status",
+            content="已停止",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_active_turn_status_records_are_not_lru_evicted(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        for index in range(513):
+            adapter.register_turn_status_message(
+                trigger_message_id=f"trigger-{index}",
+                chat_id="oc_chat",
+                status_message_id=f"status-{index}",
+            )
+
+        self.assertIn("trigger-0", adapter._turn_status_messages)
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("status-0"))
+            event = SimpleNamespace(message_id="trigger-0")
+            self._run(
+                adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+            )
+
+        self.assertNotIn("trigger-0", adapter._turn_status_messages)
+        self.assertEqual(tracker.delete_calls, ["r_typing"])
+        self.assertEqual(
+            tracker.create_calls, ["Typing", "CheckMark", "CheckMark"]
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_active_processing_reactions_are_not_lru_evicted(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        with self._patch_to_thread():
+            for index in range(1025):
+                self._run(adapter.start_processing_reaction(f"message-{index}"))
+
+            self._run(
+                adapter.complete_processing_reaction(
+                    "message-0", ProcessingOutcome.CANCELLED
+                )
+            )
+
+        self.assertEqual(len(tracker.create_calls), 1025)
+        self.assertEqual(tracker.delete_calls, ["r_typing"])
+        self.assertNotIn("message-0", adapter._pending_processing_reactions)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_terminal_edit_exception_still_clears_status_typing(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(side_effect=RuntimeError("edit failed"))
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("om_status"))
+            self._run(adapter.on_processing_start(self._event()))
+            self._run(
+                adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
+            )
+
+        self.assertEqual(tracker.delete_calls, ["r_typing", "r_typing"])
+        self.assertEqual(
+            tracker.create_calls,
+            ["Typing", "Typing", "CheckMark", "CheckMark"],
+        )
+        self.assertNotIn("om_msg", adapter._turn_status_messages)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_terminal_edit_rejection_still_clears_status_typing(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="edit rejected")
+        )
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        event = MagicMock()
+        event.message_id = "om_msg"
+        with self._patch_to_thread():
+            self._run(adapter.start_processing_reaction("om_status"))
+            self._run(adapter.on_processing_start(event))
+            self._run(
+                adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+            )
+
+        self.assertEqual(tracker.delete_calls, ["r_typing", "r_typing"])
+        self.assertEqual(
+            tracker.create_calls,
+            ["Typing", "Typing", "CrossMark", "CrossMark"],
+        )
+        self.assertNotIn("om_msg", adapter._turn_status_messages)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_failure_removes_typing_then_adds_cross_mark(self):
@@ -1886,10 +2060,10 @@ class TestProcessingReactions(unittest.TestCase):
 
     # ------------------------- delete failure: don't stack badges -----------
     @patch.dict(os.environ, {}, clear=True)
-    def test_delete_failure_on_failure_outcome_skips_cross_mark(self):
+    def test_delete_failure_retries_then_releases_handle_without_cross_mark(self):
         # Removing Typing is best-effort — but if it fails, we must NOT
         # additionally add CrossMark, or the UI would show two contradictory
-        # badges. The handle stays in the cache for LRU to clean up later.
+        # badges. Cleanup retries are bounded and then release the handle.
         adapter, tracker = self._build_adapter(
             next_reaction_id="r_typing", delete_success=False,
         )
@@ -1899,16 +2073,100 @@ class TestProcessingReactions(unittest.TestCase):
                 adapter.on_processing_complete(self._event(), ProcessingOutcome.FAILURE)
             )
         self.assertEqual(tracker.create_calls, ["Typing"])  # CrossMark NOT added
-        self.assertEqual(tracker.delete_calls, ["r_typing"])  # delete was attempted
-        self.assertEqual(
-            adapter._pending_processing_reactions["om_msg"], "r_typing",
-        )  # handle retained
+        self.assertEqual(tracker.delete_calls, ["r_typing"] * 3)
+        self.assertNotIn("om_msg", adapter._pending_processing_reactions)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_delete_retry_can_recover_and_add_terminal_reaction(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
+        adapter._pending_processing_reactions["om_msg"] = "r_typing"
+        adapter._remove_reaction = AsyncMock(side_effect=[False, False, True])
+
+        with patch(
+            "plugins.platforms.feishu.adapter.asyncio.sleep", new=AsyncMock()
+        ):
+            with self._patch_to_thread():
+                self._run(
+                    adapter.complete_processing_reaction(
+                        "om_msg", ProcessingOutcome.SUCCESS
+                    )
+                )
+
+        self.assertEqual(adapter._remove_reaction.await_count, 3)
+        self.assertEqual(tracker.create_calls, ["CheckMark"])
+        self.assertNotIn("om_msg", adapter._pending_processing_reactions)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_replacement_adapter_owns_status_terminal_cleanup(self):
+        inbound_adapter, inbound = self._build_adapter(next_reaction_id="r_inbound")
+        status_adapter, status = self._build_adapter(next_reaction_id="r_status")
+        status_adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        status_adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status",
+        )
+        source = MagicMock()
+        source._feishu_turn_status_adapter = status_adapter
+        event = MagicMock()
+        event.message_id = "om_msg"
+        event.source = source
+
+        with self._patch_to_thread():
+            self._run(inbound_adapter.on_processing_start(event))
+            self._run(status_adapter.start_processing_reaction("om_status"))
+            self._run(
+                inbound_adapter.on_processing_complete(
+                    event, ProcessingOutcome.SUCCESS
+                )
+            )
+
+        self.assertEqual(inbound.create_calls, ["Typing", "CheckMark"])
+        self.assertEqual(inbound.delete_calls, ["r_inbound"])
+        self.assertEqual(status.create_calls, ["Typing", "CheckMark"])
+        self.assertEqual(status.delete_calls, ["r_status"])
+        status_adapter.edit_message.assert_awaited_once()
+        self.assertNotIn("om_msg", status_adapter._turn_status_messages)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_stale_status_completion_cannot_finalize_newer_duplicate_turn(self):
+        adapter, tracker = self._build_adapter(next_reaction_id="unused")
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status_old",
+            lifecycle_id="om_msg:old",
+        )
+        adapter.register_turn_status_message(
+            trigger_message_id="om_msg",
+            chat_id="oc_chat",
+            status_message_id="om_status_new",
+            lifecycle_id="om_msg:new",
+        )
+        adapter._pending_processing_reactions["om_status_old"] = "r_old"
+        adapter._pending_processing_reactions["om_status_new"] = "r_new"
+
+        with self._patch_to_thread():
+            self._run(
+                adapter._finalize_turn_status(
+                    "om_msg:old", ProcessingOutcome.SUCCESS
+                )
+            )
+
+        self.assertNotIn("om_msg:old", adapter._turn_status_messages)
+        self.assertIn("om_msg:new", adapter._turn_status_messages)
+        self.assertIn("om_status_new", adapter._pending_processing_reactions)
+        adapter.edit_message.assert_awaited_once_with(
+            chat_id="oc_chat",
+            message_id="om_status_old",
+            content="已完成\n共執行 0 個工具操作",
+        )
+        self.assertEqual(tracker.delete_calls, ["r_old"])
+        self.assertEqual(tracker.create_calls, ["CheckMark"])
 
 
     # ------------------------------------------------------------- env toggle
-
-    # ------------------------------------------------------------- LRU bounds
-
 
 class TestFeishuMentionMap(unittest.TestCase):
 

--- a/tests/gateway/test_run_feishu_turn_status.py
+++ b/tests/gateway/test_run_feishu_turn_status.py
@@ -1,0 +1,365 @@
+"""Feishu keeps one editable turn-status message for all tool progress."""
+
+import asyncio
+import importlib
+import queue
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import TurnRunner
+from gateway.session import SessionSource
+from gateway.turn_context import TurnContext
+
+
+class FeishuStatusAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.FEISHU)
+        self.sent = []
+        self.edits = []
+        self.typing = []
+        self.registered = []
+        self.reaction_starts = []
+        self.status_updates = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id="unexpected-new-message")
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize=False, metadata=None
+    ) -> SendResult:
+        self.edits.append({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "content": content,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        self.typing.append({"chat_id": chat_id, "metadata": metadata})
+
+    def register_turn_status_message(self, **kwargs) -> None:
+        self.registered.append(kwargs)
+
+    async def start_processing_reaction(self, message_id: str) -> None:
+        self.reaction_starts.append(message_id)
+
+    def update_turn_status_progress(
+        self, trigger_message_id: str, *, tool_count: int, current_stage: str
+    ) -> None:
+        self.status_updates.append({
+            "trigger_message_id": trigger_message_id,
+            "tool_count": tool_count,
+            "current_stage": current_stage,
+        })
+
+
+class IntegratedProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for index in range(10):
+            self.tool_progress_callback(
+                "tool.started", "terminal", f"command-{index}", {}
+            )
+            self.tool_progress_callback(
+                "tool.completed", "terminal", None, None
+            )
+        time.sleep(0.5)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class PermanentEditFailureAdapter(FeishuStatusAdapter):
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize=False, metadata=None
+    ) -> SendResult:
+        self.edits.append({"message_id": message_id, "content": content})
+        return SendResult(success=False, error="message cannot be edited")
+
+
+class InitialStatusFailureAdapter(FeishuStatusAdapter):
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=False, error="status send failed")
+
+
+def _make_gateway_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_precreates_one_threaded_feishu_status_message(
+    monkeypatch, tmp_path
+):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(yaml.dump({}), encoding="utf-8")
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = IntegratedProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = FeishuStatusAdapter()
+    runner = _make_gateway_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt_thread",
+    )
+
+    result = await runner._run_agent(
+        message="run tools",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-status",
+        session_key="agent:main:feishu:thread:oc_chat:omt_thread",
+        event_message_id="om_trigger",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    status_send = adapter.sent[0]
+    assert status_send["content"] == "處理中"
+    assert status_send["reply_to"] == "om_trigger"
+    assert status_send["metadata"] == {"thread_id": "omt_thread"}
+    assert len(adapter.registered) == 1
+    registration = adapter.registered[0]
+    assert registration["trigger_message_id"] == "om_trigger"
+    assert registration["chat_id"] == "oc_chat"
+    assert registration["status_message_id"] == "unexpected-new-message"
+    assert registration["lifecycle_id"].startswith("om_trigger:")
+    assert adapter.reaction_starts == ["unexpected-new-message"]
+    assert getattr(source, "_feishu_turn_status_adapter") is adapter
+    assert adapter.edits
+    assert {edit["message_id"] for edit in adapter.edits} == {
+        "unexpected-new-message"
+    }
+    assert adapter.status_updates[-1]["tool_count"] == 10
+
+
+@pytest.mark.asyncio
+async def test_initial_feishu_status_failure_never_falls_back_to_progress_bubbles(
+    monkeypatch, tmp_path
+):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({
+            "display": {
+                "platforms": {
+                    "feishu": {
+                        "tool_progress": "all",
+                        "turn_status_message": True,
+                    }
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = IntegratedProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = InitialStatusFailureAdapter()
+    runner = _make_gateway_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt_thread",
+    )
+
+    result = await runner._run_agent(
+        message="run tools",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-status-failure",
+        session_key="agent:main:feishu:thread:oc_chat:omt_thread",
+        event_message_id="om_trigger",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == "處理中"
+    assert adapter.edits == []
+    assert adapter.registered == []
+
+
+@pytest.mark.asyncio
+async def test_ten_tool_calls_only_edit_registered_feishu_status_message():
+    adapter = FeishuStatusAdapter()
+    replacement_adapter = FeishuStatusAdapter()
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt_thread",
+    )
+    progress_queue = queue.Queue()
+    for index in range(10):
+        progress_queue.put(f"tool-{index}")
+        progress_queue.put(("__status_completed__",))
+
+    current = True
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: current,
+        progress_queue=progress_queue,
+        progress_grouping="separate",
+        tool_progress_enabled=True,
+        status_message_id="om_status",
+        turn_status_enabled=True,
+        _turn_status_adapter=adapter,
+        _progress_metadata={
+            "thread_id": "omt_thread",
+            "reply_to_message_id": "om_trigger",
+        },
+        _progress_reply_to="om_trigger",
+    )
+    # A reconnect may replace the registry entry mid-turn. Progress must stay
+    # bound to the adapter that created and registered this status message.
+    gateway = SimpleNamespace(
+        _adapter_for_source=lambda _source: replacement_adapter
+    )
+    runner = TurnRunner(gateway, ctx)
+
+    task = asyncio.create_task(runner.send_progress_messages())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert adapter.sent == []
+    assert adapter.edits
+    assert replacement_adapter.edits == []
+    assert {call["message_id"] for call in adapter.edits} == {"om_status"}
+    final = adapter.edits[-1]["content"]
+    assert final.startswith("處理中\n目前：tool-9\n已完成：10 個工具操作")
+    assert "tool-4" not in final
+    for index in range(5, 10):
+        assert f"• tool-{index}" in final
+
+
+@pytest.mark.asyncio
+async def test_permanent_feishu_status_edit_failure_never_falls_back_to_new_messages():
+    adapter = PermanentEditFailureAdapter()
+    source = SessionSource(platform=Platform.FEISHU, chat_id="oc_chat")
+    progress_queue = queue.Queue()
+    for index in range(3):
+        progress_queue.put(f"tool-{index}")
+        progress_queue.put(("__status_completed__",))
+
+    current = True
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: current,
+        progress_queue=progress_queue,
+        tool_progress_enabled=True,
+        status_message_id="om_status",
+        turn_status_enabled=True,
+    )
+    gateway = SimpleNamespace(_adapter_for_source=lambda _source: adapter)
+    task = asyncio.create_task(TurnRunner(gateway, ctx).send_progress_messages())
+    await asyncio.sleep(0.8)
+    current = False
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert adapter.edits
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_feishu_status_reset_marker_does_not_create_second_message():
+    adapter = FeishuStatusAdapter()
+    source = SessionSource(platform=Platform.FEISHU, chat_id="oc_chat")
+    progress_queue = queue.Queue()
+    progress_queue.put("first tool")
+    progress_queue.put(("__reset__",))
+    progress_queue.put("second tool")
+
+    current = True
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: current,
+        progress_queue=progress_queue,
+        progress_grouping="grouped",
+        tool_progress_enabled=True,
+        status_message_id="om_status",
+        turn_status_enabled=True,
+    )
+    gateway = SimpleNamespace(_adapter_for_source=lambda _source: adapter)
+    runner = TurnRunner(gateway, ctx)
+
+    task = asyncio.create_task(runner.send_progress_messages())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert adapter.sent == []
+    assert {call["message_id"] for call in adapter.edits} == {"om_status"}
+    assert "first tool" in adapter.edits[-1]["content"]
+    assert "second tool" in adapter.edits[-1]["content"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1846,9 +1846,14 @@ display:
       tool_progress: verbose  # detailed progress on Telegram
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
+    feishu:
+      turn_status_message: true       # one editable status message per turn (default)
+      interim_assistant_messages: false  # keep the turn to status + final answer (default)
 ```
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
+
+Feishu enables `turn_status_message` by default. It pre-creates one editable status message, routes tool progress into that message, and finalizes it after answer delivery. Feishu also defaults `interim_assistant_messages` to `false` so mid-turn commentary does not create extra chat bubbles. Either setting can be overridden under `display.platforms.feishu`.
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -422,7 +422,21 @@ Plain text messages (no markdown detected) are sent as the simple `text` message
 
 ## Processing Status Reactions
 
-While the agent is working, the bot shows a `Typing` reaction on your message. It's cleared when the reply arrives, or replaced with `CrossMark` if processing failed.
+By default, each Feishu turn creates one editable `處理中` status message. Tool progress updates edit that message in place instead of posting a new message for every tool call. The final answer remains a separate message.
+
+The status message keeps the five most recent tool operations and a total count. When delivery finishes, it becomes `已完成`, `處理失敗`, or `已停止`.
+
+While the agent is working, the bot shows a `Typing` reaction on both your message and the turn-status message. Successful delivery replaces it with `CheckMark`; failure replaces it with `CrossMark`; cancellation removes `Typing` without adding a terminal reaction.
+
+Disable the single status message, or restore separate interim assistant updates, with per-platform display settings:
+
+```yaml
+display:
+  platforms:
+    feishu:
+      turn_status_message: false
+      interim_assistant_messages: true
+```
 
 Set `FEISHU_REACTIONS=false` to turn it off.
 


### PR DESCRIPTION
## What does this PR do?

Adds a Feishu-specific, single editable turn-status message. Tool progress updates edit the same message instead of posting one bubble per tool call, while the final answer remains separate.

The lifecycle is deterministic across both the inbound message and the status message:

- processing: `Typing`
- success: remove `Typing`, add `CheckMark`
- failure: remove `Typing`, add `CrossMark`
- cancellation: remove `Typing`, add no terminal reaction

Status-send/edit failures never fall back to creating extra progress bubbles. Active reaction handles remain lifecycle-owned until completion; terminal removal uses bounded retries, and per-turn owner/lifecycle IDs keep reconnects or stale runs from finalizing the wrong status.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/display_config.py`: enable one turn-status message by default for Feishu and suppress separate interim assistant bubbles.
- `gateway/run.py` / `gateway/turn_context.py`: pre-create and retain a unique per-turn status identity and adapter owner, route progress edits to it, and preserve thread/reply metadata.
- `plugins/platforms/feishu/adapter.py`: register/finalize status records and reaction handles for success, failure, and cancellation, including bounded reaction-removal retries and reconnect-safe ownership.
- `tests/gateway/`: cover unconfigured defaults, ten-tool accumulation, thread routing, send/edit failure, cancellation, high concurrency, stale duplicate runs, adapter replacement, and platform isolation.
- `website/docs/`: document the lifecycle and display overrides.

## How to Test

1. Run the focused Feishu, display, and progress suites:

   ```bash
   python -m pytest \
     tests/gateway/test_feishu.py \
     tests/gateway/test_run_feishu_turn_status.py \
     tests/gateway/test_display_config.py \
     tests/gateway/test_run_progress_topics.py \
     tests/gateway/test_run_progress_interrupt.py \
     tests/gateway/test_run_cleanup_progress.py -q
   ```

   Expected: `135 passed`.

2. Start a Feishu turn that invokes multiple tools. Confirm only one `處理中` status message is created, it is edited in place, and the final answer is sent separately.
3. Verify success, failure, and `/stop` produce the documented reaction/text terminal states.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Python 3.11

The full `tests/gateway` run reached `5003 passed, 5 skipped, 1 xfailed, 9 failed`. The same four tests fail individually on clean current `origin/main`; the other five pass individually on both the feature branch and baseline, indicating existing suite-order dependence rather than a changed-area regression. The focused affected suites pass completely.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (the key is documented under `display.platforms.feishu`; no generated CLI config entry exists for per-platform display keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (Feishu API/gateway logic only; no OS-specific paths or process APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
135 passed in 19.45s
```
