### PR TITLE
feat(models): add curated cross-provider model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3047,6 +3047,32 @@ def _is_profile_api_key_provider(provider_id: str) -> bool:
         return False
 
 
+def _model_flow_my_models(config, current_model=""):
+    """Select from Nicholas's curated cross-provider model shortcut."""
+    from hermes_cli.config import save_config
+    from hermes_cli.my_models import MY_MODELS
+
+    labels = [label for label, _, _ in MY_MODELS]
+    current_idx = next(
+        (i for i, (_, provider, model) in enumerate(MY_MODELS)
+         if model == current_model or f"{provider}/{model}" == current_model),
+        0,
+    )
+    idx = _prompt_provider_choice(labels, default=current_idx, title="Select My Model:")
+    if idx is None:
+        return
+    label, provider, model = MY_MODELS[idx]
+    model_cfg = config.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+        config["model"] = model_cfg
+    model_cfg["default"] = model
+    model_cfg["provider"] = provider
+    model_cfg.pop("base_url", None)
+    save_config(config)
+    print(f"Selected {label}: {provider} · {model}")
+
+
 def select_provider_and_model(args=None):
     """Core provider selection + model picking logic.
 
@@ -3353,6 +3379,8 @@ def select_provider_and_model(args=None):
         else:
             ordered.append((key, label, members))
 
+    ordered.append(("my-models", "My Models ▸", []))
+
     for key, provider_info in _custom_provider_map.items():
         name = provider_info["name"]
         base_url = provider_info["base_url"]
@@ -3414,7 +3442,9 @@ def select_provider_and_model(args=None):
         return
 
     # Step 2: Provider-specific setup + model selection
-    if selected_provider == "openrouter":
+    if selected_provider == "my-models":
+        _model_flow_my_models(config, current_model)
+    elif selected_provider == "openrouter":
         _model_flow_openrouter(config, current_model)
     elif selected_provider == "moa":
         _model_flow_moa(config, current_model)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3181,6 +3181,23 @@ def list_picker_providers(
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
+    # Nicholas's curated cross-provider shortcut. Keep the real provider in
+    # each opaque model ID; the gateway resolves it at selection time.
+    try:
+        from hermes_cli.my_models import picker_models
+        curated = picker_models()
+        providers = [{
+            "slug": "my-models",
+            "name": "My Models",
+            "models": curated,
+            "total_models": len(curated),
+            "is_current": False,
+            "is_user_defined": False,
+            "source": "curated-shortcut",
+        }, *providers]
+    except Exception:
+        pass
+
     filtered: List[dict] = []
     for p in providers:
         slug = str(p.get("slug", "")).lower()

--- a/hermes_cli/my_models.py
+++ b/hermes_cli/my_models.py
@@ -1,0 +1,47 @@
+"""Nicholas's curated cross-provider model picker entries."""
+
+MY_MODELS = [
+    # Keep subscription and paid API routes visibly separate.
+    ("Luna Sub", "openai-codex", "gpt-5.6-luna"),
+    ("Sol Sub", "openai-codex", "gpt-5.6-sol"),
+    ("Luna Paid API (direct)", "openai", "gpt-5.6-luna"),
+    ("Luna Pro API (direct)", "openai", "gpt-5.6-luna-pro"),
+    ("GPT-5.4 (direct API)", "openai", "gpt-5.4"),
+    ("GPT-5.4 Mini (direct API)", "openai", "gpt-5.4-mini"),
+    ("Gemini 3.5 Flash (direct API)", "google", "gemini-3.5-flash"),
+    ("Gemini 3.1 Flash Lite (direct, experimental tools)", "google", "gemini-3.1-flash-lite"),
+
+    # OpenRouter-paid shortlist: current, capable, and useful for agent work.
+    ("GLM 5.2", "openrouter", "z-ai/glm-5.2"),
+    ("Kimi K3", "openrouter", "moonshotai/kimi-k3"),
+    ("Qwen 3.7 Max", "openrouter", "qwen/qwen3.7-max"),
+    ("Qwen 3.8 Max", "openrouter", "qwen/qwen3.8-max"),
+    ("Grok 4.5", "openrouter", "x-ai/grok-4.5"),
+    ("MiniMax M3", "openrouter", "minimax/minimax-m3"),
+    ("MiMo V2.5 Pro", "openrouter", "xiaomi/mimo-v2.5-pro"),
+]
+
+# Internal picker IDs remain opaque to the UI but preserve the real provider.
+# The delimiter is deliberately uncommon in model IDs.
+_PREFIX = "my-model::"
+
+
+def picker_models() -> list[str]:
+    return [f"{_PREFIX}{provider}::{model}" for _, provider, model in MY_MODELS]
+
+
+def display_name(picker_id: str) -> str:
+    for label, provider, model in MY_MODELS:
+        if picker_id == f"{_PREFIX}{provider}::{model}":
+            return label
+    return picker_id
+
+
+def resolve(picker_id: str) -> tuple[str, str] | None:
+    if not picker_id.startswith(_PREFIX):
+        return None
+    value = picker_id[len(_PREFIX):]
+    provider, separator, model = value.partition("::")
+    if not separator or not provider or not model:
+        return None
+    return provider, model

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6015,6 +6015,11 @@ class TelegramAdapter(BasePlatformAdapter):
         for i, model_id in enumerate(page_models):
             abs_idx = start + i
             short = model_id.split("/")[-1] if "/" in model_id else model_id
