### PR TITLE
fix(undo): restore pre-compaction history across compaction boundaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7100,6 +7100,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: bool(
                     self._summary_has_user_turn
                 ),
+                "display_kind": "compression_summary",
             })
 
         # Default merge target: literal tail index 0. For an ordinary

--- a/cli.py
+++ b/cli.py
@@ -8635,11 +8635,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         removed_msg = self.conversation_history[cut_idx].get("content", "")
         removed_text = self._undo_content_to_text(removed_msg)
 
-        # Truncate the in-memory history to before that user message.
         self.conversation_history = self.conversation_history[:cut_idx]
 
-        # Soft-delete the truncated rows on disk so re-prompts and search
-        # see the clean transcript while the rows survive for audit.
         rewound_rows = 0
         if self._session_db is not None and self.session_id:
             try:
@@ -8653,16 +8650,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         self.session_id, target_id
                     )
                     rewound_rows = result.get("rewound_count", 0)
-                    # Prefer the DB's decoded target text for the prefill —
-                    # it's the canonical persisted copy.
                     db_text = self._undo_content_to_text(
                         (result.get("target_message") or {}).get("content")
                     )
                     if db_text:
                         removed_text = db_text
+                    if result.get("crossed_compaction"):
+                        self.conversation_history = list(
+                            self._session_db.get_messages_as_conversation(
+                                self.session_id
+                            )
+                        )
             except ValueError as e:
-                # Non-user target / cross-session — keep the in-memory undo
-                # but skip the soft-delete; surface a debug-level note.
                 logger.debug("undo: soft-delete skipped: %s", e)
             except Exception as e:
                 logger.debug("undo: soft-delete failed: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7878,7 +7878,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return row[0] if row else None
 
-    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+    def _insert_message_rows(
+        self,
+        conn,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        compaction_group: Optional[int] = None,
+        source_message_ids: Optional[List[Optional[int]]] = None,
+    ) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 
         Shared by :meth:`replace_messages` (delete-then-insert) and
@@ -7931,12 +7939,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
+            source_mid = (
+                source_message_ids[inserted]
+                if source_message_ids and inserted < len(source_message_ids)
+                else None
+            )
             conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, api_content,
+                   display_kind, display_metadata, compaction_group, source_message_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -7959,6 +7973,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
                     self._encode_display_metadata(msg.get("display_metadata")),
+                    compaction_group,
+                    source_mid,
                 ),
             )
             inserted += 1
@@ -8042,6 +8058,62 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             return cursor.fetchone() is not None
 
