### PR TITLE
fix(desktop): stop rendering a repo's main checkout as a duplicate sidebar lane

### DIFF
--- a/contributors/emails/bb@users.noreply.github.com
+++ b/contributors/emails/bb@users.noreply.github.com
@@ -1,0 +1,1 @@
+OutThisLife

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -189,6 +189,52 @@ def test_unrecorded_and_recorded_main_share_one_lane():
     assert len(main_lanes[0]["sessions"]) == 2
 
 
+def test_main_checkout_detected_when_roots_differ_only_in_path_spelling():
+    # The two roots come from DIFFERENT git probes: `rev-parse --show-toplevel`
+    # emits forward slashes, while the `--git-common-dir` path goes through
+    # os.path.dirname and keeps Windows backslashes. The main checkout must be
+    # recognized by path IDENTITY, not by raw string equality — otherwise the
+    # repo's own checkout is misread as a linked worktree and the sidebar shows
+    # both a dir-labeled lane and a branch-labeled "main" lane for one checkout.
+    resolve = _resolver(
+        {
+            "C:/repo": ("C:\\repo", "C:/repo"),
+        }
+    )
+    sessions = [_session("C:/repo", branch="main")]
+
+    tree = pt.build_tree([], sessions, [], resolve, hydrate=True)
+    project = next(p for p in tree["projects"] if pt._path_key(p["id"]) == pt._path_key("C:/repo"))
+    lanes = [g for repo in project["repos"] for g in repo["groups"]]
+
+    assert len(lanes) == 1
+    assert lanes[0]["isMain"] is True
+    # Labeled by branch (a main checkout), never by the directory basename.
+    assert lanes[0]["label"] == "main"
+
+
+def test_main_and_linked_worktree_do_not_duplicate_one_checkout():
+    # End-to-end shape of the reported bug: the repo's own checkout plus a real
+    # linked worktree. Mixed separators across probes must still yield exactly
+    # one lane per checkout — a branch lane for main, a dir lane for the linked
+    # worktree — not three lanes for two checkouts.
+    resolve = _resolver(
+        {
+            "C:/repo": ("C:\\repo", "C:/repo"),
+            "C:/repo-wt": ("C:\\repo", "C:/repo-wt"),
+        }
+    )
+    sessions = [_session("C:/repo", branch="main"), _session("C:/repo-wt", branch="feature")]
+
+    tree = pt.build_tree([], sessions, [], resolve, hydrate=True)
+    project = next(p for p in tree["projects"] if pt._path_key(p["id"]) == pt._path_key("C:/repo"))
+    lanes = [g for repo in project["repos"] for g in repo["groups"]]
+
+    assert len(lanes) == 2
+    assert [g["label"] for g in lanes] == ["main", "repo-wt"]
+    assert [g["isMain"] for g in lanes] == [True, False]
+
+
 def test_persisted_repo_root_used_when_no_live_probe():
     # No resolver (remote backend): fall back to the persisted git_repo_root and
     # split the main checkout by the session's recorded branch.

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -141,6 +141,14 @@ def common_repo_root(cwd: str) -> str:
     splits every worktree into a separate "repo". The common ``.git`` dir
     (``--git-common-dir``) is shared by a repo and all its worktrees, so its
     parent is the one true repo root; fall back to the toplevel root otherwise.
+
+    The returned path is normalized to git's forward-slash spelling so it can be
+    compared against :func:`repo_root` (which returns raw ``--show-toplevel``
+    output). ``os.path.realpath`` rewrites separators to the platform's native
+    ``\\`` on Windows, so without this the SAME directory came back spelled two
+    ways and the repo's own checkout compared unequal to its common root — the
+    main checkout was then misread as a linked worktree and the desktop sidebar
+    rendered it twice (a dir-labeled lane plus a branch-labeled ``main`` lane).
     """
     if not cwd:
         return ""
@@ -150,7 +158,7 @@ def common_repo_root(cwd: str) -> str:
         if gitdir:
             gitdir = os.path.realpath(gitdir)
             if os.path.basename(gitdir) == ".git":
-                return os.path.dirname(gitdir)
+                return os.path.dirname(gitdir).replace(os.sep, "/")
         return repo_root(cwd)
 
     return _cache.resolve(f"common:{cwd}", _probe)

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -230,7 +230,7 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
     if info and info.get("repo_root") and info.get("worktree_root"):
         repo_root = info["repo_root"]
         worktree_root = info["worktree_root"]
-        is_main = worktree_root == repo_root or bool(info.get("is_main"))
+        is_main = _path_key(worktree_root) == _path_key(repo_root) or bool(info.get("is_main"))
 
         if is_main:
             # Unrecorded branch folds into the one trunk lane, so a repo never


### PR DESCRIPTION
Two `main` rows showed up in the desktop sidebar for a single repo checkout — one with a home glyph, one with a git-branch glyph — both built from the same sessions.

The cause is a path-spelling mismatch between the two git probes that `git_probe.resolve()` combines. Each derives the same directory a different way:

| Field | Derived from | Actual value |
|---|---|---|
| `worktree_root` | raw `rev-parse --show-toplevel` | `C:/Users/.../hermes-agent` |
| `repo_root` | `--git-common-dir` → `os.path.realpath` → `os.path.dirname` | `C:\Users\...\hermes-agent` |

`os.path.realpath` rewrites separators to the platform-native `\` on Windows, so one directory came back spelled two ways from a single `resolve()` call. `project_tree._place` compared them with raw string equality:

```python
is_main = worktree_root == repo_root or bool(info.get("is_main"))  # False
```

With `is_main` wrongly `False`, the repo's own checkout fell through to the *linked worktree* branch and was labeled by directory basename. The branch-labeled `main` lane was then built from those same sessions alongside it — one checkout, two lanes.

Confirmed against a real session DB. Before:

```
lane label='hermes-agent'          isMain=False   <-- the bug
lane label='hermes-agent-midclick' isMain=False
```

After:

```
lane label='main'                  isMain=True    id='...::branch::main'
lane label='hermes-agent-midclick' isMain=False
```

## Changes

Fixed at both layers, so neither a caller nor the probe can reintroduce it:

- **`tui_gateway/git_probe.py`** — the root cause. Normalize the derived common root back to git's forward-slash spelling so both probes agree byte-for-byte. Verified end-to-end: main checkout resolves `True`, linked worktree `False`.
- **`tui_gateway/project_tree.py`** — compare with `_path_key` rather than raw `==`, so platform path identity decides. This matches how every other path comparison in the module is already keyed, hardening the bug class rather than the single symptom.

Line 233 was the only raw-compare site in the module; every other comparison already went through `_path_key`.

## Tests

`tests/tui_gateway/test_project_tree.py` gains two cases asserting the invariant (path identity decides main-checkout classification) rather than snapshotting values — one for a lone checkout, one for main plus a linked worktree.

Both fail before the fix (`assert ['repo', 'repo-wt'] == ['main', 'repo-wt']`) and pass after. Every pre-existing test passed identical strings for both roots, which is why this went uncaught.

`scripts/run_tests.sh` on `test_project_tree.py`, `test_projects_rpc.py`, `test_session_cwd_follow.py`, and `test_project_metadata.py`: 66 passed, 0 failed.
