### PR TITLE
fix(gateway): scope multiplex session recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10975,22 +10975,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # point at one active session. Load and prune the durable routing index
         # first, then fail closed with a redacted operator error before any
         # platform can receive a message.
-        try:
-            await self.async_session_store.assert_no_cross_profile_session_aliases()
-        except MultiplexSessionCollisionError as exc:
-            reason = str(exc)
-            logger.error("Gateway multiplex session collision: %s", reason)
+        if getattr(self.config, "multiplex_profiles", False):
             try:
-                from gateway.status import write_runtime_status
-                write_runtime_status(
-                    gateway_state="startup_failed",
-                    exit_reason="multiplex_session_collision",
+                await (
+                    self.async_session_store
+                    .assert_no_cross_profile_session_aliases()
                 )
-            except Exception:
-                pass
-            self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
-            self._request_clean_exit(reason)
-            return True
+            except MultiplexSessionCollisionError as exc:
+                reason = str(exc)
+                logger.error("Gateway multiplex session collision: %s", reason)
+                try:
+                    from gateway.status import write_runtime_status
+                    write_runtime_status(
+                        gateway_state="startup_failed",
+                        exit_reason="multiplex_session_collision",
+                    )
+                except Exception:
+                    pass
+                self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+                self._request_clean_exit(reason)
+                return True
         
         # Warn if no user allowlists are configured and open access is not opted in
         _builtin_allowed_vars = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2370,6 +2370,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    MultiplexSessionCollisionError,
     SessionEntry,
     SessionStore,
     SessionSource,
@@ -10968,6 +10969,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=True,
             )
         if await self._abort_startup_if_shutdown_requested():
+            return True
+
+        # Multiplexed adapters must never connect while two profile namespaces
+        # point at one active session. Load and prune the durable routing index
+        # first, then fail closed with a redacted operator error before any
+        # platform can receive a message.
+        try:
+            await self.async_session_store.assert_no_cross_profile_session_aliases()
+        except MultiplexSessionCollisionError as exc:
+            reason = str(exc)
+            logger.error("Gateway multiplex session collision: %s", reason)
+            try:
+                from gateway.status import write_runtime_status
+                write_runtime_status(
+                    gateway_state="startup_failed",
+                    exit_reason="multiplex_session_collision",
+                )
+            except Exception:
+                pass
+            self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+            self._request_clean_exit(reason)
             return True
         
         # Warn if no user allowlists are configured and open access is not opted in

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2060,6 +2060,11 @@ class SessionStore:
         that tuple does not contain a workspace id and could therefore revive
         another team's session. The caller performs one explicit exact lookup
         of the old unscoped key instead.
+
+        Multiplexed gateways disable it for the same reason: the tuple carries
+        no profile either, so a profile whose own key does not resolve would
+        adopt whichever sibling profile last spoke in that chat wherever the
+        two namespaces still share one state.db.
         """
         if not self._db:
             return None
@@ -2104,7 +2109,10 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=(
+                legacy_key is None
+                and not getattr(self.config, "multiplex_profiles", False)
+            ),
             raise_on_lookup_error=raise_on_lookup_error,
         )
         migrated_legacy = False
@@ -2183,7 +2191,10 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=(
+                legacy_key is None
+                and not getattr(self.config, "multiplex_profiles", False)
+            ),
         )
         migrated_legacy = False
         if (

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1232,6 +1232,10 @@ class AsyncSessionStore:
         return _offloaded
 
 
+class MultiplexSessionCollisionError(RuntimeError):
+    """Active gateway routing aliases one session across profile namespaces."""
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -1317,6 +1321,37 @@ class SessionStore:
         """Load sessions index from disk if not already loaded."""
         with self._lock:
             self._ensure_loaded_locked()
+
+    def assert_no_cross_profile_session_aliases(self) -> None:
+        """Reject active routing that aliases one session across profiles.
+
+        Loading also prunes routing entries whose durable session is already
+        ended. Duplicate keys within one normalized profile are legitimate
+        aliases, but a live session ID shared by distinct profile namespaces
+        would merge caches, transcripts, and turn leases.
+
+        The raised error deliberately omits routing keys and session IDs.
+        """
+        if not getattr(self.config, "multiplex_profiles", False):
+            return
+
+        self._ensure_loaded()
+        profiles_by_session: Dict[str, set[str]] = {}
+        with self._lock:
+            for session_key, entry in self._entries.items():
+                profile = self._profile_from_session_key(session_key)
+                if profile is None:
+                    continue
+                profiles_by_session.setdefault(entry.session_id, set()).add(profile)
+
+        collisions = sum(
+            1 for profiles in profiles_by_session.values() if len(profiles) > 1
+        )
+        if collisions:
+            raise MultiplexSessionCollisionError(
+                "multiplex routing contains "
+                f"{collisions} active cross-profile session collision(s)"
+            )
 
     def _routing_scope(self) -> str:
         """Namespace for this store's rows in the gateway_routing table.