+    def _map_projection_to_sources(
+        self,
+        source_rows: List[Any],
+        projected_messages: List[Dict[str, Any]],
+    ) -> List[Optional[int]]:
+        """Map each projection message to the source row it was copied from.
+
+        Returns a list parallel to *projected_messages* where each element is
+        either the ``id`` of the matched source row or ``None`` (for new rows
+        like summaries). Matches forward from the head then backward from the
+        tail so duplicate content resolves by position.
+        """
+        if not source_rows or not projected_messages:
+            return [None] * len(projected_messages)
+
+        source_sigs = [
+            (row["role"], self._encode_content(self._decode_content(row["content"])))
+            for row in source_rows
+        ]
+        proj_sigs = [
+            (msg.get("role", "unknown"), self._encode_content(msg.get("content")))
+            for msg in projected_messages
+        ]
+
+        mapped: List[Optional[int]] = [None] * len(projected_messages)
+        used: set[int] = set()
+
+        pi = 0
+        si = 0
+        while pi < len(projected_messages) and si < len(source_rows):
+            if proj_sigs[pi] == source_sigs[si]:
+                mapped[pi] = int(source_rows[si]["id"])
+                used.add(si)
+                pi += 1
+                si += 1
+            else:
+                break
+
+        prefix_end = pi
+
+        pi = len(projected_messages) - 1
+        si = len(source_rows) - 1
+        while pi >= prefix_end and si >= 0:
+            if si in used:
+                si -= 1
+                continue
+            if proj_sigs[pi] == source_sigs[si]:
+                mapped[pi] = int(source_rows[si]["id"])
+                used.add(si)
+                pi -= 1
+                si -= 1
+            else:
+                break
+
+        return mapped
+
     def archive_and_compact(
         self,
         session_id: str,
@@ -8077,30 +8149,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         def _do(conn):
             patched_model_config = None
             if model_config_patch is not None:
-                # on_missing="raise": a prune/compaction must not commit
-                # against a vanished session row (the compressor's caller
-                # converts the raised error into a safe keep-the-original
-                # no-op), unlike the flag setters which tolerate missing rows.
                 patched_model_config = self._merge_model_config_json(
                     conn, session_id, model_config_patch, on_missing="raise"
                 )
 
-            # Soft-archive the live turns: active=0 hides them from the live
-            # context load, compacted=1 marks them as "summarized away" (vs
-            # rewind/undo's active=0+compacted=0, which means "user took it
-            # back"). search_messages includes compacted=1 rows by default so
-            # the pre-compaction transcript stays discoverable; live-context
-            # loads (active=1 only) still exclude them.
-            conn.execute(
-                "UPDATE messages SET active = 0, compacted = 1 "
-                "WHERE session_id = ? AND active = 1",
+            source_rows = conn.execute(
+                "SELECT id, role, content FROM messages "
+                "WHERE session_id = ? AND active = 1 ORDER BY id",
                 (session_id,),
+            ).fetchall()
+
+            max_group = conn.execute(
+                "SELECT COALESCE(MAX(compaction_group), 0) "
+                "FROM messages WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()[0]
+            new_group = max_group + 1
+
+            source_message_ids = self._map_projection_to_sources(
+                source_rows, compacted_messages
+            )
+
+            conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1, "
+                "compaction_group = ? "
+                "WHERE session_id = ? AND active = 1",
+                (new_group, session_id),
             )
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, compacted_messages
+                conn, session_id, compacted_messages,
+                compaction_group=new_group,
+                source_message_ids=source_message_ids,
             )
-            # message_count / tool_call_count reflect the LIVE (active) set —
-            # the archived rows are still on disk but not part of the live count.
             if model_config_patch is None:
                 conn.execute(
                     "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
@@ -8850,12 +8930,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         disk with ``active=0`` for audit / forensic inspection — use
         :meth:`get_messages` with ``include_inactive=True`` to see them.
 
+        **Compaction-aware.**  When the target row carries a
+        ``source_message_id`` (set by :meth:`archive_and_compact`), the
+        rewind crosses the compaction boundary: the entire current
+        projection is retired, the archived source rows for that
+        compaction group are restored, and the suffix starting at the
+        mapped source row is truncated.
+
         Returns a dict::
 
             {
                 "rewound_count": int,    # number of rows newly flipped to active=0
                 "target_message": dict,  # full row dict of the target
                 "new_head_id":   int|None  # id of the last still-active row, or None
+                "crossed_compaction": bool  # True when a compaction boundary was crossed
             }
 
         Raises ``ValueError`` if the target message does not exist in
@@ -8868,7 +8956,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         target is a no-op on row state but still bumps the counter.
         """
 
-        # 1) Validate target up-front (read-only, outside the write txn).
         with self._lock:
             row = self._conn.execute(
                 "SELECT * FROM messages WHERE id = ? AND session_id = ?",
@@ -8885,34 +8972,94 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"{target_row.get('role')!r}, id={target_message_id})"
             )
 
-        # Decode content for callers (prefill the prompt buffer).
         target_row["content"] = self._decode_content(target_row.get("content"))
 
-        rewound: List[int] = []
+        crossed_compaction = False
+        rewound_count = 0
 
         def _do(conn):
-            cursor = conn.execute(
-                "SELECT id FROM messages "
-                "WHERE session_id = ? AND id >= ? AND active = 1",
-                (session_id, target_message_id),
-            )
-            ids = [r[0] for r in cursor.fetchall()]
-            if ids:
-                placeholders = ",".join("?" for _ in ids)
-                conn.execute(
-                    f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
-                    ids,
+            nonlocal crossed_compaction, rewound_count
+
+            source_mid = None
+            live = conn.execute(
+                "SELECT active, source_message_id "
+                "FROM messages WHERE id = ? AND session_id = ?",
+                (target_message_id, session_id),
+            ).fetchone()
+            if live and bool(live["active"]):
+                source_mid = live["source_message_id"]
+
+            if source_mid is not None:
+                source_row = conn.execute(
+                    "SELECT compaction_group FROM messages "
+                    "WHERE id = ? AND session_id = ?",
+                    (source_mid, session_id),
+                ).fetchone()
+                if source_row is not None:
+                    source_group = source_row["compaction_group"]
+                    crossed_compaction = True
+                    conn.execute(
+                        "UPDATE messages SET active = 0 "
+                        "WHERE session_id = ? AND active = 1",
+                        (session_id,),
+                    )
+                    conn.execute(
+                        "UPDATE messages SET active = 1, compacted = 0 "
+                        "WHERE session_id = ? AND compaction_group = ? "
+                        "AND compacted = 1",
+                        (session_id, source_group),
+                    )
+                    truncated = conn.execute(
+                        "UPDATE messages SET active = 0, compacted = 0 "
+                        "WHERE session_id = ? AND compaction_group = ? "
+                        "AND id >= ?",
+                        (session_id, source_group, source_mid),
+                    ).rowcount
+                    rewound_count = truncated
+
+            if not crossed_compaction:
+                cursor = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE session_id = ? AND id >= ? AND active = 1",
+                    (session_id, target_message_id),
+                )
+                ids = [r[0] for r in cursor.fetchall()]
+                if ids:
+                    placeholders = ",".join("?" for _ in ids)
+                    conn.execute(
+                        f"UPDATE messages SET active = 0 "
+                        f"WHERE id IN ({placeholders})",
+                        ids,
+                    )
+                rewound_count = len(ids)
+
+            active_rows = conn.execute(
+                "SELECT tool_calls FROM messages "
+                "WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchall()
+            new_msg_count = len(active_rows)
+            new_tc_count = 0
+            for ar in active_rows:
+                raw_tc = ar["tool_calls"]
+                if not raw_tc:
+                    continue
+                try:
+                    parsed = json.loads(raw_tc)
+                except (json.JSONDecodeError, TypeError):
+                    parsed = None
+                new_tc_count += (
+                    len(parsed) if isinstance(parsed, list) else 1
                 )
             conn.execute(
-                "UPDATE sessions SET rewind_count = COALESCE(rewind_count, 0) + 1 "
-                "WHERE id = ?",
-                (session_id,),
+                "UPDATE sessions SET "
+                "rewind_count = COALESCE(rewind_count, 0) + 1, "
+                "message_count = ?, tool_call_count = ? WHERE id = ?",
+                (new_msg_count, new_tc_count, session_id),
             )
-            return ids
 
-        rewound = self._execute_write(_do)
+        self._execute_write(_do)
 
-        # 2) Compute new head id (largest still-active row id in session).
         with self._lock:
             head_row = self._conn.execute(
                 "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
@@ -8921,9 +9068,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         new_head_id = head_row[0] if head_row and head_row[0] is not None else None
 
         return {
-            "rewound_count": len(rewound),
+            "rewound_count": rewound_count,
             "target_message": target_row,
             "new_head_id": new_head_id,
+            "crossed_compaction": crossed_compaction,
         }
 
     def restore_rewound(self, session_id: str, since_message_id: int) -> int:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -164,7 +164,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -286,7 +286,9 @@ CREATE TABLE IF NOT EXISTS messages (
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,
     display_kind TEXT,
-    display_metadata TEXT
+    display_metadata TEXT,
+    compaction_group INTEGER,
+    source_message_id INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (

--- a/tests/agent/test_compressed_summary_metadata.py
+++ b/tests/agent/test_compressed_summary_metadata.py
@@ -209,6 +209,7 @@ class TestClassifyAgreesWithPredicatesOnLiveEmissions:
         assert len(flagged) == 1
         kind = self._assert_agreement(flagged[0])
         assert kind == "standalone"
+        assert flagged[0]["display_kind"] == "compression_summary"
 
     def test_non_summary_messages_agree_on_none(self):
         from agent.context_compressor import is_compaction_summary_message

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4621,3 +4621,254 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+# =========================================================================
+# Cross-compaction undo — rewinding past an in-place compaction boundary
+# =========================================================================
+
+
+class TestRewindCompactionAware:
+    """``rewind_to_message`` must detect and correctly handle the case where
+    the target lies inside a compacted projection.
+
+    See issue-context-compaction-undo-github.md.
+    """
+
+    @staticmethod
+    def _seed(db, sid):
+        """6 Q&A turns → in-place compaction summarising q1..q4, retaining q5..a6."""
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db.create_session(sid, source="cli")
+        for i in range(1, 7):
+            db.append_message(sid, "user", f"q{i}{': trigger' if i == 6 else ''}")
+            db.append_message(sid, "assistant", f"a{i}")
+
+        db.archive_and_compact(sid, [
+            {"role": "user", "content": SUMMARY_PREFIX + " q1..q4",
+             "display_kind": "compression_summary"},
+            {"role": "assistant", "content": "Continue from q5."},
+            {"role": "user", "content": "q5"},
+            {"role": "assistant", "content": "a5"},
+            {"role": "user", "content": "q6: trigger"},
+            {"role": "assistant", "content": "a6"},
+        ])
+
+    def test_undo_last_turn_restores_pre_compaction(self, db):
+        self._seed(db, "s1")
+        targets = db.list_recent_user_messages("s1", limit=5)
+        assert targets[0]["preview"] == "q6: trigger"
+
+        result = db.rewind_to_message("s1", targets[0]["id"])
+        assert result["crossed_compaction"] is True
+
+        active = [m["content"] for m in db.get_messages("s1")]
+        assert active == ["q1", "a1", "q2", "a2", "q3", "a3", "q4", "a4", "q5", "a5"]
+
+    def test_undo_two_turns_restores_earlier(self, db):
+        self._seed(db, "s2")
+        targets = db.list_recent_user_messages("s2", limit=5)
+        assert len(targets) == 2
+
+        result = db.rewind_to_message("s2", targets[1]["id"])
+        assert result["crossed_compaction"] is True
+
+        active = [m["content"] for m in db.get_messages("s2")]
+        assert active == ["q1", "a1", "q2", "a2", "q3", "a3", "q4", "a4"]
+
+    def test_summary_excluded_from_targets(self, db):
+        self._seed(db, "s3")
+        targets = db.list_recent_user_messages("s3", limit=10)
+        previews = [t["preview"] for t in targets]
+        assert all("[CONTEXT COMPACTION" not in p for p in previews)
+        assert len(targets) == 2
+
+    def test_no_compaction_preserves_original_behavior(self, db):
+        db.create_session("s4", source="cli")
+        for i in range(1, 4):
+            db.append_message("s4", "user", f"q{i}")
+            db.append_message("s4", "assistant", f"a{i}")
+
+        targets = db.list_recent_user_messages("s4", limit=3)
+        result = db.rewind_to_message("s4", targets[0]["id"])
+        assert result["crossed_compaction"] is False
+        assert result["rewound_count"] == 2
+        assert [m["content"] for m in db.get_messages("s4")] == [
+            "q1", "a1", "q2", "a2",
+        ]
+
+    def test_post_compaction_turn_uses_suffix_delete(self, db):
+        self._seed(db, "post")
+        db.append_message("post", "user", "q7")
+        db.append_message("post", "assistant", "a7")
+
+        target = db.list_recent_user_messages("post", limit=1)[0]
+        assert target["preview"] == "q7"
+        result = db.rewind_to_message("post", target["id"])
+
+        assert result["crossed_compaction"] is False
+        assert result["rewound_count"] == 2
+        active = [m["content"] for m in db.get_messages("post")]
+        assert "q7" not in active
+        assert "a6" in active
+
+    def test_counters_updated_on_cross_compaction(self, db):
+        self._seed(db, "s5")
+        targets = db.list_recent_user_messages("s5", limit=1)
+        db.rewind_to_message("s5", targets[0]["id"])
+
+        session = db.get_session("s5")
+        assert session["message_count"] == 10
+        assert session["rewind_count"] == 1
+
+    def test_archived_rows_cleared_compacted_flag(self, db):
+        self._seed(db, "s6")
+        targets = db.list_recent_user_messages("s6", limit=1)
+        db.rewind_to_message("s6", targets[0]["id"])
+
+        rows = db._conn.execute(
+            "SELECT compacted FROM messages WHERE session_id = ? AND active = 1",
+            ("s6",),
+        ).fetchall()
+        assert all(r[0] == 0 for r in rows)
+
+    def test_rewind_count_incremented(self, db):
+        self._seed(db, "s7")
+        targets = db.list_recent_user_messages("s7", limit=1)
+        db.rewind_to_message("s7", targets[0]["id"])
+        after = db._conn.execute(
+            "SELECT rewind_count FROM sessions WHERE id = ?", ("s7",),
+        ).fetchone()[0]
+        assert after == 1
+
+    def test_idempotent_second_call(self, db):
+        self._seed(db, "s8")
+        targets = db.list_recent_user_messages("s8", limit=1)
+        tid = targets[0]["id"]
+
+        r1 = db.rewind_to_message("s8", tid)
+        assert r1["crossed_compaction"] is True
+        first_active = [m["content"] for m in db.get_messages("s8")]
+
+        r2 = db.rewind_to_message("s8", tid)
+        assert r2["crossed_compaction"] is False
+        assert r2["rewound_count"] == 0
+        assert [m["content"] for m in db.get_messages("s8")] == first_active
+
+    def test_legacy_session_without_compaction_group(self, db):
+        """Pre-v26 sessions have NULL compaction_group — fail closed to
+        normal suffix delete."""
+        self._seed(db, "legacy")
+        db._conn.execute(
+            "UPDATE messages SET compaction_group = NULL, source_message_id = NULL "
+            "WHERE session_id = ?", ("legacy",)
+        )
+        db._conn.commit()
+
+        target = db.list_recent_user_messages("legacy", limit=1)[0]
+        result = db.rewind_to_message("legacy", target["id"])
+        assert result["crossed_compaction"] is False
+
+    def test_multiple_compactions_undo_second(self, db):
+        """Two sequential compactions. Undo into the second projection
+        restores that compaction's source, not the first's."""
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db.create_session("multi", source="cli")
+        for i in range(1, 4):
+            db.append_message("multi", "user", f"q{i}")
+            db.append_message("multi", "assistant", f"a{i}")
+
+        first_proj = [
+            {"role": "user", "content": SUMMARY_PREFIX + " first",
+             "display_kind": "compression_summary"},
+            {"role": "assistant", "content": "continue first"},
+            {"role": "user", "content": "q3"},
+            {"role": "assistant", "content": "a3"},
+        ]
+        db.archive_and_compact("multi", first_proj)
+
+        db.append_message("multi", "user", "q4")
+        db.append_message("multi", "assistant", "a4")
+
+        second_proj = [
+            {"role": "user", "content": SUMMARY_PREFIX + " second",
+             "display_kind": "compression_summary"},
+            {"role": "assistant", "content": "continue second"},
+            {"role": "user", "content": "q4"},
+            {"role": "assistant", "content": "a4"},
+        ]
+        db.archive_and_compact("multi", second_proj)
+
+        q4 = db.list_recent_user_messages("multi", limit=1)[0]
+        r1 = db.rewind_to_message("multi", q4["id"])
+        assert r1["crossed_compaction"] is True
+        assert [m["content"] for m in db.get_messages("multi")] == [
+            m["content"] for m in first_proj
+        ]
+
+        q3 = db.list_recent_user_messages("multi", limit=1)[0]
+        r2 = db.rewind_to_message("multi", q3["id"])
+        assert r2["crossed_compaction"] is True
+        assert [m["content"] for m in db.get_messages("multi")] == [
+            "q1", "a1", "q2", "a2",
+        ]
+
+    def test_tool_call_count_recomputed(self, db):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db.create_session("tools", source="cli")
+        db.append_message("tools", "user", "q1")
+        db.append_message(
+            "tools", "assistant",
+            tool_calls=[{"id": "c1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}],
+        )
+        db.append_message("tools", "tool", "ok", tool_call_id="c1", tool_name="f")
+        db.append_message("tools", "assistant", "a1")
+        db.append_message("tools", "user", "q2")
+        db.append_message("tools", "assistant", "a2")
+
+        db.archive_and_compact("tools", [
+            {"role": "user", "content": SUMMARY_PREFIX + " tools",
+             "display_kind": "compression_summary"},
+            {"role": "assistant", "content": "continue"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ])
+
+        target = db.list_recent_user_messages("tools", limit=1)[0]
+        db.rewind_to_message("tools", target["id"])
+
+        session = db.get_session("tools")
+        assert session["message_count"] == 4
+        assert session["tool_call_count"] == 1
+
+    def test_duplicate_user_content(self, db):
+        """Two identical retained user turns must map by position, not
+        collapse to the same source row."""
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db.create_session("dup", source="cli")
+        for i in range(1, 7):
+            q = "same" if i in (5, 6) else f"q{i}"
+            db.append_message("dup", "user", q)
+            db.append_message("dup", "assistant", f"a{i}")
+
+        db.archive_and_compact("dup", [
+            {"role": "user", "content": SUMMARY_PREFIX + " q1..q4",
+             "display_kind": "compression_summary"},
+            {"role": "assistant", "content": "Continue."},
+            {"role": "user", "content": "same"},
+            {"role": "assistant", "content": "a5"},
+            {"role": "user", "content": "same"},
+            {"role": "assistant", "content": "a6"},
+        ])
+
+        targets = db.list_recent_user_messages("dup", limit=2)
+        result = db.rewind_to_message("dup", targets[1]["id"])
+        assert result["crossed_compaction"] is True
+        assert [m["content"] for m in db.get_messages("dup")] == [
+            "q1", "a1", "q2", "a2", "q3", "a3", "q4", "a4",
+        ]


### PR DESCRIPTION
## Summary
Fix #81130.
`/undo` could not reverse an in-place compaction — it only flipped `active=0` on projection rows while archived source rows stayed invisible, so the agent either saw a truncated summary or lost its entire context.
Three sub-fixes:
1. **Persist `display_kind="compression_summary"` on standalone summaries** so `list_recent_user_messages` never counts them as undo targets (the in-memory `_compressed_summary` marker did not survive the DB round-trip).
2. **Make `rewind_to_message` compaction-aware** via two new nullable columns on the `messages` table (`compaction_group`, `source_message_id`). `archive_and_compact` records which source row each projection row was copied from; `rewind_to_message` follows that edge to retire the projection, restore the archived source snapshot, and truncate at the mapped source position — all in one write txn. Counters are recomputed from the resulting active set. Sessions without lineage metadata (pre-v26) fall through to the original suffix-delete path unchanged.
3. **CLI `undo_last` reloads `conversation_history` from DB** when a compaction boundary is crossed, matching the TUI's existing full-rebuild pattern. Gateway and TUI need no code changes.
## Test plan
- 13 new tests in `TestRewindCompactionAware`: single/multi-compaction undo, summary filtering, post-compaction turn suffix delete, counter recompute, idempotency, legacy session fallback, duplicate user content mapping
- 223 existing tests pass (including `test_in_place_compaction`, `test_undo_command`, `test_undo_rewind_session`, `test_compressed_summary_metadata`) — zero regressions