### PR TITLE
fix(gateway): release pending clarify on free-form input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14764,8 +14764,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Intercept messages that are responses to a pending clarify.
         # Open-ended prompts and "Other" responses are captured as free text;
         # direct replies to multi-choice prompts are accepted too ("2" maps
-        # to the second option, arbitrary text becomes a custom answer). Slash
-        # commands still bypass this path so /stop and friends keep working.
+        # to the second option). Free-form input cancels a native choice prompt
+        # and continues as a normal turn. Slash commands still bypass this path
+        # so /stop and friends keep working.
         _clarify_mod = None
         try:
             from tools import clarify_gateway as _clarify_mod
@@ -14817,6 +14818,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+
+                # Native interactive choice prompts reject arbitrary prose as
+                # an answer. End that exact pending wait before allowing the
+                # message through as a new turn; otherwise the active-session
+                # queue holds the message until the clarify timeout expires.
+                # Cancellation is first-wins, so a concurrent button callback
+                # cannot be overwritten (and vice versa).
+                if _clarify_mod.cancel_gateway_clarify(
+                    _pending_clarify.clarify_id
+                ):
+                    logger.info(
+                        "Gateway cancelled pending clarify for free-form input "
+                        "(session=%s, id=%s)",
+                        _quick_key,
+                        _pending_clarify.clarify_id,
+                    )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -7,12 +7,13 @@ consume ANY non-command message in the session as the clarify answer —
 arbitrary prose vanished into clarify resolution and the agent appeared to
 ignore the user's thread messages.
 
-After the fix (``tools/clarify_gateway._coerce_text_response`` rejects
+After the fix (``tools.clarify_gateway._coerce_text_response`` rejects
 arbitrary prose for native multi-choice prompts):
 
-  * numeric selections ("2") and exact choice labels still resolve, and
-  * arbitrary prose falls through the intercept and continues as a normal
-    message-handling turn.
+  * numeric selections ("2") and exact choice labels still resolve,
+  * arbitrary prose cancels the pending choice wait and continues as a normal
+    message-handling turn, and
+  * cancellation is first-wins with any concurrent button callback.
 
 Open-ended clarifies, explicit "Other" text-capture mode, and the base
 adapter's numbered-text fallback (which flips ``awaiting_text`` at send time)
@@ -109,8 +110,8 @@ async def _dispatch(runner, event):
 
 
 @pytest.mark.asyncio
-async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
-    """Arbitrary prose during a pending button-clarify continues as a normal turn."""
+async def test_thread_prose_cancels_native_multi_choice_clarify_and_falls_through():
+    """A normal follow-up ends the button clarify before continuing as a new turn."""
     _clear_clarify_state()
     from tools import clarify_gateway as cm
 
@@ -123,11 +124,10 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
     with pytest.raises(_FellThroughIntercept):
         await _dispatch(runner, _event("just checking the visual UI, no need to pass any data"))
 
-    # The clarify entry must still be pending and unresolved.
-    with cm._lock:
-        entry = cm._entries.get("cl-native")
-    assert entry is not None
-    assert not entry.event.is_set()
+    # The free-form message is not a clarify answer, but it must release the
+    # pending wait before continuing through normal message handling.
+    assert entry.event.is_set()
+    assert entry.response == ""
     _clear_clarify_state()
 
 

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -42,6 +42,46 @@ class TestClarifyPrimitive:
         result = cm.wait_for_response("id1", timeout=10.0)
         assert result == "B"
 
+    def test_cancel_releases_blocked_wait_immediately(self):
+        """Free-form cancellation releases the waiter instead of waiting for timeout."""
+        from tools import clarify_gateway as cm
+
+        cm.register("id-cancel", "sk-cancel", "Pick one", ["A", "B"])
+        result = {}
+
+        waiter = threading.Thread(
+            target=lambda: result.setdefault(
+                "response", cm.wait_for_response("id-cancel", timeout=10.0)
+            )
+        )
+        waiter.start()
+
+        assert cm.cancel_gateway_clarify("id-cancel") is True
+        waiter.join(timeout=1.0)
+
+        assert not waiter.is_alive()
+        assert result["response"] == ""
+        assert cm.resolve_gateway_clarify("id-cancel", "B") is False
+
+    def test_cancel_does_not_overwrite_a_concurrent_answer(self):
+        """The first terminal action wins when free-form cancellation races a button."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-race", "sk-race", "Pick one", ["A", "B"])
+        assert cm.resolve_gateway_clarify("id-race", "B") is True
+        assert cm.cancel_gateway_clarify("id-race") is False
+        assert entry.event.is_set()
+        assert entry.response == "B"
+
+    def test_duplicate_resolutions_are_first_wins(self):
+        """Concurrent transport callbacks cannot replace an accepted response."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-double", "sk-double", "Pick one", ["A", "B"])
+        assert cm.resolve_gateway_clarify("id-double", "A") is True
+        assert cm.resolve_gateway_clarify("id-double", "B") is False
+        assert entry.response == "A"
+
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -164,16 +164,21 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
     """Unblock the agent thread waiting on ``clarify_id``.
 
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
+    The first terminal action wins. This matters when a native button
+    callback races a free-form message cancelling the same prompt.
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.event.is_set():
             return False
-    entry.response = str(response) if response is not None else ""
-    entry.event.set()
-    return True
+        entry.response = str(response) if response is not None else ""
+        entry.event.set()
+        return True
+
+
+def cancel_gateway_clarify(clarify_id: str) -> bool:
+    """Cancel one pending clarify and release its waiter with no answer."""
+    return resolve_gateway_clarify(clarify_id, "")
 
 
 def get_pending_for_session(


### PR DESCRIPTION
## Summary

- cancel a pending native choice `clarify` when the user sends unrelated free-form input
- let that input continue through normal turn handling instead of waiting for the clarify timeout
- make clarify resolution/cancellation first-wins so a racing button callback cannot overwrite an accepted result

## Problem

Native multi-choice prompts correctly reject arbitrary prose as a button answer. However, the rejected message then continues through busy-session handling while the original agent remains blocked in `wait_for_response()`.

With queue-mode busy handling, the new message waits behind the blocked turn until the default one-hour clarify timeout expires. The user sees their message as ignored even though it was queued.

## Fix

When arbitrary prose is rejected as a native choice response:

1. cancel that exact pending clarify with an empty result, releasing its waiter;
2. allow the free-form message to continue as a normal turn/follow-up;
3. retain existing behavior for numeric/exact choices, open-ended prompts, and explicit **Other** text capture.

Resolution is now atomic and first-wins under the module lock, covering races between free-form cancellation and button callbacks.

## Tests

TDD regression evidence on clean `main` (tests only):

- 3 failures: the pending event remained unset, cancellation did not exist, and a duplicate callback overwrote the first response

Green verification with the repository's canonical isolated test runner and CI Python/dependency profile:

```text
scripts/run_tests.sh -j 4 \
  tests/gateway/test_clarify_thread_followup_not_swallowed.py \
  tests/tools/test_clarify_gateway.py \
  tests/tools/test_clarify_tool.py \
  tests/plugins/platforms/photon/test_poll_clarify.py \
  tests/gateway/test_telegram_clarify_buttons.py \
  tests/gateway/test_slack_clarify_buttons.py \
  tests/gateway/test_discord_clarify_buttons.py \
  tests/gateway/test_clarify_active_session_bypass.py \
  tests/gateway/test_clarify_progress_leak.py
```

Result: **70 passed, 0 failed**.

`ruff check` also passes for all four changed files.
