### PR TITLE
fix(gateway): isolate bounded workers and recover interrupted turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10778,6 +10778,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
 
+    async def _consume_clean_shutdown_marker(self, marker_path) -> int:
+        """Discard orphan turn markers before consuming a clean-exit receipt.
+
+        If either persistence or marker removal fails, startup must fail closed.
+        Continuing with the old receipt would let a later unclean exit masquerade
+        as clean and discard genuinely interrupted turns.
+        """
+        discarded = await self.async_session_store.discard_active_turn_markers()
+        marker_path.unlink()
+        return discarded
+
     async def _recover_unclean_sessions(self) -> tuple[int, int]:
         """Recover exact active turns, then run the legacy recency fallback."""
         exact = 0
@@ -11146,18 +11157,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _clean_marker.exists():
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
-                discarded = await self.async_session_store.discard_active_turn_markers()
-                if discarded:
-                    logger.info(
-                        "Discarded %d orphan active-turn marker(s) after clean shutdown",
-                        discarded,
-                    )
+                discarded = await self._consume_clean_shutdown_marker(_clean_marker)
             except Exception as exc:
-                logger.warning("Clean-start marker cleanup failed: %s", exc)
-            try:
-                _clean_marker.unlink()
-            except Exception:
-                pass
+                logger.error(
+                    "Clean-start marker cleanup failed; refusing startup so the "
+                    "clean-exit receipt cannot mask a later unclean exit: %s",
+                    exc,
+                )
+                raise RuntimeError("clean-start recovery cleanup failed") from exc
+            if discarded:
+                logger.info(
+                    "Discarded %d orphan active-turn marker(s) after clean shutdown",
+                    discarded,
+                )
         else:
             exact, fallback = await self._recover_unclean_sessions()
             recovered = exact + fallback

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10778,6 +10778,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
 
+    async def _recover_unclean_sessions(self) -> tuple[int, int]:
+        """Recover exact active turns, then run the legacy recency fallback."""
+        exact = 0
+        fallback = 0
+        try:
+            exact = await self.async_session_store.recover_interrupted_turns()
+        except Exception as exc:
+            logger.warning("Exact active-turn recovery on startup failed: %s", exc)
+        try:
+            fallback = await self.async_session_store.suspend_recently_active(
+                max_age_seconds=120
+            )
+        except Exception as exc:
+            logger.warning("Legacy session recovery on startup failed: %s", exc)
+        return exact, fallback
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -11113,10 +11129,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
-        # Suspend sessions that were active when the gateway last exited.
-        # This prevents stuck sessions from being blindly resumed on restart,
-        # which can create an unrecoverable loop (#7536).  Suspended sessions
-        # auto-reset on the next incoming message, giving the user a clean start.
+        # Recover sessions that were active when the gateway last exited.
+        # Exact durable turn markers cover long-running work; the 120-second
+        # recency heuristic remains as an upgrade fallback for turns started by
+        # older Hermes versions that did not write exact markers.
         #
         # SKIP suspension after a clean (graceful) shutdown — the previous
         # process already drained active agents, so sessions aren't stuck.
@@ -11126,16 +11142,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _clean_marker.exists():
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
+                discarded = await self.async_session_store.discard_active_turn_markers()
+                if discarded:
+                    logger.info(
+                        "Discarded %d orphan active-turn marker(s) after clean shutdown",
+                        discarded,
+                    )
+            except Exception as exc:
+                logger.warning("Clean-start marker cleanup failed: %s", exc)
+            try:
                 _clean_marker.unlink()
             except Exception:
                 pass
         else:
-            try:
-                suspended = await self.async_session_store.suspend_recently_active()
-                if suspended:
-                    logger.info("Marked %d in-flight session(s) as resumable from previous run", suspended)
-            except Exception as e:
-                logger.warning("Session suspension on startup failed: %s", e)
+            exact, fallback = await self._recover_unclean_sessions()
+            recovered = exact + fallback
+            if recovered:
+                logger.info(
+                    "Marked %d in-flight session(s) as resumable from previous run "
+                    "(%d exact, %d legacy)",
+                    recovered,
+                    exact,
+                    fallback,
+                )
 
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
@@ -15923,6 +15952,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # and interrupt alike.
             self._restore_moa_one_shot(event, _quick_key)
             self._restore_pending_one_turn_model_override(_quick_key)
+            # Normal completion/exception/interrupt owns and clears this exact
+            # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
+            # the next unclean startup's recovery pass.
+            await self._clear_durable_active_turn(event)
             # Unconditional release covers every exit path. _release_running_agent_state
             # is idempotent (pop-on-absent is harmless) and, called without a
             # run_generation guard, always clears the slot regardless of which
@@ -16452,6 +16485,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             facade = AsyncSessionStore(self.session_store)
             self._async_session_store = facade
         return facade
+
+    async def _mark_durable_active_turn(
+        self,
+        event: "MessageEvent",
+        session_key: str,
+    ) -> bool:
+        """Persist the exact resolved routing key for this running turn."""
+        try:
+            token = await self.async_session_store.mark_turn_active(session_key)
+        except Exception as exc:
+            logger.warning(
+                "Could not persist active-turn marker for %s: %s",
+                session_key,
+                exc,
+            )
+            return False
+        if not token:
+            return False
+        # Private event attributes are process-local ownership state.  Keep the
+        # token out of public metadata, transcripts, and platform payloads.
+        setattr(event, "_gateway_active_turn_session_key", session_key)
+        setattr(event, "_gateway_active_turn_token", token)
+        return True
+
+    async def _clear_durable_active_turn(self, event: "MessageEvent") -> bool:
+        """Best-effort CAS clear of the marker owned by *event*."""
+        session_key = getattr(event, "_gateway_active_turn_session_key", None)
+        token = getattr(event, "_gateway_active_turn_token", None)
+        try:
+            if not session_key or not token:
+                return False
+            return bool(
+                await self.async_session_store.clear_turn_active(session_key, token)
+            )
+        except Exception as exc:
+            # Never let marker cleanup block in-memory agent/lease release.  A
+            # stale marker is safer than wedging the live routing slot and is
+            # bounded by recover_interrupted_turns' maximum age.
+            logger.warning(
+                "Could not clear active-turn marker for %s: %s",
+                session_key,
+                exc,
+            )
+            return False
+        finally:
+            for attr in (
+                "_gateway_active_turn_session_key",
+                "_gateway_active_turn_token",
+            ):
+                try:
+                    delattr(event, attr)
+                except AttributeError:
+                    pass
 
     def _get_cached_session_source(self, session_key: str):
         if not session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10783,7 +10783,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         exact = 0
         fallback = 0
         try:
-            exact = await self.async_session_store.recover_interrupted_turns()
+            agent_timeout = max(1.0, _float_env("HERMES_AGENT_TIMEOUT", 1800))
+            marker_max_age = max(60 * 60, int(agent_timeout * 2))
+            exact = await self.async_session_store.recover_interrupted_turns(
+                max_age_seconds=marker_max_age
+            )
         except Exception as exc:
             logger.warning("Exact active-turn recovery on startup failed: %s", exc)
         try:
@@ -16516,17 +16520,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             if not session_key or not token:
                 return False
-            return bool(
-                await self.async_session_store.clear_turn_active(session_key, token)
-            )
-        except Exception as exc:
+            last_error: Optional[Exception] = None
+            for attempt in range(1, 4):
+                try:
+                    return bool(
+                        await self.async_session_store.clear_turn_active(
+                            session_key, token
+                        )
+                    )
+                except Exception as exc:
+                    last_error = exc
+                    if attempt < 3:
+                        logger.debug(
+                            "Retrying active-turn marker cleanup for %s (%d/3): %s",
+                            session_key,
+                            attempt,
+                            exc,
+                        )
             # Never let marker cleanup block in-memory agent/lease release.  A
-            # stale marker is safer than wedging the live routing slot and is
-            # bounded by recover_interrupted_turns' maximum age.
+            # stale marker is bounded by the configured agent timeout and the
+            # clean-start orphan-marker discard path.
             logger.warning(
-                "Could not clear active-turn marker for %s: %s",
+                "Could not clear active-turn marker for %s after 3 attempts: %s",
                 session_key,
-                exc,
+                last_error,
             )
             return False
         finally:
@@ -16881,6 +16898,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _lease_state = self._session_state(_quick_key).turn
                 _lease_state.lease_token = _lease_token
                 _lease_state.lease_generation = run_generation
+
+        # A turn only becomes durable recovery work after it owns (or has
+        # explicitly degraded past) the per-session lease.  Marking before the
+        # await above would falsely recover an alias-routed message that never
+        # began processing if the gateway died while it was still waiting.
+        await self._mark_durable_active_turn(event, session_entry.session_key)
 
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2829,7 +2829,7 @@ class SessionStore:
 
     def recover_interrupted_turns(
         self,
-        max_age_seconds: int = 7 * 24 * 60 * 60,
+        max_age_seconds: int = 60 * 60,
     ) -> int:
         """Promote exact crash-left turn markers into ``resume_pending``.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -852,6 +852,13 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Durable ownership marker for the agent turn currently executing on this
+    # routing entry.  A normal unwind clears it with compare-and-swap semantics;
+    # SIGKILL/OOM leaves it behind so the next unclean startup can recover the
+    # exact interrupted session instead of guessing from ``updated_at``.
+    active_turn_token: Optional[str] = None
+    active_turn_started_at: Optional[datetime] = None
+
     # Session-scoped /model override (model/provider/base_url ONLY — never
     # credentials).  ``_session_model_overrides`` in the gateway runner is
     # in-memory, so before this field a gateway restart silently reverted
@@ -888,6 +895,12 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "active_turn_token": self.active_turn_token,
+            "active_turn_started_at": (
+                self.active_turn_started_at.isoformat()
+                if self.active_turn_started_at
+                else None
+            ),
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -922,6 +935,20 @@ class SessionEntry:
                 last_resume_marked_at = datetime.fromisoformat(_lrma)
             except (TypeError, ValueError):
                 last_resume_marked_at = None
+
+        active_turn_started_at = None
+        _atsa = data.get("active_turn_started_at")
+        if _atsa:
+            try:
+                active_turn_started_at = datetime.fromisoformat(_atsa)
+            except (TypeError, ValueError):
+                active_turn_started_at = None
+        active_turn_token = data.get("active_turn_token")
+        if not isinstance(active_turn_token, str) or not active_turn_token:
+            # The token/timestamp pair is written atomically.  A partial or
+            # malformed pair is not trustworthy enough to auto-resume.
+            active_turn_token = None
+            active_turn_started_at = None
 
         session_key = data["session_key"]
         session_id = data["session_id"]
@@ -965,6 +992,8 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            active_turn_token=active_turn_token,
+            active_turn_started_at=active_turn_started_at,
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -2755,6 +2784,125 @@ class SessionStore:
                 self._save()
                 return True
         return False
+
+    def mark_turn_active(self, session_key: str) -> Optional[str]:
+        """Persist exact ownership of the agent turn running for *session_key*.
+
+        The opaque token is returned to the caller and must be supplied to
+        :meth:`clear_turn_active`.  Re-marking replaces the previous token so
+        a stale asynchronous unwind cannot clear a newer turn.
+        """
+        token = uuid.uuid4().hex
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            now = _now()
+            entry.active_turn_token = token
+            entry.active_turn_started_at = now
+            # Keep the legacy 120-second startup heuristic effective during a
+            # rolling downgrade/upgrade window where an older binary cannot
+            # understand the exact marker fields.
+            entry.updated_at = now
+
+        # This is a per-turn metadata update, so use the existing durable
+        # single-entry fast path rather than rewriting the full routing index.
+        self._save_entry(session_key)
+        return token
+
+    def clear_turn_active(self, session_key: str, token: str) -> bool:
+        """Compare-and-swap clear an active-turn marker.
+
+        Returns ``False`` when the entry disappeared or a newer turn owns it.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.active_turn_token != token:
+                return False
+            entry.active_turn_token = None
+            entry.active_turn_started_at = None
+
+        self._save_entry(session_key)
+        return True
+
+    def recover_interrupted_turns(
+        self,
+        max_age_seconds: int = 7 * 24 * 60 * 60,
+    ) -> int:
+        """Promote exact crash-left turn markers into ``resume_pending``.
+
+        This must only be called by the unclean-startup path.  Old or invalid
+        markers are cleared without resuming so a downgrade/re-upgrade cycle
+        cannot revive arbitrarily stale work.  Explicitly suspended sessions
+        are likewise never re-armed.
+
+        Returns the number of newly promoted sessions.
+        """
+        from datetime import timedelta
+
+        now = _now()
+        max_age = timedelta(seconds=max(0, max_age_seconds))
+        promoted = 0
+        changed = False
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if not entry.active_turn_token:
+                    continue
+
+                started_at = entry.active_turn_started_at
+                try:
+                    marker_is_stale = (
+                        started_at is None
+                        or (max_age_seconds > 0 and now - started_at > max_age)
+                    )
+                except TypeError:
+                    # Mixed aware/naive timestamps are invalid for this local
+                    # marker.  Clear rather than risking an unsafe old resume.
+                    marker_is_stale = True
+
+                if not marker_is_stale and not entry.suspended:
+                    if entry.resume_pending:
+                        # A drain-timeout marker is more specific than the
+                        # generic crash reason; preserve it and its freshness.
+                        if entry.last_resume_marked_at is None:
+                            entry.last_resume_marked_at = now
+                    else:
+                        entry.resume_pending = True
+                        entry.resume_reason = "restart_interrupted"
+                        # Freshness starts when recovery is discovered, not
+                        # when a potentially hours-long turn began.
+                        entry.last_resume_marked_at = now
+                        promoted += 1
+
+                entry.active_turn_token = None
+                entry.active_turn_started_at = None
+                changed = True
+
+            if changed:
+                # Cold-start batch: one durable rewrite is clearer and cheaper
+                # than an upsert per interrupted routing entry.
+                self._save()
+
+        return promoted
+
+    def discard_active_turn_markers(self) -> int:
+        """Clear orphan turn markers after a verified clean shutdown."""
+        cleared = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if not entry.active_turn_token and entry.active_turn_started_at is None:
+                    continue
+                entry.active_turn_token = None
+                entry.active_turn_started_at = None
+                cleared += 1
+            if cleared:
+                self._save()
+        return cleared
 
     def mark_resume_pending(
         self,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1697,14 +1697,10 @@ class SessionStore:
             )
             entry_json = json.dumps(serialized_entry)
             revision = self._next_routing_generation_locked()
