### PR TITLE
feat(kanban): add --on-duplicate comment to make a deduped card show recurrence

### DIFF
--- a/contributors/emails/alton@frontanalytics.com
+++ b/contributors/emails/alton@frontanalytics.com
@@ -1,0 +1,1 @@
+altonalexander

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -347,8 +347,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
-                          help="Dedup key. If a non-archived task with this key exists, "
-                               "its id is returned instead of creating a duplicate.")
+                          help="Dedup key. If a matching task with this key exists, "
+                               "its id is returned instead of creating a duplicate. "
+                               "See --dedupe-scope for what counts as matching.")
+    p_create.add_argument("--dedupe-scope", default="any",
+                          choices=sorted(kb.VALID_DEDUPE_SCOPES),
+                          help="What --idempotency-key matches. 'any' (default) "
+                               "matches any non-archived task, including completed "
+                               "ones — right for retried webhooks, where the second "
+                               "call is the same event. 'open' matches only tasks "
+                               "that are still open — right for recurring alerts, "
+                               "where a task that was already fixed and closed must "
+                               "not suppress the next occurrence.")
     p_create.add_argument("--max-runtime", default=None,
                           help="Per-task runtime cap. Accepts seconds (300) or "
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
@@ -1511,6 +1521,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             parents=tuple(args.parent or ()),
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
+            dedupe_scope=getattr(args, "dedupe_scope", "any") or "any",
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -359,6 +359,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "that are still open — right for recurring alerts, "
                                "where a task that was already fixed and closed must "
                                "not suppress the next occurrence.")
