### PR TITLE
fix(desktop): keep folder refs below sticky messages

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -67,14 +67,14 @@ async function moveFocusOutside(editor: HTMLElement) {
   outside.remove()
 }
 
-function userMessage(): ThreadMessage {
+function userMessage(custom: Record<string, unknown> = {}): ThreadMessage {
   return {
     id: 'user-1',
     role: 'user',
     content: [{ type: 'text', text: 'edit me please' }],
     attachments: [],
     createdAt,
-    metadata: { custom: {} }
+    metadata: { custom }
   } as ThreadMessage
 }
 
@@ -96,8 +96,14 @@ function assistantMessage(): ThreadMessage {
 }
 
 // Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
-function IncrementalHarness({ onEdit }: { onEdit: (message: AppendMessage) => Promise<void> }) {
-  const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
+function IncrementalHarness({
+  onEdit,
+  user = userMessage()
+}: {
+  onEdit: (message: AppendMessage) => Promise<void>
+  user?: ThreadMessage
+}) {
+  const repository = ExportedMessageRepository.fromArray([user, assistantMessage()])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: repository,
@@ -133,6 +139,24 @@ function StockHarness({ onEdit }: { onEdit: () => Promise<void> }) {
 }
 
 describe('click-to-edit user message', () => {
+  it('keeps sent attachment references below the sticky user bubble', async () => {
+    const { container } = render(
+      <IncrementalHarness
+        onEdit={async () => {}}
+        user={userMessage({ attachmentRefs: ['@folder:C:\\Hermes-Agent\\Portable-Bundle'] })}
+      />
+    )
+
+    const chip = await screen.findByTitle('C:\\Hermes-Agent\\Portable-Bundle')
+    const row = chip.parentElement?.parentElement
+
+    expect(row?.className).toContain('mb-2')
+    expect(row?.className).not.toContain('-mt-3')
+    expect(container.querySelector('[data-slot="aui_user-message-root"]')?.compareDocumentPosition(row ?? chip)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
   it('opens the edit composer with the incremental runtime', async () => {
     const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -67,14 +67,14 @@ async function moveFocusOutside(editor: HTMLElement) {
   outside.remove()
 }
 
-function userMessage(): ThreadMessage {
+function userMessage(custom: Record<string, unknown> = {}): ThreadMessage {
   return {
     id: 'user-1',
     role: 'user',
     content: [{ type: 'text', text: 'edit me please' }],
     attachments: [],
     createdAt,
-    metadata: { custom: {} }
+    metadata: { custom }
   } as ThreadMessage
 }
 
@@ -96,8 +96,8 @@ function assistantMessage(): ThreadMessage {
 }
 
 // Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
-function IncrementalHarness({ onEdit }: { onEdit: () => Promise<void> }) {
-  const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
+function IncrementalHarness({ onEdit, user = userMessage() }: { onEdit: () => Promise<void>; user?: ThreadMessage }) {
+  const repository = ExportedMessageRepository.fromArray([user, assistantMessage()])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: repository,
@@ -133,6 +133,24 @@ function StockHarness({ onEdit }: { onEdit: () => Promise<void> }) {
 }
 
 describe('click-to-edit user message', () => {
+  it('keeps sent attachment references below the sticky user bubble', async () => {
+    const { container } = render(
+      <IncrementalHarness
+        onEdit={async () => {}}
+        user={userMessage({ attachmentRefs: ['@folder:C:\\Hermes-Agent\\Portable-Bundle'] })}
+      />
+    )
+
+    const chip = await screen.findByTitle('C:\\Hermes-Agent\\Portable-Bundle')
+    const row = chip.parentElement?.parentElement
+
+    expect(row?.className).toContain('mb-2')
+    expect(row?.className).not.toContain('-mt-3')
+    expect(container.querySelector('[data-slot="aui_user-message-root"]')?.compareDocumentPosition(row ?? chip)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
   it('opens the edit composer with the incremental runtime', async () => {
     const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -436,7 +436,7 @@ export const UserMessage: FC<{
           // scroll away behind the pinned bubble instead of riding along with
           // it. Image refs render as thumbnails, file refs as chips; no border.
           attachmentRefs.length > 0 ? (
-            <div className="flex flex-wrap gap-1 -mt-3 mb-2">
+            <div className="flex flex-wrap gap-1 mb-2">
               <DirectiveContent text={attachmentRefs.join(' ')} />
             </div>
           ) : null

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -268,7 +268,7 @@ export const UserMessage: FC<{
           // scroll away behind the pinned bubble instead of riding along with
           // it. Image refs render as thumbnails, file refs as chips; no border.
           attachmentRefs.length > 0 ? (
-            <div className="flex flex-wrap gap-1 -mt-3 mb-2">
+            <div className="flex flex-wrap gap-1 mb-2">
               <DirectiveContent text={attachmentRefs.join(' ')} />
             </div>
           ) : null


### PR DESCRIPTION
## What does this PR do?

Keeps sent folder-reference chips below the sticky user message bubble instead of allowing the sticky surface to cover them.

## Related Issue

Fixes #78847

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Removed the negative top margin from the attachment-reference row in `apps/desktop/src/components/assistant-ui/thread/user-message.tsx`.
- Added a regression test that renders a Windows-style folder reference and verifies the reference row remains below the sticky user message.

## Root Cause

The attachment-reference row was pulled upward with `-mt-3` while the user message bubble uses an opaque sticky surface with a higher stacking order. The row therefore rendered underneath the bubble and appeared partially covered.

## How to Test

- `npm run test:ui -- src/components/assistant-ui/thread/user-message-edit.test.tsx src/components/assistant-ui/thread/user-message-text.test.tsx`
- `npm run typecheck`
- `npx --no-install prettier --check src/components/assistant-ui/thread/user-message.tsx src/components/assistant-ui/thread/user-message-edit.test.tsx`
- `git diff --check`

The repository lint script could not run in this checkout because `eslint` is not included in the installed desktop workspace dependencies.
