### PR TITLE
fix(anthropic): honor CLAUDE_CONFIG_DIR when locating Claude Code credentials

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -997,18 +997,44 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     return None
 
 
+def _claude_code_credentials_path() -> Path:
+    """Resolve the Claude Code OAuth credentials file path.
+
+    Honors ``CLAUDE_CONFIG_DIR`` per Anthropic's docs: "If you've set the
+    CLAUDE_CONFIG_DIR environment variable on Linux or Windows, the
+    .credentials.json file lives under that directory instead."
+    (https://code.claude.com/docs/en/authentication). Unset or
+    empty/whitespace-only falls back to the default
+    ``~/.claude/.credentials.json`` — identical to prior behavior, so this
+    is strictly additive. Deliberately NOT gated by platform: Claude Code
+    itself honors the var on Linux/Windows, and adding a Darwin check here
+    would only add a branch with no behavioral benefit — macOS users who
+    don't set it get the same default path either way.
+
+    Resolved fresh on every call (never cached at import time) so tests
+    and users that set/change the env var after import take effect.
+    """
+    config_dir = os.getenv("CLAUDE_CONFIG_DIR", "").strip()
+    if config_dir:
+        expanded = os.path.expandvars(os.path.expanduser(config_dir))
+        return Path(expanded) / ".credentials.json"
+    return Path.home() / ".claude" / ".credentials.json"
+
+
 def _read_claude_code_credentials_from_file() -> Optional[Dict[str, Any]]:
     """Read Claude Code OAuth credentials from ~/.claude/.credentials.json.
 
+    Honors ``CLAUDE_CONFIG_DIR`` — see ``_claude_code_credentials_path``.
+
     Returns dict with {accessToken, refreshToken?, expiresAt?, source} or None.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = _claude_code_credentials_path()
     if not cred_path.exists():
         return None
     try:
         data = json.loads(cred_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError, IOError) as e:
-        logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+        logger.debug("Failed to read Claude Code credentials file %s: %s", cred_path, e)
         return None
 
     oauth_data = data.get("claudeAiOauth")
@@ -1206,12 +1232,17 @@ def _write_claude_code_credentials(
 ) -> None:
     """Write refreshed credentials back to ~/.claude/.credentials.json.
 
+    Honors ``CLAUDE_CONFIG_DIR`` — see ``_claude_code_credentials_path``. Without
+    this, a refresh on a host with ``CLAUDE_CONFIG_DIR`` set would create a
+    stale duplicate credentials file at the default path that Claude Code
+    itself never reads.
+
     The optional *scopes* list (e.g. ``["user:inference", "user:profile", ...]``)
     is persisted so that Claude Code's own auth check recognises the credential
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = _claude_code_credentials_path()
     try:
         # Read existing file to preserve other fields
         existing = {}

