### PR TITLE
fix(gateway): keep auto vision preprocess concise (salvage #10852)

### DIFF
--- a/contributors/emails/gnani.nutakki@gmail.com
+++ b/contributors/emails/gnani.nutakki@gmail.com
@@ -1,0 +1,1 @@
+gnanirahulnutakki

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21723,9 +21723,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from agent.memory_manager import sanitize_context
 
         analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
+            "Concisely describe this image in 2-4 sentences "
+            "(~200 Chinese characters or ~150 English words). "
+            "Cover the main subject, key visible text/data/code, and overall context. "
+            "If it is a chart, diagram, or scientific figure, include the important "
+            "labels, legend, and key values. Skip decorative details."
         )
 
         enriched_parts = []

--- a/tests/gateway/test_vision_preprocess.py
+++ b/tests/gateway/test_vision_preprocess.py
@@ -1,0 +1,34 @@
+"""Gateway vision pre-process prompt should stay concise."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_uses_concise_prompt():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({"success": True, "analysis": "A cat on a chair."}),
+    ) as mock_vision:
+        result = await runner._enrich_message_with_vision(
+            user_text="What is happening here?",
+            image_paths=["/tmp/cat.png"],
+        )
+
+    assert "A cat on a chair." in result
+    assert "What is happening here?" in result
+    assert (
+        "Concisely describe this image in 2-4 sentences"
+        in mock_vision.await_args.kwargs["user_prompt"]
+    )
+    assert "Skip decorative details." in mock_vision.await_args.kwargs["user_prompt"]
+    # No output cap is forwarded: per the max-tokens-knob policy the aux
+    # client decides token handling; conciseness comes from the prompt.
+    assert "max_tokens" not in mock_vision.await_args.kwargs


### PR DESCRIPTION
## Summary
Gateway auto image-preprocess now asks the vision model for a concise 2-4 sentence summary instead of "everything visible in thorough detail", cutting ~2000-char descriptions (35s+ on local models) out of every image-bearing message.

Fixes #10809

## Changes
- `gateway/run.py` `_enrich_message_with_vision`: concise analysis prompt (main subject, key text/data/code, chart labels/values; skip decorative detail)
- `tests/gateway/test_vision_preprocess.py`: pins the concise prompt AND pins that no `max_tokens` cap is forwarded
- `contributors/emails/gnani.nutakki@gmail.com`: attribution mapping

## What was deliberately dropped from the original PR
#10852 also enforced `max_tokens=500` via a new `preserve_max_tokens` opt-in threaded through 10+ call sites in `agent/auxiliary_client.py` + `tools/vision_tools.py`. That cap machinery conflicts with the max-tokens-knob policy direction (#75253 removes the hardcoded vision caps entirely, per the sweeper re-scope of #74945). The latency win in #10809 comes overwhelmingly from the shorter ask — a 2-4 sentence request yields a short answer without wire-level enforcement — so this salvage takes the prompt and leaves token-cap policy to #75253.

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_vision_preprocess.py` | 1 passed |
| py_compile `gateway/run.py` | clean |

## Credit
Salvages #10852 by @gnanirahulnutakki — commit cherry-picked with authorship preserved (prompt portion; cap plumbing dropped as described above).

Closes #10852
