### PR TITLE
fix(agent): parse Azure output-cap rejection phrasing (#78405)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1571,6 +1571,22 @@ def get_context_length_from_provider_error(
     return None
 
 
+# Signals that the error ALSO clearly describes an oversized INPUT, even when
+# it mentions max_tokens / a completion-token ceiling.  Shared by
+# parse_available_output_tokens_from_error (Azure extraction guard) and
+# is_output_cap_error (input-overflow exclusion) so genuine input overflows
+# keep routing to compression.
+_OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS = (
+    "prompt is too long",
+    "prompt too long",
+    "input is too long",
+    "input token",
+    "prompt length",
+    "prompt contains",
+    "reduce the length",
+)
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
@@ -1616,6 +1632,15 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # The input itself fits — this is purely an output-cap error, so reduce
         # max_tokens and retry; do NOT compress.
         "range of max_tokens should be" in error_lower
+    ) or (
+        # Azure OpenAI phrasing:
+        #   "max_tokens is too large: 65536. This model supports at most
+        #    32768 completion tokens."
+        # The rejection names the OUTPUT parameter and the model's advertised
+        # completion-token ceiling — the input itself fits, so reduce
+        # max_tokens and retry; do NOT compress.
+        "max_tokens is too large" in error_lower
+        and "supports at most" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1629,6 +1654,23 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     if _m_range:
         _cap = int(_m_range.group(1))
         if _cap >= 1:
+            return _cap
+
+    # Azure form: "max_tokens is too large: 65536. This model supports at
+    # most 32768 completion tokens."  The advertised completion-token
+    # ceiling is the available output cap for the failed request.
+    _m_azure = re.search(
+        r'supports at most\s+(\d+)\s*(?:completion\s+)?tokens',
+        error_lower,
+    )
+    if _m_azure:
+        _cap = int(_m_azure.group(1))
+        if _cap >= 1:
+            # If the message ALSO clearly describes an oversized INPUT, it is
+            # a genuine context overflow that happens to name the ceiling —
+            # return None so the caller falls through to compression.
+            if any(p in error_lower for p in _OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS):
+                return None
             return _cap
 
     # Extract the available_tokens figure.
@@ -1739,6 +1781,10 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "should be" in error_lower                       # generic "max_tokens should be <= N"
         or "less than or equal" in error_lower
         or "must be" in error_lower
+        or (
+            "max_tokens is too large" in error_lower        # Azure: "max_tokens is too large: 65536. This model supports at most 32768 completion tokens."
+            and ("completion tokens" in error_lower or "supports at most" in error_lower)
+        )
     )
     if not output_cap_signal:
         return False
@@ -1746,16 +1792,7 @@ def is_output_cap_error(error_msg: str) -> bool:
     # If the error ALSO clearly describes an oversized INPUT, it is a genuine
     # context overflow that happens to mention max_tokens — let the
     # context-overflow path handle it (it can compress the input).
-    input_overflow_signal = (
-        "prompt is too long" in error_lower
-        or "prompt too long" in error_lower
-        or "input is too long" in error_lower
-        or "input token" in error_lower
-        or "prompt length" in error_lower
-        or "prompt contains" in error_lower
-        or "reduce the length" in error_lower
-    )
-    return not input_overflow_signal
+    return not any(p in error_lower for p in _OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS)
 
 
 def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1721,6 +1721,22 @@ def get_context_length_from_provider_error(
     return None
 
 
+# Signals that the error ALSO clearly describes an oversized INPUT, even when
+# it mentions max_tokens / a completion-token ceiling.  Shared by
+# parse_available_output_tokens_from_error (Azure extraction guard) and
+# is_output_cap_error (input-overflow exclusion) so genuine input overflows
+# keep routing to compression.
+_OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS = (
+    "prompt is too long",
+    "prompt too long",
+    "input is too long",
+    "input token",
+    "prompt length",
+    "prompt contains",
+    "reduce the length",
+)
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
@@ -1773,6 +1789,15 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
+    ) or (
+        # Azure OpenAI phrasing:
+        #   "max_tokens is too large: 65536. This model supports at most
+        #    32768 completion tokens."
+        # The rejection names the OUTPUT parameter and the model's advertised
+        # completion-token ceiling — the input itself fits, so reduce
+        # max_tokens and retry; do NOT compress.
+        "max_tokens is too large" in error_lower
+        and "supports at most" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1797,6 +1822,23 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     if _m_range:
         _cap = int(_m_range.group(1))
         if _cap >= 1:
+            return _cap
+
+    # Azure form: "max_tokens is too large: 65536. This model supports at
+    # most 32768 completion tokens."  The advertised completion-token
+    # ceiling is the available output cap for the failed request.
+    _m_azure = re.search(
+        r'supports at most\s+(\d+)\s*(?:completion\s+)?tokens',
+        error_lower,
+    )
+    if _m_azure:
+        _cap = int(_m_azure.group(1))
+        if _cap >= 1:
+            # If the message ALSO clearly describes an oversized INPUT, it is
+            # a genuine context overflow that happens to name the ceiling —
+            # return None so the caller falls through to compression.
+            if any(p in error_lower for p in _OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS):
+                return None
             return _cap
 
     # Extract the available_tokens figure.
@@ -1926,6 +1968,10 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "must be" in error_lower
         or ("exceeds model" in error_lower
             and "maximum output tokens" in error_lower)
+        or (
+            "max_tokens is too large" in error_lower        # Azure: "max_tokens is too large: 65536. This model supports at most 32768 completion tokens."
+            and ("completion tokens" in error_lower or "supports at most" in error_lower)
+        )
     )
     if not output_cap_signal:
         return False
