### PR TITLE
fix(delegation): preserve scout report through fallback

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1747,6 +1747,65 @@ class TestFallbackModelInheritance(unittest.TestCase):
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
 
+    def test_routed_child_uses_parent_primary_as_last_report_fallback(self):
+        """A routed scout can finish its report on the parent's primary model."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "custom"
+        parent.model = "gpt-5.6-sol"
+        parent.base_url = "https://codex-lb.example/v1"
+        parent.api_key = "parent-key"
+        parent._fallback_chain = []
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="research then report",
+                context=None,
+                toolsets=None,
+                model="gpt-5.6-luna",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(
+            kwargs["fallback_model"],
+            [{
+                "provider": "custom",
+                "model": "gpt-5.6-sol",
+                "base_url": "https://codex-lb.example/v1",
+                "api_key": "parent-key",
+            }],
+        )
+
+    def test_parent_primary_follows_configured_child_fallbacks(self):
+        """Explicit fallback order remains authoritative before parent recovery."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "custom"
+        parent.model = "gpt-5.6-sol"
+        parent.base_url = "https://codex-lb.example/v1"
+        configured = {"provider": "openrouter", "model": "backup-model"}
+        parent._fallback_chain = [configured]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="research then report",
+                context=None,
+                toolsets=None,
+                model="gpt-5.6-luna",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["fallback_model"][0], configured)
+        self.assertEqual(kwargs["fallback_model"][1]["model"], "gpt-5.6-sol")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1567,11 +1567,56 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Inherit the parent's configured fallback chain. When a delegation route
+    # selects a different model/backend, also keep the parent's primary runtime
+    # as the last fallback. A scout can complete useful tool calls and then lose
+    # every account for its routed model before it writes the final report; the
+    # parent model can finish that same conversation without discarding the
+    # collected tool results or changing the user's configured primary route.
+    parent_fallback = list(getattr(parent_agent, "_fallback_chain", None) or [])
+    parent_provider = getattr(parent_agent, "provider", None)
+    parent_model = getattr(parent_agent, "model", None)
+    parent_base_url = _inherit_parent_base_url(
+        parent_agent, getattr(parent_agent, "base_url", None)
+    )
+    if parent_provider and parent_model:
+        from agent.backend_identity import BackendIdentity, should_skip_candidate
+
+        parent_entry = {
+            "provider": parent_provider,
+            "model": parent_model,
+            "base_url": parent_base_url,
+        }
+        if parent_api_key:
+            parent_entry["api_key"] = parent_api_key
+        parent_identity = BackendIdentity.build(
+            provider=parent_provider,
+            model=parent_model,
+            base_url=parent_base_url,
+        )
+        child_identity = BackendIdentity.build(
+            provider=effective_provider,
+            model=effective_model,
+            base_url=effective_base_url,
+        )
+        configured_identities = [
+            BackendIdentity.build(
+                provider=entry.get("provider"),
+                model=entry.get("model"),
+                base_url=entry.get("base_url"),
+            )
+            for entry in parent_fallback
+            if isinstance(entry, dict)
+        ]
+        if (
+            not should_skip_candidate(parent_identity, child_identity)
+            and not any(
+                should_skip_candidate(parent_identity, configured_identity)
+                for configured_identity in configured_identities
+            )
+        ):
+            parent_fallback.append(parent_entry)
+    parent_fallback = parent_fallback or None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing


### PR DESCRIPTION
## Summary
- keep the parent primary runtime as the final fallback for children routed to a different model/backend
- retain the child conversation and completed tool results when the routed Scout model exhausts its accounts before final reporting
- preserve configured fallback order and avoid duplicate backend entries

## Verification
- `scripts/run_tests.sh tests/tools/test_delegate.py -q` (65 passed)
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/run_agent/test_conversation_fallback_state.py -q` (16 passed)
- `uv run ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
- `uv run python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`