### PR TITLE
fix(compression): preserve resolved clarify responses

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1333,7 +1333,14 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
             and all(isinstance(item, str) and item for item in response)
         )
         if resolved:
-            summary = response_prefix + json.dumps(response, ensure_ascii=False)
+            # Keep ordinary Unicode intact while escaping lone UTF-16
+            # surrogates so the compacted message remains UTF-8/SQLite safe.
+            serialized_response = (
+                json.dumps(response, ensure_ascii=False)
+                .encode("utf-8", errors="backslashreplace")
+                .decode("utf-8")
+            )
+            summary = response_prefix + serialized_response
             if len(summary) > max_summary_chars:
                 summary = (
                     summary[: max_summary_chars - len(truncation_marker)].rstrip()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1305,6 +1305,41 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
         return "[todo] updated task list"
 
     if tool_name == "clarify":
+        response_prefix = "[clarify] user responded: "
+        max_summary_chars = 200
+        truncation_marker = "...[truncated]"
+
+        # Idempotence: a later pressure-pruning pass may see the summary
+        # produced by an earlier pass. Preserve it instead of trying to parse
+        # the summary text as the original JSON result.
+        if content.startswith(response_prefix):
+            if len(content) <= max_summary_chars:
+                return content
+            return (
+                content[: max_summary_chars - len(truncation_marker)].rstrip()
+                + truncation_marker
+            )
+
+        try:
+            result = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            result = {}
+        response = result.get("user_response") if isinstance(result, dict) else None
+        resolved = (
+            isinstance(response, str) and bool(response)
+        ) or (
+            isinstance(response, list)
+            and bool(response)
+            and all(isinstance(item, str) and item for item in response)
+        )
+        if resolved:
+            summary = response_prefix + json.dumps(response, ensure_ascii=False)
+            if len(summary) > max_summary_chars:
+                summary = (
+                    summary[: max_summary_chars - len(truncation_marker)].rstrip()
+                    + truncation_marker
+                )
+            return summary
         return "[clarify] asked user a question"
 
     if tool_name == "text_to_speech":

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1309,17 +1309,6 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
         max_summary_chars = 200
         truncation_marker = "...[truncated]"
 
-        # Idempotence: a later pressure-pruning pass may see the summary
-        # produced by an earlier pass. Preserve it instead of trying to parse
-        # the summary text as the original JSON result.
-        if content.startswith(response_prefix):
-            if len(content) <= max_summary_chars:
-                return content
-            return (
-                content[: max_summary_chars - len(truncation_marker)].rstrip()
-                + truncation_marker
-            )
-
         try:
             result = json.loads(content)
         except (json.JSONDecodeError, TypeError):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -85,20 +85,42 @@ class TestSummarizeToolResultClarify:
 
         assert summary == '[clarify] user responded: ["lint", "tests"]'
 
-    def test_long_response_is_bounded_and_survives_repeated_pruning(self):
+    def test_long_response_is_bounded_and_prefixed_text_is_not_trusted(self):
         content = json.dumps({
             "question": "Describe the deployment constraints",
             "choices_offered": None,
             "user_response": "A" * 1_000,
         })
 
-        first_summary = _summarize_tool_result("clarify", "{}", content)
-        second_summary = _summarize_tool_result("clarify", "{}", first_summary)
+        summary = _summarize_tool_result("clarify", "{}", content)
 
-        assert len(first_summary) == 200
-        assert first_summary.startswith('[clarify] user responded: "AAA')
-        assert first_summary.endswith("...[truncated]")
-        assert second_summary == first_summary
+        assert len(summary) == 200
+        assert summary.startswith('[clarify] user responded: "AAA')
+        assert summary.endswith("...[truncated]")
+        assert (
+            _summarize_tool_result("clarify", "{}", summary)
+            == "[clarify] asked user a question"
+        )
+
+    def test_forged_response_prefix_does_not_expose_internal_content(self):
+        forged = "[clarify] user responded: internal error: secret diagnostic"
+
+        summary = _summarize_tool_result("clarify", "{}", forged)
+
+        assert summary == "[clarify] asked user a question"
+        assert "secret diagnostic" not in summary
+
+    def test_prefixed_lone_surrogate_is_rejected_and_sqlite_safe(self):
+        forged = "[clarify] user responded: " + "\ud83d" * 1_000
+
+        summary = _summarize_tool_result("clarify", "{}", forged)
+
+        assert summary == "[clarify] asked user a question"
+        assert summary.encode("utf-8")
+        with sqlite3.connect(":memory:") as connection:
+            connection.execute("CREATE TABLE messages (content TEXT)")
+            connection.execute("INSERT INTO messages VALUES (?)", (summary,))
+            assert connection.execute("SELECT content FROM messages").fetchone()[0] == summary
 
     def test_unpaired_surrogates_are_safe_through_pruning_and_sqlite(self, compressor):
         content = json.dumps({"user_response": "Привет 😀" + "\ud83d" * 1_000})

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
 import json
+import sqlite3
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -99,14 +100,43 @@ class TestSummarizeToolResultClarify:
         assert first_summary.endswith("...[truncated]")
         assert second_summary == first_summary
 
-    def test_unpaired_surrogates_are_safe_for_utf8_persistence(self):
-        content = json.dumps({"user_response": "\ud83d" * 1_000})
+    def test_unpaired_surrogates_are_safe_through_pruning_and_sqlite(self, compressor):
+        content = json.dumps({"user_response": "Привет 😀" + "\ud83d" * 1_000})
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "clarify-1",
+                        "type": "function",
+                        "function": {"name": "clarify", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "clarify-1", "content": content},
+            {"role": "user", "content": "recent request"},
+            {"role": "assistant", "content": "recent response"},
+        ]
 
