### PR TITLE
feat: add Perplexity provider with strict tool-schema repair

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -243,6 +243,54 @@ def sanitize_moonshot_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     return sanitized if any_change else tools
 
 
+def _ensure_properties_recursive(node: Any) -> Any:
+    """Deep-walk a schema; every object-typed node gets a ``properties`` key."""
+    if isinstance(node, dict):
+        out = {k: _ensure_properties_recursive(v) for k, v in node.items()}
+        if out.get("type") == "object" and "properties" not in out:
+            out["properties"] = {}
+        return out
+    if isinstance(node, list):
+        return [_ensure_properties_recursive(item) for item in node]
+    return node
+
+
+def ensure_object_properties_in_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Add ``properties: {}`` to every object-typed node in all tool schemas.
+
+    Perplexity's Chat Completions endpoint validates tool schemas strictly
+    and 400s ("invalid request") on any object-typed parameter that omits
+    ``properties`` — Hermes's ``tool_call.arguments`` (a schemaless free-form
+    object) is the canonical offender.  Input is not mutated; the original
+    list is returned unchanged when nothing needed repair.
+    """
+    if not tools:
+        return tools
+
+    sanitized: List[Dict[str, Any]] = []
+    any_change = False
+    for tool in tools:
+        if not isinstance(tool, dict):
+            sanitized.append(tool)
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            sanitized.append(tool)
+            continue
+        params = fn.get("parameters")
+        if not isinstance(params, dict):
+            sanitized.append(tool)
+            continue
+        repaired = _ensure_properties_recursive(copy.deepcopy(params))
+        if repaired != params:
+            any_change = True
+            sanitized.append({**tool, "function": {**fn, "parameters": repaired}})
+        else:
+            sanitized.append(tool)
+
+    return sanitized if any_change else tools
+
+
 def is_moonshot_model(model: str | None) -> bool:
     """True for any Kimi / Moonshot model slug, regardless of aggregator prefix.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -13,7 +13,11 @@ import json
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
-from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
+from agent.moonshot_schema import (
+    ensure_object_properties_in_tools,
+    is_moonshot_model,
+    sanitize_moonshot_tools,
+)
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
@@ -641,8 +645,12 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Tools — apply Moonshot/Kimi schema sanitization regardless of path
         if tools:
-            if is_moonshot_model(model):
+            if is_moonshot_model(model) or getattr(
+                profile, "sanitize_tool_schemas", False
+            ):
                 tools = sanitize_moonshot_tools(tools)
