### PR TITLE
fix(voice): prevent ALSA underruns for beeps/thinking sound on WSL

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -708,6 +708,45 @@ class TestPlayBeep:
         assert audio_arg.dtype == np.int16
         assert len(audio_arg) > 0
 
+    def test_beep_wsl_warmup_and_blocksize(self, mock_sd, monkeypatch):
+        """On WSL the beep must carry 0.1 s of warmup silence and a 4096
+        blocksize (WSLg RDP underrun fix, microsoft/wslg#1257)."""
+        np = pytest.importorskip("numpy")
+        monkeypatch.setattr("tools.voice_mode._is_wsl", lambda: True)
+
+        mock_stream = MagicMock()
+        mock_stream.active = False
+        mock_sd.get_stream.return_value = mock_stream
+
+        from tools.voice_mode import play_beep, SAMPLE_RATE
+
+        play_beep(frequency=880, duration=0.1, count=1)
+
+        mock_sd.play.assert_called_once()
+        kwargs = mock_sd.play.call_args.kwargs
+        assert kwargs.get("blocksize") == 4096
+        audio_arg = mock_sd.play.call_args[0][0]
+        # 0.1 s silence + the 0.1 s beep.
+        assert len(audio_arg) >= int(SAMPLE_RATE * 0.2)
+        assert int(np.abs(audio_arg[:100]).max()) == 0
+
+    def test_beep_non_wsl_default_blocksize(self, mock_sd, monkeypatch):
+        np = pytest.importorskip("numpy")
+        monkeypatch.setattr("tools.voice_mode._is_wsl", lambda: False)
+
+        mock_stream = MagicMock()
+        mock_stream.active = False
+        mock_sd.get_stream.return_value = mock_stream
+
+        from tools.voice_mode import play_beep, SAMPLE_RATE
+
+        play_beep(frequency=880, duration=0.1, count=1)
+
+        kwargs = mock_sd.play.call_args.kwargs
+        assert kwargs.get("blocksize") == 0
+        audio_arg = mock_sd.play.call_args[0][0]
+        assert len(audio_arg) == int(SAMPLE_RATE * 0.1)
+
 # ============================================================================
 # Silence detection
 # ============================================================================

--- a/tests/tools/test_voice_thinking_sound.py
+++ b/tests/tools/test_voice_thinking_sound.py
@@ -29,8 +29,8 @@ class _FakeSD:
     def __init__(self):
         self.played = []
 
-    def play(self, audio, samplerate=None):
-        self.played.append((audio, samplerate))
+    def play(self, audio, samplerate=None, **kwargs):
+        self.played.append((audio, samplerate, kwargs))
 
     def stop(self):
         pass
@@ -137,3 +137,43 @@ class TestAudioOutputRefcount:
             vm.play_audio_file(str(tmp_path / "x.wav"))
         assert seen == [True]
         assert vm.is_audio_output_active() is False
+
+
+class TestWslUnderrunMitigation:
+    """WSLg's RDP bridge underruns short blips on the default small buffer
+    (ALSA snd_pcm_recover spam, microsoft/wslg#1257). On WSL the loop must
+    prepend 0.1 s of warmup silence and play with blocksize=4096 — same
+    treatment play_audio_file already applies to its WSL path."""
+
+    def _one_blip_kwargs(self, wsl: bool):
+        _reset()
+        fake = _FakeSD()
+        stop = threading.Event()
+        with patch.object(vm, "_sounddevice_output_allowed", return_value=True), \
+             patch.object(vm, "_import_audio", return_value=(fake, np)), \
+             patch.object(vm, "_get_beep_volume", return_value=0.3), \
+             patch.object(vm, "_is_wsl", return_value=wsl):
+            t = threading.Thread(
+                target=vm._thinking_sound_loop, args=(stop, None), daemon=True
+            )
+            t.start()
+            deadline = time.monotonic() + 3.0
+            while not fake.played and time.monotonic() < deadline:
+                time.sleep(0.01)
+            stop.set()
+            t.join(timeout=3.0)
+        assert fake.played, "loop never played a blip"
+        audio, _, kwargs = fake.played[0]
+        return audio, kwargs
+
+    def test_wsl_blips_warmed_up_and_large_blocksize(self):
+        audio, kwargs = self._one_blip_kwargs(wsl=True)
+        assert kwargs.get("blocksize") == 4096
+        # 0.1 s warmup silence + the 0.16 s blip.
+        assert len(audio) >= int(vm.SAMPLE_RATE * 0.26)
+        assert int(np.abs(audio[:100]).max()) == 0  # leading silence
+
+    def test_off_wsl_default_blocksize(self):
+        audio, kwargs = self._one_blip_kwargs(wsl=False)
+        assert kwargs.get("blocksize") == 0
+        assert len(audio) == int(vm.SAMPLE_RATE * 0.16)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -514,10 +514,18 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
             return
 
         try:
