### PR TITLE
feat(skills): add profile-scoped source policy

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -812,6 +812,16 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Optional profile-scoped Skills Hub allowlist. Leave source_policy empty
+  # (the default) to preserve every built-in source. When github_taps is
+  # present, each exact owner/repo must first be added with `hermes skills tap
+  # add owner/repo`; the restriction applies to search and direct installs.
+  # hub:
+  #   source_policy:
+  #     mode: allowlist
+  #     sources: [github]
+  #     github_taps: [myorg/approved-skills]
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1833,6 +1833,12 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Optional profile-scoped policy for Skills Hub discovery and installs.
+        # Empty preserves the complete built-in source set. See the Skills
+        # System guide for the strict allowlist shape.
+        "hub": {
+            "source_policy": {},
+        },
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11164,7 +11164,7 @@ def cmd_skills(args):
     else:
         from hermes_cli.skills_hub import skills_command
 
-        skills_command(args)
+        return skills_command(args)
 
 
 def cmd_pairing(args):

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -124,6 +124,9 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
 
 def _resolve_source_meta_and_bundle(identifier: str, sources):
     """Resolve metadata and bundle for a specific identifier."""
+    require_identifier = getattr(sources, "require_identifier", None)
+    if callable(require_identifier):
+        require_identifier(identifier)
     meta = None
     bundle = None
     matched_source = None
@@ -1722,7 +1725,19 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> None:
+def skills_command(args) -> int:
+    """Run a ``hermes skills`` command with user-facing policy errors."""
+    from tools.skills_hub import SkillsHubSourcePolicyError
+
+    try:
+        _skills_command(args)
+    except SkillsHubSourcePolicyError as exc:
+        _console.print(f"[bold red]Error:[/] {exc}\n")
+        return 2
+    return 0
+
+
+def _skills_command(args) -> None:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
     action = getattr(args, "skills_action", None)
 
@@ -1797,6 +1812,17 @@ def skills_command(args) -> None:
 # ---------------------------------------------------------------------------
 
 def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
