### PR TITLE
fix(gateway): preserve image attachments during clarify replies (#81117)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14776,6 +14776,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _clarify_has_audio = bool(self._pending_event_audio_paths(event))
+            _clarify_image_paths = self._pending_event_image_paths(event)
             _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
             if _clarify_has_audio and not _raw_clarify_reply:
                 logger.info(
@@ -14785,6 +14786,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _pending_clarify.clarify_id,
                 )
                 return ""
+            # An image-only reply (no text, no audio) would produce an empty
+            # _raw_clarify_reply and silently fall through to the busy-session
+            # path, losing the attachment.  Resolve it with a descriptive
+            # placeholder so the agent receives both the image (via
+            # native_image_paths) and an informative text (#81117).
+            if not _raw_clarify_reply and _clarify_image_paths:
+                _raw_clarify_reply = _build_media_placeholder(event)
+            # Preserve image attachments for the agent's next turn so the
+            # clarify resolution carries the visual content alongside the
+            # text reply (#81117).
+            if _clarify_image_paths:
+                self._session_state(
+                    _quick_key
+                ).persistent.native_image_paths = list(_clarify_image_paths)
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks
@@ -21915,6 +21930,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _event_media_is_stt_input(event, i):
                 audio_paths.append(path)
         return audio_paths
+
+    def _pending_event_image_paths(self, event) -> List[str]:
+        """Return image attachment paths from a pending event.
+
+        Mirrors ``_pending_event_audio_paths`` for images so that a media
+        reply during a pending clarify can preserve the attachment instead
+        of silently dropping it (#81117).
+        """
+        image_paths: List[str] = []
+        media_urls = getattr(event, "media_urls", None) or []
+        for i, path in enumerate(media_urls):
+            if _event_media_is_image(event, i):
+                image_paths.append(path)
+        return image_paths
 
     async def _transcribe_pending_audio_event_once(
         self,

--- a/tests/gateway/test_81117_clarify_image_reply.py
+++ b/tests/gateway/test_81117_clarify_image_reply.py
@@ -1,0 +1,313 @@
+"""Regression tests for image replies during a pending clarify (#81117).
+
+When a platform sends an image (image-only or image+caption) while the agent
+is blocked in a pending ``clarify``, the gateway must preserve the image
+attachment alongside the text reply instead of silently dropping it.
+
+The bug: ``_prepare_clarify_reply_text`` returns ``""`` for image-only events
+(no text, no audio). The clarify interception block sees an empty reply and
+falls through to the busy-session path, where the image is treated as a media
+placeholder interrupt and the actual attachment is lost. For image+caption
+events, the caption text resolved the clarify but the image was still dropped
+because the normal media routing block was never reached.
+
+The fix mirrors the existing voice-clarify pattern: when a pending clarify
+event carries image media, preserve those paths into the session's
+``native_image_paths`` (the same mechanism used by the normal media routing
+block) so the agent's next turn includes the image natively.
+"""
+import asyncio
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _event_media_is_image
+from gateway.session import SessionSource
+
+try:
+    from gateway.config import Platform
+except Exception:
+    Platform = SimpleNamespace(FEISHU=MagicMock(value="feishu"), TELEGRAM=MagicMock(value="telegram"))
+
+
+def _source(platform_val=None):
+    if platform_val is None:
+        platform_val = Platform.FEISHU
+    return SessionSource(
+        platform=platform_val,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _runner():
+    """Build a minimal GatewayRunner for testing the clarify interception."""
+    runner = object.__new__(GatewayRunner)
+    runner._consume_pending_native_image_paths = MagicMock(return_value=[])
+    runner._session_key_for_source = lambda _source: "feishu:dm:chat-1"
+    runner._adapter_for_source = lambda _source: None
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._is_session_running = lambda _key: False
+    runner._get_unauthorized_dm_behavior = lambda _plat, profile=None: "reject"
+    runner._pairing_store_for = lambda _source: None
+    return runner
+
+
+def _image_event(text="", media_urls=None, media_types=None):
+    """Build a MessageEvent that represents a Feishu image message."""
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.PHOTO,
+        source=_source(),
+        message_id="msg-img-1",
+        media_urls=media_urls or ["/tmp/feishu_image_001.png"],
+        media_types=media_types or ["image/png"],
+    )
+
+
+def _text_event(text="hello"):
+    """Build a plain-text MessageEvent."""
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="msg-text-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _pending_event_image_paths
+# ---------------------------------------------------------------------------
+
+class TestPendingEventImagePaths:
+    """The new helper that extracts image paths from a pending event."""
+
+    def test_returns_image_paths_for_photo_event(self):
+        runner = _runner()
+        event = _image_event(
+            media_urls=["/tmp/img1.png", "/tmp/img2.jpg"],
+            media_types=["image/png", "image/jpeg"],
+        )
+        paths = runner._pending_event_image_paths(event)
+        assert paths == ["/tmp/img1.png", "/tmp/img2.jpg"]
+
+    def test_returns_empty_for_text_only_event(self):
+        runner = _runner()
+        event = _text_event("hello")
+        paths = runner._pending_event_image_paths(event)
+        assert paths == []
+
+    def test_returns_empty_for_audio_event(self):
+        runner = _runner()
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=_source(),
+            message_id="msg-voice",
+            media_urls=["/tmp/voice.ogg"],
+            media_types=["audio/ogg"],
+        )
+        paths = runner._pending_event_image_paths(event)
+        assert paths == []
+
+    def test_mixed_image_and_audio_returns_only_images(self):
+        runner = _runner()
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.PHOTO,
+            source=_source(),
+            message_id="msg-mixed",
+            media_urls=["/tmp/img.png", "/tmp/voice.ogg"],
+            media_types=["image/png", "audio/ogg"],
+        )
+        paths = runner._pending_event_image_paths(event)
+        assert paths == ["/tmp/img.png"]
+
+    def test_photo_without_mime_uses_message_type(self):
+        """A PHOTO event with empty media_types should still classify as image."""
+        runner = _runner()
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.PHOTO,
+            source=_source(),
+            message_id="msg-photo-no-mime",
+            media_urls=["/tmp/photo.png"],
+            media_types=[""],
+        )
+        paths = runner._pending_event_image_paths(event)
+        assert paths == ["/tmp/photo.png"]
+
+
+# ---------------------------------------------------------------------------
+# Clarify interception with images
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestClarifyImageReply:
+    """When a clarify is pending and the user sends an image, the image must
+    be preserved and the clarify resolved."""
+
+    def _setup_pending_clarify(self, runner):
+        """Patch clarify_gateway so a pending clarify is visible."""
+        mock_entry = SimpleNamespace(clarify_id="clarify-1")
+        return mock_entry
+
+    async def test_image_only_preserves_native_paths_and_resolves(self):
+        """An image-only message during pending clarify must:
+        1. Preserve image paths to native_image_paths
+        2. Resolve the clarify (not leave it hanging)
+        """
+        runner = _runner()
+        runner._session_state = MagicMock()
+        mock_state = MagicMock()
+        mock_state.persistent.native_image_paths = []
+        runner._session_state.return_value = mock_state
+
+        event = _image_event()
+
+        resolve_calls = []
+
+        def _fake_resolve(session_key, response):
+            resolve_calls.append((session_key, response))
+            return True
+
+        mock_clarify = self._setup_pending_clarify(runner)
+
+        # Pre-import so patch can find the attribute
+        import tools.clarify_gateway  # noqa: F401
+        with patch("tools.clarify_gateway") as mock_cm, \
+             patch.object(runner, "_adapter_for_source", return_value=None):
+            mock_cm.get_pending_for_session.return_value = mock_clarify
+            mock_cm.resolve_text_response_for_session.side_effect = _fake_resolve
+
+            result = await runner._handle_message(event)
+
+        # Clarify was resolved
+        assert len(resolve_calls) == 1
+        session_key, reply_text = resolve_calls[0]
+        assert session_key == "feishu:dm:chat-1"
+
+        # Image paths were preserved for the agent's next turn
+        assert mock_state.persistent.native_image_paths == ["/tmp/feishu_image_001.png"]
+
+        # Reply text is not empty — contains a media indicator
+        assert reply_text  # not empty
+
+    async def test_image_plus_caption_preserves_image_and_uses_caption(self):
+        """An image+caption message during pending clarify must:
+        1. Use the caption text as the clarify response
+        2. Preserve the image attachment
+        """
+        runner = _runner()
+        runner._session_state = MagicMock()
+        mock_state = MagicMock()
+        mock_state.persistent.native_image_paths = []
+        runner._session_state.return_value = mock_state
+
+        event = _image_event(
+            text="Here is the screenshot",
+            media_urls=["/tmp/screenshot.png"],
+            media_types=["image/png"],
+        )
+
+        resolve_calls = []
+
+        def _fake_resolve(session_key, response):
+            resolve_calls.append((session_key, response))
+            return True
+
+        mock_clarify = self._setup_pending_clarify(runner)
+
+        import tools.clarify_gateway  # noqa: F401
+        with patch("tools.clarify_gateway") as mock_cm, \
+             patch.object(runner, "_adapter_for_source", return_value=None):
+            mock_cm.get_pending_for_session.return_value = mock_clarify
+            mock_cm.resolve_text_response_for_session.side_effect = _fake_resolve
+
+            await runner._handle_message(event)
+
+        # Clarify was resolved with the caption text
+        assert len(resolve_calls) == 1
+        _, reply_text = resolve_calls[0]
+        assert "screenshot" in reply_text.lower()
+
+        # Image paths were preserved
+        assert mock_state.persistent.native_image_paths == ["/tmp/screenshot.png"]
+
+    async def test_text_only_clarify_does_not_set_native_image_paths(self):
+        """A plain text clarify response must NOT set native_image_paths."""
+        runner = _runner()
+        runner._session_state = MagicMock()
+        mock_state = MagicMock()
+        mock_state.persistent.native_image_paths = []
+        runner._session_state.return_value = mock_state
+
+        event = _text_event("my answer")
+
+        resolve_calls = []
+
+        def _fake_resolve(session_key, response):
+            resolve_calls.append((session_key, response))
+            return True
+
+        mock_clarify = self._setup_pending_clarify(runner)
+
+        import tools.clarify_gateway  # noqa: F401
+        with patch("tools.clarify_gateway") as mock_cm, \
+             patch.object(runner, "_adapter_for_source", return_value=None):
+            mock_cm.get_pending_for_session.return_value = mock_clarify
+            mock_cm.resolve_text_response_for_session.side_effect = _fake_resolve
+
+            await runner._handle_message(event)
+
+        assert len(resolve_calls) == 1
+        _, reply_text = resolve_calls[0]
+        assert reply_text == "my answer"
+
+        # No image paths should be set
+        assert mock_state.persistent.native_image_paths == []
+
+    async def test_image_only_does_not_resolve_with_empty_text(self):
+        """An image-only clarify reply must NOT resolve with an empty string
+        that would confuse the agent. It should use a descriptive placeholder."""
+        runner = _runner()
+        runner._session_state = MagicMock()
+        mock_state = MagicMock()
+        mock_state.persistent.native_image_paths = []
+        runner._session_state.return_value = mock_state
+
+        event = _image_event(text="", media_urls=["/tmp/img.png"])
+
+        resolve_calls = []
+
+        def _fake_resolve(session_key, response):
+            resolve_calls.append((session_key, response))
+            return True
+
+        mock_clarify = self._setup_pending_clarify(runner)
+
+        import tools.clarify_gateway  # noqa: F401
+        with patch("tools.clarify_gateway") as mock_cm, \
+             patch.object(runner, "_adapter_for_source", return_value=None):
+            mock_cm.get_pending_for_session.return_value = mock_clarify
+            mock_cm.resolve_text_response_for_session.side_effect = _fake_resolve
+
+            await runner._handle_message(event)
+
+        assert len(resolve_calls) == 1
+        _, reply_text = resolve_calls[0]
+        # Must NOT be empty
+        assert reply_text, "Image-only clarify reply must not be empty"
+        # Should contain a reference to the image
+        assert "image" in reply_text.lower() or "img" in reply_text.lower()


