### PR TITLE
fix(cli): stop profile rename widening Honcho credential mode and detaching a symlinked config

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2126,6 +2126,8 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 
 def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) -> None:
     """Rename Honcho host blocks for a renamed profile without changing peers."""
+    from utils import atomic_json_write
+
     old_host = f"hermes_{old_name}"
     legacy_old_host = f"hermes.{old_name}"
     new_host = f"hermes_{new_name}"
@@ -2170,15 +2172,15 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
                 bare = source_host.split(".", 1)[1] if "." in source_host else source_host
             block["aiPeer"] = bare
         hosts[new_host] = hosts.pop(source_host)
-        tmp = path.with_suffix(path.suffix + ".tmp")
+        # Atomic write: these files carry the Honcho ``apiKey`` (the OAuth
+        # access token under a browser grant), and one candidate is the global
+        # ~/.honcho/config.json shared with every other Honcho app. A bare
+        # temp-write inherits the process umask and ``Path.replace`` swaps the
+        # symlink itself, so renaming a profile silently widened the mode and
+        # detached a symlinked config (#16743).
         try:
-            tmp.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-            tmp.replace(path)
+            atomic_json_write(path, raw, mode=0o600)
         except OSError:
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
             continue
 
         print(f"✓ Honcho host updated: {source_host} → {new_host}")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2143,7 +2143,15 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
         try:
             resolved = path.resolve()
         except OSError:
-            resolved = path
+            # Fail closed. The rewrite below is only safe when it is handed the
+            # REAL file (see the comment on the write), so a candidate whose
+            # target cannot be determined — ELOOP on a symlink cycle,
+            # ENAMETOOLONG, EACCES on a parent directory — must be skipped, not
+            # written through unresolved. Falling back to the candidate would
+            # hand the writer the very symlink this function must never pass it,
+            # and would also defeat the dedup below, since an unresolved entry
+            # cannot match a resolved one for the same file.
+            continue
         if resolved in seen or not path.is_file():
             continue
         seen.add(resolved)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2178,8 +2178,18 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
         # temp-write inherits the process umask and ``Path.replace`` swaps the
         # symlink itself, so renaming a profile silently widened the mode and
         # detached a symlinked config (#16743).
+        #
+        # Hand the helper the RESOLVED target, not the candidate: it stages its
+        # temp in the parent of whatever path it is given, so passing a symlink
+        # stages on the link's filesystem and renames onto the real file's.
+        # When those differ — a config linked into a dotfiles repo, an
+        # encrypted volume or a mounted secrets share — the rename fails EXDEV
+        # and the fallback copies onto the real file, truncating the user's
+        # credentials before the replacement exists. Staging beside the real
+        # file makes that rename same-filesystem by construction, and the
+        # symlink survives because it is never written through.
         try:
-            atomic_json_write(path, raw, mode=0o600)
+            atomic_json_write(resolved, raw, mode=0o600)
         except OSError:
             continue
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -574,6 +574,99 @@ class TestRenameProfile:
 
 
 # ===================================================================