@@ -1969,7 +2004,10 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=(
+                legacy_key is None
+                and not getattr(self.config, "multiplex_profiles", False)
+            ),
             raise_on_lookup_error=raise_on_lookup_error,
         )
         migrated_legacy = False
@@ -2031,7 +2069,10 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=(
+                legacy_key is None
+                and not getattr(self.config, "multiplex_profiles", False)
+            ),
         )
         migrated_legacy = False
         if (

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -16,6 +16,7 @@ import yaml
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import GatewayConfig, Platform
 from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import SessionDB
 
 
 def _src(**kw) -> SessionSource:
@@ -172,3 +173,180 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+# ── Cross-profile recovery inside one state.db ───────────────────────────────
+# Peer tuple shared by both namespaces below: one Telegram DM, one owner.
+_PEER = dict(source="telegram", user_id="owner-1", chat_id="99", chat_type="dm")
+_MAIN_KEY = "agent:main:telegram:dm:99"
+_JARVIS_KEY = "agent:jarvis:telegram:dm:99"
+_STARTED_AT = 1700000000.0
+_RESET_AT = 1700000060.0
+_ACTIVE_AT = 1700000120.0
+
+
+def _seed_gateway_session(
+    db, session_id, session_key, *, last_activity_at, reset=False
+):
+    """Write one keyed, message-bearing gateway session row."""
+    db.create_session(
+        session_id,
+        _PEER["source"],
+        user_id=_PEER["user_id"],
+        session_key=session_key,
+        chat_id=_PEER["chat_id"],
+        chat_type=_PEER["chat_type"],
+    )
+    db.append_message(session_id, "user", "hello")
+    db.append_message(session_id, "assistant", "hi")
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, last_activity_at=?, "
+            "ended_at=?, end_reason=? WHERE id=?",
+            (
+                _STARTED_AT,
+                last_activity_at,
+                _RESET_AT if reset else None,
+                "session_reset" if reset else None,
+                session_id,
+            ),
+        )
+        db._conn.commit()
+
+
+def _shared_profile_db(db_path, *, reset_key=None):
+    """One state.db holding BOTH profile namespaces for the same peer.
+
+    ``reset_key`` ends that namespace's row on a reset boundary, which is what
+    a plain ``/new`` leaves behind: the profile's own key stops resolving while
+    the *other* profile's live row keeps sitting in the same file.
+    """
+    db = SessionDB(db_path=db_path)
+    for key, session_id in (
+        (_MAIN_KEY, "sess-main"),
+        (_JARVIS_KEY, "sess-jarvis"),
+    ):
+        reset = key == reset_key
+        _seed_gateway_session(
+            db,
+            session_id,
+            key,
+            last_activity_at=_RESET_AT if reset else _ACTIVE_AT,
+            reset=reset,
+        )
+    return db
+
+
+class TestMultiplexedRecoveryStaysInsideProfile:
+    """Recovery must not cross profiles inside one shared state.db.
+
+    #88734 gave each profile its own state.db *file* and #89860 minted session
+    keys per bot, but neither reaches the recovery *query*: whenever two
+    namespaces still resolve one store — an un-migrated root store, or a
+    default-profile handler pinned to the root scope while profile-stamped
+    keys land in the same file — ``find_latest_gateway_session_for_peer``'s
+    fallback matches on (source, user_id, chat_id, chat_type, thread_id) with
+    no profile predicate and hands one profile the other's live session. The
+    downstream profile guard is inert here: it returns early once
+    ``multiplex_profiles`` is on.
+    """
+
+    def _store(self, tmp_path, db):
+        config = GatewayConfig(multiplex_profiles=True)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        # Pin the one handle both namespaces resolve to (the precondition).
+        store._db = db
+        store._loaded = True
+        return store
+
+    def test_one_state_db_holds_both_profile_namespaces(self, tmp_path):
+        """Precondition, asserted rather than assumed."""
+        db = _shared_profile_db(tmp_path / "state.db")
+        try:
+            with db._lock:
+                rows = db._conn.execute(
+                    "SELECT session_key, source, user_id, chat_id, chat_type, "
+                    "thread_id FROM sessions ORDER BY session_key"
+                ).fetchall()
+        finally:
+            db.close()
+
+        keys = [r["session_key"] for r in rows]
+        assert keys == [_JARVIS_KEY, _MAIN_KEY]
+        peers = {
+            (r["source"], r["user_id"], r["chat_id"], r["chat_type"], r["thread_id"])
+            for r in rows
+        }
+        assert peers == {("telegram", "owner-1", "99", "dm", None)}
+
+    @pytest.mark.parametrize(
+        "recover",
+        [
+            lambda store, key, source, now: store._recover_session_from_db(
+                session_key=key, source=source, now=now
+            ),
+            lambda store, key, source, now: store._query_recoverable_session(
+                session_key=key, source=source, now=now
+            ),
+        ],
+        ids=["recover_session_from_db", "query_recoverable_session"],
+    )
+    @pytest.mark.parametrize(
+        "requested_key,profile",
+        [
+            (_JARVIS_KEY, "jarvis"),
+            (_MAIN_KEY, "default"),
+        ],
+        ids=["jarvis_requests", "default_requests"],
+    )
+    def test_reset_profile_never_adopts_the_other_profiles_session(
+        self, tmp_path, recover, requested_key, profile
+    ):
+        db = _shared_profile_db(tmp_path / "state.db", reset_key=requested_key)
+        try:
+            store = self._store(tmp_path, db)
+            source = _src(user_id=_PEER["user_id"], profile=profile)
+
+            recovered = recover(
+                store,
+                requested_key,
+                source,
+                datetime.fromtimestamp(_ACTIVE_AT + 1),
+            )
+
+            assert recovered is None, (
+                f"{requested_key} recovered {getattr(recovered, 'session_id', None)}"
+            )
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize(
+        "requested_key,profile,own_id,foreign_id",
+        [
+            (_JARVIS_KEY, "jarvis", "sess-jarvis", "sess-main"),
+            (_MAIN_KEY, "default", "sess-main", "sess-jarvis"),
+        ],
+        ids=["jarvis_requests", "default_requests"],
+    )
+    def test_exact_profile_key_still_recovers_its_own_session(
+        self, tmp_path, requested_key, profile, own_id, foreign_id
+    ):
+        """Guardrail: scoping the fallback must not disable exact recovery."""
+        db = _shared_profile_db(tmp_path / "state.db")
+        try:
+            store = self._store(tmp_path, db)
+            source = _src(user_id=_PEER["user_id"], profile=profile)
+
+            recovered = store._recover_session_from_db(
+                session_key=requested_key,
+                source=source,
+                now=datetime.fromtimestamp(_ACTIVE_AT + 1),
+            )
+
+            assert recovered is not None
+            assert recovered.session_id == own_id
+            assert recovered.session_id != foreign_id
+            assert recovered.session_key == requested_key
+        finally:
+            db.close()

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -10,12 +10,19 @@ Covers the three Phase 0 deliverables:
 """
 import pytest
 from datetime import datetime
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 import yaml
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import GatewayConfig, Platform
-from gateway.session import SessionSource, SessionStore, build_session_key
+from gateway.session import (
+    MultiplexSessionCollisionError,
+    SessionEntry,
+    SessionSource,
+    SessionStore,
+    build_session_key,
+)
 
 
 def _src(**kw) -> SessionSource:
@@ -107,6 +114,27 @@ class _RecoveringDB:
         self.reopened.append(session_id)
 
 
+class _ExactOrPeerRecoveringDB:
+    """Model SessionDB's exact-key lookup followed by peer fallback."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+        self.reopened = []
+
+    def find_latest_gateway_session_for_peer(self, **kwargs):
+        self.calls.append(kwargs)
+        exact = self.rows.get(kwargs["session_key"])
+        if exact is not None:
+            return exact
+        if kwargs.get("chat_id") is not None:
+            return next(iter(self.rows.values()), None)
+        return None
+
+    def reopen_session(self, session_id):
+        self.reopened.append(session_id)
+
+
 class TestSessionStoreUnmultiplexedRecovery:
     """Turning multiplexing off must not recover another profile's session."""
 
