### PR TITLE
fix(deepseek): support V4 DSML tool round-trips

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1154,6 +1154,216 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+
+def _prepare_deepseek_v4_synthetic_tool_history(api_messages: list) -> list:
+    """Rewrite Hermes-synthetic DeepSeek V4 tool history to native DSML replay.
+
+    DeepSeek V4 models may emit DSML tool intent as textual assistant content.
+    Hermes converts that intent to native tool_calls internally so its normal
+    tool executor, UI, persistence, and audit paths continue to work.
+
+    Some OpenAI-compatible DeepSeek V4 endpoints reject replay of those
+    synthetic calls as assistant.tool_calls + role=tool.  At the provider
+    boundary only, convert Hermes-synthetic dsml_* / deepseek_xml_* calls back
+    to DeepSeek V4's native textual protocol:
+
+        assistant: <｜DSML｜tool_calls>...</｜DSML｜tool_calls>
+        user:      <tool_result>...</tool_result>
+
+    Canonical internal Hermes history is not modified.
+    """
+
+    def _arguments_to_dsml(arguments_text):
+        try:
+            arguments = json.loads(arguments_text or "{}")
+        except Exception:
+            arguments = {"arguments": arguments_text or ""}
+
+        if not isinstance(arguments, dict):
+            arguments = {"arguments": arguments}
+
+        params = []
+
+        for key, value in arguments.items():
+            if isinstance(value, str):
+                is_string = "true"
+                rendered = value
+            else:
+                is_string = "false"
+                rendered = json.dumps(value, ensure_ascii=False)
+
+            params.append(
+                f'<｜DSML｜parameter name="{key}" string="{is_string}">'
+                f'{rendered}'
+                f'</｜DSML｜parameter>'
+            )
+
+        return "\n".join(params)
+
+    def _tool_calls_to_dsml(tool_calls):
+        invokes = []
+
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                return None
+
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                return None
+
+            name = fn.get("name")
+            if not isinstance(name, str) or not name:
+                return None
+
+            params = _arguments_to_dsml(fn.get("arguments"))
+
+            if params:
+                invoke = (
+                    f'<｜DSML｜invoke name="{name}">\n'
+                    f'{params}\n'
+                    f'</｜DSML｜invoke>'
+                )
+            else:
+                invoke = (
+                    f'<｜DSML｜invoke name="{name}">\n'
+                    f'</｜DSML｜invoke>'
+                )
+
+            invokes.append(invoke)
+
+        if not invokes:
+            return None
+
+        return (
+            "<｜DSML｜tool_calls>\n"
+            + "\n".join(invokes)
+            + "\n</｜DSML｜tool_calls>"
+        )
+
+    rewritten = []
+    i = 0
+
+    while i < len(api_messages):
+        msg = api_messages[i]
+
+        if not isinstance(msg, dict):
+            rewritten.append(msg)
+            i += 1
+            continue
+
+        tool_calls = msg.get("tool_calls")
+
+        if (
+            msg.get("role") == "assistant"
+            and isinstance(tool_calls, list)
+            and tool_calls
+        ):
+            synthetic_ids = []
+            all_synthetic = True
+
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    all_synthetic = False
+                    break
+
+                tc_id = tc.get("id") or ""
+
+                if not (
+                    isinstance(tc_id, str)
+                    and tc_id.startswith(("dsml_", "deepseek_xml_"))
+                ):
+                    all_synthetic = False
+                    break
+
+                synthetic_ids.append(tc_id)
+
+            if all_synthetic:
+                dsml_content = _tool_calls_to_dsml(tool_calls)
+
+                # Collect the immediately following Hermes tool results.
+                j = i + 1
+                tool_results = {}
+
+                while j < len(api_messages):
+                    candidate = api_messages[j]
+
+                    if not (
+                        isinstance(candidate, dict)
+                        and candidate.get("role") == "tool"
+                    ):
+                        break
+
+                    result_id = candidate.get("tool_call_id")
+
+                    if result_id in synthetic_ids:
+                        tool_results[result_id] = candidate
+
+                    j += 1
+
+                # Rewrite only a complete call/result batch.  Partial batches
+                # remain untouched so generic Hermes recovery can handle them.
+                if (
+                    dsml_content is not None
+                    and len(tool_results) == len(synthetic_ids)
+                    and all(tc_id in tool_results for tc_id in synthetic_ids)
+                ):
+                    assistant_replay = {
+                        k: v
+                        for k, v in msg.items()
+                        if k != "tool_calls"
+                    }
+
+                    existing_content = assistant_replay.get("content")
+                    if isinstance(existing_content, str) and existing_content.strip():
+                        assistant_replay["content"] = (
+                            existing_content.rstrip()
+                            + "\n\n"
+                            + dsml_content
+                        )
+                    else:
+                        assistant_replay["content"] = dsml_content
+
+                    rewritten.append(assistant_replay)
+
+                    result_blocks = []
+
+                    # DeepSeek V4 requires results in preceding tool-call order.
+                    for tc_id in synthetic_ids:
+                        tool_msg = tool_results[tc_id]
+                        content = tool_msg.get("content")
+
+                        if content is None:
+                            content = ""
+                        elif not isinstance(content, str):
+                            content = json.dumps(
+                                content,
+                                ensure_ascii=False,
+                            )
+
+                        result_blocks.append(
+                            f"<tool_result>{content}</tool_result>"
+                        )
+
+                    rewritten.append({
+                        "role": "user",
+                        "content": "\n".join(result_blocks),
+                    })
+
+                    logger.info(
+                        "Rewrote DeepSeek V4 synthetic tool history "
+                        "to native DSML/tool_result replay (%d call(s)).",
+                        len(synthetic_ids),
+                    )
+
+                    i = j
+                    continue
+
+        rewritten.append(msg)
+        i += 1
+
+    return rewritten
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
@@ -1351,6 +1561,19 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         # (e.g. DeepSeek, Kimi). The legacy path below already does this, but
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
+
+        # DeepSeek V4 compatibility: textual DSML/XML tool intent is converted
+        # to native Hermes tool calls for local execution, but compatible V4
+        # endpoints may reject replayed assistant.tool_calls / role=tool history.
+        # Rewrite only Hermes-synthetic deepseek_xml_*/dsml_* call/result batches
+        # at the provider boundary; canonical internal history remains untouched.
+        if (
+            (agent.provider or "").strip().lower() == "deepseek"
+            and (agent.model or "").strip().lower().startswith("deepseek-v4-")
+        ):
+            api_messages = _prepare_deepseek_v4_synthetic_tool_history(
+                api_messages
+            )
 
         return _ct.build_kwargs(
             model=agent.model,
@@ -3408,6 +3631,160 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         # Build mock response matching non-streaming shape
         full_content = "".join(content_parts) or None
+
+        # DeepSeek V4 DSML tool-call compatibility fallback.
+        # Strictly scoped to native DeepSeek V4 models and used only
+        # when no OpenAI-native tool_calls were received.
+        _provider_name = str(getattr(agent, "provider", "") or "").lower()
+        _model_name_lower = str(getattr(agent, "model", "") or "").lower()
+
+        if (
+            not tool_calls_acc
+            and _provider_name == "deepseek"
+            and _model_name_lower.startswith("deepseek-v4-")
+            and isinstance(full_content, str)
+            and "DSML" in full_content
+        ):
+            _dsml = re.sub(r"｜+DSML｜+", "DSML", full_content)
+
+            _tool_block_match = re.search(
+                r"<DSMLtool_calls>(.*?)</DSMLtool_calls>",
+                _dsml,
+                flags=re.DOTALL,
+            )
+
+            if _tool_block_match:
+                _tool_block = _tool_block_match.group(1)
+                _invoke_matches = list(re.finditer(
+                    r'<DSMLinvoke\s+name="([^"]+)">(.*?)</DSMLinvoke>',
+                    _tool_block,
+                    flags=re.DOTALL,
+                ))
+
+                _parsed_calls = {}
+
+                for _idx, _invoke_match in enumerate(_invoke_matches):
+                    _tool_name = _invoke_match.group(1).strip()
+                    _invoke_body = _invoke_match.group(2)
+
+                    _arguments = {}
+                    for _param_match in re.finditer(
+                        r'<DSMLparameter\s+name="([^"]+)"(?:\s+string="([^"]+)")?'
+                        r'>(.*?)</DSMLparameter>',
+                        _invoke_body,
+                        flags=re.DOTALL,
+                    ):
+                        _param_name = _param_match.group(1).strip()
+                        _is_string = (
+                            (_param_match.group(2) or "").strip().lower()
+                            == "true"
+                        )
+                        _raw_value = _param_match.group(3).strip()
+
+                        if _is_string:
+                            _value = _raw_value
+                        else:
+                            try:
+                                _value = json.loads(_raw_value)
+                            except (json.JSONDecodeError, TypeError):
+                                _value = _raw_value
+
+                        _arguments[_param_name] = _value
+
+                    # DeepSeek V4 DSML may emit read_file's path argument as
+                    # "file", while Hermes' canonical read_file schema expects
+                    # "path". Normalize only this known compatibility case.
+                    if (
+                        _tool_name == "read_file"
+                        and "path" not in _arguments
+                        and "file" in _arguments
+                    ):
+                        _arguments["path"] = _arguments.pop("file")
+
+                    if _tool_name:
+                        _parsed_calls[_idx] = {
+                            "id": f"dsml_{uuid.uuid4().hex}",
+                            "type": "function",
+                            "function": {
+                                "name": _tool_name,
+                                "arguments": json.dumps(
+                                    _arguments,
+                                    ensure_ascii=False,
+                                ),
+                            },
+                            "extra_content": None,
+                        }
+
+                if _parsed_calls:
+                    tool_calls_acc.update(_parsed_calls)
+
+                    _before = _dsml[:_tool_block_match.start()].strip()
+                    _after = _dsml[_tool_block_match.end():].strip()
+                    _remaining = "\n".join(
+                        part for part in (_before, _after) if part
+                    )
+                    full_content = _remaining or None
+
+                    logger.info(
+                        "Converted DeepSeek V4 DSML content to %d native "
+                        "Hermes tool call(s).",
+                        len(_parsed_calls),
+                    )
+
+        # DeepSeek V4 simple XML read_file compatibility fallback.
+        # Some compatible endpoints emit a textual read_file block instead
+        # of OpenAI-native structured tool_calls.
+        if (
+            not tool_calls_acc
+            and _provider_name == "deepseek"
+            and _model_name_lower.startswith("deepseek-v4-")
+            and isinstance(full_content, str)
+        ):
+            _xml_read_pattern = (
+                re.escape("<read_file>")
+                + r"\s*"
+                + re.escape("<path>")
+                + r"(.*?)"
+                + re.escape("</path>")
+                + r"\s*"
+                + re.escape("</read_file>")
+            )
+
+            _xml_read_match = re.search(
+                _xml_read_pattern,
+                full_content,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+
+            if _xml_read_match:
+                _path = _xml_read_match.group(1).strip()
+
+                if _path:
+                    tool_calls_acc[0] = {
+                        "id": f"deepseek_xml_{uuid.uuid4().hex}",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": json.dumps(
+                                {"path": _path},
+                                ensure_ascii=False,
+                            ),
+                        },
+                        "extra_content": None,
+                    }
+
+                    _before = full_content[:_xml_read_match.start()].strip()
+                    _after = full_content[_xml_read_match.end():].strip()
+                    _remaining = "\n".join(
+                        part for part in (_before, _after) if part
+                    )
+                    full_content = _remaining or None
+
+                    logger.info(
+                        "Converted DeepSeek V4 simple XML read_file content "
+                        "to native Hermes tool call."
+                    )
+
         mock_tool_calls = None
         has_truncated_tool_args = False
         if tool_calls_acc:

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -91,6 +91,7 @@ deepseek = DeepSeekProfile(
     display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
+    default_headers={"User-Agent": "curl/8.7.1"},
     fallback_models=(
         "deepseek-v4-pro",
         "deepseek-v4-flash",

--- a/tests/run_agent/test_deepseek_v4_dsml_compat.py
+++ b/tests/run_agent/test_deepseek_v4_dsml_compat.py
@@ -1,0 +1,276 @@
+"""Regression tests for DeepSeek V4 textual DSML tool compatibility.
+
+DeepSeek V4-compatible endpoints may emit textual DSML instead of
+OpenAI-native tool_calls. Hermes converts those calls to its canonical
+internal representation for execution, then rewrites only the synthetic
+history back to DSML + <tool_result> at the provider boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import (
+    _prepare_deepseek_v4_synthetic_tool_history,
+)
+
+
+def _chunk(content=None, *, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        delta=delta,
+        finish_reason=finish_reason,
+    )
+    return SimpleNamespace(
+        choices=[choice],
+        model="deepseek-v4-flash",
+        usage=None,
+    )
+
+
+def _run_deepseek_stream(content: str):
+    from run_agent import AIAgent
+
+    chunks = [
+        _chunk(content),
+        _chunk(finish_reason="stop"),
+    ]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+
+    with (
+        patch(
+            "run_agent.AIAgent._create_request_openai_client",
+            return_value=mock_client,
+        ),
+        patch("run_agent.AIAgent._close_request_openai_client"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://deepseekv4.network/api/v1",
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        return agent._interruptible_streaming_api_call({})
+
+
+def test_dsml_read_file_normalizes_file_to_path():
+    response = _run_deepseek_stream(
+        """<｜DSML｜tool_calls>
+<｜DSML｜invoke name="read_file">
+<｜DSML｜parameter name="file" string="true">/tmp/test.txt</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>"""
+    )
+
+    calls = response.choices[0].message.tool_calls
+
+    assert calls is not None
+    assert len(calls) == 1
+    assert calls[0].id.startswith("dsml_")
+    assert calls[0].function.name == "read_file"
+    assert json.loads(calls[0].function.arguments) == {
+        "path": "/tmp/test.txt",
+    }
+
+
+def test_dsml_decodes_typed_parameters():
+    response = _run_deepseek_stream(
+        """<｜DSML｜tool_calls>
+<｜DSML｜invoke name="search_files">
+<｜DSML｜parameter name="query" string="true">alpha</｜DSML｜parameter>
+<｜DSML｜parameter name="limit" string="false">2</｜DSML｜parameter>
+<｜DSML｜parameter name="recursive" string="false">true</｜DSML｜parameter>
+<｜DSML｜parameter name="paths" string="false">["a","b"]</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>"""
+    )
+
+    calls = response.choices[0].message.tool_calls
+    assert calls is not None
+    assert len(calls) == 1
+
+    args = json.loads(calls[0].function.arguments)
+
+    assert args == {
+        "query": "alpha",
+        "limit": 2,
+        "recursive": True,
+        "paths": ["a", "b"],
+    }
+
+
+def test_dsml_multiple_invokes_become_multiple_tool_calls():
+    response = _run_deepseek_stream(
+        """<｜DSML｜tool_calls>
+<｜DSML｜invoke name="read_file">
+<｜DSML｜parameter name="path" string="true">/tmp/a.txt</｜DSML｜parameter>
+</｜DSML｜invoke>
+<｜DSML｜invoke name="search_files">
+<｜DSML｜parameter name="query" string="true">needle</｜DSML｜parameter>
+<｜DSML｜parameter name="limit" string="false">3</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>"""
+    )
+
+    calls = response.choices[0].message.tool_calls
+
+    assert calls is not None
+    assert len(calls) == 2
+    assert [call.function.name for call in calls] == [
+        "read_file",
+        "search_files",
+    ]
+
+    assert json.loads(calls[0].function.arguments) == {
+        "path": "/tmp/a.txt",
+    }
+    assert json.loads(calls[1].function.arguments) == {
+        "query": "needle",
+        "limit": 3,
+    }
+
+
+def test_simple_xml_read_file_fallback():
+    response = _run_deepseek_stream(
+        "<read_file><path>/tmp/xml.txt</path></read_file>"
+    )
+
+    calls = response.choices[0].message.tool_calls
+
+    assert calls is not None
+    assert len(calls) == 1
+    assert calls[0].id.startswith("deepseek_xml_")
+    assert calls[0].function.name == "read_file"
+    assert json.loads(calls[0].function.arguments) == {
+        "path": "/tmp/xml.txt",
+    }
+
+
+def test_synthetic_history_rewrites_to_dsml_and_tool_result():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "dsml_001",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path":"/tmp/a.txt"}',
+                },
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "dsml_001",
+            "content": "VALUE_A",
+        },
+    ]
+
+    out = _prepare_deepseek_v4_synthetic_tool_history(messages)
+
+    assert len(out) == 2
+
+    assert out[0]["role"] == "assistant"
+    assert "tool_calls" not in out[0]
+    assert "<｜DSML｜tool_calls>" in out[0]["content"]
+    assert '<｜DSML｜invoke name="read_file">' in out[0]["content"]
+    assert (
+        '<｜DSML｜parameter name="path" string="true">'
+        '/tmp/a.txt'
+        '</｜DSML｜parameter>'
+    ) in out[0]["content"]
+
+    assert out[1] == {
+        "role": "user",
+        "content": "<tool_result>VALUE_A</tool_result>",
+    }
+
+
+def test_synthetic_batch_preserves_tool_call_result_order():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "dsml_a",
+                    "type": "function",
+                    "function": {
+                        "name": "search_files",
+                        "arguments": '{"query":"alpha","limit":2}',
+                    },
+                },
+                {
+                    "id": "dsml_b",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"/tmp/b.txt"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "dsml_b",
+            "content": "RESULT_B",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "dsml_a",
+            "content": "RESULT_A",
+        },
+    ]
+
+    out = _prepare_deepseek_v4_synthetic_tool_history(messages)
+
+    assert len(out) == 2
+    assert out[0]["content"].count("<｜DSML｜invoke") == 2
+
+    assert out[1]["content"] == (
+        "<tool_result>RESULT_A</tool_result>\n"
+        "<tool_result>RESULT_B</tool_result>"
+    )
+
+
+def test_native_tool_history_is_not_rewritten():
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_native_001",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path":"/tmp/native.txt"}',
+                },
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_native_001",
+            "content": "NATIVE_RESULT",
+        },
+    ]
+
+    out = _prepare_deepseek_v4_synthetic_tool_history(messages)
+
+    assert out == messages


### PR DESCRIPTION
## Summary

Adds compatibility handling for DeepSeek V4 models that emit textual DSML tool calls instead of OpenAI-native `tool_calls`.

The change keeps Hermes' internal tool execution model unchanged:

1. DeepSeek V4 textual DSML is detected in streamed assistant content.
2. DSML tool intent is converted into native Hermes `tool_calls`.
3. Hermes executes the tool normally.
4. At the DeepSeek provider boundary only, Hermes-generated synthetic tool history is converted back to DeepSeek-style DSML + `<tool_result>` replay.

A narrow XML `read_file` fallback is also retained for compatible endpoints that emit:

```xml
<read_file><path>...</path></read_file>

instead of DSML.

Problem

Some DeepSeek V4-compatible endpoints return tool intent as textual DSML, for example:

<｜DSML｜tool_calls>
<｜DSML｜invoke name="read_file">
<｜DSML｜parameter name="file" string="true">/path/to/file</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜tool_calls>

Hermes previously treated this as ordinary assistant text because no OpenAI-native tool_calls were present, so the requested tool was never executed.

There is a second compatibility issue with some OpenAI-compatible DeepSeek V4 endpoints: after Hermes converts the textual tool call and executes it, replaying the synthetic history as:

assistant.tool_calls
role=tool

can be rejected by the endpoint with HTTP 400.

Direct provider testing showed that the same endpoint accepts the equivalent DeepSeek-style replay:

assistant: <｜DSML｜tool_calls>...</｜DSML｜tool_calls>
user:      <tool_result>...</tool_result>
Changes
DSML → native Hermes tool calls

When all of the following are true:

provider is deepseek
model name starts with deepseek-v4-
no native OpenAI tool_calls were received
assistant content contains DSML

Hermes parses the textual DSML and creates normal internal tool calls.

Native OpenAI tool_calls always take precedence.

Typed DSML parameters

DSML parameters now preserve their declared type:

string="true"

is treated as a string, while:

string="false"

is JSON-decoded when possible.

This allows values such as numbers, booleans, lists and objects to reach Hermes tools with their original type.

read_file argument normalization

Observed DeepSeek V4 DSML can use:

name="file"

for read_file, while Hermes' canonical tool schema expects:

{"path": "..."}

The compatibility parser normalizes this specific case from file to path.

Provider-bound synthetic history replay

Only Hermes-generated synthetic tool call IDs:

dsml_*
deepseek_xml_*

are rewritten for DeepSeek V4 replay.

Canonical internal conversation history is not modified.

Complete synthetic call/result batches are converted to:

assistant: DSML tool call block
user:      <tool_result>...</tool_result>

Multiple tool results preserve the original tool-call order.

Native tool-call history such as call_* is left unchanged.

Simple XML fallback

A narrow compatibility fallback converts:

<read_file>
  <path>/path/to/file</path>
</read_file>

into a native Hermes read_file call.

Provider header compatibility

Adds:

default_headers={"User-Agent": "curl/8.7.1"}

to the DeepSeek provider profile.

During debugging, the tested DeepSeek V4-compatible endpoint returned HTTP 403 with the OpenAI SDK default User-Agent, while the same request succeeded when only the User-Agent was overridden.

Scope

The DSML compatibility behavior is deliberately gated to:

provider == "deepseek"
model starts with "deepseek-v4-"

and does not affect other providers or model families.

Synthetic-history rewriting is additionally restricted to Hermes-generated dsml_* and deepseek_xml_* tool call IDs.

Tests

Added:

tests/run_agent/test_deepseek_v4_dsml_compat.py

Regression coverage includes:

DSML read_file parsing
file → path normalization
typed DSML parameters
multiple DSML tool calls
simple XML read_file fallback
synthetic DSML + <tool_result> history replay
preservation of tool-result ordering
native tool-call history remaining untouched

Results:

7 passed

DeepSeek-focused regression suite:

54 passed

A broader regression run produced:

80 passed
3 failed

All three failures were unrelated Anthropic streaming tests that could not initialize because the local test environment did not have the optional anthropic package installed.

Manual validation

The change was also tested end-to-end through Hermes WebUI with DeepSeek V4 Flash.

Observed flow:

DeepSeek textual DSML
→ Hermes native tool call
→ read_file execution
→ synthetic history rewritten to DSML + <tool_result>
→ DeepSeek follow-up accepted
→ final assistant response

The previous HTTP 400 on the post-tool request no longer occurred, and the final response contained the actual contents returned by read_file.

Notes

The User-Agent workaround was required by the tested DeepSeek V4-compatible endpoint. The default DeepSeek provider profile also targets the official DeepSeek API, so this header behavior may deserve separate review if broader upstream compatibility is a concern.