+    """Run a ``/skills`` command with user-facing policy errors."""
+    from tools.skills_hub import SkillsHubSourcePolicyError
+
+    c = console or _console
+    try:
+        _handle_skills_slash(cmd, console=c)
+    except SkillsHubSourcePolicyError as exc:
+        c.print(f"[bold red]Error:[/] {exc}\n")
+
+
+def _handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     """
     Parse and dispatch `/skills <subcommand> [args]` from the chat interface.
 

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -56,10 +56,27 @@ async def install_skill_hub(body: SkillInstallRequest, profile: Optional[str] = 
     identifier = (body.identifier or "").strip()
     if not identifier:
         raise HTTPException(status_code=400, detail="identifier is required")
+    effective_profile = body.profile or profile
+    try:
+        from tools.skills_hub import create_source_router
+
+        with _config_profile_scope(effective_profile):
+            sources = create_source_router()
+            require_identifier = getattr(sources, "require_identifier", None)
+            if callable(require_identifier):
+                require_identifier(identifier)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        from tools.skills_hub import SkillsHubSourceDisabledError
+
+        if isinstance(exc, SkillsHubSourceDisabledError):
+            raise HTTPException(status_code=403, detail=str(exc))
+        raise
     name = _hub_action_name("install", identifier)
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(body.profile or profile)
+            _profile_cli_args(effective_profile)
             + ["skills", "install", identifier, "--yes"],
             name,
         )
@@ -227,6 +244,10 @@ async def search_skills_hub(
     except HTTPException:
         raise
     except Exception as exc:
+        from tools.skills_hub import SkillsHubSourceDisabledError
+
+        if isinstance(exc, SkillsHubSourceDisabledError):
+            raise HTTPException(status_code=403, detail=str(exc))
         _log.exception("skills hub search failed")
         raise HTTPException(status_code=502, detail=f"Hub search failed: {exc}")
 
@@ -289,6 +310,10 @@ async def preview_skill_hub(identifier: str = "", profile: Optional[str] = None)
     try:
         result = await asyncio.to_thread(_run)
     except Exception as exc:
+        from tools.skills_hub import SkillsHubSourceDisabledError
+
+        if isinstance(exc, SkillsHubSourceDisabledError):
+            raise HTTPException(status_code=403, detail=str(exc))
         _log.exception("skills hub preview failed")
         raise HTTPException(status_code=502, detail=f"Hub preview failed: {exc}")
     if result is None:
@@ -384,6 +409,10 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
     try:
         result = await asyncio.to_thread(_run)
     except Exception as exc:
+        from tools.skills_hub import SkillsHubSourceDisabledError
+
+        if isinstance(exc, SkillsHubSourceDisabledError):
+            raise HTTPException(status_code=403, detail=str(exc))
         _log.exception("skills hub scan failed")
         raise HTTPException(status_code=502, detail=f"Hub scan failed: {exc}")
     if result is None:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -590,6 +590,63 @@ class _FakeBundle:
         self.metadata = {}
 
 
+class TestSkillsHubSourcePolicyEndpoints:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client, _ = _client()
+
+    @staticmethod
+    def _router(*, sources, github_taps=None):
+        from tools.skills_hub import SkillsHubSourcePolicy, SourceRouter
+
+        return SourceRouter(
+            [],
+            SkillsHubSourcePolicy(
+                allowed_sources=frozenset(sources),
+                allowed_github_taps=(
+                    frozenset(github_taps) if github_taps is not None else None
+                ),
+            ),
+        )
+
+    def test_search_returns_403_for_disabled_source(self, monkeypatch):
+        router = self._router(sources={"official"})
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: router)
+
+        response = self.client.get("/api/skills/hub/search?q=demo&source=github")
+
+        assert response.status_code == 403
+        assert "github" in response.json()["detail"]
+
+    def test_preview_returns_403_for_disallowed_github_tap(self, monkeypatch):
+        router = self._router(
+            sources={"github"}, github_taps={"openai/skills"}
+        )
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: router)
+
+        response = self.client.get(
+            "/api/skills/hub/preview",
+            params={"identifier": "anthropics/skills/skills/pdf"},
+        )
+
+        assert response.status_code == 403
+        assert "anthropics/skills" in response.json()["detail"]
+
+    def test_install_is_rejected_before_spawning_for_disabled_source(
+        self, monkeypatch
+    ):
+        router = self._router(sources={"official"})
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: router)
+
+        response = self.client.post(
+            "/api/skills/hub/install",
+            json={"identifier": "openai/skills/skills/example"},
+        )
+
+        assert response.status_code == 403
+        assert "github" in response.json()["detail"]
+
+
 class TestSkillsHubSourcesEndpoint:
     @pytest.fixture(autouse=True)
     def _setup(self, _isolate_hermes_home):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,14 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_install,
+    do_list,
+    do_update,
+    handle_skills_slash,
+    skills_command,
+)
 
 
 class _DummyLockFile:
@@ -101,6 +108,28 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_skills_command_surfaces_source_policy_error(monkeypatch):
+    from types import SimpleNamespace
+    import hermes_cli.skills_hub as cli_hub
+    from tools.skills_hub import SkillsHubSourcePolicy, SourceRouter
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    router = SourceRouter(
+        [], SkillsHubSourcePolicy(allowed_sources=frozenset({"official"}))
+    )
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda auth: router)
+    monkeypatch.setattr(cli_hub, "_console", console)
+
+    result = skills_command(SimpleNamespace(
+        skills_action="search", query="demo", source="github", limit=10, json=False
+    ))
+
+    assert result == 2
+    assert "github" in sink.getvalue()
+    assert "disabled" in sink.getvalue()
 
 
 
@@ -312,4 +341,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -16,6 +16,7 @@ probes used to confirm the bug class.
 
 import threading
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -77,6 +78,38 @@ class TestSkillsHubPathResolution:
         assert b_lock == prof_b / "skills" / ".hub" / "lock.json"
         assert b_audit == prof_b / "skills" / ".hub" / "audit.log"
         assert b_index == prof_b / "skills" / ".hub" / "index-cache"
+
+    def test_source_policy_follows_active_profile(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        (prof_a / "config.yaml").write_text(
+            "skills:\n"
+            "  hub:\n"
+            "    source_policy:\n"
+            "      mode: allowlist\n"
+            "      sources: [official]\n",
+            encoding="utf-8",
+        )
+        (prof_b / "config.yaml").write_text(
+            "skills:\n"
+            "  hub:\n"
+            "    source_policy:\n"
+            "      mode: allowlist\n"
+            "      sources: [url]\n",
+            encoding="utf-8",
+        )
+
+        from tools.skills_hub import GitHubAuth, create_source_router
+
+        auth = MagicMock(spec=GitHubAuth)
+        a_ids = _under_override(
+            prof_a, lambda: [source.source_id() for source in create_source_router(auth)]
+        )
+        b_ids = _under_override(
+            prof_b, lambda: [source.source_id() for source in create_source_router(auth)]
+        )
+
+        assert a_ids == ["official"]
+        assert b_ids == ["url"]
 
 
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -11,6 +11,7 @@ import pytest
 from tools.skills_hub import (
     GitHubAuth,
     GitHubSource,
+    HermesIndexSource,
     LobeHubSource,
     SkillsShSource,
     UrlSource,
@@ -21,6 +22,9 @@ from tools.skills_hub import (
     SkillMeta,
     HubLockFile,
     TapsManager,
+    SkillsHubSourcePolicy,
+    SkillsHubSourcePolicyError,
+    SourceRouter,
     bundle_content_hash,
     check_for_skill_updates,
     create_source_router,
@@ -28,6 +32,7 @@ from tools.skills_hub import (
     unified_search,
     append_audit_log,
     quarantine_bundle,
+    resolve_source_policy,
 )
 
 
@@ -468,6 +473,154 @@ class TestCreateSourceRouter:
         url_idx = next(i for i, src in enumerate(sources) if isinstance(src, UrlSource))
         gh_idx = next(i for i, src in enumerate(sources) if isinstance(src, GitHubSource))
         assert url_idx < gh_idx
+
+    def test_empty_policy_preserves_every_existing_source(self):
+        sources = create_source_router(
+            auth=MagicMock(spec=GitHubAuth),
+            policy=SkillsHubSourcePolicy(),
+        )
+        assert [source.source_id() for source in sources] == [
+            "official",
+            "hermes-index",
+            "skills-sh",
+            "well-known",
+            "url",
+            "github",
+            "clawhub",
+            "lobehub",
+            "browse-sh",
+        ]
+
+    def test_allowlist_builds_only_enabled_sources_and_github_taps(self):
+        policy = resolve_source_policy(
+            {
+                "skills": {
+                    "hub": {
+                        "source_policy": {
+                            "mode": "allowlist",
+                            "sources": ["official", "github"],
+                            "github_taps": ["openai/skills"],
+                        }
+                    }
+                }
+            },
+            configured_github_taps=GitHubSource.DEFAULT_TAPS,
+        )
+
+        sources = create_source_router(
+            auth=MagicMock(spec=GitHubAuth), policy=policy
+        )
+
+        assert [source.source_id() for source in sources] == ["official", "github"]
+        github = next(source for source in sources if source.source_id() == "github")
+        assert {tap["repo"].lower() for tap in github.taps} == {"openai/skills"}
+
+    def test_explicitly_disabled_source_fails_before_search(self):
+        source = MagicMock(spec=SkillSource)
+        source.source_id.return_value = "official"
+        router = SourceRouter(
+            [source],
+            SkillsHubSourcePolicy(allowed_sources=frozenset({"official"})),
+        )
+
+        with pytest.raises(SkillsHubSourcePolicyError, match="github.*disabled"):
+            parallel_search_sources(router, query="demo", source_filter="github")
+
+        source.search.assert_not_called()
+
+
+class TestSkillsHubSourcePolicy:
+
+    def test_unknown_source_fails_closed(self):
+        with pytest.raises(SkillsHubSourcePolicyError, match="Unknown Skills Hub source"):
+            resolve_source_policy({
+                "skills": {"hub": {"source_policy": {
+                    "mode": "allowlist", "sources": ["typo-source"],
+                }}}
+            })
+
+    def test_unconfigured_allowed_tap_fails_closed(self):
+        with pytest.raises(SkillsHubSourcePolicyError, match="not configured"):
+            resolve_source_policy(
+                {"skills": {"hub": {"source_policy": {
+                    "mode": "allowlist",
+                    "sources": ["github"],
+                    "github_taps": ["example/private-skills"],
+                }}}},
+                configured_github_taps=GitHubSource.DEFAULT_TAPS,
+            )
+
+    def test_empty_github_tap_allowlist_is_rejected(self):
+        with pytest.raises(SkillsHubSourcePolicyError, match="cannot be empty"):
+            resolve_source_policy({"skills": {"hub": {"source_policy": {
+                "mode": "allowlist",
+                "sources": ["github"],
+                "github_taps": [],
+            }}}})
+
+    def test_index_requires_an_allowed_provenance_source(self):
+        with pytest.raises(SkillsHubSourcePolicyError, match="provenance source"):
+            resolve_source_policy({"skills": {"hub": {"source_policy": {
+                "mode": "allowlist",
+                "sources": ["hermes-index"],
+            }}}})
+
+    def test_github_adapter_rejects_direct_install_outside_allowed_taps(self):
+        source = GitHubSource(
+            auth=MagicMock(spec=GitHubAuth),
+            allowed_taps=frozenset({"openai/skills"}),
+        )
+
+        with patch.object(source, "_fetch_file_content") as fetch:
+            assert source.fetch("anthropics/skills/skills/example") is None
+
+        fetch.assert_not_called()
+
+    def test_index_filters_provenance_and_github_repo(self):
+        policy = SkillsHubSourcePolicy(
+            allowed_sources=frozenset({"hermes-index", "official", "github"}),
+            allowed_github_taps=frozenset({"openai/skills"}),
+        )
+        source = HermesIndexSource(
+            auth=MagicMock(spec=GitHubAuth), policy=policy
+        )
+        source._loaded = True
+        source._index = {"skills": [
+            {
+                "name": "official-demo", "source": "official",
+                "identifier": "official/demo",
+            },
+            {
+                "name": "openai-demo", "source": "github",
+                "identifier": "openai/skills/skills/demo", "repo": "openai/skills",
+            },
+            {
+                "name": "anthropic-demo", "source": "github",
+                "identifier": "anthropics/skills/skills/demo", "repo": "anthropics/skills",
+            },
+            {
+                "name": "claw-demo", "source": "clawhub",
+                "identifier": "claw-demo",
+            },
+        ]}
+
+        assert [meta.name for meta in source.search("", limit=10)] == [
+            "official-demo", "openai-demo",
+        ]
+        assert source.inspect("anthropics/skills/skills/demo") is None
+        assert source.inspect("openai/skills/skills/demo").name == "openai-demo"
+
+    def test_identifier_guard_rejects_disallowed_tap(self):
+        router = SourceRouter(
+            [],
+            SkillsHubSourcePolicy(
+                allowed_sources=frozenset({"github"}),
+                allowed_github_taps=frozenset({"openai/skills"}),
+            ),
+        )
+
+        with pytest.raises(SkillsHubSourcePolicyError, match="anthropics/skills.*disabled"):
+            router.require_identifier("anthropics/skills/skills/pdf")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -28,7 +28,7 @@ from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Tuple, Union
 from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunparse
 
 import httpx
@@ -540,6 +540,275 @@ def github_provider_for(repo: str) -> Optional[str]:
 _PROVIDER_FILTER_VALUES = frozenset(v.lower() for v in GITHUB_TAP_PROVIDERS.values())
 
 
+HUB_SOURCE_IDS = frozenset({
+    "official",
+    "hermes-index",
+    "skills-sh",
+    "well-known",
+    "url",
+    "github",
+    "clawhub",
+    "lobehub",
+    "browse-sh",
+})
+_HERMES_INDEX_PROVENANCE_IDS = HUB_SOURCE_IDS - {"hermes-index", "url"}
+_SOURCE_ID_ALIASES = {"skills.sh": "skills-sh"}
+
+
+class SkillsHubSourcePolicyError(ValueError):
+    """The active profile's Skills Hub source policy is invalid or denied an operation."""
+
+
+class SkillsHubSourceDisabledError(SkillsHubSourcePolicyError):
+    """A valid source policy denied an explicitly requested source."""
+
+
+def _normalize_source_id(value: str) -> str:
+    normalized = value.strip().lower()
+    return _SOURCE_ID_ALIASES.get(normalized, normalized)
+
+
+def _normalize_github_repo(value: str) -> str:
+    repo = value.strip().strip("/")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        raise SkillsHubSourcePolicyError(
+            f"Invalid GitHub tap {value!r}; expected an exact 'owner/repo' name."
+        )
+    return repo.lower()
+
+
+@dataclass(frozen=True)
+class SkillsHubSourcePolicy:
+    """Resolved source policy for one Hermes profile.
+
+    ``allowed_sources=None`` is the backwards-compatible unrestricted state.
+    In allowlist mode, GitHub taps are independently restricted only when
+    ``allowed_github_taps`` is not ``None``. Exact repo identities are used so
+    policy does not depend on display labels or source ordering.
+    """
+
+    allowed_sources: Optional[FrozenSet[str]] = None
+    allowed_github_taps: Optional[FrozenSet[str]] = None
+
+    @property
+    def restricted(self) -> bool:
+        return self.allowed_sources is not None
+
+    def allows_source(self, source_id: str) -> bool:
+        return (
+            self.allowed_sources is None
+            or _normalize_source_id(source_id) in self.allowed_sources
+        )
+
+    def allows_github_repo(self, repo: str) -> bool:
+        return (
+            self.allowed_github_taps is None
+            or repo.strip().strip("/").lower() in self.allowed_github_taps
+        )
+
+    def allows_provider(self, provider: str) -> bool:
+        if not self.allows_source("github"):
+            return False
+        if self.allowed_github_taps is None:
+            return True
+        wanted = provider.strip().lower()
+        return any(
+            repo in self.allowed_github_taps and label.lower() == wanted
+            for repo, label in GITHUB_TAP_PROVIDERS.items()
+        )
+
+    def allows_index_entry(self, entry: Mapping[str, Any]) -> bool:
+        source_id = _normalize_source_id(str(entry.get("source", "")))
+        if not self.allows_source(source_id):
+            return False
+        if source_id != "github" or self.allowed_github_taps is None:
+            return True
+        repos = []
+        repo = str(entry.get("repo", "")).strip()
+        if repo:
+            repos.append(repo)
+        resolved = str(entry.get("resolved_github_id", ""))
+        parts = resolved.split("/", 2)
+        if len(parts) >= 2 and all(parts[:2]):
+            repos.append("/".join(parts[:2]))
+        return bool(repos) and all(self.allows_github_repo(item) for item in repos)
+
+
+def resolve_source_policy(
+    config: Optional[Mapping[str, Any]] = None,
+    *,
+    configured_github_taps: Optional[List[Mapping[str, Any]]] = None,
+) -> SkillsHubSourcePolicy:
+    """Resolve and validate the active profile's Skills Hub source policy.
+
+    The empty/default block is deliberately unrestricted. Any non-empty block
+    must declare a mode; invalid or misspelled policy fails closed instead of
+    restoring the full source set.
+    """
+    if config is None:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+
+    skills = config.get("skills", {}) if isinstance(config, Mapping) else {}
+    if not isinstance(skills, Mapping):
+        raise SkillsHubSourcePolicyError("skills must be a mapping in config.yaml.")
+    hub = skills.get("hub", {})
+    if not isinstance(hub, Mapping):
+        raise SkillsHubSourcePolicyError("skills.hub must be a mapping in config.yaml.")
+    raw = hub.get("source_policy", {})
+    if raw is None or raw == {}:
+        return SkillsHubSourcePolicy()
+    if not isinstance(raw, Mapping):
+        raise SkillsHubSourcePolicyError(
+            "skills.hub.source_policy must be a mapping in config.yaml."
+        )
+
+    unknown_keys = set(raw) - {"mode", "sources", "github_taps"}
+    if unknown_keys:
+        raise SkillsHubSourcePolicyError(
+            "Unknown skills.hub.source_policy field(s): "
+            + ", ".join(sorted(str(key) for key in unknown_keys))
+        )
+
+    mode = str(raw.get("mode", "")).strip().lower()
+    if mode == "all":
+        if raw.get("sources") or raw.get("github_taps"):
+            raise SkillsHubSourcePolicyError(
+                "source_policy mode 'all' cannot include allowlist entries."
+            )
+        return SkillsHubSourcePolicy()
+    if mode != "allowlist":
+        raise SkillsHubSourcePolicyError(
+            "skills.hub.source_policy.mode must be 'all' or 'allowlist'."
+        )
+
+    raw_sources = raw.get("sources")
+    if not isinstance(raw_sources, list) or not all(
+        isinstance(item, str) and item.strip() for item in raw_sources
+    ):
+        raise SkillsHubSourcePolicyError(
+            "source_policy.sources must be a list of source ids."
+        )
+    allowed_sources = frozenset(_normalize_source_id(item) for item in raw_sources)
+    unknown_sources = allowed_sources - HUB_SOURCE_IDS
+    if unknown_sources:
+        raise SkillsHubSourcePolicyError(
+            "Unknown Skills Hub source id(s): " + ", ".join(sorted(unknown_sources))
+        )
+    if (
+        "hermes-index" in allowed_sources
+        and not allowed_sources.intersection(_HERMES_INDEX_PROVENANCE_IDS)
+    ):
+        raise SkillsHubSourcePolicyError(
+            "'hermes-index' requires at least one indexed provenance source in "
+            "source_policy.sources."
+        )
+
+    allowed_taps: Optional[FrozenSet[str]] = None
+    if "github_taps" in raw:
+        raw_taps = raw["github_taps"]
+        if not isinstance(raw_taps, list) or not all(
+            isinstance(item, str) and item.strip() for item in raw_taps
+        ):
+            raise SkillsHubSourcePolicyError(
+                "source_policy.github_taps must be a list of exact owner/repo names."
+            )
+        if "github" not in allowed_sources:
+            raise SkillsHubSourcePolicyError(
+                "source_policy.github_taps requires 'github' in source_policy.sources."
+            )
+        allowed_taps = frozenset(_normalize_github_repo(item) for item in raw_taps)
+        if not allowed_taps:
+            raise SkillsHubSourcePolicyError(
+                "source_policy.github_taps cannot be empty; remove 'github' from "
+                "source_policy.sources to disable GitHub."
+            )
+
+        if configured_github_taps is not None:
+            configured = {
+                str(tap.get("repo", "")).strip().strip("/").lower()
+                for tap in configured_github_taps
+                if isinstance(tap, Mapping) and tap.get("repo")
+            }
+            missing = allowed_taps - configured
+            if missing:
+                raise SkillsHubSourcePolicyError(
+                    "GitHub tap(s) allowed by source policy are not configured: "
+                    + ", ".join(sorted(missing))
+                )
+
+    return SkillsHubSourcePolicy(
+        allowed_sources=allowed_sources,
+        allowed_github_taps=allowed_taps,
+    )
+
+
+class SourceRouter(list):
+    """List-compatible router carrying the effective profile source policy."""
+
+    def __init__(self, sources: List[SkillSource], policy: SkillsHubSourcePolicy):
+        super().__init__(sources)
+        self.policy = policy
+
+    def require_source_filter(self, source_filter: str) -> None:
+        requested = _normalize_source_id(source_filter)
+        if requested == "all":
+            return
+        if requested in _PROVIDER_FILTER_VALUES:
+            if not self.policy.allows_provider(requested):
+                raise SkillsHubSourceDisabledError(
+                    f"Skills Hub source provider '{source_filter}' is disabled by "
+                    "skills.hub.source_policy for this profile."
+                )
+            return
+        if requested in HUB_SOURCE_IDS and not self.policy.allows_source(requested):
+            raise SkillsHubSourceDisabledError(
+                f"Skills Hub source '{source_filter}' is disabled by "
+                "skills.hub.source_policy for this profile."
+            )
+        if requested not in HUB_SOURCE_IDS:
+            raise SkillsHubSourcePolicyError(
+                f"Unknown Skills Hub source filter: '{source_filter}'."
+            )
+
+    def require_identifier(self, identifier: str) -> None:
+        source_id, repo = _identifier_policy_identity(identifier)
+        if source_id and not self.policy.allows_source(source_id):
+            raise SkillsHubSourceDisabledError(
+                f"Skills Hub source '{source_id}' is disabled by "
+                "skills.hub.source_policy for this profile."
+            )
+        if source_id == "github" and repo and not self.policy.allows_github_repo(repo):
+            raise SkillsHubSourceDisabledError(
+                f"GitHub tap '{repo}' is disabled by skills.hub.source_policy "
+                "for this profile."
+            )
+
+
+def _identifier_policy_identity(identifier: str) -> Tuple[Optional[str], Optional[str]]:
+    ident = (identifier or "").strip()
+    lower = ident.lower()
+    for prefix, source_id in (
+        ("official/", "official"),
+        ("skills-sh/", "skills-sh"),
+        ("skills.sh/", "skills-sh"),
+        ("clawhub/", "clawhub"),
+        ("lobehub/", "lobehub"),
+        ("browse-sh/", "browse-sh"),
+    ):
+        if lower.startswith(prefix):
+            return source_id, None
+    if lower.startswith("well-known:") or "/.well-known/skills/" in lower:
+        return "well-known", None
+    if lower.startswith(("http://", "https://")):
+        return "url", None
+    parts = ident.split("/", 2)
+    if len(parts) == 3 and all(parts[:2]):
+        return "github", f"{parts[0]}/{parts[1]}"
+    return None, None
+
+
 def _filter_results_by_provider(
     results: List["SkillMeta"], provider: str
 ) -> List["SkillMeta"]:
@@ -579,11 +848,23 @@ class GitHubSource(SkillSource):
         {"repo": "garrytan/gstack", "path": ""},
     ]
 
-    def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
+    def __init__(
+        self,
+        auth: GitHubAuth,
+        extra_taps: Optional[List[Dict]] = None,
+        *,
+        allowed_taps: Optional[FrozenSet[str]] = None,
+    ):
         self.auth = auth
         self.taps = list(self.DEFAULT_TAPS)
         if extra_taps:
             self.taps.extend(extra_taps)
+        self._allowed_taps = allowed_taps
+        if allowed_taps is not None:
+            self.taps = [
+                tap for tap in self.taps
+                if str(tap.get("repo", "")).lower() in allowed_taps
+            ]
         # Per-instance cache: repo -> (default_branch, tree_entries)
         # Survives within a single search/install flow, avoiding redundant API calls.
         self._tree_cache: Dict[str, Tuple[str, List[dict]]] = {}
@@ -652,6 +933,8 @@ class GitHubSource(SkillSource):
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
+        if self._allowed_taps is not None and repo.lower() not in self._allowed_taps:
+            return None
         skill_path = parts[2]
 
         skill_md = self._fetch_file_content(repo, f"{skill_path.rstrip('/')}/SKILL.md")
@@ -714,6 +997,8 @@ class GitHubSource(SkillSource):
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
+        if self._allowed_taps is not None and repo.lower() not in self._allowed_taps:
+            return None
         skill_path = parts[2].rstrip("/")
         skill_md_path = f"{skill_path}/SKILL.md"
 