-            sd, _ = _import_audio()
+            sd, np = _import_audio()
         except (ImportError, OSError):
             return
-        sd.play(audio, samplerate=SAMPLE_RATE)
+        blocksize = 0  # default (auto)
+        if _is_wsl():
+            # WSLg RDP audio: short beeps on the default small buffer
+            # underrun over the bridge (ALSA snd_pcm_recover spam,
+            # microsoft/wslg#1257) — same treatment as play_audio_file's
+            # WSL path: warmup silence + larger blocksize.
+            audio = np.concatenate([np.zeros(int(0.1 * SAMPLE_RATE), dtype=np.int16), audio])
+            blocksize = 4096
+        sd.play(audio, samplerate=SAMPLE_RATE, blocksize=blocksize)
         # sd.wait() calls Event.wait() without timeout — hangs forever if the
         # audio device stalls.  Poll with a 2s ceiling and force-stop.
         deadline = time.monotonic() + 2.0
@@ -629,12 +637,20 @@ def _thinking_sound_loop(stop: threading.Event, should_play) -> None:
 
     pitches = (392.0, 329.6)  # G4 / E4 — calm, low, alternating
     blips = [_synth_thinking_blip(np, p) for p in pitches]
+    blocksize = 0  # default (auto)
+    if _is_wsl():
+        # WSLg RDP audio: repeated short blips on the default small buffer
+        # underrun over the bridge (ALSA snd_pcm_recover spam,
+        # microsoft/wslg#1257) — prepend warmup silence and enlarge the
+        # blocksize, same treatment as play_audio_file's WSL path.
+        blips = [np.concatenate([np.zeros(int(0.1 * SAMPLE_RATE), dtype=np.int16), b]) for b in blips]
+        blocksize = 4096
     i = 0
     while not stop.is_set():
         try:
             if should_play is None or should_play():
                 blip = blips[i % len(blips)]
-                sd.play(blip, samplerate=SAMPLE_RATE)
+                sd.play(blip, samplerate=SAMPLE_RATE, blocksize=blocksize)
                 stop.wait(len(blip) / SAMPLE_RATE + 0.02)
                 sd.stop()
                 i += 1


### PR DESCRIPTION
On WSL the voice-mode cues (`play_beep()` and the ambient thinking-sound loop) play very short blips through sounddevice with the default small PortAudio buffer. Over WSLg's RDP audio bridge the transport latency starves that buffer, spamming `ALSA lib pcm.c:(snd_pcm_recover) underrun occurred` and clipping the cues.

`play_audio_file()` already applies a mitigation for exactly this on WSL (0.1 s warmup silence + `blocksize=4096`, referencing microsoft/wslg#1257) — the two short-blip paths were missed.

**Fix** (behind `_is_wsl()`, other hosts unchanged):
- `play_beep()`: prepend 0.1 s of silence and play with `blocksize=4096`.
- `_thinking_sound_loop()`: same warmup + blocksize for each blip.

**Tests:**
- Regression tests for both paths asserting WSL on → blocksize 4096 + leading silence, WSL off → default blocksize and untouched blip length.
- `_FakeSD.play` signature widened with `**kwargs` so the fake tolerates the new kwarg (previously it would have crashed on real WSL hosts).