### PR TITLE
telegram: detect fetched-but-never-dispatched updates (dispatch-liveness heartbeat probe)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -244,6 +244,7 @@ try:
         CommandHandler,
         CallbackQueryHandler,
         MessageHandler as TelegramMessageHandler,
+        TypeHandler,
         ContextTypes,
         filters,
     )
@@ -821,6 +822,24 @@ class TelegramAdapter(BasePlatformAdapter):
         # error_callback ever fires and the gateway silently stops receiving
         # messages with the process still alive (#55769).
         self._polling_not_running_count: int = 0
+        # Consecutive heartbeat probes that saw updates sitting in PTB's
+        # in-process ``app.update_queue`` with no dispatch progress between
+        # probes. The two probes above are blind to this variant: the updater
+        # is RUNNING and FETCHING — updates are confirmed to Telegram on
+        # fetch, so ``pending_update_count`` stays 0 — while the Application's
+        # update-processing task is dead, so fetched updates pile up in
+        # ``update_queue`` and never reach handlers. Every existing signal is
+        # green (get_me() healthy, fetch progress advancing, updater.running
+        # True, Bot API queue empty) and the gateway is silently deaf.
+        # Field-observed on a long-lived gateway that had gone through the
+        # in-process reconnect ladder, which restarts only the updater and
+        # never verifies the processing half (see _start_polling_once).
+        self._polling_dispatch_stuck_count: int = 0
+        # Stamped by a group -100 TypeHandler on every update PTB dispatches:
+        # the discriminator between a queue that is busy-but-draining (stamp
+        # advances) and one filling against a dead consumer (stamp frozen).
+        self._last_dispatch_monotonic: float = 0.0
+        self._dispatch_stamp_at_last_probe: float = -1.0
         # A polling generation stays degraded until the dedicated getUpdates
         # request makes successful progress. start_polling() return and getMe()
         # success on the general request path are not polling-health signals.
@@ -2805,6 +2824,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 # CLOSE-WAIT symptoms — let PTB's own handlers surface them.
                 pass
 