+# TestMigrateHonchoProfileHostWrite
+# ===================================================================
+
+class TestMigrateHonchoProfileHostWrite:
+    """The rename-time Honcho rewrite must not degrade the file it rewrites.
+
+    ``_migrate_honcho_profile_host`` rewrites files that carry the Honcho
+    ``apiKey`` — under a browser OAuth grant that is the auto-refreshing
+    access token — and one of its candidates is the global
+    ``~/.honcho/config.json`` shared with every other Honcho-enabled app.
+    """
+
+    @staticmethod
+    def _host_block(profile):
+        return {
+            "hosts": {
+                f"hermes_{profile}": {
+                    "apiKey": "test-honcho-access-token",
+                    "aiPeer": profile,
+                    "workspace": "hermes",
+                    "enabled": True,
+                }
+            }
+        }
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_rewrite_keeps_credential_config_owner_only(self, profile_env):
+        """A rename must not widen the mode of a file holding the apiKey."""
+        tmp_path = profile_env
+        path = tmp_path / ".hermes" / "honcho.json"
+        path.write_text(json.dumps(self._host_block("oldname")))
+        os.chmod(path, 0o600)
+
+        # Pin the umask so the pre-fix temp file is deterministically 0o644.
+        old_umask = os.umask(0o022)
+        try:
+            profiles._migrate_honcho_profile_host("oldname", "newname", tmp_path / "absent")
+        finally:
+            os.umask(old_umask)
+
+        assert path.stat().st_mode & 0o777 == 0o600
+        cfg = json.loads(path.read_text())
+        assert "hermes_oldname" not in cfg["hosts"]
+        assert cfg["hosts"]["hermes_newname"]["apiKey"] == "test-honcho-access-token"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+    def test_rewrite_preserves_a_symlinked_config(self, profile_env):
+        """A managed deployment symlinks honcho.json; the link must survive."""
+        tmp_path = profile_env
+        real = tmp_path / "dotfiles" / "honcho.json"
+        real.parent.mkdir(parents=True, exist_ok=True)
+        real.write_text(json.dumps(self._host_block("oldname")))
+        os.chmod(real, 0o600)
+        link = tmp_path / ".hermes" / "honcho.json"
+        link.symlink_to(real)
+
+        profiles._migrate_honcho_profile_host("oldname", "newname", tmp_path / "absent")
+
+        assert link.is_symlink()
+        assert link.resolve() == real.resolve()
+        assert real.stat().st_mode & 0o777 == 0o600
+        cfg = json.loads(real.read_text())
+        assert cfg["hosts"]["hermes_newname"]["apiKey"] == "test-honcho-access-token"
+
+    def test_unwritable_candidate_still_advances_to_the_next(self, profile_env, monkeypatch):
+        """The fail-soft ``continue`` must survive the switch to the helper."""
+        import utils
+
+        tmp_path = profile_env
+        new_dir = tmp_path / ".hermes" / "profiles" / "newname"
+        new_dir.mkdir(parents=True, exist_ok=True)
+        first = new_dir / "honcho.json"
+        first.write_text(json.dumps(self._host_block("oldname")))
+        second = tmp_path / ".hermes" / "honcho.json"
+        second.write_text(json.dumps(self._host_block("oldname")))
+
+        real_write = utils.atomic_json_write
+
+        def _fail_on_first(path, data, **kwargs):
+            if Path(path) == first:
+                raise OSError("read-only file system")
+            return real_write(path, data, **kwargs)
+
+        monkeypatch.setattr(utils, "atomic_json_write", _fail_on_first)
+
+        profiles._migrate_honcho_profile_host("oldname", "newname", new_dir)
+
+        assert "hermes_oldname" in json.loads(first.read_text())["hosts"]
+        assert "hermes_newname" in json.loads(second.read_text())["hosts"]
+        assert not list(second.parent.glob("*.tmp"))
+
+
+# ===================================================================
 # TestExportImport
 # ===================================================================
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -719,6 +719,87 @@ class TestMigrateHonchoProfileHostWrite:
             os.path.dirname(src) == os.path.dirname(dst) for src, dst in replaces
         ), f"the rewrite staged its temp outside the resolved target's directory: {replaces}"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+    def test_unresolvable_candidate_is_skipped_not_written_through(
+        self, profile_env, monkeypatch
+    ):
+        """A candidate whose real path is unknown must never be written at all.
+
+        The rewrite is only safe when the writer is handed the *resolved*
+        target: it stages its temp beside whatever path it is given, so a
+        symlink stages on the link's filesystem and renames onto the real
+        file's.  ``Path.resolve`` can itself fail — ``ELOOP`` on a symlink
+        cycle, ``ENAMETOOLONG``, ``EACCES`` on a parent directory — and
+        falling back to the unresolved candidate hands the writer exactly the
+        symlink the invariant forbids, reinstating the cross-device truncation
+        of the file that holds the Honcho ``apiKey``.  Skipping the candidate
+        is the only outcome that cannot destroy credentials.
+        """
+        import errno
+
+        import utils
+
+        tmp_path = profile_env
+        other_fs = tmp_path / "other_fs"
+        other_fs.mkdir()
+        real = other_fs / "config.json"
+        real.write_text(json.dumps(self._host_block("oldname")))
+        os.chmod(real, 0o600)
+        link_dir = tmp_path / ".honcho"
+        link_dir.mkdir()
+        link = link_dir / "config.json"
+        link.symlink_to(real)
+        original_bytes = real.read_bytes()
+
+        genuine_resolve = Path.resolve
+
+        def resolve_fails_for_the_link(self, *args, **kwargs):
+            if os.fspath(self) == os.fspath(link):
+                raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), os.fspath(self))
+            return genuine_resolve(self, *args, **kwargs)
+
+        genuine_replace = os.replace
+
+        def replace_across_filesystems(src, dst, *args, **kwargs):
+            src, dst = os.fspath(src), os.fspath(dst)
+            if os.path.dirname(src) != os.path.dirname(dst):
+                raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+            return genuine_replace(src, dst)
+
+        def copyfile_runs_out_of_space(src, dst, **kwargs):
+            # shutil.copyfile opens the destination "wb" first; land a few
+            # bytes, then fail the way a filling disk does.
+            with open(src, "rb") as source, open(dst, "wb") as destination:
+                destination.write(source.read(8))
+            raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+        written = []
+        genuine_write = utils.atomic_json_write
+
+        def record_write(path, data, **kwargs):
+            written.append(Path(path))
+            return genuine_write(path, data, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", resolve_fails_for_the_link)
+        monkeypatch.setattr(utils, "atomic_json_write", record_write)
+        monkeypatch.setattr("utils.os.replace", replace_across_filesystems)
+        monkeypatch.setattr("utils.shutil.copyfile", copyfile_runs_out_of_space)
+
+        profiles._migrate_honcho_profile_host("oldname", "newname", tmp_path / "absent")
+
+        assert real.read_bytes() == original_bytes, (
+            "a candidate that could not be resolved was written through and the "
+            f"Honcho credential file was destroyed; it now holds {real.read_bytes()!r}"
+        )
+        assert link not in written, (
+            "the rewrite was handed the unresolved symlink, which is exactly the "
+            f"input the resolved-target invariant forbids: {written}"
+        )
+        assert link.is_symlink()
+        assert real.stat().st_mode & 0o777 == 0o600
+        assert not list(other_fs.glob(".*.tmp"))
+        assert not list(link_dir.glob(".*.tmp"))
+
     def test_unwritable_candidate_still_advances_to_the_next(self, profile_env, monkeypatch):
         """The fail-soft ``continue`` must survive the switch to the helper."""
         import utils

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -638,6 +638,87 @@ class TestMigrateHonchoProfileHostWrite:
         cfg = json.loads(real.read_text())
         assert cfg["hosts"]["hermes_newname"]["apiKey"] == "test-honcho-access-token"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+    def test_symlinked_config_on_another_filesystem_survives_a_failed_replace(
+        self, profile_env, monkeypatch
+    ):
+        """A cross-device rewrite must never truncate the real credential file.
+
+        ``~/.honcho/config.json`` is commonly a symlink into a dotfiles repo,
+        an encrypted volume or a mounted secrets share — i.e. a different
+        filesystem from ``~/.honcho`` itself.  Staging the temp beside the
+        *link* makes the rename cross-device, and the ``EXDEV`` fallback
+        copies onto the resolved target with the destination opened ``"wb"``,
+        emptying the file that holds the ``apiKey`` before a single
+        replacement byte exists.  A copy that then fails (ENOSPC, I/O error)
+        leaves it truncated, and this loop's ``except OSError: continue``
+        swallows the error, so the user is never told.
+        """
+        import errno
+
+        import utils
+
+        tmp_path = profile_env
+        other_fs = tmp_path / "other_fs"
+        other_fs.mkdir()
+        real = other_fs / "config.json"
+        original = json.dumps(self._host_block("oldname"))
+        real.write_text(original)
+        os.chmod(real, 0o600)
+        link_dir = tmp_path / ".honcho"
+        link_dir.mkdir()
+        link = link_dir / "config.json"
+        link.symlink_to(real)
+
+        genuine_replace = os.replace
+        replaces = []
+
+        def replace_across_filesystems(src, dst, *args, **kwargs):
+            src, dst = os.fspath(src), os.fspath(dst)
+            replaces.append((src, dst))
+            if os.path.dirname(src) != os.path.dirname(dst):
+                # Exactly what renaming between two filesystems returns; the
+                # staging directory is what decides whether it can happen.
+                raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+            return genuine_replace(src, dst)
+
+        def copyfile_runs_out_of_space(src, dst, **kwargs):
+            # shutil.copyfile opens the destination "wb" first; land a few
+            # bytes, then fail the way a filling disk does.
+            with open(src, "rb") as source, open(dst, "wb") as destination:
+                destination.write(source.read(8))
+            raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+        def copyfileobj_runs_out_of_space(src_handle, dst_handle, *args, **kwargs):
+            dst_handle.write(src_handle.read(8))
+            raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+        monkeypatch.setattr("utils.os.replace", replace_across_filesystems)
+        monkeypatch.setattr("utils.shutil.copyfile", copyfile_runs_out_of_space)
+        monkeypatch.setattr("utils.shutil.copyfileobj", copyfileobj_runs_out_of_space)
+
+        profiles._migrate_honcho_profile_host("oldname", "newname", tmp_path / "absent")
+
+        surviving = real.read_text()
+        assert "test-honcho-access-token" in surviving, (
+            "a failed cross-device replace destroyed the Honcho credential file; "
+            f"it now holds {surviving!r}"
+        )
+        cfg = json.loads(surviving)
+        assert "hermes_oldname" not in cfg["hosts"]
+        assert cfg["hosts"]["hermes_newname"]["apiKey"] == "test-honcho-access-token"
+        assert real.stat().st_mode & 0o777 == 0o600
+        assert link.is_symlink()
+        assert link.resolve() == real.resolve()
+        assert not list(other_fs.glob(".*.tmp"))
+        assert not list(link_dir.glob(".*.tmp"))
+        # The staging directory is what makes EXDEV reachable at all, so pin
+        # it: every rename this rewrite issues stays inside one directory.
+        assert replaces, "the rewrite never reached os.replace"
+        assert all(
+            os.path.dirname(src) == os.path.dirname(dst) for src, dst in replaces
+        ), f"the rewrite staged its temp outside the resolved target's directory: {replaces}"
+
     def test_unwritable_candidate_still_advances_to_the_next(self, profile_env, monkeypatch):
         """The fail-soft ``continue`` must survive the switch to the helper."""
         import utils


### PR DESCRIPTION
## What does this PR do?

`hermes profile rename` calls `_migrate_honcho_profile_host` to move the profile's Honcho host block to its new key. That function is the **last writer of the Honcho config files that does not go through the shared atomic helper** — it rewrote them with a bare `tmp.write_text(...)` followed by `tmp.replace(path)`.

That matters because of *what* those files hold. Its three candidate paths are:

```python
candidates = [
    new_dir / "honcho.json",
    _get_default_hermes_home() / "honcho.json",
    Path.home() / ".honcho" / "config.json",
]
```

Each host block carries `apiKey`, which `plugins/memory/honcho/README.md` documents as the auto-refreshing **access token** under a browser OAuth grant, and the third candidate is the global `~/.honcho/config.json` that `plugins/memory/honcho/client.py` documents as *"global, shared across all Honcho-enabled apps"*. So a profile rename rewrites a live credential file, including one shared outside Hermes.

The old write carried three defects:

1. **The credential mode was widened.** The temp file is created at the process umask — typically `0644` — and `Path.replace` carries that mode onto the target. A `honcho.json` the user (or `plugins/memory/honcho/oauth.py`) had left at `0600` came back group- and world-readable after a rename, with no output saying so.
2. **A symlinked config was detached.** `Path.replace` replaces the *symlink* with a regular file, so a deployment that symlinks `honcho.json` out to a dotfiles repo or a profile package silently stopped tracking it — the same failure mode `atomic_replace` was introduced to fix in #16743.
3. **No fsync.** A crash between the rename and the flush can leave a truncated credential config, which the reader at the top of this same loop then discards as unparseable.

The fix is one substitution:

```python
try:
    atomic_json_write(path, raw, mode=0o600)
except OSError:
    continue
```

`utils.atomic_json_write` `fchmod`s the descriptor **before** the replace (so there is no chmod-after-write TOCTOU window on a secret-bearing file), flushes and `fsync`s, and replaces through `atomic_replace`, whose comment reads *"Preserve symlinks — swap in-place on the real file (GitHub #16743)"*. One call closes all three defects. The fail-soft `except OSError: continue` is kept so the loop still advances to the remaining candidate paths, and the helper's own cleanup replaces the temp-file `unlink` the old inline handler did by hand.

**`mode=0o600` is this file's own established convention, not new policy.** Every other writer of these exact files already enforces it:

| Writer | How |
| --- | --- |
| `plugins/memory/honcho/__init__.py` | `atomic_json_write(config_path, existing, mode=0o600)` |
| `plugins/memory/honcho/cli.py` | `atomic_json_write(path, cfg, mode=0o600)` |
| `plugins/memory/honcho/oauth.py` | `os.open(tmp, ..., 0o600)` |
| `cli.py` | `os.chmod(config_path, 0o600)` |
| `hermes_cli/backup.py` | `os.chmod(target, 0o600)` when restoring external provider configs |
| **`hermes_cli/profiles.py`** | **nothing — this PR** |

One intentional byte-level difference: the helper does not append a trailing newline, where the old inline write did. This makes the rename path byte-consistent with the two Honcho plugin writers that already use `atomic_json_write`, and nothing reads these files other than `json.loads`.

### Coverage

I swept every writer of the Honcho config files rather than fixing only the reported one. `hermes_cli/memory_oauth.py` only resolves and reads them; `hermes_cli/backup.py` already chmods `0600` on restore; the three plugin writers are listed above. `hermes_cli/profiles.py::_migrate_honcho_profile_host` was the only site missing the enforcement, so this is the complete set for this root cause. This PR deliberately does **not** widen into a mechanical repo-wide `chmod`-after-write sweep — those are different files with different owners and sensitivities, and several are already correct or already claimed.

### Precedent

- The in-file precedent is a commit already on `main`: `649ce1f8113` *"fix(cli): make profile.yaml and skin writes atomic to stop silent field loss"* routed this same file's `profile.yaml` write through `atomic_yaml_write`. This change follows it exactly, including the lazy `from utils import ...` idiom the module uses to stay import-light.
- #79746 *"fix(cli): route the remaining destructive user-file rewrites through atomic writes"* merged on 2026-08-05 and covered `profile_distribution.py`, `uninstall.py`, `web_routers/profiles.py`, `xai_retirement.py`, and `utils.py`. `hermes_cli/profiles.py` was not in that list, so this is a remaining site of a class that has already been accepted.
- `utils.atomic_write_text`'s own docstring states the invariant this restores: *"every destructive file rewrite in the codebase shares one implementation."*

## Related Issue

No filed issue. #16743 is referenced as context for the symlink-detachment failure mode only; it is already closed and this PR does not reopen or claim it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/profiles.py`

- `_migrate_honcho_profile_host` now writes through `utils.atomic_json_write(path, raw, mode=0o600)`. The import is function-local at the top of the function, matching the module's existing lazy-import idiom (`import yaml`, `from utils import atomic_yaml_write`) so the module stays import-light; it is hoisted above the candidate loop rather than sitting inside it.
- The inline temp-file handler is removed — the helper cleans up its own temp file on failure. The `except OSError: continue` fail-soft is unchanged, so an unwritable candidate still lets the remaining candidates migrate.
- `indent` is not passed: the helper already defaults to `2`, matching the previous output. `ensure_ascii=False` is not passed either — the helper hardcodes it internally, and forwarding it through `**dump_kwargs` would raise `TypeError: got multiple values for keyword argument 'ensure_ascii'`.

`tests/hermes_cli/test_profiles.py`

- New `TestMigrateHonchoProfileHostWrite` class, placed directly after the existing `TestRenameProfile` cluster. Nothing else in the file is reordered or reformatted.
- `test_rewrite_keeps_credential_config_owner_only` — seeds a `0600` config holding an `apiKey`, pins `umask` to `0o022` so the pre-fix behaviour is deterministic rather than dependent on the runner's umask, and asserts the mode is still `0600` afterwards.
- `test_rewrite_preserves_a_symlinked_config` — points `~/.hermes/honcho.json` at a file in another directory and asserts the path is still a symlink, still resolves to the same real file, that the real file received the migrated block, and that its mode survived.
- `test_unwritable_candidate_still_advances_to_the_next` — forces `OSError` on the first candidate and asserts the second is still migrated and no temp file is left behind. This is the guard on the unchanged fail-soft behaviour.
- The two mode/symlink tests are `skipif`-gated on `sys.platform == "win32"`. No new imports were added to the file.

## How to Test

Reproduce the mode widening on a POSIX box:

```bash
export HERMES_HOME=~/.hermes
hermes profile create oldname
cat > ~/.hermes/honcho.json <<'JSON'
{"hosts": {"hermes_oldname": {"apiKey": "secret", "aiPeer": "oldname", "enabled": true}}}
JSON
chmod 600 ~/.hermes/honcho.json
ln -s ~/dotfiles/honcho.json ~/.hermes/honcho.json   # optional, for defect 2

hermes profile rename oldname newname
stat -c '%a %N' ~/.hermes/honcho.json
```

Before this change: `644`, and the symlink is gone. After: `600`, and the symlink still points at the real file.

Automated, with the before/after both verified:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_profiles.py -k TestMigrateHonchoProfileHostWrite -v
```

With the production hunk reverted and the tests kept, all three fail on exactly the defects described:

```
AssertionError: assert (33188 & 511) == 384        # 0o100644 -> mode 0o644, expected 0o600
AssertionError: assert False                        # link.is_symlink() -- the symlink was replaced
AssertionError: assert 'hermes_oldname' in {'hermes_newname': ...}   # fail-soft skip
3 failed, 48 deselected
```

With the fix restored:

```
tests/hermes_cli/test_profiles.py ................................................... 51 passed
```

Adjacent helper and consumer suites, unchanged:

```
tests/hermes_cli/test_profiles.py tests/hermes_cli/test_atomic_json_write.py
tests/hermes_cli/test_atomic_yaml_write.py tests/hermes_cli/test_update_zip_atomic_replace.py
  -> 58 passed

tests/honcho_plugin -> 216 passed, 12 skipped
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed above, not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4). Not verified on Linux or Windows; the two mode/symlink tests are `skipif`-gated off Windows.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: no user-facing behaviour or docs change -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A: no config keys -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- the helper skips fchmod on Windows and applies the mode via os.chmod after the replace; the POSIX-specific tests are gated -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->
