### PR TITLE
fix(api): close agents after API server runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6267,6 +6267,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         # succeeded but the turn never reached registration.
                         self._shutdown_interruptible_agents.pop(id(agent), None)
                     clear_session_vars(tokens)
+                    if agent is not None:
+                        try:
+                            agent.close()
+                        except Exception:
+                            pass
 
         self._activate_admitted_request()
         self._inflight_agent_runs += 1
@@ -6774,6 +6779,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     _put_event_if_active(None)
                 except Exception:
                     pass
+                _agent = self._active_run_agents.get(run_id)
+                if _agent is not None:
+                    try:
+                        _agent.close()
+                    except Exception:
+                        pass
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)

--- a/tests/gateway/test_api_server_active_work_drain.py
+++ b/tests/gateway/test_api_server_active_work_drain.py
@@ -164,6 +164,7 @@ class TestDrainWaitsForApiWork:
                 _snapshot, timed_out = await drain_task
 
         assert timed_out is False
+        mock_agent.close.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_drain_times_out_if_api_run_outlives_the_window(self):
@@ -348,6 +349,7 @@ class TestRunAgentRegistersForShutdownInterrupt:
 
         assert list(observed["during"].values()) == [agent]
         assert adapter._shutdown_interruptible_agents == {}
+        agent.close.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_agent_is_unregistered_when_the_turn_raises(self):
@@ -364,6 +366,7 @@ class TestRunAgentRegistersForShutdownInterrupt:
                 )
 
         assert adapter._shutdown_interruptible_agents == {}
+        agent.close.assert_called_once_with()
 
 
 class TestInterruptActiveRuns:


### PR DESCRIPTION
## Summary
- Close temporary API-server agents after each run completes.
- Release HTTP clients, connection pools, subprocesses, and child-agent resources.
- Add focused assertions covering successful, drained, and exception paths.

## Verification
- `scripts/run_tests.sh -j 4 tests/gateway/test_api_server_active_work_drain.py`
- 20 tests passed
- `python -m compileall -q gateway`
- `git diff --check`

This is a generic API-server lifecycle fix for Hermes deployments.