+    async def _note_dispatch_progress(self, update: object, context: object) -> None:
+        """Group -100 observer: proof PTB's update processor is alive.
+
+        Runs for every update the Application dispatches, before any routing
+        handler. The heartbeat's dispatch-liveness probe compares this stamp
+        across probes; see _probe_pending_updates.
+        """
+        self._last_dispatch_monotonic = time.monotonic()
+
     async def _probe_pending_updates(self, bot, probe_timeout: float) -> None:
         """Detect a wedged getUpdates consumer via pending_update_count.
 
@@ -2878,6 +2906,48 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return
         self._polling_not_running_count = 0
+        # Dispatch-liveness: everything below this comment and the pending
+        # probe after it verify different halves of the pipeline. The pending
+        # probe verifies the FETCH half (Bot API queue vs a live consumer);
+        # this block verifies the PROCESSING half. PTB confirms updates to
+        # Telegram on fetch, so when the Application's update-processing task
+        # is dead behind a running updater the Bot API queue stays EMPTY while
+        # ``app.update_queue`` fills — ``pending_update_count`` is blind to it
+        # by construction. An update sitting in ``update_queue`` while the
+        # dispatch stamp has not moved since the previous probe can only mean
+        # a dead consumer: a live one drains a queued update in milliseconds,
+        # not 90 seconds. Two consecutive stuck probes escalate to the
+        # retryable-fatal rebuild — deliberately NOT the reconnect ladder,
+        # which restarts only the updater and would leave the dead processing
+        # task exactly where it was.
+        queue = getattr(self._app, "update_queue", None) if self._app else None
+        qsize = queue.qsize() if queue is not None and callable(getattr(queue, "qsize", None)) else 0
+        stamp = self._last_dispatch_monotonic
+        dispatch_stalled = qsize > 0 and stamp == self._dispatch_stamp_at_last_probe
+        self._dispatch_stamp_at_last_probe = stamp
+        if dispatch_stalled:
+            self._polling_dispatch_stuck_count += 1
+            logger.warning(
+                "[%s] Telegram polling heartbeat: %d update(s) fetched but not "
+                "dispatched, no handler progress since previous probe "
+                "(stuck probe %d/2)",
+                self.name, qsize, self._polling_dispatch_stuck_count,
+            )
+            if self._polling_dispatch_stuck_count >= 2:
+                self._polling_dispatch_stuck_count = 0
+                if getattr(self, "_polling_teardown_started", False):
+                    return
+                self._set_fatal_error(
+                    "telegram_dispatch_stalled",
+                    "Telegram updates are fetched but not dispatched (update "
+                    "processor dead behind a running updater); forcing gateway "
+                    "reconnect.",
+                    retryable=True,
+                )
+                await self._handoff_polling_fatal_error()
+                return
+        else:
+            self._polling_dispatch_stuck_count = 0
         get_webhook_info = getattr(bot, "get_webhook_info", None)
         if not callable(get_webhook_info):
             return
@@ -3889,6 +3959,14 @@ class TelegramAdapter(BasePlatformAdapter):
             self._bot = self._app.bot
             
             # Register handlers
+            # Group -100, block=False: observes every dispatched update
+            # without affecting routing. This stamp is the dispatch-liveness
+            # signal _probe_pending_updates uses to catch a dead
+            # update-processing task hiding behind a healthy updater.
+            self._app.add_handler(
+                TypeHandler(object, self._note_dispatch_progress, block=False),
+                group=-100,
+            )
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -4021,6 +4099,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._app = builder.build()
                         self._bot = self._app.bot
                         # Re-register handlers on the new app
+                        # Same dispatch-liveness observer as the fresh-build
+                        # registration above — a rebuilt app must not lose it.
+                        self._app.add_handler(
+                            TypeHandler(object, self._note_dispatch_progress, block=False),
+                            group=-100,
+                        )
                         self._app.add_handler(TelegramMessageHandler(
                             filters.TEXT & ~filters.COMMAND,
                             self._handle_text_message

--- a/tests/gateway/test_telegram_dispatch_liveness_probe.py
+++ b/tests/gateway/test_telegram_dispatch_liveness_probe.py
@@ -1,0 +1,141 @@
+"""TelegramAdapter dispatch-liveness detection: fetched but never dispatched.
+
+The pending_update_count probe (#42909) and the stopped-updater probe (#55769)
+both verify the FETCH half of the pipeline. Neither can see the inverse
+failure: the updater RUNNING and FETCHING — PTB confirms updates to Telegram
+on fetch, so ``pending_update_count`` stays 0 — while the Application's
+update-processing task is dead, so fetched updates pile up in
+``app.update_queue`` and never reach handlers. get_me() is healthy, fetch
+progress advances, ``updater.running`` is True, the Bot API queue is empty:
+every existing signal is green and the gateway is silently deaf.
+
+``_probe_pending_updates`` therefore also compares ``update_queue.qsize()``
+against a dispatch stamp written by a group -100 TypeHandler on every update
+the Application dispatches. A non-empty queue with a frozen stamp across two
+consecutive probes escalates to the retryable-fatal rebuild — deliberately
+NOT the reconnect ladder, which restarts only the updater and would leave the
+dead processing task exactly where it was.
+"""
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter(*, qsize: int, pending: int = 0) -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._webhook_mode = False
+    adapter._app = MagicMock()
+    adapter._app.updater.running = True
+    adapter._app.update_queue.qsize.return_value = qsize
+    bot = MagicMock()
+    bot.get_webhook_info = AsyncMock(
+        return_value=MagicMock(pending_update_count=pending)
+    )
+    adapter._app.bot = bot
+    adapter._bot = bot
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_first_stalled_probe_only_counts():
+    """Queue non-empty + frozen stamp: probe 1 increments, nothing escalates."""
+    adapter = _make_adapter(qsize=3)
+    adapter._last_dispatch_monotonic = 100.0
+    adapter._dispatch_stamp_at_last_probe = 100.0
+    fatal = AsyncMock()
+    with patch.object(adapter, "_handoff_polling_fatal_error", new=fatal):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+    assert adapter._polling_dispatch_stuck_count == 1
+    fatal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_two_stalled_probes_force_retryable_fatal_rebuild():
+    """The wedge state: two consecutive stuck probes rebuild the adapter.
+
+    Escalation is the retryable-fatal handoff, not the reconnect ladder — an
+    updater-only restart cannot revive a dead update-processing task.
+    """
+    adapter = _make_adapter(qsize=3)
+    adapter._last_dispatch_monotonic = 100.0
+    adapter._dispatch_stamp_at_last_probe = 100.0
+    fatal = AsyncMock()
+    set_fatal = MagicMock()
+    ladder = AsyncMock()
+    with patch.object(adapter, "_handoff_polling_fatal_error", new=fatal), \
+         patch.object(adapter, "_set_fatal_error", new=set_fatal), \
+         patch.object(adapter, "_handle_polling_network_error", new=ladder):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+    fatal.assert_awaited_once()
+    set_fatal.assert_called_once()
+    assert set_fatal.call_args[0][0] == "telegram_dispatch_stalled"
+    assert set_fatal.call_args[1].get("retryable") is True
+    ladder.assert_not_called()
+    assert adapter._polling_dispatch_stuck_count == 0
+
+
+@pytest.mark.asyncio
+async def test_busy_but_draining_queue_never_trips():
+    """Stamp advanced between probes: high-throughput traffic is healthy."""
+    adapter = _make_adapter(qsize=5)
+    adapter._last_dispatch_monotonic = 100.0
+    adapter._dispatch_stamp_at_last_probe = 90.0  # progressed since last probe
+    fatal = AsyncMock()
+    with patch.object(adapter, "_handoff_polling_fatal_error", new=fatal):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+    assert adapter._polling_dispatch_stuck_count == 0
+    fatal.assert_not_called()
+    # And the stamp baseline moved forward for the next comparison.
+    assert adapter._dispatch_stamp_at_last_probe == 100.0
+
+
+@pytest.mark.asyncio
+async def test_idle_queue_resets_the_counter():
+    """qsize 0 is the resting state of every healthy idle bot."""
+    adapter = _make_adapter(qsize=0)
+    adapter._polling_dispatch_stuck_count = 1
+    fatal = AsyncMock()
+    with patch.object(adapter, "_handoff_polling_fatal_error", new=fatal):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+    assert adapter._polling_dispatch_stuck_count == 0
+    fatal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stamp_callback_advances_the_clock():
+    """The group -100 observer stamps monotonic time on every dispatch."""
+    adapter = _make_adapter(qsize=0)
+    assert adapter._last_dispatch_monotonic == 0.0
+    await adapter._note_dispatch_progress(MagicMock(), MagicMock())
+    assert adapter._last_dispatch_monotonic > 0.0
+
+
+@pytest.mark.asyncio
+async def test_pending_probe_still_runs_after_healthy_dispatch_check():
+    """The new block must not short-circuit the existing #42909 probe."""
+    adapter = _make_adapter(qsize=0, pending=9)
+    with patch.object(adapter, "_handle_polling_network_error", new=AsyncMock()):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+    adapter._app.bot.get_webhook_info.assert_called_once()
+    assert adapter._polling_pending_stuck_count == 1


### PR DESCRIPTION
## The gap

The heartbeat's existing detectors all verify the **fetch half** of the polling pipeline:

- `pending_update_count` stuck → wedged long-poll consumer (#42909)
- `updater.running == False` → long-poll task gone (#55769)
- recovery task wedged → frozen reconnect ladder (#66377)

None of them can see the inverse failure: **the updater running and fetching while the Application's update-processing task is dead.** PTB confirms updates to Telegram on fetch, so in this state `pending_update_count` stays 0 — the Bot API queue is empty *because* updates are being fetched and acked — while they pile up in `app.update_queue` and never reach a handler. `get_me()` is healthy, fetch progress advances, `updater.running` is True. Every existing signal is green and the gateway is silently deaf.

This state is reachable through the in-process reconnect ladder: it restarts only `updater.start_polling()` on the existing app; `app.start()` happens once in `connect()` and nothing on the reconnect path verifies the processing half.

## Field report

A production gateway (0.19.1) went **20 hours** consuming updates and dispatching none, following a heartbeat-probe-triggered reconnect that logged success ("polling restarted after network error (attempt 1)"). Throughout the outage: `pending_update_count=0`, platform state "connected", zero `inbound message` log lines, all watchdog bounds green. It recovered only when an external 409 forced another generation rebuild. (We could not capture a task dump of the wedged process, so which internal task died is inferred from the consumed-but-never-logged evidence; the structural gap this PR closes is code-level regardless.)

## The fix

Same shape as #42909, one probe further down the pipeline:

- A `TypeHandler` in group `-100` (`block=False`) stamps monotonic time on every update the Application dispatches — a direct liveness signal for the processing half, zero effect on routing.
- `_probe_pending_updates` compares `app.update_queue.qsize()` against that stamp: a non-empty queue whose stamp has not moved since the previous probe can only mean a dead consumer (a live one drains a queued update in milliseconds, not 90 seconds).
- Two consecutive stuck probes (the #42909 debounce) escalate to the **retryable-fatal rebuild** — deliberately not `_handle_polling_network_error`: the reconnect ladder restarts only the updater and would leave the dead processing task exactly where it was.

Idle bots rest at `qsize == 0` and never trip it; high-throughput bots advance the stamp and never trip it.

## Tests

6 new tests in `tests/gateway/test_telegram_dispatch_liveness_probe.py` (stall counting, fatal-not-ladder escalation, busy-but-draining, idle reset, stamp callback, no short-circuit of the existing pending probe). Existing `test_telegram_pending_update_probe.py` and `test_telegram_network_reconnect.py` suites pass unchanged.

Draft: happy to adjust the escalation path, thresholds, or the stamp mechanism to whatever the maintainers prefer.