### PR TITLE
feat(kanban): add --dedupe-scope so a closed task stops hiding a recurrence

### DIFF
--- a/contributors/emails/alton@frontanalytics.com
+++ b/contributors/emails/alton@frontanalytics.com
@@ -1,0 +1,1 @@
+altonalexander

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -347,8 +347,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
-                          help="Dedup key. If a non-archived task with this key exists, "
-                               "its id is returned instead of creating a duplicate.")
+                          help="Dedup key. If a matching task with this key exists, "
+                               "its id is returned instead of creating a duplicate. "
+                               "See --dedupe-scope for what counts as matching.")
+    p_create.add_argument("--dedupe-scope", default="any",
+                          choices=sorted(kb.VALID_DEDUPE_SCOPES),
+                          help="What --idempotency-key matches. 'any' (default) "
+                               "matches any non-archived task, including completed "
+                               "ones — right for retried webhooks, where the second "
+                               "call is the same event. 'open' matches only tasks "
+                               "that are still open — right for recurring alerts, "
+                               "where a task that was already fixed and closed must "
+                               "not suppress the next occurrence.")
     p_create.add_argument("--max-runtime", default=None,
                           help="Per-task runtime cap. Accepts seconds (300) or "
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
@@ -1511,6 +1521,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             parents=tuple(args.parent or ()),
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
+            dedupe_scope=getattr(args, "dedupe_scope", "any") or "any",
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -134,6 +134,24 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
+# What an ``idempotency_key`` is allowed to match, per ``create_task``'s
+# ``dedupe_scope``. Two different needs share that one key:
+#
+#   'any'  — request idempotency. "I may send this same call twice." A retried
+#            webhook is the same event, so matching a completed task is right.
+#   'open' — open-item dedup. "Do not open a second ticket while one is open."
+#            A recurring alert is a NEW event, so a completed task must not
+#            match: the fault came back after somebody fixed it, which is the
+#            most important moment to have a card on the board.
+#
+# 'any' stays the default because changing it would silently alter the meaning
+# of every existing caller's key.
+DEDUPE_EXCLUDED_STATUSES = {
+    "any": ("archived",),
+    "open": ("archived", "done"),
+}
+VALID_DEDUPE_SCOPES = frozenset(DEDUPE_EXCLUDED_STATUSES)
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -2893,6 +2911,7 @@ def create_task(
     parents: Iterable[str] = (),
     triage: bool = False,
     idempotency_key: Optional[str] = None,
+    dedupe_scope: str = "any",
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
@@ -2915,10 +2934,29 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
-    If ``idempotency_key`` is provided and a non-archived task with the
-    same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    If ``idempotency_key`` is provided and a matching task already exists,
+    returns the existing task's id instead of creating a duplicate. Useful
+    for retried webhooks / automation that should not double-write.
+
+    ``dedupe_scope`` decides what "already exists" means, because two
+    different needs have always been sharing this one key:
+
+    * ``"any"`` (default, and the historical behaviour) matches any
+      non-archived task. This is *request* idempotency: "I may send this
+      same call twice, do not create two tasks." Correct for a webhook
+      retry, where the second call is the same event.
+
+    * ``"open"`` matches only tasks that are still open — anything not
+      ``done`` and not ``archived``. This is *open-item* dedup: "do not
+      open a second ticket while one is already open." Correct for
+      recurring automation, where the second call is a *new* occurrence.
+
+    The distinction matters because under ``"any"`` a completed task keeps
+    matching forever. Alerting automation files once, a human fixes it and
+    marks it ``done``, and from then on every recurrence silently returns
+    the closed task's id — while still exiting 0 with a plausible id, so the
+    caller cannot tell it was suppressed. The fault reappears and the board
+    stays empty. ``"open"`` is almost always what recurring automation wants.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3122,11 +3160,19 @@ def create_task(
     # acceptable: two concurrent creators with the same key might both
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
+        if dedupe_scope not in VALID_DEDUPE_SCOPES:
+            raise ValueError(
+                f"dedupe_scope must be one of {sorted(VALID_DEDUPE_SCOPES)}"
+            )
+        # 'open' additionally excludes `done`, so a completed task cannot
+        # suppress a fresh occurrence of a recurring fault.
+        excluded = DEDUPE_EXCLUDED_STATUSES[dedupe_scope]
+        placeholders = ", ".join("?" * len(excluded))
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
+            f"AND status NOT IN ({placeholders}) "
             "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
+            (idempotency_key, *excluded),
         ).fetchone()
         if row:
             return row["id"]

--- a/tests/hermes_cli/test_kanban_dedupe_scope.py
+++ b/tests/hermes_cli/test_kanban_dedupe_scope.py
@@ -1,0 +1,134 @@
+"""``--dedupe-scope`` separates request idempotency from open-item dedup.
+
+The two have always shared one key. Under the historical behaviour a
+completed task keeps matching its key forever, so recurring automation goes
+permanently silent after the first fix: it files once, a human closes the
+task, and every later occurrence quietly returns the closed id — exiting 0
+with a plausible task id, so the caller cannot detect the suppression.
+
+`any` keeps that behaviour for webhook retries, where the second call really
+is the same event. `open` is for alerts, where it is a new one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _set_status(conn, task_id: str, status: str) -> None:
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+# --- the shared behaviour both scopes keep ----------------------------------
+
+
+@pytest.mark.parametrize("scope", ["any", "open"])
+def test_open_task_always_dedupes(board, scope):
+    """Neither scope should open a second ticket while one is still open."""
+    first = kb.create_task(board, title="disk full", idempotency_key="k",
+                           dedupe_scope=scope)
+    second = kb.create_task(board, title="disk full", idempotency_key="k",
+                            dedupe_scope=scope)
+    assert second == first
+
+
+@pytest.mark.parametrize("scope", ["any", "open"])
+def test_archived_never_dedupes(board, scope):
+    """Archiving has always meant "gone"; that is unchanged."""
+    first = kb.create_task(board, title="disk full", idempotency_key="k",
+                           dedupe_scope=scope)
+    _set_status(board, first, "archived")
+    second = kb.create_task(board, title="disk full", idempotency_key="k",
+                            dedupe_scope=scope)
+    assert second != first
+
+
+# --- where they diverge: a completed task -----------------------------------
+
+
+def test_any_scope_still_matches_a_done_task(board):
+    """Backward compatibility. `any` is the default and must not change."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="any")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="any")
+    assert second == first
+
+
+def test_default_scope_is_unchanged_behaviour(board):
+    """Callers that pass no scope keep exactly what they had before."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k")
+    assert second == first
+
+
+def test_open_scope_files_again_after_a_fix(board):
+    """The bug this flag exists for: a regression must reach the board."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    assert second != first, "a completed task swallowed a fresh occurrence"
+
+
+def test_open_scope_dedupes_against_the_newest_open_task(board):
+    """After a regression files a second card, that card dedupes in turn.
+
+    Otherwise the fix would trade silence for 144 cards a day.
+    """
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    third = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    assert third == second != first
+
+
+@pytest.mark.parametrize("status", ["blocked", "running", "review", "todo", "triage"])
+def test_open_scope_treats_in_flight_states_as_open(board, status):
+    """Anything a human or worker is still holding counts as open."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, status)
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    assert second == first
+
+
+# --- guardrails --------------------------------------------------------------
+
+
+def test_unknown_scope_is_rejected(board):
+    with pytest.raises(ValueError, match="dedupe_scope"):
+        kb.create_task(board, title="x", idempotency_key="k", dedupe_scope="sometimes")
+
+
+def test_scope_is_ignored_without_a_key(board):
+    """No key means no dedup at all, whatever the scope says."""
+    a = kb.create_task(board, title="x", dedupe_scope="open")
+    b = kb.create_task(board, title="x", dedupe_scope="open")
+    assert a != b


### PR DESCRIPTION
Part 2 of 3 for #81297. This is the actual fix. Independent of #81299.

## Problem

`--idempotency-key` has been serving two different needs with one key, and only one of them works.

| | meaning | should a `done` task match? |
|---|---|---|
| **Request idempotency** | "I may send this same call twice" | **Yes** — a retried webhook is the same event |
| **Open-item dedup** | "Don't open a second ticket while one is open" | **No** — a recurring alert is a new event |

The lookup implements the first (`status != 'archived'`). The docstring advertises the second — *"automation that should not double-write"* — and that is what recurring automation actually reaches for.

For that use the current behaviour is a trap. `done` is not excluded, so once a task is completed it keeps matching its key forever. Alerting automation files a card, a human fixes it and closes it, and every later occurrence silently returns the closed task's id. `create` exits 0 with a plausible id, so the caller cannot tell it was suppressed.

We hit this on a job firing every ten minutes: hours of failures, an empty board, and a green exit code each time.

```
hermes kanban create "pipeline down" --idempotency-key alert:k   # -> t_aaa
hermes kanban complete t_aaa                                     # human fixes it
hermes kanban create "pipeline down" --idempotency-key alert:k   # -> t_aaa, exit 0
hermes kanban list                                               # board is empty
```

## Change

`--dedupe-scope {any,open}` names the two. `any` is the default and is bit-for-bit the old behaviour, so no existing caller changes. `open` additionally excludes `done`.

## On not changing the default

Deliberate. Flipping it would silently alter the meaning of every key already in use, including one-shot tasks that rely on never being re-filed.

I do think it is worth revisiting for a major — a default whose failure mode is undetectable silence is a poor default — but that is a separate argument from making the correct behaviour available at all, and I did not want to bundle them.

## Tests

`tests/hermes_cli/test_kanban_dedupe_scope.py` — 15 cases: behaviour shared by both scopes, the divergence on `done`, explicit coverage that the default is unchanged, in-flight statuses treated as open, and that a second card dedupes in turn (so the fix does not trade silence for 144 cards a day).

Full existing kanban suite passes. One pre-existing unrelated failure locally (`test_pid_alive_detects_zombie`, a conftest live-system guard) reproduces identically on unmodified `main`.
