### PR TITLE
feat(kanban): expose idempotency_key in task JSON

### DIFF
--- a/contributors/emails/alton@frontanalytics.com
+++ b/contributors/emails/alton@frontanalytics.com
@@ -1,0 +1,1 @@
+altonalexander

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -656,6 +656,19 @@ def _read_script_for_scanning(script_path: str) -> str:
     resolved = _resolve_script_path(script_path)
     if resolved is None:
         return ""
+    if not resolved.exists():
+        # Creation now rejects a job whose script is missing, so reaching the
+        # scanner with no file means something bypassed that check (a direct
+        # CLI/store write, or the file vanished between validation and scan).
+        # Still return "" — failing closed here would change the guard's
+        # security contract and reject legitimate agent-mode jobs — but say so,
+        # because "nothing to scan" and "nothing there" used to look identical
+        # in the logs, and that is how the empty-script job stayed invisible.
+        logger.warning(
+            "cron lifecycle scan: script %s does not exist; scanning prompt only",
+            resolved,
+        )
+        return ""
     script_text, unsafe = _read_referenced_script(resolved)
     if unsafe:
         return "hermes gateway restart"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -259,6 +259,10 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
     "qqbot", "yuanbao",
+    # Deliverable since cron learned to reach non-push adapters by starting a
+    # turn (see _deliver_via_wake) rather than by pushing to a socket the HTTP
+    # request/response cycle does not keep open.
+    "api_server",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to
@@ -1602,6 +1606,90 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+# How long to wait for a wake turn to confirm before assuming it is in flight.
+# gateway.wake allows the turn itself up to WAKE_TURN_TIMEOUT_SECONDS (600s),
+# but blocking a scheduler thread that long would stall every other job's
+# delivery. Wait a bounded slice and then apply the same in-flight reasoning the
+# adapter path uses for a slow confirmation (#38922).
+_WAKE_CONFIRM_TIMEOUT_SECONDS = 120
+
+
+def _deliver_via_wake(
+    runtime_adapter,
+    text: str,
+    chat_id,
+    loop,
+    job: dict,
+    platform_name: str,
+    target_errors: list,
+) -> tuple[bool, bool]:
+    """Deliver to a non-push adapter by starting a turn on its session.
+
+    An adapter that cannot be pushed to can still be *woken*: gateway.wake
+    self-posts the text to the in-pod API server as an ordinary session turn,
+    which lands in the same message store the dashboard reads its history from.
+    This is the mechanism the kanban notifier already uses to reach exactly
+    these sessions, so cron is adopting a proven path, not inventing one.
+
+    Returns ``(adapter_ok, timed_out)`` matching the live-adapter branch's
+    contract, so the caller's downstream logic is unchanged.
+    """
+    from agent.async_utils import safe_schedule_threadsafe
+    from gateway.wake import deliver_wake
+
+    # For a non-push adapter the chat_id IS the raw session id — the same
+    # X-Hermes-Session-Id the client sent and state.db keys messages by.
+    session_id = str(chat_id)
+    if loop is None or not getattr(loop, "is_running", lambda: False)():
+        target_errors.append(
+            f"wake delivery to {platform_name}:{chat_id} needs a running "
+            f"gateway loop; none available"
+        )
+        return False, False
+
+    future = safe_schedule_threadsafe(
+        deliver_wake(runtime_adapter, text=text, session_id=session_id),
+        loop,
+    )
+    if future is None:
+        target_errors.append("wake delivery event loop scheduling failed")
+        return False, False
+
+    try:
+        future.result(timeout=_WAKE_CONFIRM_TIMEOUT_SECONDS)
+    except TimeoutError:
+        # Same split as the adapter path: cancel() == False means the turn was
+        # already running and cannot be un-started, so re-sending would produce
+        # a duplicate turn on the user's session. cancel() == True means it
+        # never started, and nothing was delivered.
+        if future.cancel():
+            msg = (
+                f"wake delivery to {platform_name}:{chat_id} timed out before "
+                f"the turn was dispatched"
+            )
+            logger.warning("Job '%s': %s", job["id"], msg)
+            target_errors.append(msg)
+            return False, False
+        logger.warning(
+            "Job '%s': wake turn for %s:%s still running after %ss; already "
+            "dispatched, assuming delivered",
+            job["id"], platform_name, chat_id, _WAKE_CONFIRM_TIMEOUT_SECONDS,
+        )
+        return True, True
+    except Exception as ex:
+        # deliver_wake raises on exhausted retries / HTTP error, deliberately,
+        # so a failure is never mistaken for a delivery.
+        msg = f"wake delivery to {platform_name}:{chat_id} failed: {ex}"
+        logger.warning("Job '%s': %s", job["id"], msg)
+        target_errors.append(msg)
+        return False, False
+
+    logger.info(
+        "Job '%s': delivered to %s:%s via wake turn", job["id"], platform_name, chat_id
+    )
+    return True, False
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1764,6 +1852,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         )
         delivered = False
         target_errors = []
+
+        # Some adapters have no channel to push into after a turn ends — the
+        # api_server adapter behind the dashboard is the live example: its
+        # send() is a deliberate stub, because an HTTP request/response cycle
+        # holds no socket to write to later. Calling send() on one is
+        # guaranteed to fail, and so is the standalone retry, which resolves
+        # the very same adapter; that double failure is how a cron job could
+        # report last_status: ok next to a permanent delivery error. Such
+        # sessions are reachable — just by starting a turn rather than by
+        # pushing to one (gateway.wake) — so route them there instead.
+        push_capable = True
+        if runtime_adapter is not None:
+            try:
+                from gateway.wake import adapter_supports_push
+
+                push_capable = adapter_supports_push(runtime_adapter)
+            except Exception:  # pragma: no cover - import guard
+                push_capable = True
 
         # Continuable cron surface (D1/D2/D6): resolve the delivery surface for
         # this platform generically from its config ``extra``. Default "thread"
@@ -1938,7 +2044,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
-                if text_to_send:
+                if text_to_send and not push_capable:
+                    adapter_ok, timed_out = _deliver_via_wake(
+                        runtime_adapter,
+                        text_to_send,
+                        chat_id,
+                        loop,
+                        job,
+                        platform_name,
+                        target_errors,
+                    )
+                elif text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
                     router = DeliveryRouter(config, adapters)