### PR DESCRIPTION
## Summary

When a Feishu/Lark gateway session is blocked in `clarify`, sending an image as the reply drops the attachment. The clarify interception block reads `_prepare_clarify_reply_text(event)` before normal media routing, so image-only messages produce an empty reply and silently fall through to the busy-session path where the attachment is lost. Image+caption messages resolved with the caption but still dropped the image.

The downstream vision tool then received the literal placeholder `[Image]` instead of a real path and errored with `media file not found: '[Image]'`.

## Fix

Mirrors the existing voice-clarify pattern (`_pending_event_audio_paths`):

1. **`_pending_event_image_paths(event)`** — new helper that extracts image attachment paths from a pending event, classifying by per-attachment MIME (falling back to `MessageType.PHOTO`).

2. **Clarify interception block** — when a pending clarify event has image media:
   - Image-only (no text, no audio): resolve with `_build_media_placeholder(event)` so the agent gets an informative `[User sent an image: <path>]` text alongside the preserved attachment
   - Image+caption: resolve with the caption text, image still preserved
   - Both: image paths stored to `native_image_paths` via the same mechanism the normal media-routing block uses

3. **Platform-agnostic** — the fix is in the shared gateway runner, so any platform (Telegram, Discord, etc.) sending an image during clarify benefits.

