### PR TITLE
fix(gateway): keep media history reads off event loop

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -45,6 +45,10 @@ _AUDIO_EXTS = frozenset(_AUDIO_MIME_TYPES)
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+# Delivery-time history is best-effort dedup metadata, not canonical state.
+# Keep this comfortably below the Discord heartbeat watchdog window and fail
+# open rather than withholding a legitimate attachment.
+_HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS = 5.0
 
 
 def _platform_name(platform) -> str:
@@ -5892,16 +5896,6 @@ class BasePlatformAdapter(ABC):
                 media_files, response = self.extract_media(response)
                 media_files = self.filter_media_delivery_paths(media_files)
 
-                # Do NOT deduplicate MEDIA tags against prior turns here.
-                # The auto-append path in GatewayRunner._run_agent_inner already
-                # deduplicates auto-appended tags via _collect_auto_append_media_tags
-                # with history_media_paths, so this filter would only catch explicit
-                # MEDIA tags the model deliberately included in its response — which
-                # must be preserved (user asked to resend an image, the model echoed
-                # a path intentionally, etc.).  Bare-file-path dedup still applies
-                # to local_files below via the same _history_media_paths set.
-                _history_media_paths = self._history_media_paths_for_session(session_key)
-
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561).
@@ -5920,6 +5914,30 @@ class BasePlatformAdapter(ABC):
                     # instead of becoming native uploads.
                     local_files, text_content = self.extract_local_files(text_content)
                     local_files = self.filter_local_delivery_paths(local_files)
+                    # Do NOT load the full SQLite transcript for ordinary text or
+                    # explicit MEDIA tags.  History is needed only for bare local
+                    # paths auto-detected above.  Run that synchronous DB/decode
+                    # work off the platform event loop so a slow state.db read
+                    # cannot block Discord heartbeats and trigger the liveness
+                    # watchdog.  On lookup failure the helper returns None and we
+                    # fail open by delivering the candidate file.
+                    _history_media_paths = None
+                    if local_files:
+                        try:
+                            _history_media_paths = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    self._history_media_paths_for_session,
+                                    session_key,
+                                ),
+                                timeout=_HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "[%s] Timed out loading media-delivery history for %s; "
+                                "delivering bare local file path(s) without history dedup",
+                                self.name,
+                                session_key,
+                            )
                     if _history_media_paths:
                         _suppressed = [p for p in local_files if p in _history_media_paths]
                         if _suppressed:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -16,6 +16,7 @@ import socket as _socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 import weakref
@@ -49,6 +50,13 @@ _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
 # Keep this comfortably below the Discord heartbeat watchdog window and fail
 # open rather than withholding a legitimate attachment.
 _HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS = 5.0
+# Timed-out reads cannot be cancelled while SQLite/Python code is already
+# running. Isolate and cap them so wedged best-effort dedup work cannot consume
+# the shared asyncio executor or create an unbounded number of worker threads.
+_HISTORY_MEDIA_LOOKUP_MAX_WORKERS = 2
+_HISTORY_MEDIA_LOOKUP_ADMISSION = threading.BoundedSemaphore(
+    _HISTORY_MEDIA_LOOKUP_MAX_WORKERS
+)
 
 
 def _platform_name(platform) -> str:
@@ -3480,6 +3488,66 @@ class BasePlatformAdapter(ABC):
         from gateway.run import _collect_history_media_paths
         return _collect_history_media_paths(history)
 
