### PR TITLE
fix(desktop): re-assert persisted zoom on window focus regain (alt-tab)

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -73,7 +73,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-display moves on macOS and Windows', () => {
+test('installZoomReassertOnWindowEvents wires show, restore, resize, cross-display moves, and focus regain on macOS and Windows', () => {
   const handlers = new Map()
 
   const win = {
@@ -97,7 +97,32 @@ test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-d
   handlers.get('restore')()
   handlers.get('resized')()
   handlers.get('moved')()
-  assert.equal(calls, 4)
+  handlers.get('focus')()
+  assert.equal(calls, 5)
+})
+
+test('installZoomReassertOnWindowEvents re-asserts on focus regain (alt-tab on high-DPI, #50837)', () => {
+  const handlers = new Map()
+
+  const win = {
+    isDestroyed: () => false,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+
+  let calls = 0
+  installZoomReassertOnWindowEvents(
+    win,
+    () => {
+      calls += 1
+    },
+    'win32'
+  )
+
+  assert.ok(handlers.has('focus'))
+  handlers.get('focus')()
+  assert.equal(calls, 1)
 })
 
 test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {
@@ -133,10 +158,14 @@ test('installZoomReassertOnWindowEvents debounces Linux resize and move events a
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     assert.equal(calls, 1)
 
+    // `focus` re-asserts directly — it is not part of the debounced pair.
+    handlers.get('focus')()
+    assert.equal(calls, 2)
+
     handlers.get('resize')()
     destroyed = true
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
-    assert.equal(calls, 1)
+    assert.equal(calls, 2)
   } finally {
     vi.useRealTimers()
   }
@@ -159,6 +188,7 @@ test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
   })
   destroyed = true
   handlers.get('show')()
+  handlers.get('focus')()
   assert.equal(calls, 0)
 })
 

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -58,14 +58,18 @@ export function applyZoomLevel(webContents, level) {
 }
 
 // Chromium can drop webContents zoom when a BrowserWindow is resized, minimized
-// and restored, or crosses onto a monitor with different display scaling. macOS
-// and Windows provide trailing `resized`/`moved` events; Linux only provides the
-// noisy `resize`/`move` pair, so debounce those fallbacks before re-applying the
-// persisted level.
+// and restored, crosses onto a monitor with different display scaling, or
+// regains focus after alt-tab on a high-DPI display. macOS and Windows provide
+// trailing `resized`/`moved` events; Linux only provides the noisy
+// `resize`/`move` pair, so debounce those fallbacks before re-applying the
+// persisted level. `focus` is not noisy anywhere, so it re-asserts directly on
+// every platform.
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux' ? ['show', 'restore', 'resize', 'move'] : ['show', 'restore', 'resized', 'moved']
+  return platform === 'linux'
+    ? ['show', 'restore', 'resize', 'move', 'focus']
+    : ['show', 'restore', 'resized', 'moved', 'focus']
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {


### PR DESCRIPTION
## What

Adds `focus` to the zoom re-assert event list (`zoomReassertWindowEvents`) so the persisted UI scale is re-applied whenever a window regains focus — e.g. after alt-tab on a Windows high-DPI display, where Chromium drops the webContents zoom and nothing re-applies it.

## Why

Fixes #50837 (zoom resets to default after alt-tab on Windows high-DPI). The existing reassert wiring covers `show`, `restore`, `resized`/`moved`, and `did-finish-load`, but alt-tab fires `focus` — that was the gap. Related: #60693, #48658.

## How

- `electron/zoom.ts`: `zoomReassertWindowEvents()` now includes `focus` on every platform. `focus` is not noisy, so it fires directly (unlike the debounced Linux `resize`/`move` pair). Only chat windows are affected — helper windows already opt out via `zoomWiringForWindowKind`.
- `electron/zoom.test.ts`: extended the win32 event-list test (5 events), added a dedicated focus-regain regression test referencing the issue, and asserted `focus` re-asserts immediately on Linux (not debounced) and still respects the destroyed-window guard.

## Verification

- `vitest run --project electron electron/zoom.test.ts` → 18/18 pass
- `tsc -p tsconfig.electron.json --noEmit` → clean
- Reproduced locally on Windows 10: set 125% UI scale → alt-tab away and back → scale holds (was reverting to default before)

## Notes

Re-applying on focus is idempotent (same persisted level), so it is safe on macOS/Linux too, where Chromium does not drop zoom on focus regain.