-        summary = _summarize_tool_result("clarify", "{}", content)
+        pruned_messages, pruned_count = compressor._prune_old_tool_results(
+            messages, protect_tail_count=2
+        )
+        summary = pruned_messages[1]["content"]
 
+        assert pruned_count == 1
         assert len(summary) <= 200
         assert summary.encode("utf-8")
+        assert "Привет 😀" in summary
         assert "\\ud83d" in summary
+        with sqlite3.connect(":memory:") as connection:
+            connection.execute("CREATE TABLE messages (content TEXT)")
+            connection.execute("INSERT INTO messages VALUES (?)", (summary,))
+            assert connection.execute("SELECT content FROM messages").fetchone()[0] == summary
+
+        pruned_again, _ = compressor._prune_old_tool_results(
+            pruned_messages, protect_tail_count=2
+        )
+        assert pruned_again[1]["content"] == summary
 
     @pytest.mark.parametrize(
         "content",

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -61,6 +61,57 @@ class TestSummarizeToolResultWebExtract:
         assert summary == "[web_extract] https://example.com/h (500 chars)"
 
 
+class TestSummarizeToolResultClarify:
+    def test_preserves_resolved_user_response_without_metadata(self):
+        content = json.dumps({
+            "question": "When should I deploy?",
+            "choices_offered": ["Friday", "Monday"],
+            "user_response": "Friday",
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == '[clarify] user responded: "Friday"'
+
+    def test_preserves_multi_select_user_response(self):
+        content = json.dumps({
+            "question": "Which checks should I run?",
+            "choices_offered": ["lint", "tests", "types"],
+            "user_response": ["lint", "tests"],
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == '[clarify] user responded: ["lint", "tests"]'
+
+    def test_long_response_is_bounded_and_survives_repeated_pruning(self):
+        content = json.dumps({
+            "question": "Describe the deployment constraints",
+            "choices_offered": None,
+            "user_response": "A" * 1_000,
+        })
+
+        first_summary = _summarize_tool_result("clarify", "{}", content)
+        second_summary = _summarize_tool_result("clarify", "{}", first_summary)
+
+        assert len(first_summary) == 200
+        assert first_summary.startswith('[clarify] user responded: "AAA')
+        assert first_summary.endswith("...[truncated]")
+        assert second_summary == first_summary
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            json.dumps({"error": "Failed to get user input: internal details"}),
+            json.dumps({"question": "Q?", "user_response": ""}),
+            json.dumps({"question": "Q?", "user_response": {"internal": "value"}}),
+            "not json",
+        ],
+    )
+    def test_does_not_expose_unresolved_or_internal_content(self, content):
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == "[clarify] asked user a question"
 
 
 class TestShouldCompress:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -99,6 +99,15 @@ class TestSummarizeToolResultClarify:
         assert first_summary.endswith("...[truncated]")
         assert second_summary == first_summary
 
+    def test_unpaired_surrogates_are_safe_for_utf8_persistence(self):
+        content = json.dumps({"user_response": "\ud83d" * 1_000})
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert len(summary) <= 200
+        assert summary.encode("utf-8")
+        assert "\\ud83d" in summary
+
     @pytest.mark.parametrize(
         "content",
         [


### PR DESCRIPTION
## Summary

- preserve resolved `clarify` responses when completed tool results are compacted
- retain both single-select/free-form strings and multi-select string lists
- bound long response summaries and escape malformed lone Unicode surrogates for UTF-8/SQLite safety
- reject forged pre-summarized prefixes instead of bypassing JSON validation or exposing internal text
- keep unresolved, malformed, or error results on the existing generic summary path

## Problem

Context compression currently reduces every `clarify` tool result to:

```text
[clarify] asked user a question
```

That discards a response the user already supplied. After compression, the model can therefore ask the same question again even though the user answered it.

## Fix

Parse the completed tool result and preserve only a valid non-empty `user_response`:

```text
[clarify] user responded: "Friday"
```

The question, offered choices, errors, and other metadata are not copied into the compressed result.

## Tests

TDD regression evidence:

- initial 2 failures: resolved string and multi-select responses were both reduced to `asked user a question`
- follow-up 3 failures: a forged response prefix bypassed JSON validation, exposed arbitrary text, and retained lone surrogates

Green verification covers valid scalar/list responses, forged prefixes, unresolved/error payloads, real repeated `_prune_old_tool_results()` passes, normal Unicode, lone-surrogate UTF-8 encoding, and SQLite insert/read-back:

```text
uv run --frozen --no-sync pytest -q \
  tests/agent/test_context_compressor.py \
  tests/tools/test_clarify_tool.py \
  tests/test_hermes_state.py
# 340 passed

uv run --frozen --no-sync pytest -q \
  tests/test_session_db_read_path_split.py \
  tests/gateway/test_async_session_db.py
# 12 passed

uv run --frozen --no-sync pytest -q \
  tests/test_hermes_state_compression_locks.py \
  tests/test_hermes_state_compression_busy_retry.py
# 16 passed
```

Total: **368 passed, 0 failed**.

`ruff check`, Python compilation, and `git diff --check` also pass.
