### PR TITLE
fix(tui_gateway): answer /context for an idle session

### DIFF
--- a/tests/tui_gateway/test_context_idle_session.py
+++ b/tests/tui_gateway/test_context_idle_session.py
@@ -1,0 +1,93 @@
+"""``/context`` must answer for an idle session, not report "No active agent".
+
+The gateway already renders a full context view from persisted state
+(``_format_live_context_output``), but the routing gate only reached it for
+compute-host sessions, i.e. when ``dashboard.process_isolation.turn_isolation``
+is on. With the default config the command fell through to the CLI handler,
+which requires ``self.agent`` and answers "No active agent -- send a message
+first." for a session that plainly has messages.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from tui_gateway import server
+
+
+def _session(*, agent=None, messages=2):
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ][:messages]
+    return {
+        "session_key": "sk-1",
+        "history": history,
+        "history_lock": threading.Lock(),
+        "agent": agent,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _no_db(monkeypatch):
+    """Render from in-memory history so the test needs no state.db."""
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+
+def test_context_answers_for_an_idle_session(monkeypatch):
+    """The bug: an agentless session got None here and fell through to the CLI."""
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+
+    out = server._live_slash_command_output("sid", _session(agent=None), "context", "")
+
+    assert out is not None, "/context fell through to the CLI handler for an idle session"
+    assert "No active agent" not in out
+    assert "Conversation:" in out
+
+
+def test_context_still_reaches_the_cli_handler_when_an_agent_is_live(monkeypatch):
+    """Guard: a live agent keeps the richer CLI rendering, unchanged."""
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+
+    out = server._live_slash_command_output(
+        "sid", _session(agent=object()), "context", ""
+    )
+
+    assert out is None
+
+
+def test_compute_host_context_path_is_unchanged(monkeypatch):
+    """Guard: the isolated/compute-host route this gate was built for still works."""
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: True)
+
+    out = server._live_slash_command_output(
+        "sid", _session(agent=object()), "context", ""
+    )
+
+    assert out is not None
+    assert "Conversation:" in out
+
+
+def test_tools_is_not_widened_by_this_change(monkeypatch):
+    """Scope guard: /tools consults the agent, so it must keep its old routing."""
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+
+    out = server._live_slash_command_output("sid", _session(agent=None), "tools", "")
+
+    assert out is None
+
+
+def test_context_without_a_session_still_declines(monkeypatch):
+    """No session dict means nothing to render from; the caller keeps its path."""
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+
+    assert server._live_slash_command_output("sid", None, "context", "") is None
+
+
+def test_serves_persisted_read_predicate():
+    assert server._serves_persisted_read({"agent": None}, "context") is True
+    assert server._serves_persisted_read({"agent": object()}, "context") is False
+    assert server._serves_persisted_read({"agent": None}, "tools") is False
+    assert server._serves_persisted_read(None, "context") is False

--- a/tui_gateway/methods_slash.py
+++ b/tui_gateway/methods_slash.py
@@ -18,6 +18,24 @@ _registry = HandlerRegistry()
 # Answered from the live session ONLY when the agent lives on a compute host.
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
+# Read-only views that render entirely from persisted session state (transcript,
+# usage mirror) and never touch the live agent. Without this, an idle session
+# falls through to the CLI handler, which needs ``self.agent`` and answers
+# "No active agent -- send a message first." for a session that plainly has
+# messages. Scoped to /context: the other isolated-read commands do consult the
+# agent (``_format_live_tools_output`` reads ``session["agent"]``), so serving
+# them from here would answer worse, not better.
+_PERSISTED_READ_COMMANDS = frozenset({"context"})
+
+
+def _serves_persisted_read(session, name: str) -> bool:
+    """True when *name* can be answered from stored state for an agentless session."""
+    return (
+        name in _PERSISTED_READ_COMMANDS
+        and session is not None
+        and session.get("agent") is None
+    )
+
 _NO_AGENT_USAGE = "(._.) No active agent -- send a message first."
 _NO_AGENT = "No active agent -- send a message first."
 
@@ -209,7 +227,10 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     arg = arg or ""
     if name == "model" and not arg.strip():
         return _format_live_model_output(session or {})
-    if name in _ISOLATED_SESSION_READ_COMMANDS and not (session is not None and _session_uses_compute_host(session)):
+    if name in _ISOLATED_SESSION_READ_COMMANDS and not (
+        (session is not None and _session_uses_compute_host(session))
+        or _serves_persisted_read(session, name)
+    ):
         return None
     entry = _LIVE_SLASH_OUTPUT.get(name)
     if entry is None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12390,6 +12390,23 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
 
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
+# Read-only views that render entirely from persisted session state (transcript,
+# usage mirror) and never touch the live agent. Without this, an idle session
+# falls through to the CLI handler, which needs ``self.agent`` and answers
+# "No active agent -- send a message first." for a session that plainly has
+# messages. Scoped to /context: the other isolated-read commands do consult the
+# agent, so serving them from here would answer worse, not better.
+_PERSISTED_READ_COMMANDS = frozenset({"context"})
+
+
+def _serves_persisted_read(session: Optional[dict], name: str) -> bool:
+    """True when *name* can be answered from stored state for an agentless session."""
+    return (
+        name in _PERSISTED_READ_COMMANDS
+        and session is not None
+        and session.get("agent") is None
+    )
+
 
 def _format_live_usage_output(session: dict) -> str:
     agent = session.get("agent")
@@ -12573,14 +12590,18 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
         return _format_live_model_output(session or {})
     if name not in _LIVE_SESSION_DIRECT_COMMANDS:
         if not (
-            name in _ISOLATED_SESSION_READ_COMMANDS
-            and session is not None
-            and _session_uses_compute_host(session)
+            (
+                name in _ISOLATED_SESSION_READ_COMMANDS
+                and session is not None
+                and _session_uses_compute_host(session)
+            )
+            or _serves_persisted_read(session, name)
         ):
             return None
 
     if name in _ISOLATED_SESSION_READ_COMMANDS and not (
-        session is not None and _session_uses_compute_host(session)
+        (session is not None and _session_uses_compute_host(session))
+        or _serves_persisted_read(session, name)
     ):
         return None
     if name == "compress":


### PR DESCRIPTION
## What does this PR do?

`/context` in Desktop and the TUI answers:

```
(._.) No active agent -- send a message first.
```

for a session that plainly has messages, as soon as the agent goes idle.

The gateway already knows how to answer. `_format_live_context_output()` renders the whole view from persisted state: the transcript out of `state.db` (falling back to the session's in-memory history), the usage snapshot, and the metadata mirror. It never touches the live agent.

The routing gate in `_live_slash_command_output` is what makes it unreachable:

```python
if name not in _LIVE_SESSION_DIRECT_COMMANDS:          # "context" is not in this set
    if not (
        name in _ISOLATED_SESSION_READ_COMMANDS         # it is in this one
        and session is not None
        and _session_uses_compute_host(session)         # ... but this decides
    ):
        return None
```

`_session_uses_compute_host()` returns `False` outright unless `dashboard.process_isolation.turn_isolation` is enabled. With the default config the gate returns `None`, the request falls through to the CLI handler, and that handler needs `self.agent` (it calls `build_system_prompt_parts(agent)` and reads `agent.tools` / `agent.context_compressor`). Idle session, no agent, wrong answer.

So the read-only path was built for compute-host sessions only, and the case that needs it most, a normal session whose agent has been torn down, was never routed to it.

### The fix

Serve `/context` from persisted state when the session has no live agent, regardless of turn isolation.

```python
_PERSISTED_READ_COMMANDS = frozenset({"context"})


def _serves_persisted_read(session, name) -> bool:
    return (
        name in _PERSISTED_READ_COMMANDS
        and session is not None
        and session.get("agent") is None
    )
```

Deliberately narrow, in two directions:

- **Only when there is no agent.** A live agent still falls through to the CLI handler, so the richer 5x20 grid rendering is untouched. This adds an answer where there was an error; it does not replace a working one.
- **Only `/context`.** `_ISOLATED_SESSION_READ_COMMANDS` also holds `tools` and `help`, and I left both alone. `_format_live_tools_output()` reads `session["agent"]` through `_session_info()`, so routing it here for an agentless session would return "No tools available." That is a worse answer than the CLI's, not a better one. `/tools` and `/usage` have the same underlying shape as this bug but need their own persisted renderers, which is a bigger change than the reported defect justifies.

## Related Issue

Fixes #81251 (P2, `comp/tui`, `comp/desktop`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81251"                       --limit 25   # 0
gh search prs --repo NousResearch/hermes-agent "/context in:title"           --limit 25   # nothing on this path
gh search prs --repo NousResearch/hermes-agent "No active agent"             --limit 25   # only #42772, /usage
gh search prs --repo NousResearch/hermes-agent "context command no active agent" --limit 25 # 0
gh search prs --repo NousResearch/hermes-agent "context breakdown gateway"   --limit 25   # 0
```

The nearest neighbour is #42772 ("show persisted usage without live agent", open), which adds a persisted fallback for `/usage` only. It does not touch `/context` and does not touch this gate, so the two do not collide and either can merge first. #64360 / #64396 / #64551 are about the wording of `/usage` on fresh sessions, not routing.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `tui_gateway/server.py` - added `_PERSISTED_READ_COMMANDS` and `_serves_persisted_read()`; both arms of the routing gate now also admit a persisted read.
- `tests/tui_gateway/test_context_idle_session.py` - new, 6 tests.

## How to Test

```
pytest tests/tui_gateway/test_context_idle_session.py -q
```

6 passed: the idle session now answers; a live agent still falls through to the CLI; the compute-host route the gate was written for is unchanged; `/tools` is explicitly not widened; a missing session still declines; and the predicate itself across its four cases.

Reverting only `tui_gateway/server.py` and rerunning:

```
FAILED test_context_answers_for_an_idle_session
FAILED test_serves_persisted_read_predicate
2 failed, 4 passed
```

with

```
E  AssertionError: /context fell through to the CLI handler for an idle session
E  assert None is not None
```

`test_serves_persisted_read_predicate` fails on `AttributeError` because it is the unit test of the new helper. The behavioural probe is `test_context_answers_for_an_idle_session`, which fails on unpatched `main` for the reason above.

The other three pass both before and after by design. They are guards, not regression probes: they pin that this change does not disturb the live-agent path, the compute-host path, or `/tools`.

`tests/tui_gateway/` + `tests/test_tui_gateway_server.py`, this branch vs `main`, same environment, run serially:

```
main:   2 failed, 895 passed
branch: 2 failed, 902 passed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical (`test_slash_worker_mcp_discovery.py::test_profile_local_mcp_tool_is_visible_in_slash_worker` and `test_slash_worker_sys_path.py::test_slash_worker_imports_from_cwd_with_colliding_utils`, both pre-existing subprocess-spawning slash-worker tests). The +7 is this PR's 6 new tests plus one flaky concurrency test (`test_write_json_serializes_concurrent_writes`) that failed on an earlier baseline run and passed on both sides here; I am flagging it rather than claiming this branch fixed it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui_gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the new constant and helper carry comments recording why `/context` is safe to serve without an agent and why its siblings are not
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A, dict lookups and set membership
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The issue reports this on Windows 11, but nothing here is platform-specific: the gate turns on config, not OS, so any Desktop or TUI user without `turn_isolation` sees it.

Two follow-ups I deliberately did not fold in. `/usage` has the same shape and is already claimed by #42772. `/tools` would need a persisted renderer that lists tools without an agent, which is real work rather than a routing change. If you would rather see one shared "persisted read" renderer for all three, say so and I will follow that shape instead.
