### PR TITLE
fix(install): bound winget installs of ripgrep/ffmpeg with a wall-clock timeout

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -36,3 +36,11 @@ jobs:
       - name: 8.3 short-path normalization (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+
+      - name: winget install wall-clock timeout guard (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-winget-timeout.ps1
+
+      - name: winget install wall-clock timeout guard (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-winget-timeout.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1655,7 +1655,7 @@ function Invoke-ProcessWithWallClockTimeout {
     # $null (PowerShell issues #20400 / #5421). Touching .Handle forces the
     # underlying handle open, which is what WaitForExit() and .ExitCode
     # need to work. Harmless no-op on hosts without the bug.
-    $null = $proc.Handle
+    try { $null = $proc.Handle } catch { }
     $exited = $proc.WaitForExit($TimeoutSec * 1000)
     if (-not $exited) {
         # Kill the whole tree rooted at $proc, not just $proc itself.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1608,6 +1608,72 @@ function Update-ProcessPathForPackages {
     $env:Path = [string]::Join(';', $ordered)
 }
 
+function Invoke-ProcessWithWallClockTimeout {
+    # Launch $FilePath as a genuine child process (NOT wrapped in a
+    # PowerShell background job) and enforce a hard wall-clock timeout,
+    # killing the whole process tree if it doesn't finish in time. Mirrors
+    # the bash installer's run_with_timeout so a stalled installer step
+    # (e.g. winget waiting on a source update, a stuck download, or a UAC
+    # prompt that never gets answered when invoked non-interactively via
+    # `irm | iex`) can't hang the installer indefinitely (see #78085).
+    #
+    # This intentionally does NOT use Start-Job/Wait-Job/Stop-Job: a
+    # background job's Stop-Job only tears down the job's own runspace, it
+    # does not recursively kill native child processes the script block
+    # spawned (verified directly -- a process started inside a job via
+    # Start-Process is still alive after Stop-Job + Remove-Job -Force).
+    # For winget specifically that would leave the real winget.exe (and
+    # anything IT spawns, e.g. an elevated installer or msiexec) orphaned
+    # and running in the background instead of actually terminated, and
+    # able to collide with the next package's winget invocation via
+    # winget's own single-instance lock. Launching the real process
+    # ourselves gives us its PID so we can kill the whole tree on timeout.
+    #
+    # Returns a hashtable:
+    #   TimedOut -- $true if the timeout fired before the process exited
+    #   ExitCode -- the process's exit code, or $null if it timed out
+    param(
+        [Parameter(Mandatory=$true)] [string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [Parameter(Mandatory=$true)] [int]$TimeoutSec,
+        [string]$RedirectStandardOutput,
+        [string]$RedirectStandardError
+    )
+    $startArgs = @{
+        FilePath     = $FilePath
+        ArgumentList = $ArgumentList
+        PassThru     = $true
+        NoNewWindow  = $true
+    }
+    if ($RedirectStandardOutput) { $startArgs.RedirectStandardOutput = $RedirectStandardOutput }
+    if ($RedirectStandardError) { $startArgs.RedirectStandardError = $RedirectStandardError }
+    $proc = Start-Process @startArgs
+    $exited = $proc.WaitForExit($TimeoutSec * 1000)
+    if (-not $exited) {
+        # Kill the whole tree rooted at $proc, not just $proc itself.
+        # Process.Kill(bool) with recursive-tree support needs .NET Core 3+
+        # (pwsh 6+); Windows PowerShell 5.1 runs on .NET Framework and lacks
+        # that overload, so fall back to `taskkill /T` there -- both paths
+        # are Windows-only anyway (WinPS 5.1 never runs elsewhere).
+        if ($PSVersionTable.PSVersion.Major -ge 6) {
+            try { $proc.Kill($true) } catch { }
+        } else {
+            & taskkill /PID $proc.Id /T /F 2>&1 | Out-Null
+        }
+        # Give the OS a bounded window to finish tearing down the tree so
+        # file handles and winget's single-instance lock are released before
+        # the caller reads the redirect files or launches the next package.
+        try { $null = $proc.WaitForExit(5000) } catch { }
+        return @{ TimedOut = $true; ExitCode = $null; ProcessId = $proc.Id }
+    }
+    # WaitForExit(ms) returning $true only means the process exited; with
+    # redirected output the background stream readers may still be flushing
+    # the files. The parameterless overload waits for those too, so the
+    # caller's Get-Content sees complete output.
+    try { $proc.WaitForExit() } catch { }
+    return @{ TimedOut = $false; ExitCode = $proc.ExitCode; ProcessId = $proc.Id }
+}
+
 function Install-SystemPackages {
     $script:HasRipgrep = $false
     $script:HasFfmpeg = $false
@@ -1668,36 +1734,67 @@ function Install-SystemPackages {
         foreach ($pkg in $wingetPkgs) {
             $log = "$env:TEMP\hermes-winget-$($pkg -replace '[^A-Za-z0-9]','_')-$(Get-Random).log"
             $pkgLogs[$pkg] = $log
+            $stdOutPath = "$log.stdout.tmp"
+            $stdErrPath = "$log.stderr.tmp"
             # --source winget pins us to the github-backed source.  Without this,
             # a broken msstore source (cert validation failures like 0x8a15005e
             # are common on Windows-on-ARM and some corporate networks) makes
             # winget bail with "please specify --source" *before* attempting any
             # install -- and it exits 0, so the surrounding try/catch never fires.
             # We don't ship anything from msstore, so pinning is safe.
+            #
+            # Run through Invoke-ProcessWithWallClockTimeout: winget can hang
+            # indefinitely (a stalled source update, a stuck download, or a
+            # UAC prompt that never gets answered when the installer is
+            # invoked non-interactively via `irm | iex`), which previously
+            # froze the whole installer on "Installing ripgrep ... via
+            # winget..." forever (#78085). 600s mirrors the bash installer's
+            # NODE_DEPS_TIMEOUT default and the Playwright install guard --
+            # generous enough for a large ffmpeg download on a slow link, but
+            # it bounds the hang so the choco/scoop fallback (or the manual
+            # instructions below) actually runs instead of blocking forever.
+            $commonArgs = @("install", "--exact", "--id", $pkg, "--source", "winget", "--silent")
+            $agreementArgs = @("--accept-package-agreements", "--accept-source-agreements")
             try {
-                $output = winget install --exact --id $pkg --source winget --silent `
-                    --accept-package-agreements --accept-source-agreements 2>&1
-                $code = $LASTEXITCODE
-                $output | Out-File -FilePath $log -Encoding utf8
-                "winget exit: $code" | Out-File -FilePath $log -Encoding utf8 -Append
-                # 0x8A15002B (-1978335189) = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE.
-                # winget treats `install` on a package it already has registered as
-                # an *upgrade*, finds no newer version, and bails with this code --
-                # even when the binary is gone from disk/PATH (stale registration,
-                # files removed outside winget, or a missing alias shim). We KNOW the
-                # command was missing (that's why we're here), so a plain install
-                # dead-ends forever. Force a reinstall to repair the registration so
-                # the shim reappears.
-                if ($code -eq -1978335189) {
-                    "-> already-installed/no-upgrade; retrying with --force" | Out-File -FilePath $log -Encoding utf8 -Append
-                    $output = winget install --exact --id $pkg --source winget --silent --force `
-                        --accept-package-agreements --accept-source-agreements 2>&1
-                    $output | Out-File -FilePath $log -Encoding utf8 -Append
-                    "winget exit (force): $LASTEXITCODE" | Out-File -FilePath $log -Encoding utf8 -Append
+                $wingetResult = Invoke-ProcessWithWallClockTimeout -FilePath "winget" `
+                    -ArgumentList ($commonArgs + $agreementArgs) -TimeoutSec 600 `
+                    -RedirectStandardOutput $stdOutPath -RedirectStandardError $stdErrPath
+                Get-Content -Path $stdOutPath, $stdErrPath -ErrorAction SilentlyContinue |
+                    Out-File -FilePath $log -Encoding utf8
+                Remove-Item -Path $stdOutPath, $stdErrPath -ErrorAction SilentlyContinue
+                if ($wingetResult.TimedOut) {
+                    "winget exit: <timed out after 600s>" | Out-File -FilePath $log -Encoding utf8 -Append
+                } else {
+                    $code = $wingetResult.ExitCode
+                    "winget exit: $code" | Out-File -FilePath $log -Encoding utf8 -Append
+                    # 0x8A15002B (-1978335189) = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE.
+                    # winget treats `install` on a package it already has registered as
+                    # an *upgrade*, finds no newer version, and bails with this code --
+                    # even when the binary is gone from disk/PATH (stale registration,
+                    # files removed outside winget, or a missing alias shim). We KNOW the
+                    # command was missing (that's why we're here), so a plain install
+                    # dead-ends forever. Force a reinstall to repair the registration so
+                    # the shim reappears.
+                    if ($code -eq -1978335189) {
+                        "-> already-installed/no-upgrade; retrying with --force" | Out-File -FilePath $log -Encoding utf8 -Append
+                        $forceResult = Invoke-ProcessWithWallClockTimeout -FilePath "winget" `
+                            -ArgumentList ($commonArgs + @("--force") + $agreementArgs) -TimeoutSec 600 `
+                            -RedirectStandardOutput $stdOutPath -RedirectStandardError $stdErrPath
+                        Get-Content -Path $stdOutPath, $stdErrPath -ErrorAction SilentlyContinue |
+                            Out-File -FilePath $log -Encoding utf8 -Append
+                        Remove-Item -Path $stdOutPath, $stdErrPath -ErrorAction SilentlyContinue
+                        if ($forceResult.TimedOut) {
+                            "winget exit (force): <timed out after 600s>" | Out-File -FilePath $log -Encoding utf8 -Append
+                        } else {
+                            "winget exit (force): $($forceResult.ExitCode)" | Out-File -FilePath $log -Encoding utf8 -Append
+                        }
+                    }
                 }
             } catch {
                 $_ | Out-File -FilePath $log -Encoding utf8 -Append
                 "winget exit: <exception>" | Out-File -FilePath $log -Encoding utf8 -Append
+            } finally {
+                Remove-Item -Path $stdOutPath, $stdErrPath -ErrorAction SilentlyContinue
             }
         }
         # Refresh PATH so packages winget exposed via "command line aliases" in

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1648,6 +1648,14 @@ function Invoke-ProcessWithWallClockTimeout {
     if ($RedirectStandardOutput) { $startArgs.RedirectStandardOutput = $RedirectStandardOutput }
     if ($RedirectStandardError) { $startArgs.RedirectStandardError = $RedirectStandardError }
     $proc = Start-Process @startArgs
+    # Force the process handle to be opened IMMEDIATELY. On Windows
+    # PowerShell 5.1 (and pwsh 7.4.0 on Windows; fixed upstream in 7.4.1),
+    # Start-Process -NoNewWindow -PassThru returns a Process object whose
+    # handle was never acquired, so WaitForExit()/ExitCode silently read as
+    # $null (PowerShell issues #20400 / #5421). Touching .Handle forces the
+    # underlying handle open, which is what WaitForExit() and .ExitCode
+    # need to work. Harmless no-op on hosts without the bug.
+    $null = $proc.Handle
     $exited = $proc.WaitForExit($TimeoutSec * 1000)
     if (-not $exited) {
         # Kill the whole tree rooted at $proc, not just $proc itself.

--- a/scripts/tests/test-install-ps1-winget-timeout.ps1
+++ b/scripts/tests/test-install-ps1-winget-timeout.ps1
@@ -1,0 +1,164 @@
+# Smoke tests for the wall-clock timeout guard around winget installs in
+# install.ps1 (see #78085 -- the installer could hang forever on "Installing
+# ripgrep ... via winget..." with no way to recover).
+#
+# Run from a PowerShell prompt:
+#
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-winget-timeout.ps1
+#
+# This test extracts ONLY the Invoke-ProcessWithWallClockTimeout function
+# from install.ps1 (via the PowerShell AST, not a hand-copied duplicate) and
+# exercises it directly against a real child process (not real winget). It
+# deliberately does NOT run the whole install.ps1 file (dot-sourcing it
+# would fall through to Main() and attempt a real install) or invoke real
+# winget.
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot "scripts\install.ps1"
+
+if (-not (Test-Path $installScript)) {
+    throw "Could not locate install.ps1 at $installScript"
+}
+
+$failures = 0
+function Assert-Equal {
+    param([AllowNull()][Parameter(Mandatory=$true)] $Expected,
+          [AllowNull()][Parameter(Mandatory=$true)] $Actual,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if ($Expected -ne $Actual) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        Write-Host "  expected: $Expected"
+        Write-Host "  actual:   $Actual"
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+function Assert-True {
+    param([Parameter(Mandatory=$true)] $Condition,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if (-not $Condition) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Extract Invoke-ProcessWithWallClockTimeout from install.ps1 via the AST and
+# load just that function -- proves the shipped source defines it, without
+# executing the rest of the (side-effecting) installer script.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- extracting Invoke-ProcessWithWallClockTimeout from install.ps1 --"
+
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($installScript, [ref]$tokens, [ref]$parseErrors)
+Assert-Equal -Expected 0 -Actual $parseErrors.Count -Label "install.ps1 parses with no syntax errors"
+
+$fnAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -eq "Invoke-ProcessWithWallClockTimeout"
+}, $true)
+
+Assert-True ($null -ne $fnAst) -Label "install.ps1 defines Invoke-ProcessWithWallClockTimeout"
+
+if (-not $fnAst) {
+    Write-Host ""
+    Write-Host "FAILED: Invoke-ProcessWithWallClockTimeout is missing -- winget installs have no timeout guard (#78085)." -ForegroundColor Red
+    exit 1
+}
+
+. ([scriptblock]::Create($fnAst.Extent.Text))
+Assert-True (Get-Command Invoke-ProcessWithWallClockTimeout -ErrorAction SilentlyContinue) -Label "Invoke-ProcessWithWallClockTimeout is callable after extraction"
+
+# Use the currently-running PowerShell host itself as the "real command" to
+# launch -- it's a genuine external process (not a job, not a builtin) on
+# both Windows and non-Windows hosts, which is what lets this test run the
+# same way in CI as it does against a real `winget install` on Windows.
+$hostExe = (Get-Process -Id $PID).Path
+
+# -----------------------------------------------------------------------------
+# Test: a fast child process completes normally and returns its exit code
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- fast child process --"
+$fastOut = [System.IO.Path]::GetTempFileName()
+$fastErr = [System.IO.Path]::GetTempFileName()
+try {
+    $fastResult = Invoke-ProcessWithWallClockTimeout -FilePath $hostExe `
+        -ArgumentList @("-NoProfile", "-Command", "exit 0") -TimeoutSec 15 `
+        -RedirectStandardOutput $fastOut -RedirectStandardError $fastErr
+    Assert-Equal -Expected $false -Actual $fastResult.TimedOut -Label "fast process does not time out"
+    Assert-Equal -Expected 0 -Actual $fastResult.ExitCode -Label "fast process returns its exit code"
+} finally {
+    Remove-Item -Path $fastOut, $fastErr -ErrorAction SilentlyContinue
+}
+
+# -----------------------------------------------------------------------------
+# Test: a hanging child process is killed at the timeout instead of hanging
+# forever -- this is the actual bug from #78085 (winget "Installing ripgrep
+# ... via winget..." never returning). Uses a short 2s timeout against a
+# process that sleeps far longer, and asserts the CALL ITSELF returns well
+# within a generous wall-clock bound instead of blocking indefinitely, AND
+# (the gap the previous job-based implementation had) that the actual spawned
+# process is gone afterward, not merely detached from.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- hanging child process (simulates a stuck winget install) --"
+$hangOut = [System.IO.Path]::GetTempFileName()
+$hangErr = [System.IO.Path]::GetTempFileName()
+try {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $hangResult = Invoke-ProcessWithWallClockTimeout -FilePath $hostExe `
+        -ArgumentList @("-NoProfile", "-Command", "Start-Sleep -Seconds 120; exit 0") -TimeoutSec 2 `
+        -RedirectStandardOutput $hangOut -RedirectStandardError $hangErr
+    $sw.Stop()
+
+    Assert-Equal -Expected $true -Actual $hangResult.TimedOut -Label "hanging process is reported as timed out"
+    Assert-Equal -Expected $null -Actual $hangResult.ExitCode -Label "timed-out process has no exit code"
+    Assert-True ($sw.Elapsed.TotalSeconds -lt 30) -Label "call returns promptly instead of hanging (took $([math]::Round($sw.Elapsed.TotalSeconds, 1))s, must be < 30s for a 2s timeout)"
+
+    # Give the OS a moment to finish tearing the process down, then confirm
+    # it's actually gone -- Stop-Job/Remove-Job (the old implementation)
+    # only tears down the wrapping job, never the real process it launched.
+    Start-Sleep -Seconds 1
+    $stillAlive = $false
+    try { $null = Get-Process -Id $hangResult.ProcessId -ErrorAction Stop; $stillAlive = $true } catch { }
+    Assert-True (-not $stillAlive) -Label "timed-out process (PID $($hangResult.ProcessId)) is actually killed, not just detached from"
+} finally {
+    Remove-Item -Path $hangOut, $hangErr -ErrorAction SilentlyContinue
+}
+
+# -----------------------------------------------------------------------------
+# Test: the winget install call site inside Install-SystemPackages actually
+# routes through the timeout guard (not just defined-but-unused)
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- Install-SystemPackages wiring --"
+$installFnAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -eq "Install-SystemPackages"
+}, $true)
+Assert-True ($null -ne $installFnAst) -Label "install.ps1 defines Install-SystemPackages"
+if ($installFnAst) {
+    Assert-True ($installFnAst.Extent.Text -match "Invoke-ProcessWithWallClockTimeout") `
+        -Label "Install-SystemPackages calls Invoke-ProcessWithWallClockTimeout around the winget install"
+}
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "All smoke tests passed." -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## Summary

`install.ps1` ran `winget install` for ripgrep/ffmpeg with **no wall-clock timeout**. A stalled source update, stuck download, or unanswered UAC prompt hung the whole installer forever on `Installing ripgrep ... via winget...` — see #78085.

This PR adds `Invoke-ProcessWithWallClockTimeout` (mirroring the bash installer's `run_with_timeout`) and routes both winget call sites — the normal install and the `0x8A15002B` `--force` retry — through it with a **600s bound per package** (matches the bash installer's `NODE_DEPS_TIMEOUT` default and the existing Playwright install guard).

Key design points:

- **Real PID, not a job.** `Start-Process -PassThru` launches the actual `winget.exe` so we hold its PID. A `Start-Job`/`Stop-Job` wrapper only tears down the job's own runspace — the native child (and anything it spawned, e.g. an elevated installer) survives and can collide with the next winget invocation via winget's single-instance lock.
- **Whole-tree kill on timeout.** `$proc.Kill($true)` on pwsh 6+, `taskkill /PID <pid> /T /F` on Windows PowerShell 5.1 (which lacks the recursive overload).
- **Bounded post-kill wait** so file handles and the winget lock are released before the caller reads the redirect files or starts the next package.
- **Output fidelity preserved.** stdout/stderr are redirected to temp files and folded into the existing per-package `hermes-winget-<pkg>.log`; the `--source winget` pin and `-1978335189` force-retry logic are unchanged.
- On timeout the installer **falls through to the existing choco/scoop fallback** (or the manual-install instructions) instead of blocking forever — the hang becomes a bounded, logged degradation.

## Prior art

This re-lands work by @chelsealong (commits `0f71de50` + `f7f24be`, never opened as a PR) onto current main, with the redirect-file output capture, 600s timeout, and the post-kill teardown wait folded in. All credit for the core approach goes to that author.

## Tests

- New `scripts/tests/test-install-ps1-winget-timeout.ps1` (AST-extraction smoke test, same pattern as the other install.ps1 tests):
  - fast child process returns its exit code without timing out
  - hanging child is killed at the timeout, the call returns promptly, and the spawned PID is **actually gone** afterward (the gap the job-based implementation had)
  - `Install-SystemPackages` routes the winget install through the guard
- Wired into `.github/workflows/installer-tests.yml` for both pwsh 7 and Windows PowerShell 5.1.
- Verified locally on pwsh 7.6.4: 9/9 assertions pass; `test-install-ps1-longpath.ps1` still passes.

## Notes

**Open question:** the choco/scoop fallback paths also lack timeouts on main. I scoped this PR to winget (the reported bug); adding the same guard to choco/scoop would be a natural follow-up if maintainers want it.

Closes #78085
