### PR TITLE
fix(mcp): reject fabricated DCR for providers without RFC 7591 registration (#78190)

### DIFF
--- a/tests/tools/test_mcp_failure_classification.py
+++ b/tests/tools/test_mcp_failure_classification.py
@@ -17,7 +17,9 @@ from tools.mcp_tool import (
     InvalidMcpUrlError,
     MCPServerTask,
     NonMcpEndpointError,
+    _auth_error_detail,
     _classify_mcp_failure,
+    _mcp_call_failed_message,
     _unwrap_exception_group,
 )
 
@@ -68,6 +70,52 @@ class TestClassifyMcpFailure:
         # Classification must apply to the UNWRAPPED root cause.
         g = _group(_group(FileNotFoundError("cmd not found")))
         assert _classify_mcp_failure(g) == "permanent"
+
+
+# ── _auth_error_detail / _mcp_call_failed_message ────────────────────────────
+
+class TestAuthErrorSurfacing:
+    def test_registration_detail_surfaces(self):
+        """The actionable registration guidance raised by the DCR guard must
+        reach the needs_reauth tool error (GH#78190)."""
+        pytest.importorskip("mcp.client.auth")
+        from mcp.client.auth import OAuthRegistrationError
+
+        exc = OAuthRegistrationError(
+            "MCP OAuth 'gmail': this provider does not support automatic "
+            "client registration ... add it under config.yaml "
+            "mcp_servers.<name>.oauth (client_id, client_secret), then run "
+            "`hermes mcp login gmail`."
+        )
+        detail = _auth_error_detail(exc)
+        assert detail.startswith(" ")
+        assert "config.yaml" in detail
+        assert "client_id" in detail
+
+    def test_registration_detail_unwraps_group(self):
+        """The transport raises the auth error inside a TaskGroup wrapper —
+        the detail must still be found."""
+        pytest.importorskip("mcp.client.auth")
+        from mcp.client.auth import OAuthRegistrationError
+
+        exc = OAuthRegistrationError("config.yaml guidance")
+        assert "config.yaml" in _auth_error_detail(_group(exc))
+
+    def test_non_registration_no_detail(self):
+        assert _auth_error_detail(ValueError("nope")) == ""
+        assert _auth_error_detail(_group(TimeoutError("t"))) == ""
+
+    def test_mcp_call_failed_message_unwraps_group(self):
+        """The generic error path must surface the group root cause instead
+        of the opaque TaskGroup wrapper text."""
+        pytest.importorskip("mcp.client.auth")
+        from mcp.client.auth import OAuthRegistrationError
+
+        exc = OAuthRegistrationError("registration guidance text")
+        msg = _mcp_call_failed_message(_group(exc))
+        assert "OAuthRegistrationError" in msg
+        assert "registration guidance text" in msg
+        assert "TaskGroup" not in msg
 
 
 # ── Keepalive failure log surfaces the root cause ────────────────────────────

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -834,3 +834,34 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+def test_humanize_404_registration_error_guidance():
+    """A 404 on the registration endpoint surfaces pre-registered-client
+    guidance instead of the raw SDK traceback (GH#78190 — Google's hosted
+    Gmail/Drive MCP servers answer the SDK's guessed /register with 404)."""
+    from tools.mcp_oauth import humanize_oauth_registration_error
+
+    msg = humanize_oauth_registration_error(
+        "gmail",
+        "Registration failed: 404 <html>Error 404 (Not Found)!!1</html>",
+        server_url="https://gmailmcp.googleapis.com/mcp/v1",
+    )
+    assert msg is not None
+    assert "does not support automatic client registration" in msg
+    assert "client_id" in msg
+    assert "hermes mcp login gmail" in msg
+
+
+def test_humanize_404_non_registration_passthrough():
+    """A 404 that has nothing to do with registration stays raw."""
+    from tools.mcp_oauth import humanize_oauth_registration_error
+
+    assert (
+        humanize_oauth_registration_error(
+            "srv",
+            RuntimeError("HTTP 404: no such tool"),
+            server_url="https://example.com/mcp",
+        )
+        is None
+    )

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -208,3 +208,254 @@ async def _noop_callback() -> tuple[str, str | None]:
     raise AssertionError(
         "callback handler should not be invoked in bidirectional-generator tests"
     )
+
+
+@pytest.mark.asyncio
+async def test_fabricated_dcr_registration_rejected_before_network(tmp_path, monkeypatch):
+    """The bridge must raise instead of sending the SDK's *fabricated* DCR POST.
+
+    Google's hosted Gmail/Drive MCP servers advertise no RFC 7591
+    ``registration_endpoint`` in their ASM, so the SDK falls back to guessing
+    ``POST {server_origin}/register`` (``create_client_registration_request``,
+    mcp/client/auth/utils.py) — a URL those servers answer with an opaque 404
+    (GH#78190). The guard in ``HermesMCPOAuthProvider`` must intercept that
+    guessed request and raise an actionable ``OAuthRegistrationError`` before
+    any network call, instead of letting the gateway burn the reconnect
+    ladder on an unrecoverable registration failure.
+
+    Drive the full discovery dance (401 -> PRM -> ASM without
+    registration_endpoint -> fabricated registration POST) through the
+    generator manually, exactly like the other tests in this file.
+    """
+    import httpx
+    from mcp.client.auth import OAuthRegistrationError
+    from mcp.shared.auth import OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    # Empty storage: no tokens, no client_info — the SDK's 401 branch must
+    # take the registration path (this is the cold gateway state for a
+    # provider whose cached client is gone).
+    storage = HermesTokenStorage("srv")
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    # 1. Initial outbound MCP request.
+    outbound = await flow.__anext__()
+    assert outbound is not None
+
+    # 2. 401 with a resource_metadata pointer -> SDK starts PRM discovery.
+    fake_401 = httpx.Response(
+        401,
+        request=outbound,
+        headers={
+            "www-authenticate": (
+                'Bearer resource_metadata="https://example.com/.well-known/'
+                'oauth-protected-resource"'
+            )
+        },
+    )
+    prm_request = await flow.asend(fake_401)
+    assert isinstance(prm_request, httpx.Request)
+    assert prm_request.method == "GET"
+
+    # 3. Serve PRM pointing at a fake authorization server.
+    prm_response = httpx.Response(
+        200,
+        request=prm_request,
+        headers={"Content-Type": "application/json"},
+        json={
+            "authorization_servers": ["https://auth.example.com"],
+            "resource": "https://example.com/mcp",
+            "bearer_methods_supported": ["header"],
+        },
+    )
+    asm_request = await flow.asend(prm_response)
+    assert isinstance(asm_request, httpx.Request)
+    assert asm_request.method == "GET"
+
+    # 4. Serve ASM with NO registration_endpoint (the Google Gmail/Drive
+    #    MCP class of provider).
+    asm_response = httpx.Response(
+        200,
+        request=asm_request,
+        headers={"Content-Type": "application/json"},
+        json={
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "response_types_supported": ["code"],
+            "code_challenge_methods_supported": ["S256"],
+        },
+    )
+
+    # 5. The SDK now wants to POST the fabricated registration URL — the
+    #    bridge must raise the actionable error instead of yielding it.
+    with pytest.raises(OAuthRegistrationError) as excinfo:
+        await flow.asend(asm_response)
+    text = str(excinfo.value)
+    assert "does not support automatic client registration" in text
+    assert "https://example.com/register" in text
+    assert "config.yaml" in text
+    assert "hermes mcp login srv" in text
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_advertised_registration_endpoint_passes_through(tmp_path, monkeypatch):
+    """A server that *advertises* a registration endpoint must NOT be blocked.
+
+    Real-world case: Linear's MCP ASM advertises
+    ``registration_endpoint: https://mcp.linear.app/register`` — the same
+    origin+path the SDK would fabricate. The guard's AND condition (exact
+    fabricated URL **and** no advertised registration_endpoint) must let
+    such servers through; otherwise every legitimate DCR flow breaks.
+    """
+    import httpx
+    from mcp.shared.auth import OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    outbound = await flow.__anext__()
+    fake_401 = httpx.Response(
+        401,
+        request=outbound,
+        headers={
+            "www-authenticate": (
+                'Bearer resource_metadata="https://example.com/.well-known/'
+                'oauth-protected-resource"'
+            )
+        },
+    )
+    prm_request = await flow.asend(fake_401)
+    prm_response = httpx.Response(
+        200,
+        request=prm_request,
+        headers={"Content-Type": "application/json"},
+        json={
+            "authorization_servers": ["https://auth.example.com"],
+            "resource": "https://example.com/mcp",
+            "bearer_methods_supported": ["header"],
+        },
+    )
+    asm_request = await flow.asend(prm_response)
+
+    # ASM DOES advertise a registration endpoint — at origin+/register,
+    # exactly the URL the SDK would otherwise fabricate (Linear's ASM does
+    # this: https://mcp.linear.app/register).
+    asm_response = httpx.Response(
+        200,
+        request=asm_request,
+        headers={"Content-Type": "application/json"},
+        json={
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "registration_endpoint": "https://example.com/register",
+            "response_types_supported": ["code"],
+            "code_challenge_methods_supported": ["S256"],
+        },
+    )
+
+    # The registration POST must be yielded (not blocked): the SDK uses the
+    # advertised endpoint and the guard must pass it through.
+    registration_request = await flow.asend(asm_response)
+    assert isinstance(registration_request, httpx.Request)
+    assert registration_request.method == "POST"
+    assert str(registration_request.url) == "https://example.com/register"
+
+    # No OAuthRegistrationError may have been raised along the way. (The
+    # dance ends here: a 200 registration response would hand control to the
+    # browser-redirect flow, which is outside this test's scope.)
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_guard_ignores_non_fabricated_post_paths(tmp_path, monkeypatch):
+    """A POST to a *different* path must never be blocked by the guard.
+
+    The guard is exact-URL matched: only the SDK's fabricated
+    ``{origin}/register`` POST is rejected when the ASM lacks a
+    registration_endpoint. A server-side registration at ``/foo/register``
+    or any other path passes through untouched.
+    """
+    import httpx
+    from mcp.shared.auth import OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=HermesTokenStorage("srv"),
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    # No ASM discovered yet (oauth_metadata None) — the guard must still
+    # ignore anything that is not the fabricated origin+/register POST.
+    for url in (
+        "https://example.com/foo/register",
+        "https://example.com/register/",
+        "https://example.com/registers",
+        "https://other.example.com/register",
+    ):
+        await provider._maybe_reject_fabricated_registration(
+            httpx.Request("POST", url)
+        )  # must not raise

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1270,7 +1270,14 @@ def humanize_oauth_registration_error(
     """
     msg = str(exc)
     lowered = msg.lower()
-    if "403" not in msg and "forbidden" not in lowered:
+    # 404 on a registration endpoint (e.g. Google's Gmail/Drive MCP servers
+    # answer the SDK's guessed /register with a 404 page) is the same
+    # permanent "no RFC 7591 DCR" class as 403 — surface the pre-registered
+    # client guidance instead of the raw traceback.
+    is_404_registration = "404" in msg and (
+        "not found" in lowered or "/register" in lowered
+    )
+    if not is_404_registration and "403" not in msg and "forbidden" not in lowered:
         return None
     looks_like_registration = (
         "regist" in lowered
@@ -1291,6 +1298,17 @@ def humanize_oauth_registration_error(
             f"client_name: {_FIGMA_DCR_CLIENT_NAME!r} automatically. If you "
             "set oauth.client_name yourself, change it to one of those, or "
             "clear it and re-run:\n"
+            f"  hermes mcp login {server_name}"
+        )
+
+    if is_404_registration:
+        return (
+            f"'{server_name}' does not support automatic client registration "
+            "— the registration request returned 404 (typical for Google's "
+            "hosted Gmail/Drive MCP servers and other providers without "
+            "RFC 7591 dynamic client registration). Create an OAuth client "
+            "for this provider and add it under config.yaml as "
+            "`oauth: {client_id: ..., client_secret: ...}`, then re-run:\n"
             f"  hermes mcp login {server_name}"
         )
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -111,6 +111,7 @@ def _make_hermes_provider_class() -> Optional[type]:
     """
     try:
         from mcp.client.auth.oauth2 import OAuthClientProvider
+        from mcp.client.auth import OAuthRegistrationError
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
 
@@ -387,6 +388,75 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
+        async def _maybe_reject_fabricated_registration(self, outgoing: Any) -> None:
+            """Refuse to send the SDK's *fabricated* dynamic client registration.
+
+            When the authorization server advertises no ``registration_endpoint``
+            (RFC 8414 ASM) and no ``client_metadata_url``, the MCP SDK's
+            ``create_client_registration_request`` guesses
+            ``POST {server_origin}/register`` (mcp/client/auth/utils.py). Providers
+            that don't support RFC 7591 DCR — Google's hosted Gmail/Drive MCP
+            servers, Atlassian, and similar — answer that guessed URL with an
+            opaque 404 (``OAuthRegistrationError: Registration failed: 404``), and
+            the gateway burns the reconnect ladder on an unrecoverable failure.
+
+            The supported path for such providers is a pre-registered client
+            (``oauth.client_id`` / ``oauth.client_secret`` in config.yaml) — the
+            same guidance the CLI login path already gives
+            (``hermes_cli/mcp_config.py``). Raise instead of sending the request
+            so the user sees the actionable message, not a 404 traceback.
+
+            Conservative by construction — fires ONLY when both hold:
+
+              * the outgoing request is a POST to the exact URL the SDK would
+                fabricate from the server origin (``urljoin(origin, "/register")``),
+                and
+              * the discovered ASM has no ``registration_endpoint``.
+
+            Servers that advertise a real RFC 7591 endpoint — even one hosted at
+            ``origin/register`` — pass through untouched.
+            """
+            import httpx  # local import: httpx is an MCP SDK dependency
+            from urllib.parse import urljoin
+
+            if not isinstance(outgoing, httpx.Request):
+                return
+            if outgoing.method != "POST":
+                return
+            meta = getattr(self.context, "oauth_metadata", None)
+            if meta is not None and getattr(meta, "registration_endpoint", None):
+                return
+            # Build the expected URL as an httpx.URL so component semantics
+            # (scheme/host/port/path, default-port handling) are identical on
+            # both sides of the comparison — a urlsplit() counterpart would
+            # diverge if httpx ever fills default ports. Fail-open if the SDK
+            # ever changes how it builds the URL: the old 404 behaviour
+            # simply returns.
+            expected = httpx.URL(
+                urljoin(
+                    self.context.get_authorization_base_url(self.context.server_url),
+                    "/register",
+                )
+            )
+            if (
+                outgoing.url.scheme != expected.scheme
+                or outgoing.url.host != expected.host
+                or outgoing.url.port != expected.port
+                or outgoing.url.path != expected.path
+            ):
+                return
+            raise OAuthRegistrationError(
+                f"MCP OAuth '{self._hermes_server_name}': this provider does not "
+                "support automatic client registration (its authorization server "
+                "advertises no registration_endpoint), so the SDK's fallback "
+                f"would POST {str(expected)} and fail (Google's hosted "
+                "Gmail/Drive MCP servers and similar providers return 404 for "
+                "it). Create an OAuth client for this provider and add it under "
+                "config.yaml mcp_servers.<name>.oauth (client_id, client_secret), "
+                "then run "
+                f"`hermes mcp login {self._hermes_server_name}`."
+            )
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -420,6 +490,9 @@ def _make_hermes_provider_class() -> Optional[type]:
             try:
                 outgoing = await inner.__anext__()
                 while True:
+                    # Refuse the SDK's fabricated DCR request (ASM without a
+                    # registration_endpoint) before it hits the network.
+                    await self._maybe_reject_fabricated_registration(outgoing)
                     incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4166,12 +4166,52 @@ def _handle_auth_error_and_retry(
     # retrying the tool.
     _bump_server_error(server_name)
     return tool_error(
-        f"MCP server '{server_name}' requires re-authentication. "
+        f"MCP server '{server_name}' requires re-authentication."
+        f"{_auth_error_detail(exc)} "
         f"Run `hermes mcp login {server_name}` (or delete the tokens "
         f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
         f"this tool — ask the user to re-authenticate.",
         needs_reauth=True,
         server=server_name,
+    )
+
+
+def _auth_error_detail(exc: BaseException) -> str:
+    """Return actionable detail for registration-class auth failures.
+
+    The mcp SDK raises :class:`OAuthRegistrationError` when dynamic client
+    registration fails — e.g. the 404 from a provider that doesn't support
+    RFC 7591 DCR (Google's hosted Gmail/Drive MCP servers). The guard in
+    ``HermesMCPOAuthProvider`` raises that error with the exact next step
+    (create an OAuth client, add ``oauth.client_id`` to config.yaml);
+    surface its text here instead of only the generic re-auth wording so
+    the model can relay it to the user. Unwraps TaskGroup wrappers because
+    the transport raises the auth error inside a group.
+    """
+    try:
+        from mcp.client.auth import OAuthRegistrationError
+    except ImportError:  # pragma: no cover — SDK required in CI
+        return ""
+    root = _unwrap_exception_group(exc)
+    if isinstance(root, OAuthRegistrationError):
+        text = str(root).strip()
+        if text:
+            return f" {_sanitize_error(text)}"
+    return ""
+
+
+def _mcp_call_failed_message(exc: BaseException) -> str:
+    """Build the generic tool-error text, surfacing the group root cause.
+
+    The MCP SDK's streamable-HTTP transport wraps transport failures in a
+    TaskGroup ``ExceptionGroup`` whose ``str()`` is opaque ("unhandled
+    errors in a TaskGroup (1 sub-exception)"). Unwrap so the model and the
+    user see the actual error (e.g. the actionable registration guidance
+    from ``OAuthRegistrationError``) instead of the wrapper text.
+    """
+    root = _unwrap_exception_group(exc)
+    return _sanitize_error(
+        f"MCP call failed: {type(root).__name__}: {_exc_str(root)}"
     )
 
 
@@ -5341,9 +5381,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(_mcp_call_failed_message(exc))
 
     return _handler
 
@@ -5397,9 +5435,7 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
             logger.error(
                 "MCP %s/list_resources failed: %s", server_name, exc,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(_mcp_call_failed_message(exc))
 
     return _handler
 
@@ -5458,9 +5494,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             logger.error(
                 "MCP %s/read_resource failed: %s", server_name, exc,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(_mcp_call_failed_message(exc))
 
     return _handler
 
@@ -5519,9 +5553,7 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
             logger.error(
                 "MCP %s/list_prompts failed: %s", server_name, exc,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(_mcp_call_failed_message(exc))
 
     return _handler
 
@@ -5584,9 +5616,7 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             logger.error(
                 "MCP %s/get_prompt failed: %s", server_name, exc,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(_mcp_call_failed_message(exc))
 
     return _handler
 


### PR DESCRIPTION
## Summary

Fixes #78190: gateway sessions (Slack, cron, etc.) fail for **Gmail MCP and any Google-hosted MCP server** with `OAuthRegistrationError: Registration failed: 404` on `POST /register`, while `hermes mcp login` / `hermes mcp test` look healthy.

## Root cause

1. **`tools/list` is unauthenticated on Google's hosted MCP servers.** `initialize` and `tools/list` return `200` without any credentials (the server is a stateless ESF endpoint), so `hermes mcp test` "succeeds" and `hermes mcp login` re-uses cached tokens without ever exercising a protected call. The failure only appears on the first real **tool call**, which returns `401` with `WWW-Authenticate: Bearer resource_metadata="…/oauth-protected-resource/list_labels"`.
2. **The mcp SDK fabricates the registration URL.** Discovery resolves to `authorization_servers: ["https://accounts.google.com/"]`, whose ASM advertises **no `registration_endpoint`** and no `client_metadata_url`. In that case `mcp/client/auth/utils.py:create_client_registration_request` falls back to guessing `POST urljoin(server_origin, "/register")` — i.e. `https://gmailmcp.googleapis.com/register` — which Google answers with its generic 404 page. `handle_registration_response` then raises `OAuthRegistrationError: Registration failed: 404` — the exact traceback in #78190.
3. **Hermes had no guard and no actionable error path.** No code checked whether the registration URL was fabricated; `humanize_oauth_registration_error` only covered 403/Figma; and the 404 error surfaced to the model as either an opaque TaskGroup wrapper (`MCP call failed: ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)`) or the generic "requires re-authentication" text with no explanation of what to do.

Google does not support RFC 7591 dynamic client registration for these servers; the supported path (already documented in the CLI login flow, `hermes_cli/mcp_config.py`) is a **pre-registered OAuth client** configured under `mcp_servers.<name>.oauth.client_id` / `client_secret`.

## The fix

- **`tools/mcp_oauth_manager.py`** — `HermesMCPOAuthProvider._maybe_reject_fabricated_registration()` intercepts the SDK's fabricated registration POST in the bidirectional `auth_flow` bridge and raises an actionable `OAuthRegistrationError` (create an OAuth client, add `oauth.client_id`/`client_secret` under `mcp_servers.<name>.oauth` in `config.yaml`, run `hermes mcp login <name>`) **before any network request**. Conservative by construction: fires only when the outgoing POST targets the exact SDK-fabricated URL **and** the discovered ASM has no `registration_endpoint` — servers advertising a real RFC 7591 endpoint (e.g. Figma) pass through untouched.
- **`tools/mcp_tool.py`** — the `needs_reauth` tool error now includes the registration guidance when the underlying error is an `OAuthRegistrationError` (unwrapping TaskGroup exception groups), and the generic `MCP call failed` path unwraps the group so the root cause reaches the model instead of the opaque wrapper text.
- **`tools/mcp_oauth.py`** — `humanize_oauth_registration_error` treats 404 registration failures (body mentions "not found" or "/register") the same as 403: pre-registered-client guidance instead of the raw traceback (CLI login path).

## Testing

- New: full discovery dance (401 → PRM → ASM without `registration_endpoint` → fabricated POST) driven through the real generator bridge, asserting the guard raises before any network send.
- New: positive pass-through (ASM *with* an advertised endpoint at origin+`/register` — Linear's shape — must not be blocked) and exact-match negatives (other paths/hosts/trailing slash must not be blocked).
- New: humanize 404 + non-registration 404 passthrough; `_auth_error_detail` direct and group-unwrapped; `_mcp_call_failed_message` group unwrap.
- `pytest tests/tools -k "mcp or oauth"`: **494 passed, 2 skipped**. `ruff check` clean.

## Notes

- **Open question:** the guard intentionally blocks the SDK's guessed `POST {origin}/register` for servers that don't advertise a `registration_endpoint` — including any legacy server that would have *accepted* the guess without advertising it (the SDK's fallback exists for non-conformant servers). Such a server would now surface an actionable pre-registered-client error instead of registering. If maintainers prefer to preserve the guess for those servers, the guard could be gated on an opt-in config key instead.
- **Open question:** the mtime first-observation race from #39551 is a separate, related bug (both fix PRs #39569 / #56470 remain open; reviewer feedback on #39569 suggests a `None` sentinel instead of the `old == 0` check). This PR intentionally does not fold that in; landing it separately keeps the two fixes independently reviewable. #67833 (idle-expired token reset on reconnect) is also orthogonal and unmerged.
- The CLI login path already tells users with non-DCR providers to configure a pre-registered client; this PR makes the runtime gateway path do the same instead of retrying into a 404.
- Related tracking: #53870 (login never triggers OAuth when `initialize` is public) and #78354 (documenting Google Workspace remote MCP servers) both remain open.
