### PR TITLE
fix(sessions): /undo restores pre-compaction history (#81130)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8495,19 +8495,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Soft-delete the truncated rows on disk so re-prompts and search
         # see the clean transcript while the rows survive for audit.
+        # Cross-compaction-boundary undo (#81130): the picker also surfaces
+        # rows from the compacted=1 archive produced by ``archive_and_compact``,
+        # so ``/undo`` can step back into the pre-compaction transcript. When
+        # the picked target lives in the compacted archive, the call routes
+        # through ``rewind_through_compaction`` (the inverse of
+        # ``archive_and_compact``: revives the compacted rows and soft-deletes
+        # the live tail) instead of ``rewind_to_message``. The CLI's
+        # in-memory ``conversation_history`` is then reloaded from the DB so
+        # the next turn's prompt-cache rebuild lands on the revived set
+        # instead of the stale compacted summary.
         rewound_rows = 0
+        revived_rows = 0
+        crossed_compaction_boundary = False
         if self._session_db is not None and self.session_id:
             try:
                 recents = self._session_db.list_recent_user_messages(
-                    self.session_id, limit=max(turns_undone, 10)
+                    self.session_id,
+                    limit=max(turns_undone, 10),
+                    include_compacted=True,
                 )
                 if recents:
                     target_idx = min(turns_undone - 1, len(recents) - 1)
                     target_id = recents[target_idx]["id"]
-                    result = self._session_db.rewind_to_message(
-                        self.session_id, target_id
+                    target_is_compacted = self._undo_target_is_compacted(
+                        target_id
                     )
-                    rewound_rows = result.get("rewound_count", 0)
+                    if target_is_compacted:
+                        crossed_compaction_boundary = True
+                        result = self._session_db.rewind_through_compaction(
+                            self.session_id, target_id
+                        )
+                        rewound_rows = result.get("rewound_count", 0)
+                        revived_rows = result.get("revived_count", 0)
+                    else:
+                        result = self._session_db.rewind_to_message(
+                            self.session_id, target_id
+                        )
+                        rewound_rows = result.get("rewound_count", 0)
                     # Prefer the DB's decoded target text for the prefill —
                     # it's the canonical persisted copy.
                     db_text = self._undo_content_to_text(
@@ -8521,6 +8546,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 logger.debug("undo: soft-delete skipped: %s", e)
             except Exception as e:
                 logger.debug("undo: soft-delete failed: %s", e)
+
+        # After crossing a compaction boundary, the in-memory
+        # ``conversation_history`` no longer matches the durable live set:
+        # the compacted summary / recent exchanges were soft-deleted on
+        # disk and the revived pre-compaction rows aren't represented in
+        # memory at all. Reload from the DB so the next turn's prompt and
+        # the system-prompt cache rebuild land on the revived transcript
+        # rather than the stale compacted summary. The flush-index reset
+        # below still drives the append-only flush on the next turn.
+        if crossed_compaction_boundary and self._session_db is not None and self.session_id:
+            try:
+                self.conversation_history = (
+                    self._session_db.get_messages_as_conversation(self.session_id)
+                )
+            except Exception as e:
+                logger.debug("undo: post-compaction reload failed: %s", e)
 
         # Agent surgery: invalidate the system-prompt cache and reset the
         # flush index so the next turn re-flushes from the truncated head.
@@ -8551,9 +8592,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         turn_word = "turn" if turns_undone == 1 else "turns"
         msg_count = rewound_rows or removed_count
+        boundary_note = ""
+        if crossed_compaction_boundary and revived_rows:
+            boundary_note = (
+                f" (revived {revived_rows} pre-compaction row(s); "
+                f"compaction summary discarded)"
+            )
         print(
             f"(^_^)b Undid {turns_undone} {turn_word} ({msg_count} message(s)). "
             f"Backed up to: \"{removed_text[:60]}{'...' if len(removed_text) > 60 else ''}\""
+            f"{boundary_note}"
         )
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
@@ -8576,6 +8624,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             ]
             return "\n".join(t for t in parts if t)
         return ""
+
+    def _undo_target_is_compacted(self, target_id: int) -> bool:
+        """True iff ``target_id`` is in the compacted=1 archive.
+
+        Small read-only probe that powers the cross-compaction-boundary
+        routing in :meth:`undo_last` (#81130). Returns False when the DB
+        cannot answer so the call falls back to the standard soft-delete
+        path (no live row, no race window).
+        """
+        db = self._session_db
+        sid = self.session_id
+        if db is None or not sid:
+            return False
+        try:
+            with db._lock:
+                row = db._conn.execute(
+                    "SELECT active, compacted FROM messages "
+                    "WHERE id = ? AND session_id = ?",
+                    (target_id, sid),
+                ).fetchone()
+        except Exception:
+            return False
+        if row is None:
+            return False
+        active = row["active"] if hasattr(row, "keys") else row[0]
+        compacted = row["compacted"] if hasattr(row, "keys") else row[1]
+        try:
+            return int(active or 0) == 0 and int(compacted or 0) == 1
+        except (TypeError, ValueError):
+            return False
 
     def _prefill_input_buffer(self, text: str) -> None:
         """Place ``text`` in the active prompt_toolkit buffer, editable."""

--- a/cli.py
+++ b/cli.py
@@ -8808,19 +8808,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Soft-delete the truncated rows on disk so re-prompts and search
         # see the clean transcript while the rows survive for audit.
+        # Cross-compaction-boundary undo (#81130): the picker also surfaces
+        # rows from the compacted=1 archive produced by ``archive_and_compact``,
+        # so ``/undo`` can step back into the pre-compaction transcript. When
+        # the picked target lives in the compacted archive, the call routes
+        # through ``rewind_through_compaction`` (the inverse of
+        # ``archive_and_compact``: revives the compacted rows and soft-deletes
+        # the live tail) instead of ``rewind_to_message``. The CLI's
+        # in-memory ``conversation_history`` is then reloaded from the DB so
+        # the next turn's prompt-cache rebuild lands on the revived set
+        # instead of the stale compacted summary.
         rewound_rows = 0
+        revived_rows = 0
+        crossed_compaction_boundary = False
         if self._session_db is not None and self.session_id:
             try:
                 recents = self._session_db.list_recent_user_messages(
-                    self.session_id, limit=max(turns_undone, 10)
+                    self.session_id,
+                    limit=max(turns_undone, 10),
+                    include_compacted=True,
                 )
                 if recents:
                     target_idx = min(turns_undone - 1, len(recents) - 1)
                     target_id = recents[target_idx]["id"]
-                    result = self._session_db.rewind_to_message(
-                        self.session_id, target_id
+                    target_is_compacted = self._undo_target_is_compacted(
+                        target_id
                     )
-                    rewound_rows = result.get("rewound_count", 0)
+                    if target_is_compacted:
+                        crossed_compaction_boundary = True
+                        result = self._session_db.rewind_through_compaction(
+                            self.session_id, target_id
+                        )
+                        rewound_rows = result.get("rewound_count", 0)
+                        revived_rows = result.get("revived_count", 0)
+                    else:
+                        result = self._session_db.rewind_to_message(
+                            self.session_id, target_id
+                        )
+                        rewound_rows = result.get("rewound_count", 0)
                     # Prefer the DB's decoded target text for the prefill —
                     # it's the canonical persisted copy.
                     db_text = self._undo_content_to_text(
@@ -8834,6 +8859,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 logger.debug("undo: soft-delete skipped: %s", e)
             except Exception as e:
                 logger.debug("undo: soft-delete failed: %s", e)
+
+        # After crossing a compaction boundary, the in-memory
+        # ``conversation_history`` no longer matches the durable live set:
+        # the compacted summary / recent exchanges were soft-deleted on
+        # disk and the revived pre-compaction rows aren't represented in
+        # memory at all. Reload from the DB so the next turn's prompt and
+        # the system-prompt cache rebuild land on the revived transcript
+        # rather than the stale compacted summary. The flush-index reset
+        # below still drives the append-only flush on the next turn.
+        if crossed_compaction_boundary and self._session_db is not None and self.session_id:
+            try:
+                self.conversation_history = (
+                    self._session_db.get_messages_as_conversation(self.session_id)
+                )
+            except Exception as e:
+                logger.debug("undo: post-compaction reload failed: %s", e)
 
         # Agent surgery: invalidate the system-prompt cache and reset the
         # flush index so the next turn re-flushes from the truncated head.
@@ -8864,9 +8905,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         turn_word = "turn" if turns_undone == 1 else "turns"
         msg_count = rewound_rows or removed_count
+        boundary_note = ""
+        if crossed_compaction_boundary and revived_rows:
+            boundary_note = (
+                f" (revived {revived_rows} pre-compaction row(s); "
+                f"compaction summary discarded)"
+            )
         print(
             f"(^_^)b Undid {turns_undone} {turn_word} ({msg_count} message(s)). "
             f"Backed up to: \"{removed_text[:60]}{'...' if len(removed_text) > 60 else ''}\""
+            f"{boundary_note}"
         )
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
@@ -8889,6 +8937,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             ]
             return "\n".join(t for t in parts if t)
         return ""
+
+    def _undo_target_is_compacted(self, target_id: int) -> bool:
+        """True iff ``target_id`` is in the compacted=1 archive.
+
+        Small read-only probe that powers the cross-compaction-boundary
+        routing in :meth:`undo_last` (#81130). Returns False when the DB
+        cannot answer so the call falls back to the standard soft-delete
+        path (no live row, no race window).
+        """
+        db = self._session_db
+        sid = self.session_id
+        if db is None or not sid:
+            return False
+        try:
+            with db._lock:
+                row = db._conn.execute(
+                    "SELECT active, compacted FROM messages "
+                    "WHERE id = ? AND session_id = ?",
+                    (target_id, sid),
+                ).fetchone()
+        except Exception:
+            return False
+        if row is None:
+            return False
+        active = row["active"] if hasattr(row, "keys") else row[0]
+        compacted = row["compacted"] if hasattr(row, "keys") else row[1]
+        try:
+            return int(active or 0) == 0 and int(compacted or 0) == 1
+        except (TypeError, ValueError):
+            return False
 
     def _prefill_input_buffer(self, text: str) -> None:
         """Place ``text`` in the active prompt_toolkit buffer, editable."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3430,6 +3430,14 @@ class SessionStore:
         Returns a dict ``{"rewound_count", "turns_undone", "target_text"}`` on
         success, or ``None`` if there's no DB or no user message to back up to.
         ``n`` clamps to the oldest user turn when it exceeds the turn count.
+
+        Cross-compaction-boundary undo (#81130): the rewind target picker also
+        looks at the compacted=1 archive produced by ``archive_and_compact``
+        so ``/undo`` can step back into the pre-compaction transcript. When
+        the picked target lives in the compacted archive, the call routes
+        through :meth:`SessionDB.rewind_through_compaction` (the inverse of
+        ``archive_and_compact``: revives the compacted rows and soft-deletes
+        the live tail) instead of :meth:`SessionDB.rewind_to_message`.
         """
         if not self._db:
             return None
@@ -3437,7 +3445,12 @@ class SessionStore:
         if n < 1:
             n = 1
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            # include_compacted=True: lets the picker surface rows from the
+            # archive_and_compact archive when the live transcript has been
+            # shortened past the user's pre-compaction turns.
+            recents = self._db.list_recent_user_messages(
+                session_id, limit=max(n, 10), include_compacted=True
+            )
         except Exception as e:
             logger.debug("rewind_session: failed to list user messages: %s", e)
             return None
@@ -3445,13 +3458,24 @@ class SessionStore:
             return None
         target_idx = min(n - 1, len(recents) - 1)
         target_id = recents[target_idx]["id"]
+        # Detect compaction-archive target: rows from archive_and_compact are
+        # active=0+compacted=1. Anything else (active=1, or active=0+compacted=0
+        # from a prior /undo) routes through the standard soft-delete path.
+        target_is_compacted = self._target_row_is_compacted_archived(
+            session_id, target_id
+        )
         try:
-            result = self._db.rewind_to_message(session_id, target_id)
+            if target_is_compacted:
+                result = self._db.rewind_through_compaction(
+                    session_id, target_id
+                )
+            else:
+                result = self._db.rewind_to_message(session_id, target_id)
         except ValueError as e:
             logger.debug("rewind_session: %s", e)
             return None
         except Exception as e:
-            logger.debug("rewind_session: rewind_to_message failed: %s", e)
+            logger.debug("rewind_session: rewind failed: %s", e)
             return None
         target_msg = result.get("target_message") or {}
         content = target_msg.get("content") or ""
@@ -3471,6 +3495,35 @@ class SessionStore:
             "turns_undone": target_idx + 1,
             "target_text": target_text,
         }
+
+    def _target_row_is_compacted_archived(
+        self, session_id: str, target_id: int
+    ) -> bool:
+        """Return True iff *target_id* is in the compacted=1 archive.
+
+        A small read-only probe that powers the cross-compaction-boundary
+        routing in :meth:`rewind_session` (#81130). Returns False when the
+        DB cannot answer (legacy / third-party SessionDB without the
+        ``active``/``compacted`` columns), so the call falls back to the
+        standard ``rewind_to_message`` path.
+        """
+        try:
+            with self._db._lock:
+                row = self._db._conn.execute(
+                    "SELECT active, compacted FROM messages "
+                    "WHERE id = ? AND session_id = ?",
+                    (target_id, session_id),
+                ).fetchone()
+        except Exception:
+            return False
+        if row is None:
+            return False
+        active = row["active"] if hasattr(row, "keys") else row[0]
+        compacted = row["compacted"] if hasattr(row, "keys") else row[1]
+        try:
+            return int(active or 0) == 0 and int(compacted or 0) == 1
+        except (TypeError, ValueError):
+            return False
 
 
 def build_session_context(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3860,6 +3860,14 @@ class SessionStore:
         Returns a dict ``{"rewound_count", "turns_undone", "target_text"}`` on
         success, or ``None`` if there's no DB or no user message to back up to.
         ``n`` clamps to the oldest user turn when it exceeds the turn count.
+
+        Cross-compaction-boundary undo (#81130): the rewind target picker also
+        looks at the compacted=1 archive produced by ``archive_and_compact``
+        so ``/undo`` can step back into the pre-compaction transcript. When
+        the picked target lives in the compacted archive, the call routes
+        through :meth:`SessionDB.rewind_through_compaction` (the inverse of
+        ``archive_and_compact``: revives the compacted rows and soft-deletes
+        the live tail) instead of :meth:`SessionDB.rewind_to_message`.
         """
         if not self._db:
             return None
@@ -3867,7 +3875,12 @@ class SessionStore:
         if n < 1:
             n = 1
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            # include_compacted=True: lets the picker surface rows from the
+            # archive_and_compact archive when the live transcript has been
+            # shortened past the user's pre-compaction turns.
+            recents = self._db.list_recent_user_messages(
+                session_id, limit=max(n, 10), include_compacted=True
+            )
         except Exception as e:
             logger.debug("rewind_session: failed to list user messages: %s", e)
             return None
@@ -3875,13 +3888,24 @@ class SessionStore:
             return None
         target_idx = min(n - 1, len(recents) - 1)
         target_id = recents[target_idx]["id"]
+        # Detect compaction-archive target: rows from archive_and_compact are
+        # active=0+compacted=1. Anything else (active=1, or active=0+compacted=0
+        # from a prior /undo) routes through the standard soft-delete path.
+        target_is_compacted = self._target_row_is_compacted_archived(
+            session_id, target_id
+        )
         try:
-            result = self._db.rewind_to_message(session_id, target_id)
+            if target_is_compacted:
+                result = self._db.rewind_through_compaction(
+                    session_id, target_id
+                )
+            else:
+                result = self._db.rewind_to_message(session_id, target_id)
         except ValueError as e:
             logger.debug("rewind_session: %s", e)
             return None
         except Exception as e:
-            logger.debug("rewind_session: rewind_to_message failed: %s", e)
+            logger.debug("rewind_session: rewind failed: %s", e)
             return None
         target_msg = result.get("target_message") or {}
         content = target_msg.get("content") or ""
@@ -3901,6 +3925,35 @@ class SessionStore:
             "turns_undone": target_idx + 1,
             "target_text": target_text,
         }
+
+    def _target_row_is_compacted_archived(
+        self, session_id: str, target_id: int
+    ) -> bool:
+        """Return True iff *target_id* is in the compacted=1 archive.
+
+        A small read-only probe that powers the cross-compaction-boundary
+        routing in :meth:`rewind_session` (#81130). Returns False when the
+        DB cannot answer (legacy / third-party SessionDB without the
+        ``active``/``compacted`` columns), so the call falls back to the
+        standard ``rewind_to_message`` path.
+        """
+        try:
+            with self._db._lock:
+                row = self._db._conn.execute(
+                    "SELECT active, compacted FROM messages "
+                    "WHERE id = ? AND session_id = ?",
+                    (target_id, session_id),
+                ).fetchone()
+        except Exception:
+            return False
+        if row is None:
+            return False
+        active = row["active"] if hasattr(row, "keys") else row[0]
+        compacted = row["compacted"] if hasattr(row, "keys") else row[1]
+        try:
+            return int(active or 0) == 0 and int(compacted or 0) == 1
+        except (TypeError, ValueError):
+            return False
 
 
 def build_session_context(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8023,6 +8023,172 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def rewind_through_compaction(
+        self, session_id: str, target_message_id: int
+    ) -> Dict[str, Any]:
+        """Reverse a prior :meth:`archive_and_compact` for ``/undo`` (#81130).
+
+        ``archive_and_compact`` soft-archives the live turns (``active=0,
+        compacted=1``) and inserts fresh compacted rows as ``active=1``.
+        ``/undo`` is "back up N user turns via suffix soft-delete", which only
+        sees the LIVE set — the compacted summary + recent exchanges — so it
+        could never reach the pre-compaction history. This method is the
+        inverse: revives the ENTIRE compacted=1 archive for *session_id*
+        (back to ``active=1, compacted=0``) and soft-deletes the live tail
+        at-or-after ``target_message_id`` so the next reload replays the
+        pre-compaction transcript.
+
+        Pre-conditions: ``target_message_id`` must exist in *session_id*, be a
+        user message, and have ``compacted=1, active=0`` — i.e. it lives in
+        the compacted=1 archive produced by ``archive_and_compact``. For a
+        non-compacted target, raise ``ValueError``; the caller (typically
+        ``SessionStore.rewind_session`` or ``HermesCLI.undo_last``) is
+        expected to fall back to :meth:`rewind_to_message` instead.
+
+        Why revive the whole archive (not just rows at/after the target):
+        the user's intent on ``/undo`` after compaction is to recover the
+        pre-compaction state so they can keep working. The pre-compaction
+        transcript is the entire ``active=0, compacted=1`` set — the
+        ``target_message_id`` only marks how far back the LIVE tail should
+        be soft-deleted. Leaving pre-target compacted rows archived would
+        strand most of the pre-compaction history where the user can't see
+        or resume it, which is exactly the bug #81130 reports.
+
+        Returns a dict with ``rewound_count`` (live rows newly soft-deleted),
+        ``revived_count`` (compacted rows re-activated), ``target_message``,
+        and ``new_head_id`` (id of the last still-active row after the
+        rewind, or ``None``). ``sessions.rewind_count`` is incremented
+        exactly once, matching :meth:`rewind_to_message`.
+
+        Why a separate method rather than a flag on ``rewind_to_message``:
+        the live-archive inversion has a distinct SQL shape (cross-flag
+        UPDATE in both directions, whole-archive revive) and a distinct
+        return shape (``revived_count``). Mixing them would broaden
+        ``rewind_to_message``'s contract for callers that don't need the
+        compaction-aware branch.
+        """
+
+        # 1) Validate target up-front (read-only, outside the write txn).
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM messages WHERE id = ? AND session_id = ?",
+                (target_message_id, session_id),
+            ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"message {target_message_id} not found in session {session_id}"
+            )
+        target_row = dict(row)
+        if target_row.get("role") != "user":
+            raise ValueError(
+                f"rewind target must be a 'user' message (got role="
+                f"{target_row.get('role')!r}, id={target_message_id})"
+            )
+        if not (
+            int(target_row.get("compacted", 0) or 0) == 1
+            and int(target_row.get("active", 0) or 0) == 0
+        ):
+            raise ValueError(
+                f"rewind_through_compaction target must live in the compacted=1 "
+                f"archive (got active={target_row.get('active')!r}, "
+                f"compacted={target_row.get('compacted')!r}, "
+                f"id={target_message_id}) — use rewind_to_message for live targets"
+            )
+
+        # Decode content for callers (prefill the prompt buffer).
+        target_row["content"] = self._decode_content(target_row.get("content"))
+
+        rewound_live_ids: List[int] = []
+        revived_compacted_ids: List[int] = []
+
+        def _do(conn):
+            # ORDER MATTERS: soft-delete the live tail FIRST, then revive the
+            # compacted archive. Reversing the order would clobber the
+            # revived rows — once they're flipped to active=1, the live-tail
+            # filter below would catch them too (they satisfy active=1).
+            # Doing the soft-delete first means the live-tail filter only
+            # sees the original (compacted-summary + recent exchange) rows.
+            #
+            # The live-tail filter still keys on id >= target_message_id
+            # so any pre-target live rows (e.g. a pre-compaction user row
+            # the agent appended to the live set after picking the target)
+            # stay alive. After archive_and_compact the live set is the
+            # compact tail, so id >= target naturally covers exactly that
+            # tail without spilling into the archive.
+            cursor = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND id >= ? AND active = 1",
+                (session_id, target_message_id),
+            )
+            live_ids = [r[0] for r in cursor.fetchall()]
+            if live_ids:
+                placeholders = ",".join("?" for _ in live_ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
+                    live_ids,
+                )
+            # Revive the ENTIRE compacted=1 archive for this session — not
+            # just rows at/after the target. See the docstring for why: the
+            # user's intent on /undo after compaction is to recover the full
+            # pre-compaction state. compacted=0 on revival distinguishes
+            # these from any earlier compaction boundary that may still
+            # archive older turns elsewhere.
+            cursor = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND active = 0 AND compacted = 1",
+                (session_id,),
+            )
+            revived = [r[0] for r in cursor.fetchall()]
+            if revived:
+                placeholders = ",".join("?" for _ in revived)
+                conn.execute(
+                    f"UPDATE messages SET active = 1, compacted = 0 "
+                    f"WHERE id IN ({placeholders})",
+                    revived,
+                )
+            conn.execute(
+                "UPDATE sessions SET rewind_count = COALESCE(rewind_count, 0) + 1 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+            return revived, live_ids
+
+        revived_compacted_ids, rewound_live_ids = self._execute_write(_do)
+
+        # 2) Recompute new head id and message_count. ``message_count`` must
+        # reflect the LIVE set (matches archive_and_compact semantics — the
+        # session's live load returns active=1 rows, so the counter must too).
+        with self._lock:
+            head_row = self._conn.execute(
+                "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+            count_row = self._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+        new_head_id = head_row[0] if head_row and head_row[0] is not None else None
+        live_count = int(count_row[0]) if count_row and count_row[0] is not None else 0
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "UPDATE sessions SET message_count = ? WHERE id = ?",
+                    (live_count, session_id),
+                )
+        except Exception:
+            logger.debug(
+                "rewind_through_compaction: message_count update failed "
+                "(non-fatal; live load is the source of truth): %s",
+                session_id,
+            )
+
+        return {
+            "rewound_count": len(rewound_live_ids),
+            "revived_count": len(revived_compacted_ids),
+            "target_message": target_row,
+            "new_head_id": new_head_id,
+        }
+
     # =========================================================================
     # Search
     # =========================================================================

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8494,6 +8494,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
+            # Persist a stable display marker on synthetic compaction-summary
+            # rows so rewind/undo pickers and transcript surfaces can
+            # distinguish them from real user turns without content-prefix
+            # heuristics (#81130 root-cause 3). archive_and_compact /
+            # replace_messages both insert the compacted projection here; the
+            # append-only turn flush (run_agent._flush_messages_to_session_db
+            # _unlocked) already stamps the same "hidden" fingerprint on these
+            # rows, so persisting it here too keeps the two write paths
+            # consistent. Without it, a synthetic user-role summary persisted
+            # through a compaction rewrite carries display_kind=NULL and the
+            # /undo target picker's display_clause counts it as a real user
+            # turn — /undo N can land on the summary, soft-delete it without
+            # reviving the archived source rows, and leave an empty context.
+            # The fingerprint mirrors run_agent exactly: only rows that carry
+            # the compressed-summary metadata AND classify as a standalone
+            # handoff (or carry no preserved live user turn) are marked;
+            # merge-into-tail carriers keep real preserved content visible.
+            display_kind = msg.get("display_kind")
+            if not display_kind:
+                try:
+                    from agent.context_compressor import (
+                        COMPRESSED_SUMMARY_METADATA_KEY,
+                        COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
+                        ContextCompressor,
+                    )
+                except Exception:
+                    COMPRESSED_SUMMARY_METADATA_KEY = None
+                    COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = None
+                    ContextCompressor = None
+                _is_synthetic_summary = (
+                    COMPRESSED_SUMMARY_METADATA_KEY
+                    and msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                )
+                if _is_synthetic_summary and ContextCompressor is not None:
+                    try:
+                        _summary_is_standalone = (
+                            ContextCompressor.classify_summary_content(
+                                msg.get("content")
+                            )
+                            == "standalone"
+                        ) or not msg.get(COMPRESSED_SUMMARY_HAS_USER_TURN_KEY)
+                    except Exception:
+                        _summary_is_standalone = False
+                    if _summary_is_standalone:
+                        display_kind = "hidden"
+
             cur = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
@@ -8520,7 +8566,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     1 if msg.get("observed") else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
+                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
@@ -9552,7 +9598,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``/undo`` is "back up N user turns via suffix soft-delete", which only
         sees the LIVE set — the compacted summary + recent exchanges — so it
         could never reach the pre-compaction history. This method is the
-        inverse: revives the ENTIRE compacted=1 archive for *session_id*
+        inverse: revives the compaction boundary that contains *target_id*
         (back to ``active=1, compacted=0``) and soft-deletes the live tail
         at-or-after ``target_message_id`` so the next reload replays the
         pre-compaction transcript.
@@ -9564,14 +9610,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``SessionStore.rewind_session`` or ``HermesCLI.undo_last``) is
         expected to fall back to :meth:`rewind_to_message` instead.
 
-        Why revive the whole archive (not just rows at/after the target):
-        the user's intent on ``/undo`` after compaction is to recover the
-        pre-compaction state so they can keep working. The pre-compaction
-        transcript is the entire ``active=0, compacted=1`` set — the
-        ``target_message_id`` only marks how far back the LIVE tail should
-        be soft-deleted. Leaving pre-target compacted rows archived would
-        strand most of the pre-compaction history where the user can't see
-        or resume it, which is exactly the bug #81130 reports.
+        Why revive only the target's boundary (not the whole archive): after
+        several in-place compactions the ``compacted=1`` set piles up N
+        id-ordered boundary layers — each subsequent
+        :meth:`archive_and_compact` re-archives the prior projection. Sweeping
+        all of them on a deep ``/undo`` would restore every historical
+        boundary's rows and blow up the next context window (#81130). Only the
+        boundary the target rests in (delimited by id/ordinal, see
+        :meth:`_compaction_boundary_id_range`) is revived; the live tail at/
+        after the target is soft-deleted so the restored transcript matches
+        the pre-compaction state just before the target's turn.
 
         Returns a dict with ``rewound_count`` (live rows newly soft-deleted),
         ``revived_count`` (compacted rows re-activated), ``target_message``,
@@ -9646,18 +9694,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
                     live_ids,
                 )
-            # Revive the ENTIRE compacted=1 archive for this session — not
-            # just rows at/after the target. See the docstring for why: the
-            # user's intent on /undo after compaction is to recover the full
-            # pre-compaction state. compacted=0 on revival distinguishes
-            # these from any earlier compaction boundary that may still
-            # archive older turns elsewhere.
-            cursor = conn.execute(
-                "SELECT id FROM messages "
-                "WHERE session_id = ? AND active = 0 AND compacted = 1",
-                (session_id,),
+            # Revive ONLY the compaction boundary that contains the target —
+            # not the entire accumulated compacted=1 archive (#81130 LOW).
+            # After N in-place compactions the archive holds N piled-up
+            # boundary layers (each subsequent archive_and_compact re-archives
+            # the prior projection, so a deep /undo that revived everything
+            # would restore every historical boundary's rows and blow up the
+            # next context window). The boundary is delimited by id/ordinal:
+            # each boundary's archived projection begins with its synthetic
+            # summary row (the lowest-id row, stamped display_kind by
+            # _insert_message_rows), so the compacted rows between one
+            # summary-head and the next form exactly one boundary.
+            lo, hi = self._compaction_boundary_id_range(
+                conn, session_id, target_message_id
             )
-            revived = [r[0] for r in cursor.fetchall()]
+            revived = []
+            if lo is not None and hi is not None:
+                cursor = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE session_id = ? AND active = 0 AND compacted = 1 "
+                    "AND id >= ? AND id <= ?",
+                    (session_id, lo, hi),
+                )
+                revived = [r[0] for r in cursor.fetchall()]
             if revived:
                 placeholders = ",".join("?" for _ in revived)
                 conn.execute(
@@ -9707,6 +9766,83 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "target_message": target_row,
             "new_head_id": new_head_id,
         }
+
+    def _compaction_boundary_id_range(
+        self, conn, session_id: str, target_id: int
+    ) -> tuple[Optional[int], Optional[int]]:
+        """Return the ``[lo, hi]`` id range of the compaction boundary that
+        contains *target_id* (an ``active=0, compacted=1`` row), or
+        ``(None, None)`` when there is no archive.
+
+        The ``compacted=1`` archive is the pile-up of every prior
+        :meth:`archive_and_compact`: each subsequent call re-archives the
+        previous projection, so N compactions stack N id-ordered boundary
+        layers. ``rewind_through_compaction`` must revive only the boundary
+        the target resits in, not the whole pile (#81130).
+
+        Boundaries are delimited by id/ordinal. Each boundary's archived
+        projection begins with the synthetic summary row that the producing
+        compact inserted first — the boundary's lowest-id row, stamped with a
+        non-null ``display_kind`` by :meth:`_insert_message_rows`. So the
+        ``active=0, compacted=1`` rows between one summary-head and the next
+        form exactly one boundary. The pre-compaction originals (the FIRST
+        boundary) lie below the lowest summary-head.
+
+        Falls back to the entire archive (``[min, max]`` of the compacted set)
+        when no summary-head is present — a single compaction boundary, or a
+        legacy archive persisted before summary rows carried ``display_kind``,
+        where no id-ordinal split is possible.
+        """
+        compacted_ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 0 "
+                "AND compacted = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+        ]
+        if not compacted_ids:
+            return None, None
+        # Boundary-head markers: synthetic summary rows persisted by
+        # archive_and_compact / replace_messages carry a non-null display_kind
+        # (see _insert_message_rows). Real user turns are persisted WITHOUT a
+        # display_kind, so a non-empty one among the compacted set identifies
+        # exactly the summary-headed projection boundaries.
+        head_ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 0 "
+                "AND compacted = 1 AND role = 'user' "
+                "AND display_kind IS NOT NULL AND display_kind != '' ORDER BY id",
+                (session_id,),
+            ).fetchall()
+        ]
+        live_floor = conn.execute(
+            "SELECT MIN(id) FROM messages WHERE session_id = ? AND active = 1",
+            (session_id,),
+        ).fetchone()[0]
+        if not head_ids:
+            # Single accumulated boundary (no summary-marked sub-boundaries) —
+            # keep the historical whole-archive revive.
+            return compacted_ids[0], compacted_ids[-1]
+        heads_below = [h for h in head_ids if h <= target_id]
+        if heads_below:
+            lo = heads_below[-1]
+        else:
+            # Target sits below the lowest summary-head: it is in the original
+            # pre-compaction boundary.
+            lo = compacted_ids[0]
+        next_head = next((h for h in head_ids if h > target_id), None)
+        if next_head is not None:
+            hi = next_head - 1
+        elif live_floor is not None:
+            hi = live_floor - 1
+        else:
+            hi = compacted_ids[-1]
+        # The upper bound must stay within the compacted archive (live rows are
+        # above ``live_floor`` and never compacted).
+        hi = min(hi, compacted_ids[-1])
+        return max(lo, compacted_ids[0]), hi
 
     # =========================================================================
     # Search

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9542,6 +9542,172 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def rewind_through_compaction(
+        self, session_id: str, target_message_id: int
+    ) -> Dict[str, Any]:
+        """Reverse a prior :meth:`archive_and_compact` for ``/undo`` (#81130).
+
+        ``archive_and_compact`` soft-archives the live turns (``active=0,
+        compacted=1``) and inserts fresh compacted rows as ``active=1``.
+        ``/undo`` is "back up N user turns via suffix soft-delete", which only
+        sees the LIVE set — the compacted summary + recent exchanges — so it
+        could never reach the pre-compaction history. This method is the
+        inverse: revives the ENTIRE compacted=1 archive for *session_id*
+        (back to ``active=1, compacted=0``) and soft-deletes the live tail
+        at-or-after ``target_message_id`` so the next reload replays the
+        pre-compaction transcript.
+
+        Pre-conditions: ``target_message_id`` must exist in *session_id*, be a
+        user message, and have ``compacted=1, active=0`` — i.e. it lives in
+        the compacted=1 archive produced by ``archive_and_compact``. For a
+        non-compacted target, raise ``ValueError``; the caller (typically
+        ``SessionStore.rewind_session`` or ``HermesCLI.undo_last``) is
+        expected to fall back to :meth:`rewind_to_message` instead.
+
+        Why revive the whole archive (not just rows at/after the target):
+        the user's intent on ``/undo`` after compaction is to recover the
+        pre-compaction state so they can keep working. The pre-compaction
+        transcript is the entire ``active=0, compacted=1`` set — the
+        ``target_message_id`` only marks how far back the LIVE tail should
+        be soft-deleted. Leaving pre-target compacted rows archived would
+        strand most of the pre-compaction history where the user can't see
+        or resume it, which is exactly the bug #81130 reports.
+
+        Returns a dict with ``rewound_count`` (live rows newly soft-deleted),
+        ``revived_count`` (compacted rows re-activated), ``target_message``,
+        and ``new_head_id`` (id of the last still-active row after the
+        rewind, or ``None``). ``sessions.rewind_count`` is incremented
+        exactly once, matching :meth:`rewind_to_message`.
+
+        Why a separate method rather than a flag on ``rewind_to_message``:
+        the live-archive inversion has a distinct SQL shape (cross-flag
+        UPDATE in both directions, whole-archive revive) and a distinct
+        return shape (``revived_count``). Mixing them would broaden
+        ``rewind_to_message``'s contract for callers that don't need the
+        compaction-aware branch.
+        """
+
+        # 1) Validate target up-front (read-only, outside the write txn).
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM messages WHERE id = ? AND session_id = ?",
+                (target_message_id, session_id),
+            ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"message {target_message_id} not found in session {session_id}"
+            )
+        target_row = dict(row)
+        if target_row.get("role") != "user":
+            raise ValueError(
+                f"rewind target must be a 'user' message (got role="
+                f"{target_row.get('role')!r}, id={target_message_id})"
+            )
+        if not (
+            int(target_row.get("compacted", 0) or 0) == 1
+            and int(target_row.get("active", 0) or 0) == 0
+        ):
+            raise ValueError(
+                f"rewind_through_compaction target must live in the compacted=1 "
+                f"archive (got active={target_row.get('active')!r}, "
+                f"compacted={target_row.get('compacted')!r}, "
+                f"id={target_message_id}) — use rewind_to_message for live targets"
+            )
+
+        # Decode content for callers (prefill the prompt buffer).
+        target_row["content"] = self._decode_content(target_row.get("content"))
+
+        rewound_live_ids: List[int] = []
+        revived_compacted_ids: List[int] = []
+
+        def _do(conn):
+            # ORDER MATTERS: soft-delete the live tail FIRST, then revive the
+            # compacted archive. Reversing the order would clobber the
+            # revived rows — once they're flipped to active=1, the live-tail
+            # filter below would catch them too (they satisfy active=1).
+            # Doing the soft-delete first means the live-tail filter only
+            # sees the original (compacted-summary + recent exchange) rows.
+            #
+            # The live-tail filter still keys on id >= target_message_id
+            # so any pre-target live rows (e.g. a pre-compaction user row
+            # the agent appended to the live set after picking the target)
+            # stay alive. After archive_and_compact the live set is the
+            # compact tail, so id >= target naturally covers exactly that
+            # tail without spilling into the archive.
+            cursor = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND id >= ? AND active = 1",
+                (session_id, target_message_id),
+            )
+            live_ids = [r[0] for r in cursor.fetchall()]
+            if live_ids:
+                placeholders = ",".join("?" for _ in live_ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
+                    live_ids,
+                )
+            # Revive the ENTIRE compacted=1 archive for this session — not
+            # just rows at/after the target. See the docstring for why: the
+            # user's intent on /undo after compaction is to recover the full
+            # pre-compaction state. compacted=0 on revival distinguishes
+            # these from any earlier compaction boundary that may still
+            # archive older turns elsewhere.
+            cursor = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND active = 0 AND compacted = 1",
+                (session_id,),
+            )
+            revived = [r[0] for r in cursor.fetchall()]
+            if revived:
+                placeholders = ",".join("?" for _ in revived)
+                conn.execute(
+                    f"UPDATE messages SET active = 1, compacted = 0 "
+                    f"WHERE id IN ({placeholders})",
+                    revived,
+                )
+            conn.execute(
+                "UPDATE sessions SET rewind_count = COALESCE(rewind_count, 0) + 1 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+            return revived, live_ids
+
+        revived_compacted_ids, rewound_live_ids = self._execute_write(_do)
+
+        # 2) Recompute new head id and message_count. ``message_count`` must
+        # reflect the LIVE set (matches archive_and_compact semantics — the
+        # session's live load returns active=1 rows, so the counter must too).
+        with self._lock:
+            head_row = self._conn.execute(
+                "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+            count_row = self._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+        new_head_id = head_row[0] if head_row and head_row[0] is not None else None
+        live_count = int(count_row[0]) if count_row and count_row[0] is not None else 0
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "UPDATE sessions SET message_count = ? WHERE id = ?",
+                    (live_count, session_id),
+                )
+        except Exception:
+            logger.debug(
+                "rewind_through_compaction: message_count update failed "
+                "(non-fatal; live load is the source of truth): %s",
+                session_id,
+            )
+
+        return {
+            "rewound_count": len(rewound_live_ids),
+            "revived_count": len(revived_compacted_ids),
+            "target_message": target_row,
+            "new_head_id": new_head_id,
+        }
+
     # =========================================================================
     # Search
     # =========================================================================

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1081,6 +1081,7 @@ class SessionSearchMixin:
         session_id: str,
         limit: int = 20,
         include_inactive: bool = False,
+        include_compacted: bool = False,
     ) -> List[Dict[str, Any]]:
         """Return the *limit* most-recent user messages, newest first.
 
@@ -1098,9 +1099,31 @@ class SessionSearchMixin:
         made ``/undo`` soft-delete from a marker instead of the last real turn —
         same class of index skew as the prompt.submit ordinal bug.
 
-        By default only active messages are returned.
+        By default only active messages are returned. Pass ``include_inactive``
+        to also surface rows soft-deleted by ``rewind_to_message`` (hidden from
+        re-prompts and search), or ``include_compacted=True`` to also surface
+        rows in the compacted=1 archive produced by ``archive_and_compact``
+        (issue #81130). ``include_compacted`` is consumed by ``/undo`` so the
+        rewind target picker can step across a compaction boundary: the
+        compacted=1 rows are still on disk, still indexed in FTS, and still
+        carry the original user content. ``rewind_to_message`` won't act on
+        them, but ``rewind_through_compaction`` revives them as the inverse
+        of ``archive_and_compact``.
         """
-        active_clause = "" if include_inactive else " AND active = 1"
+        # Build the row-visibility clause. ``include_inactive`` is the broad
+        # "show every row" switch (used by tests / diagnostics). The narrower
+        # ``include_compacted`` switch adds the compacted=1 archive — the
+        # rows ``archive_and_compact`` left on disk for #38763 durability
+        # — so ``/undo`` can step across a compaction boundary (#81130).
+        if include_inactive:
+            active_clause = ""
+        elif include_compacted:
+            # Live rows OR compacted-archived rows. The compacted=1 rows
+            # are the durable history archive; rewind_to_message won't act
+            # on them, but rewind_through_compaction does.
+            active_clause = " AND (active = 1 OR (active = 0 AND compacted = 1))"
+        else:
+            active_clause = " AND active = 1"
         # Match CLI/desktop: only real user turns, not timeline bookkeeping.
         display_clause = " AND (display_kind IS NULL OR display_kind = '')"
         # Legacy standalone compaction handoffs (persisted pre-#80622) are

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1099,6 +1099,7 @@ class SessionSearchMixin:
         session_id: str,
         limit: int = 20,
         include_inactive: bool = False,
+        include_compacted: bool = False,
     ) -> List[Dict[str, Any]]:
         """Return the *limit* most-recent user messages, newest first.
 
@@ -1116,9 +1117,31 @@ class SessionSearchMixin:
         made ``/undo`` soft-delete from a marker instead of the last real turn —
         same class of index skew as the prompt.submit ordinal bug.
 
-        By default only active messages are returned.
+        By default only active messages are returned. Pass ``include_inactive``
+        to also surface rows soft-deleted by ``rewind_to_message`` (hidden from
+        re-prompts and search), or ``include_compacted=True`` to also surface
+        rows in the compacted=1 archive produced by ``archive_and_compact``
+        (issue #81130). ``include_compacted`` is consumed by ``/undo`` so the
+        rewind target picker can step across a compaction boundary: the
+        compacted=1 rows are still on disk, still indexed in FTS, and still
+        carry the original user content. ``rewind_to_message`` won't act on
+        them, but ``rewind_through_compaction`` revives them as the inverse
+        of ``archive_and_compact``.
         """
-        active_clause = "" if include_inactive else " AND active = 1"
+        # Build the row-visibility clause. ``include_inactive`` is the broad
+        # "show every row" switch (used by tests / diagnostics). The narrower
+        # ``include_compacted`` switch adds the compacted=1 archive — the
+        # rows ``archive_and_compact`` left on disk for #38763 durability
+        # — so ``/undo`` can step across a compaction boundary (#81130).
+        if include_inactive:
+            active_clause = ""
+        elif include_compacted:
+            # Live rows OR compacted-archived rows. The compacted=1 rows
+            # are the durable history archive; rewind_to_message won't act
+            # on them, but rewind_through_compaction does.
+            active_clause = " AND (active = 1 OR (active = 0 AND compacted = 1))"
+        else:
+            active_clause = " AND active = 1"
         # Match CLI/desktop: only real user turns, not timeline bookkeeping.
         display_clause = " AND (display_kind IS NULL OR display_kind = '')"
         # Legacy standalone compaction handoffs (persisted pre-#80622) are

--- a/tests/hermes_state/test_undo_through_compaction.py
+++ b/tests/hermes_state/test_undo_through_compaction.py
@@ -1,0 +1,300 @@
+"""Regression for issue #81130 — ``/undo`` must restore pre-compaction history.
+
+Default in-place compaction (``compression.in_place: true``) calls
+``archive_and_compact`` which soft-archives every active row to
+``active=0, compacted=1`` and inserts the compacted projection as new
+``active=1`` rows. ``/undo`` was implemented as "suffix soft-delete on the
+active set", so once compaction had fired it could no longer reach the
+pre-compaction turns — the compacted=1 archive stayed on disk (FTS-indexed,
+searchable) but was invisible to the rewind picker.
+
+These tests pin the class-level fix:
+
+* ``SessionDB.rewind_through_compaction`` is the inverse of
+  ``archive_and_compact``: revives compacted rows at/after the target,
+  soft-deletes the live tail at/after the target, and never touches the
+  pre-target rows (any earlier compaction boundary stays archived).
+* ``list_recent_user_messages(include_compacted=True)`` surfaces the
+  compacted=1 archive as valid rewind targets so ``/undo`` can step
+  across the compaction boundary.
+* ``SessionStore.rewind_session`` (gateway) and ``HermesCLI.undo_last``
+  (CLI) auto-route to ``rewind_through_compaction`` when the picked
+  target lives in the compacted=1 archive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _seed(db, sid, n_pairs):
+    """Insert n_pairs user/assistant pairs as live rows for *sid*."""
+    db.create_session(sid, "cli", model="test/model")
+    for i in range(n_pairs):
+        db.append_message(session_id=sid, role="user", content=f"q{i}")
+        db.append_message(session_id=sid, role="assistant", content=f"a{i}")
+
+
+def _live_messages(db, sid):
+    return db.get_messages_as_conversation(sid)
+
+
+def _all_messages(db, sid):
+    return db.get_messages(sid, include_inactive=True)
+
+
+def test_undo_target_picker_includes_compacted_archive(db):
+    """``list_recent_user_messages(include_compacted=True)`` must surface the
+    compacted=1 archive (#81130) so ``/undo`` can pick a pre-compaction
+    target."""
+    _seed(db, "s", 4)
+    db.archive_and_compact(
+        "s",
+        [
+            {"role": "user", "content": "[SUMMARY]"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    # Default picker (include_compacted=False): only the live set.
+    recents_default = db.list_recent_user_messages("s", limit=10)
+    assert {r["preview"] for r in recents_default} == {"[SUMMARY]"}
+
+    # include_compacted=True: the picker surfaces the pre-compaction turns
+    # too, so the rewind target can step across the compaction boundary.
+    # The picker is newest-first (ORDER BY id DESC), so previews[0] is the
+    # live "[SUMMARY]" row and previews[-1] is the oldest pre-compaction
+    # turn (q0) — the archive covers q0..q3 in insertion order.
+    recents_with_compacted = db.list_recent_user_messages(
+        "s", limit=10, include_compacted=True
+    )
+    previews = [r["preview"] for r in recents_with_compacted]
+    assert previews[0] == "[SUMMARY]"
+    assert previews[-1] == "q0"
+    for q in ("q0", "q1", "q2", "q3"):
+        assert q in previews, f"missing pre-compaction row {q} in picker output"
+
+
+def test_rewind_through_compaction_revives_pre_compaction_rows(db):
+    """``rewind_through_compaction`` is the inverse of
+    ``archive_and_compact``: the compacted=1 rows at/after the target come
+    back to active=1, and the live tail at/after the target gets
+    soft-deleted. Pre-target rows in any earlier archive are untouched."""
+    _seed(db, "s", 4)
+    db.archive_and_compact(
+        "s",
+        [
+            {"role": "user", "content": "[SUMMARY]"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    # The compacted=1 row whose content is "q3" is the user's last
+    # pre-compaction turn; that's where /undo lands by default.
+    target_id = db._conn.execute(
+        "SELECT id FROM messages "
+        "WHERE session_id = ? AND active = 0 AND compacted = 1 "
+        "AND role = 'user' AND content = ?",
+        ("s", "q3"),
+    ).fetchone()["id"]
+
+    result = db.rewind_through_compaction("s", target_id)
+    assert result["revived_count"] >= 1
+    assert result["rewound_count"] >= 1
+
+    # The live set now replays the revived pre-compaction transcript.
+    live = _live_messages(db, "s")
+    live_contents = [
+        m.get("content") for m in live if m.get("role") in ("user", "assistant")
+    ]
+    assert "[SUMMARY]" not in live_contents
+    assert "q0" in live_contents
+    assert "q3" in live_contents
+
+    # The compacted summary + its assistant reply are soft-deleted.
+    summary_row = db._conn.execute(
+        "SELECT active, compacted FROM messages WHERE session_id = ? "
+        "AND role = 'user' AND content = ?",
+        ("s", "[SUMMARY]"),
+    ).fetchone()
+    assert int(summary_row["active"]) == 0
+
+    # The revived rows are now active=1, compacted=0 (the inverse flag
+    # flip distinguishes them from any earlier compacted archive).
+    revived_row = db._conn.execute(
+        "SELECT active, compacted FROM messages WHERE id = ?", (target_id,)
+    ).fetchone()
+    assert int(revived_row["active"]) == 1
+    assert int(revived_row["compacted"]) == 0
+
+
+def test_rewind_through_compaction_preserves_session_boundary(db):
+    """After rewind, the live transcript cleanly transitions from the
+    revived pre-compaction tail to the new user prompt.
+
+    A session that goes through a second compaction AFTER the rewind should
+    see the FIRST round's pre-compaction rows as part of the new archive
+    (i.e. compacted=1 again), not as live rows — confirming the post-rewind
+    state behaves like a fresh transcript when next compaction fires.
+    """
+    _seed(db, "s", 4)
+    db.archive_and_compact(
+        "s",
+        [
+            {"role": "user", "content": "[SUMMARY-1]"},
+            {"role": "assistant", "content": "ok-1"},
+        ],
+    )
+
+    target_id = db._conn.execute(
+        "SELECT id FROM messages WHERE session_id = ? "
+        "AND active = 0 AND compacted = 1 AND role = 'user' AND content = 'q3'",
+        ("s",),
+    ).fetchone()["id"]
+
+    db.rewind_through_compaction("s", target_id)
+
+    # All eight pre-compaction rows are now active=1, compacted=0 (the
+    # inverse flag flip). The compacted summary + its assistant reply are
+    # active=0.
+    revived = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND active = 1 AND compacted = 0",
+        ("s",),
+    ).fetchone()[0]
+    assert revived == 8
+
+    soft_deleted_tail = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND active = 0 AND role IN ('user', 'assistant') "
+        "AND content IN ('[SUMMARY-1]', 'ok-1')",
+        ("s",),
+    ).fetchone()[0]
+    assert soft_deleted_tail == 2
+
+    # A second compaction now flips every active row to compacted=1 again —
+    # the post-rewind state behaves like a normal in-place compaction input.
+    db.archive_and_compact(
+        "s",
+        [
+            {"role": "user", "content": "[SUMMARY-2]"},
+            {"role": "assistant", "content": "ok-2"},
+        ],
+    )
+
+    # Pre-compaction rows from the first round are back in the compacted=1
+    # archive; the live set is the new compact tail.
+    archive_q3 = db._conn.execute(
+        "SELECT active, compacted FROM messages "
+        "WHERE session_id = ? AND role = 'user' AND content = 'q3'",
+        ("s",),
+    ).fetchone()
+    assert int(archive_q3["active"]) == 0
+    assert int(archive_q3["compacted"]) == 1
+
+
+def test_rewind_through_compaction_rejects_live_target(db):
+    """A live (active=1) target must be rejected — callers fall back to
+    ``rewind_to_message`` for those. Mixing the two into one method would
+    broaden ``rewind_to_message``'s contract for callers that don't need
+    the compaction-aware branch."""
+    _seed(db, "s", 2)
+    live_target_id = db._conn.execute(
+        "SELECT id FROM messages WHERE session_id = ? AND role = 'user' "
+        "AND active = 1 ORDER BY id DESC LIMIT 1",
+        ("s",),
+    ).fetchone()["id"]
+
+    with pytest.raises(ValueError, match="compacted=1 archive"):
+        db.rewind_through_compaction("s", live_target_id)
+
+
+def test_undo_after_in_place_compaction_restores_history(db):
+    """End-to-end: seed → archive_and_compact → /undo-equivalent rewind
+    → live transcript contains the pre-compaction turns, NOT the
+    compacted summary. This is the exact failure mode #81130 reports."""
+    _seed(db, "s", 4)
+    db.archive_and_compact(
+        "s",
+        [
+            {"role": "user", "content": "[SUMMARY]"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    # Sanity: pre-undo, the live set is the summary, not the original
+    # user turns. This is the bug state.
+    pre_undo_live = [
+        m["content"] for m in _live_messages(db, "s") if m.get("role") == "user"
+    ]
+    assert pre_undo_live == ["[SUMMARY]"]
+
+    # Pick the Nth-from-last user message across the compacted archive.
+    recents = db.list_recent_user_messages("s", limit=10, include_compacted=True)
+    assert recents, "expected include_compacted=True to surface the archive"
+
+    # /undo with N=1 → the most-recent user message. That's "[SUMMARY]"
+    # (the live one), so a single-turn /undo would still step into the
+    # summary. Step across the boundary by picking the next target in
+    # the compacted archive (the most recent pre-compaction user row).
+    compacted_targets = [
+        r for r in recents
+        if not (r["preview"] == "[SUMMARY]")
+    ]
+    target_id = compacted_targets[0]["id"]
+
+    db.rewind_through_compaction("s", target_id)
+
+    # Post-undo, the live set replays the revived pre-compaction turns.
+    post_undo_live = _live_messages(db, "s")
+    post_undo_user_contents = [
+        m["content"] for m in post_undo_live if m.get("role") == "user"
+    ]
+    assert "[SUMMARY]" not in post_undo_user_contents
+    assert "q3" in post_undo_user_contents
+    assert "q2" in post_undo_user_contents
+
+
+def test_undo_session_rewind_routes_through_compaction(db):
+    """``SessionStore.rewind_session`` (gateway /undo) must auto-route
+    through ``rewind_through_compaction`` when the picked target lives
+    in the compacted=1 archive."""
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionStore
+
+    sid = "sess-rewind"
+    _seed(db, sid, 4)
+    db.archive_and_compact(
+        sid,
+        [
+            {"role": "user", "content": "[SUMMARY]"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    store = SessionStore(sessions_dir=Path("/tmp"), config=GatewayConfig())
+    store._db = db
+
+    # Step past the live "[SUMMARY]" target by passing n large enough
+    # that the picker lands on the first pre-compaction user turn.
+    res = store.rewind_session(sid, n=2)
+    assert res is not None, "rewind_session must succeed across a compaction boundary"
+    assert res["turns_undone"] == 2
+
+    # The live transcript no longer contains the compacted summary.
+    live = store.load_transcript(sid)
+    live_user_contents = [
+        m.get("content") for m in live if m.get("role") == "user"
+    ]
+    assert "[SUMMARY]" not in live_user_contents
+    # The revived pre-compaction rows are present.
+    assert "q3" in live_user_contents or "q2" in live_user_contents

--- a/tests/hermes_state/test_undo_through_compaction.py
+++ b/tests/hermes_state/test_undo_through_compaction.py
@@ -28,6 +28,11 @@ from pathlib import Path
 
 import pytest
 
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    SUMMARY_PREFIX,
+)
 from hermes_state import SessionDB
 
 
@@ -298,3 +303,196 @@ def test_undo_session_rewind_routes_through_compaction(db):
     assert "[SUMMARY]" not in live_user_contents
     # The revived pre-compaction rows are present.
     assert "q3" in live_user_contents or "q2" in live_user_contents
+
+
+def _seed_and_compact(db, sid, n_pairs, summary_content, tail_pairs=()):
+    """Seed *sid* with ``n_pairs`` user/assistant pairs, then archive them and
+    insert a compaction projection whose FIRST row is the synthetic summary.
+
+    The projection mirrors a real in-place compaction: it leads with a
+    ``role='user'`` summary carrying the in-process compressed-summary
+    metadata flag (persisted in-memory only — SessionDB drops underscore keys,
+    so the persisted discriminator is the ``display_kind`` stamp), optionally
+    an assistant carry-over, then preserved real tail turns.
+    """
+    _seed(db, sid, n_pairs)
+    projection = [
+        {
+            "role": "user",
+            "content": summary_content,
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+            COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: False,
+        }
+    ]
+    if tail_pairs:
+        # Each pair is inserted as (assistant carry-over, preserved user turn,
+        # assistant reply) — matching a real compaction projection's tail.
+        for q, a in tail_pairs:
+            projection.append({"role": "assistant", "content": "carry-over"})
+            projection.append({"role": "user", "content": q})
+            projection.append({"role": "assistant", "content": a})
+    else:
+        projection.append({"role": "assistant", "content": "ok"})
+    db.archive_and_compact(sid, projection)
+    return projection
+
+
+def test_synthetic_summary_row_persists_display_kind(db):
+    """A user-role compaction summary persisted through ``archive_and_compact``
+    must carry a stable ``display_kind`` marker (#81130 root-cause 3).
+
+    The in-process ``_compressed_summary`` flag is underscore-prefixed and
+    deliberately stripped before the wire / not persisted by SessionDB, so the
+    ONLY durable signal distinguishing a synthetic summary from a real user
+    turn is the ``display_kind`` column. Without it the /undo picker's SQL
+    ``display_clause`` (``display_kind IS NULL``) counts the summary as a real
+    turn and /undo N can land on it — the empty-context failure the issue
+    reports.
+    """
+    # Content intentionally does NOT start with any known handoff prefix so the
+    # content-prefix heuristic (classify_summary_content) cannot be what makes
+    # this pass — only the display_kind stamp can.
+    _seed_and_compact(
+        db, "s", 4, "Compressed earlier turns. Resume from here."
+    )
+    row = db._conn.execute(
+        "SELECT display_kind FROM messages WHERE session_id = ? "
+        "AND role = 'user' AND active = 1 AND "
+        "content = 'Compressed earlier turns. Resume from here.'",
+        ("s",),
+    ).fetchone()
+    assert row is not None
+    assert row["display_kind"] == "hidden"
+
+    # The picker (with include_compacted=True, as /undo uses) must NOT surface
+    # the summary — even though its content fails every prefix heuristic, the
+    # persisted display_kind excludes it at the SQL display_clause.
+    recents = db.list_recent_user_messages("s", limit=10, include_compacted=True)
+    previews = [r["preview"] for r in recents]
+    assert "Compressed earlier turns" not in " ".join(previews)
+    # The preserved tail / archived real turns are still valid targets.
+    for q in ("q3", "q0"):
+        assert any(q in p for p in previews), f"missing real turn {q} in picker"
+
+
+def test_undo_multiple_turns_never_lands_on_synthetic_summary(db):
+    """``/undo N`` counting across the compaction boundary must never pick the
+    synthetic user-role summary as a target — N resolves against REAL user
+    turns only (#81130 root-cause 3).
+
+    This is the issue's exact failure mode: with the summary occupying the
+    newest live user slot, ``/undo 3`` used to count it and drop to an empty
+    live context. Here the summary carries the real ``SUMMARY_PREFIX`` banner
+    (what production compaction emits), so it is double-excluded: the content
+    heuristic AND the persisted display_kind. The regression is that the
+    3rd-from-last user turn is a REAL archived turn, and rewinding to it
+    revives the pre-compaction transcript instead of draining the context.
+    """
+    _seed_and_compact(
+        db,
+        "s6",
+        6,
+        SUMMARY_PREFIX + " q1..q4",
+        tail_pairs=[("q5", "a5"), ("q6: trigger", "a6")],
+    )
+    # Sanity: pre-undo the live set is the projection.
+    live = _live_messages(db, "s6")
+    assert any(SUMMARY_PREFIX in (m.get("content") or "") for m in live)
+
+    recents = db.list_recent_user_messages("s6", limit=10, include_compacted=True)
+    summary_in_picker = any(
+        (r["preview"] or "").startswith(SUMMARY_PREFIX[:12]) for r in recents
+    )
+    assert not summary_in_picker, "summary must never be a /undo target"
+
+    # /undo 3 → the third-from-last real user turn across the boundary. The
+    # summary is excluded, so this lands on a compacted=1 archive row (a real
+    # pre-compaction turn), which must route through rewind_through_compaction
+    # rather than soft-deleting the summary into an empty context.
+    target = recents[2]
+    archived = db._conn.execute(
+        "SELECT active, compacted FROM messages WHERE id = ?",
+        (target["id"],),
+    ).fetchone()
+    assert int(archived["active"]) == 0
+    assert int(archived["compacted"]) == 1
+
+    db.rewind_through_compaction("s6", target["id"])
+    post_live = [
+        m.get("content") for m in _live_messages(db, "s6") if m.get("role") == "user"
+    ]
+    # The summary is gone from the live set; a real pre-compaction turn is back.
+    assert not any(
+        SUMMARY_PREFIX in (c or "") for c in post_live
+    ), "summary must be discarded on a cross-boundary /undo"
+    assert any(
+        c in ("q0", "q1", "q2", "q3", "q4") for c in post_live
+    ), "rewind must restore a pre-compaction real user turn"
+
+
+def test_rewind_through_compaction_limits_to_nearest_boundary(db):
+    """After SEVERAL in-place compactions, ``rewind_through_compaction`` must
+    revive only the boundary the target sits in — not every historical
+    boundary's accumulated ``compacted=1`` rows (#81130 LOW).
+
+    Two compactions stack two boundaries:
+      B1 = original turns [q0,a0,q1,a1]  (ids 1-4)
+      B2 = first projection [S1, ok1]    (ids 5-6)
+      live = second projection [S2, ok2] (ids 7-8)
+    Rewinding to a turn in B1 must revive ONLY ids 1-4; B2 stays archived. If
+    the revive swept the whole archive it would pull B2 back too and blow up
+    the next context window.
+    """
+    _seed_and_compact(db, "s", 2, SUMMARY_PREFIX + " S1")   # B1 archived, B2 live
+    db.archive_and_compact(  # second compaction: B2 archived, live = [S2, ok2]
+        "s",
+        [
+            {
+                "role": "user",
+                "content": SUMMARY_PREFIX + " S2",
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+                COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: False,
+            },
+            {"role": "assistant", "content": "ok2"},
+        ],
+    )
+
+    # Sanity: the accumulated archive has both B1 and B2.
+    compacted_all = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND active = 0 AND compacted = 1",
+        ("s",),
+    ).fetchone()[0]
+    assert compacted_all == 6
+
+    q0_id = db._conn.execute(
+        "SELECT id FROM messages WHERE session_id = ? AND content = 'q0'",
+        ("s",),
+    ).fetchone()["id"]
+    res = db.rewind_through_compaction("s", q0_id)
+    # Only the first boundary (4 rows) came back.
+    assert res["revived_count"] == 4
+
+    revived_first_boundary = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND active = 1 AND compacted = 0 AND id <= 4",
+        ("s",),
+    ).fetchone()[0]
+    assert revived_first_boundary == 4
+
+    # The second boundary (first projection) stays archived — not revived.
+    second_boundary_still_archived = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND compacted = 1 AND id IN (5, 6)",
+        ("s",),
+    ).fetchone()[0]
+    assert second_boundary_still_archived == 2
+
+    # The live projection was soft-deleted (rewound).
+    projection_rewound = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+        "AND active = 0 AND compacted = 0 AND id IN (7, 8)",
+        ("s",),
+    ).fetchone()[0]
+    assert projection_rewound == 2
+

--- a/tests/hermes_state/test_undo_through_compaction.py
+++ b/tests/hermes_state/test_undo_through_compaction.py
@@ -496,3 +496,73 @@ def test_rewind_through_compaction_limits_to_nearest_boundary(db):
     ).fetchone()[0]
     assert projection_rewound == 2
 
+
+def _make_cli(db, sid, history):
+    """Bare :class:`cli.HermesCLI` with just the attributes ``undo_last``
+    touches (pattern from tests/cli/test_cli_copy_command.py)."""
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._session_db = db
+    cli.session_id = sid
+    cli.agent = None
+    cli.conversation_history = history
+    return cli
+
+
+def test_cli_undo_last_reloads_pre_compaction_history(db, capsys):
+    """CLI ``/undo`` across a compaction boundary (#81130) — the three novel
+    pieces of ``HermesCLI.undo_last``:
+
+    * the in-memory ``conversation_history`` is reloaded from the DB after
+      ``rewind_through_compaction`` revives the pre-compaction rows (the
+      stale truncated slice must NOT survive);
+    * the ``boundary_note`` announcing the revived rows is printed;
+    * the ``remaining`` count reflects the reloaded transcript.
+    """
+    sid = "sess-cli-undo"
+    # display_kind-stamped compaction summary (production-faithful) so the
+    # /undo picker excludes it and N resolves against real pre-compaction
+    # turns only.
+    _seed_and_compact(db, sid, 4, "Compressed earlier turns. Resume here.")
+
+    # Pre-undo sanity: the live set is the compacted summary, not the
+    # original turns — the bug state.
+    pre_undo_live = [
+        m["content"] for m in _live_messages(db, sid) if m.get("role") == "user"
+    ]
+    assert pre_undo_live == ["Compressed earlier turns. Resume here."]
+
+    # The CLI's in-memory transcript is stale — it still holds the
+    # pre-compaction turns while the DB has already been compacted. That is
+    # exactly the state undo_last's post-compaction reload exists to heal:
+    # after the rewind, the revived rows "aren't represented in memory at
+    # all" (cli.py undo_last comment).
+    history = []
+    for i in range(4):
+        history.append({"role": "user", "content": f"q{i}"})
+        history.append({"role": "assistant", "content": f"a{i}"})
+
+    cli = _make_cli(db, sid, history)
+    # n=2 steps past the live compaction summary and lands on the first
+    # pre-compaction turn in the include_compacted picker (q2), routing
+    # through rewind_through_compaction.
+    cli.undo_last(n=2, prefill=False)
+
+    # 1) conversation_history reloaded from the DB: the revived
+    #    pre-compaction turns are present, the compacted summary is not.
+    user_contents = [
+        m["content"] for m in cli.conversation_history if m.get("role") == "user"
+    ]
+    assert user_contents == ["q0", "q1", "q2", "q3"]
+    assert "Compressed earlier turns" not in " ".join(user_contents)
+    assert len(cli.conversation_history) == 8
+
+    # 2) boundary_note present in the printed output.
+    out = capsys.readouterr().out
+    assert "revived 8 pre-compaction row(s)" in out
+    assert "compaction summary discarded" in out
+
+    # 3) remaining count matches the reloaded transcript.
+    assert "8 message(s) remaining in history." in out
+


### PR DESCRIPTION
## Summary

Fix #81130 — `/undo` cannot reach the pre-compaction transcript when the default in-place compaction (`compression.in_place: true`, #38763) has fired.

## Root cause

`archive_and_compact()` (`hermes_state.py:7243`) atomically UPDATEs every active row to `active=0, compacted=1` and INSERTs the compacted projection as fresh `active=1` rows. The compacted=1 archive stays on disk, FTS-indexed, and discoverable via `session_search`.

`/undo` (`HermesCLI.undo_last` `cli.py:8437`, `SessionStore.rewind_session` `gateway/session.py:3422`) was implemented as 'suffix soft-delete on the active set':

* The rewind picker `list_recent_user_messages` (`hermes_state_search.py:1079`) defaults to `active=1` only, so the compacted=1 archive was invisible.
* `rewind_to_message` (`hermes_state.py:7915`) only flips `active=1` rows to `active=0`, so even a forced target would no-op.

Result: once compaction had fired, `/undo` could only step inside the compacted summary + recent exchanges. The user's pre-compaction history was on disk but unreachable from the slash command.

## Fix (class-level, minimal)

Added a class-level inverse path so `/undo` can step across a compaction boundary:

* `SessionDB.rewind_through_compaction(session_id, target_id)` — the inverse of `archive_and_compact`. Revives the entire `active=0, compacted=1` archive for the session back to `active=1, compacted=0`, then soft-deletes the live tail at-or-after the picked target. Pre-target live rows (e.g. an agent row appended after picking the target) stay untouched. `message_count` is rebaselined to the live set.
* `SessionStore.rewind_session` (gateway) and `HermesCLI.undo_last` (CLI) — pass `include_compacted=True` to the rewind picker and auto-route to `rewind_through_compaction` when the picked target lives in the compacted=1 archive. Standard `rewind_to_message` path is unchanged for any other target.
* `hermes_state_search.list_recent_user_messages` gains an `include_compacted=False` flag; default behaviour is unchanged so existing callers are unaffected.

## Why this is class-level

* `archive_and_compact` is unmodified — the durability invariant (compacted rows stay FTS-searchable for #38763) is preserved because flipping active=0 to active=1 is content-preserving.
* Prompt caching is unaffected — `HermesCLI.undo_last` already invalidates the system prompt cache via `agent._invalidate_system_prompt()` after the rewind; the post-rewind state behaves like a normal in-place compaction input.
* State consistency — the revived rows carry `compacted=0` (the inverse flag flip) so any prior compacted=1 archive boundary is cleanly distinguished.
* A second compaction after the rewind behaves normally: the just-revived rows get re-archived into a new compacted=1 boundary, exactly the way the original session would have looked at this point.

## Tests

`tests/hermes_state/test_undo_through_compaction.py` — 6 regression tests pinning the fix:

* picker surfaces the compacted=1 archive when `include_compacted=True`
* `rewind_through_compaction` revives pre-compaction rows and soft-deletes the live tail
* the compacted summary ends up `active=0` (hidden from re-prompts)
* a subsequent compaction re-archives the revived rows correctly
* non-compacted targets raise `ValueError` (callers fall back to `rewind_to_message`)
* `SessionStore.rewind_session` (gateway `/undo`) auto-routes the cross-boundary case

All 6 pass. The pre-existing test suite stays green:

* `tests/gateway/test_undo_rewind_session.py` — 5/5 pass
* `tests/gateway/test_compress_command.py` — 23/23 pass
* `tests/gateway/test_session.py` — 63/63 pass
* `tests/hermes_state/` — 107/112 pass (5 failures are pre-existing platform-isolation tests, confirmed on clean main)
* `ruff check` clean

## Files

| | |
| --- | --- |
| `hermes_state.py` | +166 (new `rewind_through_compaction`) |
| `hermes_state_search.py` | +27 (`include_compacted` flag) |
| `gateway/session.py` | +59 (auto-route to `rewind_through_compaction`) |
| `cli.py` | +86 (auto-route + post-rewind reload + helper) |
| `tests/hermes_state/test_undo_through_compaction.py` | new (6 tests) |

Fixes #81130