+            try:
+                from hermes_cli.my_models import display_name
+                short = display_name(model_id)
+            except Exception:
+                pass
             if len(short) > 38:
                 short = short[:35] + "..."
             buttons.append(
@@ -6175,6 +6180,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
             model_id = model_list[idx]
             provider_slug = state.get("selected_provider", "")
+            if provider_slug == "my-models":
+                try:
+                    from hermes_cli.my_models import resolve
+                    resolved = resolve(model_id)
+                    if resolved:
+                        provider_slug, model_id = resolved
+                except Exception:
+                    pass
             callback = state.get("on_model_selected")
 
             if not callback:
@@ -6224,6 +6237,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
             model_id = model_list[idx]
             provider_slug = state.get("selected_provider", "")
+            if provider_slug == "my-models":
+                try:
+                    from hermes_cli.my_models import resolve
+                    resolved = resolve(model_id)
+                    if resolved:
+                        provider_slug, model_id = resolved
+                except Exception:
+                    pass
             callback = state.get("on_model_selected")
 
             if not callback:

--- a/tests/hermes_cli/test_my_models.py
+++ b/tests/hermes_cli/test_my_models.py
@@ -1,0 +1,12 @@
+from hermes_cli.my_models import MY_MODELS, display_name, picker_models, resolve
+
+
+def test_qwen_38_max_is_available_through_openrouter():
+    entry = ("Qwen 3.8 Max", "openrouter", "qwen/qwen3.8-max")
+
+    assert entry in MY_MODELS
+
+    picker_id = "my-model::openrouter::qwen/qwen3.8-max"
+    assert picker_id in picker_models()
+    assert display_name(picker_id) == "Qwen 3.8 Max"
+    assert resolve(picker_id) == ("openrouter", "qwen/qwen3.8-max")


### PR DESCRIPTION
## Summary
- Add a curated My Models row to the CLI and Telegram model pickers.
- Preserve the real provider/model route behind opaque picker IDs.
- Render friendly labels and resolve both normal and confirmation selection paths.

## Verification
- `scripts/run_tests.sh -j 4 tests/hermes_cli/test_my_models.py tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_picker_persist.py`
- 7 tests passed
- `python -m compileall -q hermes_cli plugins`
- `git diff --check`

The feature is configuration-independent and contains no credentials or deployment-specific configuration.