+            if getattr(profile, "sanitize_tool_schemas", False):
+                tools = ensure_object_properties_in_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/plugins/model-providers/perplexity/__init__.py
+++ b/plugins/model-providers/perplexity/__init__.py
@@ -1,0 +1,39 @@
+"""Perplexity provider profile.
+
+Perplexity's sonar models are search-grounded: answers arrive with live web
+citations baked in. OpenAI-compatible Chat Completions at
+https://api.perplexity.ai (note: no /v1 path segment). Auth is a Bearer API
+key from https://www.perplexity.ai/settings/api — API billing is separate
+from the consumer Pro subscription.
+
+Schema strictness: the endpoint validates tool parameter schemas and 400s
+("invalid request") on any object-typed parameter that omits ``properties``
+— Hermes's ``tool_call.arguments`` (a schemaless free-form object) is the
+canonical offender. ``sanitize_tool_schemas=True`` routes outgoing tools
+through the shared schema-repair pass
+(``agent.moonshot_schema.ensure_object_properties_in_tools``), which adds
+``properties: {}`` to every object-typed node.
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+perplexity = ProviderProfile(
+    name="perplexity",
+    aliases=("pplx", "sonar"),
+    env_vars=("PERPLEXITY_API_KEY",),
+    display_name="Perplexity",
+    description="Perplexity — sonar search-grounded models with citations",
+    signup_url="https://www.perplexity.ai/settings/api",
+    fallback_models=(
+        "sonar-pro",
+        "sonar",
+    ),
+    base_url="https://api.perplexity.ai",
+    sanitize_tool_schemas=True,
+    default_aux_model="sonar",
+)
+
+register_provider(perplexity)

--- a/plugins/model-providers/perplexity/plugin.yaml
+++ b/plugins/model-providers/perplexity/plugin.yaml
@@ -1,0 +1,5 @@
+name: perplexity-provider
+kind: model-provider
+version: 1.0.0
+description: Perplexity — sonar search-grounded models with citations
+author: Hermes Agent community

--- a/providers/base.py
+++ b/providers/base.py
@@ -78,6 +78,13 @@ class ProviderProfile:
     # top-level fields rather than ignoring them.
     supports_prompt_cache_key: bool = False
 
+    # True when the provider's Chat Completions endpoint validates tool
+    # parameter schemas strictly and rejects object-typed parameters that
+    # omit ``properties`` (e.g. Perplexity, HTTP 400 "invalid request").
+    # The transport runs the shared schema-repair pass
+    # (agent.moonshot_schema.sanitize_moonshot_tools) on outgoing tools.
+    sanitize_tool_schemas: bool = False
+
     # ── Model catalog ─────────────────────────────────────────
     # fallback_models: curated list shown in /model picker when live fetch fails.
     # Only agentic models that support tool calling should appear here.

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 from agent.moonshot_schema import (
+    ensure_object_properties_in_tools,
     is_moonshot_model,
     sanitize_moonshot_tool_parameters,
     sanitize_moonshot_tools,
@@ -393,3 +394,84 @@ class TestUnionTypeList:
         assert sort["type"] == "string"
         assert sort["enum"] == ["asc", "desc"]
         assert params["properties"]["sort"]["type"] == ["string", "null"]
+
+
+class TestEnsureObjectPropertiesInTools:
+    """ensure_object_properties_in_tools() — strict-schema providers (Perplexity).
+
+    Perplexity's Chat Completions endpoint 400s ("invalid request") on any
+    object-typed tool parameter that omits ``properties``. Hermes's
+    ``tool_call.arguments`` (a schemaless free-form object) is the canonical
+    offender. These tests pin the repair contract.
+    """
+
+    @staticmethod
+    def _tool_call_tool():
+        return {
+            "type": "function",
+            "function": {
+                "name": "tool_call",
+                "description": "Invoke a deferred tool.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "arguments": {"type": "object"},
+                    },
+                    "required": ["name", "arguments"],
+                },
+            },
+        }
+
+    def test_schemaless_object_param_gains_empty_properties(self):
+        out = ensure_object_properties_in_tools([self._tool_call_tool()])
+        args = out[0]["function"]["parameters"]["properties"]["arguments"]
+        assert args["properties"] == {}
+
+    def test_does_not_mutate_input(self):
+        tool = self._tool_call_tool()
+        ensure_object_properties_in_tools([tool])
+        assert "properties" not in tool["function"]["parameters"]["properties"]["arguments"]
+
+    def test_nested_objects_repaired_recursively(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "nested",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {"type": "object"},
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+        out = ensure_object_properties_in_tools(tools)
+        items = out[0]["function"]["parameters"]["properties"]["items"]["items"]
+        assert items["properties"] == {}
+
+    def test_already_valid_schema_is_passthrough(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "fine",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"x": {"type": "object", "properties": {}}},
+                    },
+                },
+            }
+        ]
+        assert ensure_object_properties_in_tools(tools) is tools
+
+    def test_empty_and_malformed_inputs_are_safe(self):
+        assert ensure_object_properties_in_tools([]) == []
+        assert ensure_object_properties_in_tools(None) is None
+        out = ensure_object_properties_in_tools(["not-a-dict", {"no": "function"}])
+        assert out[0] == "not-a-dict"

--- a/tests/providers/test_perplexity_profile.py
+++ b/tests/providers/test_perplexity_profile.py
@@ -1,0 +1,88 @@
+"""Perplexity provider profile tests.
+
+Covers two contracts:
+
+1. The bundled profile registers and resolves (name + aliases) with the
+   expected endpoint/auth wiring.
+2. The transport honours ``sanitize_tool_schemas`` — profiles carrying the
+   flag get the object-properties repair applied to outgoing tool schemas;
+   profiles without it are untouched.
+
+Reproduction behind the flag: Perplexity's Chat Completions endpoint returns
+HTTP 400 "invalid request" for any object-typed tool parameter that omits
+``properties`` (Hermes's ``tool_call.arguments``). Verified live against
+api.perplexity.ai 2026-08-07.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agent.transports.chat_completions import ChatCompletionsTransport
+from providers import get_provider_profile
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+def _msgs():
+    return [{"role": "user", "content": "hello"}]
+
+
+def _tool_call_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "tool_call",
+            "description": "Invoke a deferred tool.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "arguments": {"type": "object"},
+                },
+                "required": ["name", "arguments"],
+            },
+        },
+    }
+
+
+class TestPerplexityProfileRegistration:
+    def test_resolves_by_name_and_aliases(self):
+        profile = get_provider_profile("perplexity")
+        assert profile is not None
+        assert get_provider_profile("pplx") is profile
+        assert get_provider_profile("sonar") is profile
+
+    def test_wiring(self):
+        profile = get_provider_profile("perplexity")
+        assert profile.base_url == "https://api.perplexity.ai"
+        assert "PERPLEXITY_API_KEY" in profile.env_vars
+        assert profile.sanitize_tool_schemas is True
+        # Behavior contract, not a snapshot: every fallback model must be a
+        # sonar-family id (the only family Perplexity serves).
+        assert profile.fallback_models
+        assert all(m.startswith("sonar") for m in profile.fallback_models)
+
+
+class TestSanitizeToolSchemasGating:
+    def test_flagged_profile_repairs_schemaless_objects(self, transport):
+        kwargs = transport.build_kwargs(
+            model="sonar-pro",
+            messages=_msgs(),
+            tools=[_tool_call_tool()],
+            provider_profile=get_provider_profile("perplexity"),
+        )
+        args = kwargs["tools"][0]["function"]["parameters"]["properties"]["arguments"]
+        assert args["properties"] == {}
+
+    def test_unflagged_profile_leaves_schemas_alone(self, transport):
+        kwargs = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_msgs(),
+            tools=[_tool_call_tool()],
+            provider_profile=get_provider_profile("deepseek"),
+        )
+        args = kwargs["tools"][0]["function"]["parameters"]["properties"]["arguments"]
+        assert "properties" not in args


