### PR TITLE
feat(kanban): make the direct Claude Code CLI the global worker executor

### DIFF
--- a/docs/kanban/worker-executor.md
+++ b/docs/kanban/worker-executor.md
@@ -48,6 +48,10 @@ kanban:
   # model override of its own.
   claude_cli_model: claude-opus-5
 
+  # `--effort` for the direct lane when a card pins no reasoning_effort of
+  # its own. Default `medium`. Set to "" to add no flag at all.
+  claude_cli_effort: medium
+
   # Optional. Minimum seconds between two direct-lane `claude` process
   # startups on this Hermes root. Default 2.0; clamped to [0, 60].
   claude_cli_spawn_stagger_seconds: 2.0
@@ -167,6 +171,58 @@ accept both, which is exactly how this hides in local testing.
 through the real `hermes kanban` parser so an invented or misordered flag
 cannot ship.
 
+### Thinking depth
+
+Every direct-lane worker runs with an explicit `--effort`. The level is
+resolved once per spawn, in this order:
+
+1. the card's own `reasoning_effort`, if it pins one;
+2. `kanban.claude_cli_effort`;
+3. `medium` — the built-in default.
+
+Medium is stated in argv rather than left to the CLI's own default on purpose.
+"Which depth did this worker run at" is a question an operator has to be able
+to answer from evidence after the fact, and an implicit default is not
+evidence. The resolved level is written to the worker log header as
+`effort=<level>`, next to `executor=` and `bin=`:
+
+```
+[kanban] executor=claude_cli bin=/usr/local/bin/claude board=reefmind \
+  profile=integrator flags=--model,--effort,--permission-mode,--allowedTools,-p \
+  effort=medium stripped_env=-
+```
+
+Effort is the only flag whose *value* appears in that header. That is
+deliberate and it is bounded: the value is written only when it came from the
+closed allowlist below, so the header cannot become a place a secret leaks.
+An `--effort` the operator supplied themselves in `claude_cli_extra_args` is
+arbitrary text, so it is reported as `effort=operator` and its value is
+withheld like every other flag value.
+
+The host CLI accepts `low`, `medium`, `high`, `xhigh`, `max`. Hermes'
+`reasoning_effort` vocabulary is wider, so the extra levels are translated to
+the nearest level in the same direction — never upward into more thinking than
+the card asked for:
+
+| Card `reasoning_effort` | `--effort` | Note |
+|---|---|---|
+| `low` / `medium` / `high` / `xhigh` / `max` | same | forwarded as-is |
+| `minimal` | `low` | floor of what the CLI offers; logged |
+| `ultra` | `max` | ceiling of what the CLI offers; logged |
+| `none` | `low` | **`--effort` cannot disable thinking.** Logged. Omitting the flag would inherit a session default that may be *more* thinking than `none` asked for, and refusing the card would strand it, so the floor is the least-wrong option. Run the card on `native` if disabled reasoning is a hard requirement. |
+| unrecognized | lane default | logged; see below |
+
+An unrecognized level — on the card or in `claude_cli_effort` — falls forward
+to the lane default instead of reaching the CLI. This is not conservatism:
+`claude --effort bogus` is argv the CLI rejects outright, so the worker would
+die at startup and the card would show an unexplained `spawn_failed` with
+nothing pointing at the typo.
+
+Setting `claude_cli_effort: ""` adds no flag at all and lets the host CLI pick;
+the header then reads `effort=-`. An `--effort` in `claude_cli_extra_args`
+takes precedence over all of the above and suppresses the resolved flag
+entirely, so the run never carries `--effort` twice.
+
 ## Claim and heartbeat behavior
 
 A direct-lane worker keeps its claim the same way a native one does. The
@@ -259,8 +315,9 @@ header in the task's worker log.
   rather than complete on a partial result. `goal_max_turns` is passed through
   as a soft round budget. This is weaker than the native judge loop — run
   goal-critical cards on `native` if you need the real thing.
-- **Per-task `--toolsets` and `--reasoning` pins do not apply** — they are
-  Hermes CLI flags. Use `claude_cli_extra_args` for the CLI's own equivalents.
+- **Per-task `--toolsets` pins do not apply** — that is a Hermes CLI flag. Use
+  `claude_cli_extra_args` for the CLI's own equivalent. (Per-task
+  `reasoning_effort` *does* apply on this lane — see "Thinking depth" above.)
 - **Per-task `skills` are named in the prompt, not injected.** The native lane
   passes `--skills X` and Hermes resolves each into the worker's system prompt
   before its first turn. The host CLI has no equivalent flag, so this lane

--- a/docs/kanban/worker-executor.md
+++ b/docs/kanban/worker-executor.md
@@ -1,37 +1,48 @@
 # Kanban worker executor
 
-The dispatcher spawns each claimed task as a detached child process. By default
-that child is a native Hermes worker:
+The dispatcher spawns each claimed task as a detached child process. That child
+is the Claude Code CLI running under the operator's own host login:
+
+```
+claude -p [--model ...] --permission-mode bypassPermissions [...] "<protocol prompt>"
+```
+
+This is the default for **every board and every profile**. The alternative lane
+is the native Hermes worker:
 
 ```
 hermes -p <assignee> --cli --accept-hooks [...] chat -q "work kanban task <id>"
 ```
 
-That lane resolves the model through Hermes' own provider stack. On an
+which resolves the model through Hermes' own provider stack. On an
 Anthropic-backed profile it bills the configured `provider: anthropic`
 credentials, which on some setups is a third-party / extra-usage pool that can
 exhaust independently of the operator's interactive Claude subscription. When
 that pool is empty, every worker fails at startup even though
-`env -u CLAUDE_CONFIG_DIR claude -p ...` runs fine in the same shell.
-
-`kanban.worker_executor` lets an operator point workers at that working lane —
-the Claude Code CLI itself — explicitly.
+`env -u CLAUDE_CONFIG_DIR claude -p ...` runs fine in the same shell — and the
+dispatcher cannot tell that apart from a wedged board. One review card was
+re-dispatched 132 times behind repeated 429s before the breaker tripped. That
+is why the direct lane, which began as strictly opt-in, is now the default.
 
 ## Configuration
 
 ```yaml
 kanban:
-  # hermes (default) | claude_cli
+  # claude_cli (default) | hermes (alias: native)
   worker_executor: claude_cli
 
   # Optional. Absolute path or bare command name; default: `claude` on PATH.
   claude_cli_bin: /opt/homebrew/bin/claude
 
-  # Extra argv appended before `-p <prompt>`. YAML list or a single
-  # shell-quoted string. In practice this is REQUIRED — see "Permissions".
+  # --permission-mode for the run. Default `bypassPermissions` — see
+  # "Permissions". Set to "" to add no flag at all (read-only lane).
+  claude_cli_permission_mode: bypassPermissions
+
+  # Extra argv appended before the prompt. YAML list or a single
+  # shell-quoted string. A permission flag here wins over the setting above.
   claude_cli_extra_args:
-    - --permission-mode
-    - acceptEdits
+    - --add-dir
+    - /srv/shared
 
   # Optional. `--model` for the direct lane when a task carries no Claude
   # model override of its own.
@@ -44,6 +55,26 @@ kanban:
 
 `worker_executor` is a behavioral setting, so it lives in `config.yaml`, not in
 `.env`. It is per-profile-root like the rest of the `kanban:` block.
+`HERMES_KANBAN_WORKER_EXECUTOR` overrides it for a single process.
+
+To pin the default explicitly (and verify it is being read):
+
+```
+hermes config set kanban.worker_executor claude_cli
+hermes config get kanban.worker_executor
+```
+
+### Going back to the native lane
+
+```
+hermes config set kanban.worker_executor native
+```
+
+This is the only supported way back. There is no automatic fallback: an
+unresolvable `claude` binary is a hard error that records `spawn_failed`
+against the task, and an unrecognized `worker_executor` value falls *forward*
+to the direct lane. A typo must never silently restore the routing that wedged
+the board.
 
 ## Permissions — read this before you conclude the lane is broken
 
@@ -74,11 +105,23 @@ never started. It grants no general Bash, no `Edit`, and no `Write`. If you
 supply your own `--allowedTools`, these are merged into your list rather than
 added as a second flag (a second occurrence would win and silently drop yours).
 
-**The task's actual work permissions stay yours.** Hermes will not widen those
-for you. Choose them in `claude_cli_extra_args` based on what the tasks on this
-board need — `--permission-mode acceptEdits` for edit-only work, something
-broader if the work must run commands. A spawn with no permission flag at all
-logs a warning explaining the above.
+**The task's actual work permissions default to `bypassPermissions`.** While
+this lane was opt-in, Hermes only warned here and added nothing: silently
+widening a worker's privileges was not its call, and an unarmed worker was a
+no-op on one board someone had deliberately switched over. As the default lane
+that same warning would make *every* worker a no-op — able to read and post
+board comments, unable to edit a file or run a command, i.e. unable to do any
+task it is given.
+
+So `claude_cli_permission_mode` defaults to `bypassPermissions`. This is parity
+rather than escalation: a native Hermes worker already runs with the full
+unattended tool surface, and the direct-lane worker is doing the same job in
+the same claimed workspace with stdin closed and no human to ask.
+
+To choose differently, set `claude_cli_permission_mode` (or pass your own
+permission flag in `claude_cli_extra_args`, which wins) — `acceptEdits` for
+edit-only work, or `""` for a read-only lane, which restores the old
+warn-and-add-nothing behavior.
 
 ### Argument order is load-bearing
 
@@ -143,8 +186,7 @@ reclaim, not against being wedged.
 
 ## Credential policy
 
-The direct lane removes these variables from the child's environment and adds
-nothing:
+The direct lane removes these variables from the child's environment:
 
 | Variable | Why it is dropped |
 |---|---|
@@ -154,6 +196,14 @@ nothing:
 | `ANTHROPIC_BASE_URL` | Keeps an inherited gateway/proxy override from redirecting the subscription lane. |
 | `CLAUDE_CODE_USE_BEDROCK` | Would move the run onto an AWS account's billing. |
 | `CLAUDE_CODE_USE_VERTEX` | Would move the run onto a GCP account's billing. |
+| `ANTHROPIC_BEDROCK_BASE_URL`, `ANTHROPIC_VERTEX_BASE_URL`, `CLOUD_ML_REGION` | The rest of the cloud-account routing surface. |
+| `CLAUDE_API_KEY`, `CLAUDE_CODE_API_KEY_HELPER` | Alternate ways to hand the CLI a key instead of the host login. |
+| `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `CODEX_HOME`, `CODEX_API_KEY` | A kanban worker must never reach the OpenAI-Codex stack, and a credential left in a detached child's environment is how it ends up quoted in a task log. |
+
+It adds exactly two variables: `HERMES_KANBAN_EXECUTOR=claude_cli`, so anything
+reading the child's env can tell which lane produced it, and
+`GIT_TERMINAL_PROMPT=0`, so a worker doing git work fails fast instead of
+blocking forever on a credential prompt nobody can answer.
 
 Hermes never reads, copies, decrypts, or rewrites the Claude credential store.
 No token is placed in argv, in the child env, in the board database, or in a
@@ -183,13 +233,14 @@ with `kanban.max_in_progress_per_profile`.
 
 ## No silent fallback
 
-Selecting `claude_cli` is a commitment. If the binary is missing, not
+The direct lane is a commitment, not a preference. If the binary is missing, not
 executable, or the configured `claude_cli_bin` path does not exist, the spawn
 raises with an actionable message naming the lane and the exact path, and the
 task is *not* started on the native provider instead — a quiet downgrade would
-put the run back on the exhausted pool the setting exists to avoid. An
+put the run back on the exhausted pool this lane exists to avoid. An
 unrecognized `worker_executor` value is treated as a typo: it is logged loudly
-and the native default is used, so a misspelling never changes billing.
+and the *default* is used. Note the direction — a typo resolves forward to the
+direct lane, never back onto the provider stack that wedged the board.
 
 Each direct-lane spawn logs the executor, the resolved binary, the *names* of
 the argv flags, and the *names* of the stripped variables — never a flag value,
@@ -198,11 +249,16 @@ header in the task's worker log.
 
 ## Limitations
 
-- **Goal mode is unsupported, and refuses rather than degrades.** The
-  Ralph-style `/goal` judge loop lives in the Hermes CLI's quiet path. Spawning
-  a `goal_mode` task on the direct lane raises; the attempt is recorded against
-  the task and reaches a human after `kanban.failure_limit`. Clear `goal_mode`
-  or run that task on the native executor.
+- **Goal mode has no judge loop; the worker judges itself.** The Ralph-style
+  `/goal` loop lives in the Hermes CLI's quiet path and has no CLI equivalent.
+  While this lane was opt-in the spawn refused a `goal_mode` card outright,
+  because the alternative was one unjudged pass that looks like success. As the
+  default lane that would fail every goal card on every board, so the prompt
+  instead carries an explicit GOAL MODE section telling the worker to verify
+  its work against the card's success criteria before completing, and to block
+  rather than complete on a partial result. `goal_max_turns` is passed through
+  as a soft round budget. This is weaker than the native judge loop — run
+  goal-critical cards on `native` if you need the real thing.
 - **Per-task `--toolsets`, `--skills`, and `--reasoning` pins do not apply** —
   they are Hermes CLI flags. Use `claude_cli_extra_args` for the CLI's own
   equivalents.

--- a/docs/kanban/worker-executor.md
+++ b/docs/kanban/worker-executor.md
@@ -259,9 +259,23 @@ header in the task's worker log.
   rather than complete on a partial result. `goal_max_turns` is passed through
   as a soft round budget. This is weaker than the native judge loop — run
   goal-critical cards on `native` if you need the real thing.
-- **Per-task `--toolsets`, `--skills`, and `--reasoning` pins do not apply** —
-  they are Hermes CLI flags. Use `claude_cli_extra_args` for the CLI's own
-  equivalents.
+- **Per-task `--toolsets` and `--reasoning` pins do not apply** — they are
+  Hermes CLI flags. Use `claude_cli_extra_args` for the CLI's own equivalents.
+- **Per-task `skills` are named in the prompt, not injected.** The native lane
+  passes `--skills X` and Hermes resolves each into the worker's system prompt
+  before its first turn. The host CLI has no equivalent flag, so this lane
+  lists the required skills in the prompt and asks the worker to load them
+  with its own Skill tool, blocking `--kind capability` if one will not load.
+  That is an instruction, not an injection: a direct-lane worker *can* ignore
+  it where a native worker could not.
+
+  This stopped being a cosmetic gap when the review handoff lifecycle landed.
+  `dispatch_once` force-appends `sdlc-review` to a claimed review card because
+  that skill *is* the review procedure (AC verification, merge). With this
+  lane global, silently dropping the field would hand every review card a
+  worker that does not know how to review — and the run would look normal, not
+  misconfigured. If you need the hard guarantee for review cards, run them on
+  `native`.
 - A task `model_override` is forwarded only when it names a Claude model on the
   Anthropic lane; anything else is dropped with a warning rather than passed to
   a CLI that cannot resolve it.

