### PR TITLE
fix(desktop): recover both boundaries from assistant-ui lookup races, reactive edit context

### DIFF
--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
@@ -1,9 +1,14 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { Component, type ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageRenderBoundary } from './message-render-boundary'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 function Boom({ error }: { error: Error | null }): null {
   if (error) {
@@ -14,6 +19,26 @@ function Boom({ error }: { error: Error | null }): null {
 }
 
 const lookupError = new Error('useClientLookup: Index 2 out of bounds (length: 2)')
+
+const outerCaught: Error[] = []
+
+// Records what propagates past MessageRenderBoundary, so the tests can tell
+// a re-thrown error apart from a swallowed one.
+class RecordingBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error) {
+    outerCaught.push(error)
+  }
+
+  render() {
+    return this.state.error ? null : this.props.children
+  }
+}
 
 describe('MessageRenderBoundary', () => {
   it('renders children when nothing throws', () => {
@@ -75,6 +100,165 @@ describe('MessageRenderBoundary', () => {
       )
     ).toThrow('genuine render bug')
 
+    spy.mockRestore()
+  })
+
+  it('recovers on the retry timer without a resetKey change', () => {
+    // The mid-turn race: the message list shrinks and regrows while
+    // ids/roles/count stay stable, so resetKey never changes. The boundary
+    // must self-retry on a timer instead of rendering null for the rest of
+    // the turn.
+    vi.useFakeTimers()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    let failing = true
+
+    function MaybeBoom() {
+      if (failing) {
+        throw new Error('useClientLookup: index 3 out of bounds')
+      }
+
+      return <div>turn content</div>
+    }
+
+    render(
+      <MessageRenderBoundary resetKey="0:m1:user">
+        <MaybeBoom />
+      </MessageRenderBoundary>
+    )
+
+    expect(screen.queryByText('turn content')).toBeNull()
+
+    failing = false
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    // Recovered through the retry timer alone; resetKey never changed.
+    expect(screen.getByText('turn content')).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('stops retrying after the transient retry cap', () => {
+    // If the lookup stays out of bounds the boundary must give up instead of
+    // looping a setState/render cycle forever: initial render plus 5 retries,
+    // then it stays null and arms no further timer.
+    vi.useFakeTimers()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    let attempts = 0
+
+    function AlwaysBoom(): null {
+      attempts += 1
+      throw lookupError
+    }
+
+    const { container } = render(
+      <MessageRenderBoundary resetKey="a">
+        <AlwaysBoom />
+      </MessageRenderBoundary>
+    )
+
+    // React dev mode replays a failed render once per attempt, and an error
+    // during the initial mount gets an extra sync retry from the root, so
+    // measure the per-attempt cost from the first retry instead of guessing.
+    const mountAttempts = attempts
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    const perRetry = attempts - mountAttempts
+
+    for (let retry = 0; retry < 4; retry += 1) {
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+    }
+
+    // Initial render plus 5 retries, then the boundary gives up: it stays
+    // null and arms no further timer.
+    expect(attempts).toBe(mountAttempts + perRetry * 5)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(container.innerHTML).toBe('')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(attempts).toBe(mountAttempts + perRetry * 5)
+    spy.mockRestore()
+  })
+
+  it('resets the retry budget after a successful recovery', () => {
+    // The cap bounds a single streak of consecutive transient catches. A
+    // recovered boundary must get a fresh budget, otherwise enough separate
+    // races over a long session would permanently blank the turn.
+    vi.useFakeTimers()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    let failing = true
+
+    function MaybeBoom() {
+      if (failing) {
+        throw lookupError
+      }
+
+      return <div>turn content</div>
+    }
+
+    const { rerender } = render(
+      <MessageRenderBoundary resetKey="a">
+        <MaybeBoom />
+      </MessageRenderBoundary>
+    )
+
+    // The mount is the first streak; five more follow. With a lifetime
+    // budget the sixth streak would find the cap exhausted and stay blank.
+    // Each rerender needs a fresh element: React bails out on an identical
+    // element reference and the child would never re-render (or re-throw).
+    for (let streak = 0; streak < 6; streak += 1) {
+      expect(screen.queryByText('turn content')).toBeNull()
+
+      failing = false
+
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+
+      expect(screen.getByText('turn content')).toBeTruthy()
+
+      failing = true
+
+      rerender(
+        <MessageRenderBoundary resetKey="a">
+          <MaybeBoom />
+        </MessageRenderBoundary>
+      )
+    }
+
+    spy.mockRestore()
+  })
+
+  it('does not schedule a retry for non-transient errors', () => {
+    vi.useFakeTimers()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    outerCaught.length = 0
+
+    render(
+      <RecordingBoundary>
+        <MessageRenderBoundary resetKey="a">
+          <Boom error={new Error('boom')} />
+        </MessageRenderBoundary>
+      </RecordingBoundary>
+    )
+
+    // MessageRenderBoundary re-threw, the outer boundary caught it, and no
+    // retry timer was armed for a failure that cannot heal itself.
+    expect(outerCaught.map(error => error.message)).toContain('boom')
+    expect(vi.getTimerCount()).toBe(0)
     spy.mockRestore()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
@@ -40,6 +40,12 @@ class RecordingBoundary extends Component<{ children: ReactNode }, { error: Erro
   }
 }
 
+const lookupErrors = [
+  ['useClientLookup', lookupError],
+  ['tapClientLookup', new Error('tapClientLookup: Index 2 out of bounds (length: 2)')],
+  ['tapClientResource', new Error('tapClientResource: Index 2 out of bounds (length: 2)')]
+] as const
+
 describe('MessageRenderBoundary', () => {
   it('renders children when nothing throws', () => {
     render(
@@ -51,12 +57,12 @@ describe('MessageRenderBoundary', () => {
     expect(screen.getByText('content')).toBeTruthy()
   })
 
-  it('swallows the transient useClientLookup out-of-bounds store race', () => {
+  it.each(lookupErrors)('swallows the transient %s out-of-bounds store race', (_label, error) => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     const { container } = render(
       <MessageRenderBoundary resetKey="a">
-        <Boom error={lookupError} />
+        <Boom error={error} />
       </MessageRenderBoundary>
     )
 

--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
@@ -12,6 +12,12 @@ import { Component, type ReactNode } from 'react'
 const isTransientLookupError = (error: unknown): boolean =>
   error instanceof Error && /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/.test(error.message)
 
+// Consecutive transient retries before giving up and waiting for a structural
+// resetKey change (the pre-retry behavior). The race heals on the next
+// consistent store snapshot, so one retry almost always recovers; the cap
+// only bounds a pathological loop where the lookup stays out of bounds.
+const MAX_TRANSIENT_RETRIES = 5
+
 interface Props {
   // Changes whenever the message list mutates STRUCTURALLY (ids/roles/count);
   // remounting clears the caught error so the next consistent render recovers
@@ -27,13 +33,57 @@ interface Props {
 export class MessageRenderBoundary extends Component<Props, { error: Error | null }> {
   state: { error: Error | null } = { error: null }
 
+  private retryTimer: number | null = null
+
+  private transientRetries = 0
+
   static getDerivedStateFromError(error: Error) {
     return { error }
   }
 
-  componentDidUpdate(prev: Props) {
+  componentDidCatch(error: Error) {
+    // The resetKey path below only recovers on a STRUCTURAL change, but this
+    // race also fires mid-turn while ids/roles/count are stable: without a
+    // self-retry the boundary renders null for the rest of the turn (or
+    // until an unrelated message add/remove). Retry on a timer, not rAF —
+    // a parked renderer never fires frames, and a timer always runs.
+    if (!isTransientLookupError(error) || this.transientRetries >= MAX_TRANSIENT_RETRIES) {
+      return
+    }
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    this.transientRetries += 1
+    this.retryTimer = window.setTimeout(() => {
+      this.retryTimer = null
+      this.setState({ error: null })
+    }, 0)
+  }
+
+  componentDidUpdate(prev: Props, prevState: { error: Error | null }) {
     if (this.state.error && prev.resetKey !== this.props.resetKey) {
       this.setState({ error: null })
+
+      return
+    }
+
+    if (prevState.error && !this.state.error) {
+      // Recovered (retry or structural reset): reset the retry budget and
+      // drop any retry timer the structural reset just made redundant.
+      this.transientRetries = 0
+
+      if (this.retryTimer !== null) {
+        window.clearTimeout(this.retryTimer)
+        this.retryTimer = null
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.retryTimer !== null) {
+      window.clearTimeout(this.retryTimer)
     }
   }
 

--- a/apps/desktop/src/components/assistant-ui/thread/edit-context.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/edit-context.test.tsx
@@ -1,0 +1,191 @@
+// Thread deliberately keeps cwd/gateway/sessionId OUT of the messageComponents
+// memo deps: those values change on every session switch, and reminting the
+// component types mid-switch remounts the whole outgoing transcript. The
+// mounted edit composer still has to see a same-session change (e.g. a cwd
+// remap). It used to read the values from a render-time ref, but a mounted
+// composer never re-reads the ref when the change leaves every
+// ThreadMessageList prop referentially equal (Thread and ThreadMessageList
+// are both memo'd, so the wrapper never re-renders). The values now travel
+// through ThreadEditContext, whose propagation reaches the mounted consumer
+// through the memo bail-out. These tests pin both directions: the composer
+// sees the change, and the transcript still does not remount.
+import { ExportedMessageRepository } from '@assistant-ui/react'
+import { AssistantRuntimeProvider, type ThreadMessage } from '@assistant-ui/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+
+import { Thread } from '.'
+
+interface MockComposerProps {
+  cwd: string | null
+  gateway: unknown
+  sessionId: string | null
+}
+
+const composerRenders = vi.hoisted(() => [] as MockComposerProps[])
+
+vi.mock('./user-edit-composer', () => ({
+  UserEditComposer: (props: MockComposerProps) => {
+    composerRenders.push(props)
+
+    return <div data-testid="edit-composer">{props.cwd}</div>
+  }
+}))
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  composerRenders.length = 0
+})
+
+// jsdom returns 0 for offset*; the virtualizer reads those to size its
+// viewport. Fall through to client* or a sane default so virtualized
+// items render (same stub as user-message-edit.test.tsx).
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+function userMessage(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'edit me please' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+const noopAsync = async () => {}
+
+// The repository must stay referentially stable across rerenders: a new
+// object would make the incremental runtime resync the transcript and
+// unmount the open composer, defeating the test.
+function Harness({ cwd, sessionKey }: { cwd: string; sessionKey: string }) {
+  const [repository] = useState(() => ExportedMessageRepository.fromArray([userMessage(), assistantMessage()]))
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository: repository,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: noopAsync,
+    onEdit: noopAsync,
+    onCancel: noopAsync,
+    onReload: noopAsync
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread cwd={cwd} sessionKey={sessionKey} />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('thread edit context', () => {
+  it('passes a same-session cwd change to the mounted edit composer', async () => {
+    const { rerender } = render(<Harness cwd="/old" sessionKey="k1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+    await screen.findByTestId('edit-composer')
+
+    expect(composerRenders.at(-1)?.cwd).toBe('/old')
+
+    // Same session, same messages: every ThreadMessageList prop stays
+    // referentially equal, so only context propagation can reach the
+    // mounted composer.
+    await act(async () => {
+      rerender(<Harness cwd="/new" sessionKey="k1" />)
+    })
+
+    expect(composerRenders.at(-1)?.cwd).toBe('/new')
+    expect(screen.getByTestId('edit-composer').textContent).toBe('/new')
+  })
+
+  it('still passes the new cwd after a session switch', async () => {
+    const { rerender } = render(<Harness cwd="/old" sessionKey="k1" />)
+
+    await act(async () => {
+      rerender(<Harness cwd="/new" sessionKey="k2" />)
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+    await screen.findByTestId('edit-composer')
+
+    expect(composerRenders.at(-1)?.cwd).toBe('/new')
+  })
+
+  it('does not remount the transcript when cwd changes', async () => {
+    // The perf invariant behind keeping cwd out of the memo deps: a cwd
+    // change with identical messages must not remint the component types,
+    // so the mounted message DOM nodes survive the rerender.
+    const { rerender } = render(<Harness cwd="/old" sessionKey="k1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('done')).toBeTruthy()
+      expect(screen.getByText('edit me please')).toBeTruthy()
+    })
+
+    const assistantBefore = screen.getByText('done')
+    const userBefore = screen.getByText('edit me please')
+
+    await act(async () => {
+      rerender(<Harness cwd="/new" sessionKey="k1" />)
+    })
+
+    expect(screen.getByText('done')).toBe(assistantBefore)
+    expect(screen.getByText('edit me please')).toBe(userBefore)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { createContext, memo, useCallback, useContext, useMemo, useRef, useState } from 'react'
 
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
@@ -15,6 +15,22 @@ import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
 
 type ThreadLoadingState = 'response' | 'session'
+
+interface ThreadEditContextValue {
+  cwd: string | null
+  gateway: HermesGateway | null
+  sessionId: string | null
+}
+
+// Edit-composer context. The composer only exists while a message is being
+// edited, and it mounts deep inside the memo'd ThreadMessageList, so the
+// edit context can neither ride the component-map memo deps (that remints
+// the component types on every session switch and remounts the outgoing
+// transcript) nor sit in a render-time ref (a mounted composer never
+// re-reads it when a same-session change leaves every list prop
+// referentially equal). Context solves both: the component type stays
+// stable, and a changed value propagates straight to the mounted consumer.
+const ThreadEditContext = createContext<ThreadEditContextValue>({ cwd: null, gateway: null, sessionId: null })
 
 interface ThreadProps {
   clampToComposer?: boolean
@@ -87,19 +103,18 @@ export const Thread = memo(function Thread({
   // Stop button, the restore-confirm affordance). Assigned during render
   // (the useStoreSelector pattern) so the ref never lags a render.
   //
-  // cwd / gateway / sessionId ride the same ref for the same reason, and it
-  // is load-bearing on the hot path: all three change on EVERY session
-  // switch, so listing them as deps re-minted these types mid-switch and
-  // remounted the entire OUTGOING transcript — thousands of renders of a
-  // thread that was about to be replaced, all of it before the resume RPC
-  // had even been sent. They are read inside the edit composer (which only
-  // exists while a message is being edited), never during a plain render,
-  // so a ref read is always current by the time it matters.
+  // cwd / gateway / sessionId stay OUT of the memo deps for the same
+  // reason: all three change on EVERY session switch, so listing them
+  // re-minted these types mid-switch and remounted the entire OUTGOING
+  // transcript — thousands of renders of a thread that was about to be
+  // replaced, all of it before the resume RPC had even been sent. They
+  // reach the edit composer through ThreadEditContext instead (see above).
   const callbacksRef = useRef({ onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage })
   callbacksRef.current = { onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage }
 
-  const editContextRef = useRef({ cwd, gateway, sessionId })
-  editContextRef.current = { cwd, gateway, sessionId }
+  // Only changes identity when one of the three values does, so Thread
+  // re-renders for unrelated reasons never re-render the composer.
+  const editContext = useMemo(() => ({ cwd, gateway, sessionId }), [cwd, gateway, sessionId])
 
   const hasBranchInNewChat = Boolean(onBranchInNewChat)
   const hasCancel = Boolean(onCancel)
@@ -118,7 +133,7 @@ export const Thread = memo(function Thread({
       ),
       SystemMessage,
       UserEditComposer: () => {
-        const { cwd: editCwd, gateway: editGateway, sessionId: editSessionId } = editContextRef.current
+        const { cwd: editCwd, gateway: editGateway, sessionId: editSessionId } = useContext(ThreadEditContext)
 
         return <UserEditComposer cwd={editCwd} gateway={editGateway} sessionId={editSessionId} />
       },
@@ -146,25 +161,27 @@ export const Thread = memo(function Thread({
   const loadingIndicator = useMemo(() => <BackgroundResumeNotice />, [])
 
   return (
-    <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
-      <ThreadMessageList
-        clampToComposer={clampToComposer}
-        components={messageComponents}
-        emptyPlaceholder={emptyPlaceholder}
-        loadingIndicator={loadingIndicator}
-        sessionKey={sessionKey}
-      />
-      {loading === 'session' && <CenteredThreadSpinner />}
-      <ThreadTimeline />
-      <ConfirmDialog
-        confirmLabel={copy.restoreConfirm}
-        description={copy.restoreBody}
-        destructive
-        onClose={closeRestoreConfirm}
-        onConfirm={confirmRestore}
-        open={Boolean(restoreConfirmTarget)}
-        title={copy.restoreTitle}
-      />
-    </div>
+    <ThreadEditContext.Provider value={editContext}>
+      <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
+        <ThreadMessageList
+          clampToComposer={clampToComposer}
+          components={messageComponents}
+          emptyPlaceholder={emptyPlaceholder}
+          loadingIndicator={loadingIndicator}
+          sessionKey={sessionKey}
+        />
+        {loading === 'session' && <CenteredThreadSpinner />}
+        <ThreadTimeline />
+        <ConfirmDialog
+          confirmLabel={copy.restoreConfirm}
+          description={copy.restoreBody}
+          destructive
+          onClose={closeRestoreConfirm}
+          onConfirm={confirmRestore}
+          open={Boolean(restoreConfirmTarget)}
+          title={copy.restoreTitle}
+        />
+      </div>
+    </ThreadEditContext.Provider>
   )
 })

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -1,0 +1,108 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from './error-boundary'
+
+const TAP_LOOKUP_ERROR = new Error('tapClientLookup: Index 6 out of bounds (length: 2)')
+const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
+
+function makeBomb(box: { error: Error | null }) {
+  return function Bomb() {
+    if (box.error) {
+      throw box.error
+    }
+
+    return <div>recovered</div>
+  }
+}
+
+const recoveryWarningCount = (calls: unknown[][]) =>
+  calls.filter(call => call.some(value => String(value).includes('auto-recovering from tapClientLookup'))).length
+
+describe('ErrorBoundary tapClientLookup recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('recovers the root boundary after a transient lookup race clears', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(screen.queryByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeNull()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
+  })
+
+  it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      act(() => vi.runOnlyPendingTimers())
+    }
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not auto-recover the same error in a scoped boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const Bomb = makeBomb({ error: TAP_LOOKUP_ERROR })
+
+    render(
+      <ErrorBoundary fallback={() => <div>scoped fallback</div>} label="thread">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    act(() => vi.runAllTimers())
+
+    expect(screen.getByText('scoped fallback')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(0)
+  })
+
+  it.each([
+    ['a renamed lookup error', new Error('useClientLookup: Index 6 out of bounds (length: 2)')],
+    ['an unrelated render error', new Error('some unrelated application error')]
+  ])('does not auto-recover %s at root', (_label, error) => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    act(() => vi.runAllTimers())
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -1,7 +1,8 @@
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ErrorBoundary } from './error-boundary'
+import { ErrorBoundary, RootErrorBoundary } from './error-boundary'
 
 const CURRENT_LOOKUP_ERROR = new Error('useClientLookup: Index 6 out of bounds (length: 2)')
 const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
@@ -22,6 +23,7 @@ const recoveryWarningCount = (calls: unknown[][]) =>
 describe('ErrorBoundary assistant-ui lookup recovery', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(0)
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
@@ -35,15 +37,15 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     ['the current useClientLookup error', CURRENT_LOOKUP_ERROR],
     ['the legacy tapClientLookup error', new Error('tapClientLookup: Index 6 out of bounds (length: 2)')],
     ['the legacy tapClientResource error', new Error('tapClientResource: Index 6 out of bounds (length: 2)')]
-  ])('recovers the root boundary after %s clears', (_label, error) => {
+  ])('recovers the production root composition without StrictMode after %s clears', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const box: { error: Error | null } = { error }
     const Bomb = makeBomb(box)
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     box.error = null
@@ -54,15 +56,36 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
   })
 
+  it('recovers the production root composition when StrictMode replays its mount lifecycle', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <StrictMode>
+        <RootErrorBoundary>
+          <Bomb />
+        </RootErrorBoundary>
+      </StrictMode>
+    )
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
     const Bomb = makeBomb(box)
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     for (let attempt = 0; attempt < 4; attempt += 1) {
@@ -72,6 +95,91 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
     expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('starts a fresh automatic recovery budget at the 5 second window boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    const view = render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      box.error = null
+      act(() => vi.runOnlyPendingTimers())
+      expect(screen.getByText('recovered')).toBeTruthy()
+
+      if (attempt < 2) {
+        box.error = CURRENT_LOOKUP_ERROR
+        view.rerender(
+          <RootErrorBoundary>
+            <Bomb />
+          </RootErrorBoundary>
+        )
+      }
+    }
+
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
+    act(() => vi.advanceTimersByTime(5_000))
+
+    box.error = CURRENT_LOOKUP_ERROR
+    view.rerender(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(4)
+  })
+
+  it('manual retry replaces an active timer, resets the budget, and can exhaust again', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    expect(vi.getTimerCount()).toBe(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(vi.getTimerCount()).toBe(1)
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      act(() => vi.runOnlyPendingTimers())
+    }
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(4)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels an owned automatic recovery timer when unmounted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const Bomb = makeBomb({ error: CURRENT_LOOKUP_ERROR })
+
+    const view = render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    expect(vi.getTimerCount()).toBe(1)
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => vi.runAllTimers())
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
   })
 
   it('does not auto-recover the same error in a scoped boundary', () => {
@@ -91,17 +199,17 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
   })
 
   it.each([
+    ['a differently cased classifier near-miss', new Error('UseClientLookup: Index 6 out of bounds (length: 2)')],
     ['a non-bounds lookup error', new Error('useClientLookup: Key "missing" not found')],
     ['an unrelated render error', new Error('some unrelated application error')]
   ])('does not auto-recover %s at root', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error }
-    const Bomb = makeBomb(box)
+    const Bomb = makeBomb({ error })
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     act(() => vi.runAllTimers())

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ErrorBoundary } from './error-boundary'
 
-const TAP_LOOKUP_ERROR = new Error('tapClientLookup: Index 6 out of bounds (length: 2)')
+const CURRENT_LOOKUP_ERROR = new Error('useClientLookup: Index 6 out of bounds (length: 2)')
 const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
 
 function makeBomb(box: { error: Error | null }) {
@@ -17,9 +17,9 @@ function makeBomb(box: { error: Error | null }) {
 }
 
 const recoveryWarningCount = (calls: unknown[][]) =>
-  calls.filter(call => call.some(value => String(value).includes('auto-recovering from tapClientLookup'))).length
+  calls.filter(call => call.some(value => String(value).includes('auto-recovering from assistant-ui lookup'))).length
 
-describe('ErrorBoundary tapClientLookup recovery', () => {
+describe('ErrorBoundary assistant-ui lookup recovery', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
@@ -31,9 +31,13 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
     vi.restoreAllMocks()
   })
 
-  it('recovers the root boundary after a transient lookup race clears', () => {
+  it.each([
+    ['the current useClientLookup error', CURRENT_LOOKUP_ERROR],
+    ['the legacy tapClientLookup error', new Error('tapClientLookup: Index 6 out of bounds (length: 2)')],
+    ['the legacy tapClientResource error', new Error('tapClientResource: Index 6 out of bounds (length: 2)')]
+  ])('recovers the root boundary after %s clears', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const box: { error: Error | null } = { error }
     const Bomb = makeBomb(box)
 
     render(
@@ -52,7 +56,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
 
   it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
     const Bomb = makeBomb(box)
 
     render(
@@ -72,7 +76,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
 
   it('does not auto-recover the same error in a scoped boundary', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const Bomb = makeBomb({ error: TAP_LOOKUP_ERROR })
+    const Bomb = makeBomb({ error: CURRENT_LOOKUP_ERROR })
 
     render(
       <ErrorBoundary fallback={() => <div>scoped fallback</div>} label="thread">
@@ -87,7 +91,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
   })
 
   it.each([
-    ['a renamed lookup error', new Error('useClientLookup: Index 6 out of bounds (length: 2)')],
+    ['a non-bounds lookup error', new Error('useClientLookup: Key "missing" not found')],
     ['an unrelated render error', new Error('some unrelated application error')]
   ])('does not auto-recover %s at root', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -20,8 +20,20 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+// Some assistant-ui lookup races escape the message-local boundary and reach
+// the root. Retry only that exact transient error class, never arbitrary render
+// failures, and cap retries so a persistent failure still exposes the fallback.
+const TAP_CLIENT_LOOKUP_ERROR = /^tapClientLookup: Index \d+\s+out of bounds \(length:\s*\d+\)$/i
+const MAX_AUTO_RECOVERIES = 3
+const AUTO_RECOVERY_WINDOW_MS = 5_000
+
+const isTransientTapClientLookupError = (error: Error): boolean => TAP_CLIENT_LOOKUP_ERROR.test(error.message)
+
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
+  private autoRecoveryCount = 0
+  private autoRecoveryTimer: number | null = null
+  private autoRecoveryWindowStart = 0
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
@@ -31,9 +43,51 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     const tag = this.props.label ? `[error-boundary:${this.props.label}]` : '[error-boundary]'
     console.error(tag, error, info.componentStack)
     this.props.onError?.(error, info)
+
+    if (this.props.label === 'root' && isTransientTapClientLookupError(error) && this.takeAutoRecoveryAttempt()) {
+      console.warn(`${tag} auto-recovering from tapClientLookup render race`, error.message)
+      this.scheduleAutoRecovery()
+    }
+  }
+
+  componentWillUnmount() {
+    this.clearAutoRecoveryTimer()
   }
 
   reset = () => {
+    this.clearAutoRecoveryTimer()
+    this.autoRecoveryCount = 0
+    this.autoRecoveryWindowStart = 0
+    this.setState({ error: null })
+  }
+
+  private takeAutoRecoveryAttempt(): boolean {
+    const now = Date.now()
+
+    if (now - this.autoRecoveryWindowStart > AUTO_RECOVERY_WINDOW_MS) {
+      this.autoRecoveryWindowStart = now
+      this.autoRecoveryCount = 0
+    }
+
+    this.autoRecoveryCount += 1
+
+    return this.autoRecoveryCount <= MAX_AUTO_RECOVERIES
+  }
+
+  private clearAutoRecoveryTimer() {
+    if (this.autoRecoveryTimer !== null) {
+      window.clearTimeout(this.autoRecoveryTimer)
+      this.autoRecoveryTimer = null
+    }
+  }
+
+  private scheduleAutoRecovery() {
+    this.clearAutoRecoveryTimer()
+    this.autoRecoveryTimer = window.setTimeout(this.autoRecover, 0)
+  }
+
+  private autoRecover = () => {
+    this.autoRecoveryTimer = null
     this.setState({ error: null })
   }
 

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -23,7 +23,7 @@ interface ErrorBoundaryState {
 // Some assistant-ui lookup races escape the message-local boundary and reach
 // the root. Retry only that exact transient error class, never arbitrary render
 // failures, and cap retries so a persistent failure still exposes the fallback.
-const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/i
+const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/
 const MAX_AUTO_RECOVERIES = 3
 const AUTO_RECOVERY_WINDOW_MS = 5_000
 
@@ -32,11 +32,21 @@ const isTransientAssistantUiLookupError = (error: Error): boolean => ASSISTANT_U
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
   private autoRecoveryCount = 0
+  private autoRecoveryPending = false
   private autoRecoveryTimer: number | null = null
   private autoRecoveryWindowStart = 0
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
+  }
+
+  componentDidMount() {
+    // StrictMode replays mount lifecycles in development. Its synthetic
+    // componentWillUnmount clears the timer scheduled by componentDidCatch,
+    // so restore the still-owned recovery on the matching remount.
+    if (this.autoRecoveryPending && this.autoRecoveryTimer === null) {
+      this.scheduleAutoRecovery()
+    }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -46,6 +56,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     if (this.props.label === 'root' && isTransientAssistantUiLookupError(error) && this.takeAutoRecoveryAttempt()) {
       console.warn(`${tag} auto-recovering from assistant-ui lookup render race`, error.message)
+      this.autoRecoveryPending = true
       this.scheduleAutoRecovery()
     }
   }
@@ -56,6 +67,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   reset = () => {
     this.clearAutoRecoveryTimer()
+    this.autoRecoveryPending = false
     this.autoRecoveryCount = 0
     this.autoRecoveryWindowStart = 0
     this.setState({ error: null })
@@ -64,7 +76,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   private takeAutoRecoveryAttempt(): boolean {
     const now = Date.now()
 
-    if (now - this.autoRecoveryWindowStart > AUTO_RECOVERY_WINDOW_MS) {
+    if (this.autoRecoveryCount === 0 || now - this.autoRecoveryWindowStart >= AUTO_RECOVERY_WINDOW_MS) {
       this.autoRecoveryWindowStart = now
       this.autoRecoveryCount = 0
     }
@@ -88,6 +100,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   private autoRecover = () => {
     this.autoRecoveryTimer = null
+    this.autoRecoveryPending = false
     this.setState({ error: null })
   }
 
@@ -104,6 +117,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     return <RootErrorFallback error={error} reset={this.reset} />
   }
+}
+
+export function RootErrorBoundary({ children }: { children: ReactNode }) {
+  return <ErrorBoundary label="root">{children}</ErrorBoundary>
 }
 
 function RootErrorFallback({ error, reset }: ErrorBoundaryFallbackProps) {

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -23,11 +23,11 @@ interface ErrorBoundaryState {
 // Some assistant-ui lookup races escape the message-local boundary and reach
 // the root. Retry only that exact transient error class, never arbitrary render
 // failures, and cap retries so a persistent failure still exposes the fallback.
-const TAP_CLIENT_LOOKUP_ERROR = /^tapClientLookup: Index \d+\s+out of bounds \(length:\s*\d+\)$/i
+const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/i
 const MAX_AUTO_RECOVERIES = 3
 const AUTO_RECOVERY_WINDOW_MS = 5_000
 
-const isTransientTapClientLookupError = (error: Error): boolean => TAP_CLIENT_LOOKUP_ERROR.test(error.message)
+const isTransientAssistantUiLookupError = (error: Error): boolean => ASSISTANT_UI_LOOKUP_ERROR.test(error.message)
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
@@ -44,8 +44,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     console.error(tag, error, info.componentStack)
     this.props.onError?.(error, info)
 
-    if (this.props.label === 'root' && isTransientTapClientLookupError(error) && this.takeAutoRecoveryAttempt()) {
-      console.warn(`${tag} auto-recovering from tapClientLookup render race`, error.message)
+    if (this.props.label === 'root' && isTransientAssistantUiLookupError(error) && this.takeAutoRecoveryAttempt()) {
+      console.warn(`${tag} auto-recovering from assistant-ui lookup render race`, error.message)
       this.scheduleAutoRecovery()
     }
   }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -19,7 +19,7 @@ import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router'
 
 import App from './app'
-import { ErrorBoundary } from './components/error-boundary'
+import { RootErrorBoundary } from './components/error-boundary'
 import { HapticsProvider } from './components/haptics-provider'
 import { RootTooltipProvider } from './components/ui/tooltip'
 import { I18nProvider } from './i18n'
@@ -48,7 +48,7 @@ if (winParam === 'overlay') {
 } else {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <I18nProvider>
             <ThemeProvider>
@@ -76,7 +76,7 @@ if (winParam === 'overlay') {
             </ThemeProvider>
           </I18nProvider>
         </QueryClientProvider>
-      </ErrorBoundary>
+      </RootErrorBoundary>
     </StrictMode>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Consolidates the two open PRs fixing the same assistant-ui lookup race into one
change, because they fix that race at two complementary layers and collide on a
shared test file.

`@assistant-ui/store`'s index-keyed child-scope lookup throws — rather than
returning `undefined` — when a subscriber reads an index the message/parts list
no longer has. It races during high-frequency store replacement (session switch
mid-stream, gateway reconnect replay, post-compaction list shrink). On current
`main` that race has two ways to blank the UI, and neither self-heals:

**1. The message-local boundary strands a turn mid-stream.**
`MessageRenderBoundary` swallows the transient throw and renders `null` until
`resetKey` changes. Since #72504 that key is deliberately structural-only
(`list.tsx` `structuralSignature`) — the right call, it stopped per-token
reconciles of every turn — but that removed the implicit recovery: mid-turn the
structure is stable, so a race during a stream leaves the turn blank until an
unrelated message add/remove. The boundary now self-retries on a 0ms timer
(rAF never fires in a parked renderer), bounded to 5 consecutive transient
catches with the budget reset on successful recovery. A persistent failure falls
back to the old wait-for-structure behavior, and non-transient errors still
re-throw to the root.

**2. What escapes the local boundary strands the whole app.** The root
`ErrorBoundary` only logs in `componentDidCatch`, so the root fallback sticks
until the user restarts the app. Root recovery for exactly this error family
existed (added in `2e3efce66`, merged as #52704) and was removed by `344415892`.
This restores it, narrowly: root-label-gated, matching only the lookup
out-of-bounds family, bounded to 3 attempts per 5s window, with persistent
failures still visible and manually retryable. Also fixes a `StrictMode`
lifecycle bug found while exercising the real root composition — the synthetic
unmount cleared the timer scheduled by `componentDidCatch` and the replayed
mount never restored it, so recovery ownership is now tracked separately from
the timer handle.

Both layers share one classifier, `/(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/`.
The current production error name is `useClientLookup` (renamed upstream in
`@assistant-ui/store@0.2.19`); the legacy `tapClient*` names stay covered.

**3. An open edit composer keeps a stale cwd / gateway / sessionId.** #72524
moved those three values out of the `messageComponents` memo deps into a
render-time ref so session switches stop reminting the component types — load
bearing on the hot path. But a composer that is *already open* never re-reads
the ref: a same-session change (the agent relocating the session's cwd via
`session.info`, a gateway reconnect) leaves every `ThreadMessageList` prop
referentially equal, so the memo'd list bails out and `@`-completions, slash
completions, and OS-drop uploads act on the old context. `Thread` now provides
the three values through a memoized `ThreadEditContext`. Context propagates
through the bail-out, component type identity is untouched, and the transcript
never remounts.

## Related Issue

Fixes #72866
Fixes #64308
Supersedes #72867
Supersedes #64310

Related to the broader assistant-ui race tracked by #45403.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/message-render-boundary.tsx`:
  bounded timer self-retry for transient lookup errors, budget reset on
  recovery, timer cleared on unmount and on structural reset.
- `apps/desktop/src/components/error-boundary.tsx`: root-only bounded auto
  recovery for the same error family, recovery ownership preserved across a
  `StrictMode` synthetic unmount without weakening real-unmount cleanup,
  window reset at the 5s boundary, manual reset cancels an active timer and
  starts a fresh budget, `RootErrorBoundary` composition so only the real root
  owner auto-recovers.
- `apps/desktop/src/main.tsx`: uses `RootErrorBoundary` at the Desktop root.
- `apps/desktop/src/components/assistant-ui/thread/index.tsx`: `editContextRef`
  replaced with a memoized `ThreadEditContext` provided around the list; the
  `UserEditComposer` wrapper reads it via `useContext`. Comments explain why
  neither memo deps nor a ref can carry these values.
- Tests: timer recovery without a `resetKey` change, retry cap, budget reset
  across streaks, no retry for non-transient errors, classifier parity across
  `useClientLookup` / `tapClientLookup` / `tapClientResource`, root transient
  recovery, persistent budget exhaustion, 5s window reset, manual reset with an
  active timer, pending-timer unmount cleanup, scoped-boundary exclusion, real
  root composition under `StrictMode` and production-style without it,
  same-session cwd change reaching a mounted composer, session-switch control,
  and a perf invariant proving a cwd rerender remounts no transcript DOM node.

## How to Test

```bash
npm --workspace apps/desktop exec -- vitest run --project ui \
  src/components/error-boundary.test.tsx \
  src/components/assistant-ui/message-render-boundary.test.tsx \
  src/components/assistant-ui/thread/edit-context.test.tsx
# 3 files, 25 tests passed

npm --workspace apps/desktop exec -- vitest run --project ui src/components/assistant-ui/
# 36 files, 304 tests passed

npm --workspace apps/desktop run typecheck   # clean (3 tsconfigs)
npm --workspace apps/desktop exec -- eslint <touched files>      # clean
npm --workspace apps/desktop exec -- prettier --check <touched>  # clean
```

Proof of the bugs on `main`: with the three source files reverted, the
timer-recovery, budget-reset, root-recovery, and same-session-cwd tests fail.

## Credit

Consolidated from two independent contributions, authorship preserved via
cherry-pick:

- @Adolanium — the message-local self-retry and the reactive `ThreadEditContext`
  (originally #72867).
- @frizikk — the bounded root-boundary recovery and the `StrictMode` timer
  ownership fix (originally #64310).
- @patrykkopycinski — caught that the root matcher was using the legacy
  `tapClientLookup` name while the live production error is `useClientLookup`,
  with a real production trace (496-message session, active list shrank to 12,
  stale subscriber read index 89). That review is why both layers now share one
  classifier.

The only edit on top of their commits was resolving an additive conflict in
`message-render-boundary.test.tsx`, where both PRs added distinct test helpers —
both are kept.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — this PR
      *is* the consolidation of the two that existed
- [x] My PR contains only changes related to this fix
- [x] I've run the vitest suites above and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (contributors: Windows 11, CachyOS Linux)

### Documentation & Housekeeping

- [x] Documentation N/A — no user-facing workflow or configuration changed
- [x] `cli-config.yaml.example` N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture change
- [x] Cross-platform impact considered — React class boundaries, context, and
      browser timers only; no platform API
- [x] Tool descriptions/schemas N/A — no tool behavior changed
