### PR TITLE
fix(egress): allow mapped CONNECTs to reach MITM (#81281)

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -1173,16 +1173,15 @@ def build_proxy_config(
                 # don't want body inspection forced for every request.
                 "match_query": True,
                 "match_body": False,
-                # Fail closed (maxpetrusenko P1): when a request reaches an
-                # allowlisted upstream WITHOUT the proxy token present in a
-                # matched location, reject it instead of forwarding as-is.
-                # Without this, a real provider key that a sandbox process
-                # sent directly (not via the minted token) would still pass
-                # the proxy boundary to the allowed host. With require=true,
-                # iron-proxy returns ActionReject when no token swap fired
-                # (v0.39 secrets transform: replaceConfig.Require, enforced in
-                # TransformRequest — verified present in the pinned version).
-                "require": True,
+                # A CONNECT is evaluated before TLS MITM, so its synthetic
+                # header-less request cannot contain the proxy token.  iron-
+                # proxy v0.39 applies ``require`` at that stage and rejects
+                # every mapped CONNECT before the post-MITM request can be
+                # inspected.  Leave enforcement to the tokenized proxy
+                # listener and the allowlist until iron-proxy supports
+                # deferring this check to the post-MITM request (as it does
+                # for aws_auth).
+                "require": False,
             },
             "rules": [{"host": h} for h in m.upstream_hosts],
         })

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -93,6 +93,27 @@ def test_build_proxy_config_custom_allowed_hosts(tmp_path):
     assert "openrouter.ai" in domains  # comes from the mapping
 
 
+def test_build_proxy_config_does_not_require_token_on_synthetic_connect(tmp_path):
+    """iron-proxy v0.39 must inspect the token after CONNECT MITM.
+
+    A ``require: true`` secrets rule is evaluated against the synthetic,
+    header-less CONNECT and rejects mapped HTTPS requests before the real
+    request can be transformed.
+    """
+
+    cfg = ip.build_proxy_config(
+        mappings=[_sample_mapping("OPENAI_API_KEY")],
+        ca_cert=tmp_path / "ca.crt",
+        ca_key=tmp_path / "ca.key",
+    )
+    secrets = next(
+        transform for transform in cfg["transforms"]
+        if transform["name"] == "secrets"
+    )
+    rule = secrets["config"]["secrets"][0]
+    assert rule["replace"]["require"] is False
+
+
 # ---------------------------------------------------------------------------
 # Default SSRF deny list (regression: docs promise cloud metadata is denied)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the generated iron-proxy secrets rules for mapped HTTPS providers.

## Root cause

With iron-proxy v0.39, `require: true` is evaluated against the synthetic, header-less CONNECT request before TLS MITM. A CONNECT can therefore never contain the sandbox proxy token, so mapped-provider tunnels were rejected before the post-MITM request could be transformed.

## Changes

- Set generated secrets replacement rules to `require: false` so CONNECT reaches MITM and token replacement can run on the real request.
- Add a regression test covering the generated rule.

This PR addresses the secrets-transform finding in #81281. Rootless Docker bridge selection is separate and remains unchanged.

Closes #81281