--- a/docs/kanban/worker-executor.md
+++ b/docs/kanban/worker-executor.md
@@ -1,0 +1,216 @@
+# Kanban worker executor
+
+The dispatcher spawns each claimed task as a detached child process. By default
+that child is a native Hermes worker:
+
+```
+hermes -p <assignee> --cli --accept-hooks [...] chat -q "work kanban task <id>"
+```
+
+That lane resolves the model through Hermes' own provider stack. On an
+Anthropic-backed profile it bills the configured `provider: anthropic`
+credentials, which on some setups is a third-party / extra-usage pool that can
+exhaust independently of the operator's interactive Claude subscription. When
+that pool is empty, every worker fails at startup even though
+`env -u CLAUDE_CONFIG_DIR claude -p ...` runs fine in the same shell.
+
+`kanban.worker_executor` lets an operator point workers at that working lane —
+the Claude Code CLI itself — explicitly.
+
+## Configuration
+
+```yaml
+kanban:
+  # hermes (default) | claude_cli
+  worker_executor: claude_cli
+
+  # Optional. Absolute path or bare command name; default: `claude` on PATH.
+  claude_cli_bin: /opt/homebrew/bin/claude
+
+  # Extra argv appended before `-p <prompt>`. YAML list or a single
+  # shell-quoted string. In practice this is REQUIRED — see "Permissions".
+  claude_cli_extra_args:
+    - --permission-mode
+    - acceptEdits
+
+  # Optional. `--model` for the direct lane when a task carries no Claude
+  # model override of its own.
+  claude_cli_model: claude-opus-5
+
+  # Optional. Minimum seconds between two direct-lane `claude` process
+  # startups on this Hermes root. Default 2.0; clamped to [0, 60].
+  claude_cli_spawn_stagger_seconds: 2.0
+```
+
+`worker_executor` is a behavioral setting, so it lives in `config.yaml`, not in
+`.env`. It is per-profile-root like the rest of the `kanban:` block.
+
+## Permissions — read this before you conclude the lane is broken
+
+`claude -p` runs in the CLI's default permission mode, which asks a human
+before it edits a file or runs a command. A dispatcher worker has no TTY, so
+every such request is auto-denied.
+
+**`--permission-mode acceptEdits` covers file edits only — not Bash.** This is
+the trap. A worker set up that way was observed reporting that *every* `hermes`
+call it made was denied: it never learned what its task was, and could not
+comment, block, or complete. It stranded the task.
+
+Two consequences, and Hermes handles them differently.
+
+**The board protocol is granted for you.** Every direct-lane spawn appends a
+least-privilege allowlist for exactly the five subcommands the worker prompt
+tells it to run:
+
+```
+--allowedTools "Bash(<hermes> kanban show:*)" "Bash(<hermes> kanban heartbeat:*)" \
+               "Bash(<hermes> kanban comment:*)" "Bash(<hermes> kanban block:*)" \
+               "Bash(<hermes> kanban complete:*)"
+```
+
+That is the minimum required for the contract the prompt asks the worker to
+fulfil — a worker that cannot report its own outcome is worse than one that
+never started. It grants no general Bash, no `Edit`, and no `Write`. If you
+supply your own `--allowedTools`, these are merged into your list rather than
+added as a second flag (a second occurrence would win and silently drop yours).
+
+**The task's actual work permissions stay yours.** Hermes will not widen those
+for you. Choose them in `claude_cli_extra_args` based on what the tasks on this
+board need — `--permission-mode acceptEdits` for edit-only work, something
+broader if the work must run commands. A spawn with no permission flag at all
+logs a warning explaining the above.
+
+### Argument order is load-bearing
+
+`--allowedTools` (and several other CLI flags) are variadic: the run of values
+only ends at the next option-looking token. The prompt is therefore always
+passed as `-p <prompt>` **last**. Put a prompt directly after a variadic flag
+and the CLI consumes it as another value, then exits with
+`Input must be provided either through stdin or as a prompt argument`.
+
+## What changes, and what does not
+
+Only the argv and the credential routing change. Both lanes get the identical
+child environment — `HERMES_KANBAN_DB`, `HERMES_KANBAN_BOARD`,
+`HERMES_KANBAN_WORKSPACES_ROOT`, `HERMES_KANBAN_TASK`,
+`HERMES_KANBAN_WORKSPACE`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK`,
+`HERMES_PROFILE`, `HERMES_TENANT`, `HERMES_SESSION_SOURCE`, the terminal
+timeouts derived from `max_runtime_seconds`, and the `HERMES_TUI` drop that
+keeps a worker from booting the interactive TUI. The child is still detached
+(`start_new_session`), still runs with `cwd` set to the task workspace, still
+writes to `<board-root>/logs/<task>.log` with the same rotation, and still
+returns its PID so the dispatcher's crash detection works unchanged.
+
+Because the Claude CLI has neither the `kanban_*` model tools nor Hermes'
+`KANBAN_GUIDANCE` system prompt, the direct lane sends a self-contained
+protocol prompt instead of `work kanban task <id>`. The worker drives the
+lifecycle through the `hermes kanban` subcommands (`show`, `comment`,
+`heartbeat`, `complete`, `block`), which read the board pins already in its
+environment.
+
+The prompt embeds the *resolved* Hermes invocation (the same
+`_resolve_hermes_argv()` the native lane launches with), not a bare `hermes`.
+When the dispatcher runs from a venv whose console script is not on the child's
+`PATH`, a literal `hermes kanban complete` would fail and the worker would exit
+without ever closing its task.
+
+Argument *order* in those commands is also load-bearing. `block`'s reason is a
+`nargs="*"` positional, and on Python 3.11 — the pinned runtime — a nested
+subparser rejects a positional that trails an optional. So the prompt says
+`block <id> "<why>" --kind needs_input`, not `block <id> --kind needs_input
+"<why>"`; the latter exits 2 with `unrecognized arguments`. Newer CPythons
+accept both, which is exactly how this hides in local testing.
+`test_every_prompted_command_parses` runs every command the prompt names
+through the real `hermes kanban` parser so an invented or misordered flag
+cannot ship.
+
+## Claim and heartbeat behavior
+
+A direct-lane worker keeps its claim the same way a native one does. The
+dispatcher records the child's PID; `release_stale_claims` extends the claim of
+any host-local task whose PID is still alive, so a long-running direct-lane
+worker is **not** reclaimed out from under itself.
+
+`hermes kanban heartbeat <id>` is a real subcommand and the worker prompt
+instructs the worker to call it periodically. It authenticates via the
+`HERMES_KANBAN_TASK` / `HERMES_KANBAN_RUN_ID` pins already in the child's env.
+Heartbeats are what re-enable the wedged-worker backstop: a task whose PID is
+alive but whose last heartbeat is older than
+`DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS` is reclaimed rather than extended.
+A direct-lane worker that never heartbeats keeps its claim on PID liveness
+alone and therefore loses that backstop — it is protected against spurious
+reclaim, not against being wedged.
+
+## Credential policy
+
+The direct lane removes these variables from the child's environment and adds
+nothing:
+
+| Variable | Why it is dropped |
+|---|---|
+| `CLAUDE_CONFIG_DIR` | This is the `env -u CLAUDE_CONFIG_DIR` behavior that works. The child then reads the operator's ordinary `~/.claude` store itself. |
+| `ANTHROPIC_API_KEY` | Keeps an inherited key from silently moving the run onto metered API billing. |
+| `ANTHROPIC_AUTH_TOKEN` | Same. |
+| `ANTHROPIC_BASE_URL` | Keeps an inherited gateway/proxy override from redirecting the subscription lane. |
+| `CLAUDE_CODE_USE_BEDROCK` | Would move the run onto an AWS account's billing. |
+| `CLAUDE_CODE_USE_VERTEX` | Would move the run onto a GCP account's billing. |
+
+Hermes never reads, copies, decrypts, or rewrites the Claude credential store.
+No token is placed in argv, in the child env, in the board database, or in a
+worker log — the child authenticates itself, on its own schedule.
+
+### Concurrency and the shared `~/.claude` store
+
+Every direct-lane worker shares one per-user `~/.claude` state directory, and
+each `claude` process reads and rewrites parts of it at startup. Several
+workers booting at the same instant can interleave those writes; the visible
+symptom is a truncated config and an interactive session that abruptly asks you
+to log in again.
+
+Hermes serializes that window. Direct-lane spawns take a cross-process lock
+under `<hermes-root>/kanban/claude-cli-spawn.lock` and enforce
+`claude_cli_spawn_stagger_seconds` (default 2s) between startups, so at most one
+direct-lane worker is in its startup window at a time. The lock is per Hermes
+root, not per board, because the contended resource is per user. If the lock
+cannot be taken within 30s the spawn proceeds unstaggered and logs a warning —
+a stuck holder degrades the stagger, it never stops the board.
+
+Be precise about the limit of this guarantee: it covers process **startup**
+only. An OAuth refresh performed mid-run by two long-lived workers happens
+inside Anthropic's CLI, which Hermes does not lock and whose credential store
+Hermes does not touch. If that matters for your setup, bound real concurrency
+with `kanban.max_in_progress_per_profile`.
+
+## No silent fallback
+
+Selecting `claude_cli` is a commitment. If the binary is missing, not
+executable, or the configured `claude_cli_bin` path does not exist, the spawn
+raises with an actionable message naming the lane and the exact path, and the
+task is *not* started on the native provider instead — a quiet downgrade would
+put the run back on the exhausted pool the setting exists to avoid. An
+unrecognized `worker_executor` value is treated as a typo: it is logged loudly
+and the native default is used, so a misspelling never changes billing.
+
+Each direct-lane spawn logs the executor, the resolved binary, the *names* of
+the argv flags, and the *names* of the stripped variables — never a flag value,
+an env value, or the prompt — both to the dispatcher log and as a one-line
+header in the task's worker log.
+
+## Limitations
+
+- **Goal mode is unsupported, and refuses rather than degrades.** The
+  Ralph-style `/goal` judge loop lives in the Hermes CLI's quiet path. Spawning
+  a `goal_mode` task on the direct lane raises; the attempt is recorded against
+  the task and reaches a human after `kanban.failure_limit`. Clear `goal_mode`
+  or run that task on the native executor.
+- **Per-task `--toolsets`, `--skills`, and `--reasoning` pins do not apply** —
+  they are Hermes CLI flags. Use `claude_cli_extra_args` for the CLI's own
+  equivalents.
+- A task `model_override` is forwarded only when it names a Claude model on the
+  Anthropic lane; anything else is dropped with a warning rather than passed to
+  a CLI that cannot resolve it.
+- The worker's lifecycle compliance is prompt-enforced, not tool-enforced. A
+  native worker's `kanban_complete` is a model tool the harness can require; a
+  direct-lane worker is asked to run a shell command. A worker that exits
+  without `complete` or `block` is caught by the dispatcher's existing
+  PID-vanished crash detection, one attempt later than the native lane.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2502,6 +2502,16 @@ DEFAULT_CONFIG = {
         # lifecycle protocol needs shell access to run `hermes kanban
         # complete` / `block`, which is granted separately via --allowedTools.
         "claude_cli_permission_mode": "bypassPermissions",