--- a/tests/agent/test_anthropic_claude_config_dir.py
+++ b/tests/agent/test_anthropic_claude_config_dir.py
@@ -1,0 +1,197 @@
+"""Tests for CLAUDE_CONFIG_DIR support in agent/anthropic_adapter.py.
+
+Anthropic's docs (https://code.claude.com/docs/en/authentication) state that
+on Linux/Windows, setting CLAUDE_CONFIG_DIR relocates
+``.credentials.json`` under that directory instead of ``~/.claude``. These
+tests cover the module-level ``_claude_code_credentials_path()`` resolver and
+its use at both call sites: ``_read_claude_code_credentials_from_file`` and
+``_write_claude_code_credentials``.
+"""
+
+import json
+import time
+
+import pytest
+
+from agent.anthropic_adapter import (
+    _claude_code_credentials_path,
+    _read_claude_code_credentials_from_file,
+    _write_claude_code_credentials,
+)
+
+
+def _write_credentials_file(path, access_token="tok", refresh_token="ref", expires_at=None):
+    """Write a minimal valid Claude Code OAuth credentials JSON file at `path`."""
+    if expires_at is None:
+        expires_at = int(time.time() * 1000) + 3600_000
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "claudeAiOauth": {
+                "accessToken": access_token,
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at,
+            }
+        }),
+        encoding="utf-8",
+    )
+
+
+class TestClaudeCodeCredentialsPathResolution:
+    """Direct coverage of the ``_claude_code_credentials_path()`` helper."""
+
+    def test_honors_claude_config_dir(self, tmp_path, monkeypatch):
+        custom_dir = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+        # Decoy home: if the helper ignored CLAUDE_CONFIG_DIR and fell back
+        # to Path.home(), the assertion below would fail against this path.
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+
+        assert _claude_code_credentials_path() == custom_dir / ".credentials.json"
+
+    def test_falls_back_to_default_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert _claude_code_credentials_path() == tmp_path / ".claude" / ".credentials.json"
+
+    @pytest.mark.parametrize("blank_value", ["", "   ", "\t\n"])
+    def test_falls_back_when_value_is_blank(self, tmp_path, monkeypatch, blank_value):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", blank_value)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert _claude_code_credentials_path() == tmp_path / ".claude" / ".credentials.json"
+
+    def test_expands_tilde_in_value(self, tmp_path, monkeypatch):
+        # os.path.expanduser reads $HOME directly, independent of Path.home().
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/custom-claude-config")
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+
+        assert _claude_code_credentials_path() == tmp_path / "custom-claude-config" / ".credentials.json"
+
+    def test_expands_dollar_var_in_value(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_TEST_CLAUDE_BASE", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "$HERMES_TEST_CLAUDE_BASE/custom-claude-config")
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+
+        assert _claude_code_credentials_path() == tmp_path / "custom-claude-config" / ".credentials.json"
+
+    def test_resolved_at_call_time_not_cached(self, tmp_path, monkeypatch):
+        """The env var must be re-read on every call — no import-time caching."""
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        assert _claude_code_credentials_path() == tmp_path / ".claude" / ".credentials.json"
+
+        later_dir = tmp_path / "set-after-first-call"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(later_dir))
+        assert _claude_code_credentials_path() == later_dir / ".credentials.json"
+
+
+class TestReadClaudeCodeCredentialsFromFileHonorsConfigDir:
+    """``_read_claude_code_credentials_from_file`` must use the resolved path."""
+
+    def test_reads_from_claude_config_dir(self, tmp_path, monkeypatch):
+        custom_dir = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+        # Decoy default-location home with no credentials file: if the read
+        # path fell back to it instead of honoring CLAUDE_CONFIG_DIR, this
+        # would incorrectly return None.
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+        _write_credentials_file(custom_dir / ".credentials.json", access_token="from-config-dir")
+
+        creds = _read_claude_code_credentials_from_file()
+
+        assert creds is not None
+        assert creds["accessToken"] == "from-config-dir"
+        assert creds["source"] == "claude_code_credentials_file"
+
+    def test_falls_back_to_default_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        _write_credentials_file(tmp_path / ".claude" / ".credentials.json", access_token="from-default")
+
+        creds = _read_claude_code_credentials_from_file()
+
+        assert creds is not None
+        assert creds["accessToken"] == "from-default"
+
+    def test_blank_value_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "   ")
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        _write_credentials_file(tmp_path / ".claude" / ".credentials.json", access_token="from-default-blank")
+
+        creds = _read_claude_code_credentials_from_file()
+
+        assert creds is not None
+        assert creds["accessToken"] == "from-default-blank"
+
+    def test_tilde_in_value_is_expanded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/custom-claude-config")
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+        _write_credentials_file(
+            tmp_path / "custom-claude-config" / ".credentials.json",
+            access_token="from-tilde-path",
+        )
+
+        creds = _read_claude_code_credentials_from_file()
+
+        assert creds is not None
+        assert creds["accessToken"] == "from-tilde-path"
+
+    def test_returns_none_when_no_file_at_resolved_location(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "empty-config-dir"))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+
+        assert _read_claude_code_credentials_from_file() is None
+
+
+class TestWriteClaudeCodeCredentialsHonorsConfigDir:
+    """``_write_claude_code_credentials`` must write to the resolved path."""
+
+    def test_write_lands_in_claude_config_dir(self, tmp_path, monkeypatch):
+        custom_dir = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+
+        _write_claude_code_credentials("new-tok", "new-ref", 99999)
+
+        default_cred_file = tmp_path / "decoy-home" / ".claude" / ".credentials.json"
+        assert not default_cred_file.exists(), "must not also write a stale duplicate at the default path"
+
+        cred_file = custom_dir / ".credentials.json"
+        assert cred_file.exists()
+        data = json.loads(cred_file.read_text(encoding="utf-8"))
+        assert data["claudeAiOauth"]["accessToken"] == "new-tok"
+        assert data["claudeAiOauth"]["refreshToken"] == "new-ref"
+        assert data["claudeAiOauth"]["expiresAt"] == 99999
+
+    def test_round_trip_write_then_read_back(self, tmp_path, monkeypatch):
+        """Write via CLAUDE_CONFIG_DIR, then confirm the read path finds it."""
+        custom_dir = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+        expires_at = int(time.time() * 1000) + 3600_000
+
+        _write_claude_code_credentials("round-trip-tok", "round-trip-ref", expires_at)
+        creds = _read_claude_code_credentials_from_file()
+
+        assert creds is not None
+        assert creds["accessToken"] == "round-trip-tok"
+        assert creds["refreshToken"] == "round-trip-ref"
+        assert creds["expiresAt"] == expires_at
+
+    def test_preserves_existing_fields_in_claude_config_dir(self, tmp_path, monkeypatch):
+        custom_dir = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path / "decoy-home")
+        cred_file = custom_dir / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({"otherField": "keep-me"}), encoding="utf-8")
+
+        _write_claude_code_credentials("new-tok", "new-ref", 99999)
+
+        data = json.loads(cred_file.read_text(encoding="utf-8"))
+        assert data["otherField"] == "keep-me"
+        assert data["claudeAiOauth"]["accessToken"] == "new-tok"


