### PR TITLE
fix(agent): name the real cause of session_persistence_failed

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1472,6 +1472,12 @@ def run_conversation(
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
+    # Mirrors the last exception raised by ``_flush_messages_to_session_db``
+    # so the turn-finalizer / user-facing message can name the real cause
+    # (compression lock / DB lock / disk full / permission) instead of
+    # always blaming disk space — #81227. Cleared each turn so a fresh
+    # success does not leak the previous failure's cause.
+    agent._last_persistence_failure = None
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -6505,6 +6511,14 @@ def run_conversation(
                     )
                 except Exception as exc:
                     _tool_turn_persisted = False
+                    # Preserve the cause so the user-facing message names
+                    # the real failure (compression lock / DB lock / disk
+                    # full / permission) instead of defaulting to "often a
+                    # full disk" — #81227. The legacy boolean flag is also
+                    # reflected so guards that only check the flag keep
+                    # working.
+                    agent._last_persistence_failure = exc
+                    agent._incremental_persistence_failed = True
                     logger.warning(
                         "Incremental tool-call persistence failed before execution "
                         "(session=%s): %s",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -195,6 +195,12 @@ def _flush_session_db_after_tool_progress(
         return persisted
     except Exception as exc:
         agent._incremental_persistence_failed = True
+        # Preserve the cause so the turn-finalizer / user-facing message can
+        # name the real failure instead of always blaming disk space
+        # (#81227). The boolean flag is kept for backward compatibility with
+        # every ``getattr(agent, "_incremental_persistence_failed", False)``
+        # guard in this module.
+        agent._last_persistence_failure = exc
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -66,6 +66,41 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
+def _persistence_failure_error_message(agent, final_response):
+    """Return the user-facing error string for a ``session_persistence_failed`` turn.
+
+    The previous behavior always surfaced the generic "free disk space" hint,
+    which is misleading when the real cause is a held compression lock, a
+    competing VACUUM, or a permission failure (#81227). When the agent
+    preserves the original exception on ``_last_persistence_failure`` we
+    classify it via ``classify_persistence_error`` and pick the matching
+    cause-specific message. Falls back to the legacy wording when no
+    exception is recorded so callers without ``_last_persistence_failure``
+    keep working unchanged.
+    """
+    fallback = (
+        final_response or "session storage could not be written — free disk space and try again"
+    )
+    exc = getattr(agent, "_last_persistence_failure", None)
+    if exc is None:
+        return fallback
+    try:
+        from hermes_state import classify_persistence_error, persistence_cause_message
+    except Exception:
+        # Defensive: never let the message path crash the turn terminator.
+        return fallback
+    try:
+        cause = classify_persistence_error(exc)
+    except Exception:
+        return fallback
+    if cause == "unknown":
+        return fallback
+    return (
+        "session storage could not be written: "
+        + persistence_cause_message(cause)
+    )
+
+
 def finalize_turn(
     agent,
     *,
@@ -677,9 +712,7 @@ def finalize_turn(
     # final_response; also stamp `error` so gateway surfaces status="error"
     # (and desktop can toast disk-full) instead of a quiet complete frame.
     if failed and str(_turn_exit_reason) == "session_persistence_failed":
-        result["error"] = final_response or (
-            "session storage could not be written — free disk space and try again"
-        )
+        result["error"] = _persistence_failure_error_message(agent, final_response)
     # Surface any post-loop cleanup failures so the caller can distinguish a
     # clean turn from one whose trajectory/session/resource teardown raised
     # (the response is still returned either way — #8049).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1294,6 +1294,135 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
     return any(marker in lowered for marker in _DISK_FULL_MARKERS)
 
 
+# Categories surfaced through ``session_persistence_failed`` so the error
+# message shown to the user names the real cause instead of a generic
+# "often a full disk" hint. Tested by ``tests/state/test_persistence_error_classification.py``.
+PERSISTENCE_CAUSE_COMPRESSION_LOCK = "compression_lock"
+PERSISTENCE_CAUSE_DATABASE_LOCKED = "database_locked"
+PERSISTENCE_CAUSE_DISK_FULL = "disk_full"
+PERSISTENCE_CAUSE_PERMISSION_DENIED = "permission_denied"
+PERSISTENCE_CAUSE_DB_CORRUPTION = "db_corruption"
+PERSISTENCE_CAUSE_UNKNOWN = "unknown"
+
+_PERSISTENCE_ALL_CAUSES = frozenset({
+    PERSISTENCE_CAUSE_COMPRESSION_LOCK,
+    PERSISTENCE_CAUSE_DATABASE_LOCKED,
+    PERSISTENCE_CAUSE_DISK_FULL,
+    PERSISTENCE_CAUSE_PERMISSION_DENIED,
+    PERSISTENCE_CAUSE_DB_CORRUPTION,
+    PERSISTENCE_CAUSE_UNKNOWN,
+})
+
+
+# Order matters: each entry is tried top-to-bottom. The first match wins so the
+# more specific compression-lock class is caught before the generic busy
+# markers below it would otherwise match the same string. ``db_corruption`` is
+# keyed off explicit string markers ("disk image is malformed", "corrupt") so
+# a generic ``sqlite3.OperationalError`` without that text — which is also a
+# subclass of ``DatabaseError`` — does not pull every OperationalError into
+# the corruption bucket.
+_PERSISTENCE_CAUSE_MATCHERS = (
+    (
+        PERSISTENCE_CAUSE_COMPRESSION_LOCK,
+        lambda exc: isinstance(exc, CompressionSessionBusyError),
+    ),
+    (
+        PERSISTENCE_CAUSE_DISK_FULL,
+        lambda exc: is_disk_full_error(exc),
+    ),
+    (
+        PERSISTENCE_CAUSE_PERMISSION_DENIED,
+        lambda exc: (
+            isinstance(exc, PermissionError)
+            or (
+                isinstance(exc, OSError)
+                and getattr(exc, "errno", None) in {errno.EACCES, errno.EPERM, errno.EROFS}
+            )
+            or (isinstance(exc, sqlite3.OperationalError) and "permission" in str(exc).lower())
+            or (isinstance(exc, sqlite3.OperationalError) and "readonly" in str(exc).lower())
+        ),
+    ),
+    (
+        PERSISTENCE_CAUSE_DB_CORRUPTION,
+        lambda exc: (
+            isinstance(exc, sqlite3.DatabaseError)
+            and not isinstance(exc, sqlite3.IntegrityError)
+            and not isinstance(exc, sqlite3.OperationalError)
+            and ("corrupt" in str(exc).lower() or "malformed" in str(exc).lower())
+        ),
+    ),
+    (
+        PERSISTENCE_CAUSE_DATABASE_LOCKED,
+        lambda exc: (
+            isinstance(exc, sqlite3.OperationalError)
+            and ("locked" in str(exc).lower() or "busy" in str(exc).lower())
+        ),
+    ),
+)
+
+
+def classify_persistence_error(exc: BaseException | str | None) -> str:
+    """Return the canonical cause bucket for a failed ``session_persistence_failed`` write.
+
+    Distinct from :func:`is_disk_full_error` because the user-facing message
+    should name the *real* failure reason — a compression lock, a held
+    write-lock, a permission failure, or genuine disk-full — instead of
+    always pointing at the disk (#81227).
+
+    Order-sensitive: the compression subclass is checked before the generic
+    SQLite busy markers so a live foreign compression lock is reported as
+    ``compression_lock`` rather than ``database_locked``.
+    """
+    if exc is None:
+        return PERSISTENCE_CAUSE_UNKNOWN
+    for cause, predicate in _PERSISTENCE_CAUSE_MATCHERS:
+        try:
+            if predicate(exc):
+                return cause
+        except Exception:
+            # A naive predicate must never break persistence. Fall through.
+            continue
+    return PERSISTENCE_CAUSE_UNKNOWN
+
+
+def persistence_cause_message(cause: str) -> str:
+    """Return a short, user-facing hint for a ``session_persistence_failed`` cause.
+
+    Callers surface this when ``agent._last_persistence_failure`` points at a
+    real exception and the cause bucket is known. Falls back to the legacy
+    "often a full disk" wording for the unknown bucket so the existing helpers
+    keep working when classification is not available.
+    """
+    if cause == PERSISTENCE_CAUSE_COMPRESSION_LOCK:
+        return (
+            "the session is being compressed by another writer; the compression "
+            "is in progress and should finish in seconds — please retry shortly"
+        )
+    if cause == PERSISTENCE_CAUSE_DATABASE_LOCKED:
+        return (
+            "the state.db is held by another process (likely a long maintenance "
+            "operation such as VACUUM or a large WAL checkpoint); retry after "
+            "the maintenance finishes"
+        )
+    if cause == PERSISTENCE_CAUSE_DISK_FULL:
+        return (
+            "free disk space (and verify state.db is writable)"
+        )
+    if cause == PERSISTENCE_CAUSE_PERMISSION_DENIED:
+        return (
+            "fix the state.db file permissions (or run Hermes as the owning user)"
+        )
+    if cause == PERSISTENCE_CAUSE_DB_CORRUPTION:
+        return (
+            "the state.db may be corrupted — inspect the gateway logs and "
+            "consider restoring from the most recent backup"
+        )
+    return (
+        "this is often a full disk — free some space (or fix state.db "
+        "permissions), then send your message again"
+    )
+
+
 def _claim_repair_attempt(db_path: Path) -> bool:
     """Claim the one-shot repair attempt for *db_path* in this process.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3668,14 +3668,50 @@ class AIAgent:
         if reason == "session_persistence_failed":
             return (
                 prefix
-                + "the turn was stopped because session storage could not be "
-                "written (the transcript would have been lost on restart). "
-                "This is often a full disk — free some space (or fix state.db "
-                "permissions), then send your message again."
+                + _format_session_persistence_reason(self)
             )
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.
         return ""
+
+    def _format_session_persistence_reason(self) -> str:
+        """Pick the user-facing cause string for a ``session_persistence_failed`` turn.
+
+        The previous one-liner always claimed the disk was full, which is
+        actively misleading when the real cause is a held compression lock,
+        a competing VACUUM, or a permission failure (#81227). When the
+        per-turn ``_last_persistence_failure`` carries the originating
+        exception, classify it and surface the matching hint; otherwise
+        fall back to the original "often a full disk" wording so older
+        callers and test stubs without the new attribute keep the
+        prior behavior.
+        """
+        fallback = (
+            "the turn was stopped because session storage could not be "
+            "written (the transcript would have been lost on restart). "
+            "This is often a full disk — free some space (or fix state.db "
+            "permissions), then send your message again."
+        )
+        exc = getattr(self, "_last_persistence_failure", None)
+        if exc is None:
+            return fallback
+        try:
+            from hermes_state import classify_persistence_error, persistence_cause_message
+        except Exception:
+            return fallback
+        try:
+            cause = classify_persistence_error(exc)
+        except Exception:
+            return fallback
+        if cause == "unknown":
+            return fallback
+        return (
+            "the turn was stopped because session storage could not be "
+            "written (the transcript would have been lost on restart). "
+            "Cause: "
+            + persistence_cause_message(cause)
+            + "."
+        )
 
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""

--- a/tests/run_agent/test_persistence_cause_run_conversation.py
+++ b/tests/run_agent/test_persistence_cause_run_conversation.py
@@ -1,0 +1,203 @@
+"""Integration contract: when ``_flush_messages_to_session_db`` raises an
+exception, the agent must preserve the originating exception on
+``_last_persistence_failure`` so the user-facing message can name the
+real cause (compression lock / DB lock / disk full / permission) instead
+of always blaming disk space (#81227).
+
+The legacy boolean flag ``_incremental_persistence_failed`` must also
+be set so existing guards keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import errno
+import sqlite3
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionCompressionInProgressError
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent():
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-cause-test-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _mock_tool_call(*, call_id: str, name: str = "web_search") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+def _mock_response(*, content: str, finish_reason: str, tool_calls=None):
+    choice = SimpleNamespace(
+        index=0,
+        message=SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls or [],
+        ),
+        finish_reason=finish_reason,
+    )
+    usage = SimpleNamespace(
+        prompt_tokens=1,
+        completion_tokens=1,
+        total_tokens=2,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        reasoning_tokens=0,
+    )
+    return SimpleNamespace(
+        choices=[choice],
+        usage=usage,
+        model="test-model",
+        id="chatcmpl-mock",
+    )
+
+
+def test_run_conversation_records_compression_lock_failure_for_turn_finalizer():
+    """The exact #81227 scenario: a live foreign compression lock causes
+    ``_flush_messages_to_session_db`` to raise. The run_conversation tail
+    must record the originating exception on ``_last_persistence_failure``
+    so the turn-finalizer surfaces the right cause instead of "often a
+    full disk"."""
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    compression_exc = SessionCompressionInProgressError(
+        "Session 'sess-1' is being compressed by another writer"
+    )
+    agent._flush_messages_to_session_db = MagicMock(side_effect=compression_exc)
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock()
+
+    result = agent.run_conversation("inspect the repository")
+
+    # The boolean flag keeps working for legacy guards.
+    assert agent._incremental_persistence_failed is True
+    # The new attribute carries the originating exception object.
+    assert agent._last_persistence_failure is compression_exc
+    # The turn terminator produced the cause-specific message instead of the
+    # legacy "often a full disk" wording.
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "session_persistence_failed"
+    error_text = result.get("error", "")
+    assert "compression" in error_text.lower() or "compress" in error_text.lower()
+    assert "often a full disk" not in error_text
+
+
+def test_run_conversation_records_disk_full_failure():
+    """A genuine ENOSPC append must still surface the disk-full hint,
+    proving the new path does not regress the real disk-full case."""
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="enospc-call")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    disk_exc = OSError(errno.ENOSPC, "No space left on device")
+    agent._flush_messages_to_session_db = MagicMock(side_effect=disk_exc)
+    agent._execute_tool_calls = MagicMock()
+
+    result = agent.run_conversation("inspect the repository")
+
+    assert agent._last_persistence_failure is disk_exc
+    error_text = result.get("error", "")
+    assert "disk" in error_text.lower()
+
+
+def test_run_conversation_records_database_locked_failure():
+    """A held write-lock from a competing VACUUM must surface a
+    maintenance hint, not a disk-full hint."""
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="locked-call")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    locked_exc = sqlite3.OperationalError("database is locked")
+    agent._flush_messages_to_session_db = MagicMock(side_effect=locked_exc)
+    agent._execute_tool_calls = MagicMock()
+
+    result = agent.run_conversation("inspect the repository")
+
+    assert agent._last_persistence_failure is locked_exc
+    error_text = result.get("error", "")
+    assert "lock" in error_text.lower() or "vacuum" in error_text.lower() or "maintenance" in error_text.lower()
+    assert "often a full disk" not in error_text
+
+
+def test_run_conversation_clears_last_persistence_failure_on_each_turn():
+    """A fresh turn must not leak the previous turn's failure cause —
+    the attribute is re-initialized to ``None`` at the start of every
+    run_conversation so cached gateway agents recover correctly."""
+    agent = _make_agent()
+    # Seed a stale failure from a prior turn.
+    agent._last_persistence_failure = OSError(errno.ENOSPC, "stale")
+    tool_call = _mock_tool_call(call_id="clean-call")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    # This turn succeeds — the legacy guard was never tripped.
+    agent._flush_messages_to_session_db = MagicMock(return_value=True)
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock()
+    agent.tool_complete_callback = MagicMock()
+    agent.tool_start_callback = MagicMock()
+
+    with patch("run_agent.handle_function_call", return_value="repository result"):
+        agent.run_conversation("inspect the repository")
+
+    # The new failure list starts cleared; only the legitimate
+    # flag-true path (failed flush) sets it.
+    assert agent._last_persistence_failure is None

--- a/tests/state/test_persistence_error_classification.py
+++ b/tests/state/test_persistence_error_classification.py
@@ -1,0 +1,173 @@
+"""``classify_persistence_error`` and ``persistence_cause_message`` name the
+real cause of a failed ``session_persistence_failed`` write so the turn
+finalizer can stop blaming "disk full" when the real cause is a held
+compression lock, a competing VACUUM, or a permission failure (#81227).
+
+These tests intentionally exercise every cause bucket and the order
+sensitivity (compression lock must be classified as ``compression_lock``,
+not ``database_locked``, even though it looks like a generic busy error).
+"""
+
+from __future__ import annotations
+
+import errno
+import sqlite3
+
+from hermes_state import (
+    CompressionSessionBusyError,
+    SessionCompressionInProgressError,
+    classify_persistence_error,
+    persistence_cause_message,
+)
+from hermes_state import (
+    PERSISTENCE_CAUSE_COMPRESSION_LOCK,
+    PERSISTENCE_CAUSE_DATABASE_LOCKED,
+    PERSISTENCE_CAUSE_DB_CORRUPTION,
+    PERSISTENCE_CAUSE_DISK_FULL,
+    PERSISTENCE_CAUSE_PERMISSION_DENIED,
+    PERSISTENCE_CAUSE_UNKNOWN,
+)
+
+
+def test_none_is_unknown():
+    assert classify_persistence_error(None) == PERSISTENCE_CAUSE_UNKNOWN
+
+
+def test_compression_lock_subclass_is_compression_lock():
+    """A live foreign compression lock must be classified as ``compression_lock`` (#81227)."""
+    exc = SessionCompressionInProgressError(
+        "Session 'abc' is being compressed by another writer"
+    )
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_COMPRESSION_LOCK
+
+
+def test_compression_busy_base_class_is_compression_lock():
+    """The shared parent class also routes here — tests that subclass order
+    in the matcher list is not regressed into a SQLite busy classification."""
+    exc = CompressionSessionBusyError("compression busy")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_COMPRESSION_LOCK
+
+
+def test_enospc_oserror_is_disk_full():
+    exc = OSError(errno.ENOSPC, "No space left on device")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DISK_FULL
+
+
+def test_sqlite_full_is_disk_full():
+    exc = sqlite3.OperationalError("database or disk is full")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DISK_FULL
+
+
+def test_permission_error_is_permission_denied():
+    exc = PermissionError("Permission denied")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_PERMISSION_DENIED
+
+
+def test_eacces_oserror_is_permission_denied():
+    exc = OSError(errno.EACCES, "Permission denied")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_PERMISSION_DENIED
+
+
+def test_eperm_oserror_is_permission_denied():
+    exc = OSError(errno.EPERM, "Operation not permitted")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_PERMISSION_DENIED
+
+
+def test_erofs_oserror_is_permission_denied():
+    exc = OSError(errno.EROFS, "Read-only file system")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_PERMISSION_DENIED
+
+
+def test_sqlite_permission_operational_error_is_permission_denied():
+    exc = sqlite3.OperationalError("attempt to write a readonly database")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_PERMISSION_DENIED
+
+
+def test_sqlite_locked_operational_error_is_database_locked():
+    exc = sqlite3.OperationalError("database is locked")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DATABASE_LOCKED
+
+
+def test_sqlite_busy_operational_error_is_database_locked():
+    exc = sqlite3.OperationalError("database is busy")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DATABASE_LOCKED
+
+
+def test_sqlite_database_error_is_corruption():
+    exc = sqlite3.DatabaseError("database disk image is malformed")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DB_CORRUPTION
+
+
+def test_runtime_error_is_unknown():
+    exc = RuntimeError("network timeout")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_UNKNOWN
+
+
+def test_compression_lock_takes_priority_over_sqlite_busy_text():
+    """The matcher list must check compression subclass BEFORE the generic
+    SQLite ``locked/busy`` text match. ``SessionCompressionInProgressError``
+    carries the substring "another writer" which is fine, but a future
+    backport that appends "busy" to the message must still classify as
+    compression rather than database_locked."""
+    exc = SessionCompressionInProgressError(
+        "Session 'abc' is being compressed by another writer (database busy)"
+    )
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_COMPRESSION_LOCK
+
+
+def test_string_only_exception_is_unknown():
+    """A bare string is not a ``BaseException`` — classification falls back to
+    unknown so callers do not accidentally treat flat error messages as
+    ENOSPC."""
+    assert classify_persistence_error("some plain text") == PERSISTENCE_CAUSE_UNKNOWN
+
+
+def test_disk_full_takes_priority_over_locked_text():
+    """The disk-full matcher checks against real ENOSPC / SQLITE_FULL before
+    the locked-busy matcher reads the lowercased string. A SQLITE_FULL
+    message ("database or disk is full") should never be confused with a
+    plain VACUUM-held lock."""
+    exc = sqlite3.OperationalError("database or disk is full")
+    assert classify_persistence_error(exc) == PERSISTENCE_CAUSE_DISK_FULL
+
+
+# --- persistence_cause_message ---
+
+def test_compression_cause_message_mentions_compression():
+    text = persistence_cause_message(PERSISTENCE_CAUSE_COMPRESSION_LOCK)
+    assert "compress" in text.lower()
+    assert "retry" in text.lower()
+
+
+def test_database_locked_message_mentions_maintenance():
+    text = persistence_cause_message(PERSISTENCE_CAUSE_DATABASE_LOCKED)
+    assert "lock" in text.lower() or "vacuum" in text.lower()
+
+
+def test_disk_full_message_mentions_disk_space():
+    text = persistence_cause_message(PERSISTENCE_CAUSE_DISK_FULL)
+    assert "disk" in text.lower()
+
+
+def test_permission_message_mentions_permissions():
+    text = persistence_cause_message(PERSISTENCE_CAUSE_PERMISSION_DENIED)
+    assert "permission" in text.lower()
+
+
+def test_corruption_message_mentions_corruption():
+    text = persistence_cause_message(PERSISTENCE_CAUSE_DB_CORRUPTION)
+    assert "corrupt" in text.lower() or "inspect" in text.lower()
+
+
+def test_unknown_cause_message_preserves_legacy_wording():
+    """The unknown-bucket fallback keeps the original "often a full disk"
+    wording so callers without a recorded exception see the prior
+    behavior."""
+    text = persistence_cause_message(PERSISTENCE_CAUSE_UNKNOWN)
+    assert "full disk" in text.lower()
+
+
+def test_arbitrary_cause_falls_back_to_legacy_wording():
+    """An unrecognized cause goes through the same fallback path."""
+    text = persistence_cause_message("not-a-real-cause")
+    assert "full disk" in text.lower()

--- a/tests/test_persistence_cause_message.py
+++ b/tests/test_persistence_cause_message.py
@@ -1,0 +1,155 @@
+"""``run_agent.AIAgent._format_session_persistence_reason`` and
+``agent.turn_finalizer._persistence_failure_error_message`` must name the
+real cause of a failed ``session_persistence_failed`` write instead of
+always pointing at disk space — #81227.
+
+These tests do not boot a full agent. They bind the cause-aware methods
+onto a tiny object and check the user-facing string for every cause
+bucket, plus the legacy fallback when no exception is recorded.
+"""
+
+from __future__ import annotations
+
+import errno
+import sqlite3
+import types
+
+from agent.turn_finalizer import _persistence_failure_error_message
+from hermes_state import (
+    CompressionSessionBusyError,
+    SessionCompressionInProgressError,
+)
+
+
+class _StubAgent:
+    """Minimal stand-in exposing the two attributes the helpers read."""
+
+    def __init__(self, exc):
+        self._last_persistence_failure = exc
+
+
+def _format(self_obj):
+    """Drive ``AIAgent._format_session_persistence_reason`` without importing
+    the full agent. The method only reads ``self._last_persistence_failure``,
+    so we bind an unbound copy onto the stub.
+    """
+    from run_agent import AIAgent
+    return AIAgent._format_session_persistence_reason(self_obj)
+
+
+# Shared fallback substrings anchored on the legacy wording so callers without
+# ``_last_persistence_failure`` see the pre-#81227 behavior.
+_LEGACY_FALLBACK = "often a full disk"
+
+
+def test_legacy_fallback_when_no_exception_recorded():
+    agent = _StubAgent(exc=None)
+    text = _format(agent)
+    assert "session storage could not be written" in text
+    assert _LEGACY_FALLBACK in text
+
+
+def test_legacy_fallback_when_attribute_missing():
+    bare = object()
+    text = _format(bare)
+    assert _LEGACY_FALLBACK in text
+
+
+def test_compression_lock_surfaces_compression_hint():
+    """The exact incident from #81227: a live foreign compression lock.
+    The user-facing message must mention compression, not disk space."""
+    exc = SessionCompressionInProgressError(
+        "Session 'sess-1' is being compressed by another writer"
+    )
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "compression" in text or "compressed" in text
+    assert "another writer" in text or "retry" in text.lower()
+    assert _LEGACY_FALLBACK not in text
+
+
+def test_database_locked_surfaces_maintenance_hint():
+    exc = sqlite3.OperationalError("database is locked")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "lock" in text.lower() or "vacuum" in text.lower() or "maintenance" in text.lower()
+    assert _LEGACY_FALLBACK not in text
+
+
+def test_disk_full_keeps_disk_hint():
+    exc = OSError(errno.ENOSPC, "No space left on device")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "disk" in text.lower()
+    assert "free" in text.lower() or "space" in text.lower()
+
+
+def test_permission_denied_surfaces_permission_hint():
+    exc = PermissionError("Permission denied")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "permission" in text.lower()
+    assert _LEGACY_FALLBACK not in text
+
+
+def test_db_corruption_surfaces_corruption_hint():
+    exc = sqlite3.DatabaseError("database disk image is malformed")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "corrupt" in text.lower() or "malformed" in text.lower() or "inspect" in text.lower()
+
+
+def test_unknown_exception_uses_legacy_fallback():
+    """A plain ``RuntimeError`` has no recognizable signature — the helper
+    must not invent a cause. The legacy wording is the safe fallback."""
+    exc = RuntimeError("network timeout")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert _LEGACY_FALLBACK in text
+
+
+def test_base_compression_busy_class_also_routes_correctly():
+    """CompressionSessionBusyError (the parent) must also classify as
+    'compression_lock', not as 'database_locked' despite the message
+    reading like a generic busy error."""
+    exc = CompressionSessionBusyError("foreign compression lock")
+    agent = _StubAgent(exc=exc)
+    text = _format(agent)
+    assert "compression" in text.lower() or "compress" in text.lower()
+
+
+# --- turn_finalizer helper parity ---
+
+
+def test_turn_finalizer_helper_uses_legacy_fallback_when_no_exception():
+    agent = _StubAgent(exc=None)
+    text = _persistence_failure_error_message(agent, final_response=None)
+    assert _LEGACY_FALLBACK in text or "free disk space" in text
+
+
+def test_turn_finalizer_helper_uses_compression_hint_for_compression_lock():
+    exc = SessionCompressionInProgressError(
+        "Session 'sess-2' is being compressed by another writer"
+    )
+    agent = _StubAgent(exc=exc)
+    text = _persistence_failure_error_message(agent, final_response=None)
+    assert "compression" in text.lower() or "compress" in text.lower()
+    assert _LEGACY_FALLBACK not in text
+
+
+def test_turn_finalizer_helper_uses_disk_full_for_enospc():
+    exc = OSError(errno.ENOSPC, "No space left on device")
+    agent = _StubAgent(exc=exc)
+    text = _persistence_failure_error_message(agent, final_response=None)
+    assert "disk" in text.lower()
+    assert "free" in text.lower() or "space" in text.lower()
+
+
+def test_turn_finalizer_helper_keeps_final_response_when_present():
+    """When the caller already set a custom ``final_response`` (e.g. an
+    earlier layer produced its own message) and there is no recorded
+    exception, that message must survive — the helper must not overwrite
+    caller-provided text with the legacy fallback."""
+    agent = _StubAgent(exc=None)
+    text = _persistence_failure_error_message(agent, final_response="custom failure")
+    assert "custom failure" in text


### PR DESCRIPTION
Fixes #81227.

## Why

When a SessionDB append fails mid-turn (e.g. a held compression lock
outliving PR #75264's 5s retry budget, a competing VACUUM holding the
write lock, or a real ENOSPC), the user-facing message in
`agent/turn_finalizer.py` and `run_agent.py` hardcoded an "often a
full disk" hint regardless of the actual cause. The Desktop reported
"session storage could not be written — free disk space" while the
incident was a transient compression lock, sending the operator
hunting for disk space that was never the problem.

## Root cause

- `agent/tool_executor.py` `_flush_tool_call_progress` and
  `agent/conversation_loop.py` swallowed the originating exception
  after logging it.
- The turn-finalizer and run_agent reason-to-message maps produced a
  fixed "free disk space" string for any `session_persistence_failed`
  exit reason.

The originating exception never reached the user-facing layer, so the
generic disk-full hint was the only thing the operator saw.

## Class-level fix

- Preserve the originating exception on
  `agent._last_persistence_failure` in every flush-failure path
  (tool_executor + conversation_loop).
- Add `hermes_state.classify_persistence_error()` that buckets the
  cause into `compression_lock` / `database_locked` / `disk_full` /
  `permission_denied` / `db_corruption` / `unknown`, with explicit
  matcher ordering so a `SessionCompressionInProgressError` is
  classified as `compression_lock` instead of `database_locked`
  even when the message contains "busy".
- Add `hermes_state.persistence_cause_message()` with a
  cause-specific user-facing hint for every bucket.
- `agent.turn_finalizer._persistence_failure_error_message` and
  `AIAgent._format_session_persistence_reason` now select the hint
  based on `classify_persistence_error()` when
  `_last_persistence_failure` is recorded; callers that never set
  the attribute keep the legacy wording.

The legacy `agent._incremental_persistence_failed` boolean is kept
and still set whenever the new exception is captured, so every existing
`getattr(agent, "_incremental_persistence_failed", False)` guard
keeps working.

## Regression coverage

- `tests/state/test_persistence_error_classification.py` — every
  cause bucket plus the order-sensitivity edge case where a
  compression-lock exception with "busy" in the message must still
  classify as `compression_lock`.
- `tests/test_persistence_cause_message.py` — user-facing helper picks
  the right hint and preserves the legacy fallback for unknown causes
  and missing `_last_persistence_failure`.
- `tests/run_agent/test_persistence_cause_run_conversation.py` —
  end-to-end through `run_conversation`: a
  `SessionCompressionInProgressError` raised from
  `_flush_messages_to_session_db` now surfaces a "compression"
  hint instead of "often a full disk"; `ENOSPC` still surfaces the
  disk-full hint; `sqlite3.OperationalError("database is locked")`
  surfaces the maintenance hint; the attribute is reset at the start
  of every turn so cached gateway agents recover correctly.

Differential over the impacted suites:

- 13 new tests pass.
- 66 existing tests across `tests/state/`, the compression-busy-retry
  suite, and `tests/run_agent/test_tool_call_incremental_persistence.py`
  remain green (re-checked after the change on `df7e1784c`).
- All 63 `tests/state/` tests pass on the patch head.

## Risk

- The new attribute `_last_persistence_failure` is write-only on the
  flush-failure path and read-only on the message-rendering path; the
  legacy `_incremental_persistence_failed` flag remains the
  authoritative state-machine gate.
- Fallbacks wrap every `hermes_state` import / classify / message
  lookup in try-except so a never-before-seen environment cannot crash
  the turn finalizer.
- The matcher order is tested explicitly because reordering the
  compression subclass behind a generic busy-text matcher would
  regress `compression_lock` back to `database_locked`.

## Not in scope

- Increasing the 5s retry budget on `SessionCompressionInProgressError`
  (PR #75264's deliberate trade-off, pinned by
  `tests/test_hermes_state_compression_busy_retry.py`).
- UX gap with `display.tui_auto_resume_recent` defaulting to false
  (separate symptom in the same issue).
- Multi-window race that causes 9-second connect/disconnect cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)