### PR TITLE
fix(moa): add max_concurrent_references preset knob for sequential reference fan-out (#78011)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1873,6 +1873,9 @@ def run_conversation(
                     degraded_reference_policy=str(
                         moa_config.get("degraded_reference_policy") or "loud"
                     ),
+                    max_concurrent_references=moa_config.get(
+                        "max_concurrent_references"
+                    ),
                     agent=agent,
                 )
                 if _moa_context:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -783,6 +783,7 @@ def _run_references_parallel(
     reference_timeout: float | None = None,
     agent: Any = None,
     late_accounting_sink: Any = None,
+    max_workers: int | None = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -791,6 +792,14 @@ def _run_references_parallel(
     the aggregator. Output order matches ``reference_models`` so the
     ``Reference {idx}`` labelling stays stable. MoA presets that reference
     another MoA preset are skipped here (recursion guard) with a labelled note.
+
+    ``max_workers`` caps how many references run CONCURRENTLY (``None`` = no
+    user cap — the module-level ``_MAX_REFERENCE_WORKERS`` ceiling applies
+    instead; the fan-out is never unlimited). Setting it to 1 forces a fully
+    sequential fan-out, which local
+    JIT-loaded inference servers (e.g. LM Studio with
+    ``model.lmstudio_load_mode: jit``) require — concurrent model-load
+    requests abort each other on a single GPU (#78011).
 
     If ``progress_callback`` is provided it is invoked as each reference
     completes: ``progress_callback(refs_done, refs_total, label)``. The total
@@ -824,7 +833,20 @@ def _run_references_parallel(
 
     results: list[tuple[str, str, Any] | None] = [None] * len(reference_models)
     futures: dict[Any, int] = {}
-    workers = min(_MAX_REFERENCE_WORKERS, len(reference_models))
+    # Defensive sanitize: callers (config coercion, web validator) guarantee a
+    # positive int or None, but a programmatic caller may pass anything. A
+    # negative or zero value must fall back to the ceiling — never reach
+    # ThreadPoolExecutor (max_workers <= 0 raises ValueError) and never mean
+    # "disable" (0 must not silently serialize via the truthiness fallback).
+    if (
+        isinstance(max_workers, int)
+        and not isinstance(max_workers, bool)
+        and max_workers > 0
+    ):
+        _cap = max_workers
+    else:
+        _cap = _MAX_REFERENCE_WORKERS
+    workers = min(_cap, len(reference_models))
     # Reference slots run on bare executor threads, which start with an empty
     # contextvars.Context — propagate the parent turn's context (approval
     # callbacks + the Nous Portal conversation tag) into each worker so
@@ -1218,6 +1240,7 @@ def aggregate_moa_context(
     reference_timeout: float | None = None,
     degraded_reference_policy: str = "loud",
     agent: Any = None,
+    max_concurrent_references: int | None = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
@@ -1232,6 +1255,10 @@ def aggregate_moa_context(
     previously truncated long aggregator syntheses (#53580) — passing
     ``reference_max_tokens`` to both calls here would silently reintroduce
     that regression.
+
+    ``max_concurrent_references`` caps how many advisors run concurrently
+    (None = module ceiling; 1 = fully sequential — required by local
+    JIT-loaded servers like LM Studio, #78011).
 
     ``temperature`` / ``aggregator_temperature`` are ``None`` by default:
     like ``reference_max_tokens``, ``call_llm`` omits temperature when None
@@ -1251,6 +1278,7 @@ def aggregate_moa_context(
         max_tokens=reference_max_tokens,
         reference_timeout=reference_timeout,
         agent=agent,
+        max_workers=max_concurrent_references,
     )
 
     successful_outputs = _successful_references(reference_outputs)
@@ -1927,6 +1955,12 @@ class MoAChatCompletions:
         reference_timeout = (
             float(raw_reference_timeout) if raw_reference_timeout else None
         )
+        # Cap on concurrent advisor calls. None (default) = no user cap —
+        # the fan-out uses its module-level _MAX_REFERENCE_WORKERS ceiling
+        # (8), never unlimited. 1 = fully sequential, required for local
+        # JIT-loaded inference servers (e.g. LM Studio with
+        # model.lmstudio_load_mode: jit, #78011).
+        max_concurrent_references = preset.get("max_concurrent_references")
         degraded_reference_policy = str(
             preset.get("degraded_reference_policy") or "loud"
         )
@@ -2077,6 +2111,7 @@ class MoAChatCompletions:
                 reference_timeout=reference_timeout,
                 agent=self._agent,
                 late_accounting_sink=self._record_late_reference_accounting,
+                max_workers=max_concurrent_references,
             )
             interrupted_any = any(
                 text == _INTERRUPTED_REFERENCE_NOTE

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -101,6 +101,26 @@ def _coerce_int_or_none(value: Any) -> int | None:
     return n if n > 0 else None
 
 
+def _coerce_concurrency(value: Any) -> int | None:
+    """Coerce to a positive reference-fan-out concurrency cap, or None.
+
+    ``None`` (the default) means 'no user cap' — the fan-out keeps its
+    module-level ``_MAX_REFERENCE_WORKERS`` ceiling. A positive int caps how
+    many reference advisors run concurrently; 1 forces a fully sequential
+    fan-out, which local JIT-loaded inference servers (e.g. LM Studio with
+    ``model.lmstudio_load_mode: jit``) require — concurrent model-load
+    requests abort each other on a single GPU (#78011). Bools are rejected
+    explicitly: ``true`` must not silently mean '1 concurrent call'.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        # Fractional concurrency is meaningless; never silently truncate
+        # 1.5 → 1. (Integral floats like 1.0 still pass through.)
+        return None
+    return _coerce_int_or_none(value)
+
+
 def _coerce_fanout(value: Any) -> str:
     """Normalize the fan-out cadence; unknown values fall back to default.
 
@@ -306,6 +326,13 @@ def _default_preset() -> dict[str, Any]:
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "user_turn",
+        # Cap on how many reference advisors run CONCURRENTLY during the
+        # fan-out. None (default) = no user cap — the fan-out still uses the
+        # module-level _MAX_REFERENCE_WORKERS ceiling. Set 1 for a fully
+        # sequential fan-out, which local JIT-loaded inference servers (e.g.
+        # LM Studio with model.lmstudio_load_mode: jit) require — concurrent
+        # load requests abort each other on a single GPU (#78011).
+        "max_concurrent_references": None,
         "enabled": True,
     }
 
@@ -366,6 +393,12 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # last advisor run. Also accepts the mapping form
         # {mode: every_n, n: N}, normalized to the canonical string.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        # Positive int → cap on concurrent advisor calls; anything else
+        # (unset, 0, negative, bool, unparseable) degrades to None → the
+        # default _MAX_REFERENCE_WORKERS ceiling, preserving prior behavior.
+        "max_concurrent_references": _coerce_concurrency(
+            raw.get("max_concurrent_references")
+        ),
     }
 
 
@@ -415,6 +448,9 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "user_turn"),
+        # Flattened for the one-shot /moa path (conversation_loop reads the
+        # top level, not presets.<name>).
+        "max_concurrent_references": active.get("max_concurrent_references"),
         "enabled": active["enabled"],
         # MoA-level (not per-preset) toggles ride at the top level alongside
         # save_traces. privacy_filter: '' (off, default) | 'display' | 'full'

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -195,7 +195,37 @@ class MoaPresetPayload(_MoaReferenceControls):
     # that round-trip the GET payload don't silently erase hand-set values.
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
+    # Cap on concurrent advisor calls during the fan-out. None (default) = no
+    # user cap (module _MAX_REFERENCE_WORKERS ceiling); 1 = fully sequential,
+    # required for local JIT-loaded inference servers (LM Studio, #78011).
+    max_concurrent_references: Optional[int] = None
     enabled: bool = True
+
+    @field_validator("max_concurrent_references", mode="before")
+    @classmethod
+    def _validate_max_concurrent_references(cls, value: Any) -> Optional[int]:
+        """Reject bools/non-integral values before int coercion."""
+        if value is None or value == "":
+            return None
+        if isinstance(value, bool):
+            raise ValueError(
+                "max_concurrent_references must be a positive integer or null"
+            )
+        if isinstance(value, float) and not value.is_integer():
+            raise ValueError(
+                "max_concurrent_references must be a positive integer or null"
+            )
+        try:
+            n = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "max_concurrent_references must be a positive integer or null"
+            ) from exc
+        if n <= 0:
+            raise ValueError(
+                "max_concurrent_references must be a positive integer or null"
+            )
+        return n
 
 
 class MoaConfigPayload(_MoaReferenceControls):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6481,6 +6481,7 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 "max_tokens": preset.max_tokens,
                 "reference_max_tokens": preset.reference_max_tokens,
                 "fanout": preset.fanout,
+                "max_concurrent_references": preset.max_concurrent_references,
                 "enabled": preset.enabled,
             }
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -72,6 +72,58 @@ def test_exact_preset_matching_skips_disabled_presets():
     assert exact_moa_preset_name(config, "klo") is None
 
 
+def test_normalize_preset_max_concurrent_references():
+    """``max_concurrent_references`` coerces to a positive int or None.
+
+    None (the default) means "no user cap" — the fan-out keeps its module
+    ceiling. 1 forces the fully sequential fan-out local JIT-loaded servers
+    (LM Studio) need (#78011). Invalid values (0, negative, bool, garbage)
+    degrade to None rather than crashing, matching the tolerant-read
+    contract of every other preset key.
+    """
+    preset = normalize_moa_config({"presets": {"p": {}}})["presets"]["p"]
+    assert preset["max_concurrent_references"] is None
+
+    preset = normalize_moa_config(
+        {"presets": {"p": {"max_concurrent_references": 1}}}
+    )["presets"]["p"]
+    assert preset["max_concurrent_references"] == 1
+
+    preset = normalize_moa_config(
+        {"presets": {"p": {"max_concurrent_references": 3}}}
+    )["presets"]["p"]
+    assert preset["max_concurrent_references"] == 3
+
+    # String forms follow _coerce_int_or_none's tolerant path.
+    preset = normalize_moa_config(
+        {"presets": {"p": {"max_concurrent_references": "2"}}}
+    )["presets"]["p"]
+    assert preset["max_concurrent_references"] == 2
+
+    # Non-positive / invalid values degrade to None → default ceiling.
+    for bad in (0, -1, True, False, "abc", 1.5):
+        preset = normalize_moa_config(
+            {"presets": {"p": {"max_concurrent_references": bad}}}
+        )["presets"]["p"]
+        assert preset["max_concurrent_references"] is None, bad
+
+
+def test_normalize_moa_config_flattens_max_concurrent_references():
+    """The top-level flattened view must carry the active preset's cap.
+
+    The one-shot /moa path (conversation_loop) reads the flattened view,
+    not ``presets.<name>``, so the active preset's value must surface at
+    the top level or the knob silently no-ops there (#78011).
+    """
+    cfg = normalize_moa_config(
+        {"default_preset": "local", "presets": {"local": {"max_concurrent_references": 1}}}
+    )
+    assert cfg["max_concurrent_references"] == 1
+
+    # Unset → None (default ceiling), never a KeyError.
+    assert normalize_moa_config({})["max_concurrent_references"] is None
+
+
 
 
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -522,6 +522,203 @@ def test_references_parallel_without_agent_is_unaffected(monkeypatch):
     assert out[0][1] == "resp-p1"
 
 
+def _inflight_tracking_call_llm(sleep_s, max_inflight, active_now):
+    """Build a call_llm stub that records the peak number of concurrent calls.
+
+    ``max_inflight`` is a one-element list the stub mutates under a lock;
+    ``active_now`` likewise receives the current count on each call entry.
+    """
+    import time
+
+    def fake_call_llm(**kwargs):
+        with active_now["lock"]:
+            active_now["n"] += 1
+            max_inflight[0] = max(max_inflight[0], active_now["n"])
+        try:
+            time.sleep(sleep_s)
+            return _response(f"resp-{kwargs['provider']}")
+        finally:
+            with active_now["lock"]:
+                active_now["n"] -= 1
+
+    return fake_call_llm
+
+
+def test_references_run_sequentially_when_max_workers_one(monkeypatch):
+    """``max_workers=1`` must force a fully sequential fan-out.
+
+    Local JIT-loaded inference servers (LM Studio with
+    ``model.lmstudio_load_mode: jit``) abort concurrent model-load requests,
+    so a preset capped at one concurrent reference must never have more than
+    one advisor call in flight — and every reference still completes, in
+    order (#78011).
+    """
+    import threading
+    import time
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+
+    max_inflight = [0]
+    active_now = {"n": 0, "lock": threading.Lock()}
+    monkeypatch.setattr(
+        moa_loop,
+        "call_llm",
+        _inflight_tracking_call_llm(0.3, max_inflight, active_now),
+    )
+
+    refs = [
+        {"provider": "p1", "model": "ok"},
+        {"provider": "p2", "model": "ok"},
+    ]
+    start = time.monotonic()
+    out = moa_loop._run_references_parallel(
+        refs, [{"role": "user", "content": "hi"}], max_workers=1,
+    )
+    elapsed = time.monotonic() - start
+
+    # Never more than one call in flight → sequential.
+    assert max_inflight[0] == 1
+    # Two 0.3s sleeps back-to-back ⇒ ≥0.6s; a parallel run would be ~0.3s.
+    assert elapsed >= 0.55, f"references did not run sequentially (took {elapsed:.2f}s)"
+    # All references complete, output order matches input order.
+    assert [label for label, _, _ in out] == ["p1:ok", "p2:ok"]
+    assert [text for _, text, _ in out] == ["resp-p1", "resp-p2"]
+
+
+def test_references_cap_concurrency_at_max_workers(monkeypatch):
+    """``max_workers=2`` must bound in-flight calls to 2 even with 3 refs."""
+    import threading
+    import time
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+
+    max_inflight = [0]
+    active_now = {"n": 0, "lock": threading.Lock()}
+    monkeypatch.setattr(
+        moa_loop,
+        "call_llm",
+        _inflight_tracking_call_llm(0.3, max_inflight, active_now),
+    )
+
+    refs = [
+        {"provider": "p1", "model": "ok"},
+        {"provider": "p2", "model": "ok"},
+        {"provider": "p3", "model": "ok"},
+    ]
+    out = moa_loop._run_references_parallel(
+        refs, [{"role": "user", "content": "hi"}], max_workers=2,
+    )
+
+    assert max_inflight[0] == 2
+    assert [text for _, text, _ in out] == ["resp-p1", "resp-p2", "resp-p3"]
+
+
+def test_references_user_cap_overrides_default_ceiling(monkeypatch):
+    """An explicit user cap replaces the default ``_MAX_REFERENCE_WORKERS``
+    ceiling — the ceiling is the fallback for *unset* values only. The
+    executor must receive ``min(user_cap, len(refs))``, never more workers
+    than references."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **k: _response("ok"))
+
+    captured = {}
+
+    def spy_executor(max_workers=1, *args, **kwargs):
+        captured["max_workers"] = max_workers
+        return ThreadPoolExecutor(max_workers, *args, **kwargs)
+
+    monkeypatch.setattr(moa_loop, "ThreadPoolExecutor", spy_executor)
+
+    # More refs than the default ceiling: a user cap above 8 must win
+    # (bounded by the reference count, never more workers than refs).
+    refs = [
+        {"provider": f"p{i}", "model": "ok"} for i in range(moa_loop._MAX_REFERENCE_WORKERS + 2)
+    ]
+    out = moa_loop._run_references_parallel(
+        refs, [{"role": "user", "content": "hi"}], max_workers=999,
+    )
+
+    assert captured["max_workers"] == len(refs)
+    assert len(out) == len(refs)
+
+
+def test_references_invalid_max_workers_falls_back_to_ceiling(monkeypatch):
+    """Non-positive / non-int programmatic ``max_workers`` values must fall
+    back to the module ceiling instead of crashing ThreadPoolExecutor or
+    silently serializing via truthiness (0 → parallel, -1 → ValueError)."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **k: _response("ok"))
+
+    captured = {}
+
+    def spy_executor(max_workers=1, *args, **kwargs):
+        captured["max_workers"] = max_workers
+        return ThreadPoolExecutor(max_workers, *args, **kwargs)
+
+    monkeypatch.setattr(moa_loop, "ThreadPoolExecutor", spy_executor)
+
+    refs = [
+        {"provider": "p1", "model": "ok"},
+        {"provider": "p2", "model": "ok"},
+    ]
+    for bad in (0, -1, -5, True, "3", 1.5, None):
+        captured.clear()
+        out = moa_loop._run_references_parallel(
+            refs, [{"role": "user", "content": "hi"}], max_workers=bad,
+        )
+        assert captured["max_workers"] == 2, bad  # min(ceiling 8, 2 refs)
+        assert len(out) == len(refs), bad
+
+
+def test_aggregate_moa_context_forwards_max_concurrent_references(monkeypatch):
+    """The one-shot /moa path must forward the preset's concurrency cap to
+    the fan-out (#78011)."""
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    outputs = [
+        ("openrouter:advisor", "useful advice", moa_loop._RefAccounting(CanonicalUsage())),
+    ]
+    fanout_kwargs = {}
+
+    def fake_fanout(*args, **kwargs):
+        fanout_kwargs.update(kwargs)
+        return outputs
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    moa_loop.aggregate_moa_context(
+        user_prompt="review this",
+        api_messages=[{"role": "user", "content": "review this"}],
+        reference_models=[{"provider": "openrouter", "model": "advisor"}],
+        aggregator={"provider": "openrouter", "model": "aggregator"},
+        max_concurrent_references=1,
+    )
+
+    assert fanout_kwargs["max_workers"] == 1
+
+
 def test_references_parallel_interrupt_aborts_wait(monkeypatch):
     """A user interrupt mid-fanout must stop the wait instead of blocking
     until every reference (including a wedged one) finishes or times out on
@@ -1153,6 +1350,51 @@ moa:
     usage2, cost2 = facade.consume_reference_usage()
     assert usage2.input_tokens == 0
     assert cost2 is None
+
+
+def test_facade_forwards_preset_max_concurrent_references(monkeypatch, tmp_path):
+    """The facade must read ``max_concurrent_references`` from the preset and
+    pass it to the fan-out as ``max_workers`` (#78011)."""
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      max_concurrent_references: 1
+      reference_models:
+        - provider: openrouter
+          model: advisor
+      aggregator:
+        provider: openrouter
+        model: aggregator
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    fanout_kwargs = {}
+
+    def fake_fanout(*args, **kwargs):
+        fanout_kwargs.update(kwargs)
+        return [(
+            "openrouter:advisor",
+            "advice",
+            moa_loop._RefAccounting(CanonicalUsage()),
+        )]
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **k: _response("acted"))
+
+    facade = moa_loop.MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "go"}], tools=[])
+
+    assert fanout_kwargs["max_workers"] == 1
 
 
 class _CountingCtxLen:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2404,6 +2404,8 @@ export interface MoaConfigResponse {
     reference_max_tokens?: number | null;
     /** Fan-out cadence (user_turn default | per_iteration | every_n:N) — round-tripped. */
     fanout?: string;
+    /** Cap on concurrent advisor calls (1 = sequential; null = default ceiling) — round-tripped. */
+    max_concurrent_references?: number | null;
     enabled: boolean;
   }>;
   reference_models: MoaModelSlot[];

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -175,6 +175,44 @@ benchmarks justify a costlier default. Presets that want per-step advising
 back set `fanout: per_iteration` explicitly.
 :::
 