+    async def _bounded_history_media_paths_for_session(
+        self, session_key: str
+    ) -> Optional[set]:
+        """Run best-effort history lookup in a bounded isolated daemon thread."""
+        admission = _HISTORY_MEDIA_LOOKUP_ADMISSION
+        if not admission.acquire(blocking=False):
+            logger.warning(
+                "[%s] Media-delivery history lookup capacity exhausted for %s; "
+                "delivering bare local file path(s) without history dedup",
+                self.name,
+                session_key,
+            )
+            return None
+
+        loop = asyncio.get_running_loop()
+        result_future = loop.create_future()
+
+        def _publish_result(result=None, error=None):
+            if result_future.done():
+                return
+            if error is not None:
+                result_future.set_exception(error)
+            else:
+                result_future.set_result(result)
+
+        def _worker():
+            try:
+                result = self._history_media_paths_for_session(session_key)
+            except BaseException as exc:
+                try:
+                    loop.call_soon_threadsafe(_publish_result, None, exc)
+                except RuntimeError:
+                    pass  # Event loop already closed during gateway shutdown.
+            else:
+                try:
+                    loop.call_soon_threadsafe(_publish_result, result, None)
+                except RuntimeError:
+                    pass  # Event loop already closed during gateway shutdown.
+            finally:
+                admission.release()
+
+        threading.Thread(
+            target=_worker,
+            name="media-history-lookup",
+            daemon=True,
+        ).start()
+        try:
+            return await asyncio.wait_for(
+                result_future,
+                timeout=_HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] Timed out loading media-delivery history for %s; "
+                "delivering bare local file path(s) without history dedup",
+                self.name,
+                session_key,
+            )
+            return None
+
     @abstractmethod
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -5923,21 +5991,11 @@ class BasePlatformAdapter(ABC):
                     # fail open by delivering the candidate file.
                     _history_media_paths = None
                     if local_files:
-                        try:
-                            _history_media_paths = await asyncio.wait_for(
-                                asyncio.to_thread(
-                                    self._history_media_paths_for_session,
-                                    session_key,
-                                ),
-                                timeout=_HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS,
+                        _history_media_paths = (
+                            await self._bounded_history_media_paths_for_session(
+                                session_key
                             )
-                        except asyncio.TimeoutError:
-                            logger.warning(
-                                "[%s] Timed out loading media-delivery history for %s; "
-                                "delivering bare local file path(s) without history dedup",
-                                self.name,
-                                session_key,
-                            )
+                        )
                     if _history_media_paths:
                         _suppressed = [p for p in local_files if p in _history_media_paths]
                         if _suppressed:

--- a/tests/gateway/test_73771_media_resend_dedup.py
+++ b/tests/gateway/test_73771_media_resend_dedup.py
@@ -23,6 +23,7 @@ sibling):
 
 import asyncio
 import logging
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -216,6 +217,105 @@ async def test_bare_local_path_history_dedup_survives_and_logs(tmp_path, monkeyp
     assert any("Suppressing" in r.getMessage() for r in caplog.records), (
         "suppression must be logged (#73771 observability)"
     )
+
+
+@pytest.mark.asyncio
+async def test_plain_text_response_does_not_load_transcript():
+    """Ordinary text delivery must not touch SQLite-backed history at all."""
+    adapter = _DummyAdapter()
+    adapter._keep_typing = _hold_typing
+
+    class _ExplodingStore:
+        calls = 0
+
+        def peek_session_id(self, _session_key):
+            self.calls += 1
+            raise AssertionError("plain text delivery loaded session history")
+
+    store = _ExplodingStore()
+    adapter.set_session_store(store)
+
+    async def handler(_event):
+        return "Plain response with no local attachment path."
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert store.calls == 0
+    assert any("Plain response" in item["content"] for item in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_bare_path_history_lookup_does_not_block_event_loop(tmp_path, monkeypatch):
+    """A slow transcript read must run outside the platform event loop."""
+    pdf = _allowed_file(tmp_path, monkeypatch, "slow-history.pdf")
+    monkeypatch.setattr("gateway.platforms.base.LOCAL_DELIVERY_SAFE_ROOTS", (pdf.parent,), raising=False)
+    adapter = _DummyAdapter()
+    adapter._keep_typing = _hold_typing
+    monkeypatch.setattr(
+        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths: list(paths))
+    )
+
+    class _SlowStore:
+        def peek_session_id(self, _session_key):
+            return "sess-slow"
+
+        def load_transcript(self, _session_id):
+            time.sleep(0.15)
+            return [{"role": "user", "content": "current"}]
+
+    adapter.set_session_store(_SlowStore())
+
+    async def handler(_event):
+        return f"Generated file: {pdf}"
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    delivery = asyncio.create_task(
+        adapter._process_message_background(event, build_session_key(event.source))
+    )
+    await asyncio.sleep(0.02)
+    assert not delivery.done()
+    # If load_transcript ran on the event-loop thread, this 20 ms sleep would
+    # not resume until after the 150 ms blocking read completed.
+    assert not adapter.documents
+    await delivery
+    assert adapter.documents == [str(pdf)]
+
+
+@pytest.mark.asyncio
+async def test_bare_path_history_lookup_timeout_fails_open(tmp_path, monkeypatch):
+    """A wedged transcript read must not hold response delivery indefinitely."""
+    pdf = _allowed_file(tmp_path, monkeypatch, "timeout-history.pdf")
+    monkeypatch.setattr("gateway.platforms.base.LOCAL_DELIVERY_SAFE_ROOTS", (pdf.parent,), raising=False)
+    monkeypatch.setattr("gateway.platforms.base._HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS", 0.02)
+    adapter = _DummyAdapter()
+    adapter._keep_typing = _hold_typing
+    monkeypatch.setattr(
+        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths: list(paths))
+    )
+
+    class _WedgedStore:
+        def peek_session_id(self, _session_key):
+            return "sess-wedged"
+
+        def load_transcript(self, _session_id):
+            time.sleep(0.2)
+            return []
+
+    adapter.set_session_store(_WedgedStore())
+
+    async def handler(_event):
+        return f"Generated file: {pdf}"
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    started = time.monotonic()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert time.monotonic() - started < 0.15
+    assert adapter.documents == [str(pdf)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_73771_media_resend_dedup.py
+++ b/tests/gateway/test_73771_media_resend_dedup.py
@@ -23,6 +23,7 @@ sibling):
 
 import asyncio
 import logging
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -247,6 +248,34 @@ async def test_plain_text_response_does_not_load_transcript():
 
 
 @pytest.mark.asyncio
