### PR TITLE
fix(desktop/review): give the diff panel a definite height (regression from 5ecf06e0e)

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -157,9 +157,15 @@ export function ReviewPane() {
         <PaneEmptyState label={t.rightSidebar.noDiffs} />
       )}
 
-      {/* Selected file's diff — reuses the shiki-highlighted FileDiffPanel. */}
+      {/* Selected file's diff — reuses the shiki-highlighted FileDiffPanel.
+          `h-[55%]`, not `max-h-[55%]`: the panel below is virtualized, so it
+          renders `absolute inset-0` and contributes no intrinsic height. With
+          only a maximum this `shrink-0` box sized to its content — a 37px
+          header plus a `flex-1` body whose basis is zero — and the diff
+          collapsed to nothing. A definite height is what the windowed panel
+          resolves its `h-full` against. */}
       {selectedFile && (
-        <div className="flex max-h-[55%] shrink-0 flex-col border-t border-(--ui-stroke-secondary)">
+        <div className="flex h-[55%] shrink-0 flex-col border-t border-(--ui-stroke-secondary)">
           <div className="flex items-center gap-1 px-2.5 py-1.5" data-suppress-pane-reveal-side="">
             <span
               className="min-w-0 flex-1 truncate font-mono text-[0.66rem] text-(--ui-text-secondary)"


### PR DESCRIPTION
Fixes #81263

One-line fix for a regression that has made the Review pane's diff body invisible for every file since 2026-07-19.

## The bug

Selecting any file opened the bottom panel with a correct header (path, ± counts, stage/close) and **no diff body**. The content was in the DOM the whole time — it rendered at `height: 0`.

`max-h-[55%]` is a maximum, not a height. With `shrink-0` the container sized to its content: a 37px header plus a `flex-1` body whose basis is zero. So the container measured **37px — exactly the header**. `FileDiffPanel` in `virtualized` mode renders `absolute inset-0`, contributing no intrinsic height, and its `h-full` resolved against a parent that had none.

## The regression

`5ecf06e0e` (*perf(desktop): virtualize the review-pane diff — no more full-Shiki freeze*) changed only the call site:

```diff
- <FileDiffPanel diff={diff} path={selectedFile.path} />
+ <FileDiffPanel className="mx-0 mb-0 h-full max-h-none" diff={diff} path={selectedFile.path} virtualized />
```

Before it, the compact path's `DIFF_BOX_CLASS` carried `max-h-[12rem]` and let content flow, which gave the container a real height. `virtualized` + `max-h-none` removed both, and the container was never adjusted to compensate. The perf win was real; the layout consequence went unnoticed.

## The fix

```diff
- <div className="flex max-h-[55%] shrink-0 flex-col ...">
+ <div className="flex h-[55%] shrink-0 flex-col ...">
```

A definite height is what the windowed panel resolves its `h-full` against. This is what the file preview already does — same inner markup (`min-h-0 flex-1 overflow-auto` → `h-full max-h-none`), but with `flex h-full flex-col` outside.

## Verification

Measured in the running Electron app via Playwright, on `[data-slot="file-diff-panel"]`, selecting a modified tracked file:

|  | container | body | panel |
|---|---|---|---|
| before | 37 | 4 | **0** |
| after | 406 | 373 | **369** |

The diff then renders correctly — syntax-highlighted, with removal and addition tints.

Also confirmed the mechanism independently before writing the patch: forcing `container.style.height = '340px'` in the unpatched build took the panel from `h:0` to `h:303`.

Not a window-size artifact — reproduced at both 1220×800 and 1800×1100.

`typecheck` clean, `eslint` clean, `prettier --check` clean, 134 renderer tests passing.

## Note on the alternative

`flex-1 max-h-[55%]` instead of `shrink-0 max-h-[55%]` would also give a definite height (from flex resolution) while preserving the cap semantics, at the cost of changing how the file list above is sized. That felt like a product call rather than a regression fix, so this PR takes the minimal route. Happy to switch if maintainers prefer it.

## Relationship to #81164

Independent. #81164 fixes untracked **folder** rows returning an empty diff payload; this fixes the payload having nowhere to render. Both are needed for the pane to be usable — with only this one, folder rows still show an empty state; with only that one, nothing is visible at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)