### PR TITLE
fix(gemini): accept video_url media parts (salvage of #27321)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -255,8 +255,9 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url"}:
+            media_key = "video_url" if ptype == "video_url" else "image_url"
+            url = ((item.get(media_key) or {}).get("url") or "")
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -298,6 +298,22 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+def test_extract_multimodal_parts_accepts_video_url_data_urls():
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    parts = _extract_multimodal_parts([
+        {"type": "text", "text": "describe this video"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mp4;base64,QUJD"},
+        },
+    ])
+
+    assert parts[0] == {"text": "describe this video"}
+    assert parts[1]["inlineData"]["mimeType"] == "video/mp4"
+    assert parts[1]["inlineData"]["data"] == "QUJD"
+
+
 # ---------------------------------------------------------------------------
 # X-Goog-Api-Client header tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Salvages #27321 onto current `main`.

`_extract_multimodal_parts()` in `agent/gemini_native_adapter.py` translates OpenAI-format content blocks into Gemini-native `parts`. It handles `type: "text"` and `type: "image_url"`, but has no branch for `type: "video_url"` — the block type `video_analyze` emits (`tools/vision_tools.py`). Those blocks fall through the `if/elif` chain silently.

The result is the worst shape a bug can take: the request reaches Gemini carrying the text prompt alone, the model answers from the prompt and filename, and it produces a confident description of footage it never received. The tool returns `success: true` and no error surfaces, so the failure is invisible to the caller.

This extends the existing, already-validated data-URL-to-`inlineData` path to cover `video_url` rather than introducing a second code path.

**Why this PR exists alongside #27321:** the code change here is byte-identical to that PR. @teknium1 reviewed it on 2026-06-13 (`keep_open`, `salvageability=high`, "no blocking correctness or design issues") but noted the branch had gone `DIRTY` and "should be manually salvaged rather than cleanly merged". This is that salvage, rebased onto `33edfe9a8`, with original authorship preserved via `Co-authored-by`. Happy to close this in favour of #27321 if it gets rebased instead.

## Related Issue

Fixes #21920.

Also covers #27311 (already labelled duplicate), and supersedes #27321.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py` — `_extract_multimodal_parts()` accepts `video_url` alongside `image_url`, resolving the payload key per block type. +3/−2.
- `tests/agent/test_gemini_native_adapter.py` — adds `test_extract_multimodal_parts_accepts_video_url_data_urls`, a direct regression test for `video/mp4` data URLs. +16/−0.

## How to Test

Both runs below are against `33edfe9a8`.

```bash
# 1. The new test FAILS on unpatched main — the video part is dropped,
#    so parts[1] does not exist:
git stash push agent/gemini_native_adapter.py
python -m pytest tests/agent/test_gemini_native_adapter.py -q -k video_url
#   E  IndexError: list index out of range
#   1 failed, 9 deselected in 0.14s

# 2. With the adapter change, it passes:
git stash pop
python -m pytest tests/agent/test_gemini_native_adapter.py -q -k video_url
#   1 passed, 9 deselected in 0.34s

# 3. No regressions in the adapter suite:
python -m pytest tests/agent/test_gemini_native_adapter.py -q
#   10 passed in 0.18s
```

End-to-end reproduction of the original symptom is in #21920 (configure Gemini as the vision provider, run `video_analyze` on any small MP4, observe "you haven't provided a video" alongside `success: true`).

## Test results, stated precisely

`scripts/run_tests.sh -q` on this branch: **25,606 passed, 155 failed across 55 files**, plus 37 files where no tests ran (collection/import errors).

Those failures are **pre-existing and unrelated to this change**, and rather than assert that, I measured it. I re-ran the 92 affected files against this branch and against a pristine `origin/main` worktree — same runner, same machine, same file set, differing only by the 3-line adapter change:

| | this branch | pristine `main` |
|---|---|---|
| Files with test failures | 37 | 37 |
| Tests failed | 83 | 83 |
| Files where no tests ran | 11 | 11 |

The symmetric difference of the two failing-file sets is **empty in both directions** — nothing fails here that passes on `main`, and nothing passes here that fails on `main`.

The affected files are gateway/Slack/Discord/Matrix/ACP and network- or credential-bound tool tests. None of them import `gemini_native_adapter` or `_extract_multimodal_parts` (verified by grep across the failing set).

Two caveats, stated rather than buried: the local failure count is higher in a full run (155) than in a 92-file run (83), so parts of that suite appear order- or port-sensitive independent of this change. And I could not run the suite in a clean CI environment, so some of these are likely local-environment artifacts. CI is the authority on both points.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — found #27321, which this salvages with attribution rather than duplicates
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] ~~I've run `pytest tests/ -q` and all tests pass~~ — **not ticked, because it isn't true.** The suite does not pass cleanly on my machine. See "Test results, stated precisely" above: the failures are demonstrably identical on pristine `main`, and the suite for the file I changed is 10/10 green.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5.0, arm64), Python 3.11, pytest 9.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing surface change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure dict/string handling, no platform-bound primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; `video_analyze`'s documented contract is unchanged, this makes it behave as already documented

## Screenshots / Logs

Failure on unpatched `main`:

```
>       assert parts[1]["inlineData"]["mimeType"] == "video/mp4"
                 ^^^^^^^^
E       IndexError: list index out of range

tests/agent/test_gemini_native_adapter.py:313: IndexError
=========================== short test summary info ============================
FAILED tests/agent/test_gemini_native_adapter.py::test_extract_multimodal_parts_accepts_video_url_data_urls
1 failed, 9 deselected in 0.14s
```