@@ -2084,7 +2200,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # payload is already assumed delivered (#38922).  Record the
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
-                if adapter_ok and not timed_out and media_files:
+                if media_files and not push_capable:
+                    # Media goes out through the adapter's native attachment
+                    # send, which is the same stubbed surface the wake path
+                    # exists to avoid; a wake turn carries text only. Record the
+                    # drop rather than attempting a send that cannot work.
+                    msg = (
+                        f"{len(media_files)} media attachment(s) not delivered to "
+                        f"{platform_name}:{chat_id} — this adapter has no push "
+                        f"channel, and a wake turn delivers text only"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                elif adapter_ok and not timed_out and media_files:
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
@@ -2159,6 +2287,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if not target_errors:
                     target_errors.append(
                         f"relay delivery to {platform_name}:{chat_id} failed"
+                    )
+                delivery_errors.extend(target_errors)
+                continue
+            if not push_capable:
+                # The standalone path re-resolves this same non-push adapter and
+                # fails on the same stubbed send(). Retrying it only appends a
+                # second copy of the identical error, which is exactly the
+                # doubled "not send()" message operators had to decode. The wake
+                # path above was the real attempt; stop here.
+                if not target_errors:
+                    target_errors.append(
+                        f"wake delivery to {platform_name}:{chat_id} failed"
                     )
                 delivery_errors.extend(target_errors)
                 continue

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -152,6 +152,19 @@ DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
+# How much of a tool's output rides the chat-completions SSE channel. The
+# result shares that stream with the reply text, so an unbounded one would
+# stall the prose queued behind it. Clients needing the whole thing still
+# read it from the stored transcript.
+TOOL_RESULT_STREAM_CHARS = 4_000
+# Cap for the one-line summary a client shows on the collapsed step.
+TOOL_LABEL_STREAM_CHARS = 120
+# Queue markers the chat-completions SSE writer turns into named events
+# rather than assistant text. Keyed by the marker the producer enqueues.
+_CUSTOM_SSE_EVENTS = {
+    "__tool_progress__": "hermes.tool.progress",
+    "__reasoning__": "hermes.reasoning.delta",
+}
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
@@ -4215,29 +4228,90 @@ class APIServerAdapter(BasePlatformAdapter):
                 }))
 
             def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
-                """Emit the matching ``status: completed`` event.
+                """Emit the matching ``completed``/``failed`` lifecycle event.
 
                 Dropped if the start was filtered (internal tool, missing
                 id, or never seen) so clients never get an orphaned
                 ``completed`` they can't correlate to a prior ``running``.
+
+                Carries the tool's output and its success/failure verdict.
+                Without them a client can only turn its spinner into an
+                unconditional green check: the output arrives when the
+                turn's transcript is re-read — minutes later, at the end of
+                the turn — and until then a tool that actually failed is
+                indistinguishable from one that succeeded.
+
+                Failure is derived from the result here rather than taken
+                from ``tool_progress_callback``. That callback does carry an
+                ``is_error`` flag, but no ``tool_call_id`` to correlate it
+                by, and wiring it for tool events would duplicate every chip
+                on this channel (see the callback wiring below).
                 """
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
+                from agent.display import _detect_tool_failure
+                from agent.tool_dispatch_helpers import _multimodal_text_summary
+                # A projection for display only: never let a malformed result
+                # take down the turn that produced it.
+                try:
+                    result_text = _multimodal_text_summary(function_result) or ""
+                except Exception:
+                    result_text = ""
+                try:
+                    is_error, failure_suffix = _detect_tool_failure(
+                        function_name, function_result
+                    )
+                except Exception:
+                    is_error, failure_suffix = False, ""
+                # On failure the detector's own tag (``[exit 1]``, a trimmed
+                # error message) is the most informative one line available.
+                # On success the opening line of the output is.
+                if is_error and failure_suffix:
+                    label = failure_suffix.strip().strip("[]")
+                else:
+                    label = next(
+                        (ln for ln in result_text.splitlines() if ln.strip()), ""
+                    ).strip()
                 _stream_q.put_threadsafe(("__tool_progress__", {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
-                    "status": "completed",
+                    "status": "failed" if is_error else "completed",
+                    "label": label[:TOOL_LABEL_STREAM_CHARS],
+                    "result": result_text[:TOOL_RESULT_STREAM_CHARS],
+                    "resultTruncated": len(result_text) > TOOL_RESULT_STREAM_CHARS,
                 }))
+
+            def _on_agent_progress(event_type, tool_name=None, preview=None, args=None, **kwargs):
+                """Forward reasoning, and nothing else.
+
+                ``run_agent`` fires this callback side-by-side with the
+                structured tool callbacks, so anything tool-shaped forwarded
+                here would double every chip on the wire — which is why this
+                callback used to be left unwired entirely. Reasoning is the
+                one thing with no structured equivalent: ``_on_tool_start``
+                filters ``_``-prefixed internal tools, and ``_thinking`` is
+                exactly such a tool, so this is the only channel on which a
+                reasoning trace can arrive while the turn is still running
+                rather than after the transcript is re-read.
+                """
+                if event_type != "reasoning.available":
+                    return
+                text = preview or ""
+                if not text:
+                    return
+                _stream_q.put_threadsafe(("__reasoning__", {"delta": text}))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
-            # ``tool_progress_callback`` is intentionally not wired here:
-            # it would duplicate every emit because ``run_agent`` fires it
+            # ``tool_progress_callback`` is wired only for reasoning — see
+            # ``_on_agent_progress``. Forwarding its tool events too would
+            # duplicate every emit, because ``run_agent`` fires it
             # side-by-side with ``tool_start_callback``/``tool_complete_callback``.
             # The structured callbacks are strictly richer (they carry
-            # the tool_call id), so they own the chat-completions SSE channel.
+            # the tool_call id), so they still own the tool lifecycle on the
+            # chat-completions SSE channel.
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
@@ -4245,6 +4319,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                tool_progress_callback=_on_agent_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
@@ -4424,14 +4499,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 """Write a single queue item to the SSE stream.
 
                 Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