+### Limiting advisor concurrency with `max_concurrent_references`
+
+By default the reference fan-out dispatches **every advisor at once** (up to
+a built-in ceiling of 8 concurrent calls). For remote APIs that is the right
+shape — the turn only waits as long as the slowest advisor. Some local
+inference servers cannot handle concurrent requests, though: LM Studio's JIT
+loader (`model.lmstudio_load_mode: jit`) aborts a model load when another
+load request arrives on the same GPU, so a parallel fan-out over several
+LM Studio models ends up loading only one of them.
+
+Set `max_concurrent_references: 1` on a preset to force a fully **sequential**
+fan-out — each advisor runs, completes, and is unloaded before the next one
+starts, so every JIT-loaded model gets a chance to answer. Any positive
+integer works as a cap (e.g. `2` on a dual-GPU box); unset, `0`, or invalid
+values fall back to the default ceiling.
+
+```yaml
+moa:
+  presets:
+    local:
+      reference_models:
+        - provider: lmstudio
+          model: qwen/qwen3.6-27b
+        - provider: lmstudio
+          model: llama/llama-4-70b
+      aggregator:
+        provider: lmstudio
+        model: qwen/qwen3.6-27b
+      max_concurrent_references: 1   # sequential: one JIT load at a time
+```
+
+:::note
+The sequential fan-out still waits for every advisor before the aggregator
+acts — it only removes the concurrency, not the join semantics. With local
+models this trades per-turn latency for correctness; with remote APIs keep
+the default (parallel) shape.
+:::
+
 ### Privacy filter for advisor outputs
 
 Advisor outputs can echo sensitive data from the conversation — emails,