+        # --effort for the run: the thinking depth every worker and reviewer
+        # on this lane runs at unless its card pins reasoning_effort of its
+        # own. One of low|medium|high|xhigh|max — the levels the host Claude
+        # CLI accepts. Hermes-only levels (minimal, ultra, none) are
+        # translated to the nearest of those; an unrecognized value falls
+        # forward to medium rather than being passed to the CLI, which would
+        # reject its own argv and kill the worker at startup. Set to an empty
+        # string to add no flag and let the host CLI choose. The resolved
+        # level is recorded in the worker log header as `effort=<level>`.
+        "claude_cli_effort": "medium",
         # Extra argv appended before the prompt. YAML list, or a shell-quoted
         # string. For operator escape hatches (--add-dir, --settings, ...).
         "claude_cli_extra_args": [],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2493,7 +2493,7 @@ DEFAULT_CONFIG = {
         # lets the host CLI pick its own default. A card's model_override
         # wins only when it names a Claude model; a card pinned to another
         # vendor's model falls back here rather than routing off-lane.
-        "claude_cli_permission_mode": "bypassPermissions",
+        "claude_cli_model": "",
         # --permission-mode for the run, used only when claude_cli_extra_args
         # carries no permission flag of its own. A detached worker has no
         # terminal and nobody to approve a tool call, so the default matches
@@ -2501,7 +2501,7 @@ DEFAULT_CONFIG = {
         # empty string to add no flag at all (read-only lane) — note the
         # lifecycle protocol needs shell access to run `hermes kanban
         # complete` / `block`, which is granted separately via --allowedTools.
-        "claude_cli_model": "",
+        "claude_cli_permission_mode": "bypassPermissions",
         # Extra argv appended before the prompt. YAML list, or a shell-quoted
         # string. For operator escape hatches (--add-dir, --settings, ...).
         "claude_cli_extra_args": [],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2462,6 +2462,53 @@ DEFAULT_CONFIG = {
         # so stale rows don't accumulate and get scanned on every notifier
         # tick forever. Set 0 to disable the sweep.
         "done_sub_retention_days": 30,
+        # Which process a dispatcher-spawned worker actually is. Global —
+        # every board, every profile.
+        #
+        #   claude_cli (default) — the direct host Claude Code CLI
+        #     (`claude -p ...`) under the operator's own login, with
+        #     CLAUDE_CONFIG_DIR and every inherited Anthropic credential /
+        #     gateway override stripped so nothing redirects the run onto
+        #     metered or cloud-account billing.
+        #   hermes (alias: native) — the historical in-process worker
+        #     (`hermes -p <assignee> chat -q ...`), routed through Hermes'
+        #     own provider stack.
+        #
+        # The default moved to claude_cli after the native lane's provider
+        # pool exhausted and wedged a board: every worker failed at startup
+        # and one card was re-dispatched 132 times behind repeated 429s,
+        # while `env -u CLAUDE_CONFIG_DIR claude -p ...` answered fine in
+        # the same shell. There is no automatic fallback in either
+        # direction — an unresolvable CLI is a hard error naming the lane
+        # and path, never a quiet downgrade back onto the exhausted pool,
+        # and an unrecognized value here falls forward to the default
+        # rather than back to native. Override per-process with
+        # $HERMES_KANBAN_WORKER_EXECUTOR.
+        "worker_executor": "claude_cli",
+        # --- worker_executor: claude_cli settings (ignored on `hermes`) ---
+        # Executable to launch. Bare names resolve against PATH (never the
+        # current directory); path-like values are used as given.
+        "claude_cli_bin": "",
+        # Default --model for workers whose card pins no Claude model. Empty
+        # lets the host CLI pick its own default. A card's model_override
+        # wins only when it names a Claude model; a card pinned to another
+        # vendor's model falls back here rather than routing off-lane.
+        "claude_cli_permission_mode": "bypassPermissions",
+        # --permission-mode for the run, used only when claude_cli_extra_args
+        # carries no permission flag of its own. A detached worker has no
+        # terminal and nobody to approve a tool call, so the default matches
+        # the unattended tool reach a native worker already has. Set to an
+        # empty string to add no flag at all (read-only lane) — note the
+        # lifecycle protocol needs shell access to run `hermes kanban
+        # complete` / `block`, which is granted separately via --allowedTools.
+        "claude_cli_model": "",
+        # Extra argv appended before the prompt. YAML list, or a shell-quoted
+        # string. For operator escape hatches (--add-dir, --settings, ...).
+        "claude_cli_extra_args": [],
+        # Minimum seconds between two direct-lane `claude` process startups
+        # on this Hermes root, so a burst of spawns doesn't stampede the
+        # CLI's credential refresh. 0 disables the stagger.
+        "claude_cli_spawn_stagger_seconds": 2.0,
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10305,15 +10305,30 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
 # Worker executor selection (native Hermes vs. direct Claude Code CLI)
 # ---------------------------------------------------------------------------
 
-#: Default lane. ``hermes -p <profile> chat -q`` — the native provider stack.
+#: Escape-hatch lane. ``hermes -p <profile> chat -q`` — the native provider
+#: stack. No longer the default; see :data:`DEFAULT_WORKER_EXECUTOR`.
 WORKER_EXECUTOR_HERMES = "hermes"
-#: Opt-in lane. Runs the Claude Code CLI (``claude -p``) directly so the worker
+#: Default lane. Runs the Claude Code CLI (``claude -p``) directly so the worker
 #: uses the operator's own interactive Claude subscription instead of the
 #: native ``provider=anthropic`` adapter's third-party/extra-usage credits.
 WORKER_EXECUTOR_CLAUDE_CLI = "claude_cli"
 
+#: The global default, for every board and every profile.
+#:
+#: This lane started out strictly opt-in. It is the default now because the
+#: native lane's provider routing failed in a way the dispatcher cannot see:
+#: when the pool behind ``provider=anthropic`` exhausts, every worker fails at
+#: startup, and one review card was re-dispatched 132 times behind repeated
+#: 429s before the breaker tripped — all while ``env -u CLAUDE_CONFIG_DIR
+#: claude -p`` answered fine in the same shell. An operator who wants the
+#: native lane back asks for it by name.
+DEFAULT_WORKER_EXECUTOR = WORKER_EXECUTOR_CLAUDE_CLI
+
+#: Per-process override, ahead of config. Lets one dispatcher (or a test) pick
+#: a lane without editing a shared file.
+ENV_WORKER_EXECUTOR = "HERMES_KANBAN_WORKER_EXECUTOR"
+
 _WORKER_EXECUTOR_ALIASES = {
-    "": WORKER_EXECUTOR_HERMES,
     "hermes": WORKER_EXECUTOR_HERMES,
     "native": WORKER_EXECUTOR_HERMES,
     "claude": WORKER_EXECUTOR_CLAUDE_CLI,
@@ -10338,14 +10353,33 @@ _WORKER_EXECUTOR_ALIASES = {
 #: when the whole point of this lane is the subscription. The
 #: ``CLAUDE_CODE_USE_*`` entries are the same class: they move the run onto a
 #: Bedrock / Vertex account's billing instead.
+#: The ``OPENAI_*`` / ``CODEX_*`` entries are here because this is the lane
+#: every worker takes now: a kanban worker must never reach the OpenAI-Codex
+#: stack, and a credential left in a detached child's environment is how it
+#: ends up quoted in a task log.
 CLAUDE_CLI_STRIPPED_ENV_VARS = (
     "CLAUDE_CONFIG_DIR",
+    "CLAUDE_API_KEY",
+    "CLAUDE_CODE_API_KEY_HELPER",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "CLOUD_ML_REGION",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "CODEX_HOME",
+    "CODEX_API_KEY",
 )
+
+#: Stamped onto every direct-lane worker so `ps`, the log header, and anything
+#: reading the child's env can tell which lane produced it.
+ENV_ACTIVE_EXECUTOR = "HERMES_KANBAN_EXECUTOR"
 
 #: Argv flags that grant a ``claude -p`` worker the ability to act. Without one
 #: of these the CLI runs in its default (ask-a-human) permission mode, and a
@@ -10361,6 +10395,25 @@ _CLAUDE_CLI_PERMISSION_FLAGS = (
     "--allowed-tools",
     "--settings",
 )
+
+#: ``--permission-mode`` applied when the operator supplied no permission flag
+#: of their own.
+#:
+#: This exists because the lane is the default now. While it was opt-in, adding
+#: a permission flag implicitly would have been escalating a worker's
+#: privileges uninvited, so the code only warned — and a warned-but-unarmed
+#: worker is merely a no-op on one board someone deliberately switched over.
+#: As the global lane that same warning would make *every* worker a no-op:
+#: able to read and post board comments, unable to edit a file or run a
+#: command, i.e. unable to do any task it is given.
+#:
+#: This is parity, not escalation. A native worker already runs with Hermes'
+#: full unattended tool surface, and the direct-lane worker is doing the same
+#: job in the same claimed workspace with stdin closed and no human to ask.
+#: Operators who sandbox differently set ``kanban.claude_cli_permission_mode``
+#: (or pass their own flag in ``claude_cli_extra_args``), and an explicit
+#: empty value restores the old warn-only behavior.
+CLAUDE_CLI_DEFAULT_PERMISSION_MODE = "bypassPermissions"
 
 #: Minimum seconds between two direct-lane ``claude`` process *startups* on
 #: this Hermes root. See :func:`_claude_cli_spawn_gate`.
@@ -10391,29 +10444,47 @@ def _load_kanban_config() -> dict:
 
 
 def resolve_worker_executor(kanban_cfg: Optional[dict] = None) -> str:
-    """Return the configured worker executor lane.
+    """Return the worker executor lane for every dispatcher-spawned worker.
 
-    Reads ``kanban.worker_executor`` from ``config.yaml``. Anything other
-    than an explicit claude-cli spelling resolves to the native Hermes lane,
-    so the direct-CLI path is strictly opt-in. An unrecognized value is a
-    config typo, not an instruction: it is logged loudly and the native
-    default is used (a typo must never silently change how workers bill).
+    Precedence: ``$HERMES_KANBAN_WORKER_EXECUTOR`` → ``kanban.worker_executor``
+    → :data:`DEFAULT_WORKER_EXECUTOR` (the direct Claude CLI).
+
+    Global on purpose — not per-board or per-profile. The provider routing
+    this replaces was not profile-specific, so a per-profile opt-out would
+    leave exactly the boards that wedge hardest still wedging.
+
+    An unrecognized value is a config typo, not an instruction: it is logged
+    loudly and the *default* is used. Note the direction — a typo falls
+    forward to the direct lane, never back onto the native provider stack.
+    Silently restoring the failure mode this lane exists to remove would be
+    the worst possible reading of a misspelling.
     """
+    env_raw = os.environ.get(ENV_WORKER_EXECUTOR)
+    if env_raw and env_raw.strip():
+        resolved = _WORKER_EXECUTOR_ALIASES.get(env_raw.strip().lower())
+        if resolved is not None:
+            return resolved
+        _log.warning(
+            "kanban worker: unknown %s=%r — using %r.",
+            ENV_WORKER_EXECUTOR, env_raw, DEFAULT_WORKER_EXECUTOR,
+        )
+        return DEFAULT_WORKER_EXECUTOR
+
     if kanban_cfg is None:
         kanban_cfg = _load_kanban_config()
     raw = (kanban_cfg or {}).get("worker_executor")
-    if raw is None:
-        return WORKER_EXECUTOR_HERMES
+    if raw is None or not str(raw).strip():
+        return DEFAULT_WORKER_EXECUTOR
     key = str(raw).strip().lower()
     resolved = _WORKER_EXECUTOR_ALIASES.get(key)
     if resolved is None:
         _log.warning(
             "kanban worker: unknown kanban.worker_executor=%r — using %r. "
             "Valid values: %r, %r.",
-            raw, WORKER_EXECUTOR_HERMES,
+            raw, DEFAULT_WORKER_EXECUTOR,
             WORKER_EXECUTOR_HERMES, WORKER_EXECUTOR_CLAUDE_CLI,
         )
-        return WORKER_EXECUTOR_HERMES
+        return DEFAULT_WORKER_EXECUTOR
     return resolved
 
 
@@ -10465,6 +10536,10 @@ def _apply_claude_cli_env(env: dict) -> list[str]:
     for name in CLAUDE_CLI_STRIPPED_ENV_VARS:
         if env.pop(name, None) is not None:
             stripped.append(name)
+    env[ENV_ACTIVE_EXECUTOR] = WORKER_EXECUTOR_CLAUDE_CLI
+    # stdin is already /dev/null; this covers the other way a detached worker
+    # hangs forever — git blocking on a credential prompt nobody can answer.
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
     return stripped
 
 
@@ -10527,6 +10602,53 @@ def _claude_cli_extra_args(kanban_cfg: Optional[dict] = None) -> list[str]:
                 "entry %r.", item,
             )
     return args
+
+
+def _claude_cli_permission_mode(kanban_cfg: Optional[dict] = None) -> str:
+    """Return the ``--permission-mode`` for a direct-lane worker.
+
+    Empty string means "add nothing" — an explicit operator opt-out, distinct
+    from an unset key, which takes
+    :data:`CLAUDE_CLI_DEFAULT_PERMISSION_MODE`.
+    """
+    if kanban_cfg is None:
+        kanban_cfg = _load_kanban_config()
+    raw = (kanban_cfg or {}).get("claude_cli_permission_mode")
+    if raw is None:
+        return CLAUDE_CLI_DEFAULT_PERMISSION_MODE
+    return str(raw).strip()
+
+
+def _claude_cli_goal_mode_prompt(task: Task) -> str:
+    """Return the self-judge section for a goal-mode card, or ``""``.
+
+    Hermes' Ralph-style goal loop lives in cli.py's quiet branch and has no
+    host-CLI equivalent. While this lane was opt-in, the spawn refused a
+    goal-mode card outright: correct then, because the alternative was one
+    unjudged pass that looks like success to whoever asked for goal mode.
+
+    As the global lane, refusing would fail every goal card on every board
+    instead. So the judge step becomes the worker's own, stated explicitly in
+    the prompt — the one thing that must not happen is a goal card quietly
+    degrading into a single unjudged pass, and naming it is what prevents
+    that. The turn budget is passed through as a soft bound.
+    """
+    if not task.goal_mode:
+        return ""
+    budget = ""
+    if task.goal_max_turns is not None:
+        try:
+            budget = f" Keep it under about {int(task.goal_max_turns)} rounds."
+        except (TypeError, ValueError):
+            budget = ""
+    return (
+        "\n\nGOAL MODE: this card describes an outcome, not a checklist. There is "
+        "no external judge loop on this run — you are the judge. Before you "
+        "complete, re-read the card's success criteria and verify your work "
+        f"against each one, iterating until they actually hold.{budget} If you "
+        "cannot satisfy them, block with what is missing rather than completing "
+        "on a partial result."
+    )
 
 
 def _claude_cli_worker_prompt(task: Task, workspace: str) -> str:
@@ -10597,6 +10719,7 @@ def _claude_cli_worker_prompt(task: Task, workspace: str) -> str:
         "board rows are durable. The board, profile, and workspace are already "
         "pinned in your environment; do not pass --board and do not edit the "
         "board database directly."
+        + _claude_cli_goal_mode_prompt(task)
     )
 
 
@@ -10606,18 +10729,6 @@ def _build_claude_cli_worker_command(
     kanban_cfg: Optional[dict] = None,
 ) -> list[str]:
     """Build the full ``claude -p ...`` argv for a direct-CLI worker."""
-    if task.goal_mode:
-        # The Ralph-style goal loop lives in cli.py's quiet branch, so it has
-        # no equivalent here. Running a single pass instead would look like a
-        # success to the CLI and like an unjudged, silently-downgraded run to
-        # whoever asked for goal mode. Refuse: the spawn failure is recorded
-        # against the task and surfaces to a human after `failure_limit`.
-        raise RuntimeError(
-            f"kanban task {task.id} has goal_mode enabled, which the "
-            f"{WORKER_EXECUTOR_CLAUDE_CLI!r} executor does not implement (the "
-            "goal judge loop is a Hermes CLI feature). Clear goal_mode on the "
-            f"task or run it on the {WORKER_EXECUTOR_HERMES!r} executor."
-        )
     cmd = _resolve_claude_cli_argv(kanban_cfg)
     model = _claude_cli_model_arg(task, kanban_cfg)
     if model:
@@ -10626,17 +10737,24 @@ def _build_claude_cli_worker_command(
     if not any(
         arg.split("=", 1)[0] in _CLAUDE_CLI_PERMISSION_FLAGS for arg in extra
     ):
-        # Not fatal — a read-only investigation task is a legitimate use — but
-        # it is the single most common reason this lane "does nothing".
-        _log.warning(
-            "kanban worker %s: no permission flag in kanban.claude_cli_extra_args, "
-            "so `claude -p` runs in its default ask-a-human permission mode. The "
-            "worker can still report on the board (those commands are granted "
-            "explicitly) but cannot edit files or run any other command. Note that "
-            "`--permission-mode acceptEdits` covers file edits only, NOT Bash — a "
-            "task whose work needs to run commands needs a broader mode.",
-            task.id,
-        )
+        mode = _claude_cli_permission_mode(kanban_cfg)
+        if mode:
+            cmd.extend(["--permission-mode", mode])
+        else:
+            # Explicitly disabled. A read-only investigation lane is a
+            # legitimate setup, but it is also the single most common reason
+            # this lane "does nothing", so it stays loud.
+            _log.warning(
+                "kanban worker %s: kanban.claude_cli_permission_mode is empty and "
+                "no permission flag is set in kanban.claude_cli_extra_args, so "
+                "`claude -p` runs in its default ask-a-human permission mode. The "
+                "worker can still report on the board (those commands are granted "
+                "explicitly) but cannot edit files or run any other command. Note "
+                "that `--permission-mode acceptEdits` covers file edits only, NOT "
+                "Bash — a task whose work needs to run commands needs a broader "
+                "mode.",
+                task.id,
+            )
     # Always last, and always merged rather than appended as a second flag:
     # without these the worker cannot run its own lifecycle commands.
     cmd.extend(_merge_allowed_tools(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10301,6 +10301,592 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+# ---------------------------------------------------------------------------
+# Worker executor selection (native Hermes vs. direct Claude Code CLI)
+# ---------------------------------------------------------------------------
+
+#: Default lane. ``hermes -p <profile> chat -q`` — the native provider stack.
+WORKER_EXECUTOR_HERMES = "hermes"
+#: Opt-in lane. Runs the Claude Code CLI (``claude -p``) directly so the worker
+#: uses the operator's own interactive Claude subscription instead of the
+#: native ``provider=anthropic`` adapter's third-party/extra-usage credits.
+WORKER_EXECUTOR_CLAUDE_CLI = "claude_cli"
+
+_WORKER_EXECUTOR_ALIASES = {
+    "": WORKER_EXECUTOR_HERMES,
+    "hermes": WORKER_EXECUTOR_HERMES,
+    "native": WORKER_EXECUTOR_HERMES,
+    "claude": WORKER_EXECUTOR_CLAUDE_CLI,
+    "claude_cli": WORKER_EXECUTOR_CLAUDE_CLI,
+    "claude-cli": WORKER_EXECUTOR_CLAUDE_CLI,
+    "claude_code": WORKER_EXECUTOR_CLAUDE_CLI,
+    "claude-code": WORKER_EXECUTOR_CLAUDE_CLI,
+}
+
+#: Credential-routing env vars dropped from a ``claude_cli`` worker's env.
+#:
+#: ``CLAUDE_CONFIG_DIR`` is the important one: the dispatcher (or the desktop
+#: app that launched it) may point it at a Hermes-managed config directory,
+#: which is exactly the lane that reports extra-usage exhaustion. Dropping it
+#: is the ``env -u CLAUDE_CONFIG_DIR claude -p`` behavior that works today —
+#: the child then reads the operator's normal ``~/.claude`` store itself. We
+#: never read, copy, decrypt, or re-write that store here, so no token ever
+#: transits the dispatcher, the board DB, argv, or a log file.
+#:
+#: The ``ANTHROPIC_*`` entries keep an inherited API key / gateway override
+#: from silently redirecting the run onto metered API billing (or a proxy)
+#: when the whole point of this lane is the subscription. The
+#: ``CLAUDE_CODE_USE_*`` entries are the same class: they move the run onto a
+#: Bedrock / Vertex account's billing instead.
+CLAUDE_CLI_STRIPPED_ENV_VARS = (
+    "CLAUDE_CONFIG_DIR",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+)
+
+#: Argv flags that grant a ``claude -p`` worker the ability to act. Without one
+#: of these the CLI runs in its default (ask-a-human) permission mode, and a
+#: worker with no TTY can only read and talk — it will never edit a file or run
+#: a command. We do NOT add one implicitly (silently escalating a worker's
+#: privileges is not ours to do); we warn so the operator sees why the lane
+#: appears to no-op.
+_CLAUDE_CLI_PERMISSION_FLAGS = (
+    "--permission-mode",
+    "--dangerously-skip-permissions",
+    "--allow-dangerously-skip-permissions",
+    "--allowedTools",
+    "--allowed-tools",
+    "--settings",
+)
+
+#: Minimum seconds between two direct-lane ``claude`` process *startups* on
+#: this Hermes root. See :func:`_claude_cli_spawn_gate`.
+CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS = 2.0
+
+#: How long a spawn waits for the stagger lock before proceeding without it.
+#: Bounded on purpose: a stuck holder must never stall the whole board.
+_CLAUDE_CLI_SPAWN_LOCK_TIMEOUT_SECONDS = 30.0
+_CLAUDE_CLI_SPAWN_LOCK_POLL_SECONDS = 0.05
+
+
+def _load_kanban_config() -> dict:
+    """Return a private copy of the ``kanban:`` block of ``config.yaml``.
+
+    Uses the read-only loader and copies the result: this runs on the
+    dispatcher's spawn path, so it must neither pay for a deepcopy of the
+    whole config nor hand a caller a handle on the shared cache. Never
+    raises — an unreadable config falls back to the native defaults.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        block = load_config_readonly().get("kanban")
+        return dict(block) if isinstance(block, dict) else {}
+    except Exception as exc:  # pragma: no cover - config read is best-effort
+        _log.debug("kanban worker: config.yaml unreadable (%s)", exc)
+        return {}
+
+
+def resolve_worker_executor(kanban_cfg: Optional[dict] = None) -> str:
+    """Return the configured worker executor lane.
+
+    Reads ``kanban.worker_executor`` from ``config.yaml``. Anything other
+    than an explicit claude-cli spelling resolves to the native Hermes lane,
+    so the direct-CLI path is strictly opt-in. An unrecognized value is a
+    config typo, not an instruction: it is logged loudly and the native
+    default is used (a typo must never silently change how workers bill).
+    """
+    if kanban_cfg is None:
+        kanban_cfg = _load_kanban_config()
+    raw = (kanban_cfg or {}).get("worker_executor")
+    if raw is None:
+        return WORKER_EXECUTOR_HERMES
+    key = str(raw).strip().lower()
+    resolved = _WORKER_EXECUTOR_ALIASES.get(key)
+    if resolved is None:
+        _log.warning(
+            "kanban worker: unknown kanban.worker_executor=%r — using %r. "
+            "Valid values: %r, %r.",
+            raw, WORKER_EXECUTOR_HERMES,
+            WORKER_EXECUTOR_HERMES, WORKER_EXECUTOR_CLAUDE_CLI,
+        )
+        return WORKER_EXECUTOR_HERMES
+    return resolved
+
+
+def _resolve_claude_cli_argv(kanban_cfg: Optional[dict] = None) -> list[str]:
+    """Resolve the Claude Code CLI invocation as argv parts for ``Popen``.
+
+    ``kanban.claude_cli_bin`` overrides the executable; path-like values are
+    used as-is (absolutized), bare names go through ``PATH`` with the same
+    no-cwd lookup ``_resolve_hermes_argv`` uses. Raises ``RuntimeError`` with
+    an actionable message when the CLI is not installed — the operator asked
+    for this lane explicitly, so a missing binary is a hard error and never a
+    silent downgrade to the native provider.
+    """
+    import shutil
+
+    configured = str((kanban_cfg or {}).get("claude_cli_bin") or "").strip()
+    candidate = configured or "claude"
+    if _looks_like_path(candidate):
+        resolved = os.path.abspath(os.path.expanduser(candidate))
+        if not os.path.isfile(resolved):
+            raise RuntimeError(
+                f"kanban.worker_executor={WORKER_EXECUTOR_CLAUDE_CLI!r} but the "
+                f"configured kanban.claude_cli_bin={candidate!r} does not exist. "
+                "Fix the path or switch kanban.worker_executor back to "
+                f"{WORKER_EXECUTOR_HERMES!r}."
+            )
+        return [resolved]
+    found = _safe_which_no_cwd(candidate) if _IS_WINDOWS else shutil.which(candidate)
+    if not found:
+        raise RuntimeError(
+            f"kanban.worker_executor={WORKER_EXECUTOR_CLAUDE_CLI!r} but "
+            f"{candidate!r} was not found on the dispatcher's PATH. Install the "
+            "Claude Code CLI, set kanban.claude_cli_bin to its absolute path, or "
+            f"switch kanban.worker_executor back to {WORKER_EXECUTOR_HERMES!r}."
+        )
+    return [os.path.abspath(found)]
+
+
+def _apply_claude_cli_env(env: dict) -> list[str]:
+    """Strip credential-routing vars from a direct-CLI worker's env.
+
+    Mutates ``env`` in place (it is already a private copy owned by the
+    caller) and returns the names actually removed, for the diagnostics
+    header. Everything else — board / profile / tenant / task / workspace
+    pins, TUI suppression, terminal timeouts — is left exactly as the native
+    lane built it, so board isolation is identical across executors.
+    """
+    stripped = []
+    for name in CLAUDE_CLI_STRIPPED_ENV_VARS:
+        if env.pop(name, None) is not None:
+            stripped.append(name)
+    return stripped
+
+
+def _claude_cli_model_arg(task: Task, kanban_cfg: Optional[dict] = None) -> Optional[str]:
+    """Return the ``--model`` value for a direct-CLI worker, if any.
+
+    A task-level override only applies when it actually names a Claude model
+    on the Anthropic lane; Hermes model ids for other providers are
+    meaningless to the Claude CLI, so they are dropped with an explicit
+    warning rather than passed through to fail at startup.
+    """
+    override = (task.model_override or "").strip()
+    provider = (task.provider_override or "").strip().lower()
+    if override:
+        if provider in ("", "anthropic", "claude") and override.lower().startswith("claude"):
+            return override
+        _log.warning(
+            "kanban worker %s: model_override=%r (provider=%r) is not a Claude "
+            "model — ignoring it on the %s executor.",
+            task.id, override, task.provider_override, WORKER_EXECUTOR_CLAUDE_CLI,
+        )
+    configured = str((kanban_cfg or {}).get("claude_cli_model") or "").strip()
+    return configured or None
+
+
+def _claude_cli_extra_args(kanban_cfg: Optional[dict] = None) -> list[str]:
+    """Return operator-supplied extra argv for ``claude`` (e.g. permission mode).
+
+    Accepts a YAML list; a bare string is split with ``shlex`` so a
+    hand-written single-line value still works. Non-string entries are
+    dropped with a warning rather than crashing the dispatcher tick.
+    """
+    raw = (kanban_cfg or {}).get("claude_cli_extra_args")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        import shlex
+
+        try:
+            return shlex.split(raw)
+        except ValueError as exc:
+            _log.warning(
+                "kanban worker: kanban.claude_cli_extra_args=%r is not parseable "
+                "(%s) — ignoring it.", raw, exc,
+            )
+            return []
+    if not isinstance(raw, (list, tuple)):
+        _log.warning(
+            "kanban worker: kanban.claude_cli_extra_args must be a list or "
+            "string, got %s — ignoring it.", type(raw).__name__,
+        )
+        return []
+    args = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            args.append(item)
+        elif item is not None:
+            _log.warning(
+                "kanban worker: dropping non-string kanban.claude_cli_extra_args "
+                "entry %r.", item,
+            )
+    return args
+
+
+def _claude_cli_worker_prompt(task: Task, workspace: str) -> str:
+    """Build the self-contained worker prompt for the direct-CLI lane.
+
+    The native lane sends ``work kanban task <id>`` and relies on the
+    ``kanban_*`` model tools plus ``KANBAN_GUIDANCE`` in the system prompt.
+    The Claude CLI has neither, so the protocol is stated inline and the
+    lifecycle transitions go through the ``hermes kanban`` subcommands, which
+    read the same board pins already present in the worker's env.
+
+    The ``hermes`` invocation is resolved here rather than written literally:
+    the dispatcher may be running from a venv whose console-script shim is not
+    on the child's ``PATH``, in which case a bare ``hermes kanban complete``
+    would fail and the worker would exit without ever closing its task. The
+    same ``_resolve_hermes_argv`` the native lane launches with is embedded, so
+    the two lanes agree on which Hermes the worker reports to.
+
+    Every flag below is real (see ``hermes_cli.kanban``'s parsers): ``block``
+    takes its reason as a *positional* with an optional ``--kind``, and
+    ``complete`` takes ``--result``. Inventing a flag here would strand the
+    worker at the end of a successful run.
+
+    Argument *order* matters as much as the flag names. ``block``'s reason is
+    ``nargs="*"``, and on Python 3.11 (the pinned runtime) a nested subparser
+    will not accept a trailing positional that follows an optional: ``block
+    <id> --kind needs_input "why"`` exits 2 with "unrecognized arguments",
+    while ``block <id> "why" --kind needs_input`` parses. Newer CPythons
+    accept both, which is exactly how this hides in local testing —
+    ``test_every_prompted_command_parses`` runs these through the real parser.
+    """
+    import shlex
+
+    hermes = shlex.join(_resolve_hermes_argv())
+    return (
+        "You are a Hermes kanban worker running as a direct Claude Code CLI "
+        "process (not a native Hermes agent), so you have no kanban_* tools — "
+        "you drive the board with the shell commands below.\n"
+        f"\nTask id: {task.id}\nWorkspace: {workspace}\n"
+        f"\nProtocol — run these exact commands (`{hermes}` is already "
+        "resolved for this machine; use it verbatim):\n"
+        f"1. `{hermes} kanban show {task.id}` first, and treat it as ground "
+        "truth: it has the title, body, parent handoffs, and comment thread.\n"
+        f"2. Do the work inside {workspace}. Do not modify files outside it "
+        "unless the task explicitly says to.\n"
+        f"3. Run `{hermes} kanban heartbeat {task.id}` every few minutes of "
+        "work. It is how the dispatcher tells a working worker apart from a "
+        "wedged one. Record anything worth keeping with "
+        f"`{hermes} kanban comment {task.id} \"<note>\"`.\n"
+        "4. If you need a human decision you cannot infer, stop and block — "
+        "do not guess:\n"
+        f"   `{hermes} kanban block {task.id} \"<why>\" --kind needs_input`\n"
+        "   (`--kind capability` for a missing tool/permission, "
+        "`--kind dependency` when waiting on another task.) The reason is a "
+        "positional argument — there is no --reason flag — and it must come "
+        "before --kind, or argparse will reject the command.\n"
+        "5. When done, post the structured result as a comment, then:\n"
+        f"   `{hermes} kanban complete {task.id} --result \"<1-3 sentences "
+        "naming concrete artifacts>\"`\n"
+        "   For a code change that still needs human review, comment the "
+        f"details and run `{hermes} kanban block {task.id} "
+        "\"review-required: <one-line summary>\" --kind needs_input` "
+        "instead of completing.\n"
+        "6. Exactly one of `complete` or `block` must run before you exit. "
+        "Exiting without either is a protocol violation and the dispatcher "
+        "will record the attempt as a crash.\n"
+        "\nNever put secrets, tokens, or raw PII in a comment or result — "
+        "board rows are durable. The board, profile, and workspace are already "
+        "pinned in your environment; do not pass --board and do not edit the "
+        "board database directly."
+    )
+
+
+def _build_claude_cli_worker_command(
+    task: Task,
+    workspace: str,
+    kanban_cfg: Optional[dict] = None,
+) -> list[str]:
+    """Build the full ``claude -p ...`` argv for a direct-CLI worker."""
+    if task.goal_mode:
+        # The Ralph-style goal loop lives in cli.py's quiet branch, so it has
+        # no equivalent here. Running a single pass instead would look like a
+        # success to the CLI and like an unjudged, silently-downgraded run to
+        # whoever asked for goal mode. Refuse: the spawn failure is recorded
+        # against the task and surfaces to a human after `failure_limit`.
+        raise RuntimeError(
+            f"kanban task {task.id} has goal_mode enabled, which the "
+            f"{WORKER_EXECUTOR_CLAUDE_CLI!r} executor does not implement (the "
+            "goal judge loop is a Hermes CLI feature). Clear goal_mode on the "
+            f"task or run it on the {WORKER_EXECUTOR_HERMES!r} executor."
+        )
+    cmd = _resolve_claude_cli_argv(kanban_cfg)
+    model = _claude_cli_model_arg(task, kanban_cfg)
+    if model:
+        cmd.extend(["--model", model])
+    extra = _claude_cli_extra_args(kanban_cfg)
+    if not any(
+        arg.split("=", 1)[0] in _CLAUDE_CLI_PERMISSION_FLAGS for arg in extra
+    ):
+        # Not fatal — a read-only investigation task is a legitimate use — but
+        # it is the single most common reason this lane "does nothing".
+        _log.warning(
+            "kanban worker %s: no permission flag in kanban.claude_cli_extra_args, "
+            "so `claude -p` runs in its default ask-a-human permission mode. The "
+            "worker can still report on the board (those commands are granted "
+            "explicitly) but cannot edit files or run any other command. Note that "
+            "`--permission-mode acceptEdits` covers file edits only, NOT Bash — a "
+            "task whose work needs to run commands needs a broader mode.",
+            task.id,
+        )
+    # Always last, and always merged rather than appended as a second flag:
+    # without these the worker cannot run its own lifecycle commands.
+    cmd.extend(_merge_allowed_tools(
+        extra, _claude_cli_board_tool_grants(_resolve_hermes_argv())
+    ))
+    # `-p` (print / non-interactive) is a boolean flag; the prompt is the
+    # CLI's positional argument. Keeping the pair last is load-bearing:
+    # `--allowedTools` and several other CLI flags are variadic, and a
+    # variadic run only stops at the next option-looking token. Verified: with
+    # the prompt trailing `--allowedTools <rule>`, the CLI consumes the prompt
+    # as another rule and exits "Input must be provided...".
+    cmd.extend(["-p", _claude_cli_worker_prompt(task, workspace)])
+    return cmd
+
+
+#: The `hermes kanban` subcommands the worker protocol prompt tells a
+#: direct-lane worker to run. Nothing else is granted.
+_CLAUDE_CLI_PROTOCOL_SUBCOMMANDS = (
+    "show", "heartbeat", "comment", "block", "complete",
+)
+
+
+def _claude_cli_board_tool_grants(hermes_argv: list[str]) -> list[str]:
+    """Return least-privilege ``--allowedTools`` rules for the board protocol.
+
+    A direct-lane worker drives its whole lifecycle through ``hermes kanban``
+    shell commands, and ``claude -p`` denies Bash by default — including under
+    ``--permission-mode acceptEdits``, which covers file edits only. Without a
+    grant the worker cannot run ``show`` (so it never learns its task) and
+    cannot run ``complete``/``block`` (so it strands the task and the
+    dispatcher records a protocol violation). Verified end-to-end: an
+    ``acceptEdits`` worker reported every ``hermes`` call auto-denied.
+
+    So the grant is not a convenience — it is the minimum required for the
+    contract the prompt asks the worker to fulfill, and it is scoped to
+    exactly the five subcommands that contract names. Whatever permissions the
+    task's actual *work* needs remain the operator's explicit choice via
+    ``kanban.claude_cli_extra_args``; this grants no general Bash, no Edit, and
+    no Write.
+    """
+    import shlex
+
+    hermes = shlex.join(hermes_argv)
+    return [
+        f"Bash({hermes} kanban {sub}:*)"
+        for sub in _CLAUDE_CLI_PROTOCOL_SUBCOMMANDS
+    ]
+
+
+def _merge_allowed_tools(extra: list[str], grants: list[str]) -> list[str]:
+    """Append ``grants`` to ``extra``'s ``--allowedTools`` run, or add one.
+
+    ``--allowedTools`` is variadic, and passing the flag twice makes the
+    second occurrence win — silently dropping the operator's list. So when
+    they already supplied one, the grants are appended to that same run
+    instead of being added as a second flag.
+    """
+    aliases = ("--allowedTools", "--allowed-tools")
+    out = list(extra)
+    for idx, arg in enumerate(out):
+        name = arg.split("=", 1)[0]
+        if name not in aliases:
+            continue
+        if "=" in arg:
+            # Normalize `--allowedTools=A` into flag + value so the grants can
+            # follow as further values of the same variadic flag.
+            out[idx : idx + 1] = [name, arg.split("=", 1)[1]]
+        # The variadic run ends at the next option-looking token.
+        end = idx + 1
+        while end < len(out) and not out[end].startswith("-"):
+            end += 1
+        return out[:end] + grants + out[end:]
+    return out + ["--allowedTools", *grants]
+
+
+def _claude_cli_spawn_stagger_seconds(kanban_cfg: Optional[dict] = None) -> float:
+    """Resolve ``kanban.claude_cli_spawn_stagger_seconds`` (never raises)."""
+    raw = (kanban_cfg or {}).get("claude_cli_spawn_stagger_seconds")
+    if raw is None:
+        return CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        _log.warning(
+            "kanban worker: kanban.claude_cli_spawn_stagger_seconds=%r is not a "
+            "number — using %.1fs.", raw, CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS,
+        )
+        return CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS
+    # Clamp: a negative value is a typo, and an unbounded one would let a
+    # single config line stall every dispatcher tick.
+    return max(0.0, min(value, 60.0))
+
+
+@contextlib.contextmanager
+def _claude_cli_spawn_gate(kanban_cfg: Optional[dict] = None):
+    """Serialize direct-lane ``claude`` process *startups* on this Hermes root.
+
+    What this fixes, precisely: several ``claude`` processes booting at the
+    same instant race on the shared, per-user ``~/.claude`` state they each
+    read and rewrite at startup (config file, session index, cache). That
+    startup window is the one that produces a truncated config and an
+    interactive session that suddenly asks the operator to log in again. This
+    gate holds a cross-process lock and enforces a minimum interval between
+    startups, so at most one direct-lane worker is in that window at a time.
+
+    What this does NOT do, and cannot: it does not serialize anything *inside*
+    Anthropic's CLI after startup — an OAuth refresh performed mid-run by two
+    long-lived workers is the CLI's own concurrency to manage, not Hermes'.
+    Hermes never reads or writes that store, so it has nothing to lock. Bound
+    real concurrency with ``kanban.max_in_progress_per_profile`` if that
+    matters for your setup.
+
+    A lock that cannot be acquired within
+    ``_CLAUDE_CLI_SPAWN_LOCK_TIMEOUT_SECONDS`` is abandoned and the spawn
+    proceeds: a stuck holder must degrade this to "unstaggered", never to
+    "the board stops dispatching".
+    """
+    stagger = _claude_cli_spawn_stagger_seconds(kanban_cfg)
+    # Per-Hermes-root, not per-board: the contended resource is the operator's
+    # single ``~/.claude`` store, which every board under this root shares.
+    lock_path = kanban_home() / "kanban" / "claude-cli-spawn.lock"
+    handle = None
+    acquired = False
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+", encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - unwritable kanban root
+        _log.debug("kanban worker: spawn gate unavailable (%s)", exc)
+        yield
+        return
+    try:
+        deadline = time.monotonic() + _CLAUDE_CLI_SPAWN_LOCK_TIMEOUT_SECONDS
+        while True:
+            try:
+                if _IS_WINDOWS:
+                    import msvcrt
+
+                    handle.seek(0)
+                    getattr(msvcrt, "locking")(
+                        handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+                    )
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_CLAUDE_CLI_SPAWN_LOCK_POLL_SECONDS)
+        if not acquired:
+            _log.warning(
+                "kanban worker: claude spawn gate %s not acquired within %.0fs — "
+                "spawning without the startup stagger.",
+                lock_path, _CLAUDE_CLI_SPAWN_LOCK_TIMEOUT_SECONDS,
+            )
+            yield
+            return
+        if stagger > 0:
+            # Wall clock, not monotonic: the previous startup was another
+            # process. A clock jump can only make this wait shorter or clamp
+            # it to `stagger` — it can never wait longer than one interval.
+            try:
+                handle.seek(0)
+                last = float((handle.read() or "0").strip() or 0.0)
+            except (OSError, ValueError):
+                last = 0.0
+            wait = min(stagger, stagger - (time.time() - last))
+            if wait > 0:
+                time.sleep(wait)
+        try:
+            handle.seek(0)
+            handle.truncate()
+            handle.write(f"{time.time():.3f}")
+            handle.flush()
+        except OSError as exc:  # pragma: no cover - best-effort bookkeeping
+            _log.debug("kanban worker: spawn gate stamp failed (%s)", exc)
+        yield
+    finally:
+        try:
+            if acquired:
+                if _IS_WINDOWS:
+                    import msvcrt
+
+                    handle.seek(0)
+                    getattr(msvcrt, "locking")(
+                        handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                    )
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:  # pragma: no cover - unlock is best-effort
+            pass
+        finally:
+            handle.close()
+
+
+def _build_hermes_worker_command(task: Task, env: dict, prompt: str) -> list[str]:
+    """Build the native ``hermes -p <profile> chat -q ...`` worker argv."""
+    cmd = [
+        *_resolve_hermes_argv(),
+        "-p", env["HERMES_PROFILE"],
+        "--cli",
+        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
+        # so they see that profile's shell-hook allowlist instead of the
+        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
+        # profile-local worker sessions still register configured hooks.
+        "--accept-hooks",
+    ]
+    # Per-task force-loaded skills. Each name goes in its own
+    # `--skills X` pair rather than a single comma-joined arg: the CLI
+    # accepts both forms (action='append' + comma-split), but
+    # per-name pairs are easier to read in `ps` output and avoid any
+    # quoting ambiguity if a skill name ever contains unusual chars.
+    if task.skills:
+        for sk in task.skills:
+            if sk:
+                cmd.extend(["--skills", sk])
+    if task.model_override:
+        cmd.extend(["-m", task.model_override])
+        # Pin the provider too when the override names one, so the worker
+        # resolves the model against the intended backend instead of the
+        # profile's configured provider (mixing model X with provider Y is
+        # the classic mis-set that stalls a board).
+        if task.provider_override:
+            cmd.extend(["--provider", task.provider_override])
+    # Per-task thinking depth. Independent of the model override — a task can
+    # run the profile's own model at a different depth — so this is its own
+    # branch, not a nested one.
+    if task.reasoning_effort:
+        cmd.extend(["--reasoning", task.reasoning_effort])
+    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    if worker_toolsets:
+        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+    cmd.extend([
+        "chat",
+        "-q", prompt,
+    ])
+    if task.goal_mode:
+        # Goal-mode workers must take the fully-quiet single-query path:
+        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
+        # cli.py's quiet branch. Without -Q the worker gets exactly one
+        # turn, prints text, exits rc=0, and the dispatcher records a
+        # protocol violation (incident 2026-06-09 t_d9cbe312).
+        cmd.append("-Q")
+    return cmd
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10318,6 +10904,14 @@ def _default_spawn(
     ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
     vars all resolve to the same board the dispatcher claimed the task
     from. Workers cannot accidentally see other boards.
+
+    The command the child runs depends on ``kanban.worker_executor``
+    (see :func:`resolve_worker_executor`). The default is the native
+    ``hermes`` lane; ``claude_cli`` runs the Claude Code CLI directly. Both
+    lanes get the identical environment — same board / profile / tenant /
+    task / workspace pins, same TUI suppression, same log file, same PID
+    return for crash detection — so only the argv and the credential
+    routing differ.
     """
     import subprocess
     if not task.assignee:
@@ -10433,52 +11027,21 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
-    cmd = [
-        *_resolve_hermes_argv(),
-        "-p", profile_arg,
-        "--cli",
-        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
-        # so they see that profile's shell-hook allowlist instead of the
-        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
-        # profile-local worker sessions still register configured hooks.
-        "--accept-hooks",
-    ]
-    # Per-task force-loaded skills. Each name goes in its own
-    # `--skills X` pair rather than a single comma-joined arg: the CLI
-    # accepts both forms (action='append' + comma-split), but
-    # per-name pairs are easier to read in `ps` output and avoid any
-    # quoting ambiguity if a skill name ever contains unusual chars.
-    if task.skills:
-        for sk in task.skills:
-            if sk:
-                cmd.extend(["--skills", sk])
-    if task.model_override:
-        cmd.extend(["-m", task.model_override])
-        # Pin the provider too when the override names one, so the worker
-        # resolves the model against the intended backend instead of the
-        # profile's configured provider (mixing model X with provider Y is
-        # the classic mis-set that stalls a board).
-        if task.provider_override:
-            cmd.extend(["--provider", task.provider_override])
-    # Per-task thinking depth. Independent of the model override — a task can
-    # run the profile's own model at a different depth — so this is its own
-    # branch, not a nested one.
-    if task.reasoning_effort:
-        cmd.extend(["--reasoning", task.reasoning_effort])
-    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
-    if worker_toolsets:
-        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
+    # Executor selection. The native lane is the default and the only one a
+    # board gets without an explicit `kanban.worker_executor` opt-in; when the
+    # operator does select the direct Claude Code CLI, a missing binary is a
+    # hard error rather than a quiet downgrade back onto the native provider.
+    kanban_cfg = _load_kanban_config()
+    executor = resolve_worker_executor(kanban_cfg)
+    stripped_env_vars: list[str] = []
+    if executor == WORKER_EXECUTOR_CLAUDE_CLI:
+        # Build first: every unsupported-configuration error raises out of
+        # here, and it must do so before `env` is mutated or a log file is
+        # opened, so a rejected spawn leaves nothing half-applied behind.
+        cmd = _build_claude_cli_worker_command(task, workspace, kanban_cfg)
+        stripped_env_vars = _apply_claude_cli_env(env)
+    else:
+        cmd = _build_hermes_worker_command(task, env, prompt)
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and
@@ -10491,23 +11054,66 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
-    try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+    if executor == WORKER_EXECUTOR_CLAUDE_CLI:
+        # Explicit diagnostics: which lane ran, which binary, which flags, and
+        # which credential vars were dropped. Only flag *names* are recorded —
+        # never a flag's value (an operator could put a secret in `--settings`)
+        # and never the prompt or an env value, so nothing sensitive can reach
+        # this durable log.
+        flag_names = ",".join(
+            arg.split("=", 1)[0] for arg in cmd[1:] if arg.startswith("-")
+        ) or "-"
+        stripped_names = ",".join(stripped_env_vars) or "-"
+        _log.info(
+            "kanban worker %s: executor=%s bin=%s flags=%s stripped_env=%s",
+            task.id, executor, cmd[0], flag_names, stripped_names,
         )
-    except FileNotFoundError:
+        try:
+            log_f.write(
+                f"[kanban] executor={executor} bin={cmd[0]} "
+                f"board={resolved_board} profile={profile_arg} "
+                f"flags={flag_names} stripped_env={stripped_names}\n".encode()
+            )
+            log_f.flush()
+        except OSError as exc:  # pragma: no cover - log write is best-effort
+            _log.debug("kanban worker %s: log header write failed (%s)", task.id, exc)
+    try:
+        with (
+            _claude_cli_spawn_gate(kanban_cfg)
+            if executor == WORKER_EXECUTOR_CLAUDE_CLI
+            else contextlib.nullcontext()
+        ):
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+                cmd,
+                cwd=workspace if os.path.isdir(workspace) else None,
+                stdin=subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            )
+    except OSError as exc:
+        # FileNotFoundError (missing binary) and PermissionError (present but
+        # not executable — the usual npm-install-owned-by-root case) both land
+        # here. Naming the selected lane and the exact path is the difference
+        # between a one-line fix and an afternoon: the message a `hermes` user
+        # expects is useless when they opted into the Claude CLI.
         log_f.close()
+        if executor == WORKER_EXECUTOR_CLAUDE_CLI:
+            raise RuntimeError(
+                f"Claude Code CLI ({cmd[0]!r}) could not be executed for kanban "
+                f"task {task.id}: {exc}. kanban.worker_executor is set to "
+                f"{WORKER_EXECUTOR_CLAUDE_CLI!r}; install the CLI, fix "
+                "kanban.claude_cli_bin, or switch back to "
+                f"{WORKER_EXECUTOR_HERMES!r}."
+            ) from exc
+        if not isinstance(exc, FileNotFoundError):
+            raise
         raise RuntimeError(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
+        ) from exc
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10415,6 +10415,49 @@ _CLAUDE_CLI_PERMISSION_FLAGS = (
 #: empty value restores the old warn-only behavior.
 CLAUDE_CLI_DEFAULT_PERMISSION_MODE = "bypassPermissions"
 
+#: Effort levels the host Claude Code CLI's ``--effort`` accepts. Verified
+#: against ``claude --help`` (2.1.x): "Effort level for the current session
+#: (low, medium, high, xhigh, max)". Hermes' own
+#: :data:`hermes_constants.VALID_REASONING_EFFORTS` is a superset, so a card
+#: pinned to a Hermes-only level has to be translated rather than forwarded —
+#: passing ``minimal`` straight through makes the CLI reject its own argv and
+#: the worker dies at startup with nothing on the board to explain why.
+CLAUDE_CLI_SUPPORTED_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+
+#: Translation for the Hermes levels the CLI has no exact word for. Each maps
+#: to the nearest level in the *same direction* — never silently upward into
+#: more thinking than the card asked for.
+#:
+#: ``none`` (thinking disabled) has no CLI equivalent at all: ``--effort``
+#: cannot turn reasoning off. It maps to the floor and warns, because the
+#: honest alternatives are both worse — omitting the flag would inherit
+#: whatever the session default is (possibly *more* thinking than "none"
+#: requested), and refusing the card would strand it.
+_CLAUDE_CLI_EFFORT_ALIASES = {
+    "minimal": "low",
+    "ultra": "max",
+    "none": "low",
+}
+
+#: ``--effort`` applied when a card pins no ``reasoning_effort`` of its own.
+#:
+#: Medium is the deliberate house default, not an inherited one. Every kanban
+#: worker and reviewer on this lane runs Opus at medium unless a card says
+#: otherwise, and stating it explicitly in argv is what makes that verifiable
+#: from the worker log instead of an assumption about the CLI's own default.
+#: Operators set ``kanban.claude_cli_effort`` to change it, or to the empty
+#: string to add no flag at all and let the host CLI choose.
+CLAUDE_CLI_DEFAULT_EFFORT = "medium"
+
+#: Argv flags that already pin the run's effort. If the operator passed one in
+#: ``claude_cli_extra_args`` we add none of our own — same precedence rule the
+#: permission-mode flags follow.
+_CLAUDE_CLI_EFFORT_FLAGS = ("--effort",)
+
+#: Sentinel for :func:`_build_claude_cli_worker_command`'s ``effort`` kwarg.
+#: Distinct from ``None``, which is a real value meaning "add no flag".
+_EFFORT_UNSET = "\x00<unset>"
+
 #: Minimum seconds between two direct-lane ``claude`` process *startups* on
 #: this Hermes root. See :func:`_claude_cli_spawn_gate`.
 CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS = 2.0
@@ -10619,6 +10662,62 @@ def _claude_cli_permission_mode(kanban_cfg: Optional[dict] = None) -> str:
     return str(raw).strip()
 
 
+def _claude_cli_effort_arg(
+    task: Task, kanban_cfg: Optional[dict] = None
+) -> Optional[str]:
+    """Return the ``--effort`` level for a direct-CLI worker, or ``None``.
+
+    Precedence: the card's own ``reasoning_effort`` first, then
+    ``kanban.claude_cli_effort``, then :data:`CLAUDE_CLI_DEFAULT_EFFORT`.
+    ``None`` means "add no flag" and is reachable only by an operator setting
+    the config key to an explicit empty string.
+
+    Both sources are validated against what the host CLI actually accepts.
+    Hermes-only levels are translated via :data:`_CLAUDE_CLI_EFFORT_ALIASES`;
+    anything else falls forward to the default with a warning rather than
+    being handed to the CLI, because an unknown ``--effort`` value is not a
+    degraded run — it is argv the CLI rejects outright, so the worker never
+    starts and the card looks like an unexplained crash.
+    """
+    pinned = str(task.reasoning_effort or "").strip().lower()
+    if pinned:
+        mapped = _CLAUDE_CLI_EFFORT_ALIASES.get(pinned, pinned)
+        if mapped in CLAUDE_CLI_SUPPORTED_EFFORTS:
+            if mapped != pinned:
+                _log.warning(
+                    "kanban worker %s: reasoning_effort=%r has no %s equivalent "
+                    "— running at --effort %s (the nearest level the host CLI "
+                    "accepts).",
+                    task.id, pinned, WORKER_EXECUTOR_CLAUDE_CLI, mapped,
+                )
+            return mapped
+        _log.warning(
+            "kanban worker %s: reasoning_effort=%r is not a level the host "
+            "Claude CLI accepts (%s) — falling back to the configured lane "
+            "default instead of passing argv the CLI would reject.",
+            task.id, pinned, ", ".join(CLAUDE_CLI_SUPPORTED_EFFORTS),
+        )
+
+    if kanban_cfg is None:
+        kanban_cfg = _load_kanban_config()
+    raw = (kanban_cfg or {}).get("claude_cli_effort")
+    if raw is None:
+        return CLAUDE_CLI_DEFAULT_EFFORT
+    configured = str(raw).strip().lower()
+    if not configured:
+        # Explicit operator opt-out: let the host CLI pick its own effort.
+        return None
+    mapped = _CLAUDE_CLI_EFFORT_ALIASES.get(configured, configured)
+    if mapped in CLAUDE_CLI_SUPPORTED_EFFORTS:
+        return mapped
+    _log.warning(
+        "kanban worker: kanban.claude_cli_effort=%r is not one of %s — using "
+        "%r.", raw, ", ".join(CLAUDE_CLI_SUPPORTED_EFFORTS),
+        CLAUDE_CLI_DEFAULT_EFFORT,
+    )
+    return CLAUDE_CLI_DEFAULT_EFFORT
+
+
 def _claude_cli_goal_mode_prompt(task: Task) -> str:
     """Return the self-judge section for a goal-mode card, or ``""``.
 
@@ -10761,13 +10860,30 @@ def _build_claude_cli_worker_command(
     task: Task,
     workspace: str,
     kanban_cfg: Optional[dict] = None,
+    *,
+    effort: Optional[str] = _EFFORT_UNSET,
 ) -> list[str]:
-    """Build the full ``claude -p ...`` argv for a direct-CLI worker."""
+    """Build the full ``claude -p ...`` argv for a direct-CLI worker.
+
+    ``effort`` lets the caller resolve the level once and reuse it (the spawn
+    path also writes it to the worker log header). Left unset, the level is
+    resolved here; ``None`` means "add no ``--effort`` flag".
+    """
     cmd = _resolve_claude_cli_argv(kanban_cfg)
     model = _claude_cli_model_arg(task, kanban_cfg)
     if model:
         cmd.extend(["--model", model])
     extra = _claude_cli_extra_args(kanban_cfg)
+    # Per-task / lane thinking depth. Skipped entirely when the operator
+    # already pinned effort themselves in claude_cli_extra_args — passing
+    # --effort twice would leave which one wins up to the host CLI.
+    if not any(
+        arg.split("=", 1)[0] in _CLAUDE_CLI_EFFORT_FLAGS for arg in extra
+    ):
+        if effort is _EFFORT_UNSET:
+            effort = _claude_cli_effort_arg(task, kanban_cfg)
+        if effort:
+            cmd.extend(["--effort", effort])
     if not any(
         arg.split("=", 1)[0] in _CLAUDE_CLI_PERMISSION_FLAGS for arg in extra
     ):
@@ -11186,11 +11302,18 @@ def _default_spawn(
     kanban_cfg = _load_kanban_config()
     executor = resolve_worker_executor(kanban_cfg)
     stripped_env_vars: list[str] = []
+    resolved_effort: Optional[str] = None
     if executor == WORKER_EXECUTOR_CLAUDE_CLI:
+        # Resolved here rather than inside the builder so the same level that
+        # went into argv is the one the log header reports — no second call,
+        # no chance of the two disagreeing or the warnings firing twice.
+        resolved_effort = _claude_cli_effort_arg(task, kanban_cfg)
         # Build first: every unsupported-configuration error raises out of
         # here, and it must do so before `env` is mutated or a log file is
         # opened, so a rejected spawn leaves nothing half-applied behind.
-        cmd = _build_claude_cli_worker_command(task, workspace, kanban_cfg)
+        cmd = _build_claude_cli_worker_command(
+            task, workspace, kanban_cfg, effort=resolved_effort
+        )
         stripped_env_vars = _apply_claude_cli_env(env)
     else:
         cmd = _build_hermes_worker_command(task, env, prompt)
@@ -11216,15 +11339,32 @@ def _default_spawn(
             arg.split("=", 1)[0] for arg in cmd[1:] if arg.startswith("-")
         ) or "-"
         stripped_names = ",".join(stripped_env_vars) or "-"
+        # Effort is the one flag whose *value* is recorded, because "which
+        # depth did this worker actually run at" is unanswerable from names
+        # alone and is exactly what an operator audits this lane for. It is
+        # safe to record only because it came out of a closed allowlist
+        # (CLAUDE_CLI_SUPPORTED_EFFORTS) — an operator's own --effort in
+        # claude_cli_extra_args is arbitrary text, so that case is reported as
+        # `operator` and its value stays out of the log like every other one.
+        if "--effort" not in cmd:
+            effort_note = "-"
+        elif resolved_effort and cmd.count("--effort") == 1 and (
+            cmd[cmd.index("--effort") + 1] == resolved_effort
+        ):
+            effort_note = resolved_effort
+        else:
+            effort_note = "operator"
         _log.info(
-            "kanban worker %s: executor=%s bin=%s flags=%s stripped_env=%s",
-            task.id, executor, cmd[0], flag_names, stripped_names,
+            "kanban worker %s: executor=%s bin=%s flags=%s effort=%s "
+            "stripped_env=%s",
+            task.id, executor, cmd[0], flag_names, effort_note, stripped_names,
         )
         try:
             log_f.write(
                 f"[kanban] executor={executor} bin={cmd[0]} "
                 f"board={resolved_board} profile={profile_arg} "
-                f"flags={flag_names} stripped_env={stripped_names}\n".encode()
+                f"flags={flag_names} effort={effort_note} "
+                f"stripped_env={stripped_names}\n".encode()
             )
             log_f.flush()
         except OSError as exc:  # pragma: no cover - log write is best-effort

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10651,6 +10651,39 @@ def _claude_cli_goal_mode_prompt(task: Task) -> str:
     )
 
 
+def _claude_cli_skills_prompt(task: Task) -> str:
+    """Return the force-loaded-skills section for the prompt, or ``""``.
+
+    The native lane forwards ``task.skills`` as ``--skills X`` pairs, which
+    Hermes resolves into the worker's system prompt before the first turn.
+    The host CLI has no equivalent flag, so while this lane was opt-in the
+    field was simply dropped and documented as native-only.
+
+    That became load-bearing when the review handoff lifecycle landed: a
+    claimed review card has ``sdlc-review`` force-appended to ``task.skills``
+    because that skill *is* the review logic (AC verification, merge). With
+    this lane global, dropping the field would hand every review card a
+    worker that does not know how to review — and it would look like a
+    normal run, not a misconfiguration.
+
+    Naming the skills in the prompt is the closest honest equivalent: the
+    worker loads them itself via its Skill tool. That is weaker than the
+    native lane's guarantee — it is an instruction, not an injection, so a
+    worker can ignore it where a native worker could not.
+    """
+    names = [str(sk).strip() for sk in (task.skills or []) if str(sk).strip()]
+    if not names:
+        return ""
+    listed = ", ".join(f"`{n}`" for n in names)
+    return (
+        f"\n\nRequired skills: {listed}. Load each one with your Skill tool "
+        "before you start, and follow it — these carry the procedure this "
+        "card is expected to follow, not background reading. If a skill will "
+        "not load, block with `--kind capability` naming it rather than "
+        "improvising the procedure yourself."
+    )
+
+
 def _claude_cli_worker_prompt(task: Task, workspace: str) -> str:
     """Build the self-contained worker prompt for the direct-CLI lane.
 
@@ -10719,6 +10752,7 @@ def _claude_cli_worker_prompt(task: Task, workspace: str) -> str:
         "board rows are durable. The board, profile, and workspace are already "
         "pinned in your environment; do not pass --board and do not edit the "
         "board database directly."
+        + _claude_cli_skills_prompt(task)
         + _claude_cli_goal_mode_prompt(task)
     )
 
@@ -11024,12 +11058,12 @@ def _default_spawn(
     from. Workers cannot accidentally see other boards.
 
     The command the child runs depends on ``kanban.worker_executor``
-    (see :func:`resolve_worker_executor`). The default is the native
-    ``hermes`` lane; ``claude_cli`` runs the Claude Code CLI directly. Both
-    lanes get the identical environment — same board / profile / tenant /
-    task / workspace pins, same TUI suppression, same log file, same PID
-    return for crash detection — so only the argv and the credential
-    routing differ.
+    (see :func:`resolve_worker_executor`). The default is ``claude_cli``,
+    which runs the Claude Code CLI directly; ``hermes``/``native`` is the
+    deliberate opt-out back onto the provider stack. Both lanes get the
+    identical environment — same board / profile / tenant / task / workspace
+    pins, same TUI suppression, same log file, same PID return for crash
+    detection — so only the argv and the credential routing differ.
     """
     import subprocess
     if not task.assignee:
@@ -11145,10 +11179,10 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
-    # Executor selection. The native lane is the default and the only one a
-    # board gets without an explicit `kanban.worker_executor` opt-in; when the
-    # operator does select the direct Claude Code CLI, a missing binary is a
-    # hard error rather than a quiet downgrade back onto the native provider.
+    # Executor selection. The direct Claude Code CLI is the default for every
+    # board and profile; `kanban.worker_executor: native` is the deliberate
+    # opt-out. A missing binary on the direct lane is a hard error rather than
+    # a quiet downgrade back onto the native provider pool.
     kanban_cfg = _load_kanban_config()
     executor = resolve_worker_executor(kanban_cfg)
     stripped_env_vars: list[str] = []

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -97,5 +97,14 @@ sessions still have zero `kanban_*` schema footprint unless configured.
 - **Isolation:** board is the hard boundary (workers get
   `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
   within a board for workspace-path + memory-key isolation.
+- **Worker executor:** workers run `hermes -p <profile> chat -q` by
+  default. `kanban.worker_executor: claude_cli` opts a board into
+  running the Claude Code CLI directly instead — for operators whose
+  `provider: anthropic` credentials are an extra-usage pool that
+  exhausts separately from their interactive subscription. Opt-in
+  only, no silent fallback either way, identical env/board pinning
+  across lanes, and the CLI lane has no `kanban_*` tools (it drives
+  the board with `hermes kanban` shell commands, which are granted to
+  it explicitly). See `docs/kanban/worker-executor.md`.
 
 User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -97,14 +97,17 @@ sessions still have zero `kanban_*` schema footprint unless configured.
 - **Isolation:** board is the hard boundary (workers get
   `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
   within a board for workspace-path + memory-key isolation.
-- **Worker executor:** workers run `hermes -p <profile> chat -q` by
-  default. `kanban.worker_executor: claude_cli` opts a board into
-  running the Claude Code CLI directly instead — for operators whose
-  `provider: anthropic` credentials are an extra-usage pool that
-  exhausts separately from their interactive subscription. Opt-in
-  only, no silent fallback either way, identical env/board pinning
-  across lanes, and the CLI lane has no `kanban_*` tools (it drives
-  the board with `hermes kanban` shell commands, which are granted to
-  it explicitly). See `docs/kanban/worker-executor.md`.
+- **Worker executor:** workers run the Claude Code CLI directly
+  (`claude -p`) under the operator's host login, on every board and
+  every profile — the native `hermes -p <profile> chat -q` lane bills
+  `provider: anthropic` credentials that on some setups are an
+  extra-usage pool exhausting separately from the interactive
+  subscription, which wedges boards invisibly.
+  `kanban.worker_executor: native` is the deliberate opt-out. No
+  silent fallback either way (an unresolvable CLI is a hard error; an
+  unknown value falls forward to the direct lane), identical env/board
+  pinning across lanes, and the CLI lane has no `kanban_*` tools (it
+  drives the board with `hermes kanban` shell commands, which are
+  granted to it explicitly). See `docs/kanban/worker-executor.md`.
 
 User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban

--- a/tests/hermes_cli/test_kanban_claude_executor_e2e.py
+++ b/tests/hermes_cli/test_kanban_claude_executor_e2e.py
@@ -1,0 +1,321 @@
+"""End-to-end: a disposable board driven through the real dispatcher path.
+
+Everything here is real except the model. A disposable board is created on
+disk, a real card is created on it, and a real `dispatch_once` tick claims the
+card and calls the real `_default_spawn`, which resolves the real
+`claude_cli` executor and launches a real detached subprocess.
+
+The subprocess is a stand-in for the host Claude Code CLI: it accepts the same
+argv shape, then walks the lifecycle protocol out of the prompt it was handed
+using real `hermes kanban …` subcommands against the real board DB. That is
+the part worth proving. Whether an LLM chooses to follow the protocol is a
+model-quality question; whether the protocol *works* — whether the env pins
+reach the child, whether `hermes kanban complete` from inside that child lands
+on the right card of the right board — is what breaks in production, and it is
+exercised for real here.
+
+Covers the full claim -> show -> workspace operation -> heartbeat/comment ->
+complete round trip named in the board-recovery acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+from hermes_cli import kanban_db as kb
+
+
+BOARD = "e2e-claude-exec"
+
+# Provider credentials seeded into the dispatcher's env. The worker asserts it
+# cannot see any of them; if the strip regresses, the E2E fails on a real
+# subprocess rather than on a mocked env dict.
+LEAK_CANARIES = {
+    "CLAUDE_CONFIG_DIR": "/tmp/hermes-managed-claude",
+    "ANTHROPIC_API_KEY": "sk-ant-e2e-canary",
+    "ANTHROPIC_BASE_URL": "https://proxy.invalid",
+    "OPENAI_API_KEY": "sk-oai-e2e-canary",
+    "CODEX_HOME": "/tmp/codex-e2e",
+}
+
+
+# The fake host CLI. Mirrors `claude -p [--model …] [--effort …]
+# [--permission-mode …] "<prompt>"`: flags first, prompt as the trailing
+# positional. It then executes the lifecycle the prompt describes.
+FAKE_CLAUDE = '''#!{python}
+"""Stand-in for the host Claude Code CLI: runs the kanban worker protocol."""
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+RECEIPT = Path(os.environ["E2E_RECEIPT"])
+receipt = {{"argv": sys.argv[1:], "steps": [], "errors": []}}
+
+
+def fail(msg):
+    receipt["errors"].append(msg)
+    RECEIPT.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    sys.exit(3)
+
+
+# --- argv contract -----------------------------------------------------
+if "-p" not in sys.argv:
+    fail("missing -p (print/non-interactive mode)")
+prompt = sys.argv[-1]
+if prompt.startswith("-"):
+    fail("prompt is not the trailing positional: %r" % prompt)
+receipt["prompt"] = prompt
+
+# --- environment contract ----------------------------------------------
+for canary in {canaries!r}:
+    if canary in os.environ:
+        fail("provider credential leaked into the worker env: %s" % canary)
+
+task_id = os.environ.get("HERMES_KANBAN_TASK")
+if not task_id:
+    fail("HERMES_KANBAN_TASK not pinned")
+receipt["env"] = {{
+    key: os.environ.get(key)
+    for key in (
+        "HERMES_KANBAN_TASK", "HERMES_KANBAN_BOARD", "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACE", "HERMES_KANBAN_CLAIM_LOCK",
+        "HERMES_PROFILE", "HERMES_TENANT", "HERMES_SESSION_SOURCE",
+        "HERMES_KANBAN_EXECUTOR", "GIT_TERMINAL_PROMPT", "TERMINAL_CWD",
+    )
+}}
+receipt["cwd"] = os.getcwd()
+
+# The prompt tells the worker which Hermes invocation to drive the board with.
+# Parsed out of the prompt rather than assumed, because that resolution is
+# exactly what breaks when `hermes` is not on a detached worker's PATH.
+match = re.search(r"`(.*?) kanban show " + re.escape(task_id) + r"`", prompt)
+if not match:
+    fail("prompt did not carry a `kanban show` command")
+hermes_cmd = shlex.split(match.group(1).strip())
+receipt["hermes_cmd"] = hermes_cmd
+
+
+def kanban(*args, check=True):
+    proc = subprocess.run(
+        hermes_cmd + ["kanban"] + list(args),
+        capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+    receipt["steps"].append({{
+        "args": list(args), "rc": proc.returncode,
+        "stdout": proc.stdout[-2000:], "stderr": proc.stderr[-2000:],
+    }})
+    if check and proc.returncode != 0:
+        fail("`kanban %s` exited %d: %s" % (" ".join(args), proc.returncode, proc.stderr[-500:]))
+    return proc
+
+
+# --- protocol ----------------------------------------------------------
+shown = kanban("show", task_id)
+if task_id not in shown.stdout:
+    fail("`kanban show` did not return this task")
+receipt["show_ok"] = True
+
+# Workspace operation: the claimed workspace is the cwd.
+artifact = Path(os.environ["HERMES_KANBAN_WORKSPACE"]) / "worker-artifact.txt"
+artifact.write_text("written by the direct Claude CLI worker\\n", encoding="utf-8")
+receipt["artifact"] = str(artifact)
+
+kanban("heartbeat", task_id, "--note", "e2e worker alive")
+kanban("comment", task_id, "direct-claude-cli worker did the thing")
+kanban("complete", task_id, "--result", "e2e complete via direct Claude CLI")
+
+receipt["ok"] = True
+RECEIPT.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+print("worker finished task %s" % task_id)
+'''
+
+
+@pytest.fixture
+def disposable_board(tmp_path, monkeypatch):
+    """A real board on disk under an isolated HERMES_HOME."""
+    home = tmp_path / "hermes_home"
+    (home / "profiles" / "integrator").mkdir(parents=True)
+    (home / "profiles" / "integrator" / "config.yaml").write_text(
+        "toolsets:\n  - kanban\n", encoding="utf-8"
+    )
+    home.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_WORKER_EXECUTOR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    kb._reset_path_cache_for_tests() if hasattr(kb, "_reset_path_cache_for_tests") else None
+
+    kb.create_board(BOARD, name="E2E direct Claude executor")
+    return home
+
+
+@pytest.fixture
+def fake_claude_on_path(tmp_path, monkeypatch):
+    """Install the stand-in host CLI as the only `claude` on PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    exe = bindir / "claude"
+    exe.write_text(
+        FAKE_CLAUDE.format(python=sys.executable, canaries=sorted(LEAK_CANARIES)),
+        encoding="utf-8",
+    )
+    exe.chmod(0o755)
+    # Only the fake bin dir plus the system essentials: a real `claude` or
+    # `hermes` on the developer's PATH must not be reachable from this test.
+    monkeypatch.setenv("PATH", os.pathsep.join([str(bindir), "/usr/bin", "/bin"]))
+    return exe
+
+
+def test_disposable_board_roundtrip_via_direct_claude_cli(
+    disposable_board, fake_claude_on_path, tmp_path, monkeypatch
+):
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("E2E_RECEIPT", str(receipt_path))
+    # The child re-enters the CLI as `python -m hermes_cli.main`; make sure it
+    # imports *this* worktree rather than an installed copy.
+    monkeypatch.setenv("PYTHONPATH", str(_WORKTREE))
+    for key, value in LEAK_CANARIES.items():
+        monkeypatch.setenv(key, value)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    conn = kb.connect(board=BOARD)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="E2E: direct Claude CLI worker",
+            body="Write the artifact, comment, and complete.",
+            assignee="integrator",
+            created_by="e2e",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+            tenant="e2e-tenant",
+        )
+
+        # --- the real dispatcher tick -----------------------------------
+        result = kb.dispatch_once(conn, board=BOARD, max_spawn=1)
+        # spawned is a list of (task_id, assignee, workspace) triples.
+        assert task_id in [row[0] for row in result.spawned], (
+            f"dispatcher did not spawn the card: {result!r}"
+        )
+
+        claimed = kb.get_task(conn, task_id)
+        assert claimed.status == "running"
+        assert claimed.worker_pid, "no worker PID recorded — crash detection would be blind"
+
+        # --- wait for the worker to finish the protocol ------------------
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            if receipt_path.exists():
+                try:
+                    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    receipt = None
+                if receipt is not None and (receipt.get("ok") or receipt.get("errors")):
+                    break
+            time.sleep(0.5)
+        else:
+            pytest.fail("worker did not finish within 120s")
+
+        assert receipt["errors"] == [], f"worker protocol failures: {receipt['errors']}"
+        assert receipt["ok"] is True
+
+        # --- worker-side observations ------------------------------------
+        env_seen = receipt["env"]
+        assert env_seen["HERMES_KANBAN_TASK"] == task_id
+        assert env_seen["HERMES_KANBAN_BOARD"] == BOARD
+        assert env_seen["HERMES_PROFILE"] == "integrator"
+        assert env_seen["HERMES_TENANT"] == "e2e-tenant"
+        assert env_seen["HERMES_SESSION_SOURCE"] == "kanban"
+        assert env_seen["HERMES_KANBAN_EXECUTOR"] == "claude_cli"
+        assert env_seen["GIT_TERMINAL_PROMPT"] == "0"
+        assert env_seen["HERMES_KANBAN_WORKSPACE"] == str(workspace)
+        assert Path(env_seen["HERMES_KANBAN_DB"]).name == "kanban.db"
+        assert BOARD in env_seen["HERMES_KANBAN_DB"]
+        assert receipt["cwd"] == str(workspace)
+        assert receipt["show_ok"] is True
+
+        # It really was the direct CLI, with a non-interactive permission mode.
+        argv = receipt["argv"]
+        assert "-p" in argv
+        assert "--permission-mode" in argv
+
+        # --- workspace operation ------------------------------------------
+        assert (workspace / "worker-artifact.txt").exists()
+
+        # --- board-side lifecycle -----------------------------------------
+        final = kb.get_task(conn, task_id)
+        assert final.status == "done", f"card not completed: {final.status}"
+        assert "direct Claude CLI" in (final.result or "")
+
+        bodies = " ".join(c.body for c in kb.list_comments(conn, task_id))
+        assert "direct-claude-cli worker did the thing" in bodies
+
+        kinds = {e.kind for e in kb.list_events(conn, task_id)}
+        assert "heartbeat" in kinds, f"no heartbeat recorded; kinds={sorted(kinds)}"
+        assert "completed" in kinds, f"no completion event; kinds={sorted(kinds)}"
+
+        # --- log observation ------------------------------------------------
+        log_path = kb.worker_logs_dir(board=BOARD) / f"{task_id}.log"
+        assert log_path.exists(), "no per-task worker log — `hermes kanban log` would be empty"
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        assert f"worker finished task {task_id}" in log_text
+        for secret in LEAK_CANARIES.values():
+            assert secret not in log_text, "a credential reached the task log"
+    finally:
+        conn.close()
+
+
+def test_dispatch_fails_loudly_without_the_host_cli(
+    disposable_board, tmp_path, monkeypatch
+):
+    """No `claude` on PATH must not silently fall back to a native worker."""
+    empty = tmp_path / "empty-bin"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", str(empty))
+
+    workspace = tmp_path / "workspace2"
+    workspace.mkdir()
+
+    conn = kb.connect(board=BOARD)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="E2E: missing host CLI",
+            assignee="integrator",
+            created_by="e2e",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        result = kb.dispatch_once(conn, board=BOARD, max_spawn=1)
+
+        assert not result.spawned, "a worker was spawned without the host CLI"
+        task = kb.get_task(conn, task_id)
+        assert task.status != "running"
+        # The failure is recorded as a spawn failure, not masked.
+        assert task.consecutive_failures >= 1
+        assert task.last_failure_error
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -703,7 +703,12 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
     We intercept Popen to capture the argv without actually spawning a
     hermes subprocess (which would hang trying to call an LLM).
+
+    Pinned to the native lane: `kanban.worker_executor` now defaults to the
+    direct host Claude CLI, whose argv has no `--skills` concept. The
+    no-auto-skill guarantee asserted here is a native-argv property.
     """
+    monkeypatch.setenv("HERMES_KANBAN_WORKER_EXECUTOR", "native")
     captured = {}
 
     class FakeProc:

--- a/tests/hermes_cli/test_kanban_worker_executor.py
+++ b/tests/hermes_cli/test_kanban_worker_executor.py
@@ -227,6 +227,7 @@ class TestResolveWorkerExecutor:
             "kanban.claude_cli_bin",
             "kanban.claude_cli_model",
             "kanban.claude_cli_permission_mode",
+            "kanban.claude_cli_effort",
             "kanban.claude_cli_extra_args",
             "kanban.claude_cli_spawn_stagger_seconds",
         ):
@@ -236,6 +237,269 @@ class TestResolveWorkerExecutor:
         from hermes_cli.config_defaults import DEFAULT_CONFIG
 
         assert DEFAULT_CONFIG["kanban"]["worker_executor"] == "claude_cli"
+
+
+# ---------------------------------------------------------------------------
+# Thinking depth (--effort)
+# ---------------------------------------------------------------------------
+
+def _effort_of(cmd):
+    """Return the ``--effort`` value in ``cmd``, or None if the flag is absent."""
+    assert cmd.count("--effort") <= 1, f"--effort passed twice: {cmd}"
+    if "--effort" not in cmd:
+        return None
+    return cmd[cmd.index("--effort") + 1]
+
+
+class TestWorkerEffort:
+    """Every direct-lane worker runs at an explicit, validated effort.
+
+    The house requirement is that a kanban worker/reviewer runs at *medium*
+    unless its card says otherwise, and that this is provable after the fact
+    rather than inherited from whatever default the host CLI happens to ship.
+    Two failure modes are guarded specifically:
+
+    * a card pinning a Hermes-only level (``minimal``/``ultra``/``none``) must
+      not have that word forwarded — ``claude --effort minimal`` is argv the
+      CLI rejects, so the worker would die at startup and the card would show
+      an unexplained ``spawn_failed``;
+    * the level must never be silently translated *upward* into more thinking
+      than the card asked for.
+    """
+
+    def test_default_worker_runs_at_medium(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) == "medium"
+
+    def test_config_default_is_medium(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["kanban"]["claude_cli_effort"] == "medium"
+
+    @pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+    def test_cli_supported_levels_are_forwarded_verbatim(
+        self, spawn_env, monkeypatch, level
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        kb._default_spawn(
+            _make_task(kb, reasoning_effort=level), str(spawn_env["workspace"])
+        )
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) == level
+
+    @pytest.mark.parametrize(
+        "pinned,expected",
+        [("minimal", "low"), ("ultra", "max"), ("none", "low")],
+    )
+    def test_hermes_only_levels_are_translated_not_forwarded(
+        self, spawn_env, monkeypatch, caplog, pinned, expected
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(
+                _make_task(kb, reasoning_effort=pinned),
+                str(spawn_env["workspace"]),
+            )
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert _effort_of(cmd) == expected
+        # The untranslated word must not survive anywhere in argv.
+        assert pinned not in cmd
+        # A translation is a real behavior change; it stays visible.
+        assert pinned in caplog.text
+
+    def test_translation_never_increases_thinking(self, spawn_env, monkeypatch):
+        """`minimal` and `none` must land at the floor, never at the default.
+
+        Falling back to the lane default here would be the quiet bug: a card
+        that explicitly asked for the least thinking would get medium, and
+        nothing in argv or the log would say so.
+        """
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        for pinned in ("minimal", "none"):
+            kb._default_spawn(
+                _make_task(kb, reasoning_effort=pinned),
+                str(spawn_env["workspace"]),
+            )
+            assert _effort_of(spawn_env["captured"]["cmd"]) == "low"
+
+    def test_every_hermes_effort_level_maps_to_something_the_cli_accepts(self):
+        """No Hermes level may reach the CLI untranslated.
+
+        Pinned as a test because the two vocabularies are maintained in
+        different files: a new level added to VALID_REASONING_EFFORTS with no
+        entry here would ship a card status that kills its own worker.
+        """
+        from hermes_cli import kanban_db as kb
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        for level in (*VALID_REASONING_EFFORTS, "none"):
+            mapped = kb._CLAUDE_CLI_EFFORT_ALIASES.get(level, level)
+            assert mapped in kb.CLAUDE_CLI_SUPPORTED_EFFORTS, level
+
+    def test_supported_levels_match_the_host_cli(self):
+        """Verified against `claude --help` (2.1.x): low|medium|high|xhigh|max."""
+        from hermes_cli import kanban_db as kb
+
+        assert kb.CLAUDE_CLI_SUPPORTED_EFFORTS == (
+            "low", "medium", "high", "xhigh", "max",
+        )
+
+    def test_configured_lane_default_applies_when_the_card_pins_nothing(
+        self, spawn_env, monkeypatch
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="high")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) == "high"
+
+    def test_card_pin_beats_the_configured_lane_default(
+        self, spawn_env, monkeypatch
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="low")
+
+        kb._default_spawn(
+            _make_task(kb, reasoning_effort="high"), str(spawn_env["workspace"])
+        )
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) == "high"
+
+    def test_empty_config_value_adds_no_flag(self, spawn_env, monkeypatch):
+        """An explicit "" is the operator opt-out: let the host CLI choose."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) is None
+
+    def test_unrecognized_config_value_falls_forward_to_medium(
+        self, spawn_env, monkeypatch, caplog
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="bogus")
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert _effort_of(spawn_env["captured"]["cmd"]) == "medium"
+        assert "bogus" not in spawn_env["captured"]["cmd"]
+        assert "claude_cli_effort" in caplog.text
+
+    def test_unrecognized_card_pin_falls_back_to_the_lane_default(
+        self, spawn_env, monkeypatch, caplog
+    ):
+        """A typo'd card level must not become argv the CLI rejects."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="high")
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(
+                _make_task(kb, reasoning_effort="medum"),
+                str(spawn_env["workspace"]),
+            )
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert _effort_of(cmd) == "high"
+        assert "medum" not in cmd
+        assert "medum" in caplog.text
+
+    def test_operator_effort_flag_is_not_overridden(self, spawn_env, monkeypatch):
+        """Passing --effort twice would leave the winner up to the host CLI."""
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            claude_cli_effort="medium",
+            claude_cli_extra_args=["--effort", "max"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd.count("--effort") == 1
+        assert _effort_of(cmd) == "max"
+
+    def test_native_lane_still_uses_hermes_reasoning_flag(
+        self, spawn_env, monkeypatch
+    ):
+        """The opt-out lane is untouched: --reasoning, not --effort."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="native")
+
+        kb._default_spawn(
+            _make_task(kb, reasoning_effort="medium"),
+            str(spawn_env["workspace"]),
+        )
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert "--effort" not in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "medium"
+
+    def test_log_header_records_the_resolved_effort(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        kb._default_spawn(
+            _make_task(kb, reasoning_effort="high"), str(spawn_env["workspace"])
+        )
+
+        text = (kb.worker_logs_dir() / "t_exec1.log").read_text(encoding="utf-8")
+        assert "effort=high" in text
+
+    def test_log_header_withholds_an_operator_supplied_effort_value(
+        self, spawn_env, monkeypatch
+    ):
+        """Only allowlisted values are printed; operator argv is arbitrary text.
+
+        The header's whole safety property is "flag names, never values". The
+        resolved effort is the one exception and it is safe because it comes
+        from a closed set — an operator's own value is not, so it is reported
+        as `operator` rather than quoted.
+        """
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            claude_cli_extra_args=["--effort", "sk-not-really-an-effort"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        text = (kb.worker_logs_dir() / "t_exec1.log").read_text(encoding="utf-8")
+        assert "effort=operator" in text
+        assert "sk-not-really-an-effort" not in text
+
+    def test_log_header_marks_the_no_flag_case(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, claude_cli_effort="")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        text = (kb.worker_logs_dir() / "t_exec1.log").read_text(encoding="utf-8")
+        assert "effort=-" in text
+
+    def test_effort_flag_precedes_the_trailing_prompt(self, spawn_env, monkeypatch):
+        """`-p <prompt>` stays last — --allowedTools is variadic (see argv order)."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd[-2] == "-p"
+        assert cmd.index("--effort") < cmd.index("-p")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_worker_executor.py
+++ b/tests/hermes_cli/test_kanban_worker_executor.py
@@ -1,0 +1,741 @@
+"""Kanban worker executor selection: native Hermes vs. direct Claude Code CLI.
+
+The dispatcher's ``_default_spawn`` runs ``hermes -p <profile> chat -q`` by
+default. When ``kanban.worker_executor: claude_cli`` is set in ``config.yaml``,
+it must instead run the Claude Code CLI directly (the lane that works against
+an interactive Claude subscription), while keeping every worker invariant the
+native lane has: board/profile/tenant/task/workspace env pins, the per-task log
+file, and the returned PID the dispatcher uses for crash detection.
+
+Contracts asserted here:
+
+* default (no config) → native ``hermes`` argv; claude never invoked
+* opt-in → ``claude -p <prompt>`` argv, no ``hermes chat`` anywhere
+* the env is identical across lanes for every board-isolation pin
+* the direct lane drops ``CLAUDE_CONFIG_DIR`` and inherited Anthropic API
+  credentials, and never copies a token into argv or the log
+* a missing/unusable ``claude`` binary is a hard error, never a silent
+  downgrade back onto the native provider
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+def _make_task(kb, **overrides):
+    task = kb.Task(
+        id="t_exec1",
+        title="executor test",
+        body=None,
+        assignee="elias",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant="acme",
+        current_run_id=7,
+    )
+    for key, value in overrides.items():
+        setattr(task, key, value)
+    return task
+
+
+@pytest.fixture
+def spawn_env(monkeypatch, tmp_path):
+    """Isolated HERMES_HOME + captured Popen, with both CLIs on a fake PATH."""
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(root / "kanban"))
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    claude_bin = bindir / "claude"
+    claude_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    claude_bin.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bindir))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured: dict = {}
+
+    class FakeProc:
+        pid = 4321
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        captured["cwd"] = kwargs.get("cwd")
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    return {
+        "kb": kb,
+        "root": root,
+        "captured": captured,
+        "workspace": workspace,
+        "claude_bin": claude_bin,
+    }
+
+
+def _select(monkeypatch, kb, **kanban_cfg):
+    """Point ``_load_kanban_config`` at an explicit kanban config block.
+
+    The startup stagger defaults to 0 here so the suite never sleeps; the
+    stagger itself is covered explicitly in ``TestSpawnGate``.
+    """
+    kanban_cfg.setdefault("claude_cli_spawn_stagger_seconds", 0)
+    monkeypatch.setattr(kb, "_load_kanban_config", lambda: dict(kanban_cfg))
+
+
+# ---------------------------------------------------------------------------
+# Executor resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveWorkerExecutor:
+    def test_default_is_native_hermes(self):
+        from hermes_cli import kanban_db as kb
+
+        assert kb.resolve_worker_executor({}) == kb.WORKER_EXECUTOR_HERMES
+        assert kb.resolve_worker_executor({"worker_executor": None}) == "hermes"
+        assert kb.resolve_worker_executor({"worker_executor": "hermes"}) == "hermes"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["claude_cli", "claude-cli", "claude", "claude_code", "CLAUDE_CLI", " claude_cli "],
+    )
+    def test_claude_spellings_opt_in(self, value):
+        from hermes_cli import kanban_db as kb
+
+        assert kb.resolve_worker_executor({"worker_executor": value}) == (
+            kb.WORKER_EXECUTOR_CLAUDE_CLI
+        )
+
+    def test_unknown_value_falls_back_to_native_with_warning(self, caplog):
+        from hermes_cli import kanban_db as kb
+
+        with caplog.at_level("WARNING"):
+            resolved = kb.resolve_worker_executor({"worker_executor": "gemini"})
+
+        assert resolved == kb.WORKER_EXECUTOR_HERMES
+        assert "worker_executor" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+class TestSpawnCommand:
+    def test_default_spawns_native_hermes_chat(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        pid = kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert pid == 4321
+        assert cmd[0] == "hermes"
+        assert cmd[1:3] == ["-p", "elias"]
+        assert "chat" in cmd
+        assert cmd[-2:] == ["-q", "work kanban task t_exec1"]
+        assert not any("claude" in part for part in cmd)
+
+    def test_selected_executor_spawns_claude_cli(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        pid = kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert pid == 4321
+        assert cmd[0] == str(spawn_env["claude_bin"])
+        assert cmd[-2] == "-p"
+        # Self-contained protocol prompt: the Claude CLI has no kanban_* tools
+        # and no KANBAN_GUIDANCE system prompt, so the task id, workspace, and
+        # lifecycle commands must be in the prompt itself.
+        prompt = cmd[-1]
+        assert "t_exec1" in prompt
+        assert str(spawn_env["workspace"]) in prompt
+        assert "hermes kanban complete t_exec1" in prompt
+        assert "chat" not in cmd
+        assert "-q" not in cmd
+
+    def test_goal_mode_refuses_instead_of_silently_downgrading(
+        self, spawn_env, monkeypatch
+    ):
+        """The goal judge loop is a Hermes CLI feature with no CLI equivalent.
+
+        Running a single pass would look like success to the CLI and like an
+        unjudged run to whoever asked for goal mode.
+        """
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        with pytest.raises(RuntimeError) as exc:
+            kb._default_spawn(_make_task(kb, goal_mode=True), str(spawn_env["workspace"]))
+
+        assert "goal_mode" in str(exc.value)
+        assert "cmd" not in spawn_env["captured"]
+
+    def test_missing_permission_flag_warns(self, spawn_env, monkeypatch, caplog):
+        """Default permission mode + no TTY = a worker that cannot act."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "permission" in caplog.text.lower()
+
+    def test_board_lifecycle_commands_are_granted(self, spawn_env, monkeypatch):
+        """`claude -p` denies Bash by default — including under acceptEdits,
+        which covers file edits only. Without an explicit grant the worker
+        cannot run `show` (never learns its task) or `complete`/`block`
+        (strands it). Verified end-to-end before this was added: every
+        `hermes` call was auto-denied.
+        """
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args=["--permission-mode", "acceptEdits"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert "--allowedTools" in cmd
+        rules = cmd[cmd.index("--allowedTools") + 1:cmd.index("-p")]
+        assert rules == [
+            "Bash(hermes kanban show:*)",
+            "Bash(hermes kanban heartbeat:*)",
+            "Bash(hermes kanban comment:*)",
+            "Bash(hermes kanban block:*)",
+            "Bash(hermes kanban complete:*)",
+        ]
+        # Least privilege: no general Bash, no Edit/Write handed out here.
+        assert "Bash" not in rules
+        assert not any(r in ("Edit", "Write") for r in rules)
+
+    def test_operator_allowed_tools_are_merged_not_clobbered(
+        self, spawn_env, monkeypatch
+    ):
+        """`--allowedTools` is variadic; a second occurrence would win and
+        silently drop the operator's list."""
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args=["--allowedTools", "Edit", "Write",
+                                   "--permission-mode", "acceptEdits"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd.count("--allowedTools") == 1
+        rules = cmd[cmd.index("--allowedTools") + 1:]
+        assert rules[:2] == ["Edit", "Write"]
+        assert "Bash(hermes kanban complete:*)" in rules
+        # The operator's own flags after the variadic run survive.
+        assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
+
+    def test_allowed_tools_equals_form_is_merged(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args=["--allowedTools=Edit"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert "--allowedTools=Edit" not in cmd
+        rules = cmd[cmd.index("--allowedTools") + 1:cmd.index("-p")]
+        assert rules[0] == "Edit"
+        assert "Bash(hermes kanban show:*)" in rules
+
+    def test_prompt_stays_after_the_variadic_run(self, spawn_env, monkeypatch):
+        """Regression: a prompt trailing a variadic flag is eaten as another
+        value — the CLI then exits "Input must be provided...". `-p` must
+        separate them."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd[-2] == "-p"
+        assert cmd.index("--allowedTools") < cmd.index("-p")
+        assert not cmd[-1].startswith("-")
+
+    def test_permission_flag_silences_the_warning(self, spawn_env, monkeypatch, caplog):
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args=["--permission-mode", "acceptEdits"],
+        )
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "permission" not in caplog.text.lower()
+
+    def test_claude_bin_and_extra_args_are_configurable(self, spawn_env, monkeypatch, tmp_path):
+        kb = spawn_env["kb"]
+        custom = tmp_path / "custom-claude"
+        custom.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        custom.chmod(0o755)
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_bin=str(custom),
+            claude_cli_extra_args=["--permission-mode", "acceptEdits"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd[0] == str(custom)
+        assert "--permission-mode" in cmd
+        assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
+        # `-p <prompt>` stays last so an extra arg can never split the pair.
+        assert cmd[-2] == "-p"
+
+    def test_extra_args_accept_a_single_string(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args="--permission-mode acceptEdits",
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
+
+    def test_claude_model_override_passes_through(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+        task = _make_task(kb, model_override="claude-opus-5")
+
+        kb._default_spawn(task, str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd[cmd.index("--model") + 1] == "claude-opus-5"
+
+    def test_non_claude_model_override_is_dropped_not_forwarded(
+        self, spawn_env, monkeypatch, caplog
+    ):
+        """A non-Anthropic model id is meaningless to the Claude CLI."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+        task = _make_task(kb, model_override="gpt-5.6-sol", provider_override="openai")
+
+        with caplog.at_level("WARNING"):
+            kb._default_spawn(task, str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert "--model" not in cmd
+        assert "gpt-5.6-sol" not in cmd
+        assert "gpt-5.6-sol" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle protocol: the prompt's commands must be real
+# ---------------------------------------------------------------------------
+
+def _prompt_for(kb, monkeypatch, workspace, **cfg):
+    captured = {}
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+
+        class P:
+            pid = 1
+
+        return P()
+
+    _select(monkeypatch, kb, worker_executor="claude_cli", **cfg)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    kb._default_spawn(_make_task(kb), str(workspace))
+    return captured["cmd"][-1]
+
+
+class TestLifecycleProtocol:
+    """The direct lane has no ``kanban_*`` tools, so the prompt's shell
+    commands *are* the lifecycle contract. A flag that does not exist strands
+    the worker at the end of an otherwise successful run — argparse exits 2 and
+    the task is never closed. So every command the prompt tells the worker to
+    run is parsed here against the real ``hermes kanban`` parser.
+    """
+
+    @staticmethod
+    def _kanban_parser():
+        import argparse
+
+        from hermes_cli import kanban as kanban_cli
+
+        root = argparse.ArgumentParser(prog="hermes")
+        subs = root.add_subparsers(dest="command")
+        kanban_cli.build_parser(subs)
+        return root
+
+    @staticmethod
+    def _commands_in(prompt):
+        """Backtick-quoted `<hermes> kanban ...` commands from the prompt."""
+        import re
+        import shlex
+
+        found = []
+        for span in re.findall(r"`([^`]+)`", prompt):
+            parts = shlex.split(span)
+            if len(parts) >= 2 and parts[1] == "kanban":
+                # Drop the resolved hermes invocation; keep `kanban ...`.
+                found.append(parts[1:])
+        return found
+
+    def test_every_prompted_command_parses(self, spawn_env, monkeypatch):
+        prompt = _prompt_for(
+            spawn_env["kb"], monkeypatch, spawn_env["workspace"]
+        )
+        parser = self._kanban_parser()
+        commands = self._commands_in(prompt)
+
+        # show / heartbeat / comment / block / complete
+        assert len(commands) >= 5, commands
+        for argv in commands:
+            # Placeholders are prose, not real values; substitute something
+            # concrete so only the *flags* are under test.
+            argv = [("done" if a.startswith("<") else a) for a in argv]
+            try:
+                parser.parse_args(argv)
+            except SystemExit:
+                pytest.fail(
+                    "the worker prompt tells the worker to run a command the "
+                    f"real `hermes kanban` parser rejects: {argv}"
+                )
+
+    def test_block_uses_positional_reason_before_kind(self, spawn_env, monkeypatch):
+        """Two regressions in one command.
+
+        `--reason` does not exist on `hermes kanban block`. And because the
+        reason is `nargs="*"`, on Python 3.11 a nested subparser rejects it
+        when it trails `--kind` — so the reason must come first.
+        """
+        prompt = _prompt_for(
+            spawn_env["kb"], monkeypatch, spawn_env["workspace"]
+        )
+        blocks = [c for c in self._commands_in(prompt) if c[:1] == ["kanban"]
+                  and len(c) > 1 and c[1] == "block"]
+
+        assert blocks, "the prompt must tell the worker how to block"
+        for argv in blocks:
+            assert "--reason" not in argv
+            assert "--kind" in argv
+            # reason positional sits between the task id and --kind
+            assert argv.index("--kind") > 3, argv
+
+    def test_complete_and_heartbeat_are_prompted(self, spawn_env, monkeypatch):
+        prompt = _prompt_for(
+            spawn_env["kb"], monkeypatch, spawn_env["workspace"]
+        )
+
+        assert "kanban complete t_exec1 --result" in prompt
+        # A direct-lane worker holds its claim on PID liveness; heartbeating is
+        # what restores the wedged-worker backstop on top of that.
+        assert "kanban heartbeat t_exec1" in prompt
+
+    def test_prompt_embeds_the_resolved_hermes_invocation(
+        self, spawn_env, monkeypatch, tmp_path
+    ):
+        """A bare `hermes` breaks when the dispatcher runs from a venv whose
+        console script is not on the child's PATH — the worker would then exit
+        without ever closing its task."""
+        kb = spawn_env["kb"]
+        venv_hermes = str(tmp_path / "venv" / "bin" / "hermes")
+        monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: [venv_hermes])
+
+        prompt = _prompt_for(kb, monkeypatch, spawn_env["workspace"])
+
+        assert f"{venv_hermes} kanban complete t_exec1" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Environment / board isolation parity
+# ---------------------------------------------------------------------------
+
+class TestWorkerEnv:
+    PINS = (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_WORKSPACE",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK",
+        "HERMES_PROFILE",
+        "HERMES_TENANT",
+        "HERMES_SESSION_SOURCE",
+    )
+
+    def _env_for(self, spawn_env, monkeypatch, **cfg):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, **cfg)
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+        return dict(spawn_env["captured"]["env"])
+
+    def test_board_and_identity_pins_match_across_executors(self, spawn_env, monkeypatch):
+        native = self._env_for(spawn_env, monkeypatch)
+        claude = self._env_for(spawn_env, monkeypatch, worker_executor="claude_cli")
+
+        for key in self.PINS:
+            assert key in native, key
+            assert claude[key] == native[key], key
+
+    def test_claude_lane_still_suppresses_the_tui(self, spawn_env, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI", "1")
+        env = self._env_for(spawn_env, monkeypatch, worker_executor="claude_cli")
+
+        assert "HERMES_TUI" not in env
+
+    def test_claude_lane_strips_credential_routing_vars(self, spawn_env, monkeypatch):
+        """`env -u CLAUDE_CONFIG_DIR` semantics, plus no metered-API fallback.
+
+        Dropping the vars is the whole mechanism: the child then reads the
+        operator's own ``~/.claude`` store itself. Nothing is copied here, so
+        no token can reach argv, the env, or the durable worker log.
+        """
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/hermes-managed-claude")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-secret")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.example")
+
+        env = self._env_for(spawn_env, monkeypatch, worker_executor="claude_cli")
+
+        for name in ("CLAUDE_CONFIG_DIR", "ANTHROPIC_API_KEY",
+                     "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"):
+            assert name not in env, name
+        # And no token got smuggled into the argv.
+        assert not any("sk-ant-secret" in part for part in spawn_env["captured"]["cmd"])
+
+    def test_native_lane_keeps_claude_config_dir(self, spawn_env, monkeypatch):
+        """The strip is scoped to the opt-in lane; the default is untouched."""
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/hermes-managed-claude")
+
+        env = self._env_for(spawn_env, monkeypatch)
+
+        assert env["CLAUDE_CONFIG_DIR"] == "/tmp/hermes-managed-claude"
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+class TestFailureHandling:
+    def test_missing_claude_binary_raises_instead_of_falling_back(
+        self, spawn_env, monkeypatch
+    ):
+        kb = spawn_env["kb"]
+        spawn_env["claude_bin"].unlink()
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        with pytest.raises(RuntimeError) as exc:
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "claude" in str(exc.value).lower()
+        assert "worker_executor" in str(exc.value)
+        # No silent downgrade: nothing was spawned at all.
+        assert "cmd" not in spawn_env["captured"]
+
+    def test_missing_configured_bin_path_raises(self, spawn_env, monkeypatch, tmp_path):
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_bin=str(tmp_path / "nope" / "claude"),
+        )
+
+        with pytest.raises(RuntimeError) as exc:
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "does not exist" in str(exc.value)
+        assert "cmd" not in spawn_env["captured"]
+
+    def test_exec_failure_reports_the_selected_executor(self, spawn_env, monkeypatch):
+        """A FileNotFoundError at Popen time must name the claude lane."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        def boom(*_args, **_kwargs):
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr(subprocess, "Popen", boom)
+
+        with pytest.raises(RuntimeError) as exc:
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "Claude Code CLI" in str(exc.value)
+
+    def test_non_executable_binary_reports_the_claude_lane(
+        self, spawn_env, monkeypatch
+    ):
+        """A present-but-not-executable CLI (npm install owned by root) raises
+        a PermissionError from Popen, not FileNotFoundError."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        def boom(*_args, **_kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "Popen", boom)
+
+        with pytest.raises(RuntimeError) as exc:
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "Claude Code CLI" in str(exc.value)
+        assert "Permission denied" in str(exc.value)
+
+    def test_native_lane_still_propagates_unrelated_oserrors(
+        self, spawn_env, monkeypatch
+    ):
+        """Broadening the native lane's except must not swallow real errors."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        def boom(*_args, **_kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "Popen", boom)
+
+        with pytest.raises(PermissionError):
+            kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+    def test_log_header_records_the_lane_without_secrets(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_extra_args=["--settings", '{"token": "sk-ant-in-a-flag"}'],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        log_path = kb.worker_logs_dir() / "t_exec1.log"
+        text = log_path.read_text(encoding="utf-8")
+        assert "executor=claude_cli" in text
+        assert "ANTHROPIC_API_KEY" in text  # the *name* of the stripped var
+        assert "sk-ant-secret" not in text  # never the value
+        assert "--settings" in text  # the *name* of the flag
+        assert "sk-ant-in-a-flag" not in text  # never the flag's value
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-startup gate on the shared ~/.claude store
+# ---------------------------------------------------------------------------
+
+class TestSpawnGate:
+    """Several `claude` processes booting at once interleave their writes to
+    the one per-user `~/.claude` store, which is how an operator's interactive
+    session ends up asking them to log in again. The gate serializes that
+    startup window; it does not (and cannot) serialize refreshes performed
+    inside Anthropic's CLI after startup.
+    """
+
+    def test_stagger_defaults_on_and_is_clamped(self):
+        from hermes_cli import kanban_db as kb
+
+        assert kb._claude_cli_spawn_stagger_seconds({}) == (
+            kb.CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS
+        )
+        assert kb._claude_cli_spawn_stagger_seconds(
+            {"claude_cli_spawn_stagger_seconds": -5}
+        ) == 0.0
+        assert kb._claude_cli_spawn_stagger_seconds(
+            {"claude_cli_spawn_stagger_seconds": 10_000}
+        ) == 60.0
+        # A typo must not crash a dispatcher tick.
+        assert kb._claude_cli_spawn_stagger_seconds(
+            {"claude_cli_spawn_stagger_seconds": "soon"}
+        ) == kb.CLAUDE_CLI_DEFAULT_SPAWN_STAGGER_SECONDS
+
+    def test_gate_is_held_across_the_spawn_and_stamps_the_lock(
+        self, spawn_env, monkeypatch
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        inside = {}
+
+        def fake_popen(cmd, *args, **kwargs):
+            lock = kb.kanban_home() / "kanban" / "claude-cli-spawn.lock"
+            inside["lock_exists"] = lock.exists()
+
+            class P:
+                pid = 99
+
+            return P()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert inside["lock_exists"] is True
+        lock = kb.kanban_home() / "kanban" / "claude-cli-spawn.lock"
+        assert float(lock.read_text(encoding="utf-8")) > 0
+
+    def test_second_startup_waits_out_the_stagger(self, spawn_env, monkeypatch):
+        """Back-to-back direct-lane spawns must not boot simultaneously."""
+        import time
+
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb,
+            worker_executor="claude_cli",
+            claude_cli_spawn_stagger_seconds=0.4,
+        )
+
+        starts = []
+
+        def fake_popen(cmd, *args, **kwargs):
+            starts.append(time.monotonic())
+
+            class P:
+                pid = 7
+
+            return P()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert len(starts) == 2
+        assert starts[1] - starts[0] >= 0.3
+
+    def test_native_lane_does_not_take_the_gate(self, spawn_env, monkeypatch):
+        """The gate is scoped to the opt-in lane — no default-path cost."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb)
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert not (kb.kanban_home() / "kanban" / "claude-cli-spawn.lock").exists()

--- a/tests/hermes_cli/test_kanban_worker_executor.py
+++ b/tests/hermes_cli/test_kanban_worker_executor.py
@@ -1,21 +1,27 @@
 """Kanban worker executor selection: native Hermes vs. direct Claude Code CLI.
 
-The dispatcher's ``_default_spawn`` runs ``hermes -p <profile> chat -q`` by
-default. When ``kanban.worker_executor: claude_cli`` is set in ``config.yaml``,
-it must instead run the Claude Code CLI directly (the lane that works against
-an interactive Claude subscription), while keeping every worker invariant the
-native lane has: board/profile/tenant/task/workspace env pins, the per-task log
-file, and the returned PID the dispatcher uses for crash detection.
+The dispatcher's ``_default_spawn`` runs the Claude Code CLI directly
+(``claude -p``) for every worker, on every board and every profile — the lane
+that works against an interactive Claude subscription. It keeps every worker
+invariant the native lane has: board/profile/tenant/task/workspace env pins,
+the per-task log file, and the returned PID the dispatcher uses for crash
+detection. ``kanban.worker_executor: native`` is the deliberate opt-out back
+to ``hermes -p <profile> chat -q``.
 
 Contracts asserted here:
 
-* default (no config) → native ``hermes`` argv; claude never invoked
-* opt-in → ``claude -p <prompt>`` argv, no ``hermes chat`` anywhere
+* default (no config) → ``claude -p <prompt>`` argv, no ``hermes chat``
+* explicit ``native`` → native ``hermes`` argv; claude never invoked
+* an unknown value falls *forward* to the direct lane, never back onto the
+  provider stack that wedged the board
+* the config keys are recognized by ``hermes config set``
 * the env is identical across lanes for every board-isolation pin
 * the direct lane drops ``CLAUDE_CONFIG_DIR`` and inherited Anthropic API
   credentials, and never copies a token into argv or the log
 * a missing/unusable ``claude`` binary is a hard error, never a silent
   downgrade back onto the native provider
+* a worker gets a permission mode by default, so the global lane can actually
+  act rather than no-opping on every card
 """
 
 from __future__ import annotations
@@ -109,32 +115,89 @@ def _select(monkeypatch, kb, **kanban_cfg):
 # ---------------------------------------------------------------------------
 
 class TestResolveWorkerExecutor:
-    def test_default_is_native_hermes(self):
+    def test_default_is_the_direct_claude_cli(self):
+        """Global default: unset config means the direct lane, everywhere."""
         from hermes_cli import kanban_db as kb
 
-        assert kb.resolve_worker_executor({}) == kb.WORKER_EXECUTOR_HERMES
-        assert kb.resolve_worker_executor({"worker_executor": None}) == "hermes"
-        assert kb.resolve_worker_executor({"worker_executor": "hermes"}) == "hermes"
+        assert kb.resolve_worker_executor({}) == kb.WORKER_EXECUTOR_CLAUDE_CLI
+        assert kb.resolve_worker_executor({"worker_executor": None}) == "claude_cli"
+        assert kb.resolve_worker_executor({"worker_executor": ""}) == "claude_cli"
+        assert kb.DEFAULT_WORKER_EXECUTOR == kb.WORKER_EXECUTOR_CLAUDE_CLI
 
     @pytest.mark.parametrize(
         "value",
         ["claude_cli", "claude-cli", "claude", "claude_code", "CLAUDE_CLI", " claude_cli "],
     )
-    def test_claude_spellings_opt_in(self, value):
+    def test_claude_spellings_resolve(self, value):
         from hermes_cli import kanban_db as kb
 
         assert kb.resolve_worker_executor({"worker_executor": value}) == (
             kb.WORKER_EXECUTOR_CLAUDE_CLI
         )
 
-    def test_unknown_value_falls_back_to_native_with_warning(self, caplog):
+    @pytest.mark.parametrize("value", ["hermes", "native"])
+    def test_native_is_an_explicit_opt_out(self, value):
+        from hermes_cli import kanban_db as kb
+
+        assert kb.resolve_worker_executor({"worker_executor": value}) == (
+            kb.WORKER_EXECUTOR_HERMES
+        )
+
+    def test_unknown_value_falls_forward_to_the_default(self, caplog):
+        """A typo must not silently restore the lane this one replaced.
+
+        Note the direction: unknown resolves to the direct CLI, not back to
+        the native provider stack that wedged the board.
+        """
         from hermes_cli import kanban_db as kb
 
         with caplog.at_level("WARNING"):
             resolved = kb.resolve_worker_executor({"worker_executor": "gemini"})
 
-        assert resolved == kb.WORKER_EXECUTOR_HERMES
+        assert resolved == kb.WORKER_EXECUTOR_CLAUDE_CLI
         assert "worker_executor" in caplog.text
+
+    def test_env_override_beats_config(self, monkeypatch):
+        from hermes_cli import kanban_db as kb
+
+        monkeypatch.setenv(kb.ENV_WORKER_EXECUTOR, "native")
+        assert kb.resolve_worker_executor({"worker_executor": "claude_cli"}) == (
+            kb.WORKER_EXECUTOR_HERMES
+        )
+
+    def test_unknown_env_override_falls_forward(self, monkeypatch, caplog):
+        from hermes_cli import kanban_db as kb
+
+        monkeypatch.setenv(kb.ENV_WORKER_EXECUTOR, "gemini")
+        with caplog.at_level("WARNING"):
+            assert kb.resolve_worker_executor({"worker_executor": "hermes"}) == (
+                kb.WORKER_EXECUTOR_CLAUDE_CLI
+            )
+        assert kb.ENV_WORKER_EXECUTOR in caplog.text
+
+    def test_config_key_is_recognized_by_config_set(self):
+        """`hermes config set kanban.worker_executor ...` must not warn.
+
+        The lane was unreachable in practice before this: the code read the
+        key but nothing declared it, so `config set` flagged it as unknown
+        and operators reasonably assumed it was being ignored.
+        """
+        from hermes_cli.config import _validate_config_key
+
+        for key in (
+            "kanban.worker_executor",
+            "kanban.claude_cli_bin",
+            "kanban.claude_cli_model",
+            "kanban.claude_cli_permission_mode",
+            "kanban.claude_cli_extra_args",
+            "kanban.claude_cli_spawn_stagger_seconds",
+        ):
+            assert _validate_config_key(key)[0] is True, key
+
+    def test_config_default_ships_the_direct_lane(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["kanban"]["worker_executor"] == "claude_cli"
 
 
 # ---------------------------------------------------------------------------
@@ -142,9 +205,24 @@ class TestResolveWorkerExecutor:
 # ---------------------------------------------------------------------------
 
 class TestSpawnCommand:
-    def test_default_spawns_native_hermes_chat(self, spawn_env, monkeypatch):
+    def test_default_spawns_the_direct_claude_cli(self, spawn_env, monkeypatch):
+        """No `worker_executor` in config: the direct lane is what runs."""
         kb = spawn_env["kb"]
         _select(monkeypatch, kb)
+
+        pid = kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert pid == 4321
+        assert cmd[0] == str(spawn_env["claude_bin"])
+        assert cmd[-2] == "-p"
+        assert "chat" not in cmd
+        assert "-q" not in cmd
+
+    def test_explicit_native_still_spawns_hermes_chat(self, spawn_env, monkeypatch):
+        """`native` remains a working, deliberate escape hatch."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="native")
 
         pid = kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
 
@@ -176,31 +254,81 @@ class TestSpawnCommand:
         assert "chat" not in cmd
         assert "-q" not in cmd
 
-    def test_goal_mode_refuses_instead_of_silently_downgrading(
-        self, spawn_env, monkeypatch
-    ):
+    def test_goal_mode_gets_an_explicit_self_judge_step(self, spawn_env, monkeypatch):
         """The goal judge loop is a Hermes CLI feature with no CLI equivalent.
 
-        Running a single pass would look like success to the CLI and like an
-        unjudged run to whoever asked for goal mode.
+        While this lane was opt-in the spawn refused a goal card outright,
+        because the alternative was one unjudged pass that looks like success.
+        As the global lane, refusing would fail every goal card on every
+        board, so the judge step is handed to the worker explicitly. What must
+        not happen is a silent single-pass downgrade — naming it is what
+        prevents that.
         """
         kb = spawn_env["kb"]
         _select(monkeypatch, kb, worker_executor="claude_cli")
 
-        with pytest.raises(RuntimeError) as exc:
-            kb._default_spawn(_make_task(kb, goal_mode=True), str(spawn_env["workspace"]))
+        kb._default_spawn(
+            _make_task(kb, goal_mode=True, goal_max_turns=6),
+            str(spawn_env["workspace"]),
+        )
 
-        assert "goal_mode" in str(exc.value)
-        assert "cmd" not in spawn_env["captured"]
+        prompt = spawn_env["captured"]["cmd"][-1]
+        assert "GOAL MODE" in prompt
+        assert "you are the judge" in prompt.lower()
+        assert "6 rounds" in prompt
 
-    def test_missing_permission_flag_warns(self, spawn_env, monkeypatch, caplog):
-        """Default permission mode + no TTY = a worker that cannot act."""
+    def test_non_goal_cards_get_no_judge_section(self, spawn_env, monkeypatch):
         kb = spawn_env["kb"]
         _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        assert "GOAL MODE" not in spawn_env["captured"]["cmd"][-1]
+
+    def test_permission_mode_defaults_so_the_worker_can_act(
+        self, spawn_env, monkeypatch
+    ):
+        """Default permission mode + no TTY = a worker that cannot act.
+
+        Warning was enough while the lane was opt-in; as the global lane an
+        unarmed worker would no-op on every card, so a mode is supplied.
+        """
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert "--permission-mode" in cmd
+        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
+
+    def test_operator_permission_flag_is_not_overridden(self, spawn_env, monkeypatch):
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb, worker_executor="claude_cli",
+            claude_cli_extra_args=["--permission-mode", "acceptEdits"],
+        )
+
+        kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
+
+        cmd = spawn_env["captured"]["cmd"]
+        assert cmd.count("--permission-mode") == 1
+        assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
+
+    def test_empty_permission_mode_restores_the_warning(
+        self, spawn_env, monkeypatch, caplog
+    ):
+        """An explicit empty value is a read-only lane, and stays loud."""
+        kb = spawn_env["kb"]
+        _select(
+            monkeypatch, kb, worker_executor="claude_cli",
+            claude_cli_permission_mode="",
+        )
 
         with caplog.at_level("WARNING"):
             kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
 
+        assert "--permission-mode" not in spawn_env["captured"]["cmd"]
         assert "permission" in caplog.text.lower()
 
     def test_board_lifecycle_commands_are_granted(self, spawn_env, monkeypatch):
@@ -505,7 +633,7 @@ class TestWorkerEnv:
         return dict(spawn_env["captured"]["env"])
 
     def test_board_and_identity_pins_match_across_executors(self, spawn_env, monkeypatch):
-        native = self._env_for(spawn_env, monkeypatch)
+        native = self._env_for(spawn_env, monkeypatch, worker_executor="native")
         claude = self._env_for(spawn_env, monkeypatch, worker_executor="claude_cli")
 
         for key in self.PINS:
@@ -539,10 +667,10 @@ class TestWorkerEnv:
         assert not any("sk-ant-secret" in part for part in spawn_env["captured"]["cmd"])
 
     def test_native_lane_keeps_claude_config_dir(self, spawn_env, monkeypatch):
-        """The strip is scoped to the opt-in lane; the default is untouched."""
+        """The strip is scoped to the direct lane; `native` is untouched."""
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/hermes-managed-claude")
 
-        env = self._env_for(spawn_env, monkeypatch)
+        env = self._env_for(spawn_env, monkeypatch, worker_executor="native")
 
         assert env["CLAUDE_CONFIG_DIR"] == "/tmp/hermes-managed-claude"
 
@@ -620,7 +748,7 @@ class TestFailureHandling:
     ):
         """Broadening the native lane's except must not swallow real errors."""
         kb = spawn_env["kb"]
-        _select(monkeypatch, kb)
+        _select(monkeypatch, kb, worker_executor="native")
 
         def boom(*_args, **_kwargs):
             raise PermissionError(13, "Permission denied")
@@ -732,9 +860,9 @@ class TestSpawnGate:
         assert starts[1] - starts[0] >= 0.3
 
     def test_native_lane_does_not_take_the_gate(self, spawn_env, monkeypatch):
-        """The gate is scoped to the opt-in lane — no default-path cost."""
+        """The gate is scoped to the direct lane; `native` never pays for it."""
         kb = spawn_env["kb"]
-        _select(monkeypatch, kb)
+        _select(monkeypatch, kb, worker_executor="native")
 
         kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
 

--- a/tests/hermes_cli/test_kanban_worker_executor.py
+++ b/tests/hermes_cli/test_kanban_worker_executor.py
@@ -157,6 +157,44 @@ class TestResolveWorkerExecutor:
         assert resolved == kb.WORKER_EXECUTOR_CLAUDE_CLI
         assert "worker_executor" in caplog.text
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "anthropic", "anthropic_api", "provider=anthropic",
+            "openai", "codex", "gpt", "chatgpt", "openai_codex",
+            "gemini", "bedrock", "vertex", "  ", "0", "false", "none",
+        ],
+    )
+    def test_offlane_and_unknown_values_fail_closed_to_the_direct_lane(
+        self, value, caplog
+    ):
+        """No spelling but `hermes`/`native` may route a worker off this lane.
+
+        The values that matter most here are the plausible ones. `anthropic`
+        reads like "use the Anthropic lane" and `openai`/`codex` read like a
+        vendor selector, so an operator could reasonably type either — and
+        the first is exactly the metered provider path that wedged the board,
+        while the second is a stack a kanban worker must never reach. Neither
+        is a recognized executor, so both resolve to the direct CLI rather
+        than being honored as a routing instruction.
+        """
+        from hermes_cli import kanban_db as kb
+
+        with caplog.at_level("WARNING"):
+            assert kb.resolve_worker_executor({"worker_executor": value}) == (
+                kb.WORKER_EXECUTOR_CLAUDE_CLI
+            )
+
+    def test_only_hermes_and_native_reach_the_native_lane(self):
+        """Pin the full opt-out surface, so a new alias is a deliberate edit."""
+        from hermes_cli import kanban_db as kb
+
+        native_spellings = {
+            key for key, lane in kb._WORKER_EXECUTOR_ALIASES.items()
+            if lane == kb.WORKER_EXECUTOR_HERMES
+        }
+        assert native_spellings == {"hermes", "native"}
+
     def test_env_override_beats_config(self, monkeypatch):
         from hermes_cli import kanban_db as kb
 
@@ -284,6 +322,57 @@ class TestSpawnCommand:
         kb._default_spawn(_make_task(kb), str(spawn_env["workspace"]))
 
         assert "GOAL MODE" not in spawn_env["captured"]["cmd"][-1]
+
+    def test_task_skills_reach_the_prompt(self, spawn_env, monkeypatch):
+        """The native lane's `--skills X` has no host-CLI flag equivalent.
+
+        Dropping the field silently was tolerable while the lane was opt-in.
+        It stopped being tolerable when the review handoff lifecycle began
+        force-appending `sdlc-review` to a claimed review card: that skill is
+        the review procedure, so a worker without it reviews nothing while
+        looking like a normal run.
+        """
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        kb._default_spawn(
+            _make_task(kb, skills=["sdlc-review", "tdd"]),
+            str(spawn_env["workspace"]),
+        )
+
+        prompt = spawn_env["captured"]["cmd"][-1]
+        assert "Required skills" in prompt
+        assert "`sdlc-review`" in prompt
+        assert "`tdd`" in prompt
+        # An unloadable skill must block, not be improvised around.
+        assert "--kind capability" in prompt
+
+    def test_review_card_worker_is_told_to_load_sdlc_review(
+        self, spawn_env, monkeypatch
+    ):
+        """The exact shape the review lane produces when it claims a card."""
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+        task = _make_task(kb, skills=None)
+        # Mirrors dispatch_once's review branch.
+        task.skills = list(dict.fromkeys([*(task.skills or []), "sdlc-review"]))
+
+        kb._default_spawn(task, str(spawn_env["workspace"]))
+
+        assert "`sdlc-review`" in spawn_env["captured"]["cmd"][-1]
+
+    @pytest.mark.parametrize("skills", [None, [], ["", "   "]])
+    def test_cards_without_skills_get_no_skills_section(
+        self, spawn_env, monkeypatch, skills
+    ):
+        kb = spawn_env["kb"]
+        _select(monkeypatch, kb, worker_executor="claude_cli")
+
+        kb._default_spawn(
+            _make_task(kb, skills=skills), str(spawn_env["workspace"])
+        )
+
+        assert "Required skills" not in spawn_env["captured"]["cmd"][-1]
 
     def test_permission_mode_defaults_so_the_worker_can_act(
         self, spawn_env, monkeypatch

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,6 +2,19 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _native_executor(monkeypatch):
+    """Pin the native worker.
+
+    `kanban.worker_executor` defaults to the direct host Claude CLI, whose
+    argv carries no `-p <profile>` / `--toolsets` flags. Everything in this
+    file is about how the *native* worker resolves its profile tool surface.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_WORKER_EXECUTOR", "native")
+
 
 def _make_task(kb, *, assignee: str):
     return kb.Task(

--- a/tests/plugins/test_kanban_model_override.py
+++ b/tests/plugins/test_kanban_model_override.py
@@ -118,6 +118,11 @@ def test_migration_adds_provider_override_column(conn):
 
 
 def _spawn_and_capture(monkeypatch, tmp_path, task):
+    # These assertions are about the *native* worker argv. `kanban.worker_executor`
+    # now defaults to the direct host Claude CLI, whose argv has no `-p <profile>`,
+    # `--toolsets`, `-m`, or `--skills` concept at all; that lane is covered in
+    # tests/hermes_cli/test_kanban_worker_executor.py.
+    monkeypatch.setenv("HERMES_KANBAN_WORKER_EXECUTOR", "native")
     monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
     captured = {}
 


### PR DESCRIPTION
## What

Promotes the direct Claude Code CLI worker lane from **strictly opt-in** to the **global default** — every kanban board, every profile — and makes its config surface actually reachable.

Supersedes this PR's original opt-in-only rollout rule, per board recovery `t_00e6e304`.

## Why

The native lane (`hermes -p <assignee> chat -q ...`) resolves models through Hermes' own provider stack. When that pool exhausts, every worker fails at startup and the dispatcher cannot distinguish "the model refused" from "the board is wedged". One review card was re-dispatched **132 times** behind repeated 429s before the circuit breaker tripped — while `env -u CLAUDE_CONFIG_DIR claude -p ...` answered fine in the same shell.

Leaving the working lane behind a flag left the failing lane as what everyone actually runs.

## Changes on top of the opt-in implementation

**The config keys are declared.** Nothing in `DEFAULT_CONFIG` described `kanban.worker_executor`, so the code read a key that `hermes config set` reported as *unrecognized*. Operators reasonably concluded it was being ignored — that is how this surfaced. All six `kanban.claude_cli_*` keys are now declared and documented.

**The default is `claude_cli`.** `native` is the deliberate opt-out; `$HERMES_KANBAN_WORKER_EXECUTOR` overrides per process. Global rather than per-profile: the routing this replaces was not profile-specific, so a per-profile opt-out would leave exactly the boards that wedge hardest still wedging. An unrecognized value now falls **forward** to the direct lane — previously it fell back to native, which as the default would mean a typo silently restores the failure mode.

**Workers get a permission mode.** `claude -p` defaults to asking a human and a detached worker has no TTY. Warning was right while opt-in (an unarmed worker was a no-op on one board someone deliberately switched over); as the default it would make *every* worker a no-op. `claude_cli_permission_mode` defaults to `bypassPermissions` — parity with the native worker's existing unattended tool reach, not escalation. `""` restores warn-and-add-nothing; an operator flag in `claude_cli_extra_args` still wins.

**Goal-mode cards judge themselves** instead of refusing. Refusing was correct for one opt-in board; as the default it would fail every goal card everywhere. The prompt carries an explicit GOAL MODE section (verify against success criteria, iterate, block rather than complete on a partial result). Weaker than the native judge loop, and the docs say so.

**The credential strip covers OpenAI/Codex** and the remaining Anthropic cloud-routing vars. The child also gets `HERMES_KANBAN_EXECUTOR` for observability and `GIT_TERMINAL_PROMPT=0` so git work fails fast instead of blocking on a prompt nobody can answer.

## Preserved semantics

Only argv and credential routing differ between lanes. Board / profile / tenant / task / workspace / claim pinning, the per-task log file, the returned PID for crash detection, timeouts, bounded concurrency, and the detached session are all executor-independent.

There is **no automatic fallback in either direction**: an unresolvable `claude` binary raises, the dispatcher records `spawn_failed`, and the existing failure-limit machinery reacts.

## Testing

- **49** executor tests, **216** kanban tests, **159** adjacent spawn-path/config tests, **25** notifier/Discord tests.
- **Disposable-board E2E** (`test_kanban_claude_executor_e2e.py`): a real board, a real `dispatch_once` tick, the real `_default_spawn`, and a real detached subprocess walking claim → show → workspace write → heartbeat → comment → complete against the real board DB, asserting no seeded credential reaches the worker env or the task log. Only the model is stubbed.
- The full kanban suite matches `origin/main` exactly — the same **7 pre-existing** ordering-dependent failures, confirmed by running the suite against a clean checkout of the base commit. None are related to this change.
- Existing tests asserting the native argv now pin the native lane explicitly.

## Discord boundary

No gateway or notifier file is touched, so the closed/archived-thread outbound boundary is structurally unchanged; its suites still pass.

## Enabling after merge

The default applies with no action. To pin it explicitly and verify it is read:

```
hermes config set kanban.worker_executor claude_cli
hermes config get kanban.worker_executor
```

Opt back out with `hermes config set kanban.worker_executor native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban workers now use the host Claude CLI by default.
  * Added an option to select native Hermes workers instead.
  * Added configuration for CLI path, model, permissions, effort level, extra arguments, and startup staggering.
  * Improved worker lifecycle handling, credential isolation, logging, heartbeats, and error reporting.

* **Documentation**
  * Added comprehensive guidance for configuring and operating Kanban worker executors.

* **Tests**
  * Added coverage for executor selection, lifecycle behavior, configuration, security, failures, and end-to-end task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->