### PR TITLE
fix(agent): gate developer-role swap on a provider capability

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -607,12 +607,18 @@ class ChatCompletionsTransport(ProviderTransport):
         # Message preprocessing
         sanitized = profile.prepare_messages(sanitized)
 
-        # Developer role swap — model-name-based, applies to all providers
+        # Developer role swap for GPT-5/Codex models, unless the profile
+        # declares that its endpoint does not understand the ``developer``
+        # role. The model name alone cannot tell us that: an OpenAI-compatible
+        # relay serving a gpt-5* model may reject the role outright, or
+        # accept the request and silently drop the message, discarding the
+        # entire system prompt.
         _model_lower = (model or "").lower()
         if (
             sanitized
             and isinstance(sanitized[0], dict)
             and sanitized[0].get("role") == "system"
+            and getattr(profile, "supports_developer_role", True)
             and any(p in _model_lower for p in DEVELOPER_ROLE_MODELS)
         ):
             sanitized = list(sanitized)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -724,12 +724,18 @@ class ChatCompletionsTransport(ProviderTransport):
         # Message preprocessing
         sanitized = profile.prepare_messages(sanitized)
 
-        # Developer role swap — model-name-based, applies to all providers
+        # Developer role swap for GPT-5/Codex models, unless the profile
+        # declares that its endpoint does not understand the ``developer``
+        # role. The model name alone cannot tell us that: an OpenAI-compatible
+        # relay serving a gpt-5* model may reject the role outright, or
+        # accept the request and silently drop the message, discarding the
+        # entire system prompt.
         _model_lower = (model or "").lower()
         if (
             sanitized
             and isinstance(sanitized[0], dict)
             and sanitized[0].get("role") == "system"
+            and getattr(profile, "supports_developer_role", True)
             and any(p in _model_lower for p in DEVELOPER_ROLE_MODELS)
         ):
             sanitized = list(sanitized)

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -83,6 +83,10 @@ class CustomProfile(ProviderProfile):
 
 custom = CustomProfile(
     name="custom",
+    # User-configured OpenAI-compatible endpoints (vLLM, Ollama, LiteLLM,
+    # llama.cpp) commonly implement an older schema that rejects the
+    # ``developer`` role with HTTP 400 (#41125).
+    supports_developer_role=False,
     aliases=(
         "ollama",
         "local",

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -94,6 +94,10 @@ class CustomProfile(ProviderProfile):
 
 custom = CustomProfile(
     name="custom",
+    # User-configured OpenAI-compatible endpoints (vLLM, Ollama, LiteLLM,
+    # llama.cpp) commonly implement an older schema that rejects the
+    # ``developer`` role with HTTP 400 (#41125).
+    supports_developer_role=False,
     aliases=(
         "ollama",
         "local",

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -137,6 +137,10 @@ opencode_zen = ProviderProfile(
 
 opencode_go = OpenCodeGoProfile(
     name="opencode-go",
+    # The Go relay silently DISCARDS developer-role messages rather than
+    # erroring: a gpt-5* model there loses its entire system prompt and
+    # answers as a generic assistant, with HTTP 200 and no log line.
+    supports_developer_role=False,
     aliases=("opencode_go", "go", "opencode-go-sub"),
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -210,6 +210,10 @@ opencode_zen = OpenCodeZenProfile(
 
 opencode_go = OpenCodeGoProfile(
     name="opencode-go",
+    # The Go relay silently DISCARDS developer-role messages rather than
+    # erroring: a gpt-5* model there loses its entire system prompt and
+    # answers as a generic assistant, with HTTP 200 and no log line.
+    supports_developer_role=False,
     aliases=("opencode_go", "go", "opencode-go-sub"),
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",

--- a/providers/base.py
+++ b/providers/base.py
@@ -78,6 +78,15 @@ class ProviderProfile:
     # top-level fields rather than ignoring them.
     supports_prompt_cache_key: bool = False
 
+    # True when the provider's endpoint understands the ``developer`` role
+    # that newer OpenAI models expect in place of ``system``.  Defaults to
+    # True to preserve existing behaviour.  Set to False for endpoints that
+    # are OpenAI-*compatible* without implementing the newer role: some
+    # reject it outright (HTTP 400 "unknown variant developer"), and some
+    # silently drop the message, which discards the entire system prompt
+    # with a 200 response and no error.
+    supports_developer_role: bool = True
+
     # ── Model catalog ─────────────────────────────────────────
     # fallback_models: curated list shown in /model picker when live fetch fails.
     # Only agentic models that support tool calling should appear here.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -750,3 +750,49 @@ class TestPromptCacheKeyCapability:
             supports_prompt_cache_key=True,
         )
         assert kw1["prompt_cache_key"] != kw2["prompt_cache_key"]
+
+
+class TestDeveloperRoleSwap:
+    """Profile-gated ``system`` -> ``developer`` role swap.
+
+    The swap is chosen by model name (``DEVELOPER_ROLE_MODELS``), but whether
+    the *endpoint* understands the role is a provider property. Profiles that
+    set ``supports_developer_role=False`` must keep the leading ``system``
+    message untouched (#41125).
+    """
+
+    SYSTEM_FIRST = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    def _leading_role(self, transport, provider, model):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider)
+        assert profile is not None, f"no profile registered for {provider!r}"
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[dict(m) for m in self.SYSTEM_FIRST],
+            tools=[],
+            provider_profile=profile,
+            provider_name=provider,
+            base_url=profile.base_url,
+        )
+        return kw["messages"][0]["role"]
+
+    def test_custom_provider_keeps_system_role(self, transport):
+        """Custom OpenAI-compatible endpoints reject ``developer`` with a 400."""
+        assert self._leading_role(transport, "custom", "gpt-5.4") == "system"
+
+    def test_opencode_go_keeps_system_role(self, transport):
+        """OpenCode Go silently discards developer-role messages (200, no error)."""
+        assert self._leading_role(transport, "opencode-go", "gpt-5.6-luna") == "system"
+
+    def test_supporting_provider_still_swaps(self, transport):
+        """Endpoints that do understand the role keep the existing behaviour."""
+        assert self._leading_role(transport, "nous", "openai/gpt-5.6-sol") == "developer"
+
+    def test_non_gpt5_model_is_unaffected(self, transport):
+        """The swap is scoped to GPT-5/Codex model names regardless of provider."""
+        assert self._leading_role(transport, "nous", "glm-5.2") == "system"

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -875,3 +875,49 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+
+class TestDeveloperRoleSwap:
+    """Profile-gated ``system`` -> ``developer`` role swap.
+
+    The swap is chosen by model name (``DEVELOPER_ROLE_MODELS``), but whether
+    the *endpoint* understands the role is a provider property. Profiles that
+    set ``supports_developer_role=False`` must keep the leading ``system``
+    message untouched (#41125).
+    """
+
+    SYSTEM_FIRST = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    def _leading_role(self, transport, provider, model):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider)
+        assert profile is not None, f"no profile registered for {provider!r}"
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[dict(m) for m in self.SYSTEM_FIRST],
+            tools=[],
+            provider_profile=profile,
+            provider_name=provider,
+            base_url=profile.base_url,
+        )
+        return kw["messages"][0]["role"]
+
+    def test_custom_provider_keeps_system_role(self, transport):
+        """Custom OpenAI-compatible endpoints reject ``developer`` with a 400."""
+        assert self._leading_role(transport, "custom", "gpt-5.4") == "system"
+
+    def test_opencode_go_keeps_system_role(self, transport):
+        """OpenCode Go silently discards developer-role messages (200, no error)."""
+        assert self._leading_role(transport, "opencode-go", "gpt-5.6-luna") == "system"
+
+    def test_supporting_provider_still_swaps(self, transport):
+        """Endpoints that do understand the role keep the existing behaviour."""
+        assert self._leading_role(transport, "nous", "openai/gpt-5.6-sol") == "developer"
+
+    def test_non_gpt5_model_is_unaffected(self, transport):
+        """The swap is scoped to GPT-5/Codex model names regardless of provider."""
+        assert self._leading_role(transport, "nous", "glm-5.2") == "system"


### PR DESCRIPTION
## What is the issue?

The `system` → `developer` role swap is chosen purely by a model-name substring (`DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")`), with no reference to the endpoint being called. But whether an endpoint implements the `developer` role is a property of the **provider**, not the model name. It should be considered that `developer` is an OpenAI API convention, not part of the OpenAI-*compatible* chat/completions surface that third parties implement.

Resultingly, there are two failure modes result when a gpt-5\* model is served by an OpenAI-compatible endpoint:

- **Hard failure** — `HTTP 400 "unknown variant developer"` from vLLM / Ollama / LiteLLM style endpoints. 
<sup><sub>(This is what #41125 reported.)</sub></sup>
- **Silent failure** — the OpenCode Go relay accepts the request and *discards* the developer-role message. The entire system prompt (persona, skills, memory, operational constraints) never reaches the model. HTTP 200, no error, no log line. The agent stays fluent and simply answers as a generic assistant, so it reads as "this model is underperforming" rather than "the system prompt isn't being delivered". 
<sup><sub>(This is what #81278 reported.)</sub></sup>

## What does this PR do?

This PR adds `ProviderProfile.supports_developer_role` (default `True`, so no existing provider changes behaviour) and gates the swap on it, matching how `supports_vision`, `supports_vision_tool_messages` and `supports_prompt_cache_key` already express endpoint capabilities.

**Relationship to #41125.** That PR applies a similar idea, but inferior given `build_kwargs` — the legacy fallback branch, reached only when `get_provider_profile()` returns `None`. Both `custom` and `opencode-go` resolve through *registered profiles*, so they take the profile path (`_build_kwargs_from_profile`) and are unaffected by it. This is exactly what the automated review on that PR concluded:

> the changed branch is no longer the branch custom providers take … Apply the exemption at the live profile-path swap and add a test using `get_provider_profile("custom")` with `gpt-5.4`, asserting the leading role remains `system`.

This PR implements that suggestion, and generalises it: a capability flag also covers first-class providers that are not `custom`, which a `is_custom_provider` check cannot.

## Related Issue

Fixes #81278

Related: #41125 (same root cause, different code path addressed - see above).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `providers/base.py` — add `supports_developer_role: bool = True` to `ProviderProfile`, alongside the other endpoint-capability flags.
- `agent/transports/chat_completions.py` — gate the swap in `_build_kwargs_from_profile` on `getattr(profile, "supports_developer_role", True)`. Uses `getattr` so third-party/out-of-tree profile objects that predate the field keep working.
- `plugins/model-providers/custom/__init__.py` — `supports_developer_role=False` (the HTTP 400 case from #41125).
- `plugins/model-providers/opencode-zen/__init__.py` — `supports_developer_role=False` on `opencode_go` (the silent-drop case). `opencode_zen` is left at the default: it routes GPT-5/Codex to `codex_responses`, which passes the system prompt as `instructions` and never reaches this code path.
- `tests/agent/transports/test_chat_completions.py` — new `TestDeveloperRoleSwap` covering the exemptions and, importantly, the non-exempt cases.

## How to Test

Minimal reproduction of the silent variant against the Go relay — identical requests, only the role differs:

```bash
curl -s https://opencode.ai/zen/go/v1/chat/completions \
  -H "Authorization: Bearer $OPENCODE_GO_API_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6-luna","messages":[
        {"role":"system","content":"You are Jeff, the venue assistant for The Good Beer Company. Always identify yourself as Jeff."},
        {"role":"user","content":"What is your name?"}]}'
# -> "I'm Jeff, the venue assistant for The Good Beer Company."

# same request with "role":"developer"
# -> "I'm ChatGPT."
```

Automated:

```bash
scripts/run_tests.sh tests/agent/transports/test_chat_completions.py -k DeveloperRoleSwap
```

The two exemption tests fail on `main` with `AssertionError: assert 'developer' == 'system'` and pass with this change. The two control tests (`test_supporting_provider_still_swaps`, `test_non_gpt5_model_is_unaffected`) pass both before and after, so the default path is demonstrably untouched.

End-to-end, on a live agent whose persona lives in `SOUL.md`: before this change `hermes -z "What is your name?"` on `opencode-go` + `gpt-5.6-luna` answered *"I'm Hermes, an AI assistant"*; after, it answers with the configured persona.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #41125 is the closest; this PR complements/improves it rather than duplicating it (see above), and `supports_developer_role` returns no other matches.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran `scripts/run_tests.sh` on `tests/agent/transports/` (243 passed) and `tests/providers/` (50 passed); `ruff check` clean on all changed files.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 (arm64), Python 3.11.15. The production reproduction was on Ubuntu 24.04 (x86_64).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new field is documented inline in `ProviderProfile`, matching the surrounding flags. N/A otherwise.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, this is a provider-profile attribute, not user config.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact — N/A, pure request-construction logic with no platform-specific behaviour.