### PR DESCRIPTION
## What

Fixes #78011 — MoA mode with LM Studio JIT: the reference fan-out always dispatched **every advisor at once** (`ThreadPoolExecutor`, hardcoded ceiling of 8 workers, `agent/moa_loop.py`), so concurrent model-load requests to LM Studio's JIT loader aborted each other on a single GPU ("Engine protocol startup was aborted") and only the last reference model plus the aggregator ever completed.

Adds a per-preset config knob, `max_concurrent_references`, that bounds how many reference advisors run concurrently:

```yaml
moa:
  presets:
    local:
      reference_models:
        - provider: lmstudio
          model: qwen/qwen3.6-27b
        - provider: lmstudio
          model: llama/llama-4-70b
      aggregator:
        provider: lmstudio
        model: qwen/qwen3.6-27b
      max_concurrent_references: 1   # fully sequential: one JIT load at a time
```

- `1` → fully sequential fan-out: each advisor runs, completes, and is unloaded before the next starts — every JIT-loaded model gets a chance to answer.
- Any positive integer caps in-flight advisor calls (e.g. `2` on a dual-GPU box).
- Unset / `0` / invalid values → previous behavior (module ceiling of 8), so existing presets are unaffected.

## How

- `hermes_cli/moa_config.py` — new `_coerce_concurrency` (rejects bools and non-integral floats; tolerant degrade to `None`), preset normalization, and the flattened view so the one-shot `/moa` path reads the active preset's cap.
- `agent/moa_loop.py` — `_run_references_parallel(max_workers=...)` with a defensive sanitize (non-positive / non-int values fall back to the ceiling rather than crashing `ThreadPoolExecutor`), threaded through `aggregate_moa_context()` and the `MoAChatCompletions` facade.
- `agent/conversation_loop.py` — one-shot `/moa` forwards the value.
- `hermes_cli/web_models.py` / `hermes_cli/web_server.py` / `web/src/lib/api.ts` — field + validator on `MoaPresetPayload`, PUT/GET round-trip, client type.
- `website/docs/user-guide/features/mixture-of-agents.md` — new "Limiting advisor concurrency" section.

## Verification

- New tests: sequential fan-out (never more than one call in flight + serial elapsed floor), concurrency cap at 2, user cap overriding the default ceiling, invalid programmatic values falling back safely, parameter forwarding through both the facade and one-shot paths, coercion and flattened-view coverage.
- `tests/run_agent/test_moa_loop_mode.py` + `tests/hermes_cli/test_moa_config.py`: 40 passed.
- Full MoA-adjacent surface (fanout cadence, streaming, privacy filter, progress, cost slot, context max tokens, cache): 92 passed.
- The 3 failures in `tests/agent/test_auxiliary_main_first.py` when batched are pre-existing (reproduced with these changes stashed — provider-health state bleed between files, unrelated to this PR).

## Notes

- **Open question:** should an explicit cap above 8 be hard-clamped to the module ceiling, or is the current semantic (user cap replaces the default ceiling, bounded only by the reference count) the right one? The ceiling today is the fallback for *unset* values; the knob is intentionally a user override.
- `max_concurrent_references` is per-preset, matching `fanout` / `reference_max_tokens` / `degraded_reference_policy`; there is deliberately no global `moa.*` fallback yet.