### PR DESCRIPTION
## What does this PR do?

Adds a bundled **Perplexity** model-provider profile (sonar family — search-grounded answers with citations) and fixes the wire-format incompatibility that made every Hermes agent call to Perplexity fail.

Perplexity's Chat Completions endpoint validates tool parameter schemas strictly: any object-typed parameter that omits `properties` is rejected with HTTP 400 `invalid request`. Hermes's own `tool_call` tool declares `arguments` as a schemaless free-form object (`{"type": "object"}` with no `properties`), so with a naïve profile registration **every** agentic call to sonar models 400s, retries 3×, and falls down the fallback chain.

The existing Moonshot sanitizer doesn't cover this: it guarantees `required: []` arrays, not `properties` on nested object nodes.

Fix: a new opt-in `ProviderProfile.sanitize_tool_schemas` flag. When set, the chat_completions transport runs a new `ensure_object_properties_in_tools()` repair (alongside the existing Moonshot pass) that deep-walks tool schemas and adds `properties: {}` to every object-typed node. The Perplexity profile ships with the flag set — the mechanism and its consumer land together.

## Related Issue

N/A — no existing issue. Verified against the live API (2026-08-07): captured Hermes's real outgoing request on a local echo server, bisected all 33 tool schemas against `api.perplexity.ai`, and isolated `tool_call.arguments` as the rejecting node; adding `properties: {}` turns the 400 into a 200.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `providers/base.py` — new `ProviderProfile.sanitize_tool_schemas` flag (default `False`)
- `agent/moonshot_schema.py` — new `ensure_object_properties_in_tools()` + recursive walker (input never mutated; no-op passthrough)
- `agent/transports/chat_completions.py` — profile path applies the repair when the flag is set (Moonshot sanitization untouched)
- `plugins/model-providers/perplexity/` — bundled profile: `perplexity` (aliases `pplx`, `sonar`), `PERPLEXITY_API_KEY`, base URL `https://api.perplexity.ai` (no `/v1` segment), fallback models `sonar-pro` / `sonar`, aux `sonar`
- `tests/agent/test_moonshot_schema.py` — `TestEnsureObjectPropertiesInTools`: repair contract, recursion into array items, input immutability, no-op identity, malformed-input safety
- `tests/providers/test_perplexity_profile.py` — registration/alias/wiring contracts + transport gating (flagged profile repaired, unflagged untouched)

## How to Test

1. `PERPLEXITY_API_KEY=pplx-... hermes chat -q "what is today's top news story? cite a source." --provider perplexity -m sonar-pro -Q` → answer arrives with citations, served by `provider=perplexity` (check `~/.hermes/logs/agent.log` — before this PR the same command 400s 3× and falls back)
2. `pytest tests/agent/test_moonshot_schema.py tests/providers/ -q` — schema-repair + gating tests
3. Without the flag (e.g. `--provider deepseek`), outgoing tool schemas are byte-identical to before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — closest hits are a Perplexity *MCP server* catalog gap (#62677) and named custom providers (#62908); neither covers a native provider profile or this schema bug
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Apple Silicon/Intel), live API verified

### Documentation & Housekeeping

- [x] Documentation: N/A — provider profile self-documents via docstring; no new config keys
- [x] `cli-config.yaml.example` — N/A (no config keys added; key is an env var per provider convention)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture change; the flag follows the existing ProviderProfile hook pattern)
- [x] Cross-platform — pure-Python schema walk, no platform APIs
- [x] Tool descriptions/schemas — unchanged on the Hermes side; the repair only normalizes how they're *transmitted* to strict providers

## Screenshots / Logs

Live verification (after fix), `~/.hermes/logs/agent.log`:

```
INFO agent.conversation_loop: API call #1: model=sonar-pro provider=perplexity in=17342 out=51 total=17393 latency=23.2s
INFO agent.conversation_loop: Turn ended: reason=text_response(finish_reason=stop) model=sonar-pro api_calls=1/90
```

Before fix, same command:

```
WARNING agent.conversation_loop: API call failed (attempt 1/3) provider=perplexity base_url=https://api.perplexity.ai model=sonar-pro summary=invalid request
INFO agent.chat_completion_helpers: Fallback activated: sonar-pro → claude-sonnet-5 (copilot)
```