-                frontends can display them without storing the markers in
-                conversation history.  See #6972 for the original event,
-                #16588 for the ``toolCallId``/``status`` lifecycle fields.
+                Tagged tuples ``(marker, payload)`` are sent as the custom
+                SSE event that marker names, so frontends can display them
+                without storing the markers in conversation history.  See
+                #6972 for the original tool event, #16588 for the
+                ``toolCallId``/``status`` lifecycle fields.
+
+                Both custom events are additive: a client that only knows
+                about ``delta.content`` ignores them, exactly as before.
                 """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
+                if isinstance(item, tuple) and len(item) == 2 and item[0] in _CUSTOM_SSE_EVENTS:
+                    await response.write(
+                        _sse_frame(item[1], event=_CUSTOM_SSE_EVENTS[item[0]])
+                    )
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -164,7 +164,24 @@ TOOL_LABEL_STREAM_CHARS = 120
 _CUSTOM_SSE_EVENTS = {
     "__tool_progress__": "hermes.tool.progress",
     "__reasoning__": "hermes.reasoning.delta",
+    "__approval__": "hermes.approval.request",
 }
+
+
+def _approval_timeout_seconds() -> int:
+    """How long a pending approval waits before it is treated as a refusal.
+
+    Sent with the request so a client can show the deadline it is actually
+    working against rather than inventing one — silence here is a denial, not
+    a pause, so a UI that lets it lapse unannounced misleads the user.
+    """
+    try:
+        from tools.approval import _get_approval_config
+
+        raw = (_get_approval_config() or {}).get("timeout", 60)
+        return max(1, int(raw))
+    except Exception:
+        return 60
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
@@ -2096,6 +2113,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+            ("POST", "/v1/approvals/{session_key}/decision", self._handle_session_approval),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
         ]
         if _CRON_AVAILABLE:
@@ -3175,6 +3193,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
                 "session_model_lock": {"method": "POST", "path": "/api/sessions/{session_id}/model"},
+                "approval_decision": {"method": "POST", "path": "/v1/approvals/{session_key}/decision"},
             },
         })
 
@@ -4302,6 +4321,44 @@ class APIServerAdapter(BasePlatformAdapter):
                     return
                 _stream_q.put_threadsafe(("__reasoning__", {"delta": text}))
 
+            # The key the approval is registered under, and the one
+            # /v1/approvals/{key}/decision resolves against. Falls back to the
+            # completion id so a turn with neither a session key nor a session
+            # id still gets a unique one rather than colliding with every other
+            # anonymous turn on the shared "" key.
+            approval_session_key = (
+                gateway_session_key or session_id or f"chatcmpl:{completion_id}"
+            )
+
+            def _on_approval_request(approval_data):
+                """Put a pending approval on the stream for the client to answer.
+
+                Runs on the agent thread, which is blocked inside the tool
+                waiting for the decision — so this only hands the request to
+                the SSE writer and returns. The writer is still pumping (its
+                queue wait times out every 0.5s and keeps sending keepalives),
+                so the frame goes out while the tool is parked.
+                """
+                payload = dict(approval_data or {})
+                # Same egress rule as the /v1/runs notifier: the raw command
+                # can carry credentials, and this one is rendered straight
+                # into a browser.
+                if "command" in payload:
+                    from gateway.run import _redact_approval_command
+
+                    payload["command"] = _redact_approval_command(
+                        payload.get("command")
+                    )
+                payload.update({
+                    "sessionKey": approval_session_key,
+                    "choices": _approval_event_choices(
+                        smart_denied=bool(payload.get("smart_denied")),
+                        allow_permanent=payload.get("allow_permanent") is not False,
+                    ),
+                    "timeoutSeconds": _approval_timeout_seconds(),
+                })
+                _stream_q.put_threadsafe(("__approval__", payload))
+
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
@@ -4322,6 +4379,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=_on_agent_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                approval_notify_callback=_on_approval_request,
+                approval_session_key=approval_session_key,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
@@ -6199,6 +6258,8 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        approval_notify_callback=None,
+        approval_session_key: str = "",
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -6224,6 +6285,21 @@ class APIServerAdapter(BasePlatformAdapter):
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
+
+        *approval_notify_callback* is how a caller offers the user a way to
+        answer a dangerous-command approval. Without one, ``tools.approval``
+        finds no notifier for the session, files the request into an
+        in-process dict nothing reads, and returns ``pending_approval``
+        immediately — which the agent sees as a flat refusal. Every
+        approval-gated tool call therefore fails on any route that does not
+        pass this. The callback runs on the agent thread and must not block;
+        it is expected to hand the request to whatever transport can reach
+        the user (for the SSE routes, the stream itself).
+
+        *approval_session_key* is the key that callback is registered under,
+        and the one a decision endpoint must resolve against. It is bound
+        explicitly rather than inferred so the registration and the lookup
+        ``tools.approval`` performs cannot drift apart.
         """
         loop = asyncio.get_running_loop()
         # Capture before hopping to the executor — ContextVars do not follow
@@ -6240,6 +6316,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
                 )
