### PR TITLE
fix(desktop): recover every session-scoped RPC after a stale runtime-session drop

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -157,12 +157,20 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
-    ): Promise<ComposerAttachment[]> => {
+    ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const remote = $connection.get()?.mode === 'remote'
+      let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 
+      // A tile owns its own runtime binding, so a recovery here rebinds the
+      // tile's ref rather than the foreground session's.
+      const onSessionRecovered = (recoveredId: string) => {
+        liveSessionId = recoveredId
+        runtimeIdRef.current = recoveredId
+      }
+
       for (const attachment of attachments) {
-        if (!attachment.path || attachment.attachedSessionId === sessionId) {
+        if (!attachment.path || attachment.attachedSessionId === liveSessionId) {
           synced.push(attachment)
 
           continue
@@ -173,7 +181,9 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
             backendCwd: readState()?.cwd,
             remote,
             requestGateway,
-            sessionId
+            sessionId: liveSessionId,
+            storedSessionId: storedIdRef.current,
+            onSessionRecovered
           })
 
           if (options.updateComposerAttachments ?? true) {
@@ -188,7 +198,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         synced.push(attachment)
       }
 
-      return synced
+      return { attachments: synced, sessionId: liveSessionId }
     },
     [requestGateway, scope.attachments]
   )

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -367,7 +367,12 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   // the primary chat so the two can't diverge.
   const submitRewind = useCallback(
     (text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst),
+      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst, {
+        storedSessionId: storedIdRef.current,
+        onSessionRecovered: recoveredId => {
+          runtimeIdRef.current = recoveredId
+        }
+      }),
     [requestGateway]
   )
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -6,6 +6,7 @@ import { publishSessionState, setSessionTileDelegate } from '@/store/session-sta
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
+import { withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
 import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
 import type { GatewayRequester } from '../types'
@@ -41,6 +42,35 @@ export function useSessionTileDelegate({
   updateSessionState
 }: SessionTileDelegateParams): void {
   useEffect(() => {
+    // A tile's runtime binding can die the same way the foreground's does
+    // (sleep/wake, backend restart). The cache maps stored -> runtime, so walk
+    // it backwards to find the durable id this runtime belongs to.
+    const storedSessionIdForRuntime = (runtimeId: string): null | string => {
+      const cached = sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId
+
+      if (cached) {
+        return cached
+      }
+
+      for (const [storedId, mapped] of runtimeIdByStoredSessionIdRef.current) {
+        if (mapped === runtimeId) {
+          return storedId
+        }
+      }
+
+      return null
+    }
+
+    // Repoint the stored -> runtime mapping at the recovered id so subsequent
+    // tile actions use the live binding instead of re-recovering every call.
+    const rebindTileRuntime = (deadRuntimeId: string) => (recoveredId: string) => {
+      const storedId = storedSessionIdForRuntime(deadRuntimeId)
+
+      if (storedId) {
+        runtimeIdByStoredSessionIdRef.current.set(storedId, recoveredId)
+      }
+    }
+
     setSessionTileDelegate({
       archiveSession: async storedSessionId => {
         await archiveSession(storedSessionId)
@@ -55,7 +85,12 @@ export function useSessionTileDelegate({
         await executeSlashCommand(rawCommand, { sessionId })
       },
       interruptSession: async runtimeId => {
-        await requestGateway('session.interrupt', { session_id: runtimeId })
+        await withSessionNotFoundResume(
+          runtimeId,
+          storedSessionIdForRuntime(runtimeId),
+          liveId => requestGateway('session.interrupt', { session_id: liveId }),
+          { requestGateway, onRecovered: rebindTileRuntime(runtimeId) }
+        )
       },
       resumeTile: async storedSessionId => {
         const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
@@ -104,7 +139,12 @@ export function useSessionTileDelegate({
         return runtimeId
       },
       submitToSession: async (runtimeId, text) => {
-        await requestGateway('prompt.submit', { session_id: runtimeId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+        await withSessionNotFoundResume(
+          runtimeId,
+          storedSessionIdForRuntime(runtimeId),
+          liveId => requestGateway('prompt.submit', { session_id: liveId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS),
+          { requestGateway, onRecovered: rebindTileRuntime(runtimeId) }
+        )
       },
       updateSession: (runtimeId, updater) => updateSessionState(runtimeId, updater)
     })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -820,8 +820,14 @@ export function usePromptActions({
   // response interrupts + retries through the shared busy gate.
   const submitRewindPrompt = useCallback(
     (sessionId: string, text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst),
-    [requestGateway]
+      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst, {
+        storedSessionId: selectedStoredSessionIdRef.current,
+        onSessionRecovered: recoveredId => {
+          activeSessionIdRef.current = recoveredId
+          setActiveSessionId(recoveredId)
+        }
+      }),
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
   )
 
   const restoreToMessage = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -27,6 +27,7 @@ import {
   $connection,
   $currentCwd,
   $messages,
+  setActiveSessionId,
   setAwaitingResponse,
   setBusy,
   setMessages,
@@ -45,7 +46,6 @@ import type {
   ImageAttachResponse,
   SessionRedirectResponse
 } from '../../../types'
-import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import {
   applyBranchVisibility,
@@ -66,10 +66,10 @@ import {
   friendlyRemoteAttachError,
   type GatewayRequest,
   inlineErrorMessage,
-  isSessionNotFoundError,
   readFileDataUrlForAttach,
   readImageForRemoteAttach,
-  type SubmitTextOptions
+  type SubmitTextOptions,
+  withSessionNotFoundResume
 } from './utils'
 
 interface HandoffResult {
@@ -98,88 +98,106 @@ function attachmentPathNeedsUpload(path: string, backendCwd?: null | string): bo
  */
 export async function uploadComposerAttachment(
   attachment: ComposerAttachment,
-  opts: { backendCwd?: null | string; remote: boolean; requestGateway: GatewayRequest; sessionId: string }
+  opts: {
+    backendCwd?: null | string
+    remote: boolean
+    requestGateway: GatewayRequest
+    sessionId: string
+    /** Durable id used to re-register after sleep/wake or a backend restart. */
+    storedSessionId?: null | string
+    /** Called when the attach recovered onto a fresh live id. */
+    onSessionRecovered?: (sessionId: string) => void
+  }
 ): Promise<ComposerAttachment> {
-  const { backendCwd, remote, requestGateway, sessionId } = opts
+  const { backendCwd, remote, requestGateway, storedSessionId, onSessionRecovered } = opts
   const path = attachment.path ?? ''
   const label = attachment.label || pathLabel(path)
   const uploadBytes = remote || attachmentPathNeedsUpload(path, backendCwd)
 
-  if (attachment.kind === 'image') {
-    let result: ImageAttachResponse
-
-    if (uploadBytes) {
-      let payload: Awaited<ReturnType<typeof readImageForRemoteAttach>>
-
-      try {
-        payload = await readImageForRemoteAttach(path)
-      } catch (err) {
-        throw friendlyRemoteAttachError(err, label)
-      }
-
-      if (!payload) {
-        throw new Error(`Could not read ${label}`)
-      }
-
-      result = await requestGateway<ImageAttachResponse>('image.attach_bytes', {
-        session_id: sessionId,
-        content_base64: payload.contentBase64,
-        filename: payload.filename
-      })
-    } else {
-      result = await requestGateway<ImageAttachResponse>('image.attach', {
-        path,
-        session_id: sessionId
-      })
-    }
-
-    if (!result.attached) {
-      throw new Error(result.message || `Could not attach ${label}`)
-    }
-
-    const attachedPath = result.path || path
-
-    return {
-      ...attachment,
-      attachedSessionId: sessionId,
-      label: attachedPath ? pathLabel(attachedPath) : attachment.label,
-      path: attachedPath,
-      uploadState: undefined
-    }
-  }
-
-  // Non-image file.
-  let dataUrl: string | null = null
+  // Read bytes/paths ONCE, outside the retry. Only the session-scoped RPC is
+  // replayed on recovery — re-reading a multi-MB file to retry a dead session
+  // id would double the disk/IPC cost of every recovered attach.
+  let imagePayload: Awaited<ReturnType<typeof readImageForRemoteAttach>> | null = null
+  let fileDataUrl: null | string = null
 
   if (uploadBytes) {
     try {
-      dataUrl = await readFileDataUrlForAttach(path)
+      if (attachment.kind === 'image') {
+        imagePayload = await readImageForRemoteAttach(path)
+      } else {
+        fileDataUrl = await readFileDataUrlForAttach(path)
+      }
     } catch (err) {
       throw friendlyRemoteAttachError(err, label)
     }
 
-    if (!dataUrl) {
+    if (attachment.kind === 'image' ? !imagePayload : !fileDataUrl) {
       throw new Error(`Could not read ${label}`)
     }
   }
 
-  const result = await requestGateway<FileAttachResponse>('file.attach', {
-    name: label,
-    path,
-    session_id: sessionId,
-    ...(dataUrl ? { data_url: dataUrl } : {})
-  })
+  const stageForSession = async (liveSessionId: string): Promise<ComposerAttachment> => {
+    if (attachment.kind === 'image') {
+      const result = imagePayload
+        ? await requestGateway<ImageAttachResponse>('image.attach_bytes', {
+            session_id: liveSessionId,
+            content_base64: imagePayload.contentBase64,
+            filename: imagePayload.filename
+          })
+        : await requestGateway<ImageAttachResponse>('image.attach', {
+            path,
+            session_id: liveSessionId
+          })
 
-  if (!result.attached || !result.ref_text) {
-    throw new Error(result.message || `Could not attach ${label}`)
+      if (!result.attached) {
+        throw new Error(result.message || `Could not attach ${label}`)
+      }
+
+      const attachedPath = result.path || path
+
+      return {
+        ...attachment,
+        attachedSessionId: liveSessionId,
+        label: attachedPath ? pathLabel(attachedPath) : attachment.label,
+        path: attachedPath,
+        uploadState: undefined
+      }
+    }
+
+    const result = await requestGateway<FileAttachResponse>('file.attach', {
+      name: label,
+      path,
+      session_id: liveSessionId,
+      ...(fileDataUrl ? { data_url: fileDataUrl } : {})
+    })
+
+    if (!result.attached || !result.ref_text) {
+      throw new Error(result.message || `Could not attach ${label}`)
+    }
+
+    return {
+      ...attachment,
+      attachedSessionId: liveSessionId,
+      refText: result.ref_text,
+      uploadState: undefined
+    }
   }
 
-  return {
-    ...attachment,
-    attachedSessionId: sessionId,
-    refText: result.ref_text,
-    uploadState: undefined
+  // Attach runs BEFORE prompt.submit, so submit's own recovery never gets a
+  // chance: a stale runtime id fails here first and the user sees "session not
+  // found" on an image while plain text works.
+  const { result, sessionId: usedSessionId } = await withSessionNotFoundResume(
+    opts.sessionId,
+    storedSessionId,
+    stageForSession,
+    { requestGateway }
+  )
+
+  if (usedSessionId !== opts.sessionId) {
+    onSessionRecovered?.(usedSessionId)
   }
+
+  return result
 }
 
 interface PromptActionsOptions {
@@ -300,10 +318,18 @@ export function usePromptActions({
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
-    ): Promise<ComposerAttachment[]> => {
+    ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
       const remote = $connection.get()?.mode === 'remote'
+      const storedSessionId = selectedStoredSessionIdRef.current
+      let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
+
+      const onSessionRecovered = (recoveredId: string) => {
+        liveSessionId = recoveredId
+        activeSessionIdRef.current = recoveredId
+        setActiveSessionId(recoveredId)
+      }
 
       for (const original of attachments) {
         let attachment = original
@@ -322,8 +348,10 @@ export function usePromptActions({
 
         // Already-synced or pathless refs (terminal, url, etc.) pass through.
         // A drop-time eager upload may already have staged this one (matching
-        // attachedSessionId) — don't re-upload it.
-        if (!attachment.path || attachment.attachedSessionId === sessionId) {
+        // attachedSessionId) — don't re-upload it. Compare against the LIVE id:
+        // after a mid-loop recovery an earlier chip's attachedSessionId points
+        // at the dead runtime and must be re-staged.
+        if (!attachment.path || attachment.attachedSessionId === liveSessionId) {
           synced.push(attachment)
 
           continue
@@ -334,7 +362,9 @@ export function usePromptActions({
             backendCwd: $currentCwd.get(),
             remote,
             requestGateway,
-            sessionId
+            sessionId: liveSessionId,
+            storedSessionId,
+            onSessionRecovered
           })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
@@ -350,9 +380,9 @@ export function usePromptActions({
         synced.push(attachment)
       }
 
-      return synced
+      return { attachments: synced, sessionId: liveSessionId }
     },
-    [requestGateway]
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
   )
 
   // Stage a freshly dropped file as soon as it lands (when a session already
@@ -627,38 +657,22 @@ export function usePromptActions({
     clearClarifyRequest(undefined, sessionId)
 
     try {
-      await requestGateway('session.interrupt', { session_id: sessionId })
+      await withSessionNotFoundResume(
+        sessionId,
+        selectedStoredSessionIdRef.current,
+        liveId => requestGateway('session.interrupt', { session_id: liveId }),
+        {
+          requestGateway,
+          onRecovered: recoveredId => {
+            activeSessionIdRef.current = recoveredId
+            setActiveSessionId(recoveredId)
+          }
+        }
+      )
       releaseBusy()
     } catch (err) {
-      let stopError = err
-
-      if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
-        try {
-          const resumeProfile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
-
-          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: selectedStoredSessionIdRef.current,
-            source: 'desktop',
-            omit_messages: true,
-            ...(resumeProfile ? { profile: resumeProfile } : {})
-          })
-
-          const recoveredId = resumed?.session_id
-
-          if (recoveredId) {
-            activeSessionIdRef.current = recoveredId
-            await requestGateway('session.interrupt', { session_id: recoveredId })
-            releaseBusy()
-
-            return
-          }
-        } catch (resumeErr) {
-          stopError = resumeErr
-        }
-      }
-
       releaseBusy()
-      notifyError(stopError, copy.stopFailed)
+      notifyError(err, copy.stopFailed)
     }
   }, [activeSessionIdRef, busyRef, copy.stopFailed, requestGateway, selectedStoredSessionIdRef, updateSessionState])
 
@@ -733,33 +747,19 @@ export function usePromptActions({
       }
 
       try {
-        return await send(sessionId)
-      } catch (err) {
-        // A stale runtime id after reconnect 404s ("session not found"): resume
-        // the stored session and retry once, mirroring stopPrompt so a
+        // A stale runtime id after reconnect 404s ("session not found"): the
+        // shared resolver resumes the stored session and retries once, so a
         // correction right after a reconnect isn't lost to the race.
-        if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
-          try {
-            const resumeProfile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
-
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: selectedStoredSessionIdRef.current,
-              source: 'desktop',
-              omit_messages: true,
-              ...(resumeProfile ? { profile: resumeProfile } : {})
-            })
-
-            const recoveredId = resumed?.session_id
-
-            if (recoveredId) {
-              activeSessionIdRef.current = recoveredId
-
-              return await send(recoveredId)
-            }
-          } catch {
-            // fall through — caller queues so nothing is lost
+        const { result } = await withSessionNotFoundResume(sessionId, selectedStoredSessionIdRef.current, send, {
+          requestGateway,
+          onRecovered: recoveredId => {
+            activeSessionIdRef.current = recoveredId
+            setActiveSessionId(recoveredId)
           }
-        }
+        })
+
+        return result
+      } catch {
         // Swallow — caller queues the text so nothing is lost.
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -20,7 +20,8 @@ import {
   isSessionBusyError,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal,
-  withSessionBusyRetry
+  withSessionBusyRetry,
+  withSessionNotFoundResume
 } from './utils'
 
 type RequestGateway = <T = unknown>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
@@ -51,32 +52,60 @@ export function truncateSubmitParams(truncateOrdinal: number | undefined): Recor
  * (interrupting an idle agent can leave a stale interrupt flag that cancels the
  * fresh turn); live/stuck turns interrupt first, and a raced "session busy"
  * response interrupts + retries through the shared busy gate.
+ *
+ * A rewind runs right after `cancelRun`, and interrupting can drop the
+ * gateway's in-memory session — so the follow-up submit hits a dead runtime id
+ * and used to surface a bare "session not found" ("Restore checkpoint" failing
+ * after a stop). Pass `recovery` so a stale id re-registers and retries like
+ * every other session-scoped RPC.
  */
 export async function runRewindSubmit(
   requestGateway: RequestGateway,
   sessionId: string,
   text: string,
   truncateOrdinal: number | undefined,
-  interruptFirst: boolean
+  interruptFirst: boolean,
+  recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void }
 ): Promise<void> {
+  // Recovery may rebind the live id mid-flight; interrupt/submit must both
+  // follow it rather than pinning the dead one.
+  let liveSessionId = sessionId
+
   const interrupt = async () => {
     try {
-      await requestGateway('session.interrupt', { session_id: sessionId })
+      await requestGateway('session.interrupt', { session_id: liveSessionId })
     } catch {
       // Best-effort. The submit path still gates on the gateway state.
     }
   }
 
-  const submit = () =>
+  const submitFor = (targetId: string) =>
     requestGateway(
       'prompt.submit',
       {
-        session_id: sessionId,
+        session_id: targetId,
         text,
         ...truncateSubmitParams(truncateOrdinal)
       },
       PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
     )
+
+  const submit = async () => {
+    const { sessionId: usedId } = await withSessionNotFoundResume(
+      liveSessionId,
+      recovery?.storedSessionId,
+      submitFor,
+      {
+        requestGateway,
+        onRecovered: recoveredId => {
+          liveSessionId = recoveredId
+          recovery?.onSessionRecovered?.(recoveredId)
+        }
+      }
+    )
+
+    liveSessionId = usedId
+  }
 
   if (interruptFirst) {
     await interrupt()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -29,6 +29,7 @@ import {
   $sessions,
   $yoloActive,
   resolveComposerSessionKey,
+  setActiveSessionId,
   setCurrentUsage,
   setModelPickerOpen,
   setSessionPickerOpen,
@@ -62,7 +63,8 @@ import {
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
-  type SubmitTextOptions
+  type SubmitTextOptions,
+  withSessionNotFoundResume
 } from './utils'
 
 // Manual compression is LLM-bound and routinely outlives the desktop's 30s
@@ -499,7 +501,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          const { render: renderSlashOutput, sessionId, storedSessionId } = resolved
+          const { render: renderSlashOutput, sessionId: initialSessionId, storedSessionId } = resolved
+          let sessionId = initialSessionId
           const focusTopic = ctx.arg.trim()
           const noticeId = `session-compress:${sessionId}`
 
@@ -518,14 +521,40 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           })
 
           try {
-            const result = await requestGateway<SessionCompressResponse>(
-              'session.compress',
+            // Same stale-runtime recovery as prompt.submit: after sleep/wake a
+            // dead id 404s session.compress while plain chat still works, so
+            // /compress reported "session not found" on a healthy session.
+            // NOT alsoTimeout — compress is legitimately LLM-slow and a
+            // timeout here must not be retried as a dead session.
+            const { result, sessionId: liveSessionId } = await withSessionNotFoundResume(
+              sessionId,
+              storedSessionId,
+              liveId =>
+                requestGateway<SessionCompressResponse>(
+                  'session.compress',
+                  {
+                    session_id: liveId,
+                    ...(focusTopic ? { focus_topic: focusTopic } : {})
+                  },
+                  SESSION_COMPRESS_TIMEOUT_MS
+                ),
               {
-                session_id: sessionId,
-                ...(focusTopic ? { focus_topic: focusTopic } : {})
-              },
-              SESSION_COMPRESS_TIMEOUT_MS
+                requestGateway,
+                onRecovered: recoveredId => {
+                  // Move the in-flight claim onto the live id so the coalesce
+                  // guard releases the right key in `finally`.
+                  compressInFlightRef.current.delete(sessionId)
+                  compressInFlightRef.current.add(recoveredId)
+
+                  if (activeSessionIdRef.current === initialSessionId) {
+                    activeSessionIdRef.current = recoveredId
+                    setActiveSessionId(recoveredId)
+                  }
+                }
+              }
             )
+
+            sessionId = liveSessionId
 
             // Replace the transcript with the post-compress history so the
             // summarized bubbles actually disappear. `messages` is the same

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -23,6 +23,7 @@ import { requestDesktopOnboarding } from '@/store/onboarding'
 import {
   $sessions,
   resolveComposerSessionKey,
+  setActiveSessionId,
   setAwaitingResponse,
   setBusy,
   setMessages,
@@ -39,13 +40,13 @@ import {
   _submitInFlight,
   type GatewayRequest,
   inlineErrorMessage,
-  isGatewayTimeoutError,
   isProviderSetupError,
   isSessionBusyError,
-  isSessionNotFoundError,
   isTargetSessionBusy,
+  SessionRecoveryAborted,
   type SubmitTextOptions,
-  withSessionBusyRetry
+  withSessionBusyRetry,
+  withSessionNotFoundResume
 } from './utils'
 
 interface SubmitPromptDeps {
@@ -63,7 +64,7 @@ interface SubmitPromptDeps {
     sessionId: string,
     attachments: ComposerAttachment[],
     options?: { updateComposerAttachments?: boolean }
-  ) => Promise<ComposerAttachment[]>
+  ) => Promise<{ attachments: ComposerAttachment[]; sessionId: string }>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
@@ -584,23 +585,34 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       try {
-        const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
+        // Attach runs BEFORE prompt.submit, so a stale runtime id fails there
+        // first and submit's own recovery never runs — that asymmetry is why
+        // plain text survived sleep/wake but images reported "session not
+        // found". The attach path recovers and reports the live id back here.
+        const attachResult = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+
+        const syncedAttachments = attachResult.attachments
+        // Always a live string; pin it so TS narrows past the outer
+        // `string | null` sessionId binding for prompt.submit.
+        const liveSessionId = attachResult.sessionId
+
+        sessionId = liveSessionId
 
         const attachmentsDrift = sessionDriftReason()
 
         if (attachmentsDrift) {
           console.warn('[submit-drift-abort]', attachmentsDrift, { phase: 'post-attachments' })
 
-          return abortForSessionSwitch(sessionId)
+          return abortForSessionSwitch(liveSessionId)
         }
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
         // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
-        rewriteOptimistic(sessionId)
+        rewriteOptimistic(liveSessionId)
         const text = buildContextText(syncedAttachments)
 
         const submitParams = (targetId: string) => ({
@@ -616,56 +628,45 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         })
 
         // On sleep/wake the gateway's in-memory session may have been cleared
-        // while the desktop app still holds the old session ID. Detect this,
-        // resume the stored session to re-register it, and retry once.
+        // while the desktop app still holds the old session ID. The shared
+        // resolver re-registers the stored session and retries once; every
+        // other session-scoped RPC (attach, /compress, rewind, interrupt) goes
+        // through the same helper so one policy covers the whole bug class.
         let submitErr: unknown = null
 
         try {
-          await withSessionBusyRetry(() =>
-            requestGateway('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
-          )
-        } catch (firstErr) {
           const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
-          if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && recoverStoredSessionId) {
-            // Re-register the session in the gateway and get a fresh live ID.
-            // Timeouts recover the same way as "session not found": a starved
-            // backend loop (#55578 symptom d) rejects the submit even though
-            // the stored session is fine — resume + retry instead of erroring
-            // out and losing the session binding.
-            const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
-
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: recoverStoredSessionId,
-              source: 'desktop',
-              omit_messages: true,
-              ...(resumeProfile ? { profile: resumeProfile } : {})
-            })
-
-            const resumeRetryDrift = sessionDriftReason()
-
-            if (resumeRetryDrift) {
-              console.warn('[submit-drift-abort]', resumeRetryDrift, { phase: 'post-resume-retry' })
-
-              return abortForSessionSwitch(sessionId)
-            }
-
-            const recoveredId = resumed?.session_id
-
-            if (recoveredId) {
-              if (targetIsCurrentView()) {
-                activeSessionIdRef.current = recoveredId
+          await withSessionNotFoundResume(
+            sessionId,
+            recoverStoredSessionId,
+            liveId =>
+              withSessionBusyRetry(() =>
+                requestGateway('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+              ),
+            {
+              requestGateway,
+              driftReason: sessionDriftReason,
+              onRecovered: recoveredId => {
+                if (targetIsCurrentView()) {
+                  activeSessionIdRef.current = recoveredId
+                  setActiveSessionId(recoveredId)
+                }
               }
+            },
+            // A starved backend loop (#55578 symptom d) rejects the submit even
+            // though the stored session is fine — recover it like a dead id
+            // instead of erroring out and losing the session binding.
+            { alsoTimeout: true }
+          )
+        } catch (firstErr) {
+          if (firstErr instanceof SessionRecoveryAborted) {
+            console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })
 
-              await withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(recoveredId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
-              )
-            } else {
-              submitErr = firstErr
-            }
-          } else {
-            submitErr = firstErr
+            return abortForSessionSwitch(sessionId)
           }
+
+          submitErr = firstErr
         }
 
         if (submitErr !== null) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -7,6 +7,7 @@ import {
   appendText,
   base64FromDataUrl,
   friendlyRemoteAttachError,
+  type GatewayRequest,
   imageFilenameFromPath,
   inlineErrorMessage,
   isSessionBusyError,
@@ -14,9 +15,11 @@ import {
   isSessionNotFoundError,
   readFileDataUrlForAttach,
   renderRpcResult,
+  SessionRecoveryAborted,
   slashStatusText,
   visibleUserIndexAtOrdinal,
-  visibleUserOrdinal
+  visibleUserOrdinal,
+  withSessionNotFoundResume
 } from './utils'
 
 describe('isSessionIdCandidate', () => {
@@ -51,6 +54,207 @@ describe('session error classifiers', () => {
     expect(isSessionBusyError(new Error('session busy'))).toBe(true)
     expect(isSessionNotFoundError(new Error('other'))).toBe(false)
     expect(isSessionBusyError(new Error('other'))).toBe(false)
+  })
+})
+
+describe('withSessionNotFoundResume', () => {
+  const STORED = 'stored-1'
+  const DEAD = 'rt-dead'
+  const FRESH = 'rt-fresh'
+
+  // Profile resolution is injected, so these tests never reach the REST layer.
+  // Before this was a dependency the helper called resolveStoredSession ->
+  // getSession() and its coverage silently depended on $sessions/$profiles
+  // state left behind by whichever test file ran first.
+  const deps = (overrides: Record<string, unknown> = {}) => ({
+    requestGateway: vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return { session_id: FRESH }
+      }
+
+      throw new Error(`unexpected ${method}`)
+    }) as unknown as GatewayRequest,
+    resolveProfile: vi.fn(async () => undefined),
+    ...overrides
+  })
+
+  it('returns the first-call result without resuming when the RPC succeeds', async () => {
+    const d = deps()
+    const call = vi.fn(async (sid: string) => `ok:${sid}`)
+
+    expect(await withSessionNotFoundResume(DEAD, STORED, call, d)).toEqual({
+      recovered: false,
+      result: `ok:${DEAD}`,
+      sessionId: DEAD
+    })
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(d.requestGateway).not.toHaveBeenCalled()
+  })
+
+  // The whole bug class: every session-scoped RPC recovers identically. Before
+  // consolidation only prompt.submit did, so attach/compress/rewind surfaced a
+  // raw "session not found" after sleep while plain text worked.
+  it.each([
+    ['image.attach_bytes', 'attach an image'],
+    ['file.attach', 'attach a file'],
+    ['session.compress', 'run /compress'],
+    ['prompt.submit', 'submit a rewind'],
+    ['session.interrupt', 'stop a turn']
+  ])('resumes and retries once so %s can %s after a stale drop', async rpc => {
+    const d = deps()
+    let attempts = 0
+
+    const call = vi.fn(async (sid: string) => {
+      attempts += 1
+
+      if (attempts === 1) {
+        throw new Error(`${rpc} failed: session not found`)
+      }
+
+      return `ok:${sid}`
+    })
+
+    expect(await withSessionNotFoundResume(DEAD, STORED, call, d)).toEqual({
+      recovered: true,
+      result: `ok:${FRESH}`,
+      sessionId: FRESH
+    })
+    expect(call.mock.calls.map(c => c[0])).toEqual([DEAD, FRESH])
+  })
+
+  it('resumes on the session-owning profile so recovery cannot fork the conversation', async () => {
+    const d = deps({ resolveProfile: vi.fn(async () => 'work') })
+    let first = true
+
+    await withSessionNotFoundResume(
+      DEAD,
+      STORED,
+      async (sid: string) => {
+        if (first) {
+          first = false
+          throw new Error('session not found')
+        }
+
+        return sid
+      },
+      d
+    )
+
+    expect(d.requestGateway).toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ session_id: STORED, source: 'desktop', omit_messages: true, profile: 'work' })
+    )
+  })
+
+  it('publishes the recovered id exactly once', async () => {
+    const onRecovered = vi.fn()
+    const d = deps({ onRecovered })
+    let first = true
+
+    await withSessionNotFoundResume(
+      DEAD,
+      STORED,
+      async (sid: string) => {
+        if (first) {
+          first = false
+          throw new Error('session not found')
+        }
+
+        return sid
+      },
+      d
+    )
+
+    expect(onRecovered).toHaveBeenCalledExactlyOnceWith(FRESH)
+  })
+
+  it('aborts instead of retrying when the user moved on during the resume', async () => {
+    const onRecovered = vi.fn()
+    const d = deps({ driftReason: () => 'selection:a->b', onRecovered })
+
+    const call = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    await expect(withSessionNotFoundResume(DEAD, STORED, call, d)).rejects.toThrow(SessionRecoveryAborted)
+    // Retry suppressed and nothing published: landing it would run against a
+    // session the user is no longer looking at.
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(onRecovered).not.toHaveBeenCalled()
+  })
+
+  it('rethrows the original error when the resume itself 404s (never-persisted draft)', async () => {
+    const d = deps({
+      requestGateway: vi.fn(async () => {
+        throw new Error('resume failed: session not found')
+      }) as unknown as GatewayRequest
+    })
+
+    const call = vi.fn(async () => {
+      throw new Error('prompt.submit failed: original symptom')
+    })
+
+    // The ORIGINAL error, not the secondary resume failure — the double-404
+    // otherwise reported the confusing inner message.
+    await expect(withSessionNotFoundResume(DEAD, STORED, call, d)).rejects.toThrow('original symptom')
+  })
+
+  it('rethrows when no stored session id is available to resume', async () => {
+    const d = deps()
+
+    const call = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    await expect(withSessionNotFoundResume(DEAD, null, call, d)).rejects.toThrow('session not found')
+    expect(d.requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('does not recover a gateway timeout unless the caller opts in', async () => {
+    const d = deps()
+
+    const timeout = vi.fn(async () => {
+      throw new Error('request timed out: session.compress')
+    })
+
+    // /compress is legitimately LLM-slow; retrying its timeout as a dead
+    // session would double a minutes-long call.
+    await expect(withSessionNotFoundResume(DEAD, STORED, timeout, d)).rejects.toThrow('request timed out')
+    expect(d.requestGateway).not.toHaveBeenCalled()
+
+    // prompt.submit opts in: a starved backend loop is indistinguishable from
+    // a dead runtime client-side (#55578).
+    const optIn = deps()
+    let first = true
+
+    expect(
+      await withSessionNotFoundResume(
+        DEAD,
+        STORED,
+        async (sid: string) => {
+          if (first) {
+            first = false
+            throw new Error('request timed out: prompt.submit')
+          }
+
+          return `ok:${sid}`
+        },
+        optIn,
+        { alsoTimeout: true }
+      )
+    ).toMatchObject({ recovered: true, sessionId: FRESH })
+  })
+
+  it('gives up after one retry so a genuinely broken session still surfaces', async () => {
+    const d = deps()
+
+    const call = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    await expect(withSessionNotFoundResume(DEAD, STORED, call, d)).rejects.toThrow('session not found')
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(d.requestGateway).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -53,6 +53,141 @@ export function isSessionNotFoundError(error: unknown): boolean {
 }
 
 /**
+ * Thrown when a stale-session recovery resumed successfully but the caller's
+ * drift check says the user has since moved on (profile swap, route rebind,
+ * a different chat in the foreground). The retry is deliberately NOT attempted:
+ * landing it would run the prompt against a session the user is no longer
+ * looking at. Callers unwind through their own abort path (#66889).
+ */
+export class SessionRecoveryAborted extends Error {
+  constructor(
+    readonly reason: string,
+    readonly recoveredSessionId: string
+  ) {
+    super(`session recovery aborted: ${reason}`)
+    this.name = 'SessionRecoveryAborted'
+  }
+}
+
+export interface SessionRecoveryDeps {
+  requestGateway: GatewayRequest
+  /**
+   * Owning profile for a stored session. A resume without it lands on
+   * whichever gateway is active and forks the conversation into the wrong
+   * profile's DB (#67603).
+   *
+   * Injected rather than imported so this module stays free of the session
+   * store and the REST layer: the default implementation reaches through
+   * `resolveStoredSession` → `getSession()`, a real fetch that makes any unit
+   * test of this helper depend on leftover `$sessions` / `$profiles` state.
+   */
+  resolveProfile?: (storedSessionId: string) => Promise<string | undefined>
+  /**
+   * Publish the fresh live id. Implementations must update BOTH the hot ref
+   * and the `$activeSessionId` atom — a ref-only write leaves the atom
+   * pointing at the dead runtime and every atom-reading surface desyncs
+   * (#62471).
+   */
+  onRecovered?: (liveSessionId: string) => void
+  /**
+   * Non-null reason ⇒ abort instead of retrying. Evaluated AFTER the resume
+   * and BEFORE the retry, because the resume is the slow await during which a
+   * profile switch or route rebind can land.
+   */
+  driftReason?: () => null | string
+}
+
+async function defaultResolveProfile(storedSessionId: string): Promise<string | undefined> {
+  // Lazy so utils.ts has no init-time cycle with use-session-actions.
+  const { resolveSessionProfile } = await import('../use-session-actions/utils')
+
+  return resolveSessionProfile(storedSessionId)
+}
+
+/**
+ * Re-register a durable stored session after the gateway dropped its
+ * in-memory runtime id (sleep/wake, remote backend restart, long idle).
+ * Returns the fresh live id, or null when the resume yields none.
+ */
+export async function resumeStoredRuntimeSession(
+  storedSessionId: string,
+  deps: SessionRecoveryDeps
+): Promise<null | string> {
+  const resolveProfile = deps.resolveProfile ?? defaultResolveProfile
+  const profile = await resolveProfile(storedSessionId)
+
+  const resumed = await deps.requestGateway<{ session_id: string }>('session.resume', {
+    session_id: storedSessionId,
+    source: 'desktop',
+    omit_messages: true,
+    ...(profile ? { profile } : {})
+  })
+
+  return resumed?.session_id ?? null
+}
+
+/**
+ * Single resolver for "the runtime session id I hold is dead."
+ *
+ * Every session-scoped RPC needs this, not just `prompt.submit`. Attach,
+ * `/compress`, checkpoint restore, and interrupt all run against the same
+ * runtime id and all used to surface a raw "session not found" after sleep —
+ * while plain text silently recovered, which is why the bug reads as "text
+ * works, images don't."
+ *
+ * Runs `call(sessionId)`. On a stale-session error it resumes the stored
+ * session ONCE, republishes the fresh id, and retries. Bounded to a single
+ * retry: a second failure is a real error, not a stale binding.
+ *
+ * A resume that itself 404s (a never-persisted first-submit draft has no DB
+ * row until its first successful submit) rethrows the ORIGINAL error rather
+ * than the confusing secondary one (#67539).
+ */
+export async function withSessionNotFoundResume<T>(
+  sessionId: string,
+  storedSessionId: null | string | undefined,
+  call: (liveSessionId: string) => Promise<T>,
+  deps: SessionRecoveryDeps,
+  options?: { alsoTimeout?: boolean }
+): Promise<{ recovered: boolean; result: T; sessionId: string }> {
+  try {
+    return { recovered: false, result: await call(sessionId), sessionId }
+  } catch (err) {
+    // A starved backend loop rejects with a timeout that is indistinguishable
+    // from a dead runtime on the client side (#55578). Opt-in per caller:
+    // submit recovers from it, a compress/attach retry should not mask a
+    // genuinely slow LLM-bound call.
+    const recoverable = isSessionNotFoundError(err) || (Boolean(options?.alsoTimeout) && isGatewayTimeoutError(err))
+
+    if (!recoverable || !storedSessionId) {
+      throw err
+    }
+
+    let recoveredId: null | string
+
+    try {
+      recoveredId = await resumeStoredRuntimeSession(storedSessionId, deps)
+    } catch {
+      throw err
+    }
+
+    if (!recoveredId) {
+      throw err
+    }
+
+    const drift = deps.driftReason?.()
+
+    if (drift) {
+      throw new SessionRecoveryAborted(drift, recoveredId)
+    }
+
+    deps.onRecovered?.(recoveredId)
+
+    return { recovered: true, result: await call(recoveredId), sessionId: recoveredId }
+  }
+}
+
+/**
  * Is the session a prompt is about to run against currently mid-turn?
  *
  * The foreground `busyRef` is NOT the answer. It mirrors whatever chat is on


### PR DESCRIPTION
## Summary

After sleep/wake, a long idle, or a remote backend restart, the gateway drops its in-memory runtime session while the desktop still holds the old id. `prompt.submit` already recovered from this — so plain text kept working and the failure looked oddly selective: attaching an image or running `/compress` in the same chat died with a bare **"session not found"**, and starting a new chat was the only workaround.

The reason attach fails while text succeeds is ordering: attach runs *before* `prompt.submit`, so submit's recovery never gets a chance. The same gap existed on every session-scoped RPC that never got its own copy of the recovery — checkpoint restore, and the session-tile delegate's interrupt/submit.

Underneath, `main` carried **three** hand-rolled copies of one recovery policy — `prompt.submit` (`submit.ts`), `session.interrupt` (`cancelRun`), and `session.redirect` (steering) each open-coding `isSessionNotFoundError` → `resolveSessionProfile` → `session.resume` → retry. Adding a fourth copy per broken RPC is how these call sites drifted apart in the first place, so this consolidates them onto one resolver and routes every remaining path through it.

## What changed

- **One resolver.** `withSessionNotFoundResume()` in `use-prompt-actions/utils.ts`; all three pre-existing inline copies migrated onto it.
- **Recovery extended to the whole bug class:** `image.attach_bytes`, `image.attach`, `file.attach`, `session.compress`, checkpoint-restore (`runRewindSubmit`), the session-tile attach path, and the tile delegate's `interrupt` / `submit`.
- **Injected profile resolution.** The helper takes `resolveProfile` as a dependency instead of importing it. This keeps `utils.ts` free of the session store and the REST layer — and makes the recovery unit-testable without depending on ambient store state (see Testing).
- **Atom sync on recovery.** Recovery now writes both the hot ref *and* `$activeSessionId`; a ref-only write left the atom pointing at the dead runtime and every atom-reading surface desynced.
- **Drift is honored.** `driftReason` is evaluated after the resume and before the retry (the resume is the slow await where a profile switch or route rebind lands). A drifted recovery raises `SessionRecoveryAborted` and each caller unwinds through its own existing abort path — so a recovery can never resume onto a session the user has moved away from, or fork into another profile's DB.
- **Original error preserved.** A resume that itself 404s (a never-persisted first-submit draft has no DB row until its first successful submit) rethrows the *original* error, not the confusing secondary one.
- **Bounded and cost-aware.** Exactly one retry — a second failure is a real error. Attachment bytes are read once, outside the retry. Timeout recovery is opt-in per caller: `prompt.submit` takes it (a starved backend loop is indistinguishable from a dead runtime client-side), `/compress` deliberately does not, since it is legitimately LLM-slow and retrying its timeout would double a minutes-long call.

## Supersedes

Every PR below is on this same bug class. Where a fix is already correct it is preserved and credited; the shared parts are unified rather than landed N times.

| PR | Author | What it contributed |
|---|---|---|
| #79805 | @xxxigm | attach + `/compress` recovery; the `withSessionNotFoundResume` idea |
| #61440 | @zzz163519 | `file.attach` recovery |
| #70113 | @JonthanaHanh | checkpoint-restore recovery |
| #62471 | @luxles | `$activeSessionId` atom desync after recovery |
| #67539 | @JonthanaHanh | resume-itself-404s guard for never-persisted drafts |
| #67503 | @rapsealk | first-submit draft recovery (same bug, larger take) |
| #67575 | @webtecnica | first-submit double-404 |
| #66889 | @akivavh | recovery must not resume across a profile switch |

Supersedes #79805, #61440, #70113, #62471, #67539, #67503, #67575, #66889.

Closes #61285, #67502, #70077.

## Testing

`apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts` covers the bug class table-driven across every affected RPC, plus the invariants the three scattered copies disagreed on: resume targets the session-owning profile, the recovered id publishes exactly once, drift aborts instead of retrying, a double-404 rethrows the original error, timeout recovery is opt-in, and recovery is bounded to one retry.

Worth flagging for whoever reviews: #79805's version of this test **passed alone but timed out at 15s when run alongside `index.test.tsx`**, because the helper reached through `resolveStoredSession` → `getSession()` and its coverage depended on `$sessions` / `$profiles` state left behind by whichever file ran first. CI sharding hid it. Injecting `resolveProfile` removes the REST dependency entirely — the suite now runs in ~45ms instead of ~2.5s.

```
vitest run --project ui src/app/session/hooks/use-prompt-actions/
  → 158 passed (4 files)
tsc -p . --noEmit   → clean
eslint              → clean (2 pre-existing warnings on main untouched)
```

Existing drift-abort coverage (`#54527`, `#62562`, `#62805`, `#64327`) still passes unchanged, which is the check that matters most here — the consolidation preserves each caller's abort semantics rather than flattening them.

## Verification

Remote gateway, desktop: let a chat go idle (or sleep the laptop / restart the backend), then in the **same** chat — attach an image, run `/compress`, restore a checkpoint, and stop a turn. Each should recover silently instead of reporting "session not found". A tile left open across the same drop should also keep working.