## Test plan

New regression tests (`tests/gateway/test_81117_clarify_image_reply.py`, 9 tests):
- `_pending_event_image_paths`: returns image paths for PHOTO events, empty for text/audio, filters mixed media, handles missing MIME
- Clarify interception: image-only preserves native paths + resolves; image+caption preserves image + uses caption; text-only does not set native paths; image-only does not resolve with empty text

**Fail-without-fix proven**: 8 of 9 tests fail on upstream/main (base `6e87d43a5`); only `test_text_only_clarify_does_not_set_native_image_paths` passes (that path already works).

**Nearby suite**: 32 tests in clarify/busy-session/voice regression files all pass.

## Verification

```
9 passed, 32 nearby passed (41 total)
git rev-list --left-right --count upstream/main...HEAD → 0 1
git diff --check → clean
```

## Competitor analysis

PR #81179 (Enough1122) addresses the same issue with a different approach: it strips `[Image]` placeholders from clarify text and, for image-only replies, leaves the clarify pending with a "please reply with text" message. While valid per the issue's fallback option (b), it does not deliver the image to the agent — the attachment is preserved on the event but never routed to `native_image_paths`, so the vision tool still cannot see it. Our fix preserves and routes the image so the agent can actually process it.

Fixes #81117

Auto-published by Moonsong via Path B automated pipeline.