-            fallback_data: Optional[Dict[str, Any]] = None
-            if entry_data is not None:
-                fallback_data = {
-                    key: current.to_dict()
-                    for key, current in self._entries.items()
-                }
-                fallback_data[session_key] = serialized_entry
-            return entry_json, revision, fallback_data
+            # Don't eagerly build the O(n) full snapshot — only the candidate
+            # is needed for the DB upsert.  The fallback is deferred to the
+            # except branch below where it's actually used.
+            return entry_json, revision, serialized_entry if entry_data is not None else None
 
         if lock_held:
             captured = _capture()
@@ -1713,7 +1709,7 @@ class SessionStore:
                 captured = _capture()
         if captured is None:
             return
-        entry_json, revision, fallback_data = captured
+        entry_json, revision, candidate_entry = captured
         _db = getattr(self, "_db", None)
         saver = getattr(_db, "save_gateway_routing_entry", None) if _db else None
         if callable(saver):
@@ -1741,7 +1737,23 @@ class SessionStore:
                     "(%s); falling back to full index rewrite",
                     session_key, exc,
                 )
-        if fallback_data is not None:
+        if candidate_entry is not None:
+            # DB upsert failed (or no DB): build the full snapshot now, carrying
+            # the candidate entry so the fallback persists the intended
+            # transition rather than re-snapshotting the unchanged live value.
+            if lock_held:
+                # Caller already holds _lock — build snapshot in-place.
+                fallback_data: Dict[str, Any] = {
+                    key: current.to_dict()
+                    for key, current in self._entries.items()
+                }
+            else:
+                with self._lock:
+                    fallback_data = {
+                        key: current.to_dict()
+                        for key, current in self._entries.items()
+                    }
+            fallback_data[session_key] = candidate_entry
             self._persist_routing_data(fallback_data, revision)
         else:
             self._save_entries()

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1567,7 +1567,18 @@ class SessionStore:
                             "gateway.session: state.db routing save failed: %s", exc
                         )
             if getattr(self, "_write_sessions_json", True) or not db_saved:
-                self._save_sessions_json(data)
+                try:
+                    self._save_sessions_json(data)
+                except Exception as exc:
+                    if not db_saved:
+                        raise
+                    # state.db is authoritative. A failed legacy mirror must not
+                    # report the already-committed primary write as failed.
+                    logger.warning(
+                        "gateway.session: sessions.json mirror save failed "
+                        "after state.db commit: %s",
+                        exc,
+                    )
             self._persisted_routing_generation = generation
             # This rewrite supersedes fast records at or below its
             # generation; newer ones stay for the next delayed full writer.
@@ -1624,7 +1635,13 @@ class SessionStore:
             data, generation = self._snapshot_routing_locked()
         self._persist_routing_data(data, generation)
 
-    def _save_entry(self, session_key: str) -> None:
+    def _save_entry(
+        self,
+        session_key: str,
+        *,
+        entry_data: Optional[Dict[str, Any]] = None,
+        lock_held: bool = False,
+    ) -> None:
         """Persist ONE routing entry via UPSERT — the per-turn fast path.
 
         The steady-state turn only bumps ``updated_at`` /
@@ -1665,13 +1682,38 @@ class SessionStore:
         - No DB, or a failed upsert, falls back to the full rewrite so
           DB-less installs keep sessions.json — their primary store —
           durable every turn.
+
+        ``entry_data`` lets a failure-atomic metadata transition persist a
+        candidate before publishing it to the live entry.  Its full-save
+        fallback carries the same candidate instead of re-snapshotting the
+        unchanged live value.
         """
-        with self._lock:
+        def _capture() -> Optional[tuple[str, int, Optional[Dict[str, Any]]]]:
             entry = self._entries.get(session_key)
             if entry is None:
-                return
-            entry_json = json.dumps(entry.to_dict())
+                return None
+            serialized_entry = (
+                dict(entry_data) if entry_data is not None else entry.to_dict()
+            )
+            entry_json = json.dumps(serialized_entry)
             revision = self._next_routing_generation_locked()
+            fallback_data: Optional[Dict[str, Any]] = None
+            if entry_data is not None:
+                fallback_data = {
+                    key: current.to_dict()
+                    for key, current in self._entries.items()
+                }
+                fallback_data[session_key] = serialized_entry
+            return entry_json, revision, fallback_data
+
+        if lock_held:
+            captured = _capture()
+        else:
+            with self._lock:
+                captured = _capture()
+        if captured is None:
+            return
+        entry_json, revision, fallback_data = captured
         _db = getattr(self, "_db", None)
         saver = getattr(_db, "save_gateway_routing_entry", None) if _db else None
         if callable(saver):
@@ -1699,7 +1741,10 @@ class SessionStore:
                     "(%s); falling back to full index rewrite",
                     session_key, exc,
                 )
