### PR TITLE
fix(verify): drain the started app's stdout during the readiness poll

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -98,6 +99,47 @@ class VerifyResult:
 
 def _tail(text: str, limit: int = _TAIL_CHARS) -> str:
     return text[-limit:] if len(text) > limit else text
+
+
+class _BackgroundOutputReader:
+    """Drain a backgrounded child's stdout for the lifetime of the readiness poll.
+
+    The started app writes into a fixed-size OS pipe buffer (64 KiB on Linux,
+    smaller elsewhere). Nothing drained that pipe until after teardown, so a
+    start command that logs more than the buffer holds before it binds its
+    port blocks in ``write()`` and never becomes ready — a healthy app is then
+    reported as a readiness failure for the whole ``ready_timeout`` window.
+
+    Only the last ``limit`` characters are retained: the caller wants a tail,
+    and a chatty server polled for 60s must not be able to grow this buffer
+    without bound.
+    """
+
+    def __init__(self, stream, limit: int = _TAIL_CHARS) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._buf = ""
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self) -> "_BackgroundOutputReader":
+        self._thread.start()
+        return self
+
+    def _pump(self) -> None:
+        try:
+            for line in self._stream:
+                with self._lock:
+                    self._buf = (self._buf + line)[-self._limit :]
+        except (OSError, ValueError):
+            # Pipe closed under us by teardown — whatever we captured stands.
+            pass
+
+    def result(self, timeout: float = 5.0) -> str:
+        """Captured tail. Never raises: diagnostics must not fail the run."""
+        self._thread.join(timeout)
+        with self._lock:
+            return self._buf
 
 
 def _run_phase_command(
@@ -219,16 +261,14 @@ def _run_start_phase(
         text=True,
         errors="replace",
     )
-    output = ""
+    # Drain concurrently with the poll: the child must never block writing to
+    # a full pipe before it can bind its port.
+    reader = _BackgroundOutputReader(proc.stdout).start() if proc.stdout is not None else None
     try:
         ready, status, error = _poll_readiness(url, ready_timeout)
     finally:
         _terminate_process_group(proc)
-        try:
-            if proc.stdout is not None:
-                output = proc.stdout.read() or ""
-        except (OSError, ValueError):
-            output = ""
+        output = reader.result() if reader is not None else ""
     return ReadinessResult(
         url=url,
         ready=ready,

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -88,6 +89,47 @@ class VerifyResult:
 
 def _tail(text: str, limit: int = _TAIL_CHARS) -> str:
     return text[-limit:] if len(text) > limit else text
+
+
+class _BackgroundOutputReader:
+    """Drain a backgrounded child's stdout for the lifetime of the readiness poll.
+
+    The started app writes into a fixed-size OS pipe buffer (64 KiB on Linux,
+    smaller elsewhere). Nothing drained that pipe until after teardown, so a
+    start command that logs more than the buffer holds before it binds its
+    port blocks in ``write()`` and never becomes ready — a healthy app is then
+    reported as a readiness failure for the whole ``ready_timeout`` window.
+
+    Only the last ``limit`` characters are retained: the caller wants a tail,
+    and a chatty server polled for 60s must not be able to grow this buffer
+    without bound.
+    """
+
+    def __init__(self, stream, limit: int = _TAIL_CHARS) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._buf = ""
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self) -> "_BackgroundOutputReader":
+        self._thread.start()
+        return self
+
+    def _pump(self) -> None:
+        try:
+            for line in self._stream:
+                with self._lock:
+                    self._buf = (self._buf + line)[-self._limit :]
+        except (OSError, ValueError):
+            # Pipe closed under us by teardown — whatever we captured stands.
+            pass
+
+    def result(self, timeout: float = 5.0) -> str:
+        """Captured tail. Never raises: diagnostics must not fail the run."""
+        self._thread.join(timeout)
+        with self._lock:
+            return self._buf
 
 
 def _run_phase_command(
@@ -170,15 +212,15 @@ def _run_start_phase(
     started = time.monotonic()
     # start_new_session: own process group for clean teardown.
     proc = subprocess.Popen(recipe.start, cwd=str(root), start_new_session=True, **_SUBPROCESS_KW)
+    # Drain concurrently with the poll: the child must never block writing to
+    # a full pipe before it can bind its port.
+    reader = _BackgroundOutputReader(proc.stdout).start() if proc.stdout is not None else None
     output = ""
     try:
         ready, status, error = _poll_readiness(url, ready_timeout)
     finally:
         _terminate_process_group(proc)
-        try:
-            output = proc.stdout.read() or "" if proc.stdout is not None else ""
-        except (OSError, ValueError):
-            output = ""
+        output = reader.result() if reader is not None else ""
     return ReadinessResult(url, ready, status, time.monotonic() - started, error, _tail(output))
 
 

--- a/tests/verify/test_runner_output_drain.py
+++ b/tests/verify/test_runner_output_drain.py
@@ -1,0 +1,152 @@
+"""The readiness poll must drain the started app's stdout while it polls.
+
+Regression tests for a start command that logs more than the OS pipe buffer
+holds before it binds its port. Nothing read that pipe until after teardown,
+so the child blocked in ``write()``, never bound, and a healthy app was
+reported as a readiness failure for the whole ``ready_timeout`` window.
+
+These drive the real ``_run_start_phase`` against real subprocesses — the bug
+lives in the interaction between an OS pipe and the poll loop, so a mocked
+Popen cannot reproduce it.
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+import textwrap
+
+import pytest
+
+from agent.verify.recipes import Recipe
+from agent.verify.runner import _run_start_phase
+
+# Comfortably larger than the 64 KiB pipe buffer on Linux (and the smaller
+# buffers elsewhere), so the child is guaranteed to block without a drain.
+_CHATTY_LINES = 4000
+_LINE_PADDING = 40
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+def _write_app(tmp_path, *, noisy: bool):
+    """A server that logs ``_CHATTY_LINES`` lines *before* it binds its port."""
+    app = tmp_path / "app.py"
+    preamble = (
+        textwrap.dedent(
+            f"""
+            for i in range({_CHATTY_LINES}):
+                print("[boot] line %d %s" % (i, "x" * {_LINE_PADDING}), flush=True)
+            """
+        )
+        if noisy
+        else ""
+    )
+    app.write_text(
+        textwrap.dedent(
+            """
+            import sys, http.server, socketserver
+            {preamble}
+            port = int(sys.argv[1])
+            socketserver.TCPServer.allow_reuse_address = True
+            with socketserver.TCPServer(("127.0.0.1", port),
+                                        http.server.SimpleHTTPRequestHandler) as srv:
+                srv.serve_forever()
+            """
+        ).format(preamble=textwrap.indent(preamble, "")),
+        encoding="utf-8",
+    )
+    return app
+
+
+def _recipe_for(app, port: int) -> Recipe:
+    return Recipe(
+        name="chatty",
+        kind="test",
+        start=f"{sys.executable} {app} {port}",
+        port=port,
+        readiness_path="/",
+    )
+
+
+@pytest.mark.timeout(120)
+def test_chatty_start_command_still_becomes_ready(tmp_path):
+    """The bug: >64 KiB of startup logs must not stop the app binding its port."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=True)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert result.ready is True, (
+        "a healthy app that logs before binding was reported unready — "
+        f"error={result.error!r}"
+    )
+    assert result.status_code is not None
+
+
+@pytest.mark.timeout(120)
+def test_quiet_start_command_unaffected(tmp_path):
+    """Guard: the drain must not disturb the ordinary quiet-server path."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=False)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert result.ready is True
+    assert result.status_code is not None
+
+
+@pytest.mark.timeout(120)
+def test_startup_output_is_captured_not_lost_to_teardown(tmp_path):
+    """The tail now comes from the drain, so early startup logs survive."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=True)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert "[boot] line" in result.output_tail
+
+
+def test_reader_retains_only_the_tail():
+    """A server polled for 60s must not grow the capture buffer without bound."""
+    from agent.verify.runner import _BackgroundOutputReader
+
+
+    class _Stream:
+        def __init__(self, lines):
+            self._lines = iter(lines)
+
+        def __iter__(self):
+            return self._lines
+
+    reader = _BackgroundOutputReader(_Stream([f"line {i}\n" for i in range(5000)]), limit=100)
+    reader.start()
+    captured = reader.result()
+
+    assert len(captured) <= 100
+    assert captured.endswith("line 4999\n")
+
+
+def test_reader_survives_a_stream_that_raises():
+    """Diagnostics must never fail the run: a closed pipe is not an error."""
+    from agent.verify.runner import _BackgroundOutputReader
+
+
+    class _Broken:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise ValueError("I/O operation on closed file")
+
+    reader = _BackgroundOutputReader(_Broken())
+    reader.start()
+
+    assert reader.result() == ""

--- a/tests/verify/test_runner_output_drain.py
+++ b/tests/verify/test_runner_output_drain.py
@@ -1,0 +1,147 @@
+"""The readiness poll must drain the started app's stdout while it polls.
+
+Regression tests for a start command that logs more than the OS pipe buffer
+holds before it binds its port. Nothing read that pipe until after teardown,
+so the child blocked in ``write()``, never bound, and a healthy app was
+reported as a readiness failure for the whole ``ready_timeout`` window.
+
+These drive the real ``_run_start_phase`` against real subprocesses — the bug
+lives in the interaction between an OS pipe and the poll loop, so a mocked
+Popen cannot reproduce it.
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+import textwrap
+
+from agent.verify.recipes import Recipe
+from agent.verify.runner import _run_start_phase
+
+# Comfortably larger than the 64 KiB pipe buffer on Linux (and the smaller
+# buffers elsewhere), so the child is guaranteed to block without a drain.
+_CHATTY_LINES = 4000
+_LINE_PADDING = 40
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+def _write_app(tmp_path, *, noisy: bool):
+    """A server that logs ``_CHATTY_LINES`` lines *before* it binds its port."""
+    app = tmp_path / "app.py"
+    preamble = (
+        textwrap.dedent(
+            f"""
+            for i in range({_CHATTY_LINES}):
+                print("[boot] line %d %s" % (i, "x" * {_LINE_PADDING}), flush=True)
+            """
+        )
+        if noisy
+        else ""
+    )
+    app.write_text(
+        textwrap.dedent(
+            """
+            import sys, http.server, socketserver
+            {preamble}
+            port = int(sys.argv[1])
+            socketserver.TCPServer.allow_reuse_address = True
+            with socketserver.TCPServer(("127.0.0.1", port),
+                                        http.server.SimpleHTTPRequestHandler) as srv:
+                srv.serve_forever()
+            """
+        ).format(preamble=textwrap.indent(preamble, "")),
+        encoding="utf-8",
+    )
+    return app
+
+
+def _recipe_for(app, port: int) -> Recipe:
+    return Recipe(
+        name="chatty",
+        kind="test",
+        start=f"{sys.executable} {app} {port}",
+        port=port,
+        readiness_path="/",
+    )
+
+
+def test_chatty_start_command_still_becomes_ready(tmp_path):
+    """The bug: >64 KiB of startup logs must not stop the app binding its port."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=True)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert result.ready is True, (
+        "a healthy app that logs before binding was reported unready — "
+        f"error={result.error!r}"
+    )
+    assert result.status_code is not None
+
+
+def test_quiet_start_command_unaffected(tmp_path):
+    """Guard: the drain must not disturb the ordinary quiet-server path."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=False)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert result.ready is True
+    assert result.status_code is not None
+
+
+def test_startup_output_is_captured_not_lost_to_teardown(tmp_path):
+    """The tail now comes from the drain, so early startup logs survive."""
+    port = _free_port()
+    app = _write_app(tmp_path, noisy=True)
+
+    result = _run_start_phase(_recipe_for(app, port), tmp_path, ready_timeout=25.0)
+
+    assert "[boot] line" in result.output_tail
+
+
+def test_reader_retains_only_the_tail():
+    """A server polled for 60s must not grow the capture buffer without bound."""
+    from agent.verify.runner import _BackgroundOutputReader
+
+
+    class _Stream:
+        def __init__(self, lines):
+            self._lines = iter(lines)
+
+        def __iter__(self):
+            return self._lines
+
+    reader = _BackgroundOutputReader(_Stream([f"line {i}\n" for i in range(5000)]), limit=100)
+    reader.start()
+    captured = reader.result()
+
+    assert len(captured) <= 100
+    assert captured.endswith("line 4999\n")
+
+
+def test_reader_survives_a_stream_that_raises():
+    """Diagnostics must never fail the run: a closed pipe is not an error."""
+    from agent.verify.runner import _BackgroundOutputReader
+
+
+    class _Broken:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise ValueError("I/O operation on closed file")
+
+    reader = _BackgroundOutputReader(_Broken())
+    reader.start()
+
+    assert reader.result() == ""


### PR DESCRIPTION
## What does this PR do?

`_run_start_phase` launches the app with `stdout=PIPE`, then polls the readiness URL without ever reading that pipe:

```python
proc = subprocess.Popen(
    recipe.start, shell=True, cwd=str(root),
    stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
    start_new_session=True, text=True, errors="replace",
)
output = ""
try:
    ready, status, error = _poll_readiness(url, ready_timeout)   # nothing drains the pipe
finally:
    _terminate_process_group(proc)
    try:
        if proc.stdout is not None:
            output = proc.stdout.read() or ""                     # first read, after the kill
```

The pipe is a fixed-size OS buffer (64 KiB on Linux, smaller elsewhere). A start command that logs more than that **before** it binds its port blocks in `write()` and never reaches the bind. The readiness poll then fails for the entire `ready_timeout` window (60s by default) against a completely healthy app.

This is the normal shape for the servers `verify` targets. `next dev`, `vite`, `webpack serve` and friends emit banner plus route tables plus dependency-prebundle logs long before they listen.

### Measured

A test server that prints 4000 lines and then binds a port, same app both ways:

```
no drain (main):  ready=False after 25.0s   stalled at "[boot] line 1148"
with drain:       ready=True  after  0.5s   4001 lines captured
```

The stall point is the mechanism, not a coincidence: 1148 lines of ~57 bytes is ~65 KB, exactly one full pipe buffer.

### The fix

`_BackgroundOutputReader` drains the pipe on a daemon thread for the lifetime of the poll, so the child can never block on a full buffer.

Two properties worth noting, each pinned by a test:

- **Bounded.** It keeps only the last `_TAIL_CHARS`, since the caller only ever renders a tail through `_tail()`. A chatty server drained for 60s must not be able to grow this buffer without limit, which would trade one resource bug for another.
- **Total.** A stream that raises (the pipe is closed under it by teardown) yields whatever was captured rather than propagating. Diagnostics collection must not be able to fail the run it is reporting on.

The capture also gets strictly better as a side effect. Today the tail is read after the process group is killed, so it is whatever happened to be sitting in the pipe. With the drain it is the true tail of everything the app wrote.

## Related Issue

No issue; found while reading the newly landed verify subsystem (`47a35d63c`, `fa1a5c048`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "verify subsystem"    --limit 20   # only #80686, the port itself
gh search prs --repo NousResearch/hermes-agent "verify runner"       --limit 20   # only #80686
gh search prs --repo NousResearch/hermes-agent "readiness deadlock"  --limit 20   # 0
gh search prs --repo NousResearch/hermes-agent "stdout PIPE deadlock" --limit 20  # 0
gh search prs --repo NousResearch/hermes-agent "drain stdout"        --limit 20   # nothing in this subsystem
```

`cc1acfb22` already hardened teardown in this function for Windows; this is the other half of the same lifecycle, on the read side.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `agent/verify/runner.py` - added `_BackgroundOutputReader`; `_run_start_phase` starts it before the poll and takes the tail from it after teardown, replacing the post-kill `proc.stdout.read()`.
- `tests/verify/test_runner_output_drain.py` - new, 5 tests.

## How to Test

```
pytest tests/verify/test_runner_output_drain.py -q
```

5 passed. They drive the real `_run_start_phase` against real subprocesses, because the bug lives in the interaction between an OS pipe and the poll loop and a mocked `Popen` cannot reproduce it.

Reverting only `agent/verify/runner.py` and rerunning:

```
FAILED test_chatty_start_command_still_becomes_ready
FAILED test_reader_retains_only_the_tail
FAILED test_reader_survives_a_stream_that_raises
3 failed, 2 passed
```

with

```
E  AssertionError: a healthy app that logs before binding was reported unready
E  error='<urlopen error [Errno 61] Connection refused>'
E  ReadinessResult(ready=False, status_code=None, duration=25.15,
E                  ...outputTail ends at '[boot] line 1148')
```

The two that fail on `ImportError` are the unit tests of the new class, so they can only run with it present. The behavioural probe is `test_chatty_start_command_still_becomes_ready`, which fails on unpatched `main` for the reason above and passes with the drain.

Two tests pass both before and after by design, and are guards rather than regression probes: `test_quiet_start_command_unaffected` pins that the drain does not disturb an ordinary quiet server, and `test_startup_output_is_captured_not_lost_to_teardown` still passes on `main` because the leftover pipe content happens to contain the marker. It is there to keep the tail populated if the capture path is refactored again.

Full `tests/verify/` suite, this branch vs `main`, same environment, run serially:

```
main:   75 passed
branch: 80 passed
```

Zero regressions; the +5 is this PR's new tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(verify): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the class docstring records why the pipe has to be drained concurrently and why only a tail is kept
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact: the drain is a plain thread plus file iteration, so it behaves the same on Windows, where this matters more since the fallback teardown there terminates only the direct child
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The bound is `_TAIL_CHARS` (2000), reusing the constant the renderer already trims to, so nothing downstream sees a change in what it receives. If you would rather keep a larger in-memory window than you display, that is a one-line change to the `limit` default.

I kept line iteration rather than fixed-size `read()` calls because it matches how server logs arrive and keeps the class readable. The trade-off: a start command that writes megabytes with no newline at all would buffer inside `TextIOWrapper` before the tail trim applies. That is not a shape any real dev server produces, and it is strictly better than today's behaviour, where that same command deadlocks outright.