@@ -139,3 +167,207 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+class TestSessionStoreMultiplexRecovery:
+    def _store_with_rows(self, tmp_path, rows):
+        config = GatewayConfig(multiplex_profiles=True)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = _ExactOrPeerRecoveringDB(rows)
+        store._loaded = True
+        return store
+
+    @pytest.mark.parametrize(
+        "recover",
+        [
+            lambda store, key, source, now: store._recover_session_from_db(
+                session_key=key,
+                source=source,
+                now=now,
+            ),
+            lambda store, key, source, now: store._query_recoverable_session(
+                session_key=key,
+                source=source,
+                now=now,
+            ),
+        ],
+    )
+    def test_missing_jarvis_key_never_adopts_default_peer_session(
+        self, tmp_path, recover
+    ):
+        rows = {
+            "agent:main:telegram:dm:99": {
+                "id": "sess-black-panther",
+                "started_at": 1700000000,
+                "session_key": "agent:main:telegram:dm:99",
+            }
+        }
+        store = self._store_with_rows(tmp_path, rows)
+        source = _src(
+            chat_id="99",
+            user_id="same-owner",
+            profile="jarvis",
+        )
+
+        recovered = recover(
+            store,
+            "agent:jarvis:telegram:dm:99",
+            source,
+            datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is None
+        assert store._db.calls[-1]["chat_id"] is None
+        assert store._db.reopened == []
+
+    @pytest.mark.parametrize(
+        "recover",
+        [
+            lambda store, key, source, now: store._recover_session_from_db(
+                session_key=key,
+                source=source,
+                now=now,
+            ),
+            lambda store, key, source, now: store._query_recoverable_session(
+                session_key=key,
+                source=source,
+                now=now,
+            ),
+        ],
+    )
+    def test_exact_profile_key_recovery_still_works(self, tmp_path, recover):
+        key = "agent:jarvis:telegram:dm:99"
+        rows = {
+            key: {
+                "id": "sess-jarvis",
+                "started_at": 1700000000,
+                "session_key": key,
+            }
+        }
+        store = self._store_with_rows(tmp_path, rows)
+        source = _src(chat_id="99", user_id="same-owner", profile="jarvis")
+
+        recovered = recover(
+            store,
+            key,
+            source,
+            datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-jarvis"
+        assert recovered.session_key == key
+        assert store._db.calls[-1]["chat_id"] is None
+        assert store._db.reopened == ["sess-jarvis"]
+
+
+class TestMultiplexSessionCollisionInvariant:
+    def _store(self, tmp_path, entries):
+        config = GatewayConfig(multiplex_profiles=True)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        store._loaded = True
+        store._entries = entries
+        return store
+
+    @staticmethod
+    def _entry(key, session_id):
+        now = datetime.fromtimestamp(1700000000)
+        return SessionEntry(
+            session_key=key,
+            session_id=session_id,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def test_cross_profile_session_id_blocks_startup(self, tmp_path):
+        main_key = "agent:main:telegram:dm:99"
+        jarvis_key = "agent:jarvis:telegram:dm:99"
+        store = self._store(
+            tmp_path,
+            {
+                main_key: self._entry(main_key, "shared-session"),
+                jarvis_key: self._entry(jarvis_key, "shared-session"),
+            },
+        )
+
+        with pytest.raises(MultiplexSessionCollisionError) as exc:
+            store.assert_no_cross_profile_session_aliases()
+
+        assert "shared-session" not in str(exc.value)
+        assert main_key not in str(exc.value)
+        assert jarvis_key not in str(exc.value)
+
+    def test_same_profile_aliases_are_allowed(self, tmp_path):
+        first = "agent:jarvis:telegram:dm:99"
+        second = "agent:jarvis:telegram:dm:99:topic"
+        store = self._store(
+            tmp_path,
+            {
+                first: self._entry(first, "same-profile-session"),
+                second: self._entry(second, "same-profile-session"),
+            },
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    @pytest.mark.asyncio
+    async def test_gateway_aborts_before_connecting_adapters(self, tmp_path):
+        from gateway.run import GATEWAY_FATAL_CONFIG_EXIT_CODE, GatewayRunner
+
+        home_token = set_hermes_home_override(tmp_path)
+        try:
+            runner = GatewayRunner(GatewayConfig(multiplex_profiles=True))
+            collision_check = AsyncMock(
+                side_effect=MultiplexSessionCollisionError(
+                    "multiplex routing contains 1 active cross-profile "
+                    "session collision(s)"
+                )
+            )
+            runner._async_session_store = SimpleNamespace(
+                _store=runner.session_store,
+                assert_no_cross_profile_session_aliases=collision_check,
+            )
+            runner._abort_startup_if_shutdown_requested = AsyncMock(
+                return_value=False
+            )
+            runner._start_loop_liveness_guards = Mock()
+            runner._request_clean_exit = Mock()
+            runner._create_adapter = Mock()
+
+            with (
+                patch("gateway.run.faulthandler.enable"),
+                patch("gateway.status.write_runtime_status"),
+                patch(
+                    "agent.monitoring.gateway_health_export."
+                    "start_gateway_health_export",
+                    return_value=SimpleNamespace(enabled=False),
+                ),
+                patch(
+                    "hermes_cli.security_advisories.detect_compromised",
+                    return_value=[],
+                ),
+            ):
+                result = await runner.start()
+
+            assert result is True
+            collision_check.assert_awaited_once()
+            runner._create_adapter.assert_not_called()
+            runner._request_clean_exit.assert_called_once()
+            assert runner._exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+        finally:
+            reset_hermes_home_override(home_token)
+
+    def test_invariant_is_inert_outside_multiplex(self, tmp_path):
+        store = self._store(tmp_path, {})
+        store.config.multiplex_profiles = False
+        first = "agent:main:telegram:dm:99"
+        second = "agent:jarvis:telegram:dm:99"
+        store._entries = {
+            first: self._entry(first, "legacy-shared-session"),
+            second: self._entry(second, "legacy-shared-session"),
+        }
+
+        store.assert_no_cross_profile_session_aliases()


### PR DESCRIPTION
## TL;DR

A multiplexed gateway can recover one profile's session into another profile's turn when both profiles' rows live in the **same** `state.db` and share a peer tuple (every Telegram DM, where `chat.id` is the user's own id). This scopes the peer-tuple recovery fallback so it never fires under `multiplex_profiles`.

Fixes #81294.

## Why this still matters after #88734 and #89860

Those two landed and each removed a different layer of this problem, but not this one:

- **#88734** gave each profile its own `state.db` **file** — but it is forward-only ("rows already written to the root store are not migrated"), and any two namespaces that resolve to one home still share a DB (the default profile pins the root home; `profile_routes`-stamped keys land in the same root `state.db` as `agent:main`).
- **#89860** scoped which session **key** is minted per bot — nothing in the recovery path reads `_owner_profile`.

The recovery path itself is still unscoped. At the pin, `_recover_session_from_db` and `_query_recoverable_session` pass `allow_peer_fallback=(legacy_key is None)`, which for Telegram is always `True` (`_legacy_slack_session_key` returns `None` off Slack), so the keyless peer-tuple query in `find_latest_gateway_session_for_peer` — which matches source/user_id/chat_id/chat_type/thread_id with **no** profile predicate — can return a sibling profile's row. Both existing downstream guards are inert here (one returns `True` immediately when multiplex is on; the other only scopes Slack).

## Change

Two lines, one invariant: disable the peer-tuple fallback under multiplexing.

```python
allow_peer_fallback=(
    legacy_key is None
    and not getattr(self.config, "multiplex_profiles", False)
)
```
in both `_recover_session_from_db` (`gateway/session.py:2112`) and `_query_recoverable_session` (`:2194`), plus a docstring paragraph in `_find_gateway_session_row`. The exact-key recovery path is unchanged; only the keyless cross-profile fallback is closed when multiplexing is active. Flag-off behavior is byte-identical (the existing `test_flag_off_allows_active_profile_peer_fallback` stays green).

## Scope note

This PR was previously larger; I've reduced it to the recovery-scoping core so it can merge on its own. The startup-time cross-profile alias assertion that rode along before is a separable follow-up and is not in this diff.

## Proof

Regression builds the precondition explicitly — one real `SessionDB` at a single `state.db` seeded with both `agent:main:telegram:dm:99` and `agent:jarvis:telegram:dm:99` against an identical peer tuple — and asserts recovery for either key never returns the other's session (both directions, both entrypoints).

```text
Fail-before (test added, fix not applied):  4 failed, 16 passed
  AssertionError: agent:jarvis:telegram:dm:99 recovered sess-main
  AssertionError: agent:main:telegram:dm:99 recovered sess-jarvis
Pass-after:  scripts/run_tests.sh tests/gateway/test_multiplex_phase0.py \
             tests/gateway/test_multiplex_session_db_profile_scope.py -q
             → 27 passed
```

## Proof boundary

Proves the fix and its regression on the exact head (`13ce0c5c67` base). Does not claim a release, installed runtime, or customer behavior.

---

Salvage-friendly: single commit on the pin, no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
