### PR TITLE
feat: personalize chat browser tabs

### DIFF
--- a/web/src/lib/profile-tab-identity.test.ts
+++ b/web/src/lib/profile-tab-identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentDisplayName,
+  profileFaviconHref,
+  profileTabTitle,
+} from "./profile-tab-identity";
+
+describe("agentDisplayName", () => {
+  it("humanizes a profile slug into an agent name", () => {
+    expect(agentDisplayName("gun")).toBe("Gun");
+    expect(agentDisplayName("research_assistant")).toBe("Research Assistant");
+  });
+
+  it("uses Hermes for the dashboard's unscoped default profile", () => {
+    expect(agentDisplayName("")).toBe("Hermes");
+    expect(agentDisplayName("default")).toBe("Hermes");
+  });
+});
+
+describe("profileTabTitle", () => {
+  it("puts the agent first, followed by the current chat title and Hermes", () => {
+    expect(profileTabTitle("gun", "Untitled")).toBe("Gun - Untitled - Hermes");
+  });
+
+  it("uses Untitled while a new chat has not supplied a session title", () => {
+    expect(profileTabTitle("gus", null)).toBe("Gus - Untitled - Hermes");
+  });
+});
+
+describe("profileFaviconHref", () => {
+  it("generates an SVG favicon with the agent initial", () => {
+    const href = profileFaviconHref("gun");
+
+    expect(href).toContain("data:image/svg+xml,");
+    expect(decodeURIComponent(href)).toContain(">G<");
+  });
+
+  it("assigns different profiles distinct deterministic colors", () => {
+    expect(profileFaviconHref("gun")).not.toBe(profileFaviconHref("gus"));
+    expect(profileFaviconHref("gun")).toBe(profileFaviconHref("gun"));
+  });
+});

--- a/web/src/lib/profile-tab-identity.ts
+++ b/web/src/lib/profile-tab-identity.ts
@@ -1,0 +1,54 @@
+const PROFILE_COLORS = [
+  "#d9485f",
+  "#8b5cf6",
+  "#0f9d8a",
+  "#e07a2f",
+  "#2563eb",
+  "#b45309",
+  "#be3f8f",
+  "#4f7d22",
+] as const;
+
+function normalizedProfile(profile: string | null | undefined): string {
+  return (profile ?? "").trim();
+}
+
+/** A compact, human-readable identity derived from the selected profile slug. */
+export function agentDisplayName(profile: string | null | undefined): string {
+  const normalized = normalizedProfile(profile);
+  if (!normalized || normalized === "default") return "Hermes";
+
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function colorForProfile(profile: string | null | undefined): string {
+  const normalized = normalizedProfile(profile).toLowerCase() || "default";
+  let hash = 0;
+  for (const char of normalized) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+  return PROFILE_COLORS[hash % PROFILE_COLORS.length];
+}
+
+/** A profile-specific SVG favicon with the agent's initial and stable color. */
+export function profileFaviconHref(profile: string | null | undefined): string {
+  const name = agentDisplayName(profile);
+  const initial = name.charAt(0).toUpperCase() || "H";
+  const color = colorForProfile(profile);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="16" fill="${color}"/><text x="32" y="41" text-anchor="middle" font-family="system-ui, sans-serif" font-size="34" font-weight="700" fill="white">${initial}</text></svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/** Browser-tab title for an agent's currently selected chat. */
+export function profileTabTitle(
+  profile: string | null | undefined,
+  sessionTitle: string | null | undefined,
+): string {
+  const title = sessionTitle?.trim() || "Untitled";
+  return `${agentDisplayName(profile)} - ${title} - Hermes`;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -37,6 +37,7 @@ import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
+import { profileFaviconHref, profileTabTitle } from "@/lib/profile-tab-identity";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
 import {
   PTY_CONNECTING_TIMEOUT_MS,
@@ -321,7 +322,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // Profile-scoped chat: spawn the PTY under the globally selected
   // management profile. Changing it remounts the terminal (key below /
   // effect dep) so the user explicitly starts a fresh scoped session.
-  const { profile: scopedProfile } = useProfileScope();
+  const { profile: scopedProfile, currentProfile } = useProfileScope();
+  const agentProfile = scopedProfile || currentProfile || "default";
   const channel = useMemo(
     () => generateChannelId(`${resumeParam ?? ""}\0${scopedProfile}`),
     [resumeParam, scopedProfile],
@@ -343,6 +345,22 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     setTitle(sessionTitle);
     return () => setTitle(null);
   }, [isActive, sessionTitle, setTitle]);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const icon = document.querySelector<HTMLLinkElement>("link[rel~='icon']");
+    const previousTitle = document.title;
+    const previousIcon = icon?.href;
+
+    document.title = profileTabTitle(agentProfile, sessionTitle);
+    if (icon) icon.href = profileFaviconHref(agentProfile);
+
+    return () => {
+      document.title = previousTitle;
+      if (icon && previousIcon) icon.href = previousIcon;
+    };
+  }, [agentProfile, isActive, sessionTitle]);
 
   useEffect(() => {
     if (!resumeParam) return;


### PR DESCRIPTION
## Summary
- Prefix browser chat-tab titles with the selected profile/agent name.
- Render a deterministic, profile-specific colored initial favicon for each agent.

Examples: `Gun - Untitled - Hermes`, `Gus - Untitled - Hermes`.

## Verification
- `npm run typecheck`
- `npm test -- --run src/lib/profile-tab-identity.test.ts` (6 passing)