+async def test_explicit_media_response_does_not_load_transcript(tmp_path, monkeypatch):
+    """Explicit MEDIA delivery must not touch SQLite-backed history."""
+    pdf = _allowed_file(tmp_path, monkeypatch, "explicit-no-history.pdf")
+    adapter = _DummyAdapter()
+    adapter._keep_typing = _hold_typing
+
+    class _ExplodingStore:
+        calls = 0
+
+        def peek_session_id(self, _session_key):
+            self.calls += 1
+            raise AssertionError("explicit MEDIA delivery loaded session history")
+
+    store = _ExplodingStore()
+    adapter.set_session_store(store)
+
+    async def handler(_event):
+        return f"Here is the file.\nMEDIA:{pdf}"
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert store.calls == 0
+    assert adapter.documents == [str(pdf)]
+
+
+@pytest.mark.asyncio
 async def test_bare_path_history_lookup_does_not_block_event_loop(tmp_path, monkeypatch):
     """A slow transcript read must run outside the platform event loop."""
     pdf = _allowed_file(tmp_path, monkeypatch, "slow-history.pdf")
@@ -316,6 +345,48 @@ async def test_bare_path_history_lookup_timeout_fails_open(tmp_path, monkeypatch
 
     assert time.monotonic() - started < 0.15
     assert adapter.documents == [str(pdf)]
+
+
+@pytest.mark.asyncio
+async def test_history_lookup_saturation_fails_open_without_new_worker(monkeypatch):
+    """Wedged lookups are bounded and cannot consume unbounded worker threads."""
+    monkeypatch.setattr("gateway.platforms.base._HISTORY_MEDIA_LOOKUP_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(
+        "gateway.platforms.base._HISTORY_MEDIA_LOOKUP_ADMISSION",
+        threading.BoundedSemaphore(2),
+    )
+    adapter = _DummyAdapter()
+    release = threading.Event()
+    two_started = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def blocked_lookup(_session_key):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            if calls == 2:
+                two_started.set()
+        release.wait(timeout=1)
+        return None
+
+    monkeypatch.setattr(adapter, "_history_media_paths_for_session", blocked_lookup)
+    first = asyncio.create_task(adapter._bounded_history_media_paths_for_session("one"))
+    second = asyncio.create_task(adapter._bounded_history_media_paths_for_session("two"))
+    deadline = time.monotonic() + 1
+    while not two_started.is_set() and time.monotonic() < deadline:
+        await asyncio.sleep(0.005)
+    assert two_started.is_set()
+
+    began = time.monotonic()
+    third = await adapter._bounded_history_media_paths_for_session("three")
+    elapsed = time.monotonic() - began
+
+    assert third is None
+    assert elapsed < 0.1
+    assert calls == 2
+    release.set()
+    await asyncio.gather(first, second)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Prevents delivery-time transcript history reads from blocking the messaging platform event loop.

The non-streaming delivery path used to load the complete persisted transcript before every response, even when the response contained only text or explicit `MEDIA:` directives. Because that load is synchronous, a slow SQLite/storage read could block Discord heartbeats and trigger the gateway liveness watchdog after the agent had already completed its answer.

This change:

- avoids loading transcript history for ordinary text and explicit `MEDIA:` responses;
- performs the remaining lookup only when bare local paths need historical deduplication;
- runs that synchronous lookup in an isolated daemon worker;
- caps concurrent history workers at two so timed-out reads cannot exhaust the shared executor or grow without bound;
- bounds delivery waiting with a 5-second timeout; and
- fails open on timeout so optional dedup metadata cannot prevent response delivery.

## Related Issue

No public issue filed yet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Changes Made

- Added a bounded delivery-history lookup timeout.
- Moved bare-path transcript lookup off the platform event loop into isolated daemon workers with two-slot admission.
- Removed unnecessary transcript loads from plain-text and explicit-media delivery.
- Added regression tests for event-loop responsiveness, timeout behavior, bounded saturation, plain-text and explicit-media fast paths, and existing attachment-dedup behavior.

## How to Test

```bash
uv run --with pytest --with pytest-asyncio pytest -q \
  tests/gateway/test_73771_media_resend_dedup.py \
  tests/gateway/test_history_media_current_turn.py \
  tests/gateway/test_media_extraction.py \
  tests/gateway/test_media_spaced_paths_and_history_dedupe.py \
  tests/gateway/test_media_tag_separator.py \
  tests/gateway/test_post_stream_media_delivery.py \
  tests/test_session_db_read_path_split.py
```

Result after reviewer hardening: `37 passed, 5 skipped` in the isolated upstream worktree.

The live integrated checkout passed `44 passed, 4 skipped`.

Additional checks:

```bash
git diff --check
uv run python -m py_compile gateway/platforms/base.py tests/gateway/test_73771_media_resend_dedup.py
python scripts/check-windows-footguns.py gateway/platforms/base.py tests/gateway/test_73771_media_resend_dedup.py
```

All passed.

The full gateway directory suite was also attempted, but collection requires optional API/webhook test dependencies not installed in the isolated environment (`aiohttp.test_utils`). The focused media, delivery, and state-reader suites above passed.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the fix.
- [x] Focused regression tests pass locally.
- [ ] I have run the complete repository test suite.
- [x] No profile-specific paths, messages, identities, credentials, or deployment logs are included.

## Screenshots / Logs

Not applicable. This is a gateway concurrency/delivery-path fix; sanitized test results are included above.