@@ -4083,10 +4368,15 @@ class HermesIndexSource(SkillSource):
     downstream sources take over transparently.
     """
 
-    def __init__(self, auth: GitHubAuth):
+    def __init__(
+        self,
+        auth: GitHubAuth,
+        policy: Optional[SkillsHubSourcePolicy] = None,
+    ):
         self._index: Optional[dict] = None
         self._loaded = False
         self.auth = auth
+        self.policy = policy or SkillsHubSourcePolicy()
         # Lazily create GitHubSource for fetch — only used when actually
         # downloading files, which requires real GitHub API calls.
         self._github: Optional[GitHubSource] = None
@@ -4109,7 +4399,7 @@ class HermesIndexSource(SkillSource):
     def is_available(self) -> bool:
         """Whether the index is loaded and has skills."""
         index = self._ensure_loaded()
-        return bool(index.get("skills"))
+        return any(self.policy.allows_index_entry(s) for s in index.get("skills", []))
 
     def trust_level_for(self, identifier: str) -> str:
         index = self._ensure_loaded()
@@ -4131,7 +4421,10 @@ class HermesIndexSource(SkillSource):
         relevant skills.
         """
         index = self._ensure_loaded()
-        skills = index.get("skills", [])
+        skills = [
+            skill for skill in index.get("skills", [])
+            if self.policy.allows_index_entry(skill)
+        ]
         if not skills:
             return []
 