-        self._save_entries()
+        if fallback_data is not None:
+            self._persist_routing_data(fallback_data, revision)
+        else:
+            self._save_entries()
 
     def _resolve_profile_for_key(self, source: Optional[SessionSource] = None) -> Optional[str]:
         """Return the profile namespace for session keys, or None when off.
@@ -2799,16 +2844,24 @@ class SessionStore:
             if entry is None:
                 return None
             now = _now()
-            entry.active_turn_token = token
-            entry.active_turn_started_at = now
+            candidate = entry.to_dict()
+            candidate["active_turn_token"] = token
+            candidate["active_turn_started_at"] = now.isoformat()
             # Keep the legacy 120-second startup heuristic effective during a
             # rolling downgrade/upgrade window where an older binary cannot
             # understand the exact marker fields.
-            entry.updated_at = now
+            candidate["updated_at"] = now.isoformat()
 
-        # This is a per-turn metadata update, so use the existing durable
-        # single-entry fast path rather than rewriting the full routing index.
-        self._save_entry(session_key)
+            # Persist before publishing the marker in memory.  If the durable
+            # write raises, a later unrelated save cannot leak an unowned token.
+            self._save_entry(
+                session_key,
+                entry_data=candidate,
+                lock_held=True,
+            )
+            entry.active_turn_token = token
+            entry.active_turn_started_at = now
+            entry.updated_at = now
         return token
 
     def clear_turn_active(self, session_key: str, token: str) -> bool:
@@ -2821,10 +2874,19 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or entry.active_turn_token != token:
                 return False
+            candidate = entry.to_dict()
+            candidate["active_turn_token"] = None
+            candidate["active_turn_started_at"] = None
+
+            # Keep the live token until the clear is durable.  A failed write
+            # therefore remains retryable instead of becoming a false mismatch.
+            self._save_entry(
+                session_key,
+                entry_data=candidate,
+                lock_held=True,
+            )
             entry.active_turn_token = None
             entry.active_turn_started_at = None
-
-        self._save_entry(session_key)
         return True
 
     def recover_interrupted_turns(

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -9,7 +9,7 @@ marker, compare-and-swap cleanup, and promotion into the existing
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -354,6 +354,48 @@ def test_clean_startup_discards_orphan_markers_without_resuming(tmp_path):
     assert recovered.resume_pending is False
     assert recovered.active_turn_token is None
     assert recovered.active_turn_started_at is None
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_marker_is_not_consumed_when_discard_fails(tmp_path):
+    marker = tmp_path / ".clean_shutdown"
+    marker.write_text("clean", encoding="utf-8")
+    runner = object.__new__(GatewayRunner)
+    async_store = MagicMock()
+    async_store.discard_active_turn_markers = AsyncMock(
+        side_effect=OSError("state store unavailable")
+    )
+
+    with patch.object(
+        GatewayRunner,
+        "async_session_store",
+        new_callable=PropertyMock,
+        return_value=async_store,
+    ):
+        with pytest.raises(OSError, match="state store unavailable"):
+            await runner._consume_clean_shutdown_marker(marker)
+
+    assert marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_marker_is_unlinked_after_durable_discard(tmp_path):
+    marker = tmp_path / ".clean_shutdown"
+    marker.write_text("clean", encoding="utf-8")
+    runner = object.__new__(GatewayRunner)
+    async_store = MagicMock()
+    async_store.discard_active_turn_markers = AsyncMock(return_value=2)
+
+    with patch.object(
+        GatewayRunner,
+        "async_session_store",
+        new_callable=PropertyMock,
+        return_value=async_store,
+    ):
+        discarded = await runner._consume_clean_shutdown_marker(marker)
+
+    assert discarded == 2
+    assert not marker.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -39,6 +39,23 @@ def _make_store(tmp_path) -> SessionStore:
     return store
 
 
+def _make_db_store(tmp_path) -> SessionStore:
+    from hermes_state import SessionDB
+
+    sessions_dir = tmp_path / "sessions"
+    store = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    if store._db is not None:
+        store._db.close()
+    store._db = SessionDB(db_path=tmp_path / "state.db")
+    return store
+
+
+def _close_store_db(store: SessionStore) -> None:
+    db = store._db
+    assert db is not None
+    db.close()
+
+
 def _entry_for(store: SessionStore, source: SessionSource) -> SessionEntry:
     key = store._generate_session_key(source)
     with store._lock:
@@ -117,11 +134,125 @@ def test_mark_and_clear_use_single_entry_persistence(tmp_path):
 
     token = store.mark_turn_active(entry.session_key)
     assert token is not None
-    store._save_entry.assert_called_once_with(entry.session_key)
+    store._save_entry.assert_called_once_with(
+        entry.session_key,
+        entry_data=store._entries[entry.session_key].to_dict(),
+        lock_held=True,
+    )
 
     store._save_entry.reset_mock()
     assert store.clear_turn_active(entry.session_key, token) is True
-    store._save_entry.assert_called_once_with(entry.session_key)
+    store._save_entry.assert_called_once_with(
+        entry.session_key,
+        entry_data=store._entries[entry.session_key].to_dict(),
+        lock_held=True,
+    )
+
+
+def test_failed_mark_persistence_does_not_leak_marker_into_later_save(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    real_save_entry = store._save_entry
+    store._save_entry = MagicMock(side_effect=OSError("disk unavailable"))
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        store.mark_turn_active(entry.session_key)
+
+    current = _entry_for(store, source)
+    assert current.active_turn_token is None
+    assert current.active_turn_started_at is None
+
+    # A later unrelated save must not make the failed marker durable.
+    store._save_entry = real_save_entry
+    with store._lock:
+        store._entries[entry.session_key].updated_at = datetime.now()
+        store._save()
+
+    reloaded = _make_store(tmp_path)
+    assert reloaded.recover_interrupted_turns() == 0
+    assert _entry_for(reloaded, source).active_turn_token is None
+
+
+def test_failed_clear_persistence_keeps_token_retryable_and_durable_clear_wins(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    token = store.mark_turn_active(entry.session_key)
+    assert token is not None
+
+    real_save_entry = store._save_entry
+    store._save_entry = MagicMock(side_effect=OSError("disk unavailable"))
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        store.clear_turn_active(entry.session_key, token)
+
+    current = _entry_for(store, source)
+    assert current.active_turn_token == token
+    assert current.active_turn_started_at is not None
+
+    store._save_entry = real_save_entry
+    assert store.clear_turn_active(entry.session_key, token) is True
+
+    reloaded = _make_store(tmp_path)
+    persisted = _entry_for(reloaded, source)
+    assert persisted.active_turn_token is None
+    assert persisted.active_turn_started_at is None
+
+
+def test_state_db_failure_atomic_marker_round_trip(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source("state-db-active-turn")
+    entry = store.get_or_create_session(source)
+    real_save_entry = store._save_entry
+
+    store._save_entry = MagicMock(side_effect=OSError("state.db unavailable"))
+    with pytest.raises(OSError, match="state.db unavailable"):
+        store.mark_turn_active(entry.session_key)
+    assert _entry_for(store, source).active_turn_token is None
+
+    store._save_entry = real_save_entry
+    token = store.mark_turn_active(entry.session_key)
+    assert token is not None
+
+    store._save_entry = MagicMock(side_effect=OSError("state.db unavailable"))
+    with pytest.raises(OSError, match="state.db unavailable"):
+        store.clear_turn_active(entry.session_key, token)
+    assert _entry_for(store, source).active_turn_token == token
+
+    store._save_entry = real_save_entry
+    assert store.clear_turn_active(entry.session_key, token) is True
+    _close_store_db(store)
+
+    reloaded = _make_db_store(tmp_path)
+    assert reloaded.recover_interrupted_turns() == 0
+    persisted = _entry_for(reloaded, source)
+    assert persisted.active_turn_token is None
+    assert persisted.active_turn_started_at is None
+    _close_store_db(reloaded)
+
+
+def test_state_db_commit_survives_legacy_mirror_failure(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source("state-db-mirror-failure")
+    entry = store.get_or_create_session(source)
+    db = store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock(
+        side_effect=OSError("fast upsert unavailable")
+    )
+    store._save_sessions_json = MagicMock(
+        side_effect=OSError("legacy mirror unavailable")
+    )
+
+    token = store.mark_turn_active(entry.session_key)
+    assert token is not None
+    _close_store_db(store)
+
+    reloaded = _make_db_store(tmp_path)
+    recovered = _entry_for(reloaded, source)
+    assert recovered.active_turn_token == token
+    _close_store_db(reloaded)
 
 
 def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -18,7 +18,7 @@ from gateway.run import GatewayRunner
 from gateway.session import SessionEntry, SessionSource, SessionStore
 
 
-ACTIVE_TURN_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+ACTIVE_TURN_MAX_AGE_SECONDS = 60 * 60
 
 
 def _make_source(chat_id: str = "active-turn-chat") -> SessionSource:
@@ -133,7 +133,7 @@ def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):
     with store._lock:
         current = store._entries[entry.session_key]
         current.updated_at = datetime.now() - timedelta(hours=2)
-        current.active_turn_started_at = datetime.now() - timedelta(hours=2)
+        current.active_turn_started_at = datetime.now() - timedelta(minutes=10)
         store._save()
 
     # Prove the marker survives a fresh SessionStore and is not relying on the
@@ -200,7 +200,7 @@ def test_ancient_active_marker_is_cleared_without_auto_resume(tmp_path):
 
     with store._lock:
         current = store._entries[entry.session_key]
-        current.active_turn_started_at = datetime.now() - timedelta(days=8)
+        current.active_turn_started_at = datetime.now() - timedelta(hours=2)
 
     assert store.recover_interrupted_turns(
         max_age_seconds=ACTIVE_TURN_MAX_AGE_SECONDS
@@ -260,12 +260,15 @@ async def test_runner_active_turn_carrier_clears_the_exact_resolved_key():
 async def test_runner_active_turn_clear_is_best_effort():
     runner = object.__new__(GatewayRunner)
     runner.session_store = MagicMock()
+    clear_active = AsyncMock(
+        side_effect=[OSError("disk unavailable"), True]
+    )
     setattr(
         runner,
         "_async_session_store",
         SimpleNamespace(
             _store=runner.session_store,
-            clear_turn_active=AsyncMock(side_effect=OSError("disk unavailable")),
+            clear_turn_active=clear_active,
         ),
     )
     event = SimpleNamespace(
@@ -275,16 +278,47 @@ async def test_runner_active_turn_clear_is_best_effort():
 
     await runner._clear_durable_active_turn(cast(Any, event))
 
+    assert clear_active.await_count == 2
     assert not hasattr(event, "_gateway_active_turn_session_key")
     assert not hasattr(event, "_gateway_active_turn_token")
 
 
 @pytest.mark.asyncio
-async def test_unclean_recovery_promotes_exact_markers_before_legacy_fallback():
+async def test_runner_active_turn_clear_stops_after_bounded_retries():
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    clear_active = AsyncMock(side_effect=OSError("disk unavailable"))
+    setattr(
+        runner,
+        "_async_session_store",
+        SimpleNamespace(
+            _store=runner.session_store,
+            clear_turn_active=clear_active,
+        ),
+    )
+    event = SimpleNamespace(
+        _gateway_active_turn_session_key="resolved-session-key",
+        _gateway_active_turn_token="token-1",
+    )
+
+    assert await runner._clear_durable_active_turn(cast(Any, event)) is False
+
+    assert clear_active.await_count == 3
+    assert not hasattr(event, "_gateway_active_turn_session_key")
+    assert not hasattr(event, "_gateway_active_turn_token")
+
+
+@pytest.mark.asyncio
+async def test_unclean_recovery_promotes_exact_markers_before_legacy_fallback(
+    monkeypatch,
+):
     runner = object.__new__(GatewayRunner)
     calls: list[str] = []
 
-    async def _recover():
+    monkeypatch.delenv("HERMES_AGENT_TIMEOUT", raising=False)
+
+    async def _recover(*, max_age_seconds):
+        assert max_age_seconds == ACTIVE_TURN_MAX_AGE_SECONDS
         calls.append("exact")
         return 1
 

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -1,0 +1,308 @@
+"""Regression tests for exact durable active-turn restart recovery.
+
+A long-running gateway turn can outlive the legacy 120-second
+``updated_at`` crash heuristic.  These tests require an exact persisted
+marker, compare-and-swap cleanup, and promotion into the existing
+``resume_pending`` recovery path after an unclean exit.
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, SessionStore
+
+
+ACTIVE_TURN_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def _make_source(chat_id: str = "active-turn-chat") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        user_id="user-1",
+        chat_type="channel",
+        thread_id="thread-1",
+    )
+
+
+def _make_store(tmp_path) -> SessionStore:
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    # Exercise the legacy JSON fallback deterministically.  ``_save_entry``
+    # must still persist correctly when state.db is unavailable.
+    store._db = None
+    return store
+
+
+def _entry_for(store: SessionStore, source: SessionSource) -> SessionEntry:
+    key = store._generate_session_key(source)
+    with store._lock:
+        store._ensure_loaded_locked()
+        return store._entries[key]
+
+
+def test_active_turn_fields_round_trip_and_legacy_payload_defaults(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+
+    token = store.mark_turn_active(entry.session_key)
+    assert token
+
+    payload = _entry_for(store, source).to_dict()
+    assert payload["active_turn_token"] == token
+    assert payload["active_turn_started_at"] is not None
+
+    restored = SessionEntry.from_dict(payload)
+    assert restored.active_turn_token == token
+    assert restored.active_turn_started_at is not None
+
+    payload.pop("active_turn_token")
+    payload.pop("active_turn_started_at")
+    legacy = SessionEntry.from_dict(payload)
+    assert legacy.active_turn_token is None
+    assert legacy.active_turn_started_at is None
+
+    payload["active_turn_token"] = {"invalid": "not-a-token"}
+    payload["active_turn_started_at"] = datetime.now().isoformat()
+    corrupt = SessionEntry.from_dict(payload)
+    assert corrupt.active_turn_token is None
+    assert corrupt.active_turn_started_at is None
+
+
+def test_mark_refreshes_updated_at_for_legacy_upgrade_fallback(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    old_updated_at = datetime.now() - timedelta(hours=2)
+    with store._lock:
+        store._entries[entry.session_key].updated_at = old_updated_at
+
+    token = store.mark_turn_active(entry.session_key)
+
+    assert token is not None
+    assert _entry_for(store, source).updated_at > old_updated_at
+
+
+def test_active_turn_clear_is_compare_and_swap(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+
+    first = store.mark_turn_active(entry.session_key)
+    second = store.mark_turn_active(entry.session_key)
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+    assert store.clear_turn_active(entry.session_key, first) is False
+    assert _entry_for(store, source).active_turn_token == second
+
+    assert store.clear_turn_active(entry.session_key, second) is True
+    current = _entry_for(store, source)
+    assert current.active_turn_token is None
+    assert current.active_turn_started_at is None
+
+
+def test_mark_and_clear_use_single_entry_persistence(tmp_path):
+    store = _make_store(tmp_path)
+    entry = store.get_or_create_session(_make_source())
+    real_save_entry = store._save_entry
+    store._save_entry = MagicMock(wraps=real_save_entry)
+
+    token = store.mark_turn_active(entry.session_key)
+    assert token is not None
+    store._save_entry.assert_called_once_with(entry.session_key)
+
+    store._save_entry.reset_mock()
+    assert store.clear_turn_active(entry.session_key, token) is True
+    store._save_entry.assert_called_once_with(entry.session_key)
+
+
+def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    token = store.mark_turn_active(entry.session_key)
+
+    with store._lock:
+        current = store._entries[entry.session_key]
+        current.updated_at = datetime.now() - timedelta(hours=2)
+        current.active_turn_started_at = datetime.now() - timedelta(hours=2)
+        store._save()
+
+    # Prove the marker survives a fresh SessionStore and is not relying on the
+    # in-memory object that wrote it.
+    reloaded = _make_store(tmp_path)
+    assert reloaded.recover_interrupted_turns(
+        max_age_seconds=ACTIVE_TURN_MAX_AGE_SECONDS
+    ) == 1
+
+    recovered = _entry_for(reloaded, source)
+    assert recovered.resume_pending is True
+    assert recovered.resume_reason == "restart_interrupted"
+    assert recovered.last_resume_marked_at is not None
+    assert recovered.last_resume_marked_at > datetime.now() - timedelta(seconds=5)
+    assert recovered.active_turn_token is None
+    assert recovered.active_turn_started_at is None
+    assert token
+
+
+def test_suspended_active_turn_is_cleared_without_resume(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+
+    with store._lock:
+        store._entries[entry.session_key].suspended = True
+
+    assert store.recover_interrupted_turns() == 0
+    recovered = _entry_for(store, source)
+    assert recovered.suspended is True
+    assert recovered.resume_pending is False
+    assert recovered.active_turn_token is None
+    assert recovered.active_turn_started_at is None
+
+
+def test_existing_resume_reason_and_freshness_are_preserved(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+    original_mark = datetime.now() - timedelta(minutes=2)
+
+    with store._lock:
+        current = store._entries[entry.session_key]
+        current.resume_pending = True
+        current.resume_reason = "shutdown_timeout"
+        current.last_resume_marked_at = original_mark
+
+    assert store.recover_interrupted_turns() == 0
+    recovered = _entry_for(store, source)
+    assert recovered.resume_pending is True
+    assert recovered.resume_reason == "shutdown_timeout"
+    assert recovered.last_resume_marked_at == original_mark
+    assert recovered.active_turn_token is None
+    assert recovered.active_turn_started_at is None
+
+
+def test_ancient_active_marker_is_cleared_without_auto_resume(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+
+    with store._lock:
+        current = store._entries[entry.session_key]
+        current.active_turn_started_at = datetime.now() - timedelta(days=8)
+
+    assert store.recover_interrupted_turns(
+        max_age_seconds=ACTIVE_TURN_MAX_AGE_SECONDS
+    ) == 0
+    recovered = _entry_for(store, source)
+    assert recovered.resume_pending is False
+    assert recovered.active_turn_token is None
+    assert recovered.active_turn_started_at is None
+
+
+def test_clean_startup_discards_orphan_markers_without_resuming(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+
+    assert store.discard_active_turn_markers() == 1
+
+    recovered = _entry_for(store, source)
+    assert recovered.resume_pending is False
+    assert recovered.active_turn_token is None
+    assert recovered.active_turn_started_at is None
+
+
+@pytest.mark.asyncio
+async def test_runner_active_turn_carrier_clears_the_exact_resolved_key():
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    mark_active = AsyncMock(return_value="token-1")
+    clear_active = AsyncMock(return_value=True)
+    setattr(
+        runner,
+        "_async_session_store",
+        SimpleNamespace(
+            _store=runner.session_store,
+            mark_turn_active=mark_active,
+            clear_turn_active=clear_active,
+        ),
+    )
+    event = SimpleNamespace()
+
+    await runner._mark_durable_active_turn(
+        cast(Any, event), "resolved-session-key"
+    )
+
+    assert event._gateway_active_turn_session_key == "resolved-session-key"
+    assert event._gateway_active_turn_token == "token-1"
+
+    await runner._clear_durable_active_turn(cast(Any, event))
+
+    clear_active.assert_awaited_once_with("resolved-session-key", "token-1")
+    assert not hasattr(event, "_gateway_active_turn_session_key")
+    assert not hasattr(event, "_gateway_active_turn_token")
+
+
+@pytest.mark.asyncio
+async def test_runner_active_turn_clear_is_best_effort():
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    setattr(
+        runner,
+        "_async_session_store",
+        SimpleNamespace(
+            _store=runner.session_store,
+            clear_turn_active=AsyncMock(side_effect=OSError("disk unavailable")),
+        ),
+    )
+    event = SimpleNamespace(
+        _gateway_active_turn_session_key="resolved-session-key",
+        _gateway_active_turn_token="token-1",
+    )
+
+    await runner._clear_durable_active_turn(cast(Any, event))
+
+    assert not hasattr(event, "_gateway_active_turn_session_key")
+    assert not hasattr(event, "_gateway_active_turn_token")
+
+
+@pytest.mark.asyncio
+async def test_unclean_recovery_promotes_exact_markers_before_legacy_fallback():
+    runner = object.__new__(GatewayRunner)
+    calls: list[str] = []
+
+    async def _recover():
+        calls.append("exact")
+        return 1
+
+    async def _fallback(*, max_age_seconds):
+        assert max_age_seconds == 120
+        calls.append("fallback")
+        return 2
+
+    runner.session_store = MagicMock()
+    setattr(
+        runner,
+        "_async_session_store",
+        SimpleNamespace(
+            _store=runner.session_store,
+            recover_interrupted_turns=_recover,
+            suspend_recently_active=_fallback,
+        ),
+    )
+
+    assert await runner._recover_unclean_sessions() == (1, 2)
+    assert calls == ["exact", "fallback"]

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -898,6 +898,54 @@ class TestCheckpoint:
             recovered = registry.recover_from_checkpoint()
             assert recovered == 0
 
+    def test_recover_dead_wrapper_retries_unreaped_systemd_scope(
+        self, registry, tmp_path, monkeypatch
+    ):
+        checkpoint = tmp_path / "procs.json"
+        entry = {
+            "session_id": "proc_dead_scope",
+            "command": "daemonize",
+            "pid": 999999999,
+            "pid_scope": "host",
+            "host_start_time": 123.0,
+            "systemd_unit": "hermes-worker-proc_dead_scope.scope",
+        }
+        checkpoint.write_text(json.dumps([entry]))
+        monkeypatch.setattr(registry, "_host_pid_is_ours", lambda *_args: False)
+        monkeypatch.setattr(registry, "_is_host_pid_alive", lambda *_args: False)
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), patch(
+            "tools.process_registry._stop_systemd_unit", return_value=False
+        ) as stop_unit:
+            assert registry.recover_from_checkpoint() == 0
+
+        stop_unit.assert_called_once_with(entry["systemd_unit"])
+        assert json.loads(checkpoint.read_text()) == [entry]
+
+    def test_recover_dead_wrapper_drops_reaped_systemd_scope(
+        self, registry, tmp_path, monkeypatch
+    ):
+        checkpoint = tmp_path / "procs.json"
+        entry = {
+            "session_id": "proc_dead_scope",
+            "command": "daemonize",
+            "pid": 999999999,
+            "pid_scope": "host",
+            "host_start_time": 123.0,
+            "systemd_unit": "hermes-worker-proc_dead_scope.scope",
+        }
+        checkpoint.write_text(json.dumps([entry]))
+        monkeypatch.setattr(registry, "_host_pid_is_ours", lambda *_args: False)
+        monkeypatch.setattr(registry, "_is_host_pid_alive", lambda *_args: False)
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), patch(
+            "tools.process_registry._stop_systemd_unit", return_value=True
+        ) as stop_unit:
+            assert registry.recover_from_checkpoint() == 0
+
+        stop_unit.assert_called_once_with(entry["systemd_unit"])
+        assert json.loads(checkpoint.read_text()) == []
+
 
     def test_recovery_skips_explicit_sandbox_backed_entries(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
@@ -1848,17 +1896,49 @@ class TestSystemdCgroupIsolation:
             f"hermes-worker-{session.id}-pipe-fallback.scope"
         )
 
+    def test_pty_spawn_failure_does_not_fallback_when_scope_reap_fails(
+        self, registry, monkeypatch
+    ):
+        """Do not launch a duplicate command while the failed PTY scope may live."""
+        from ptyprocess import PtyProcess
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch.object(
+            PtyProcess,
+            "spawn",
+            side_effect=RuntimeError("PTY wrapper failed after scope creation"),
+        ), patch("subprocess.Popen") as pipe_spawn, patch(
+            "tools.process_registry._stop_systemd_unit", return_value=False
+        ) as stop_unit:
+            with pytest.raises(RuntimeError, match="could not be reaped"):
+                registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        stop_unit.assert_called_once()
+        pipe_spawn.assert_not_called()
+
     def test_worker_memory_limit_honors_local_guard_mb_override(self, monkeypatch):
         import tools.process_registry as pr
 
         monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "123")
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        argv = pr._build_systemd_scope_argv(
-            ["/bin/bash", "-lc", "true"],
-            unit_suffix="test",
-        )
+        with patch("tools.process_registry.logger.warning") as warning:
+            argv = pr._build_systemd_scope_argv(
+                ["/bin/bash", "-lc", "true"],
+                unit_suffix="test",
+            )
 
+        warning.assert_not_called()
         assert f"MemoryMax={123 * 1024 * 1024}" in argv
 
     def test_worker_memory_limit_caps_oversized_local_guard_override(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -26,6 +26,21 @@ def registry():
     return ProcessRegistry()
 
 
+@pytest.fixture(autouse=True)
+def _reset_systemd_scope_cache():
+    """Reset the cached ``systemd-run --user --scope`` availability flag
+    before each test so a probe run on a real systemd host (where
+    ``INVOCATION_ID`` is set) doesn't leak into tests that mock
+    ``subprocess.Popen``. Tests that exercise the probe directly reset the
+    cache themselves."""
+    import tools.process_registry as _pr
+
+    original = _pr._SYSTEMD_SCOPE_AVAILABLE
+    _pr._SYSTEMD_SCOPE_AVAILABLE = False
+    yield
+    _pr._SYSTEMD_SCOPE_AVAILABLE = original
+
+
 def _make_session(
     sid="proc_test123",
     command="echo hello",
@@ -1572,3 +1587,149 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+# =========================================================================
+# systemd cgroup isolation for gateway-spawned local executors (#70716)
+# =========================================================================
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: systemd scopes")
+class TestSystemdCgroupIsolation:
+    """Verify spawn_local wraps the worker in ``systemd-run --user --scope``
+    when running under a supervisor and systemd-run is available, and falls
+    back to the legacy ``start_new_session`` path otherwise.
+
+    Issue #70716: local background terminal executors inherit the gateway's
+    cgroup, so an OOM in a memory-heavy worker lets systemd-oomd kill the
+    ENTIRE gateway cgroup, taking down the messaging control plane.
+    """
+
+    def _fake_popen_capture(self):
+        """Return (fake_popen, captured) where captured["argv"] gets the
+        argv passed to subprocess.Popen."""
+        captured = {}
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = list(argv)
+            captured["start_new_session"] = kwargs.get("start_new_session")
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.stdin = MagicMock()
+            proc.poll.return_value = None
+            return proc
+
+        return fake_popen, captured
+
+    def test_wraps_in_systemd_scope_when_supervisor_and_available(
+        self, registry, monkeypatch
+    ):
+        """Under a supervisor with systemd-run available, the spawn argv is
+        wrapped in ``systemd-run --user --scope --unit=hermes-worker-<id>``."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+        # _build_systemd_scope_argv calls shutil.which — point it at a stub.
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("echo hello", cwd="/tmp")
+
+        argv = captured["argv"]
+        assert argv[0] == "/usr/bin/systemd-run", argv
+        assert "--user" in argv
+        assert "--scope" in argv
+        assert "--unit" in argv
+        unit_idx = argv.index("--unit")
+        assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
+        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv
+        # The original shell command must still be present at the tail.
+        assert "/bin/bash" in argv
+        assert "set +m; echo hello" in argv
+        # systemd-run owns session/cgroup creation — no start_new_session.
+        assert captured["start_new_session"] is False
+
+    def test_falls_back_when_systemd_run_unavailable(
+        self, registry, monkeypatch
+    ):
+        """Under a supervisor but without systemd-run, fall back to the
+        legacy ``start_new_session=True`` path (worker shares the gateway
+        cgroup)."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+
+        with patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        argv = captured["argv"]
+        # No systemd-run wrapping — direct shell invocation.
+        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert captured["start_new_session"] is True
+
+    def test_falls_back_when_not_under_supervisor(
+        self, registry, monkeypatch
+    ):
+        """CLI mode (no supervisor) must NOT wrap in a systemd scope even if
+        systemd-run is available — isolation is a gateway concern."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: False,
+        )
+
+        with patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        argv = captured["argv"]
+        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert captured["start_new_session"] is True
+
+    def test_systemd_run_user_scope_available_caches_after_probe(
+        self, registry, monkeypatch
+    ):
+        """The availability check probes once and caches — a second call must
+        not re-probe (and must return the same value)."""
+        import tools.process_registry as pr
+
+        # Reset the cache.
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        probe_calls = []
+
+        def fake_run(*args, **kwargs):
+            probe_calls.append(args)
+            return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        first = pr._systemd_run_user_scope_available()
+        second = pr._systemd_run_user_scope_available()
+        assert first is True
+        assert second is True
+        assert len(probe_calls) == 1, "probe must run only once (cached)"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1646,15 +1646,22 @@ class TestSystemdCgroupIsolation:
         assert argv[0] == "/usr/bin/systemd-run", argv
         assert "--user" in argv
         assert "--scope" in argv
+        assert "--quiet" in argv, "systemd-run argv must include --quiet (#70716 gap #3)"
         assert "--unit" in argv
         unit_idx = argv.index("--unit")
         assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
         assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv
-        # The original shell command must still be present at the tail.
-        assert "/bin/bash" in argv
-        assert "set +m; echo hello" in argv
+        # The original shell command must still be present at the tail,
+        # after the ``--`` separator that prevents systemd-run from
+        # interpreting command flags as its own.
+        assert "--" in argv, "systemd-run argv must use -- to separate command"
+        sep_idx = argv.index("--")
+        assert "/bin/bash" in argv[sep_idx:]
+        assert "set +m; echo hello" in argv[sep_idx:]
         # systemd-run owns session/cgroup creation — no start_new_session.
         assert captured["start_new_session"] is False
+        # The session must record the unit name so kill_process can stop it.
+        assert session.systemd_unit == f"hermes-worker-{session.id}"
 
     def test_falls_back_when_systemd_run_unavailable(
         self, registry, monkeypatch

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1717,6 +1717,71 @@ class TestSystemdCgroupIsolation:
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
+    def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
+        self, registry, monkeypatch
+    ):
+        """The scope wrapper shares the gateway PG, so cleanup must not killpg."""
+        fake_popen, _captured = self._fake_popen_capture()
+        fake_proc = fake_popen(["placeholder"])
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        broken_reader = MagicMock()
+        broken_reader.start.side_effect = RuntimeError("reader failed")
+
+        with patch("subprocess.Popen", return_value=fake_proc), \
+            patch("threading.Thread", return_value=broken_reader), \
+            patch("tools.process_registry._stop_systemd_unit", return_value=True) as stop_unit, \
+            patch("os.killpg") as killpg, \
+            patch.object(registry, "_write_checkpoint"):
+            with pytest.raises(RuntimeError, match="reader failed"):
+                registry.spawn_local("echo hello", cwd="/tmp")
+
+        stop_unit.assert_called_once()
+        assert stop_unit.call_args.args[0].startswith("hermes-worker-proc_")
+        assert stop_unit.call_args.args[0].endswith(".scope")
+        killpg.assert_not_called()
+
+    def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch):
+        """Interactive executors receive the same sibling-cgroup isolation."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock()
+        fake_pty.pid = 4321
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn, \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        argv = pty_spawn.call_args.args[0]
+        assert argv[0] == "/usr/bin/systemd-run"
+        assert "--scope" in argv
+        assert "--unit" in argv
+        assert "--" in argv
+        assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
+        assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
+
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch
     ):
@@ -1817,3 +1882,45 @@ class TestSystemdCgroupIsolation:
         assert not second.is_alive()
         assert results == [True, True]
         assert len(probe_calls) == 1
+
+    def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        clock = [100.0]
+        probe_results = [1, 0]
+        probe_calls = []
+
+        def fake_run(*args, **kwargs):
+            probe_calls.append(args)
+            return subprocess.CompletedProcess(
+                args=args[0], returncode=probe_results.pop(0)
+            )
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("tools.process_registry.time.monotonic", lambda: clock[0])
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is False
+        assert pr._systemd_run_user_scope_available() is False
+        assert len(probe_calls) == 1
+
+        clock[0] += 61
+        assert pr._systemd_run_user_scope_available() is True
+        assert len(probe_calls) == 2
+
+    def test_stop_systemd_unit_treats_absent_unit_as_clean(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemctl")
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(
+                args=args[0],
+                returncode=5,
+                stderr=b"Unit hermes-worker-gone.scope not loaded.\n",
+            ),
+        )
+
+        assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1770,3 +1770,50 @@ class TestSystemdCgroupIsolation:
         assert first is True
         assert second is True
         assert len(probe_calls) == 1, "probe must run only once (cached)"
+
+    def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
+        """Concurrent first-use callers must wait for one definitive probe.
+
+        A temporary cached ``False`` would let a racing worker spawn inside the
+        gateway cgroup, defeating the OOM isolation guarantee.
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        probe_started = threading.Event()
+        release_probe = threading.Event()
+        probe_calls = []
+        results = []
+
+        def fake_run(*args, **kwargs):
+            probe_calls.append(args)
+            probe_started.set()
+            assert release_probe.wait(timeout=2)
+            return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        first = threading.Thread(
+            target=lambda: results.append(pr._systemd_run_user_scope_available())
+        )
+        second = threading.Thread(
+            target=lambda: results.append(pr._systemd_run_user_scope_available())
+        )
+        first.start()
+        assert probe_started.wait(timeout=2)
+        second.start()
+
+        # The racing caller must be blocked behind the probe, not observe a
+        # temporary False cache value.
+        second.join(timeout=0.05)
+        assert second.is_alive()
+
+        release_probe.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert results == [True, True]
+        assert len(probe_calls) == 1

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1793,10 +1793,10 @@ class TestSystemdCgroupIsolation:
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
-    def test_worker_memory_limit_accepts_valid_byte_override(self, monkeypatch):
+    def test_worker_memory_limit_honors_local_guard_mb_override(self, monkeypatch):
         import tools.process_registry as pr
 
-        monkeypatch.setenv("HERMES_WORKER_MEMORY_MAX_BYTES", "123456789")
+        monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "123")
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
         argv = pr._build_systemd_scope_argv(
@@ -1804,7 +1804,7 @@ class TestSystemdCgroupIsolation:
             unit_suffix="test",
         )
 
-        assert "MemoryMax=123456789" in argv
+        assert f"MemoryMax={123 * 1024 * 1024}" in argv
 
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1793,6 +1793,61 @@ class TestSystemdCgroupIsolation:
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
+    def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
+        self, registry, monkeypatch
+    ):
+        """A failed PTY scope must not collide with the pipe fallback scope."""
+        from ptyprocess import PtyProcess
+
+        events = []
+        fake_proc = MagicMock()
+        fake_proc.pid = 4321
+        fake_proc.stdout = iter([])
+        fake_proc.stdin = MagicMock()
+        fake_proc.poll.return_value = None
+
+        def fake_popen(argv, **_kwargs):
+            events.append(("pipe", list(argv)))
+            return fake_proc
+
+        def fake_stop(unit_name):
+            events.append(("stop", unit_name))
+            return True
+
+        def fail_pty(*_args, **_kwargs):
+            events.append(("pty", None))
+            raise RuntimeError("PTY wrapper failed after scope creation")
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch.object(PtyProcess, "spawn", side_effect=fail_pty), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("tools.process_registry._stop_systemd_unit", side_effect=fake_stop), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert [event[0] for event in events] == ["pty", "stop", "pipe"]
+        stopped_unit = events[1][1]
+        fallback_argv = events[2][1]
+        assert stopped_unit == f"hermes-worker-{session.id}.scope"
+        unit_idx = fallback_argv.index("--unit")
+        assert fallback_argv[unit_idx + 1] == (
+            f"hermes-worker-{session.id}-pipe-fallback"
+        )
+        assert session.systemd_unit == (
+            f"hermes-worker-{session.id}-pipe-fallback.scope"
+        )
+
     def test_worker_memory_limit_honors_local_guard_mb_override(self, monkeypatch):
         import tools.process_registry as pr
 
@@ -1805,6 +1860,25 @@ class TestSystemdCgroupIsolation:
         )
 
         assert f"MemoryMax={123 * 1024 * 1024}" in argv
+
+    def test_worker_memory_limit_caps_oversized_local_guard_override(
+        self, monkeypatch
+    ):
+        import tools.process_registry as pr
+
+        monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "999999")
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+        )
+        monkeypatch.setattr(
+            pr.os,
+            "sysconf",
+            lambda *_args: (_ for _ in ()).throw(OSError("no sysconf")),
+        )
+
+        assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
 
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1650,7 +1650,7 @@ class TestSystemdCgroupIsolation:
         assert "--unit" in argv
         unit_idx = argv.index("--unit")
         assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
-        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv
+        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv  # _build_systemd_scope_argv uses bare name
         # The original shell command must still be present at the tail,
         # after the ``--`` separator that prevents systemd-run from
         # interpreting command flags as its own.
@@ -1661,7 +1661,7 @@ class TestSystemdCgroupIsolation:
         # systemd-run owns session/cgroup creation — no start_new_session.
         assert captured["start_new_session"] is False
         # The session must record the unit name so kill_process can stop it.
-        assert session.systemd_unit == f"hermes-worker-{session.id}"
+        assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
     def test_falls_back_when_systemd_run_unavailable(
         self, registry, monkeypatch
@@ -1716,6 +1716,36 @@ class TestSystemdCgroupIsolation:
         argv = captured["argv"]
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
+
+    def test_kill_recovered_detached_already_exited_stops_persisted_scope(
+        self, registry, monkeypatch
+    ):
+        """Recovered detached sessions whose wrapper PID is gone/recycled must
+        still stop their persisted systemd scope before the already_exited
+        return, while retaining the PID-reuse guard (no PID tree kill)."""
+        session = _make_session(sid="proc_recovered_scope", command="daemonize")
+        session.detached = True
+        session.pid_scope = "host"
+        session.pid = 12345
+        session.host_start_time = 67890
+        session.systemd_unit = "hermes-worker-proc_recovered_scope.scope"
+        registry._running[session.id] = session
+
+        stopped = []
+        terminated = []
+        monkeypatch.setattr(registry, "_host_pid_is_ours", lambda pid, start: False)
+        monkeypatch.setattr(registry, "_terminate_host_pid", lambda pid, start: terminated.append((pid, start)))
+        monkeypatch.setattr("tools.process_registry._stop_systemd_unit", lambda unit: stopped.append(unit) or True)
+
+        with patch.object(registry, "_write_checkpoint"):
+            result = registry.kill_process(session.id)
+
+        assert result["status"] == "already_exited"
+        assert stopped == ["hermes-worker-proc_recovered_scope.scope"]
+        assert terminated == []
+        assert session.exited is True
+        assert session.id in registry._finished
+        assert session.id not in registry._running
 
     def test_systemd_run_user_scope_available_caches_after_probe(
         self, registry, monkeypatch

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1651,6 +1651,17 @@ class TestSystemdCgroupIsolation:
         unit_idx = argv.index("--unit")
         assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
         assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv  # _build_systemd_scope_argv uses bare name
+        properties = [
+            argv[index + 1]
+            for index, value in enumerate(argv[:-1])
+            if value == "--property"
+        ]
+        assert "MemoryAccounting=yes" in properties
+        assert "OOMPolicy=kill" in properties
+        memory_max = next(
+            value for value in properties if value.startswith("MemoryMax=")
+        )
+        assert int(memory_max.split("=", 1)[1]) > 0
         # The original shell command must still be present at the tail,
         # after the ``--`` separator that prevents systemd-run from
         # interpreting command flags as its own.
@@ -1781,6 +1792,19 @@ class TestSystemdCgroupIsolation:
         assert "--" in argv
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
+
+    def test_worker_memory_limit_accepts_valid_byte_override(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.setenv("HERMES_WORKER_MEMORY_MAX_BYTES", "123456789")
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        argv = pr._build_systemd_scope_argv(
+            ["/bin/bash", "-lc", "true"],
+            unit_suffix="test",
+        )
+
+        assert "MemoryMax=123456789" in argv
 
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -51,17 +51,23 @@ class TestStartNewSession:
 
     @pytest.mark.parametrize("relpath", GUARDED_FILES)
     def test_uses_start_new_session(self, relpath):
-        """Each guarded file must use start_new_session=True for process isolation."""
+        """Each guarded file must use start_new_session instead of preexec_fn.
+
+        The value may be a variable (e.g. ``popen_start_new_session``) when
+        the spawn conditionally uses ``systemd-run --scope`` which creates its
+        own session/cgroup — in that case ``start_new_session=False`` is
+        correct and a literal ``True`` would mask scope-creation failures.
+        """
         filepath = PROJECT_ROOT / relpath
         if not filepath.exists():
             pytest.skip(f"{relpath} not found")
         source = filepath.read_text(encoding="utf-8")
-        # Files should use start_new_session=True, not preexec_fn
+        # Files should use start_new_session, not preexec_fn
         assert "preexec_fn" not in source, (
             f"{relpath} still uses preexec_fn; use start_new_session=True instead"
         )
-        assert "start_new_session=True" in source, (
-            f"{relpath} missing start_new_session=True in Popen call"
+        assert "start_new_session=" in source, (
+            f"{relpath} missing start_new_session= in Popen call"
         )
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -79,6 +79,106 @@ WATCH_GLOBAL_WINDOW_SECONDS = 10
 WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 
 
+# ---------------------------------------------------------------------------
+# systemd cgroup isolation for gateway-spawned local executors (#70716)
+# ---------------------------------------------------------------------------
+# When Hermes runs as a systemd gateway with MemoryHigh/MemoryMax limits,
+# local background terminal commands inherit the gateway's cgroup.  A
+# memory-heavy executor (Codex, tests, Node) can push the whole cgroup past
+# MemoryMax and trigger systemd-oomd to kill the ENTIRE gateway — taking down
+# the messaging control plane and silently losing the active turn.
+#
+# Wrapping the spawn in ``systemd-run --user --scope --unit=hermes-worker-<pid>``
+# places the worker in its own transient cgroup so an OOM in the worker kills
+# only the worker, not the gateway.  We probe *once* whether
+# ``systemd-run --user --scope`` is actually usable (the binary can exist on
+# the PATH while the user D-Bus session is unavailable — common for system
+# services and containers), and cache the result for the process lifetime.
+
+_SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
+
+
+def _systemd_run_user_scope_available() -> bool:
+    """Return True if ``systemd-run --user --scope`` can create a cgroup.
+
+    Cached after the first probe.  ``shutil.which`` alone is insufficient:
+    in system-service deployments (and containers) the user D-Bus session
+    bus that ``systemd-run --user`` needs may be absent even though the
+    binary is on PATH, causing every spawn to fail with
+    ``Failed to connect to user bus``.  We do a cheap no-op probe
+    (``systemd-run --user --scope --unit=… -- /bin/true``) and remember the
+    outcome.
+    """
+    global _SYSTEMD_SCOPE_AVAILABLE
+    if _SYSTEMD_SCOPE_AVAILABLE is not None:
+        return _SYSTEMD_SCOPE_AVAILABLE
+
+    _SYSTEMD_SCOPE_AVAILABLE = False
+    if _IS_WINDOWS:
+        return False
+    try:
+        import shutil
+
+        binary = shutil.which("systemd-run")
+        if not binary:
+            return False
+        # Probe: create a transient scope that immediately exits.  Use a
+        # unique unit name so concurrent probes don't collide.  A short
+        # timeout guards against a hung D-Bus.
+        probe_unit = f"hermes-probe-scope-{os.getpid()}-{int(time.time())}"
+        result = subprocess.run(
+            [
+                binary, "--user", "--scope",
+                "--unit", probe_unit,
+                "--collect",
+                "/bin/true",
+            ],
+            capture_output=True,
+            timeout=3,
+        )
+        _SYSTEMD_SCOPE_AVAILABLE = result.returncode == 0
+        if not _SYSTEMD_SCOPE_AVAILABLE:
+            logger.debug(
+                "systemd-run --user --scope probe failed (rc=%s): %s",
+                result.returncode,
+                (result.stderr or b"").decode("utf-8", "replace").strip(),
+            )
+    except Exception as exc:
+        logger.debug("systemd-run --user --scope probe error: %s", exc)
+        _SYSTEMD_SCOPE_AVAILABLE = False
+    return _SYSTEMD_SCOPE_AVAILABLE
+
+
+def _build_systemd_scope_argv(
+    shell_argv: List[str],
+    unit_suffix: str,
+) -> List[str]:
+    """Wrap *shell_argv* in a ``systemd-run --user --scope`` invocation.
+
+    The resulting cgroup gets its own memory accounting so an OOM in the
+    worker does not kill the gateway cgroup (#70716).  ``--collect`` makes
+    the transient scope self-clean after exit; ``--unit`` gives it a
+    recognisable name for ``systemctl --user status`` / journalctl.
+    """
+    import shutil
+
+    binary = shutil.which("systemd-run")
+    if binary is None:
+        # Caller should have checked _systemd_run_user_scope_available();
+        # guard anyway so we never pass None into Popen.
+        return shell_argv
+    unit_name = f"hermes-worker-{unit_suffix}"
+    return [
+        binary,
+        "--user",
+        "--scope",
+        "--unit",
+        unit_name,
+        "--collect",
+        *shell_argv,
+    ]
+
+
 def format_uptime_short(seconds: int) -> str:
     s = max(0, int(seconds))
     if s < 60:
@@ -780,8 +880,52 @@ class ProcessRegistry:
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
+        # Cgroup isolation (#70716): when running under a service manager
+        # (systemd gateway), wrap the worker in its own transient systemd
+        # scope so it gets a separate cgroup.  An OOM in the worker then
+        # kills only the worker instead of taking down the whole gateway
+        # cgroup (and the messaging control plane with it).  We only do this
+        # for the common pipe-mode path; PTY mode is left as future work.
+        shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+        use_systemd_scope = False
+        under_supervisor = False
+        try:
+            from gateway.restart import is_gateway_supervisor_process
+
+            under_supervisor = is_gateway_supervisor_process()
+            use_systemd_scope = (
+                not _IS_WINDOWS
+                and under_supervisor
+                and _systemd_run_user_scope_available()
+            )
+        except Exception:
+            use_systemd_scope = False
+
+        if use_systemd_scope:
+            spawn_argv = _build_systemd_scope_argv(
+                shell_argv, unit_suffix=session.id,
+            )
+            # systemd-run creates the new session/cgroup for us; do NOT also
+            # set start_new_session (harmless, but redundant and it can mask
+            # scope-creation failures in some systemd versions).
+            popen_start_new_session = False
+        else:
+            spawn_argv = shell_argv
+            popen_start_new_session = True
+            if not _IS_WINDOWS and under_supervisor:
+                # Running under a supervisor but could not get a private
+                # cgroup — the worker shares the gateway cgroup, so an OOM
+                # in the worker can still kill the whole gateway (#70716).
+                logger.debug(
+                    "Local background executor not isolated in a systemd scope "
+                    "(supervisor=%s, systemd-run --user available=%s); "
+                    "worker shares the gateway cgroup.",
+                    under_supervisor,
+                    _systemd_run_user_scope_available(),
+                )
+
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {safe_command}"],
+            spawn_argv,
             text=True,
             cwd=session.cwd,
             env=bg_env,
@@ -790,7 +934,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
-            start_new_session=True,
+            start_new_session=popen_start_new_session,
             **_popen_kwargs,
         )
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -97,6 +97,8 @@ WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 
 _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
+_SYSTEMD_SCOPE_PROBED_AT = 0.0
+_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
 
 
 def _systemd_run_user_scope_available() -> bool:
@@ -110,16 +112,31 @@ def _systemd_run_user_scope_available() -> bool:
     (``systemd-run --user --scope --unit=… -- /bin/true``) and remember the
     outcome.
     """
-    global _SYSTEMD_SCOPE_AVAILABLE
-    if _SYSTEMD_SCOPE_AVAILABLE is not None:
-        return _SYSTEMD_SCOPE_AVAILABLE
+    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
+    cached = _SYSTEMD_SCOPE_AVAILABLE
+    now = time.monotonic()
+    if cached is True:
+        return True
+    if (
+        cached is False
+        and now - _SYSTEMD_SCOPE_PROBED_AT < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+    ):
+        return False
 
     # Double-checked locking keeps concurrent first-use spawns from observing
     # a temporary False while the definitive probe is still in flight.  Such a
     # race would launch the losing workload back inside the gateway cgroup.
     with _SYSTEMD_SCOPE_PROBE_LOCK:
-        if _SYSTEMD_SCOPE_AVAILABLE is not None:
-            return _SYSTEMD_SCOPE_AVAILABLE
+        cached = _SYSTEMD_SCOPE_AVAILABLE
+        now = time.monotonic()
+        if cached is True:
+            return True
+        if (
+            cached is False
+            and now - _SYSTEMD_SCOPE_PROBED_AT
+            < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+        ):
+            return False
 
         available = False
         if not _IS_WINDOWS:
@@ -130,9 +147,7 @@ def _systemd_run_user_scope_available() -> bool:
                 if binary:
                     # Probe: create a transient scope that immediately exits.
                     # A unique unit avoids collisions; timeout bounds D-Bus.
-                    probe_unit = (
-                        f"hermes-probe-scope-{os.getpid()}-{int(time.time())}"
-                    )
+                    probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
                         [
                             binary, "--user", "--scope", "--quiet",
@@ -156,6 +171,7 @@ def _systemd_run_user_scope_available() -> bool:
                 logger.debug("systemd-run --user --scope probe error: %s", exc)
 
         _SYSTEMD_SCOPE_AVAILABLE = available
+        _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
         return available
 
 
@@ -215,10 +231,17 @@ def _stop_systemd_unit(unit_name: str) -> bool:
             timeout=15,
         )
         if result.returncode != 0:
+            stderr = (result.stderr or b"").decode(errors="replace").strip()
+            stderr_lower = stderr.lower()
+            if any(
+                marker in stderr_lower
+                for marker in ("not loaded", "not found", "does not exist")
+            ):
+                return True
             logger.debug(
                 "systemctl --user stop %s exited %d: %s",
                 unit_name, result.returncode,
-                result.stderr.decode(errors="replace").strip(),
+                stderr,
             )
             return False
         return True
@@ -969,7 +992,7 @@ class ProcessRegistry:
         # scope so it gets a separate cgroup.  An OOM in the worker then
         # kills only the worker instead of taking down the whole gateway
         # cgroup (and the messaging control plane with it).  We only do this
-        # for the common pipe-mode path; PTY mode is left as future work.
+        # for both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
         use_systemd_scope = False
         under_supervisor = False
@@ -1048,7 +1071,14 @@ class ProcessRegistry:
             # descendants spawned via setsid) before re-raising so they do not
             # leak as untracked background processes.
             try:
-                if not _IS_WINDOWS:
+                if session.systemd_unit:
+                    # systemd-run --scope shares the gateway's process group
+                    # because start_new_session=False.  Never killpg here: that
+                    # can signal the gateway itself.  Stop the sibling cgroup,
+                    # then safely terminate the wrapper PID tree as fallback.
+                    _stop_systemd_unit(session.systemd_unit)
+                    self._terminate_host_pid(proc.pid, session.host_start_time)
+                elif not _IS_WINDOWS:
                     try:
                         kill_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
                         os.killpg(os.getpgid(proc.pid), kill_signal)  # windows-footgun: ok - guarded by _IS_WINDOWS above

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -190,8 +190,8 @@ def _stop_systemd_unit(unit_name: str) -> bool:
     SIGTERM to every process in the unit's cgroup and escalates to SIGKILL
     after the unit's ``TimeoutStopSec``.
 
-    Returns True if the command ran (regardless of exit code — the unit may
-    already be gone), False if ``systemctl`` is unavailable.
+    Returns True if the unit was successfully stopped (or was already gone),
+    False if ``systemctl`` is unavailable or the stop command failed.
     """
     import shutil
 
@@ -199,11 +199,18 @@ def _stop_systemd_unit(unit_name: str) -> bool:
     if binary is None:
         return False
     try:
-        subprocess.run(
+        result = subprocess.run(
             [binary, "--user", "stop", unit_name],
             capture_output=True,
             timeout=15,
         )
+        if result.returncode != 0:
+            logger.debug(
+                "systemctl --user stop %s exited %d: %s",
+                unit_name, result.returncode,
+                result.stderr.decode(errors="replace").strip(),
+            )
+            return False
         return True
     except Exception as exc:
         logger.debug("systemctl --user stop %s failed: %s", unit_name, exc)
@@ -890,7 +897,7 @@ class ProcessRegistry:
                     pty_argv = _build_systemd_scope_argv(
                         pty_argv, unit_suffix=session.id,
                     )
-                    session.systemd_unit = f"hermes-worker-{session.id}"
+                    session.systemd_unit = f"hermes-worker-{session.id}.scope"
                 elif not _IS_WINDOWS:
                     try:
                         from gateway.restart import is_gateway_supervisor_process as _sup
@@ -972,7 +979,7 @@ class ProcessRegistry:
             spawn_argv = _build_systemd_scope_argv(
                 shell_argv, unit_suffix=session.id,
             )
-            session.systemd_unit = f"hermes-worker-{session.id}"
+            session.systemd_unit = f"hermes-worker-{session.id}.scope"
             # systemd-run creates the new session/cgroup for us; do NOT also
             # set start_new_session (harmless, but redundant and it can mask
             # scope-creation failures in some systemd versions).
@@ -1864,6 +1871,12 @@ class ProcessRegistry:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         if session.exited:
+            # Even if the main process already exited, a double-forked
+            # descendant may still be alive in the systemd scope (#70716,
+            # reviewer gap #2 — the ``already_exited`` early return skipped
+            # unit cleanup).  Stop the scope to reap any survivors.
+            if session.systemd_unit:
+                _stop_systemd_unit(session.systemd_unit)
             with session._lock:
                 result = {
                     "status": "already_exited",
@@ -1899,8 +1912,14 @@ class ProcessRegistry:
             elif session.detached and session.pid_scope == "host" and session.pid:
                 # Identity check, not bare liveness: if the PID is gone OR was
                 # recycled onto an unrelated process, treat our process as
-                # exited and never tree-kill the stranger.
+                # exited and never tree-kill the stranger.  If this recovered
+                # session also carries an owned systemd scope, stop that scope
+                # before returning: a daemonized descendant may still be alive
+                # there even though the wrapper PID exited or was recycled
+                # across the gateway restart (#70716, teknium1 review).
                 if not self._host_pid_is_ours(session.pid, session.host_start_time):
+                    if session.systemd_unit:
+                        _stop_systemd_unit(session.systemd_unit)
                     with session._lock:
                         session.exited = True
                         session.exit_code = None

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -128,9 +128,9 @@ def _systemd_run_user_scope_available() -> bool:
         probe_unit = f"hermes-probe-scope-{os.getpid()}-{int(time.time())}"
         result = subprocess.run(
             [
-                binary, "--user", "--scope",
+                binary, "--user", "--scope", "--quiet",
                 "--unit", probe_unit,
-                "--collect",
+                "--collect", "--",
                 "/bin/true",
             ],
             capture_output=True,
@@ -172,11 +172,42 @@ def _build_systemd_scope_argv(
         binary,
         "--user",
         "--scope",
+        "--quiet",
         "--unit",
         unit_name,
         "--collect",
+        "--",
         *shell_argv,
     ]
+
+
+def _stop_systemd_unit(unit_name: str) -> bool:
+    """Stop a transient systemd user scope by unit name.
+
+    This reaps the *entire* cgroup — catching double-forked descendants that
+    survive a plain PID signal because they were reparented to init inside the
+    scope (issue #70716, reviewer gap #2).  ``systemctl --user stop`` sends
+    SIGTERM to every process in the unit's cgroup and escalates to SIGKILL
+    after the unit's ``TimeoutStopSec``.
+
+    Returns True if the command ran (regardless of exit code — the unit may
+    already be gone), False if ``systemctl`` is unavailable.
+    """
+    import shutil
+
+    binary = shutil.which("systemctl")
+    if binary is None:
+        return False
+    try:
+        subprocess.run(
+            [binary, "--user", "stop", unit_name],
+            capture_output=True,
+            timeout=15,
+        )
+        return True
+    except Exception as exc:
+        logger.debug("systemctl --user stop %s failed: %s", unit_name, exc)
+        return False
 
 
 def format_uptime_short(seconds: int) -> str:
@@ -211,6 +242,7 @@ class ProcessSession:
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run (#70716)
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
@@ -836,8 +868,43 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                pty_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+
+                # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
+                # Wrap the PTY command in a systemd scope so interactive
+                # executors get their own cgroup, same as pipe mode.
+                pty_use_systemd_scope = False
+                try:
+                    from gateway.restart import is_gateway_supervisor_process
+
+                    pty_under_supervisor = is_gateway_supervisor_process()
+                    pty_use_systemd_scope = (
+                        not _IS_WINDOWS
+                        and pty_under_supervisor
+                        and _systemd_run_user_scope_available()
+                    )
+                except Exception:
+                    pty_use_systemd_scope = False
+
+                if pty_use_systemd_scope:
+                    pty_argv = _build_systemd_scope_argv(
+                        pty_argv, unit_suffix=session.id,
+                    )
+                    session.systemd_unit = f"hermes-worker-{session.id}"
+                elif not _IS_WINDOWS:
+                    try:
+                        from gateway.restart import is_gateway_supervisor_process as _sup
+                        if _sup():
+                            logger.debug(
+                                "PTY background executor not isolated in a "
+                                "systemd scope (systemd-run --user unavailable); "
+                                "worker shares the gateway cgroup."
+                            )
+                    except Exception:
+                        pass
+
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {safe_command}"],
+                    pty_argv,
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -905,6 +972,7 @@ class ProcessRegistry:
             spawn_argv = _build_systemd_scope_argv(
                 shell_argv, unit_suffix=session.id,
             )
+            session.systemd_unit = f"hermes-worker-{session.id}"
             # systemd-run creates the new session/cgroup for us; do NOT also
             # set start_new_session (harmless, but redundant and it can mask
             # scope-creation failures in some systemd versions).
@@ -1854,6 +1922,16 @@ class ProcessRegistry:
                         "its original runtime handle is no longer available"
                     ),
                 }
+
+            # If the worker was spawned in its own systemd scope (#70716),
+            # stop the entire unit to reap any double-forked descendants that
+            # were reparented inside the scope and survived the PID signal
+            # above (reviewer gap #2).  ``systemctl --user stop`` sends
+            # SIGTERM to every process in the cgroup and escalates to SIGKILL
+            # after TimeoutStopSec.  This is additive — the PID-based kill
+            # above already handled the main process; this catches stragglers.
+            if session.systemd_unit:
+                _stop_systemd_unit(session.systemd_unit)
             # Capture output before marking consumed, then mark consumed before
             # exposing ``exited`` to watcher tasks. This closes the delayed
             # notification race without discarding the terminal transcript.
@@ -2224,6 +2302,7 @@ class ProcessRegistry:
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
                             "host_start_time": s.host_start_time,
+                            "systemd_unit": s.systemd_unit,
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
@@ -2303,6 +2382,7 @@ class ProcessRegistry:
                 pid=pid,
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,
+                systemd_unit=entry.get("systemd_unit", ""),
                 cwd=entry.get("cwd"),
                 started_at=entry.get("started_at", time.time()),
                 detached=True,  # Can't read output, but can report status + kill

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -108,25 +108,26 @@ _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
 def _worker_memory_max_bytes() -> int:
     """Return a finite per-worker cgroup limit without widening host risk.
 
-    An explicit byte override is useful for operators with known workload
-    requirements.  Otherwise retain the tighter of the gateway's current
-    cgroup-v2 ``memory.max`` and half of physical RAM, capped at 4 GiB.  This
-    keeps the sibling worker outside the gateway cgroup while ensuring the
-    worker cannot consume memory up to the enclosing user slice or host limit.
+    The proposed local-memory-guard environment override is honored so this
+    isolation composes with PR #57121 instead of inventing a second knob.
+    Otherwise retain the tighter of the gateway's current cgroup-v2
+    ``memory.max`` and half of physical RAM, capped at 4 GiB.  This keeps the
+    sibling worker outside the gateway cgroup while ensuring the worker cannot
+    consume memory up to the enclosing user slice or host limit.
     """
-    override = os.getenv("HERMES_WORKER_MEMORY_MAX_BYTES", "").strip()
+    override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
     if override:
         try:
-            parsed = int(override)
+            parsed = int(override) * 1024 * 1024
             if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
                 return parsed
         except ValueError:
             pass
         logger.warning(
-            "Ignoring invalid HERMES_WORKER_MEMORY_MAX_BYTES=%r; "
-            "expected an integer of at least %d bytes",
+            "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
+            "expected an integer representing at least %d MiB",
             override,
-            _MIN_WORKER_MEMORY_MAX_BYTES,
+            _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
         )
 
     candidates: List[int] = []

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -108,19 +108,21 @@ _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
 def _worker_memory_max_bytes() -> int:
     """Return a finite per-worker cgroup limit without widening host risk.
 
-    The proposed local-memory-guard environment override is honored so this
-    isolation composes with PR #57121 instead of inventing a second knob.
+    The proposed local-memory-guard environment override is honored when it
+    tightens the safe bound, so this isolation composes with PR #57121 instead
+    of inventing a second knob.  An oversized override cannot widen host risk.
     Otherwise retain the tighter of the gateway's current cgroup-v2
     ``memory.max`` and half of physical RAM, capped at 4 GiB.  This keeps the
     sibling worker outside the gateway cgroup while ensuring the worker cannot
     consume memory up to the enclosing user slice or host limit.
     """
+    override_bound: Optional[int] = None
     override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
     if override:
         try:
             parsed = int(override) * 1024 * 1024
             if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
-                return parsed
+                override_bound = parsed
         except ValueError:
             pass
         logger.warning(
@@ -158,7 +160,8 @@ def _worker_memory_max_bytes() -> int:
     except (OSError, ValueError, TypeError):
         pass
 
-    return min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
+    safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
+    return min(override_bound, safe_bound) if override_bound else safe_bound
 
 
 def _systemd_run_user_scope_available() -> bool:
@@ -969,6 +972,7 @@ class ProcessRegistry:
             started_at=time.time(),
         )
 
+        pty_scope_attempted = False
         if use_pty:
             # Try PTY mode for interactive CLI tools
             try:
@@ -1002,6 +1006,7 @@ class ProcessRegistry:
                         pty_argv, unit_suffix=session.id,
                     )
                     session.systemd_unit = f"hermes-worker-{session.id}.scope"
+                    pty_scope_attempted = True
                 elif not _IS_WINDOWS:
                     try:
                         from gateway.restart import is_gateway_supervisor_process as _sup
@@ -1046,6 +1051,9 @@ class ProcessRegistry:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
+                if pty_scope_attempted and session.systemd_unit:
+                    _stop_systemd_unit(session.systemd_unit)
+                    session.systemd_unit = ""
 
         # Standard Popen path (non-PTY or PTY fallback)
         # Use the user's login shell for consistency with LocalEnvironment --
@@ -1080,10 +1088,15 @@ class ProcessRegistry:
             use_systemd_scope = False
 
         if use_systemd_scope:
-            spawn_argv = _build_systemd_scope_argv(
-                shell_argv, unit_suffix=session.id,
+            unit_suffix = (
+                f"{session.id}-pipe-fallback"
+                if pty_scope_attempted
+                else session.id
             )
-            session.systemd_unit = f"hermes-worker-{session.id}.scope"
+            spawn_argv = _build_systemd_scope_argv(
+                shell_argv, unit_suffix=unit_suffix,
+            )
+            session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
             # systemd-run creates the new session/cgroup for us; do NOT also
             # set start_new_session (harmless, but redundant and it can mask
             # scope-creation failures in some systemd versions).

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -119,18 +119,21 @@ def _worker_memory_max_bytes() -> int:
     override_bound: Optional[int] = None
     override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
     if override:
+        override_valid = False
         try:
             parsed = int(override) * 1024 * 1024
             if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
                 override_bound = parsed
+                override_valid = True
         except ValueError:
             pass
-        logger.warning(
-            "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
-            "expected an integer representing at least %d MiB",
-            override,
-            _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
-        )
+        if not override_valid:
+            logger.warning(
+                "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
+                "expected an integer representing at least %d MiB",
+                override,
+                _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
+            )
 
     candidates: List[int] = []
     try:
@@ -1052,7 +1055,11 @@ class ProcessRegistry:
             except Exception as e:
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
                 if pty_scope_attempted and session.systemd_unit:
-                    _stop_systemd_unit(session.systemd_unit)
+                    if not _stop_systemd_unit(session.systemd_unit):
+                        raise RuntimeError(
+                            "PTY scope could not be reaped; refusing pipe fallback "
+                            "to avoid duplicate command execution"
+                        ) from e
                     session.systemd_unit = ""
 
         # Standard Popen path (non-PTY or PTY fallback)
@@ -2420,7 +2427,10 @@ class ProcessRegistry:
 
     # ----- Checkpoint (crash recovery) -----
 
-    def _write_checkpoint(self):
+    def _write_checkpoint(
+        self,
+        extra_entries: Optional[List[Dict[str, Any]]] = None,
+    ):
         """Write running process metadata to checkpoint file atomically."""
         try:
             with self._lock:
@@ -2460,6 +2470,13 @@ class ProcessRegistry:
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
                         })
+                if extra_entries:
+                    tracked_ids = {item.get("session_id") for item in entries}
+                    entries.extend(
+                        item
+                        for item in extra_entries
+                        if item.get("session_id") not in tracked_ids
+                    )
             
             # Atomic write to avoid corruption on crash
             from utils import atomic_json_write
@@ -2482,6 +2499,7 @@ class ProcessRegistry:
             return 0
 
         recovered = 0
+        unresolved_scope_entries: List[Dict[str, Any]] = []
         for entry in entries:
             pid = entry.get("pid")
             if not pid:
@@ -2515,6 +2533,15 @@ class ProcessRegistry:
                         "an unrelated process; refusing to adopt it.",
                         entry.get("session_id", "?"), pid,
                     )
+                systemd_unit = entry.get("systemd_unit", "")
+                if systemd_unit and not _stop_systemd_unit(systemd_unit):
+                    logger.warning(
+                        "Could not reap persisted scope %s for dead wrapper pid %s; "
+                        "retaining checkpoint entry for the next startup",
+                        systemd_unit,
+                        pid,
+                    )
+                    unresolved_scope_entries.append(entry)
                 continue
 
             session = ProcessSession(
@@ -2559,7 +2586,7 @@ class ProcessRegistry:
                     "notify_on_complete": session.notify_on_complete,
                 })
 
-        self._write_checkpoint()
+        self._write_checkpoint(extra_entries=unresolved_scope_entries)
 
         return recovered
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -40,6 +40,7 @@ import subprocess
 import threading
 import time
 import uuid
+from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
@@ -99,6 +100,64 @@ _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
 _SYSTEMD_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
+_MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
+_DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
+_WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
+
+
+def _worker_memory_max_bytes() -> int:
+    """Return a finite per-worker cgroup limit without widening host risk.
+
+    An explicit byte override is useful for operators with known workload
+    requirements.  Otherwise retain the tighter of the gateway's current
+    cgroup-v2 ``memory.max`` and half of physical RAM, capped at 4 GiB.  This
+    keeps the sibling worker outside the gateway cgroup while ensuring the
+    worker cannot consume memory up to the enclosing user slice or host limit.
+    """
+    override = os.getenv("HERMES_WORKER_MEMORY_MAX_BYTES", "").strip()
+    if override:
+        try:
+            parsed = int(override)
+            if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
+                return parsed
+        except ValueError:
+            pass
+        logger.warning(
+            "Ignoring invalid HERMES_WORKER_MEMORY_MAX_BYTES=%r; "
+            "expected an integer of at least %d bytes",
+            override,
+            _MIN_WORKER_MEMORY_MAX_BYTES,
+        )
+
+    candidates: List[int] = []
+    try:
+        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
+            if line.startswith("0::"):
+                relative = line.partition("::")[2].lstrip("/")
+                raw_limit = (
+                    Path("/sys/fs/cgroup") / relative / "memory.max"
+                ).read_text(encoding="utf-8").strip()
+                if raw_limit.isdigit():
+                    cgroup_limit = int(raw_limit)
+                    if cgroup_limit >= _MIN_WORKER_MEMORY_MAX_BYTES:
+                        candidates.append(cgroup_limit)
+                break
+    except (OSError, ValueError):
+        pass
+
+    try:
+        physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
+            os.sysconf("SC_PAGE_SIZE")
+        )
+        physical_bound = min(
+            _WORKER_MEMORY_MAX_CAP_BYTES,
+            max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
+        )
+        candidates.append(physical_bound)
+    except (OSError, ValueError, TypeError):
+        pass
+
+    return min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
 
 
 def _systemd_run_user_scope_available() -> bool:
@@ -152,7 +211,11 @@ def _systemd_run_user_scope_available() -> bool:
                         [
                             binary, "--user", "--scope", "--quiet",
                             "--unit", probe_unit,
-                            "--collect", "--",
+                            "--collect",
+                            "--property", "MemoryAccounting=yes",
+                            "--property", f"MemoryMax={_worker_memory_max_bytes()}",
+                            "--property", "OOMPolicy=kill",
+                            "--",
                             "/bin/true",
                         ],
                         capture_output=True,
@@ -194,6 +257,7 @@ def _build_systemd_scope_argv(
         # guard anyway so we never pass None into Popen.
         return shell_argv
     unit_name = f"hermes-worker-{unit_suffix}"
+    memory_max = _worker_memory_max_bytes()
     return [
         binary,
         "--user",
@@ -202,6 +266,12 @@ def _build_systemd_scope_argv(
         "--unit",
         unit_name,
         "--collect",
+        "--property",
+        "MemoryAccounting=yes",
+        "--property",
+        f"MemoryMax={memory_max}",
+        "--property",
+        "OOMPolicy=kill",
         "--",
         *shell_argv,
     ]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -96,6 +96,7 @@ WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 # services and containers), and cache the result for the process lifetime.
 
 _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
+_SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
 
 
 def _systemd_run_user_scope_available() -> bool:
@@ -113,40 +114,49 @@ def _systemd_run_user_scope_available() -> bool:
     if _SYSTEMD_SCOPE_AVAILABLE is not None:
         return _SYSTEMD_SCOPE_AVAILABLE
 
-    _SYSTEMD_SCOPE_AVAILABLE = False
-    if _IS_WINDOWS:
-        return False
-    try:
-        import shutil
+    # Double-checked locking keeps concurrent first-use spawns from observing
+    # a temporary False while the definitive probe is still in flight.  Such a
+    # race would launch the losing workload back inside the gateway cgroup.
+    with _SYSTEMD_SCOPE_PROBE_LOCK:
+        if _SYSTEMD_SCOPE_AVAILABLE is not None:
+            return _SYSTEMD_SCOPE_AVAILABLE
 
-        binary = shutil.which("systemd-run")
-        if not binary:
-            return False
-        # Probe: create a transient scope that immediately exits.  Use a
-        # unique unit name so concurrent probes don't collide.  A short
-        # timeout guards against a hung D-Bus.
-        probe_unit = f"hermes-probe-scope-{os.getpid()}-{int(time.time())}"
-        result = subprocess.run(
-            [
-                binary, "--user", "--scope", "--quiet",
-                "--unit", probe_unit,
-                "--collect", "--",
-                "/bin/true",
-            ],
-            capture_output=True,
-            timeout=3,
-        )
-        _SYSTEMD_SCOPE_AVAILABLE = result.returncode == 0
-        if not _SYSTEMD_SCOPE_AVAILABLE:
-            logger.debug(
-                "systemd-run --user --scope probe failed (rc=%s): %s",
-                result.returncode,
-                (result.stderr or b"").decode("utf-8", "replace").strip(),
-            )
-    except Exception as exc:
-        logger.debug("systemd-run --user --scope probe error: %s", exc)
-        _SYSTEMD_SCOPE_AVAILABLE = False
-    return _SYSTEMD_SCOPE_AVAILABLE
+        available = False
+        if not _IS_WINDOWS:
+            try:
+                import shutil
+
+                binary = shutil.which("systemd-run")
+                if binary:
+                    # Probe: create a transient scope that immediately exits.
+                    # A unique unit avoids collisions; timeout bounds D-Bus.
+                    probe_unit = (
+                        f"hermes-probe-scope-{os.getpid()}-{int(time.time())}"
+                    )
+                    result = subprocess.run(
+                        [
+                            binary, "--user", "--scope", "--quiet",
+                            "--unit", probe_unit,
+                            "--collect", "--",
+                            "/bin/true",
+                        ],
+                        capture_output=True,
+                        timeout=3,
+                    )
+                    available = result.returncode == 0
+                    if not available:
+                        logger.debug(
+                            "systemd-run --user --scope probe failed (rc=%s): %s",
+                            result.returncode,
+                            (result.stderr or b"").decode(
+                                "utf-8", "replace"
+                            ).strip(),
+                        )
+            except Exception as exc:
+                logger.debug("systemd-run --user --scope probe error: %s", exc)
+
+        _SYSTEMD_SCOPE_AVAILABLE = available
+        return available
 
 
 def _build_systemd_scope_argv(


### PR DESCRIPTION
## Summary

Combines two halves of the gateway OOM incident (#70716): (1) prevention — wraps gateway-spawned local background/PTY workers in transient systemd user scopes with finite MemoryMax so an OOM in a worker kills only the worker, not the whole gateway cgroup; (2) recovery — durably records the exact active gateway turn and, after an unclean exit, routes that exact session through the existing `resume_pending` recovery path instead of guessing from `updated_at` recency.

Refreshes and extends #71378 on current `main`. Three commits from @toprakeker preserved with original authorship.

## Changes

- **tools/process_registry.py**: systemd cgroup isolation for local executors (`_systemd_run_user_scope_available`, `_build_systemd_scope_argv`, `_stop_systemd_unit`, `_worker_memory_max_bytes`), checkpoint persistence of `systemd_unit`, scope cleanup in kill/recover paths
- **gateway/session.py**: durable active-turn marker system (`mark_turn_active`, `clear_turn_active`, `recover_interrupted_turns`, `discard_active_turn_markers`), refactored `_save_entry` with `entry_data`/`lock_held` params for failure-atomic persistence, hardened `_persist_routing_data` sessions.json mirror failure
- **gateway/run.py**: clean-shutdown marker now discards orphan turn markers; unclean startup runs exact recovery + legacy fallback; `_mark_durable_active_turn`/`_clear_durable_active_turn` on the event object
- **Follow-up fix**: deferred O(n) `fallback_data` construction in `_save_entry` to the failure path (was eagerly built under the lock on every turn even when DB upsert succeeded)

## Validation

| | Before | After |
|---|---|---|
| Targeted tests | — | 183 passed |
| E2E smoke | — | mark/clear CAS, crash recovery, failure-atomic, discard all pass |
| Ruff | — | clean |
| Attribution | — | @toprakeker (3 commits) + @dombejar (9 commits) preserved via rebase |

Addresses #70716. Supersedes #71378. Coordinates with #56865 and #57121.