+    p_create.add_argument("--on-duplicate", default="return",
+                          choices=sorted(kb.VALID_ON_DUPLICATE),
+                          help="What to do when --idempotency-key matches. "
+                               "'return' (default) returns the id silently. "
+                               "'comment' also records the recurrence on the "
+                               "existing task, so one card shows how often the "
+                               "problem is still happening instead of reading "
+                               "like a one-off.")
+    p_create.add_argument("--recurrence-throttle", type=int,
+                          default=kb.DEFAULT_RECURRENCE_THROTTLE_SECONDS,
+                          metavar="SECONDS",
+                          help="With --on-duplicate comment, how long to keep "
+                               "updating one recurrence line before starting a "
+                               "new one (default: 3600). The running total stays "
+                               "accurate regardless; this only bounds how many "
+                               "lines a job on a timer can add. 0 = one line per "
+                               "occurrence.")
     p_create.add_argument("--max-runtime", default=None,
                           help="Per-task runtime cap. Accepts seconds (300) or "
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
@@ -1522,6 +1539,10 @@ def _cmd_create(args: argparse.Namespace) -> int:
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             dedupe_scope=getattr(args, "dedupe_scope", "any") or "any",
+            on_duplicate=getattr(args, "on_duplicate", "return") or "return",
+            recurrence_throttle_seconds=getattr(
+                args, "recurrence_throttle",
+                kb.DEFAULT_RECURRENCE_THROTTLE_SECONDS),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -134,6 +134,24 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
+# What an ``idempotency_key`` is allowed to match, per ``create_task``'s
+# ``dedupe_scope``. Two different needs share that one key:
+#
+#   'any'  — request idempotency. "I may send this same call twice." A retried
+#            webhook is the same event, so matching a completed task is right.
+#   'open' — open-item dedup. "Do not open a second ticket while one is open."
+#            A recurring alert is a NEW event, so a completed task must not
+#            match: the fault came back after somebody fixed it, which is the
+#            most important moment to have a card on the board.
+#
+# 'any' stays the default because changing it would silently alter the meaning
+# of every existing caller's key.
+DEDUPE_EXCLUDED_STATUSES = {
+    "any": ("archived",),
+    "open": ("archived", "done"),
+}
+VALID_DEDUPE_SCOPES = frozenset(DEDUPE_EXCLUDED_STATUSES)
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -2893,6 +2911,7 @@ def create_task(
     parents: Iterable[str] = (),
     triage: bool = False,
     idempotency_key: Optional[str] = None,
+    dedupe_scope: str = "any",
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
@@ -2915,10 +2934,29 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
-    If ``idempotency_key`` is provided and a non-archived task with the
-    same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    If ``idempotency_key`` is provided and a matching task already exists,
+    returns the existing task's id instead of creating a duplicate. Useful
+    for retried webhooks / automation that should not double-write.
+
+    ``dedupe_scope`` decides what "already exists" means, because two
+    different needs have always been sharing this one key:
+
+    * ``"any"`` (default, and the historical behaviour) matches any
+      non-archived task. This is *request* idempotency: "I may send this
+      same call twice, do not create two tasks." Correct for a webhook
+      retry, where the second call is the same event.
+
+    * ``"open"`` matches only tasks that are still open — anything not
+      ``done`` and not ``archived``. This is *open-item* dedup: "do not
+      open a second ticket while one is already open." Correct for
+      recurring automation, where the second call is a *new* occurrence.
+
+    The distinction matters because under ``"any"`` a completed task keeps
+    matching forever. Alerting automation files once, a human fixes it and
+    marks it ``done``, and from then on every recurrence silently returns
+    the closed task's id — while still exiting 0 with a plausible id, so the
+    caller cannot tell it was suppressed. The fault reappears and the board
+    stays empty. ``"open"`` is almost always what recurring automation wants.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3122,11 +3160,19 @@ def create_task(
     # acceptable: two concurrent creators with the same key might both
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
+        if dedupe_scope not in VALID_DEDUPE_SCOPES:
+            raise ValueError(
+                f"dedupe_scope must be one of {sorted(VALID_DEDUPE_SCOPES)}"
+            )
+        # 'open' additionally excludes `done`, so a completed task cannot
+        # suppress a fresh occurrence of a recurring fault.
+        excluded = DEDUPE_EXCLUDED_STATUSES[dedupe_scope]
+        placeholders = ", ".join("?" * len(excluded))
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
+            f"AND status NOT IN ({placeholders}) "
             "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
+            (idempotency_key, *excluded),
         ).fetchone()
         if row:
             return row["id"]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -152,6 +152,29 @@ DEDUPE_EXCLUDED_STATUSES = {
 }
 VALID_DEDUPE_SCOPES = frozenset(DEDUPE_EXCLUDED_STATUSES)
 
+# What ``create_task`` does when ``idempotency_key`` matches an existing task.
+#
+#   'return'  — return the id, say nothing. The historical behaviour.
+#   'comment' — record the recurrence on the existing task, then return the id.
+#
+# Deduping is right, but silence is not the same thing. A card that says
+# "failed at 15:18" reads like a one-off even when the job has failed every ten
+# minutes since; nothing on the board separates a blip from an outage. 'comment'
+# is the missing half: one card, and a visible count of how bad it is.
+VALID_ON_DUPLICATE = frozenset({"return", "comment"})
+
+# Prefix identifying a recurrence comment, so repeats can be counted and
+# throttled without a schema change.
+RECURRENCE_COMMENT_PREFIX = "[recurrence]"
+
+# How long to stay quiet after recording a recurrence, in seconds.
+#
+# Non-zero by default on purpose. The flag exists for automation that retries
+# on a timer, and a ten-minute job would otherwise leave 144 comments a day —
+# re-creating, one level down, the very noise that made dedup necessary. Pass
+# 0 to comment on every duplicate.
+DEFAULT_RECURRENCE_THROTTLE_SECONDS = 3600
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -2912,6 +2935,8 @@ def create_task(
     triage: bool = False,
     idempotency_key: Optional[str] = None,
     dedupe_scope: str = "any",
+    on_duplicate: str = "return",
+    recurrence_throttle_seconds: int = DEFAULT_RECURRENCE_THROTTLE_SECONDS,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
@@ -2957,6 +2982,14 @@ def create_task(
     the closed task's id — while still exiting 0 with a plausible id, so the
     caller cannot tell it was suppressed. The fault reappears and the board
     stays empty. ``"open"`` is almost always what recurring automation wants.
+
+    ``on_duplicate`` decides whether a deduped call leaves a trace.
+    ``"return"`` (default) is silent, as before. ``"comment"`` records the
+    recurrence on the matched task via :func:`record_recurrence`, so one card
+    carries a running count instead of reading like a single incident — the
+    difference between "failed at 15:18" and "failed at 15:18, occurrence
+    #47". ``recurrence_throttle_seconds`` bounds how many comment lines that
+    can add; the count itself is always exact.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3175,6 +3208,24 @@ def create_task(
             (idempotency_key, *excluded),
         ).fetchone()
         if row:
+            if on_duplicate not in VALID_ON_DUPLICATE:
+                raise ValueError(
+                    f"on_duplicate must be one of {sorted(VALID_ON_DUPLICATE)}"
+                )
+            if on_duplicate == "comment":
+                # Never let bookkeeping break the caller: the point of dedup is
+                # that this path is the *quiet* one. A task that vanished
+                # between the SELECT and here is exactly the race the comment
+                # is not worth failing for.
+                try:
+                    record_recurrence(
+                        conn,
+                        row["id"],
+                        author=created_by or "automation",
+                        throttle_seconds=recurrence_throttle_seconds,
+                    )
+                except (ValueError, sqlite3.Error):
+                    pass
             return row["id"]
 
     now = int(time.time())
@@ -3680,6 +3731,73 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # ---------------------------------------------------------------------------
 # Comments & events
 # ---------------------------------------------------------------------------
+
+def _latest_recurrence(conn: sqlite3.Connection, task_id: str):
+    """The most recent recurrence comment on ``task_id``, or None."""
+    return conn.execute(
+        "SELECT id, body, created_at FROM task_comments "
+        "WHERE task_id = ? AND body LIKE ? "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id, RECURRENCE_COMMENT_PREFIX + "%"),
+    ).fetchone()
+
+
+def count_recurrences(conn: sqlite3.Connection, task_id: str) -> int:
+    """How many times this task's problem has been reported again.
+
+    Read from the running total carried in the newest recurrence comment
+    rather than by counting comments, because throttling coalesces several
+    occurrences into one line — counting rows would report how often we
+    chose to write, not how often it happened.
+
+    Stored in the comment body rather than a column so recurrence tracking
+    needs no migration and degrades to 0 on any older database.
+    """
+    row = _latest_recurrence(conn, task_id)
+    if not row:
+        return 0
+    match = re.search(r"occurrence #(\d+)", row["body"] or "")
+    return int(match.group(1)) if match else 0
+
+
+def record_recurrence(
+    conn: sqlite3.Connection,
+    task_id: str,
+    author: str = "automation",
+    throttle_seconds: int = DEFAULT_RECURRENCE_THROTTLE_SECONDS,
+    detail: Optional[str] = None,
+) -> int:
+    """Note that a deduped task's underlying problem happened again.
+
+    Returns the comment id carrying the count. Within the throttle window the
+    existing comment is updated in place rather than a new one appended, so a
+    job on a ten-minute timer leaves one line that climbs — "occurrence #47" —
+    instead of 47 lines. The total stays true either way; only the number of
+    lines is throttled.
+    """
+    occurrence = count_recurrences(conn, task_id) + 1
+    body = f"{RECURRENCE_COMMENT_PREFIX} occurrence #{occurrence}"
+    if detail:
+        body = f"{body} — {detail}"
+
+    if throttle_seconds > 0:
+        last = _latest_recurrence(conn, task_id)
+        now = int(time.time())
+        if last and (now - int(last["created_at"])) < throttle_seconds:
+            # Body only — `created_at` stays anchored to the start of this
+            # window, so the window still expires and the next occurrence
+            # after it opens a fresh line. That keeps the card readable as a
+            # heartbeat ("still happening, an hour later") instead of one
+            # number that could have stopped moving days ago.
+            with write_txn(conn):
+                conn.execute(
+                    "UPDATE task_comments SET body = ? WHERE id = ?",
+                    (body, last["id"]),
+                )
+            return int(last["id"])
+
+    return add_comment(conn, task_id, author=author, body=body)
+
 
 def add_comment(
     conn: sqlite3.Connection, task_id: str, author: str, body: str

--- a/tests/hermes_cli/test_kanban_dedupe_scope.py
+++ b/tests/hermes_cli/test_kanban_dedupe_scope.py
@@ -1,0 +1,134 @@
+"""``--dedupe-scope`` separates request idempotency from open-item dedup.
+
+The two have always shared one key. Under the historical behaviour a
+completed task keeps matching its key forever, so recurring automation goes
+permanently silent after the first fix: it files once, a human closes the
+task, and every later occurrence quietly returns the closed id — exiting 0
+with a plausible task id, so the caller cannot detect the suppression.
+
+`any` keeps that behaviour for webhook retries, where the second call really
+is the same event. `open` is for alerts, where it is a new one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _set_status(conn, task_id: str, status: str) -> None:
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+# --- the shared behaviour both scopes keep ----------------------------------
+
+
+@pytest.mark.parametrize("scope", ["any", "open"])
+def test_open_task_always_dedupes(board, scope):
+    """Neither scope should open a second ticket while one is still open."""
+    first = kb.create_task(board, title="disk full", idempotency_key="k",
+                           dedupe_scope=scope)
+    second = kb.create_task(board, title="disk full", idempotency_key="k",
+                            dedupe_scope=scope)
+    assert second == first
+
+
+@pytest.mark.parametrize("scope", ["any", "open"])
+def test_archived_never_dedupes(board, scope):
+    """Archiving has always meant "gone"; that is unchanged."""
+    first = kb.create_task(board, title="disk full", idempotency_key="k",
+                           dedupe_scope=scope)
+    _set_status(board, first, "archived")
+    second = kb.create_task(board, title="disk full", idempotency_key="k",
+                            dedupe_scope=scope)
+    assert second != first
+
+
+# --- where they diverge: a completed task -----------------------------------
+
+
+def test_any_scope_still_matches_a_done_task(board):
+    """Backward compatibility. `any` is the default and must not change."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="any")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="any")
+    assert second == first
+
+
+def test_default_scope_is_unchanged_behaviour(board):
+    """Callers that pass no scope keep exactly what they had before."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k")
+    assert second == first
+
+
+def test_open_scope_files_again_after_a_fix(board):
+    """The bug this flag exists for: a regression must reach the board."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    assert second != first, "a completed task swallowed a fresh occurrence"
+
+
+def test_open_scope_dedupes_against_the_newest_open_task(board):
+    """After a regression files a second card, that card dedupes in turn.
+
+    Otherwise the fix would trade silence for 144 cards a day.
+    """
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, "done")
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    third = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    assert third == second != first
+
+
+@pytest.mark.parametrize("status", ["blocked", "running", "review", "todo", "triage"])
+def test_open_scope_treats_in_flight_states_as_open(board, status):
+    """Anything a human or worker is still holding counts as open."""
+    first = kb.create_task(board, title="import failed", idempotency_key="k",
+                           dedupe_scope="open")
+    _set_status(board, first, status)
+    second = kb.create_task(board, title="import failed", idempotency_key="k",
+                            dedupe_scope="open")
+    assert second == first
+
+
+# --- guardrails --------------------------------------------------------------
+
+
+def test_unknown_scope_is_rejected(board):
+    with pytest.raises(ValueError, match="dedupe_scope"):
+        kb.create_task(board, title="x", idempotency_key="k", dedupe_scope="sometimes")
+
+
+def test_scope_is_ignored_without_a_key(board):
+    """No key means no dedup at all, whatever the scope says."""
+    a = kb.create_task(board, title="x", dedupe_scope="open")
+    b = kb.create_task(board, title="x", dedupe_scope="open")
+    assert a != b

--- a/tests/hermes_cli/test_kanban_on_duplicate.py
+++ b/tests/hermes_cli/test_kanban_on_duplicate.py
@@ -1,0 +1,183 @@
+"""``--on-duplicate comment`` makes a deduped card show how bad things are.
+
+Deduping is right; silence is not the same thing. A card that says "failed
+at 15:18" reads like a one-off even when the job has failed every ten minutes
+since, because nothing on the board separates a blip from an ongoing outage.
+
+The throttle exists so the cure is not the disease: a ten-minute job must not
+leave 144 comments a day. It bounds *lines*, never the count — the running
+total stays exact whether it was written down once or forty-seven times.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _comments(conn, task_id):
+    return conn.execute(
+        "SELECT body, created_at FROM task_comments WHERE task_id = ? "
+        "ORDER BY id",
+        (task_id,),
+    ).fetchall()
+
+
+def _recurrence_lines(conn, task_id):
+    return [c for c in _comments(conn, task_id)
+            if c["body"].startswith(kb.RECURRENCE_COMMENT_PREFIX)]
+
+
+def _file(conn, **kw):
+    kw.setdefault("title", "nightly import failed")
+    kw.setdefault("idempotency_key", "import:nightly")
+    kw.setdefault("on_duplicate", "comment")
+    kw.setdefault("recurrence_throttle_seconds", 0)
+    return kb.create_task(conn, **kw)
+
+
+# --- default behaviour is unchanged -----------------------------------------
+
+
+def test_return_is_the_default_and_stays_silent(board):
+    first = kb.create_task(board, title="x", idempotency_key="k")
+    second = kb.create_task(board, title="x", idempotency_key="k")
+    assert second == first
+    assert _comments(board, first) == []
+
+
+def test_first_call_never_comments(board):
+    """Nothing recurred yet — the task was just created."""
+    tid = _file(board)
+    assert _recurrence_lines(board, tid) == []
+    assert kb.count_recurrences(board, tid) == 0
+
+
+# --- counting ---------------------------------------------------------------
+
+
+def test_duplicate_records_an_occurrence(board):
+    tid = _file(board)
+    assert _file(board) == tid
+    assert kb.count_recurrences(board, tid) == 1
+
+
+def test_count_climbs_with_each_duplicate(board):
+    tid = _file(board)
+    for _ in range(5):
+        _file(board)
+    assert kb.count_recurrences(board, tid) == 5
+
+
+def test_unthrottled_leaves_one_line_per_occurrence(board):
+    tid = _file(board)
+    for _ in range(3):
+        _file(board)
+    lines = _recurrence_lines(board, tid)
+    assert len(lines) == 3
+    assert "occurrence #3" in lines[-1]["body"]
+
+
+# --- throttling bounds lines, never the count -------------------------------
+
+
+def test_throttle_coalesces_into_one_line(board):
+    tid = _file(board, recurrence_throttle_seconds=3600)
+    for _ in range(10):
+        _file(board, recurrence_throttle_seconds=3600)
+
+    lines = _recurrence_lines(board, tid)
+    assert len(lines) == 1, "a job on a timer should not spam the card"
+    assert "occurrence #10" in lines[0]["body"]
+    assert kb.count_recurrences(board, tid) == 10
+
+
+def test_throttle_window_is_anchored_not_refreshed(board):
+    """The window must expire, or the card stops looking alive.
+
+    If each update pushed `created_at` forward, a frequent job would hold one
+    line open forever and you could never tell from the timestamps whether it
+    was still happening or had stopped days ago.
+    """
+    tid = _file(board, recurrence_throttle_seconds=3600)
+    _file(board, recurrence_throttle_seconds=3600)
+    anchored = _recurrence_lines(board, tid)[0]["created_at"]
+
+    _file(board, recurrence_throttle_seconds=3600)
+    lines = _recurrence_lines(board, tid)
+    assert len(lines) == 1
+    assert lines[0]["created_at"] == anchored
+
+
+def test_new_line_once_the_window_expires(board):
+    tid = _file(board, recurrence_throttle_seconds=3600)
+    _file(board, recurrence_throttle_seconds=3600)
+
+    # Backdate the open line so its window has elapsed.
+    with kb.write_txn(board):
+        board.execute(
+            "UPDATE task_comments SET created_at = ? WHERE task_id = ?",
+            (int(time.time()) - 7200, tid),
+        )
+
+    _file(board, recurrence_throttle_seconds=3600)
+    lines = _recurrence_lines(board, tid)
+    assert len(lines) == 2, "the window should expire and start a fresh line"
+    assert "occurrence #2" in lines[-1]["body"]
+    assert kb.count_recurrences(board, tid) == 2
+
+
+# --- interaction with dedupe_scope ------------------------------------------
+
+
+def test_a_regression_gets_its_own_card_not_a_comment(board):
+    """With scope=open, a closed task is not a duplicate — it is a new fault.
+
+    The recurrence count belongs to the card that is actually open, so the
+    fresh card starts from zero rather than inheriting the old one's history.
+    """
+    first = _file(board, dedupe_scope="open")
+    with kb.write_txn(board):
+        board.execute("UPDATE tasks SET status='done' WHERE id=?", (first,))
+
+    second = _file(board, dedupe_scope="open")
+    assert second != first
+    assert kb.count_recurrences(board, second) == 0
+
+
+# --- guardrails --------------------------------------------------------------
+
+
+def test_unknown_on_duplicate_is_rejected(board):
+    kb.create_task(board, title="x", idempotency_key="k")
+    with pytest.raises(ValueError, match="on_duplicate"):
+        kb.create_task(board, title="x", idempotency_key="k", on_duplicate="shout")
+
+
+def test_commenting_never_breaks_the_caller(board, monkeypatch):
+    """Dedup is the quiet path; bookkeeping must not turn it into a failure."""
+    tid = _file(board)
+
+    def boom(*_a, **_kw):
+        raise ValueError("comment subsystem is having a day")
+
+    monkeypatch.setattr(kb, "record_recurrence", boom)
+    assert _file(board) == tid


### PR DESCRIPTION
Part 3 of 3 for #81297.

**Stacked on #81300 — please merge that first.** This branch contains its commits, so the diff here will shrink to just the `--on-duplicate` change once #81300 lands.

## Problem

Deduping is right. Silence is not the same thing.

Once a fault has a card, every later occurrence returns the id and vanishes, so the board shows "failed at 15:18" whether that happened once or has been happening every ten minutes since. Nothing separates a blip from an ongoing outage — and the information needed to tell them apart was in hand each time and thrown away.

Every author of recurring automation ends up writing the same workaround by hand: find the open task, comment on it, else create. That is a primitive the board should own rather than a pattern everyone reimplements.

## Change

`--on-duplicate {return,comment}`. `return` is the default and is today's silent behaviour. `comment` records the occurrence on the matched task.

`--recurrence-throttle` (default 3600s) stops the cure becoming the disease: within the window the existing line is updated in place rather than a new one appended, so a ten-minute job leaves one line that climbs to `occurrence #47` instead of 47 lines.

This mirrors what `block_recurrences` already does for the unblock/re-block loop — count repeats and escalate, never re-file on a clock.

## Two details worth review

**`created_at` is deliberately not refreshed** when a line is updated, so the window still expires and the next occurrence after it opens a fresh line. If it were refreshed, a frequent job would hold a single line open forever and the timestamps could never tell you whether the fault was still live or had stopped days ago. The card should read as a heartbeat, not as one number that may have stopped moving.

**The count lives in the comment body, not a new column**, so this needs no migration and reads as 0 on any older database. It is parsed from the newest recurrence line rather than counted across lines — because throttling coalesces occurrences, counting rows would report how often we chose to write, not how often it happened.

Commenting failures are swallowed on purpose: dedup is the quiet path, and a task that disappeared between the lookup and the comment is not worth failing a caller for.

## Tests

`tests/hermes_cli/test_kanban_on_duplicate.py` — 11 cases: default stays silent, the first call never comments, counting under both throttled and unthrottled settings, the window staying anchored, a fresh line once it expires, interaction with `--dedupe-scope open` (a regression gets its own card starting from zero rather than inheriting history), and that a failing comment cannot break the caller.