@@ -4217,7 +4510,10 @@ class HermesIndexSource(SkillSource):
 
     def _find_entry(self, identifier: str, index: dict) -> Optional[dict]:
         """Look up a skill in the index by identifier or name."""
-        skills = index.get("skills", [])
+        skills = [
+            skill for skill in index.get("skills", [])
+            if self.policy.allows_index_entry(skill)
+        ]
 
         # Exact identifier match
         for s in skills:
@@ -4260,7 +4556,11 @@ class HermesIndexSource(SkillSource):
         )
 
 
-def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]:
+def create_source_router(
+    auth: Optional[GitHubAuth] = None,
+    *,
+    policy: Optional[SkillsHubSourcePolicy] = None,
+) -> SourceRouter:
     """
     Create all configured source adapters.
     Returns a list of active sources for search/fetch operations.
@@ -4270,20 +4570,36 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
 
     taps_mgr = TapsManager()
     extra_taps = taps_mgr.list_taps()
+    configured_taps = list(GitHubSource.DEFAULT_TAPS) + extra_taps
+    effective_policy = policy or resolve_source_policy(
+        configured_github_taps=configured_taps
+    )
 
-    sources: List[SkillSource] = [
-        OptionalSkillSource(),        # Official optional skills (highest priority)
-        HermesIndexSource(auth=auth), # Centralized index (search + resolved install paths)
-        SkillsShSource(auth=auth),
-        WellKnownSkillSource(),
-        UrlSource(),                  # Direct HTTP(S) URL to a SKILL.md file
-        GitHubSource(auth=auth, extra_taps=extra_taps),
-        ClawHubSource(),
-        LobeHubSource(),
-        BrowseShSource(),   # browse.sh: 169+ site-specific browser automation skills
-    ]
+    sources: List[SkillSource] = []
+    if effective_policy.allows_source("official"):
+        sources.append(OptionalSkillSource())
+    if effective_policy.allows_source("hermes-index"):
+        sources.append(HermesIndexSource(auth=auth, policy=effective_policy))
+    if effective_policy.allows_source("skills-sh"):
+        sources.append(SkillsShSource(auth=auth))
+    if effective_policy.allows_source("well-known"):
+        sources.append(WellKnownSkillSource())
+    if effective_policy.allows_source("url"):
+        sources.append(UrlSource())
+    if effective_policy.allows_source("github"):
+        sources.append(GitHubSource(
+            auth=auth,
+            extra_taps=extra_taps,
+            allowed_taps=effective_policy.allowed_github_taps,
+        ))
+    if effective_policy.allows_source("clawhub"):
+        sources.append(ClawHubSource())
+    if effective_policy.allows_source("lobehub"):
+        sources.append(LobeHubSource())
+    if effective_policy.allows_source("browse-sh"):
+        sources.append(BrowseShSource())
 
-    return sources
+    return SourceRouter(sources, effective_policy)
 
 
 def _search_one_source(
@@ -4315,6 +4631,8 @@ def parallel_search_sources(
     from concurrent.futures import as_completed
 
     per_source_limits = per_source_limits or {}
+    if isinstance(sources, SourceRouter):
+        sources.require_source_filter(source_filter)
 
     # A provider filter (e.g. "nvidia", "openai") targets GitHub-tap skills
     # that the runtime index stores under source="github" with an

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -563,11 +563,52 @@ hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
 | Source | Example | Notes |
 |--------|---------|-------|
 | `official` | `official/security/1password` | Optional skills shipped with Hermes. |
+| `hermes-index` | n/a | Centralized catalog accelerator. It preserves each entry's real source provenance. |
 | `skills-sh` | `skills-sh/vercel-labs/agent-skills/vercel-react-best-practices` | Searchable via `hermes skills search <query> --source skills-sh`. Hermes resolves alias-style skills when the skills.sh slug differs from the repo folder. |
 | `well-known` | `well-known:https://mintlify.com/docs/.well-known/skills/mintlify` | Skills served directly from `/.well-known/skills/index.json` on a website. Search using the site or docs URL. |
 | `url` | `https://sharethis.chat/SKILL.md` | Direct HTTP(S) URL to `SKILL.md` plus explicitly referenced support files. Name resolution: frontmatter → URL slug → interactive prompt → `--name` flag. |
 | `github` | `openai/skills/k8s` | Direct GitHub repo/path installs and custom taps. |
 | `clawhub`, `lobehub`, `browse-sh` | Source-specific identifiers | Community or marketplace integrations. |
+
+### Restricting hub sources per profile
+
+By default, every built-in source above remains available. Embedded,
+enterprise, offline, or restricted-network profiles can instead declare an
+exact allowlist in that profile's `config.yaml`:
+
+```yaml
+skills:
+  hub:
+    source_policy:
+      mode: allowlist
+      sources:
+        - github
+      github_taps:
+        - myorg/approved-skills
+```
+
+The GitHub repository must already be configured with
+`hermes skills tap add myorg/approved-skills`. `github_taps` is optional: when
+omitted, every configured default and custom GitHub tap remains available.
+When present, it restricts both discovery and direct `owner/repo/path`
+installs; it is not a display-only filter.
+
+Use the existing source ids from the table, plus `hermes-index` when the
+centralized Hermes catalog is permitted. In allowlist mode, omitting
+`hermes-index` prevents requests to it. When enabled, index entries are still
+filtered by their real source and, for GitHub entries, the exact tap allowlist.
+Therefore `hermes-index` must be listed together with at least one indexed
+provenance source; it is not an independent registry identity.
+
+The effective policy applies to the CLI, slash commands, dashboard/API, and
+agent-facing Skills Hub operations. A disabled source requested explicitly is
+an error. Unknown source ids, unknown fields, malformed tap identities, and
+allowlisted taps that are not configured also fail clearly; Hermes never
+restores the full source set as a fallback.
+
+An empty `source_policy: {}` (the default), or explicit `mode: all`, preserves
+the current unrestricted behavior. The policy is resolved from the active
+profile, so named profiles can have independent source sets.
 
 ### Integrated hubs and registries
 


### PR DESCRIPTION
## Summary

- Add an optional profile-scoped Skills Hub source policy resolved from config.yaml.
- Enforce the same allowlist across CLI, slash commands, dashboard/API, and agent-facing source-router operations.
- Restrict GitHub discovery and direct owner/repo/path installs to exact configured taps when requested.

## Why

Embedded desktop distributions, enterprise deployments, and restricted/offline environments need deterministic control over which Skills Hub sources can be queried and installed. UI-only filtering cannot protect the shared CLI/API/agent paths.

## Scope

- Empty policy and explicit mode: all preserve the existing unrestricted source set.
- Allowlist mode fails closed for unknown fields, source IDs, malformed taps, missing configured taps, and invalid index provenance configuration.
- Hermes Index entries are filtered by their real source provenance; the index is not treated as an independent registry.
- Explicit requests for disabled sources return actionable errors; API preflight prevents disabled installs from spawning a process.
- Named profiles resolve independent policies through the active Hermes home.

## Compatibility

No default source IDs, built-in taps, trust semantics, or security-scan behavior are changed when no policy is configured.

## Tests

scripts/run_tests.sh tests/tools/test_skills_hub.py tests/test_profile_isolation_runtime.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_dashboard_admin_endpoints.py tests/hermes_cli/test_skills_subparser.py tests/hermes_cli/test_skills_install_flags.py

Result: 125 tests passed.

Ruff, py_compile, and git diff --check pass.

Fixes #81260