+                # Contextvars do not follow the executor hop, so the approval
+                # key is bound here, inside the thread that will actually run
+                # the tools — the same reason the profile scope is re-entered
+                # above.
+                approval_token = None
+                if approval_notify_callback is not None and approval_session_key:
+                    from tools.approval import (
+                        register_gateway_notify,
+                        set_current_session_key,
+                    )
+
+                    approval_token = set_current_session_key(approval_session_key)
+                    register_gateway_notify(
+                        approval_session_key, approval_notify_callback
+                    )
                 agent = None
                 try:
                     agent = self._create_agent(
@@ -6407,6 +6498,23 @@ class APIServerAdapter(BasePlatformAdapter):
                         # shutdown.  pop() is a no-op when _create_agent
                         # succeeded but the turn never reached registration.
                         self._shutdown_interruptible_agents.pop(id(agent), None)
+                    # Unregistering also releases any thread still blocked on
+                    # an approval nobody is going to answer, so a turn that
+                    # crashed mid-prompt cannot leave one parked for the whole
+                    # approval timeout.
+                    if approval_token is not None:
+                        from tools.approval import (
+                            reset_current_session_key,
+                            unregister_gateway_notify,
+                        )
+
+                        try:
+                            unregister_gateway_notify(approval_session_key)
+                        finally:
+                            try:
+                                reset_current_session_key(approval_token)
+                            except Exception:
+                                pass
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()
@@ -7090,6 +7198,83 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "object": "hermes.run.approval_response",
             "run_id": run_id,
+            "choice": choice,
+            "resolved": resolved,
+        })
+
+    async def _handle_session_approval(self, request: "web.Request") -> "web.Response":
+        """POST /v1/approvals/{session_key}/decision — answer a pending approval.
+
+        The run-scoped endpoint above only reaches turns started via /v1/runs,
+        which is not the route the SSE chat surfaces use. This one resolves by
+        the session key carried on the ``hermes.approval.request`` event, so
+        any caller streaming a turn can answer the approval that turn is
+        parked on.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_key = request.match_info["session_key"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        raw_choice = str(body.get("choice", "")).strip().lower()
+        aliases = {"approve": "once", "approved": "once", "allow": "once"}
+        choice = aliases.get(raw_choice, raw_choice)
+        allowed = {"once", "session", "always", "deny"}
+        if choice not in allowed:
+            return web.json_response(
+                _openai_error(
+                    "Invalid approval choice; expected one of: once, session, always, deny",
+                    code="invalid_approval_choice",
+                ),
+                status=400,
+            )
+
+        reason = body.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            return web.json_response(
+                _openai_error("reason must be a string", code="invalid_approval_reason"),
+                status=400,
+            )
+
+        resolve_all = (
+            _coerce_request_bool(body.get("all"), default=False)
+            or _coerce_request_bool(body.get("resolve_all"), default=False)
+        )
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            resolved = resolve_gateway_approval(
+                session_key,
+                choice,
+                resolve_all=resolve_all,
+                reason=reason or None,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[api_server] approval resolution failed for session %s", session_key
+            )
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if resolved <= 0:
+            # Nothing waiting: the turn already moved on, most likely because
+            # the approval timed out. Distinguished from a bad key on purpose —
+            # both are 409, but the message says which is worth checking.
+            return web.json_response(
+                _openai_error(
+                    "No approval is pending for this session; it may have timed out.",
+                    code="approval_not_pending",
+                ),
+                status=409,
+            )
+
+        return web.json_response({
+            "object": "hermes.approval_response",
+            "session_key": session_key,
             "choice": choice,
             "resolved": resolved,
         })

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,12 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        # Automation that files tasks under an ``--idempotency-key`` has no way
+        # to ask the board what it already filed: ``create`` returns an id but
+        # never says whether it deduped, and every other lookup is by id. Without
+        # this field the only way for a caller to recognise its own tasks is to
+        # match on ``title``, which breaks the moment a human edits one.
+        "idempotency_key": t.idempotency_key,
     }
 
 

--- a/tests/cron/test_cron_cross_profile.py
+++ b/tests/cron/test_cron_cross_profile.py
@@ -1,0 +1,137 @@
+"""Cross-profile cron access.
+
+Cron stores are per-profile (#4707), which is right for isolation and wrong for
+repair: a profile handed someone else's broken automation to fix can install
+the fix but cannot fire the job to prove it worked, because the job genuinely
+does not exist in its own store. The work then comes back unverified, which
+defeats the point of routing it there at all.
+
+These tests pin the narrow opening: another profile's schedule may be inspected
+and fired, and nothing else.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def two_profiles(tmp_path, monkeypatch):
+    """A root profile with a job, and a `dev` profile running the tool."""
+    root = tmp_path / ".hermes"
+    (root / "cron" / "output").mkdir(parents=True)
+    (root / "scripts").mkdir()
+
+    dev = root / "profiles" / "dev"
+    (dev / "cron" / "output").mkdir(parents=True)
+    (dev / "scripts").mkdir()
+
+    # The caller is the dev profile.
+    monkeypatch.setenv("HERMES_HOME", str(dev))
+    monkeypatch.setenv("HERMES_PROFILE", "dev")
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", dev)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", dev / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", dev / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", dev / "cron" / "output")
+
+    # A job that exists ONLY in the root profile's store — exactly the shape of
+    # the job dev gets asked to verify and cannot see.
+    with jobs_mod.use_cron_store(root):
+        (root / "scripts" / "sums.py").write_text("print('sum is 42')\n")
+        job = jobs_mod.create_job(
+            prompt="",
+            schedule="0 9 1 * *",
+            name="Monthly random sum example",
+            script="sums.py",
+            no_agent=True,
+        )
+
+    return {"root": root, "dev": dev, "job_id": job["id"]}
+
+
+def test_own_store_does_not_show_the_other_profiles_job(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list"))
+    assert result["success"] is True
+    assert result["jobs"] == []  # The isolation still holds by default.
+
+
+def test_list_can_see_another_profiles_jobs(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list", profile="default"))
+    assert result["success"] is True
+    assert [j["job_id"] for j in result["jobs"]] == [two_profiles["job_id"]]
+
+
+def test_run_fires_the_other_profiles_job(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(action="run", job_id=two_profiles["job_id"], profile="default")
+    )
+    assert result["success"] is True
+    # Inline, not a background handle: a detached run would not inherit the
+    # redirection and would look for this job in the caller's own store. Only
+    # the background path labels itself, so the absence of the label is the
+    # evidence — as is having a real outcome instead of a handle.
+    assert result["job"].get("execution_mode") != "background"
+    assert result["job"]["executed"] is True
+    assert result["job"]["execution_success"] is True
+
+
+def test_override_is_unwound_after_the_call(two_profiles):
+    from hermes_constants import get_hermes_home
+    from tools.cronjob_tools import cronjob
+
+    before = get_hermes_home()
+    cronjob(action="list", profile="default")
+    assert get_hermes_home() == before
+
+
+def test_mutating_actions_are_refused_across_profiles(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    for action, kwargs in (
+        ("create", {"schedule": "every 1h", "prompt": "hi"}),
+        ("remove", {"job_id": two_profiles["job_id"]}),
+        ("update", {"job_id": two_profiles["job_id"], "name": "renamed"}),
+        ("pause", {"job_id": two_profiles["job_id"]}),
+    ):
+        result = json.loads(cronjob(action=action, profile="default", **kwargs))
+        assert result["success"] is False, action
+        assert "across profiles" in result["error"], action
+
+    # And the other profile's job is untouched.
+    listing = json.loads(cronjob(action="list", profile="default"))
+    assert listing["jobs"][0]["name"] == "Monthly random sum example"
+
+
+def test_unknown_profile_is_refused(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list", profile="nope"))
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+@pytest.mark.parametrize("name", ["../root", "a/b", "..", "dev\\x"])
+def test_profile_name_must_be_a_bare_name(two_profiles, name):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list", profile=name))
+    assert result["success"] is False
+    assert "not a valid profile name" in result["error"]
+
+
+def test_naming_your_own_profile_is_a_no_op(two_profiles):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list", profile="dev"))
+    assert result["success"] is True
+    assert result["jobs"] == []

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -287,6 +287,89 @@ class TestBuildJobPromptWithScript:
         assert "Simple job." in prompt
 
 
+class TestCreateTimeScriptVerification:
+    """A job must not be schedulable against a script that isn't there.
+
+    Shape validation alone (relative, no traversal) let a job be created
+    against a missing file and still return ``success: true``. The scheduler
+    only found out at fire time, so a monthly job could sit broken for a month
+    while the agent that made it reported the automation as working.
+    """
+
+    def test_create_rejects_missing_script(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="0 9 1 * *",
+            script="never_written.py",
+            no_agent=True,
+        ))
+        assert result["success"] is False
+        # The message must name the resolved path, since "which directory?" is
+        # the actual question the caller has to answer.
+        assert "never_written.py" in result["error"]
+        assert str(cron_env / "scripts") in result["error"]
+
+        # ...and nothing may be left on the schedule.
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"] == []
+
+    def test_create_smoke_runs_the_script(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "works.py").write_text(
+            "print('sum is 42')\n"
+        )
+        result = json.loads(cronjob(
+            action="create",
+            schedule="0 9 1 * *",
+            script="works.py",
+            no_agent=True,
+        ))
+        assert result["success"] is True
+        # Real output, not just a schedule receipt.
+        assert result["smoke_run"]["ok"] is True
+        assert "sum is 42" in result["smoke_run"]["output"]
+
+    def test_failing_smoke_run_is_reported_but_keeps_the_job(
+        self, cron_env, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "broken.py").write_text(
+            "raise SystemExit('boom')\n"
+        )
+        result = json.loads(cronjob(
+            action="create",
+            schedule="0 9 1 * *",
+            script="broken.py",
+            no_agent=True,
+        ))
+        # The schedule itself is valid — it is the script that is broken, so the
+        # job survives to be fixed rather than vanishing with the diagnosis.
+        assert result["success"] is True
+        assert result["smoke_run"]["ok"] is False
+        assert "FAILED" in result["message"]
+        listing = json.loads(cronjob(action="list"))
+        assert len(listing["jobs"]) == 1
+
+    def test_agent_mode_job_is_not_smoke_run(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Summarize the news",
+        ))
+        assert result["success"] is True
+        assert "smoke_run" not in result
+
+
 class TestCronjobToolScript:
     """Test the cronjob tool's script parameter."""
 
@@ -294,6 +377,10 @@ class TestCronjobToolScript:
     def test_clear_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        # The tool refuses to schedule a script it cannot find, so the file has
+        # to exist before the job referencing it can be created.
+        (cron_env / "scripts" / "some_script.py").write_text("print('ok')\n")
 
         create_result = json.loads(cronjob(
             action="create",
@@ -314,6 +401,8 @@ class TestCronjobToolScript:
     def test_list_shows_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "data_collector.py").write_text("print('ok')\n")
 
         cronjob(
             action="create",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -315,6 +315,9 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post(
+        "/v1/approvals/{session_key}/decision", adapter._handle_session_approval
+    )
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
@@ -1514,6 +1517,175 @@ class TestChatCompletionsEndpoint:
             if chunk.get("object") == "chat.completion.chunk":
                 for choice in chunk.get("choices", []):
                     assert "first step" not in (choice.get("delta", {}).get("content") or "")
+
+    @pytest.mark.asyncio
+    async def test_stream_registers_an_approval_notifier(self, adapter):
+        """A streamed turn must give the user a way to answer an approval.
+
+        Without a registered notifier ``tools.approval`` files the request
+        into an in-process dict nothing reads and returns immediately, so
+        every approval-gated tool call fails on this route no matter what the
+        user would have said. The run-scoped notifier does not cover it: that
+        one is registered by /v1/runs, which the SSE chat surfaces don't use.
+        """
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            seen = {}
+
+            async def _mock_run_agent(**kwargs):
+                seen["cb"] = kwargs.get("approval_notify_callback")
+                seen["key"] = kwargs.get("approval_session_key")
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                await resp.text()
+
+        assert callable(seen.get("cb")), "no approval notifier was wired"
+        # The key must be non-empty, or concurrent anonymous turns would all
+        # register under "" and resolve each other's approvals.
+        assert seen.get("key")
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_approval_request(self, adapter):
+        """The pending approval must reach the client as its own event."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                approve_cb = kwargs.get("approval_notify_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if approve_cb:
+                    approve_cb({
+                        "command": "rm -rf /tmp/x",
+                        "description": "terminal command",
+                        "pattern_key": "terminal:rm",
+                        "pattern_keys": ["terminal:rm"],
+                        "allow_permanent": True,
+                    })
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "delete it"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        payloads = []
+        lines = body.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip() != "event: hermes.approval.request":
+                continue
+            for follow in lines[i + 1: i + 4]:
+                if follow.startswith("data: "):
+                    payloads.append(_json.loads(follow[len("data: "):]))
+                    break
+
+        assert len(payloads) == 1, payloads
+        req = payloads[0]
+        assert req["description"] == "terminal command"
+        # The key the client has to send back to answer it.
+        assert req["sessionKey"]
+        # Choices drive the buttons; silence is a denial, so the deadline
+        # travels with the request rather than being guessed client-side.
+        assert "deny" in req["choices"] and "once" in req["choices"]
+        assert isinstance(req["timeoutSeconds"], int) and req["timeoutSeconds"] > 0
+
+    @pytest.mark.asyncio
+    async def test_approval_decision_endpoint(self, adapter):
+        """The decision endpoint resolves by session key, not run id."""
+        import tools.approval as A
+
+        app = _create_app(adapter)
+        session_key = "sess_decision_test"
+
+        async with TestClient(TestServer(app)) as cli:
+            # Nothing pending yet — must not report success.
+            resp = await cli.post(
+                f"/v1/approvals/{session_key}/decision",
+                json={"choice": "once"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["error"]["code"] == "approval_not_pending"
+
+            # A bad choice is rejected before anything is resolved.
+            resp = await cli.post(
+                f"/v1/approvals/{session_key}/decision",
+                json={"choice": "maybe"},
+            )
+            assert resp.status == 400
+
+            # Park a real entry the way a blocked tool would, then answer it.
+            entry = A._ApprovalEntry({"command": "rm -rf /tmp/x"})
+            with A._lock:
+                A._gateway_queues[session_key] = [entry]
+            try:
+                resp = await cli.post(
+                    f"/v1/approvals/{session_key}/decision",
+                    json={"choice": "approve"},  # alias for "once"
+                )
+                assert resp.status == 200
+                assert (await resp.json())["choice"] == "once"
+                # The blocked thread is released with the decision attached.
+                assert entry.event.is_set()
+                assert entry.result == "once"
+            finally:
+                with A._lock:
+                    A._gateway_queues.pop(session_key, None)
+
+    @pytest.mark.asyncio
+    async def test_approval_decision_relays_deny_reason(self, adapter):
+        """A denial with a reason lets the agent adapt instead of just retrying."""
+        import tools.approval as A
+
+        app = _create_app(adapter)
+        session_key = "sess_deny_reason"
+        entry = A._ApprovalEntry({"command": "rm -rf /"})
+        with A._lock:
+            A._gateway_queues[session_key] = [entry]
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    f"/v1/approvals/{session_key}/decision",
+                    json={"choice": "deny", "reason": "wrong directory"},
+                )
+                assert resp.status == 200
+            assert entry.result == "deny"
+            assert entry.reason == "wrong directory"
+        finally:
+            with A._lock:
+                A._gateway_queues.pop(session_key, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1189,9 +1189,10 @@ class TestChatCompletionsEndpoint:
                 cb = kwargs.get("stream_delta_callback")
                 ts_cb = kwargs.get("tool_start_callback")
                 tc_cb = kwargs.get("tool_complete_callback")
-                # The structured callbacks own the chat-completions SSE
-                # channel now; ``tool_progress_callback`` is intentionally
-                # not wired so each tool start emits exactly one event.
+                # The structured callbacks own the tool lifecycle on the
+                # chat-completions SSE channel; ``tool_progress_callback``
+                # is wired only for reasoning, so each tool start still
+                # emits exactly one event.
                 if ts_cb:
                     ts_cb("call_terminal_1", "terminal", {"command": "ls -la"})
                 if tc_cb:
@@ -1290,6 +1291,229 @@ class TestChatCompletionsEndpoint:
             assert "call_orphan_1" not in body
             assert '"status": "running"' not in body
             assert '"status": "completed"' not in body
+
+    @staticmethod
+    def _tool_progress_payloads(body: str) -> list:
+        """Every ``hermes.tool.progress`` payload in an SSE body, in order."""
+        import json as _json
+
+        out = []
+        lines = body.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip() != "event: hermes.tool.progress":
+                continue
+            for follow in lines[i + 1: i + 4]:
+                if follow.startswith("data: "):
+                    try:
+                        out.append(_json.loads(follow[len("data: "):]))
+                    except _json.JSONDecodeError:
+                        pass
+                    break
+        return out
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_completion_carries_result_and_failure(self, adapter):
+        """A settled tool must carry its output and its verdict live.
+
+        The lifecycle event used to be a bare ``status: completed`` with no
+        output attached, so a client could only render the spinner turning
+        into an unconditional green check. The output arrived when the
+        turn's transcript was re-read at the end of the turn, which meant a
+        tool that had actually failed was indistinguishable from one that
+        succeeded for as long as the turn kept running.
+        """
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb("call_ok_1", "terminal", {"command": "true"})
+                    ts_cb("call_bad_1", "terminal", {"command": "false"})
+                if tc_cb:
+                    tc_cb(
+                        "call_ok_1", "terminal", {"command": "true"},
+                        '{"exit_code": 0, "output": "all good"}',
+                    )
+                    # A non-zero exit is the canonical terminal failure.
+                    tc_cb(
+                        "call_bad_1", "terminal", {"command": "false"},
+                        '{"exit_code": 1, "error": "boom"}',
+                    )
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "run"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        settled = [
+            p for p in self._tool_progress_payloads(body)
+            if p.get("status") in ("completed", "failed")
+        ]
+        assert len(settled) == 2, settled
+
+        ok = next(p for p in settled if p["toolCallId"] == "call_ok_1")
+        assert ok["status"] == "completed"
+        # The output rides the event, so an expanded step has something to
+        # show before the transcript is ever re-read.
+        assert "all good" in ok["result"]
+        assert ok["resultTruncated"] is False
+
+        bad = next(p for p in settled if p["toolCallId"] == "call_bad_1")
+        assert bad["status"] == "failed"
+        assert "boom" in bad["result"]
+        # The one-line summary a collapsed step shows comes from the
+        # failure detector rather than the head of the raw JSON.
+        assert "boom" in bad["label"]
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_result_is_truncated(self, adapter):
+        """Tool output shares the stream with the reply, so it is capped."""
+        import asyncio
+
+        from gateway.platforms.api_server import TOOL_RESULT_STREAM_CHARS
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb("call_big_1", "read_file", {"path": "big.txt"})
+                if tc_cb:
+                    tc_cb(
+                        "call_big_1", "read_file", {"path": "big.txt"},
+                        "x" * (TOOL_RESULT_STREAM_CHARS * 3),
+                    )
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "read"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        settled = [
+            p for p in self._tool_progress_payloads(body)
+            if p.get("status") in ("completed", "failed")
+        ]
+        assert len(settled) == 1, settled
+        assert len(settled[0]["result"]) == TOOL_RESULT_STREAM_CHARS
+        assert settled[0]["resultTruncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_reasoning_events(self, adapter):
+        """Reasoning must reach the client while the turn is still running.
+
+        ``_thinking`` is an underscore-prefixed internal tool, so the
+        structured tool callbacks filter it off this channel by design.
+        ``tool_progress_callback`` is therefore wired for reasoning alone —
+        and must stay filtered to it, or every tool chip would be emitted
+        twice (once structured, once via progress).
+        """
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                tp_cb = kwargs.get("tool_progress_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                assert tp_cb is not None, "reasoning channel must be wired"
+                tp_cb("reasoning.available", "_thinking", "**Plan**\nfirst step", None)
+                # run_agent fires the progress callback side-by-side with the
+                # structured ones; these must not produce a second chip.
+                tp_cb("tool.started", "terminal", "ls -la", None)
+                if ts_cb:
+                    ts_cb("call_t_1", "terminal", {"command": "ls -la"})
+                tp_cb("tool.completed", "terminal", None, None)
+                if tc_cb:
+                    tc_cb("call_t_1", "terminal", {"command": "ls -la"}, "ok")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        reasoning = []
+        lines = body.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip() != "event: hermes.reasoning.delta":
+                continue
+            for follow in lines[i + 1: i + 4]:
+                if follow.startswith("data: "):
+                    reasoning.append(_json.loads(follow[len("data: "):]))
+                    break
+
+        assert len(reasoning) == 1, reasoning
+        assert "first step" in reasoning[0]["delta"]
+
+        # The tool lifecycle stays single-emit: forwarding the progress
+        # callback's tool events too would double every chip.
+        pairs = [
+            (p.get("status"), p.get("toolCallId"))
+            for p in self._tool_progress_payloads(body)
+        ]
+        assert pairs == [("running", "call_t_1"), ("completed", "call_t_1")], pairs
+
+        # Reasoning must never leak into assistant text — the model would
+        # learn to imitate it instead of actually reasoning.
+        for line in lines:
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            try:
+                chunk = _json.loads(line[len("data: "):])
+            except _json.JSONDecodeError:
+                continue
+            if chunk.get("object") == "chat.completion.chunk":
+                for choice in chunk.get("choices", []):
+                    assert "first step" not in (choice.get("delta", {}).get("content") or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_idempotency_key_exposed.py
+++ b/tests/hermes_cli/test_kanban_idempotency_key_exposed.py
@@ -1,0 +1,61 @@
+"""``idempotency_key`` must survive the trip back out through the CLI.
+
+Automation that files a task under a dedup key needs to recognise that task
+later — to notice it is already open, to comment on it, to decide whether to
+file again. ``create`` returns an id but never says whether it deduped, and
+every other lookup is by id, so without the key on the way out the only
+available handle is ``title``. That is not a key: a human editing the title
+detaches the automation from its own task, silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban import _task_to_dict
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_idempotency_key_is_serialized(board):
+    tid = kb.create_task(board, title="nightly import failed",
+                         idempotency_key="import:nightly")
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["idempotency_key"] == "import:nightly"
+
+
+def test_absent_key_serializes_as_none(board):
+    """A hand-created task has no key, and must not blow up serialization."""
+    tid = kb.create_task(board, title="written by a human")
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["idempotency_key"] is None
+
+
+def test_key_survives_a_title_edit(board):
+    """The reason title is not a substitute for the key."""
+    tid = kb.create_task(board, title="original title",
+                         idempotency_key="alert:disk-full")
+    with kb.write_txn(board):
+        board.execute(
+            "UPDATE tasks SET title = ? WHERE id = ?",
+            ("disk full on prod-3 (renamed by hand)", tid),
+        )
+
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["title"] != "original title"
+    assert payload["idempotency_key"] == "alert:disk-full"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -7,6 +7,7 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 
 import json
 import logging
+import os
 import re
 import sys
 import threading
@@ -376,6 +377,67 @@ def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> 
     )
 
 
+def _smoke_run_new_script_job(
+    job: Dict[str, Any], no_agent: bool
+) -> Optional[Dict[str, Any]]:
+    """Run a newly created ``no_agent`` script job once, and report what happened.
+
+    A schedule receipt is not evidence that an automation works. Creation used
+    to return ``success: true`` for a job whose script had never been executed,
+    so the first proof of life was the first scheduled fire — a month away for a
+    monthly job, by which time the agent that created it had long since told the
+    user it was done. Everything needed to run it is available here, so run it
+    here and return the real outcome.
+
+    A failing smoke run does NOT roll the job back. The job is a valid,
+    correctly-registered schedule; what failed is the script. Deleting it would
+    throw away the user's intent along with the diagnosis, and leave nothing on
+    the board to fix. Report and keep.
+
+    Returns ``None`` when there is nothing to smoke-run (agent-mode jobs, or no
+    script), so the caller can omit the field entirely.
+    """
+    if not no_agent:
+        return None  # Agent-mode jobs need a live model turn; not a smoke test.
+    script = (job.get("script") or "").strip()
+    if not script:
+        return None
+
+    try:
+        from cron.scheduler import _run_job_script
+
+        ok, output = _run_job_script(script, workdir=job.get("workdir") or None)
+    except Exception as exc:  # never let verification break creation
+        logger.warning("cron smoke run failed to execute for %s: %s", job.get("id"), exc)
+        return {
+            "ran": False,
+            "ok": False,
+            "message": (
+                f"Could not smoke-run the script ({exc}); the job is scheduled "
+                f"but unverified."
+            ),
+        }
+
+    text = (output or "").strip()
+    truncated = text if len(text) <= 2000 else text[:2000] + "… (truncated)"
+    if ok:
+        return {
+            "ran": True,
+            "ok": True,
+            "output": truncated,
+            "message": f"Smoke run succeeded; output: {truncated!r}",
+        }
+    return {
+        "ran": True,
+        "ok": False,
+        "error": truncated,
+        "message": (
+            f"WARNING: the job is scheduled but its first run FAILED: {truncated}. "
+            f"Fix this before reporting the automation as working."
+        ),
+    }
+
+
 def _repeat_display(job: Dict[str, Any]) -> str:
     times = (job.get("repeat") or {}).get("times")
     completed = (job.get("repeat") or {}).get("completed", 0)
@@ -532,11 +594,14 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     # Reject absolute paths and ~ expansion at the API boundary.
     # Only relative paths within ~/.hermes/scripts/ are allowed.
+    # The scripts dir is per-profile, so naming ~/.hermes/scripts here is wrong
+    # for every profile but default and sends the reader to the wrong directory.
+    scripts_display = f"{display_hermes_home()}/scripts/"
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {scripts_display}. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts in {scripts_display} and use just the filename."
         )
 
     # Validate containment after resolution
@@ -548,6 +613,24 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     if containment_error:
         return (
             f"Script path escapes the scripts directory via traversal: {raw!r}"
+        )
+
+    # The script must exist NOW, not at first fire. Shape validation alone let a
+    # job be created against a missing file and still return success: true — the
+    # scheduler only discovers the truth when it runs ("Script not found: ..."),
+    # so a monthly job sat broken for a month while its author reported it done.
+    # Whether the file is there is knowable at this point, so decide here.
+    resolved = scripts_dir / raw
+    if not resolved.is_file():
+        profile = (os.environ.get("HERMES_PROFILE") or "default").strip() or "default"
+        return (
+            f"Script not found: {resolved}. Cron resolves `script` under "
+            f"HERMES_HOME/scripts for the profile that owns the job (profile "
+            f"{profile!r}, {scripts_display}), and that is the only directory it "
+            f"will look in — there is no search path and no fallback. Write the "
+            f"script to that exact path first, then create the job. If this "
+            f"profile cannot write there, hand the work to one that can rather "
+            f"than scheduling a job that cannot run."
         )
 
     return None
@@ -1148,22 +1231,25 @@ def cronjob(
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
                 _create_message = f"{_create_message} {_local_notice}"
-            return json.dumps(
-                {
-                    "success": True,
-                    "job_id": job["id"],
-                    "name": job["name"],
-                    "skill": job.get("skill"),
-                    "skills": job.get("skills", []),
-                    "schedule": job["schedule_display"],
-                    "repeat": _repeat_display(job),
-                    "deliver": job.get("deliver", "local"),
-                    "next_run_at": job["next_run_at"],
-                    "job": _format_job(job),
-                    "message": _create_message,
-                },
-                indent=2,
-            )
+            _smoke = _smoke_run_new_script_job(job, _no_agent)
+            if _smoke is not None:
+                _create_message = f"{_create_message} {_smoke['message']}"
+            _payload = {
+                "success": True,
+                "job_id": job["id"],
+                "name": job["name"],
+                "skill": job.get("skill"),
+                "skills": job.get("skills", []),
+                "schedule": job["schedule_display"],
+                "repeat": _repeat_display(job),
+                "deliver": job.get("deliver", "local"),
+                "next_run_at": job["next_run_at"],
+                "job": _format_job(job),
+                "message": _create_message,
+            }
+            if _smoke is not None:
+                _payload["smoke_run"] = _smoke
+            return json.dumps(_payload, indent=2)
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -5,6 +5,7 @@ Expose a single compressed action-oriented tool to avoid schema/context bloat.
 Compatibility wrappers remain for direct Python callers and legacy tests.
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -375,6 +376,101 @@ def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> 
         "notified when it runs, recreate or update the job with deliver set to "
         "a gateway-connected platform, e.g. deliver='telegram' or deliver='all'."
     )
+
+
+# Actions a caller may perform on ANOTHER profile's cron store. Deliberately
+# limited to inspecting and firing: those are what a profile fixing someone
+# else's automation needs in order to verify its own fix. Creating, editing or
+# deleting jobs in another profile's store is not verification — it is writing
+# unattended schedules into a profile whose owner never asked for them, and the
+# per-profile split (#4707) exists to prevent exactly that.
+_CROSS_PROFILE_ACTIONS = frozenset({"list", "run"})
+
+
+class _CrossProfileDenied(Exception):
+    """A cross-profile request that must be reported rather than performed."""
+
+
+def _resolve_cross_profile_home(profile: str, action: str):
+    """Resolve ``profile`` to a HERMES_HOME, or raise ``_CrossProfileDenied``.
+
+    Returns ``None`` when the request is a no-op (the caller named its own
+    profile), so the caller can take the ordinary path.
+    """
+    from hermes_constants import get_default_hermes_root, get_hermes_home
+
+    name = (profile or "").strip()
+    if not name:
+        return None
+    # A profile name is a single directory component. Anything with a separator
+    # is either a mistake or an attempt to point the cron store at an arbitrary
+    # directory, and neither should be honoured.
+    if "/" in name or "\\" in name or name in {".", ".."}:
+        raise _CrossProfileDenied(
+            f"profile {name!r} is not a valid profile name (expected a bare "
+            f"name like 'default' or 'dev')."
+        )
+    if action not in _CROSS_PROFILE_ACTIONS:
+        raise _CrossProfileDenied(
+            f"action {action!r} is not allowed across profiles. Cron stores are "
+            f"per-profile; another profile's schedule may be inspected and fired "
+            f"({', '.join(sorted(_CROSS_PROFILE_ACTIONS))}) so a fix can be "
+            f"verified, but not created, edited or removed from here."
+        )
+
+    root = get_default_hermes_root()
+    target = root if name == "default" else root / "profiles" / name
+    if not target.is_dir():
+        raise _CrossProfileDenied(
+            f"profile {name!r} not found (looked for {target}). Use the profile "
+            f"directory name, or 'default' for the root profile."
+        )
+    if target.resolve() == get_hermes_home().resolve():
+        return None  # Naming your own profile is just the ordinary path.
+    return target
+
+
+@contextlib.contextmanager
+def _cron_profile_context(profile: Optional[str], action: str):
+    """Point cron storage and script resolution at another profile, temporarily.
+
+    Cron is per-profile by design, which is right for isolation and wrong for
+    repair: a profile handed a broken automation to fix could install the fix
+    but could not run the job to prove it worked, because the job genuinely
+    does not exist in its own store. The work would come back unverified,
+    which defeats the point of routing it there.
+
+    Both the cron store and HERMES_HOME are redirected, because a job's script
+    resolves under HERMES_HOME/scripts — redirecting only the store would find
+    the job and then look for its script in the wrong profile's directory.
+
+    Every crossing is logged: the isolation is intentional, so stepping over it
+    should leave a trace rather than being indistinguishable from ordinary use.
+    """
+    target = None
+    if profile:
+        target = _resolve_cross_profile_home(profile, action)
+    if target is None:
+        yield None
+        return
+
+    from cron.jobs import use_cron_store
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    caller = (os.environ.get("HERMES_PROFILE") or "default").strip() or "default"
+    logger.warning(
+        "cronjob: profile %r performing cross-profile action %r against profile "
+        "%r (%s)", caller, action, profile, target,
+    )
+    token = set_hermes_home_override(str(target))
+    try:
+        with use_cron_store(target):
+            yield target
+    finally:
+        reset_hermes_home_override(token)
 
 
 def _smoke_run_new_script_job(
@@ -1137,12 +1233,25 @@ def cronjob(
     monitor_url: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
 
+    normalized = (action or "").strip().lower()
+    # Enter the (usually inert) profile redirection via an ExitStack so the
+    # large action body below keeps its existing shape; the finally-close is
+    # what guarantees the override is unwound on every return path.
+    _profile_stack = contextlib.ExitStack()
     try:
-        normalized = (action or "").strip().lower()
+        _cross_profile_home = _profile_stack.enter_context(
+            _cron_profile_context(profile, normalized)
+        )
+    except _CrossProfileDenied as denial:
+        _profile_stack.close()
+        return tool_error(str(denial), success=False)
+
+    try:
 
         if normalized == "create":
             if not schedule:
@@ -1338,9 +1447,19 @@ def cronjob(
             # batches of manual runs (#80xxx — the "stuck Telegram session"
             # incident). Falls back to inline execution when the session
             # runtime can't receive detached completions.
-            bg = _try_dispatch_background_run(
-                job, session_id=session_id, extra_prompt=extra_prompt
-            )
+            if _cross_profile_home is not None:
+                # The profile redirection is a ContextVar, and a detached
+                # background run does not inherit it. Dispatching there would
+                # resolve the job against the CALLER's store — finding nothing,
+                # or worse, a different job that happens to share the id. A
+                # cross-profile run is a verification step, so run it inline
+                # where the redirection still holds and the caller gets the
+                # actual outcome rather than a handle.
+                bg = None
+            else:
+                bg = _try_dispatch_background_run(
+                    job, session_id=session_id, extra_prompt=extra_prompt
+                )
             if bg is not None and bg.get("dispatched"):
                 _notify_provider_jobs_changed_safe()
                 result = _format_job(get_job(job_id) or {"id": job_id})
@@ -1522,6 +1641,11 @@ def cronjob(
 
     except Exception as e:
         return tool_error(str(e), success=False)
+    finally:
+        # Unwind any cross-profile redirection on every path, including the
+        # early returns above — a leaked override would silently point the rest
+        # of this context's cron work at the wrong profile's store.
+        _profile_stack.close()
 
 
 
@@ -1536,6 +1660,10 @@ Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing
 action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue. Optionally pass 'prompt' with action='run' to inject transient per-run context (appended to the job's stored prompt for that single fire only, never persisted).
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
+
+Cron stores are PER-PROFILE: action='list' shows only jobs created by your own profile, so a job you were asked to fix or verify may be invisible here and its job_id will not resolve. That means the job is missing, not the id — pass 'profile' with the owning profile's name (e.g. profile='default') to list and run it.
+
+A job's `script` must already exist under this profile's scripts directory before you can schedule it; creation refuses a script it cannot find, and a no_agent job is run once at creation so you get its real output instead of just a schedule.
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
@@ -1556,6 +1684,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "job_id": {
                 "type": "string",
                 "description": "Required for update/pause/resume/remove/run"
+            },
+            "profile": {
+                "type": "string",
+                "description": "Optional. Cron stores are per-profile, so a job created by another profile is invisible here by default. Set this to that profile's name (e.g. 'default') to inspect or fire ITS jobs — use it when you have been asked to fix or verify an automation you did not create and action='list' shows nothing. Only 'list' and 'run' are permitted across profiles; creating, editing or removing another profile's jobs is refused. Omit for your own jobs."
             },
             "prompt": {
                 "type": "string",
@@ -1699,6 +1831,7 @@ registry.register(
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
+        profile=args.get("profile"),
     ),
     check_fn=check_cronjob_requirements,
     emoji="⏰",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -688,11 +688,18 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     raw = script.strip()
 
-    # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
-    # The scripts dir is per-profile, so naming ~/.hermes/scripts here is wrong
-    # for every profile but default and sends the reader to the wrong directory.
-    scripts_display = f"{display_hermes_home()}/scripts/"
+    # Reject absolute paths and ~ expansion at the API boundary; only relative
+    # paths inside this profile's scripts dir are allowed.
+    #
+    # The scripts dir is per-profile, so the old hardcoded "~/.hermes/scripts"
+    # named the wrong directory for every profile but default. Report the real
+    # one — and report it as an absolute path, not via display_hermes_home():
+    # that helper renders "~/."
+    # when HERMES_HOME *is* the home directory — the containerised layout —
+    # which turned this hint into the actively unhelpful "~/./scripts/". These
+    # messages exist to answer "which directory?", and only an absolute path
+    # answers that in every layout and every profile.
+    scripts_display = f"{get_hermes_home()}/scripts/"
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
             f"Script path must be relative to {scripts_display}. "


### PR DESCRIPTION
Part 1 of 3 for #81297. Independent of the other two — safe to merge alone.

## Problem

Automation that files tasks under `--idempotency-key` cannot ask the board what it already filed. `create` returns an id but never says whether it deduped, and every other lookup is by id, so a caller wanting to know "is my alert already open?" has nothing to match on but `title`.

Title is not a key. A human tidying up a card's wording silently detaches the automation from its own task, and the next occurrence files a duplicate.

## Change

`idempotency_key` is already on `Task` and already indexed (`idx_tasks_idempotency`); it was simply absent from `_task_to_dict`, so `kanban list --json` and `kanban show --json` dropped it on the way out. This adds it.

Purely additive — no existing field changes shape.

## Tests

`tests/hermes_cli/test_kanban_idempotency_key_exposed.py` — round-trip, `None` when absent, and survival across a title edit (the case that motivates it).