### PR DESCRIPTION
## Symptom

A Linux/Windows user who sets `CLAUDE_CONFIG_DIR` to relocate Claude
Code's config directory gets **silently switched from subscription/plan
billing to prepaid API credits** when using hermes-agent as an Anthropic
provider. `agent/anthropic_adapter.py` looked for Claude Code's OAuth
credentials at a hardcoded `~/.claude/.credentials.json`, never checking
`CLAUDE_CONFIG_DIR`. When that file isn't found at the default path,
`resolve_anthropic_token()` falls through its priority chain all the way
to the `ANTHROPIC_API_KEY` branch — trading Bearer-auth OAuth (plan
allowance) for `x-api-key` auth (metered credits), with all of the
diagnostic breadcrumbs at `logger.debug`. The credential **refresh
write-back** path had a second, worse instance of the same bug: on
refresh it wrote a stale duplicate credentials file to the default path
— a file Claude Code itself never reads.

## Docs justification

Per Anthropic's official Claude Code docs
(https://code.claude.com/docs/en/authentication):

> On Linux, credentials are stored in `~/.claude/.credentials.json`. On
> Windows, credentials are stored in
> `%USERPROFILE%\.claude\.credentials.json`. **If you've set the
> `CLAUDE_CONFIG_DIR` environment variable on Linux or Windows, the
> `.credentials.json` file lives under that directory instead.**

`CLAUDE_CONFIG_DIR` was honored nowhere in this repo prior to this PR
(repo-wide grep returned 0 hits).

## Fix

Added one module-level helper, `_claude_code_credentials_path()`, and
used it at both call sites that previously inlined the hardcoded path:

- `_read_claude_code_credentials_from_file()`
- `_write_claude_code_credentials()`

Behavior:
- If `CLAUDE_CONFIG_DIR` is set and non-empty after `.strip()`, resolves
  to `<that dir>/.credentials.json`.
- Empty/whitespace-only is treated as unset (matches the existing
  `os.getenv(...).strip()` convention already used in
  `resolve_anthropic_token()`).
- Expands `~` and `$VAR` via `os.path.expanduser` + `os.path.expandvars`
  (covers `CLAUDE_CONFIG_DIR=~/foo`).
- Resolved fresh on every call — never cached at import time — so
  processes that set/change the env var after import pick it up.

**Platform-unconditional by design** (no Darwin/Windows gate): when the
var is unset, the helper's output is byte-identical to the prior
hardcoded expression, so this is strictly additive. A platform check
would only add a branch with no behavioral benefit — macOS users who
never set `CLAUDE_CONFIG_DIR` get the same default path either way.

## Relationship to #75146

Independent of, and does not conflict with, #75146 — that PR only
touches `_read_claude_code_credentials_from_keychain` (the macOS
Keychain path). This PR touches only the file read
(`_read_claude_code_credentials_from_file`) and the write-back
(`_write_claude_code_credentials`). Neither function nor line range
overlaps.

## Testing

New file `tests/agent/test_anthropic_claude_config_dir.py` (14 tests,
real imports, no mocking of the module under test, `tmp_path` +
`monkeypatch`, invariant-based assertions):

- read path honors `CLAUDE_CONFIG_DIR`
- read path falls back to the default when unset
- empty/whitespace-only value falls back to the default (parametrized)
- `~` and `$VAR` expansion in the configured value
- env var re-read at call time, not cached
- write-back lands in the `CLAUDE_CONFIG_DIR` location, including a
  write → read round trip through the real read path
- existing fields in the credentials file are preserved when writing
  under `CLAUDE_CONFIG_DIR`

## Verification

```
export HERMES_PYTHON=<repo>/.venv/bin/python
scripts/run_tests.sh tests/agent/test_anthropic_claude_config_dir.py   # 16 passed, 0 failed
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py             # 84 passed, 0 failed (no regressions)
ruff check .                                                            # All checks passed
$HERMES_PYTHON scripts/check-windows-footguns.py --all                 # 0 footguns (893 files scanned)
```

Confirmed the worktree's interpreter imports the worktree's own code
(not the main checkout) via `python -c "import agent.anthropic_adapter
as m; print(m.__file__)"` before running any gate.

## Scope

Minimal and surgical — one new helper, two call sites updated to use it,
no changes to the atomic-write / 0600 / `os.replace` logic in
`_write_claude_code_credentials`, no refactor of the surrounding file.