@@ -1933,16 +1979,7 @@ def is_output_cap_error(error_msg: str) -> bool:
     # If the error ALSO clearly describes an oversized INPUT, it is a genuine
     # context overflow that happens to mention max_tokens — let the
     # context-overflow path handle it (it can compress the input).
-    input_overflow_signal = (
-        "prompt is too long" in error_lower
-        or "prompt too long" in error_lower
-        or "input is too long" in error_lower
-        or "input token" in error_lower
-        or "prompt length" in error_lower
-        or "prompt contains" in error_lower
-        or "reduce the length" in error_lower
-    )
-    return not input_overflow_signal
+    return not any(p in error_lower for p in _OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS)
 
 
 def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -132,3 +132,82 @@ class TestParseVllmTokenBasedOutputCap:
         assert available is not None
         assert available + 65537 <= 131072
 
+
+class TestParseAzureOutputCap:
+    """Azure OpenAI rejects an over-cap output request by naming the OUTPUT
+    parameter and the model's advertised completion-token ceiling:
+
+        "max_tokens is too large: 65536. This model supports at most
+         32768 completion tokens."
+
+    The input itself fits — this is purely an output-cap error.  Until this
+    phrasing was parsed, the recovery path classified it as context overflow
+    (the bare ``max_tokens`` substring) and looped through compression on a
+    tiny conversation, ending in "cannot compress further" (issue #78405).
+    """
+
+    # Verbatim Azure OpenAI 400 from issue #78405 (gpt-4.1-mini, 32k ceiling).
+    _AZURE_MSG = (
+        "Error: max_tokens is too large: 65536. This model supports at most "
+        "32768 completion tokens."
+    )
+
+    def test_azure_supports_at_most_format(self):
+        # The advertised completion-token ceiling is the available output cap.
+        assert parse_available_output_tokens_from_error(self._AZURE_MSG) == 32768
+
+    def test_azure_arbitrary_bound(self):
+        msg = ("Error: max_tokens is too large: 65536. This model supports "
+               "at most 16384 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 16384
+
+    def test_azure_without_completion_word(self):
+        # Variant without the "completion" qualifier — the regex allows it.
+        msg = ("Error: max_tokens is too large: 65536. This model supports "
+               "at most 32768 tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 32768
+        assert is_output_cap_error(msg) is True
+
+    def test_azure_case_insensitive(self):
+        msg = ("ERROR: Max_Tokens Is Too Large: 65536. THIS MODEL SUPPORTS "
+               "AT MOST 32768 COMPLETION TOKENS.")
+        assert parse_available_output_tokens_from_error(msg) == 32768
+        assert is_output_cap_error(msg) is True
+
+    def test_azure_is_output_cap(self):
+        assert is_output_cap_error(self._AZURE_MSG) is True
+
+    def test_azure_retry_fits_inside_window(self):
+        # The retried cap (cap - 64 margin, applied by the caller) plus the
+        # tiny input must fit inside the advertised ceiling.
+        available = parse_available_output_tokens_from_error(self._AZURE_MSG)
+        assert available is not None
+        assert available - 64 >= 1
+
+    def test_input_overflow_mentioning_ceiling_is_not_output_cap(self):
+        # An input-overflow that happens to cite the completion-token ceiling
+        # must stay on the compression path: no "max_tokens is too large".
+        msg = ("Error: input tokens (80000) exceed the model's context "
+               "window; the model supports at most 32768 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_input_overflow_mentioning_max_tokens_is_not_output_cap(self):
+        # Genuine input overflow that also names max_tokens (no "is too
+        # large" phrasing) must not be flagged as an output-cap error.
+        msg = ("This model's maximum context length is 32768 tokens. However, "
+               "your messages resulted in 35000 tokens. Please reduce the "
+               "length of the messages or max_tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_input_overflow_with_too_large_phrase_is_not_output_cap(self):
+        # Even with the "max_tokens is too large" phrase, a message that
+        # clearly describes oversized INPUT must stay on the compression
+        # path (input-overflow signals win in both functions).
+        msg = ("Error: max_tokens is too large for this request: input tokens "
+               "(80000) exceed the model's context window; this model "
+               "supports at most 32768 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,82 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+class TestParseAzureOutputCap:
+    """Azure OpenAI rejects an over-cap output request by naming the OUTPUT
+    parameter and the model's advertised completion-token ceiling:
+
+        "max_tokens is too large: 65536. This model supports at most
+         32768 completion tokens."
+
+    The input itself fits — this is purely an output-cap error.  Until this
+    phrasing was parsed, the recovery path classified it as context overflow
+    (the bare ``max_tokens`` substring) and looped through compression on a
+    tiny conversation, ending in "cannot compress further" (issue #78405).
+    """
+
+    # Verbatim Azure OpenAI 400 from issue #78405 (gpt-4.1-mini, 32k ceiling).
+    _AZURE_MSG = (
+        "Error: max_tokens is too large: 65536. This model supports at most "
+        "32768 completion tokens."
+    )
+
+    def test_azure_supports_at_most_format(self):
+        # The advertised completion-token ceiling is the available output cap.
+        assert parse_available_output_tokens_from_error(self._AZURE_MSG) == 32768
+
+    def test_azure_arbitrary_bound(self):
+        msg = ("Error: max_tokens is too large: 65536. This model supports "
+               "at most 16384 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 16384
+
+    def test_azure_without_completion_word(self):
+        # Variant without the "completion" qualifier — the regex allows it.
+        msg = ("Error: max_tokens is too large: 65536. This model supports "
+               "at most 32768 tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 32768
+        assert is_output_cap_error(msg) is True
+
+    def test_azure_case_insensitive(self):
+        msg = ("ERROR: Max_Tokens Is Too Large: 65536. THIS MODEL SUPPORTS "
+               "AT MOST 32768 COMPLETION TOKENS.")
+        assert parse_available_output_tokens_from_error(msg) == 32768
+        assert is_output_cap_error(msg) is True
+
+    def test_azure_is_output_cap(self):
+        assert is_output_cap_error(self._AZURE_MSG) is True
+
+    def test_azure_retry_fits_inside_window(self):
+        # The retried cap (cap - 64 margin, applied by the caller) plus the
+        # tiny input must fit inside the advertised ceiling.
+        available = parse_available_output_tokens_from_error(self._AZURE_MSG)
+        assert available is not None
+        assert available - 64 >= 1
+
+    def test_input_overflow_mentioning_ceiling_is_not_output_cap(self):
+        # An input-overflow that happens to cite the completion-token ceiling
+        # must stay on the compression path: no "max_tokens is too large".
+        msg = ("Error: input tokens (80000) exceed the model's context "
+               "window; the model supports at most 32768 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_input_overflow_mentioning_max_tokens_is_not_output_cap(self):
+        # Genuine input overflow that also names max_tokens (no "is too
+        # large" phrasing) must not be flagged as an output-cap error.
+        msg = ("This model's maximum context length is 32768 tokens. However, "
+               "your messages resulted in 35000 tokens. Please reduce the "
+               "length of the messages or max_tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_input_overflow_with_too_large_phrase_is_not_output_cap(self):
+        # Even with the "max_tokens is too large" phrase, a message that
+        # clearly describes oversized INPUT must stay on the compression
+        # path (input-overflow signals win in both functions).
+        msg = ("Error: max_tokens is too large for this request: input tokens "
+               "(80000) exceed the model's context window; this model "
+               "supports at most 32768 completion tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+


### PR DESCRIPTION
## What does this PR do?

Azure OpenAI rejects an over-cap `max_tokens` with a 400 that names the OUTPUT parameter and the model's advertised completion-token ceiling:

```
Error: max_tokens is too large: 65536. This model supports at most 32768 completion tokens.
```

The bare `"max_tokens"` substring in the error classifier's `_CONTEXT_OVERFLOW_PATTERNS` classifies this as a context overflow (it is deliberately broad — it also catches Anthropic's `max_tokens: N > context_window: ...` phrasing, and the output-cap branch is only reachable through that classification). But neither `parse_available_output_tokens_from_error()` nor `is_output_cap_error()` recognized the Azure wording, so the recovery path fell through into the real compression loop. Compression cannot help an output-cap rejection (the input already fits), so on a small conversation it no-ops and the turn dies with `Context length exceeded (N tokens). Cannot compress further.` — issue #78405, the same death-loop class #55570 fixed for the DashScope phrasing.

This PR adds the Azure form to both gates and extracts the advertised completion-token ceiling as the available output budget. The existing retry logic then shrinks `max_tokens` (with its `-64` safety margin, clamped against the local request estimate) and retries without compressing — matching the #55570 pattern.

## Related Issue

Fixes #78405

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`:
  - `parse_available_output_tokens_from_error()`: recognize the Azure gate (`max_tokens is too large` + `supports at most`) and extract the ceiling via `supports at most N (completion )?tokens`
  - `is_output_cap_error()`: new output-cap signal (`max_tokens is too large` paired with `completion tokens`/`supports at most`), still overridden by the input-overflow exclusion
  - New shared module constant `_OUTPUT_CAP_INPUT_OVERFLOW_SIGNALS`: the extraction is guarded by the same input-overflow signals as the gate, so a genuine input overflow that happens to name the ceiling still routes to compression (the inline list in `is_output_cap_error` was hoisted to it, behavior-identical)
- `tests/test_output_cap_parsing.py`: 9 new cases — verbatim Azure 400, arbitrary bound, variant without the "completion" qualifier, case-insensitive, output-cap gate, retry margin, and three input-overflow false positives that mention the ceiling / `max_tokens` / the "too large" phrase

## How to Test

1. Unit: `pytest tests/test_output_cap_parsing.py tests/test_ctx_halving_fix.py -q` → 36 passed
2. Regression: `pytest tests/run_agent/test_run_agent.py -k "output or compress or context"` → 15 passed
3. Repro from #78405: configure a custom provider pointing at a model whose max output ceiling is below 65536 (e.g. Azure gpt-4.1-mini, 32k) and send any message with the default output cap. Before: 400 → compression death loop → "Cannot compress further". After: one retry with a reduced `max_tokens` succeeds.

Full-suite note: a complete `pytest tests/ -q` run in this dev environment shows pre-existing, order-dependent failures (a live Hermes Desktop instance shares ports/state); sampled failing files pass in isolation on both this branch and clean `main`, and `tests/run_agent/test_run_agent.py`'s single failure (`test_interruptible_anthropic_interrupt_never_closes_shared_client`) reproduces on clean `main` unchanged. CI remains the authoritative gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites for this change are green; see full-suite note above for local-environment port conflicts)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

## Notes

Related issues that share the output-cap/compression misclassification family but are **not** closed by this PR (each has a distinct remaining gap): #51773 (Volcengine Ark wording), #49686 (max_tokens set to context length on custom endpoints), #72281 (relay-wrapped output-cap 400s), #56901 (auxiliary title generation with inflated max_tokens). Open PRs #72283, #62197, #70152, #58319, #58981 address adjacent pieces; none of them covers the `supports at most N completion tokens` phrasing this PR adds.

**Open question (follow-up candidate, not blocking this PR):** the reporter's config used `max_output_tokens` under `models.main`, which is not a recognized key — the documented output-cap keys are `model.max_tokens` and `custom_providers[].max_output_tokens`, both already honored on main. Should `models.<name>.max_output_tokens` be accepted as an alias, or is documentation the right fix? Happy to file a separate issue if either direction is wanted.


## Rebase note

Rebased onto current `main` (4209d371aa) after the relay-phrasing parser (`99c980f466`, "exceeds model maximum output tokens") and the vLLM retry-convergence fix landed. Azure's phrasing remains uncovered on main after those commits — verified empirically (`parse → None`, `is_output_cap_error → False` for the verbatim Azure 400) — so this PR's gates compose with (not duplicate) the relay form: both clauses coexist in the output-cap gate, and main's new `test_vllm_retry_converges` regression is preserved alongside the 9 new Azure cases (40 tests passing across `tests/test_output_cap_parsing.py` + `tests/test_ctx_halving_fix.py`, 19 in the `run_agent` output/compression selection).
