### PR TITLE
feat(remote): host gateway for Hermes Remote (HRA-2026-001)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -450,3 +450,47 @@ describe('buildToolView memory status', () => {
     expect(view.subtitle).toContain('Memory is full')
   })
 })
+
+describe('buildToolView palimpsest_remember', () => {
+  const remember = (overrides: Partial<Parameters<typeof part>[0]> = {}) =>
+    buildToolView(part({ toolName: 'palimpsest_remember', ...overrides }), '')
+
+  it('flags a landed write as palimpsest-legendary', () => {
+    const view = remember({
+      result: {
+        episode_id: '019fdf79-9179-7da0-8966-49dca635d804',
+        fact_id: '019fdf79-919c-7613-81c6-fc79c33e3637',
+        status: 'saved'
+      }
+    })
+
+    expect(view.status).toBe('success')
+    expect(view.title).toBe('Saved to Palimpsest')
+    expect(view.palimpsestLegendary).toBe(true)
+    expect(view.subtitle).toContain('episode 019fdf79…')
+    expect(view.subtitle).toContain('fact 019fdf79…')
+  })
+
+  it('does not flag pending or failed saves', () => {
+    expect(remember({ result: undefined }).palimpsestLegendary).toBeUndefined()
+
+    expect(
+      remember({
+        result: { error: 'palimpsest error: unreachable', status: 'error' }
+      }).palimpsestLegendary
+    ).toBeUndefined()
+  })
+
+  it('shows recall copy for palimpsest_recall', () => {
+    const view = buildToolView(
+      part({
+        toolName: 'palimpsest_recall',
+        result: { items: [] }
+      }),
+      ''
+    )
+
+    expect(view.title).toBe('Recalled from Palimpsest')
+    expect(view.icon).toBe('search')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -189,6 +189,14 @@ const TOOL_META: Record<ToolTitleKey, ToolMetaSpec> = {
     icon: 'brain',
     tone: 'agent'
   },
+  palimpsest_remember: {
+    icon: 'layers',
+    tone: 'agent'
+  },
+  palimpsest_recall: {
+    icon: 'search',
+    tone: 'agent'
+  },
   patch: { icon: 'edit', tone: 'file' },
   read_file: { icon: 'file', tone: 'file' },
   search_files: {
@@ -1044,11 +1052,32 @@ function toolSubtitle(
     return url ? hostnameOf(url) : 'Fetched webpage'
   }
 
-  if (toolName === 'memory') {
+  if (toolName === 'memory' || toolName === 'palimpsest_remember') {
     // The raw payload is bookkeeping the user never needs: usage counters, a
     // note telling the model not to retry, and the full operations array. The
     // human-readable line is the only part worth showing.
-    return firstStringField(resultRecord, ['message', 'error'])
+    const message = firstStringField(resultRecord, ['message', 'error'])
+
+    if (message) {
+      return message
+    }
+
+    // Palimpsest receipts carry episode/fact ids instead of a message —
+    // show the same short ids the desktop pane prints after a save.
+    if (toolName === 'palimpsest_remember') {
+      const episode = firstStringField(resultRecord, ['episode_id'])
+      const fact = firstStringField(resultRecord, ['fact_id'])
+      const parts = [
+        episode ? `episode ${episode.slice(0, 8)}…` : '',
+        fact ? `fact ${fact.slice(0, 8)}…` : ''
+      ].filter(Boolean)
+
+      if (parts.length) {
+        return parts.join(' · ')
+      }
+    }
+
+    return ''
   }
 
   if (toolName === 'cronjob') {
@@ -1140,10 +1169,29 @@ function toolDetailText(
     }
   }
 
-  if (part.toolName === 'memory') {
+  if (part.toolName === 'memory' || part.toolName === 'palimpsest_remember') {
     // Same reasoning as toolSubtitle: without this the generic fallback dumps
     // the whole args + result payload into the expanded row.
-    return firstStringField(resultRecord, ['message', 'error'])
+    const message = firstStringField(resultRecord, ['message', 'error'])
+
+    if (message) {
+      return message
+    }
+
+    if (part.toolName === 'palimpsest_remember') {
+      const episode = firstStringField(resultRecord, ['episode_id'])
+      const fact = firstStringField(resultRecord, ['fact_id'])
+      const parts = [
+        episode ? `episode ${episode.slice(0, 8)}…` : '',
+        fact ? `fact ${fact.slice(0, 8)}…` : ''
+      ].filter(Boolean)
+
+      if (parts.length) {
+        return parts.join(' · ')
+      }
+    }
+
+    return ''
   }
 
   if (isFileEditTool(part.toolName)) {
@@ -1416,6 +1464,10 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
   const error = status === 'success' ? '' : toolErrorText(part, resultRecord)
   // Over-budget memory refusals stay amber — don't claim "Saved".
   const memoryMissed = part.toolName === 'memory' && part.result !== undefined && status !== 'success'
+  // Landed memory write gets gold→purple chrome; a landed Palimpsest write
+  // gets its own cyan→violet ink chrome (see fallback.tsx).
+  const palimpsestLegendary =
+    part.toolName === 'palimpsest_remember' && status === 'success' && part.result !== undefined
 
   const baseTitle =
     part.result === undefined
@@ -1482,6 +1534,7 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
     icon: meta.icon,
     imageUrl: toolImageUrl(argsRecord, resultRecord),
     inlineDiff,
+    palimpsestLegendary: palimpsestLegendary || undefined,
     previewTarget: toolPreviewTarget(part.toolName, argsRecord, resultRecord),
     rendersAnsi: rendersAnsi || undefined,
     searchQuery: searchQuery || undefined,

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/types.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/types.ts
@@ -40,6 +40,10 @@ export interface ToolView {
    *  (terminal/execute_code) so the renderer knows to run them through
    *  the ANSI parser instead of printing them as literals. */
   rendersAnsi?: boolean
+  /** Landed memory write (base memory) — gold→purple legendary chrome. */
+  legendary?: 'memory'
+  /** Landed Palimpsest write — cyan→violet ink legendary chrome. */
+  palimpsestLegendary?: boolean
   /** Original query, shown above structured web-search results. */
   searchQuery?: string
   searchHits?: SearchResultRow[]

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -211,6 +211,10 @@ function statusGlyph(status: ToolStatus, copy: ToolStatusCopy): ReactNode {
 // Leading glyph for any tool-row header. Status (running/error/warning)
 // takes precedence; otherwise falls back to the tool's codicon. Returns
 // null when neither applies so callers can render unconditionally.
+// Which legendary chrome (if any) a landed memory write gets: base memory is
+// gold→purple, Palimpsest is cyan→violet ink. Undefined = no chrome.
+type LegendaryVariant = 'memory' | 'palimpsest'
+
 function ToolGlyph({
   copy,
   filePath,
@@ -221,8 +225,9 @@ function ToolGlyph({
   copy: ToolStatusCopy
   filePath?: string
   icon?: string
-  /** Landed memory write — keep the brain glyph, tint it gold→purple. */
-  legendary?: boolean
+  /** Landed memory write — keep the glyph, tint it gold→purple (memory) or
+   *  cyan→violet ink (palimpsest). */
+  legendary?: LegendaryVariant
   status?: ToolStatus
 }) {
   const node = status ? (
@@ -231,14 +236,25 @@ function ToolGlyph({
     <FileTypeIcon className="text-(--ui-text-tertiary)" path={filePath} size="0.875rem" />
   ) : icon ? (
     <ToolIcon
-      className={legendary ? 'text-(--tool-memory-legendary-icon)' : 'text-(--ui-text-tertiary)'}
+      className={
+        legendary
+          ? `text-(--tool-${legendary}-legendary-icon)`
+          : 'text-(--ui-text-tertiary)'
+      }
       name={icon}
       size="0.875rem"
     />
   ) : null
 
   return node ? (
-    <span className={cn(TOOL_HEADER_GLYPH_WRAP_CLASS, legendary && 'tool-memory-legendary-glyph')}>{node}</span>
+    <span
+      className={cn(
+        TOOL_HEADER_GLYPH_WRAP_CLASS,
+        legendary && `tool-${legendary}-legendary-glyph`
+      )}
+    >
+      {node}
+    </span>
   ) : null
 }
 
@@ -291,7 +307,7 @@ function ToolTitle({
   titleAction
 }: {
   isPending: boolean
-  legendary?: boolean
+  legendary?: LegendaryVariant
   status: ToolStatus
   title: string
   titleAction?: ToolTitleAction
@@ -303,7 +319,7 @@ function ToolTitle({
         isPending && 'text-(--conversation-scaffold-meta)',
         status === 'error' && 'text-destructive',
         status === 'warning' && 'text-amber-700 dark:text-amber-300',
-        legendary && !isPending && 'tool-memory-legendary-title text-transparent'
+        legendary && !isPending && `tool-${legendary}-legendary-title text-transparent`
       )}
     >
       {isPending && titleAction ? (
@@ -479,9 +495,18 @@ function ToolEntry({ part }: ToolEntryProps) {
 
   const showDiffStats = !isPending && Boolean(diffStats && (diffStats.added > 0 || diffStats.removed > 0))
 
-  // Landed memory write gets gold→purple chrome instead of the plain scaffold grey.
-  const memoryLegendary = !isPending && part.toolName === 'memory' && view.status === 'success'
-  const memoryMetaClass = memoryLegendary ? 'tool-memory-legendary-meta' : undefined
+  // Landed memory write gets gold→purple chrome instead of the plain scaffold
+  // grey; a landed Palimpsest write gets its own cyan→violet ink chrome.
+  const memoryLegendary: LegendaryVariant | undefined =
+    !isPending && part.toolName === 'memory' && view.status === 'success'
+      ? 'memory'
+      : undefined
+
+  const palimpsestLegendary: LegendaryVariant | undefined =
+    !isPending && view.palimpsestLegendary === true ? 'palimpsest' : undefined
+
+  const legendary = memoryLegendary ?? palimpsestLegendary
+  const legendaryMetaClass = legendary ? `tool-${legendary}-legendary-meta` : undefined
 
   // The header trailing slot only carries the live duration timer while the
   // tool is running. The copy control used to live here too, but an
@@ -559,18 +584,18 @@ function ToolEntry({ part }: ToolEntryProps) {
               copy={copy}
               filePath={isFileEdit ? view.subtitle : undefined}
               icon={view.icon}
-              legendary={memoryLegendary}
+              legendary={legendary}
               status={leadingStatus(isPending, view.status)}
             />
             <ToolTitle
               isPending={isPending}
-              legendary={memoryLegendary}
+              legendary={legendary}
               status={view.status}
               title={view.title}
               titleAction={view.titleAction}
             />
             {!isPending && view.countLabel && (
-              <span className={cn(SCAFFOLD_META_CLASS, memoryMetaClass)}>{view.countLabel}</span>
+              <span className={cn(SCAFFOLD_META_CLASS, legendaryMetaClass)}>{view.countLabel}</span>
             )}
             {showDiffStats && diffStats && (
               <span className="flex shrink-0 items-center gap-1 font-mono text-[0.625rem] tabular-nums">
@@ -583,7 +608,7 @@ function ToolEntry({ part }: ToolEntryProps) {
               </span>
             )}
             {!isFileEdit && !isPending && view.durationLabel && (
-              <span className={cn(SCAFFOLD_META_CLASS, memoryMetaClass)}>{view.durationLabel}</span>
+              <span className={cn(SCAFFOLD_META_CLASS, legendaryMetaClass)}>{view.durationLabel}</span>
             )}
           </span>
         </DisclosureRow>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2854,6 +2854,16 @@ export const en: Translations = {
         image_generate: { done: 'Generated image', pending: 'Generating image', pendingAction: 'Generating' },
         list_files: { done: 'Listed files', pending: 'Listing files', pendingAction: 'Listing' },
         memory: { done: 'Saved to memory', pending: 'Saving to memory', pendingAction: 'Saving' },
+        palimpsest_remember: {
+          done: 'Saved to Palimpsest',
+          pending: 'Saving to Palimpsest',
+          pendingAction: 'Saving'
+        },
+        palimpsest_recall: {
+          done: 'Recalled from Palimpsest',
+          pending: 'Recalling from Palimpsest',
+          pendingAction: 'Recalling'
+        },
         patch: { done: 'Patched file', pending: 'Patching file', pendingAction: 'Patching' },
         read_file: { done: 'Read file', pending: 'Reading file', pendingAction: 'Reading' },
         search_files: { done: 'Searched files', pending: 'Searching files', pendingAction: 'Searching' },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -21,6 +21,8 @@ export type ToolTitleKey =
   | 'image_generate'
   | 'list_files'
   | 'memory'
+  | 'palimpsest_remember'
+  | 'palimpsest_recall'
   | 'patch'
   | 'read_file'
   | 'search_files'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3021,6 +3021,8 @@ export const zh: Translations = {
         image_generate: { done: '已生成图片', pending: '正在生成图片', pendingAction: '正在生成' },
         list_files: { done: '已列出文件', pending: '正在列出文件', pendingAction: '正在列出' },
         memory: { done: '已保存到记忆', pending: '正在保存到记忆', pendingAction: '正在保存' },
+        palimpsest_remember: { done: '已保存到 Palimpsest', pending: '正在保存到 Palimpsest', pendingAction: '正在保存' },
+        palimpsest_recall: { done: '已从 Palimpsest 召回', pending: '正在从 Palimpsest 召回', pendingAction: '正在召回' },
         patch: { done: '已修补文件', pending: '正在修补文件', pendingAction: '正在修补' },
         read_file: { done: '已读取文件', pending: '正在读取文件', pendingAction: '正在读取' },
         search_files: { done: '已搜索文件', pending: '正在搜索文件', pendingAction: '正在搜索' },

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -195,6 +195,12 @@
     --tool-memory-legendary-icon: color-mix(in srgb, var(--ui-yellow) 55%, var(--ui-purple));
     --tool-memory-legendary-meta: color-mix(in srgb, var(--ui-purple) 58%, var(--ui-text-tertiary));
     --tool-memory-legendary-glow: color-mix(in srgb, var(--ui-purple) 38%, transparent);
+    --tool-palimpsest-legendary-from: color-mix(in srgb, var(--ui-cyan) 78%, #7dd3fc);
+    --tool-palimpsest-legendary-mid: color-mix(in srgb, var(--ui-blue) 52%, var(--ui-purple));
+    --tool-palimpsest-legendary-to: color-mix(in srgb, var(--ui-purple) 80%, #c4b5fd);
+    --tool-palimpsest-legendary-icon: color-mix(in srgb, var(--ui-cyan) 58%, var(--ui-blue));
+    --tool-palimpsest-legendary-meta: color-mix(in srgb, var(--ui-blue) 58%, var(--ui-text-tertiary));
+    --tool-palimpsest-legendary-glow: color-mix(in srgb, var(--ui-cyan) 42%, transparent);
     /* Diff add/remove, derived from the semantic palette so every diff surface
        (tool cards, preview, review pane) tracks the theme's green/red. Only the
        foregrounds need a dark override — they mix toward the page instead of
@@ -886,6 +892,49 @@
 
 .tool-memory-legendary-meta {
   color: var(--tool-memory-legendary-meta);
+}
+
+/* Landed `palimpsest_remember` tool row — cyan "ink" → violet, with a slow
+   shimmer sweep so Palimpsest reads as a distinct, living surface next to
+   the static gold of base memory. */
+.tool-palimpsest-legendary-title {
+  background-image: linear-gradient(
+    105deg,
+    var(--tool-palimpsest-legendary-from) 0%,
+    var(--tool-palimpsest-legendary-mid) 48%,
+    var(--tool-palimpsest-legendary-to) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent !important;
+  font-weight: 600;
+  background-size: 200% 100%;
+  animation: palimpsest-legendary-shimmer 7s ease-in-out infinite;
+}
+
+.tool-palimpsest-legendary-glyph {
+  filter: drop-shadow(0 0 0.28rem var(--tool-palimpsest-legendary-glow));
+}
+
+.tool-palimpsest-legendary-meta {
+  color: var(--tool-palimpsest-legendary-meta);
+}
+
+@keyframes palimpsest-legendary-shimmer {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-palimpsest-legendary-title {
+    animation: none;
+    background-size: auto;
+  }
 }
 
 .quest-glow {

--- a/gateway/platforms/remote.py
+++ b/gateway/platforms/remote.py
@@ -99,6 +99,13 @@ _CAPABILITIES = {
 _REMOTE_SCOPES = ["read", "approve", "chat", "control", "admin"]
 _MIN_HOST_VERSION = "0.9.0"
 
+# The remote platform's own release (HRA-2026-001 v1.0.0 contract), NOT
+# the hermes-agent core's version. The Android app gates the connection
+# on capabilities.version >= its MIN_HOST_VERSION (1.0.0); the core's
+# 0.20.0 would read as an outdated host and block the WS. The core
+# version is still exposed as "hermesVersion" for diagnosis.
+_REMOTE_PLATFORM_VERSION = "1.0.0"
+
 
 def _platform_version() -> str:
     try:
@@ -456,7 +463,7 @@ class RemoteDeviceAdapter(APIServerAdapter):
         extra = config.extra or {}
         self._state = RemoteState(extra.get("state_dir"))
         self._remote_host = str(extra.get("host") or "0.0.0.0")
-        self._remote_port = int(extra.get("port") or 8643)
+        self._remote_port = int(extra.get("port", 8643))
         self._urls: List[str] = [str(u) for u in (extra.get("urls") or [])]
         self._ttl_seconds = int(extra.get("ttl_seconds") or DEFAULT_TTL_SECONDS)
 
@@ -697,13 +704,15 @@ class RemoteDeviceAdapter(APIServerAdapter):
         return web_json({
             "status": "ok",
             "platform": "hermes-agent",
-            "version": _platform_version(),
+            "version": _REMOTE_PLATFORM_VERSION,
+            "hermesVersion": _platform_version(),
         }, 200)
 
     async def _handle_capabilities(self, request) -> Any:
         return web_json({
             "platform": "hermes-agent",
-            "version": _platform_version(),
+            "version": _REMOTE_PLATFORM_VERSION,
+            "hermesVersion": _platform_version(),
             "capabilities": _CAPABILITIES,
             "minHostVersion": _MIN_HOST_VERSION,
             "remote": {

--- a/gateway/platforms/remote.py
+++ b/gateway/platforms/remote.py
@@ -1,0 +1,1240 @@
+"""Remote device control platform — the host side of Hermes Remote.
+
+Wire contract: HRA-2026-001 (the Hermes Remote Android app's
+``/api/remote/v1`` surface, pinned by ``core:testkit`` FakeHost and the
+24 hermetic integration tests). The Android app is the contract owner;
+this module implements the host side that the app was built against.
+
+Design (host-integration doctrine: build the delta layer, not a
+parallel protocol):
+
+- Subclasses :class:`APIServerAdapter`: the remote surface MOUNTS the
+  same session/run/job/approval handlers the API server serves, behind
+  DEVICE-token auth + per-route scope enforcement instead of the global
+  API key. The SSE run stream, approvals, jobs and sessions are the
+  exact same code paths.
+- Adds the pairing ceremony (``hra://`` QR code, single-use secret,
+  TTL, 6-digit host-side confirmation code derived via HKDF — pinned by
+  the app's ConfirmationCode golden vectors), the device registry
+  (token hashes at rest, tokens issued inside an ECIES envelope to the
+  device's own P-256 public key), the event ring, audit, idempotency
+  keys, and the approval front-door.
+- TLS is mandatory: a self-signed cert whose SPKI SHA-256 is the QR's
+  ``fp``. The app pins exactly that (PinOrCaTrustManager) — trust-on-
+  first-use by design; CA-verified hosts still work.
+
+Run standalone with ``hermes remote start`` (the CLI owns lifecycle).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import ipaddress
+import json
+import logging
+import os
+import secrets
+import socket
+import ssl
+import sys
+import threading
+import time
+import uuid
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from aiohttp import web
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+logger = logging.getLogger("hermes.remote")
+
+# ---------------------------------------------------------------------------
+# Constants (pinned by the app's contract: PairingClient, FakeHost, DTOs)
+# ---------------------------------------------------------------------------
+
+DEFAULT_TTL_SECONDS = 600
+PAIRING_RATE_LIMIT_PER_MIN = 5
+EVENT_RING_SIZE = 200
+TOKEN_PREFIX = "hrd_"
+
+_PUBLIC_PATHS = (
+    "/api/remote/v1/health",
+    "/api/remote/v1/pair/register",
+)
+
+# Path -> required scope (SPEC §2.1.1 route table + device scopes).
+_SCOPE_READ = "read"
+_SCOPE_CHAT = "chat"
+_SCOPE_CONTROL = "control"
+_SCOPE_APPROVE = "approve"
+_SCOPE_ADMIN = "admin"
+
+_ALL_SCOPES = {_SCOPE_READ, _SCOPE_CHAT, _SCOPE_CONTROL, _SCOPE_APPROVE, _SCOPE_ADMIN}
+
+# The default grant for every paired device: read + approve, plus
+# control when the phone asks for it (the Operator role). Higher scopes
+# are host decisions (SPEC §2.3 D-2).
+_DEFAULT_GRANT = {_SCOPE_READ, _SCOPE_APPROVE}
+
+_CAPABILITIES = {
+    "jobs": True,
+    "kanban": True,
+    "remote_sessions": True,
+    "devices": True,
+    "audit": True,
+}
+
+_REMOTE_SCOPES = ["read", "approve", "chat", "control", "admin"]
+_MIN_HOST_VERSION = "0.9.0"
+
+
+def _platform_version() -> str:
+    try:
+        from importlib import metadata
+
+        return metadata.version("hermes-agent") or "0.0.0"
+    except Exception:
+        return "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Pairing primitives (byte-identical to the app's domain layer)
+# ---------------------------------------------------------------------------
+
+
+def derive_confirmation_code(secret_hex: str) -> str:
+    """The 6-digit confirmation code (SPEC §2.3 D-2 step 3).
+
+    ikm = the 32-byte pairing secret; salt = ``hermes-pair-code-v1``;
+    info = ``pair-confirmation``; 4 output bytes -> big-endian int
+    % 1_000_000 -> zero-padded 6 digits. Pinned by the app's
+    ConfirmationCodeTest golden vectors (717261 / 802349).
+    """
+    ikm = bytes.fromhex(secret_hex)
+    okm = HKDF(
+        algorithm=hashes.SHA256(), length=4,
+        salt=b"hermes-pair-code-v1", info=b"pair-confirmation",
+    ).derive(ikm)
+    return f"{int.from_bytes(okm, 'big') % 1_000_000:06d}"
+
+
+def ecies_encrypt(peer_spki_b64: str, plaintext: bytes) -> bytes:
+    """ECIES envelope exactly as EciesEnvelope.kt builds/parses it.
+
+    Layout: 65 B SEC1 uncompressed ephemeral point || 12 B IV ||
+    ciphertext||tag. Key derivation: ECDH(P-256), HKDF-SHA256 with
+    salt = ``hermes-ecies-v1`` + ephemeral point + peer point, info =
+    ``hermes-remote-push-v1``; AES-128-GCM (12 B nonce).
+    """
+    peer_der = base64.b64decode(peer_spki_b64)
+    peer = serialization.load_der_public_key(peer_der)
+    if not isinstance(peer, ec.EllipticCurvePublicKey):
+        raise ValueError("pairing public key must be P-256")
+    ephem = ec.generate_private_key(ec.SECP256R1())
+    point = ephem.public_key().public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+    peer_point = peer.public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+    shared = ephem.exchange(ec.ECDH(), peer)
+    salt = b"hermes-ecies-v1" + point + peer_point
+    okm = HKDF(
+        algorithm=hashes.SHA256(), length=32, salt=salt,
+        info=b"hermes-remote-push-v1",
+    ).derive(shared)
+    iv = secrets.token_bytes(12)
+    ct = AESGCM(okm).encrypt(iv, plaintext, None)
+    return point + iv + ct
+
+
+def qr_url_for(
+    host_name: str,
+    urls: List[str],
+    fp: str,
+    secret_hex: str,
+    ttl_seconds: int,
+) -> str:
+    """The ``hra://`` payload the app's PairingQr parses (SPEC §2.3 D-1)."""
+    urls_part = "[" + ",".join(urls) + "]"
+    return (
+        f"hra://pair?v=1&host={host_name}&urls={urls_part}"
+        f"&fp={fp}&secret={secret_hex}&ttl={ttl_seconds}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# State (single source of truth on disk; mtime-reload so CLI confirm and
+# revoke reach a running server; RLock because save() re-enters)
+# ---------------------------------------------------------------------------
+
+
+class RemoteState:
+    """Persistent host state: host identity, pairings, devices, audit.
+
+    The file is the single source of truth. EVERY mutator reloads first
+    (``reload_if_changed``) before locking and saving, or it clobbers
+    the file with stale in-memory state.
+    """
+
+    def __init__(self, state_dir: Optional[Path] = None) -> None:
+        if state_dir is None:
+            base = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+            state_dir = base / "remote"
+        self.state_dir = Path(state_dir)
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self._file = self.state_dir / "devices.json"
+        self._audit_file = self.state_dir / "audit.jsonl"
+        self._lock = threading.RLock()
+        self._mtime: Optional[float] = None
+        self._data: Dict[str, Any] = self._load()
+
+    # -- file plumbing -----------------------------------------------------
+
+    def _load(self) -> Dict[str, Any]:
+        if self._file.exists():
+            try:
+                data = json.loads(self._file.read_text())
+                if isinstance(data, dict) and "pairings" in data:
+                    self._mtime = self._file.stat().st_mtime
+                    return data
+            except Exception:
+                logger.exception("[remote] state file unreadable; starting empty")
+        return {
+            "host": {"id": uuid.uuid4().hex, "name": self._default_host_name()},
+            "pairings": {},
+            "devices": {},
+        }
+
+    @staticmethod
+    def _default_host_name() -> str:
+        try:
+            import getpass
+
+            return getpass.getuser() or "hermes"
+        except Exception:
+            return "hermes"
+
+    def reload_if_changed(self) -> None:
+        """Pick up CLI-side writes (confirm, revoke) before mutating."""
+        if not self._file.exists():
+            return
+        try:
+            mtime = self._file.stat().st_mtime
+        except OSError:
+            return
+        if mtime != self._mtime:
+            with self._lock:
+                self._data = self._load()
+
+    def save(self) -> None:
+        with self._lock:
+            tmp = self._file.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(self._data, indent=2))
+            os.replace(tmp, self._file)
+            self._mtime = self._file.stat().st_mtime
+
+    # -- host identity -----------------------------------------------------
+
+    def host_id(self) -> str:
+        return self._data["host"]["id"]
+
+    def host_name(self) -> str:
+        return self._data["host"].get("name") or self._default_host_name()
+
+    def set_host_name(self, name: str) -> None:
+        self.reload_if_changed()
+        with self._lock:
+            self._data["host"]["name"] = str(name)[:64]
+            self.save()
+
+    def spki_fingerprint_hex(self) -> str:
+        cert_path = self.state_dir / "tls-cert.pem"
+        if not cert_path.exists():
+            return ""
+        try:
+            cert = x509.load_pem_x509_certificate(cert_path.read_bytes())
+            spki = cert.public_key().public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return hashlib.sha256(spki).hexdigest()
+        except Exception:
+            return ""
+
+    # -- pairings ----------------------------------------------------------
+
+    def list_pairings(self) -> Dict[str, Any]:
+        return self._data["pairings"]
+
+    def create_pairing(self, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Dict[str, Any]:
+        self.reload_if_changed()
+        with self._lock:
+            reg_id = uuid.uuid4().hex
+            secret = secrets.token_bytes(32).hex()
+            pairing = {
+                "secret_hex": secret,
+                "ttl_seconds": ttl_seconds,
+                "created_at_ms": int(time.time() * 1000),
+                "status": "pending",
+                "device_name": None,
+                "requested_scopes": [],
+                "public_key_spki": None,
+                "device_id": None,
+                "confirm_attempts": 0,
+                "locked": False,
+            }
+            self._data["pairings"][reg_id] = pairing
+            self.save()
+            return {"registration_id": reg_id, **pairing}
+
+    def find_pairing_by_code(self, code: str) -> Optional[Tuple[str, Dict[str, Any]]]:
+        for reg_id, p in self._data["pairings"].items():
+            if p.get("status") != "pending":
+                continue
+            if derive_confirmation_code(p["secret_hex"]) == code:
+                return reg_id, p
+        return None
+
+    def get_pairing(self, reg_id: str) -> Optional[Dict[str, Any]]:
+        return self._data["pairings"].get(reg_id)
+
+    def expire_pairings(self) -> None:
+        now = int(time.time() * 1000)
+        with self._lock:
+            changed = False
+            for p in self._data["pairings"].values():
+                if p.get("status") == "pending" and p["created_at_ms"] + p["ttl_seconds"] * 1000 <= now:
+                    p["status"] = "expired"
+                    changed = True
+            if changed:
+                self.save()
+
+    def confirm_by_code(self, code: str) -> Optional[Dict[str, Any]]:
+        """Host ceremony: match the 6-digit code shown on the phone.
+
+        The phone must have POSTed pair/register FIRST (the secret is
+        single-use and the pubkey is captured there); only then does
+        the code match produce a confirmed device + ECIES token.
+        """
+        self.reload_if_changed()
+        with self._lock:
+            found = self.find_pairing_by_code(code)
+            if found is None:
+                return None
+            reg_id, pairing = found
+            if not pairing.get("consumed") or not pairing.get("public_key_spki"):
+                return None
+            device_id = uuid.uuid4().hex
+            token = TOKEN_PREFIX + secrets.token_hex(32)
+            token_hash = hashlib.sha256(token.encode()).hexdigest()
+            scopes = _default_scopes(pairing.get("requested_scopes") or [])
+            envelope = base64.b64encode(
+                ecies_encrypt(pairing["public_key_spki"], token.encode())
+            ).decode()
+            device = {
+                "id": device_id,
+                "name": pairing.get("device_name") or "Android device",
+                "public_key_spki": pairing.get("public_key_spki"),
+                "token_hash": token_hash,
+                "created_at_ms": int(time.time() * 1000),
+                "revoked": False,
+                "scopes": scopes,
+                "requested_scopes": pairing.get("requested_scopes") or [],
+                "upgrade_requested_at": None,
+                "issued_envelope": envelope,
+            }
+            self._data["devices"][device_id] = device
+            pairing["status"] = "confirmed"
+            pairing["device_id"] = device_id
+            self.save()
+        self.audit("host", "pairing.confirmed", reg_id)
+        return {
+            "device_id": device_id,
+            "name": device["name"],
+            "scopes": scopes,
+            "token": token,
+            "registration_id": reg_id,
+        }
+
+    # -- devices -----------------------------------------------------------
+
+    def list_devices(self) -> Dict[str, Any]:
+        return self._data["devices"]
+
+    def get_device(self, device_id: str) -> Optional[Dict[str, Any]]:
+        return self._data["devices"].get(device_id)
+
+    def device_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        for d in self._data["devices"].values():
+            if d.get("token_hash") == token_hash:
+                return d
+        return None
+
+    def update_device(self, device_id: str, **fields: Any) -> Optional[Dict[str, Any]]:
+        self.reload_if_changed()
+        with self._lock:
+            device = self._data["devices"].get(device_id)
+            if device is None:
+                return None
+            for key, value in fields.items():
+                if key in ("name", "requested_scopes", "scopes", "upgrade_requested_at"):
+                    device[key] = value
+            self.save()
+            return device
+
+    def revoke_device(self, device_id: str) -> bool:
+        self.reload_if_changed()
+        with self._lock:
+            device = self._data["devices"].get(device_id)
+            if device is None:
+                return False
+            device["revoked"] = True
+            self.save()
+        self.audit("host", "device.revoked", device_id)
+        return True
+
+    # -- audit -------------------------------------------------------------
+
+    def audit(self, actor: str, action: str, target: str, result: str = "ok") -> None:
+        row = {
+            "ts": int(time.time() * 1000),
+            "actor": actor,
+            "action": action,
+            "target": target,
+            "result": result,
+        }
+        try:
+            with self._audit_file.open("a") as fh:
+                fh.write(json.dumps(row) + "\n")
+        except OSError:
+            logger.exception("[remote] audit write failed")
+
+    def read_audit(self) -> List[Dict[str, Any]]:
+        if not self._audit_file.exists():
+            return []
+        rows: List[Dict[str, Any]] = []
+        for line in self._audit_file.read_text().splitlines():
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                continue
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# The gateway adapter
+# ---------------------------------------------------------------------------
+
+
+class RemoteDeviceAdapter(APIServerAdapter):
+    """The ``/api/remote/v1`` device surface (pairing + mounted handlers).
+
+    Mounts the base host's session/run/job/approval handlers (the SAME
+    code paths the API server serves) behind device-token auth and
+    per-route scopes. Adds the pairing ceremony, device registry, event
+    ring, audit, idempotency, rate limiting, the approval front-door,
+    and the receive-only WebSocket event stream.
+    """
+
+    def __init__(self, config: PlatformConfig) -> None:
+        super().__init__(config)
+        extra = config.extra or {}
+        self._state = RemoteState(extra.get("state_dir"))
+        self._remote_host = str(extra.get("host") or "0.0.0.0")
+        self._remote_port = int(extra.get("port") or 8643)
+        self._urls: List[str] = [str(u) for u in (extra.get("urls") or [])]
+        self._ttl_seconds = int(extra.get("ttl_seconds") or DEFAULT_TTL_SECONDS)
+
+        self._ssl_context: Optional[ssl.SSLContext] = None
+        self._spki_fingerprint_hex: str = ""
+
+        self._event_lock = threading.Lock()
+        self._event_id = 0
+        self._events: deque = deque(maxlen=EVENT_RING_SIZE)
+        self._approval_lock = threading.Lock()
+        self._approval_index: Dict[str, Dict[str, Any]] = {}
+        self._idem_lock = threading.Lock()
+        self._idem: Dict[str, Dict[str, Any]] = {}
+        self._pair_lock = threading.Lock()
+        self._pair_attempts: Dict[str, List[float]] = {}
+
+        self._app = None
+        self._runner = None
+        self._site = None
+
+    @property
+    def state(self) -> RemoteState:
+        return self._state
+
+    @property
+    def tls_key_path(self) -> Path:
+        return self._state.state_dir / "tls-key.pem"
+
+    @property
+    def tls_cert_path(self) -> Path:
+        return self._state.state_dir / "tls-cert.pem"
+
+    # -- TLS ---------------------------------------------------------------
+
+    def _ensure_tls(self) -> ssl.SSLContext:
+        if self._ssl_context is not None:
+            return self._ssl_context
+        if self.tls_key_path.exists() and self.tls_cert_path.exists():
+            key = self.tls_key_path.read_bytes()
+            cert = self.tls_cert_path.read_bytes()
+        else:
+            key, cert = self._generate_self_signed()
+            self.tls_key_path.write_bytes(key)
+            self.tls_cert_path.write_bytes(cert)
+            os.chmod(self.tls_key_path, 0o600)
+            os.chmod(self.tls_cert_path, 0o600)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=str(self.tls_cert_path), keyfile=str(self.tls_key_path))
+        loaded = x509.load_pem_x509_certificate(cert)
+        spki = loaded.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        self._spki_fingerprint_hex = hashlib.sha256(spki).hexdigest()
+        self._ssl_context = ctx
+        return ctx
+
+    @staticmethod
+    def _generate_self_signed() -> Tuple[bytes, bytes]:
+        key = ec.generate_private_key(ec.SECP256R1())
+        now = time.time()
+        name = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, "hermes-remote")])
+        # SANs: loopback + any LAN IP we can see, so standard TLS clients
+        # (tests, browsers) verify; the Android app pins the SPKI and does
+        # not rely on names (PinOrCaTrustManager).
+        san_ips = ["127.0.0.1", "::1"]
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                s.connect(("8.8.8.8", 80))
+                san_ips.append(s.getsockname()[0])
+            finally:
+                s.close()
+        except OSError:
+            pass
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.fromtimestamp(now - 86400, tz=timezone.utc))
+            .not_valid_after(datetime.fromtimestamp(now + 10 * 365 * 86400, tz=timezone.utc))
+            .add_extension(
+                x509.SubjectAlternativeName(
+                    [x509.IPAddress(ipaddress.ip_address(ip)) for ip in san_ips]
+                ),
+                critical=False,
+            )
+            .sign(key, hashes.SHA256())
+        )
+        key_pem = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+        return key_pem, cert_pem
+
+    def spki_fingerprint_hex(self) -> str:
+        return self._spki_fingerprint_hex or self._state.spki_fingerprint_hex()
+
+    @staticmethod
+    def _lan_ip() -> str:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                s.connect(("8.8.8.8", 80))
+                return s.getsockname()[0]
+            finally:
+                s.close()
+        except OSError:
+            return "127.0.0.1"
+
+    # -- pairing (CLI-facing) ----------------------------------------------
+
+    def pair(self, ttl_seconds: Optional[int] = None) -> Dict[str, Any]:
+        """Create a pending pairing; CLI prints the QR + confirmation code."""
+        self.state.expire_pairings()
+        created = self.state.create_pairing(
+            ttl_seconds or self._ttl_seconds
+        )
+        return {
+            "registration_id": created["registration_id"],
+            "qr_payload": self.qr_payload(
+                created["registration_id"], created
+            ),
+            "confirmation_code": derive_confirmation_code(created["secret_hex"]),
+            "ttl_seconds": created["ttl_seconds"],
+            "host_id": self.state.host_id(),
+        }
+
+    def qr_payload(self, reg_id: str, pairing: Dict[str, Any]) -> str:
+        urls = self._urls or [f"https://{self._lan_ip()}:{self._remote_port}"]
+        fp = self.spki_fingerprint_hex()
+        return qr_url_for(
+            host_name=self.state.host_name(),
+            urls=urls,
+            fp=fp,
+            secret_hex=pairing["secret_hex"],
+            ttl_seconds=pairing["ttl_seconds"],
+        )
+
+    def confirm_pairing(self, code: str) -> Optional[Dict[str, Any]]:
+        """Host ceremony: match the 6-digit code shown on the phone."""
+        result = self.state.confirm_by_code(code)
+        if result is None:
+            return None
+        self._emit_event("device.paired", {"device_id": result["device_id"]})
+        return result
+
+    # -- auth -------------------------------------------------------------------
+
+    def _check_auth(self, request) -> Optional[Any]:
+        """Device-token auth + per-route scope enforcement (replaces the
+        API-key check the base host applies to every handler)."""
+        self.state.reload_if_changed()
+        path = request.path
+        if path.startswith(_PUBLIC_PATHS):
+            return None
+        if path.startswith("/api/remote/v1/pair/status/"):
+            return None
+        header = request.headers.get("Authorization", "")
+        if not header.startswith("Bearer "):
+            return self._unauthorized()
+        token = header[7:].strip()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        device = self.state.device_by_token_hash(token_hash)
+        if device is None or device.get("revoked"):
+            return self._unauthorized()
+        # Stash the REGISTRY id (never the token) so downstream code
+        # (audit attribution, self-service checks, idempotency keys)
+        # addresses the device by its stable id.
+        request["remote_device_id"] = device["id"]
+        required = _required_scope(path, request.method)
+        if required and required not in (device.get("scopes") or []):
+            return web_json({"code": "insufficient_scope", "message": "device lacks scope: " + required}, 403)
+        return None
+
+    @staticmethod
+    def _unauthorized() -> Any:
+        return web_json(
+            {"code": "device_revoked", "message": "token invalid"}, 401
+        )
+
+    # -- pairing routes -----------------------------------------------------------
+
+    async def _handle_pair_register(self, request) -> Any:
+        self.state.reload_if_changed()
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        secret = str(body.get("secret", ""))
+        reg = self.state.list_pairings()
+        pairing_id = None
+        for rid, p in reg.items():
+            if p.get("secret_hex") == secret:
+                pairing_id = rid
+                break
+        if pairing_id is None:
+            return web_json({"code": "pairing_secret_invalid"}, 409)
+        p = reg[pairing_id]
+        if p.get("consumed") or p.get("status") != "pending":
+            return web_json({"code": "pairing_secret_used"}, 409)
+        now = int(time.time() * 1000)
+        if p["created_at_ms"] + p["ttl_seconds"] * 1000 <= now:
+            p["status"] = "expired"
+            self.state.save()
+            return web_json({"code": "pairing_secret_expired"}, 410)
+        p["consumed"] = True
+        p["device_name"] = str(body.get("device_name", "") or "Android")
+        p["requested_scopes"] = _coerce_scopes(body.get("requested_scopes"))
+        p["public_key_spki"] = str(body.get("public_key", "") or "")
+        self.state.save()
+        self.state.audit("pending", "pairing.registered", pairing_id)
+        return web_json({"registration_id": pairing_id}, 200)
+
+    async def _handle_pair_status(self, request) -> Any:
+        self.state.reload_if_changed()
+        reg_id = request.match_info["registration_id"]
+        p = self.state.get_pairing(reg_id)
+        if p is None:
+            return web_json({"code": "pairing_not_found"}, 404)
+        status = p.get("status", "pending")
+        body: Dict[str, Any] = {"status": status, "host_id": self.state.host_id()}
+        if status == "confirmed":
+            body["device_id"] = p.get("device_id")
+            body["name"] = p.get("device_name")
+            device = self.state.get_device(p.get("device_id") or "")
+            if device:
+                body["token_envelope"] = device.get("issued_envelope")
+        return web_json(body, 200)
+
+    # -- public + capability routes ----------------------------------------------
+
+    async def _handle_health(self, request) -> Any:
+        return web_json({
+            "status": "ok",
+            "platform": "hermes-agent",
+            "version": _platform_version(),
+        }, 200)
+
+    async def _handle_capabilities(self, request) -> Any:
+        return web_json({
+            "platform": "hermes-agent",
+            "version": _platform_version(),
+            "capabilities": _CAPABILITIES,
+            "minHostVersion": _MIN_HOST_VERSION,
+            "remote": {
+                "minHostVersion": _MIN_HOST_VERSION,
+                "scopes": _REMOTE_SCOPES,
+            },
+        }, 200)
+
+    # -- event ring + WS ----------------------------------------------------------
+
+    def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+        result = super()._set_run_status(run_id, status, **fields)
+        event_type = {
+            "running": "run.started",
+            "completed": "run.completed",
+            "failed": "run.failed",
+            "cancelled": "run.cancelled",
+            "stopping": "run.stopping",
+        }.get(status)
+        if event_type:
+            self._emit_event(event_type, {"run_id": run_id})
+        return result
+
+    def _emit_event(self, event_type: str, payload: Dict[str, Any]) -> None:
+        with self._event_lock:
+            self._event_id += 1
+            self._events.append({
+                "id": str(self._event_id),
+                "type": event_type,
+                "ts": int(time.time() * 1000),
+                "payload": payload,
+            })
+
+    async def _handle_events(self, request) -> Any:
+        with self._event_lock:
+            events = sorted(self._events, key=lambda e: int(e["id"]))
+        return web_json(events, 200)
+
+    async def _handle_ws(self, request) -> Any:
+        """One receive-only WebSocket per device (SPEC §2.1.1 WS row).
+
+        The app (WsEventSource) sends NO frames; it receives RemoteEventDto
+        JSON frames and pings every 30 s (OkHttp pingInterval). aiohttp's
+        heartbeat answers the pings; the poll loop replays the event ring
+        (dedupe by id on the app side) and pushes new events as they
+        arrive. Frames are event-only — the socket cannot mutate anything.
+        """
+        ws = web.WebSocketResponse(heartbeat=30)
+        await ws.prepare(request)
+        last_id = 0
+        try:
+            while True:
+                with self._event_lock:
+                    events = list(self._events)
+                for e in events:
+                    eid = int(e["id"])
+                    if eid > last_id:
+                        last_id = eid
+                        try:
+                            await ws.send_str(json.dumps(e))
+                        except (ConnectionResetError, RuntimeError):
+                            return ws
+                if ws.closed:
+                    return ws
+                await asyncio.sleep(1.0)
+        except (ConnectionResetError, asyncio.CancelledError):
+            pass
+        return ws
+
+    async def _handle_audit(self, request) -> Any:
+        rows = self.state.read_audit()
+        return web_json(rows, 200)
+
+    # -- approvals front-door ---------------------------------------------------------
+
+    async def _handle_list_approvals(self, request) -> Any:
+        cards: List[Dict[str, Any]] = []
+        now = int(time.time() * 1000)
+        with self._approval_lock:
+            self._approval_index.clear()
+            for run_id, session_key in list(getattr(self, "_run_approval_sessions", {}).items()):
+                entries = _pending_entries(session_key)
+                for entry in entries:
+                    data = entry.data or {}
+                    command_hash = str(data.get("command_hash") or "")
+                    if not command_hash:
+                        command_hash = _hash_command(str(data.get("command", "")))
+                    approval_id = f"run:{run_id}:{command_hash}"
+                    self._approval_index[approval_id] = {
+                        "session_key": session_key,
+                        "run_id": run_id,
+                        "command_hash": command_hash,
+                    }
+                    cards.append(_approval_card(approval_id, run_id, session_key, data, now))
+        return web_json(cards, 200)
+
+    async def _handle_approval_decision(self, request) -> Any:
+        approval_id = request.match_info["approval_id"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        decision = str(body.get("decision", "")).strip().lower()
+        choice = {
+            "approve": "once",
+            "deny": "deny",
+            "allow_always": "always",
+            "once": "once",
+            "always": "always",
+        }.get(decision)
+        if choice is None:
+            return web_json({"code": "invalid_decision", "message": "expected approve|deny|allow_always"}, 400)
+        with self._approval_lock:
+            index = self._approval_index.get(approval_id)
+            if index is None:
+                # Fall back to scanning live queues (index may be cold after restart)
+                index = self._find_approval_in_queues(approval_id)
+            if index is None:
+                return web_json({"code": "approval_not_found"}, 404)
+            session_key = index["session_key"]
+            run_id = index["run_id"]
+        try:
+            from tools.approval import resolve_gateway_approval
+            resolved = resolve_gateway_approval(session_key, choice, resolve_all=False)
+        except Exception:
+            logger.exception("[remote] approval resolution failed")
+            return web_json({"code": "approval_resolution_failed"}, 500)
+        if resolved <= 0:
+            return web_json({"code": "approval_not_pending"}, 409)
+        with self._approval_lock:
+            self._approval_index.pop(approval_id, None)
+        if run_id and run_id in getattr(self, "_run_statuses", {}):
+            self._set_run_status(run_id, "running", last_event="approval.responded")
+        self.state.audit(_device_id_of(request), "approval.decision", approval_id, result=choice)
+        return web_json({"ok": True, "approval_id": approval_id, "choice": choice}, 200)
+
+    def _find_approval_in_queues(self, approval_id: str) -> Optional[Dict[str, Any]]:
+        for run_id, session_key in list(getattr(self, "_run_approval_sessions", {}).items()):
+            for entry in _pending_entries(session_key):
+                data = entry.data or {}
+                command_hash = str(data.get("command_hash") or "")
+                if not command_hash:
+                    command_hash = _hash_command(str(data.get("command", "")))
+                if f"run:{run_id}:{command_hash}" == approval_id:
+                    return {"session_key": session_key, "run_id": run_id, "command_hash": command_hash}
+        return None
+
+    # -- runs list (new: the base host has no list-runs route) -------------------------
+
+    async def _handle_list_runs(self, request) -> Any:
+        limit = int(request.query.get("limit", "50") or 50)
+        now = time.time()
+        rows = []
+        for run_id, status in list(getattr(self, "_run_statuses", {}).items()):
+            created = getattr(self, "_run_streams_created", {}).get(run_id, now)
+            rows.append({
+                "id": run_id,
+                "status": status,
+                "created_at": created,
+                "updated_at": created,
+            })
+        rows.sort(key=lambda r: r["created_at"], reverse=True)
+        return web_json(rows[:limit], 200)
+
+    # -- devices ---------------------------------------------------------------------
+
+    async def _handle_get_device(self, request) -> Any:
+        device_id = request.match_info["device_id"]
+        device = self.state.get_device(device_id)
+        if device is None:
+            return web_json({"code": "device_not_found"}, 404)
+        return web_json(_device_view(device), 200)
+
+    async def _handle_patch_device(self, request) -> Any:
+        device_id = request.match_info["device_id"]
+        authed = _device_id_of(request)
+        device = self.state.get_device(device_id)
+        if device is None:
+            return web_json({"code": "device_not_found"}, 404)
+        if authed and authed != device_id:
+            return web_json({"code": "insufficient_scope", "message": "a device may only update itself"}, 403)
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        name = body.get("name")
+        requested = _coerce_scopes(body.get("requested_scopes"))
+        if name is not None:
+            device = self.state.update_device(device_id, name=str(name)[:64])
+        if requested:
+            device = self.state.update_device(device_id, requested_scopes=requested,
+                                               upgrade_requested_at=int(time.time() * 1000))
+            self.state.audit(device_id, "device.scope_requested", ",".join(requested))
+        if device is None:
+            return web_json({"code": "device_not_found"}, 404)
+        return web_json(_device_view(device), 200)
+
+    async def _handle_test_push(self, request) -> Any:
+        device_id = request.match_info["device_id"]
+        if _device_id_of(request) != device_id:
+            return web_json({"code": "insufficient_scope", "message": "a device may only test itself"}, 403)
+        self.state.audit(device_id, "device.test_push", device_id)
+        return web_json({"ok": True, "queued": False, "reason": "push bridge not configured"}, 200)
+
+    # -- kanban (V-9 remount over the real board store) --------------------------------
+
+    async def _handle_kanban(self, request) -> Any:
+        now_ms = int(time.time() * 1000)
+        empty = {"columns": [], "latest_event_id": 0, "now": now_ms}
+        try:
+            from dataclasses import asdict
+
+            from hermes_cli import kanban_db
+
+            db_path = kanban_db.kanban_db_path()
+            if not db_path.exists():
+                return web_json(empty, 200)
+            conn = kanban_db._sqlite_connect(db_path)
+            try:
+                tasks = kanban_db.list_tasks(conn)
+            finally:
+                conn.close()
+            by_status: Dict[str, List[Dict[str, Any]]] = {}
+            for t in tasks:
+                d = asdict(t) if not isinstance(t, dict) else dict(t)
+                status = str(d.get("status") or "todo")
+                by_status.setdefault(status, []).append(d)
+            columns = []
+            for status in kanban_db.VALID_STATUSES:
+                if status in by_status:
+                    columns.append({"name": status, "tasks": by_status[status]})
+            return web_json({
+                "columns": columns,
+                "latest_event_id": now_ms,
+                "now": now_ms,
+            }, 200)
+        except Exception:
+            logger.exception("[remote] kanban board read failed")
+            return web_json(empty, 200)
+
+    async def _handle_kanban_transition(self, request) -> Any:
+        task_id = request.match_info["task_id"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        target = str(body.get("status", "")).strip().lower()
+        try:
+            from hermes_cli import kanban_db
+
+            if target not in kanban_db.VALID_STATUSES:
+                return web_json({"ok": False, "reason": f"invalid status: {target}"}, 200)
+            db_path = kanban_db.kanban_db_path()
+            if not db_path.exists():
+                return web_json({"ok": False, "reason": "no kanban board on this host"}, 200)
+            conn = kanban_db._sqlite_connect(db_path)
+            try:
+                task = kanban_db.get_task(conn, task_id)
+                if task is None:
+                    return web_json({"ok": False, "reason": f"task {task_id} not found"}, 200)
+                if target == "running":
+                    kanban_db.claim_task(conn, task_id)
+                elif target == "done":
+                    kanban_db.complete_task(conn, task_id)
+                elif target == "archived":
+                    kanban_db.archive_task(conn, task_id)
+                else:
+                    with kanban_db.write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
+                            (target, int(time.time()), task_id),
+                        )
+            finally:
+                conn.close()
+            return web_json({"ok": True}, 200)
+        except Exception:
+            logger.exception("[remote] kanban transition failed")
+            return web_json({"ok": False, "reason": "transition failed on host"}, 200)
+
+    async def _handle_kanban_decompose(self, request) -> Any:
+        task_id = request.match_info["task_id"]
+        return web_json({"ok": False, "reason": f"decompose is not available on this host (task {task_id})"}, 200)
+
+    async def _handle_kanban_specify(self, request) -> Any:
+        task_id = request.match_info["task_id"]
+        return web_json({"ok": False, "reason": f"specify is not available on this host (task {task_id})"}, 200)
+
+    # -- server lifecycle --------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Build + run the aiohttp app (TLS, device auth, remote routes)."""
+        from aiohttp import web
+
+        self._ensure_tls()
+        # Seed the event ring so the first WS connect delivers a frame
+        # immediately (the app marks the host "seen" on any valid event).
+        self._emit_event("health.changed", {"status": "ok"})
+
+        @web.middleware
+        async def _idempotency_middleware(request, handler):
+            if request.method == "GET":
+                return await handler(request)
+            key = request.headers.get("Idempotency-Key", "")
+            if not key or request.path.startswith(_PUBLIC_PATHS) or "pair/" in request.path:
+                return await handler(request)
+            device_id = _device_id_of(request) or "anon"
+            idem_key = f"{device_id}:{key}"
+            raw_body = await request.read()
+            body_hash = hashlib.sha256(raw_body).hexdigest()
+            with self._idem_lock:
+                stored = self._idem.get(idem_key)
+            if stored is not None:
+                if stored["body_hash"] != body_hash:
+                    return web_json({"code": "idempotency_key_conflict"}, 409)
+                return web.Response(
+                    body=stored["body"], status=stored["status"],
+                    content_type=stored["content_type"],
+                )
+            response = await handler(request)
+            if isinstance(response, web.StreamResponse) and not isinstance(response, web.Response):
+                return response
+            body = response.body or b""
+            with self._idem_lock:
+                self._idem[idem_key] = {
+                    "body": body, "status": response.status,
+                    "content_type": response.content_type or "application/json",
+                    "body_hash": body_hash, "at": time.time(),
+                }
+                if len(self._idem) > 5000:
+                    oldest = min(self._idem, key=lambda k: self._idem[k]["at"])
+                    self._idem.pop(oldest, None)
+            return response
+
+        @web.middleware
+        async def _pairing_rate_middleware(request, handler):
+            if not request.path.startswith("/api/remote/v1/pair/"):
+                return await handler(request)
+            ip = request.remote or "?"
+            now = time.time()
+            with self._pair_lock:
+                window = [t for t in self._pair_attempts.setdefault(ip, []) if now - t < 60]
+                if len(window) >= PAIRING_RATE_LIMIT_PER_MIN:
+                    return web_json({"code": "rate_limited", "message": "pairing attempts limited — wait and retry"}, 429)
+                window.append(now)
+                self._pair_attempts[ip] = window
+            return await handler(request)
+
+        @web.middleware
+        async def _device_auth_middleware(request, handler):
+            # One gate for every route (inherited + remote-only): device
+            # token + per-route scope. Base handlers re-check internally;
+            # the double check is idempotent.
+            rejected = self._check_auth(request)
+            if rejected is not None:
+                return rejected
+            return await handler(request)
+
+        app = web.Application(middlewares=[
+            _device_auth_middleware,
+            _idempotency_middleware,
+            _pairing_rate_middleware,
+        ])
+        for method, path, handler in self._http_route_table():
+            app.router.add_route(method, path, handler)
+        app["api_server_adapter"] = self
+
+        self._app = app
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(
+            self._runner, self._remote_host, self._remote_port,
+            ssl_context=self._ssl_context,
+            reuse_address=False if sys.platform == "darwin" else None,
+        )
+        await self._site.start()
+        logger.info(
+            "[remote] device gateway on https://%s:%d (fp=%s…)",
+            self._remote_host, self._remote_port,
+            (self._spki_fingerprint_hex or "")[:12],
+        )
+
+    async def stop(self) -> None:
+        if self._site is not None:
+            await self._site.stop()
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    # -- route table -------------------------------------------------------------------
+
+    def _http_route_table(self) -> List[Tuple[str, str, Any]]:
+        base = "/api/remote/v1"
+        return [
+            ("GET", f"{base}/health", self._handle_health),
+            ("GET", f"{base}/capabilities", self._handle_capabilities),
+            ("GET", f"{base}/sessions", self._handle_list_sessions),
+            ("POST", f"{base}/sessions", self._handle_create_session),
+            ("GET", f"{base}/sessions/{{session_id}}/messages", self._handle_session_messages),
+            ("POST", f"{base}/sessions/{{session_id}}/chat", self._handle_session_chat),
+            ("GET", f"{base}/runs", self._handle_list_runs),
+            ("GET", f"{base}/runs/{{run_id}}", self._handle_get_run),
+            ("GET", f"{base}/runs/{{run_id}}/events", self._handle_run_events),
+            ("POST", f"{base}/runs/{{run_id}}/approval", self._handle_run_approval),
+            ("POST", f"{base}/runs/{{run_id}}/stop", self._handle_stop_run),
+            ("GET", f"{base}/approvals", self._handle_list_approvals),
+            ("POST", f"{base}/approvals/{{approval_id}}/decision", self._handle_approval_decision),
+            ("GET", f"{base}/jobs", self._handle_list_jobs),
+            ("POST", f"{base}/jobs", self._handle_create_job),
+            ("GET", f"{base}/jobs/{{job_id}}", self._handle_get_job),
+            ("PATCH", f"{base}/jobs/{{job_id}}", self._handle_update_job),
+            ("DELETE", f"{base}/jobs/{{job_id}}", self._handle_delete_job),
+            ("POST", f"{base}/jobs/{{job_id}}/pause", self._handle_pause_job),
+            ("POST", f"{base}/jobs/{{job_id}}/resume", self._handle_resume_job),
+            ("POST", f"{base}/jobs/{{job_id}}/run", self._handle_run_job),
+            ("GET", f"{base}/kanban", self._handle_kanban),
+            ("POST", f"{base}/kanban/{{task_id}}/transition", self._handle_kanban_transition),
+            ("POST", f"{base}/kanban/{{task_id}}/decompose", self._handle_kanban_decompose),
+            ("POST", f"{base}/kanban/{{task_id}}/specify", self._handle_kanban_specify),
+            ("GET", f"{base}/events", self._handle_events),
+            ("GET", f"{base}/ws", self._handle_ws),
+            ("GET", f"{base}/audit", self._handle_audit),
+            ("GET", f"{base}/devices/{{device_id}}", self._handle_get_device),
+            ("PATCH", f"{base}/devices/{{device_id}}", self._handle_patch_device),
+            ("POST", f"{base}/devices/{{device_id}}/test-push", self._handle_test_push),
+            ("POST", f"{base}/pair/register", self._handle_pair_register),
+            ("GET", f"{base}/pair/status/{{registration_id}}", self._handle_pair_status),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _percent_encode(s: str) -> str:
+    from urllib.parse import quote
+
+    return quote(s, safe="")
+
+
+def _coerce_scopes(raw: Any) -> List[str]:
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for s in raw:
+        s = str(s).strip().lower()
+        if s in _ALL_SCOPES and s not in out:
+            out.append(s)
+    return out
+
+
+def _default_scopes(requested: List[str]) -> List[str]:
+    scopes = set(_DEFAULT_GRANT)
+    requested_set = set(requested)
+    for scope in (_SCOPE_CONTROL, _SCOPE_CHAT, _SCOPE_ADMIN):
+        if scope in requested_set:
+            scopes.add(scope)
+    return sorted(scopes)
+
+
+def _required_scope(path: str, method: str) -> Optional[str]:
+    if method == "GET":
+        return _SCOPE_READ
+    if path.endswith("/chat"):
+        return _SCOPE_CHAT
+    if "/approval" in path or "/decision" in path:
+        return _SCOPE_APPROVE
+    if path.endswith("/stop") or "/jobs/" in path or "/kanban/" in path or path.endswith("/test-push"):
+        return _SCOPE_CONTROL
+    if "/devices/" in path:
+        return _SCOPE_CONTROL
+    return _SCOPE_CONTROL
+
+
+def _hash_command(command: str) -> str:
+    return hashlib.sha256(command.encode()).hexdigest()[:32]
+
+
+def _approval_card(approval_id: str, run_id: str, session_key: str, data: Dict[str, Any], now_ms: int) -> Dict[str, Any]:
+    pattern_keys = data.get("pattern_keys") or ([data["pattern_key"]] if data.get("pattern_key") else [])
+    expires = data.get("expires_at")
+    if not isinstance(expires, (int, float)) or expires <= 0:
+        expires = int(time.time()) + 300
+    return {
+        "approval_id": approval_id,
+        "pattern_keys": [str(k) for k in pattern_keys],
+        "destructive": bool(data.get("destructive", False)),
+        "description": str(data.get("description") or "Approve this action on the host?"),
+        "description_provenance": str(data.get("description_provenance") or "host_approval"),
+        "surface": str(data.get("surface") or "gateway"),
+        "session_key": session_key or None,
+        "run_id": run_id,
+        "created_at": now_ms,
+        "expires_at": int(expires),
+        "status": "pending",
+    }
+
+
+def _pending_entries(session_key: str) -> List[Any]:
+    try:
+        from tools import approval as _approval
+        with _approval._lock:
+            return list(_approval._gateway_queues.get(session_key, []))
+    except Exception:
+        return []
+
+
+def _device_id_of(request) -> str:
+    # The auth middleware stashes the registry id; never derive an id
+    # from the bearer token (that leaks token material into audit rows).
+    return request.get("remote_device_id", "")
+
+
+def _device_view(device: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": device.get("id"),
+        "name": device.get("name"),
+        "scopes": device.get("scopes", []),
+        "created_at": device.get("created_at_ms", 0) / 1000.0,
+        "revoked": bool(device.get("revoked", False)),
+        "requested_scopes": device.get("requested_scopes", []),
+        "upgrade_requested_at": device.get("upgrade_requested_at"),
+    }
+
+
+def web_json(payload: Any, status: int = 200) -> web.Response:
+    return web.Response(
+        body=json.dumps(payload).encode(),
+        status=status,
+        content_type="application/json",
+    )
+
+
+def hmac_sha256(key: bytes, msg: bytes) -> bytes:
+    return hmac.new(key, msg, hashlib.sha256).digest()

--- a/gateway/platforms/remote.py
+++ b/gateway/platforms/remote.py
@@ -786,6 +786,181 @@ class RemoteDeviceAdapter(APIServerAdapter):
         rows = self.state.read_audit()
         return web_json(rows, 200)
 
+    # -- projects tree (desktop sidebar parity) ------------------------------------
+
+    async def _handle_projects_tree(self, request) -> Any:
+        """GET /projects — the same tree the desktop sidebar renders.
+
+        Mirrors tui_gateway.server._build_project_tree: sessions come from
+        the gateway's own HERMES_HOME/state.db via list_sessions_rich, and
+        projects come from the profile's projects.db. The tree is hydrated
+        (lanes carry full session rows) so the phone can drill into
+        projects exactly like the desktop sidebar.
+        """
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web_json({"error": "session_db_unavailable"}, 503)
+        try:
+            rows = db.list_sessions_rich(
+                limit=500,
+                offset=0,
+                order_by_last_active=True,
+                min_message_count=1,
+                include_children=False,
+                include_archived=False,
+            )
+            from tui_gateway.server import _project_tree_row
+
+            sessions = [_project_tree_row(r) for r in rows]
+
+            from hermes_cli import projects_db as pdb
+
+            with pdb.connect_closing() as conn:
+                projects = [p.to_dict() for p in pdb.list_projects(conn)]
+                active_id = pdb.get_active_id(conn)
+                discovered = pdb.list_discovered_repos(conn)
+
+            from tui_gateway import project_tree
+
+            tree = project_tree.build_tree(
+                projects,
+                sessions,
+                discovered,
+                None,
+                preview_limit=3,
+                hydrate=True,
+                exists=lambda _path: True,
+            )
+            tree["active_project_id"] = active_id
+            return web_json(tree, 200)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("[remote] projects tree failed")
+            return web_json({"error": f"projects tree failed: {exc}"}, 500)
+
+    # -- profiles (hermes profile parity) ------------------------------------------
+
+    async def _handle_list_profiles(self, request) -> Any:
+        """GET /profiles — list profiles exactly like `hermes profile list`."""
+        try:
+            from hermes_cli.profiles import get_active_profile_name, list_profiles
+
+            profiles = []
+            for p in list_profiles():
+                profiles.append({
+                    "name": p.name,
+                    "is_default": p.is_default,
+                    "model": p.model,
+                    "provider": p.provider,
+                    "description": p.description or "",
+                    "gateway_running": bool(p.gateway_running),
+                    "skill_count": p.skill_count,
+                })
+            return web_json({
+                "profiles": profiles,
+                "active": get_active_profile_name(),
+            }, 200)
+        except Exception as exc:
+            logger.exception("[remote] profiles list failed")
+            return web_json({"error": f"profiles list failed: {exc}"}, 500)
+
+    async def _handle_create_profile(self, request) -> Any:
+        """POST /profiles {name, description?} — create a profile."""
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        name = str(body.get("name", "")).strip()
+        if not name:
+            return web_json({"code": "invalid_name", "message": "name is required"}, 400)
+        description = body.get("description")
+        if description is not None and not isinstance(description, str):
+            return web_json({"code": "invalid_description"}, 400)
+        try:
+            from hermes_cli.profiles import create_profile
+
+            path = create_profile(name, description=description or None, no_alias=True)
+            self.state.audit(_device_id_of(request), "profile.created", name)
+            return web_json({"name": name, "path": str(path)}, 201)
+        except ValueError as exc:
+            return web_json({"code": "invalid_name", "message": str(exc)}, 400)
+        except Exception as exc:
+            logger.exception("[remote] profile create failed")
+            return web_json({"error": f"profile create failed: {exc}"}, 500)
+
+    async def _handle_rename_profile(self, request) -> Any:
+        """PATCH /profiles/{name} {new_name} — rename a profile."""
+        name = request.match_info["name"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web_json({"code": "malformed_request"}, 400)
+        new_name = str(body.get("new_name", "")).strip()
+        if not new_name:
+            return web_json({"code": "invalid_name", "message": "new_name is required"}, 400)
+        try:
+            from hermes_cli.profiles import rename_profile
+
+            path = rename_profile(name, new_name)
+            self.state.audit(_device_id_of(request), "profile.renamed", f"{name} -> {new_name}")
+            return web_json({"name": new_name, "path": str(path)}, 200)
+        except FileNotFoundError as exc:
+            return web_json({"code": "profile_not_found", "message": str(exc)}, 404)
+        except FileExistsError as exc:
+            return web_json({"code": "profile_exists", "message": str(exc)}, 409)
+        except ValueError as exc:
+            return web_json({"code": "invalid_name", "message": str(exc)}, 400)
+        except Exception as exc:
+            logger.exception("[remote] profile rename failed")
+            return web_json({"error": f"profile rename failed: {exc}"}, 500)
+
+    async def _handle_delete_profile(self, request) -> Any:
+        """DELETE /profiles/{name} — delete a profile."""
+        name = request.match_info["name"]
+        active = ""
+        try:
+            from hermes_cli.profiles import delete_profile, get_active_profile_name
+
+            active = get_active_profile_name()
+            if name == active:
+                return web_json(
+                    {"code": "profile_active", "message": "cannot delete the active profile"},
+                    409,
+                )
+            path = delete_profile(name, yes=True)
+            self.state.audit(_device_id_of(request), "profile.deleted", name)
+            return web_json({"name": name, "path": str(path)}, 200)
+        except FileNotFoundError as exc:
+            return web_json({"code": "profile_not_found", "message": str(exc)}, 404)
+        except ValueError as exc:
+            return web_json({"code": "invalid_name", "message": str(exc)}, 400)
+        except Exception as exc:
+            logger.exception("[remote] profile delete failed")
+            return web_json({"error": f"profile delete failed: {exc}"}, 500)
+
+    async def _handle_switch_profile(self, request) -> Any:
+        """POST /profiles/{name}/switch — set the active profile.
+
+        Mirrors `hermes profile use {name}`: writes ~/.hermes/active_profile.
+        The running gateway keeps serving its own home until restarted; the
+        response reports the new active profile so the app can prompt a
+        reconnect (the operator restarts the gateway with the new home).
+        """
+        name = request.match_info["name"]
+        try:
+            from hermes_cli.profiles import get_profile_dir, set_active_profile
+
+            set_active_profile(name)
+            self.state.audit(_device_id_of(request), "profile.switched", name)
+            path = str(get_profile_dir(name)) if name != "default" else None
+            return web_json({"active": name, "path": path, "restart_required": True}, 200)
+        except FileNotFoundError as exc:
+            return web_json({"code": "profile_not_found", "message": str(exc)}, 404)
+        except ValueError as exc:
+            return web_json({"code": "invalid_name", "message": str(exc)}, 400)
+        except Exception as exc:
+            logger.exception("[remote] profile switch failed")
+            return web_json({"error": f"profile switch failed: {exc}"}, 500)
+
     # -- approvals front-door ---------------------------------------------------------
 
     async def _handle_list_approvals(self, request) -> Any:
@@ -1109,8 +1284,16 @@ class RemoteDeviceAdapter(APIServerAdapter):
             ("GET", f"{base}/capabilities", self._handle_capabilities),
             ("GET", f"{base}/sessions", self._handle_list_sessions),
             ("POST", f"{base}/sessions", self._handle_create_session),
+            ("PATCH", f"{base}/sessions/{{session_id}}", self._handle_patch_session),
+            ("DELETE", f"{base}/sessions/{{session_id}}", self._handle_delete_session),
             ("GET", f"{base}/sessions/{{session_id}}/messages", self._handle_session_messages),
             ("POST", f"{base}/sessions/{{session_id}}/chat", self._handle_session_chat),
+            ("GET", f"{base}/projects", self._handle_projects_tree),
+            ("GET", f"{base}/profiles", self._handle_list_profiles),
+            ("POST", f"{base}/profiles", self._handle_create_profile),
+            ("PATCH", f"{base}/profiles/{{name}}", self._handle_rename_profile),
+            ("DELETE", f"{base}/profiles/{{name}}", self._handle_delete_profile),
+            ("POST", f"{base}/profiles/{{name}}/switch", self._handle_switch_profile),
             ("GET", f"{base}/runs", self._handle_list_runs),
             ("GET", f"{base}/runs/{{run_id}}", self._handle_get_run),
             ("GET", f"{base}/runs/{{run_id}}/events", self._handle_run_events),
@@ -1177,6 +1360,14 @@ def _required_scope(path: str, method: str) -> Optional[str]:
         return _SCOPE_READ
     if path.endswith("/chat"):
         return _SCOPE_CHAT
+    # Session lifecycle (create/patch/delete) is the chat surface — the
+    # phone manages its own conversation list with the chat scope it
+    # already holds. Host-level surfaces (jobs, kanban, devices, profiles)
+    # stay on control.
+    if "/sessions" in path:
+        return _SCOPE_CHAT
+    if "/profiles" in path:
+        return _SCOPE_CONTROL
     if "/approval" in path or "/decision" in path:
         return _SCOPE_APPROVE
     if path.endswith("/stop") or "/jobs/" in path or "/kanban/" in path or path.endswith("/test-push"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -480,6 +480,7 @@ from hermes_cli.subcommands.insights import build_insights_parser
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
+from hermes_cli.subcommands.remote import build_remote_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
@@ -11173,6 +11174,12 @@ def cmd_pairing(args):
     pairing_command(args)
 
 
+def cmd_remote(args):
+    from hermes_cli.remote_commands import remote_command
+
+    remote_command(args)
+
+
 def cmd_plugins(args):
     from hermes_cli.plugins_cmd import plugins_command
 
@@ -11620,6 +11627,11 @@ def main():
     # pairing command  (parser built in hermes_cli/subcommands/pairing.py)
     # =========================================================================
     build_pairing_parser(subparsers, cmd_pairing=cmd_pairing)
+
+    # =========================================================================
+    # remote command  (parser built in hermes_cli/subcommands/remote.py)
+    # =========================================================================
+    build_remote_parser(subparsers, cmd_remote=cmd_remote)
 
     # =========================================================================
     # skills command  (parser built in hermes_cli/subcommands/skills.py)

--- a/hermes_cli/remote_commands.py
+++ b/hermes_cli/remote_commands.py
@@ -1,0 +1,195 @@
+"""``hermes remote`` — the host side of Hermes Remote.
+
+Commands: start (run the TLS device gateway), pair (print an ``hra://``
+code + QR), confirm (finish the ceremony with the phone's 6-digit
+code), revoke (kill a device token), status (host + devices).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+DEFAULT_TTL_SECONDS = 600
+
+
+def _state():
+    from gateway.platforms.remote import RemoteState
+
+    return RemoteState()
+
+
+def _detect_external_urls(port: int) -> List[str]:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        ip = "127.0.0.1"
+    return [f"https://{ip}:{port}"]
+
+
+def _render_qr_ascii(url: str) -> str:
+    import io
+
+    import qrcode
+
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(url)
+    qr.make(fit=True)
+    buf = io.StringIO()
+    qr.print_ascii(out=buf)
+    return buf.getvalue()
+
+
+def _render_qr_png(url: str, path: str) -> None:
+    import qrcode
+
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(url)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    img.save(path)
+
+
+def _cmd_start(args) -> None:
+    from gateway.config import PlatformConfig
+    from gateway.platforms.remote import RemoteDeviceAdapter
+
+    host = str(getattr(args, "host", None) or "0.0.0.0")
+    port = int(getattr(args, "port", None) or 8643)
+    urls = [u.strip() for u in (getattr(args, "urls", "") or "").split(",") if u.strip()]
+    adapter = RemoteDeviceAdapter(PlatformConfig(
+        enabled=True,
+        extra={"host": host, "port": port, "urls": urls},
+    ))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(adapter.start())
+    except OSError as exc:
+        print(f"hermes remote: cannot bind https://{host}:{port} — {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    print(f"hermes remote: {adapter.state.host_name()} gateway on https://{host}:{port}")
+    print("Phone: open Hermes Remote, add a host, and scan a fresh "
+          "`hermes remote pair` code.")
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        loop.run_until_complete(adapter.stop())
+
+
+def _cmd_pair(args) -> None:
+    from gateway.platforms.remote import (
+        RemoteDeviceAdapter,
+        derive_confirmation_code,
+        qr_url_for,
+    )
+
+    state = _state()
+    port = int(getattr(args, "port", None) or 8643)
+    urls = getattr(args, "urls", None) or []
+    if isinstance(urls, str):
+        urls = [u.strip() for u in urls.split(",") if u.strip()]
+    if not urls:
+        urls = _detect_external_urls(port)
+    pairing = state.create_pairing(ttl_seconds=DEFAULT_TTL_SECONDS)
+    fp = state.spki_fingerprint_hex()
+    if not fp:
+        # The server has not run yet — generate the TLS material now so
+        # the QR's fp is the exact pin the app will verify.
+        from gateway.config import PlatformConfig
+
+        RemoteDeviceAdapter(PlatformConfig(
+            enabled=True,
+            extra={"host": "0.0.0.0", "port": port, "urls": urls},
+        ))._ensure_tls()
+        fp = state.spki_fingerprint_hex()
+    url = qr_url_for(
+        host_name=state.host_name(),
+        urls=urls,
+        fp=fp or "",
+        secret_hex=pairing["secret_hex"],
+        ttl_seconds=pairing["ttl_seconds"],
+    )
+    print(f"Pairing code (valid 10 minutes, single use):\n  {url}")
+    print(f"\nRegistration id: {pairing['registration_id']}")
+    print(f"Confirmation code shown on the phone: "
+          f"{derive_confirmation_code(pairing['secret_hex'])}")
+    qr_out = getattr(args, "qr_out", None)
+    if qr_out:
+        try:
+            _render_qr_png(url, qr_out)
+            print(f"QR image written: {qr_out}")
+        except Exception as exc:
+            print(f"QR image failed ({exc}); the text code above still works.")
+    else:
+        try:
+            print("\n" + _render_qr_ascii(url))
+        except Exception:
+            pass
+    print("\nIn the app: pair a host, then confirm the code on this machine "
+          "with: hermes remote confirm <CODE>")
+
+
+def _cmd_confirm(args) -> None:
+    state = _state()
+    code = (getattr(args, "code", "") or "").strip()
+    result = state.confirm_by_code(code)
+    if result is None:
+        print("No pending pairing matches that code. Run `hermes remote pair` "
+              "for a fresh code, then try again.")
+        return
+    print(f"Paired device {result['device_id']} ({result['name']}) — "
+          f"scopes: {', '.join(result['scopes'])}")
+    print("The phone will now receive its token and connect.")
+
+
+def _cmd_revoke(args) -> None:
+    state = _state()
+    device_id = (getattr(args, "device_id", "") or "").strip()
+    if state.revoke_device(device_id):
+        print(f"Revoked device {device_id}")
+    else:
+        print(f"No such device: {device_id}")
+
+
+def _cmd_status(args) -> None:
+    state = _state()
+    devices = state.list_devices()
+    active = [d for d in devices.values() if not d.get("revoked")]
+    print(f"Host id:    {state.host_id()}")
+    print(f"Host name:  {state.host_name()}")
+    fp = state.spki_fingerprint_hex()
+    print(f"SPKI pin:   {fp or '(server not started yet)'}")
+    print(f"Devices:    {len(devices)} paired ({len(active)} active)")
+    for device_id, d in devices.items():
+        print(f"  - {device_id}  {d.get('name')}  "
+              f"scopes={','.join(d.get('scopes') or [])}  "
+              f"revoked={bool(d.get('revoked'))}")
+
+
+def remote_command(args) -> None:
+    command = getattr(args, "remote_command", "") or ""
+    if command == "start":
+        _cmd_start(args)
+    elif command == "pair":
+        _cmd_pair(args)
+    elif command == "confirm":
+        _cmd_confirm(args)
+    elif command == "revoke":
+        _cmd_revoke(args)
+    elif command == "status":
+        _cmd_status(args)
+    else:
+        print("hermes remote: unknown command. Try: start | pair | confirm | revoke | status",
+              file=sys.stderr)
+        raise SystemExit(2)

--- a/hermes_cli/subcommands/remote.py
+++ b/hermes_cli/subcommands/remote.py
@@ -1,0 +1,36 @@
+"""``hermes remote`` subcommand parser (wired into hermes_cli/main.py)."""
+
+from __future__ import annotations
+
+
+def build_remote_parser(subparsers, cmd_remote=None):
+    parser = subparsers.add_parser(
+        "remote",
+        help="host gateway for the Hermes Remote Android app",
+    )
+    sub = parser.add_subparsers(dest="remote_command", required=True)
+
+    start = sub.add_parser("start", help="run the device gateway (TLS)")
+    start.add_argument("--host", default="0.0.0.0", help="bind address")
+    start.add_argument("--port", type=int, default=8643, help="bind port")
+    start.add_argument("--urls", default="", help="comma-separated public URLs")
+    start.set_defaults(func=cmd_remote)
+
+    pair = sub.add_parser("pair", help="print a pairing code + QR")
+    pair.add_argument("--port", type=int, default=8643, help="gateway port")
+    pair.add_argument("--urls", default="", help="comma-separated public URLs")
+    pair.add_argument("--qr-out", default="", help="write the QR to a PNG file")
+    pair.set_defaults(func=cmd_remote)
+
+    confirm = sub.add_parser("confirm", help="confirm a pairing with the 6-digit code")
+    confirm.add_argument("code", help="the code shown on the phone")
+    confirm.set_defaults(func=cmd_remote)
+
+    revoke = sub.add_parser("revoke", help="revoke a paired device")
+    revoke.add_argument("device_id", help="the device id from `hermes remote status`")
+    revoke.set_defaults(func=cmd_remote)
+
+    status = sub.add_parser("status", help="show host + device status")
+    status.set_defaults(func=cmd_remote)
+
+    return parser

--- a/tests/remote/test_remote_gateway.py
+++ b/tests/remote/test_remote_gateway.py
@@ -1,0 +1,496 @@
+"""E2E tests for the remote device gateway (HRA-2026-001 host side).
+
+Run against a real in-process aiohttp server with real TLS, a temp
+HERMES_HOME, and the FULL pairing ceremony — QR payload, single-use
+secret, 6-digit confirmation code, ECIES token envelope, device token,
+scoped auth. Mirrors the Android app's own gate tests where the wire
+contract overlaps (single-use secrets, revocation, scopes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import ssl
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from gateway.config import PlatformConfig
+from gateway.platforms.remote import (
+    RemoteDeviceAdapter,
+    RemoteState,
+    derive_confirmation_code,
+    qr_url_for,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: a fake "phone" (P-256 keypair + ECIES decrypt, as the app does)
+# ---------------------------------------------------------------------------
+
+
+class FakePhone:
+    """What the Android app does on the pairing side."""
+
+    def __init__(self) -> None:
+        self.key = ec.generate_private_key(ec.SECP256R1())
+
+    def public_key_spki_b64(self) -> str:
+        return base64.b64encode(self.key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )).decode()
+
+    def decrypt_envelope(self, envelope_b64: str) -> str:
+        """Mirror EciesEnvelope.kt: 65 B point || 12 B IV || ct||tag."""
+        raw = base64.b64decode(envelope_b64)
+        point = raw[:65]
+        iv = raw[65:77]
+        ct = raw[77:]
+        peer = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), point)
+        shared = self.key.exchange(ec.ECDH(), peer)
+        salt = b"hermes-ecies-v1" + point + self.key.public_key().public_bytes(
+            serialization.Encoding.X962,
+            serialization.PublicFormat.UncompressedPoint,
+        )
+        okm = HKDF(
+            algorithm=hashes.SHA256(), length=32, salt=salt,
+            info=b"hermes-remote-push-v1",
+        ).derive(shared)
+        return AESGCM(okm).decrypt(iv, ct, None).decode()
+
+
+@pytest.fixture()
+def state(tmp_path: Path):
+    return RemoteState(tmp_path)
+
+
+@pytest.fixture()
+def home_env(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _parse_qr(text: str) -> dict:
+    q = text.split("?", 1)[1]
+    return dict(kv.split("=", 1) for kv in q.split("&") if "=" in kv)
+
+
+# ---------------------------------------------------------------------------
+# Server harness
+# ---------------------------------------------------------------------------
+
+
+class Server:
+    def __init__(self, tmp_path: Path) -> None:
+        self.adapter = RemoteDeviceAdapter(PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "urls": [],
+                "state_dir": str(tmp_path),
+            },
+        ))
+        self._tmp = tmp_path
+
+    async def __aenter__(self):
+        await self.adapter.start()
+        port = self.adapter._site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False  # the app pins the SPKI, not the name
+        ctx.load_verify_locations(self._tmp / "tls-cert.pem")
+        self.ssl = ctx
+        self.base = f"https://127.0.0.1:{port}"
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.adapter.stop()
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture()
+def server(tmp_path: Path):
+    s = Server(tmp_path)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(s.__aenter__())
+    yield s
+    loop.run_until_complete(s.__aexit__())
+    loop.close()
+
+
+class Phone:
+    def __init__(self, server) -> None:
+        self.server = server
+        self.phone = FakePhone()
+        self.headers = {}
+
+    def _request(self, method, path, body=None, headers=None, raw_body=None):
+        import aiohttp
+
+        async def go():
+            kw = {}
+            if body is not None:
+                kw["data"] = json.dumps(body)
+            hdrs = dict(headers or {})
+            if body is not None:
+                hdrs["Content-Type"] = "application/json"
+            if raw_body is not None:
+                kw["data"] = raw_body
+            async with aiohttp.ClientSession() as s:
+                async with s.request(
+                    method, self.server.base + path, headers=hdrs,
+                    ssl=self.server.ssl, **kw,
+                ) as r:
+                    text = await r.text()
+                    return r.status, text
+        return _run(go())
+
+    def pair(self, secret_hex, device_name="Pixel 6"):
+        return self._request("POST", "/api/remote/v1/pair/register", {
+            "secret": secret_hex,
+            "device_name": device_name,
+            "requested_scopes": ["read", "chat", "control", "approve"],
+            "public_key": self.phone.public_key_spki_b64(),
+        })
+
+    def poll(self, reg_id):
+        return self._request("GET", f"/api/remote/v1/pair/status/{reg_id}")
+
+    def get(self, path):
+        return self._request("GET", path, headers=self.headers)
+
+    def post(self, path, body=None, headers=None):
+        merged = {**self.headers, **(headers or {})}
+        return self._request("POST", path, body, headers=merged)
+
+    def patch(self, path, body=None, headers=None):
+        merged = {**self.headers, **(headers or {})}
+        return self._request("PATCH", path, body, headers=merged)
+
+    def register_token(self, token):
+        self.headers["Authorization"] = f"Bearer {token}"
+
+    def decrypt_envelope(self, envelope_b64: str) -> str:
+        return self.phone.decrypt_envelope(envelope_b64)
+
+
+# ---------------------------------------------------------------------------
+# Unit: QR payload shape (the app's PairingQr rules)
+# ---------------------------------------------------------------------------
+
+
+def test_qr_payload_parses_under_app_rules(state):
+    pairing = state.create_pairing(ttl_seconds=600)
+    url = qr_url_for("testhost", ["https://192.168.1.5:8643"], "ab" * 32,
+                     pairing["secret_hex"], 600)
+    p = _parse_qr(url)
+    assert url.startswith("hra://pair?")
+    assert p["v"] == "1"
+    assert p["host"] == "testhost"
+    assert p["urls"].startswith("[https://")
+    assert p["urls"].endswith("]")
+    assert len(p["fp"]) == 64 and all(c in "0123456789abcdef" for c in p["fp"])
+    assert len(p["secret"]) == 64
+    assert p["ttl"] == "600"
+
+
+def test_confirmation_code_golden_vectors():
+    # Pinned in ConfirmationCodeTest.kt (independent Python derivation).
+    assert derive_confirmation_code(
+        "a1b2c3d4e5f60718293a4b5c6d7e8f901a2b3c4d5e6f708192a3b4c5d6e7f809"
+    ) == "717261"
+    assert derive_confirmation_code(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    ) == "802349"
+
+
+def test_ecies_envelope_decrypts_with_phone_key():
+    phone = FakePhone()
+    token = "hrd_" + uuid.uuid4().hex
+    from gateway.platforms.remote import ecies_encrypt
+    env = base64.b64encode(
+        ecies_encrypt(phone.public_key_spki_b64(), token.encode())
+    ).decode()
+    assert phone.decrypt_envelope(env) == token
+
+
+# ---------------------------------------------------------------------------
+# E2E: the full ceremony
+# ---------------------------------------------------------------------------
+
+
+def test_full_pairing_ceremony(server, tmp_path):
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(ttl_seconds=600)
+    phone = Phone(server)
+
+    # wrong code does not confirm
+    assert server.adapter.confirm_pairing("000000") is None
+
+    # register consumes the secret once
+    status, body = phone.pair(pairing["secret_hex"])
+    assert status == 200, body
+    reg_id = json.loads(body)["registration_id"]
+
+    # replay is rejected
+    status, body = phone.pair(pairing["secret_hex"])
+    assert status == 409 and "used" in body
+
+    # poll: pending until the host confirms
+    status, body = phone.poll(reg_id)
+    assert json.loads(body)["status"] == "pending"
+
+    # host confirms with the 6-digit code
+    code = derive_confirmation_code(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(code)
+    assert result is not None
+
+    # poll: confirmed, envelope decrypts to a working token
+    status, body = phone.poll(reg_id)
+    payload = json.loads(body)
+    assert payload["status"] == "confirmed"
+    assert payload["host_id"] == state.host_id()
+    token = phone.decrypt_envelope(payload["token_envelope"])
+    assert token.startswith("hrd_")
+
+    phone.register_token(token)
+    status, body = phone.get("/api/remote/v1/capabilities")
+    assert status == 200
+    caps = json.loads(body)
+    assert caps["platform"] == "hermes-agent"
+
+
+def test_health_is_public(server):
+    phone = Phone(server)
+    status, body = phone.get("/api/remote/v1/health")
+    assert status == 200
+    assert json.loads(body)["status"] == "ok"
+
+
+def test_unauthenticated_requests_rejected(server):
+    phone = Phone(server)
+    status, body = phone.get("/api/remote/v1/sessions")
+    assert status == 401
+    assert "device_revoked" in body
+
+
+def test_revocation_kills_every_path(server, tmp_path):
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    phone.register_token(result["token"])
+    assert phone.get("/api/remote/v1/sessions")[0] == 200
+
+    state.revoke_device(result["device_id"])
+    status, body = phone.get("/api/remote/v1/sessions")
+    assert status == 401
+
+
+def test_scope_enforcement(server, tmp_path):
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"], device_name="reader")
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    state.update_device(result["device_id"], scopes=["read"])
+    phone.register_token(result["token"])
+
+    assert phone.get("/api/remote/v1/sessions")[0] == 200
+    status, body = phone.post("/api/remote/v1/runs/some-run/stop", {})
+    assert status == 403
+    assert "insufficient_scope" in body
+
+
+def test_idempotency_key_replay(server, tmp_path):
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    phone.register_token(result["token"])
+
+    key = uuid.uuid4().hex
+    hdrs = {"Idempotency-Key": key}
+    status1, body1 = phone.post(
+        "/api/remote/v1/jobs",
+        {"name": "j", "prompt": "p", "schedule": "30m"},
+        headers=hdrs,
+    )
+    # replay with the SAME body returns the stored response
+    status2, body2 = phone.post(
+        "/api/remote/v1/jobs",
+        {"name": "j", "prompt": "p", "schedule": "30m"},
+        headers=hdrs,
+    )
+    assert status2 == status1
+    assert body2 == body1
+    # same key, DIFFERENT body -> conflict
+    status3, body3 = phone.post(
+        "/api/remote/v1/jobs",
+        {"name": "j2", "prompt": "p2", "schedule": "30m"},
+        headers=hdrs,
+    )
+    assert status3 == 409
+    assert "idempotency_key_conflict" in body3
+
+
+def test_pairing_rate_limit(server, tmp_path):
+    state = RemoteState(tmp_path)
+    phone = Phone(server)
+    from gateway.platforms.remote import PAIRING_RATE_LIMIT_PER_MIN
+    for _ in range(PAIRING_RATE_LIMIT_PER_MIN):
+        p = state.create_pairing(600)
+        phone.pair(p["secret_hex"])
+    p = state.create_pairing(600)
+    status, body = phone.pair(p["secret_hex"])
+    assert status == 429
+
+
+def _paired_phone(server, tmp_path, scopes=("read", "approve", "control")):
+    """Full ceremony; returns (phone, device_id) with a working token."""
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    phone.register_token(result["token"])
+    return phone, result["device_id"]
+
+
+def test_ws_stream_delivers_event_frames(server, tmp_path):
+    """The app's WsEventSource contract: one receive-only WS, frames are
+    RemoteEventDto JSON, replay + live push both arrive (SPEC §2.1.1)."""
+    phone, _ = _paired_phone(server, tmp_path)
+
+    async def go():
+        import aiohttp
+
+        frames = []
+        async with aiohttp.ClientSession() as s:
+            async with s.ws_connect(
+                server.base + "/api/remote/v1/ws",
+                headers=phone.headers, ssl=server.ssl,
+            ) as ws:
+                # seed frame: health.changed (replay of the ring)
+                msg = await asyncio.wait_for(ws.receive(), timeout=5)
+                assert msg.type == aiohttp.WSMsgType.TEXT
+                first = json.loads(msg.data)
+                assert {"id", "type", "ts", "payload"} <= set(first)
+                # live push: an approval becomes pending
+                server.adapter._emit_event(
+                    "approval.pending", {"approval_id": "run:x:hash1"})
+                # drain ring replay (health.changed, device.paired, ...)
+                # until the pushed frame arrives
+                second = None
+                for _ in range(8):
+                    msg = await asyncio.wait_for(ws.receive(), timeout=5)
+                    ev = json.loads(msg.data)
+                    if ev["type"] == "approval.pending":
+                        second = ev
+                        break
+                assert second is not None
+                assert second["payload"]["approval_id"] == "run:x:hash1"
+                assert int(second["id"]) > int(first["id"])
+                frames.append(first["type"])
+        return frames
+
+    frames = _run(go())
+    assert frames == ["health.changed"]
+
+
+def test_ws_rejects_unauthenticated(server):
+    async def go():
+        import aiohttp
+
+        try:
+            async with aiohttp.ClientSession() as s:
+                async with s.ws_connect(
+                    server.base + "/api/remote/v1/ws",
+                    ssl=server.ssl,
+                ) as ws:
+                    await ws.receive()
+            return None
+        except aiohttp.WSServerHandshakeError as e:
+            return e.status
+
+    assert _run(go()) == 401
+
+
+def test_device_self_service_patch(server, tmp_path):
+    """T12 self-service: a device may rename itself and request scopes;
+    another device's token cannot touch it (B1 regression)."""
+    phone, device_id = _paired_phone(server, tmp_path)
+
+    status, body = phone.patch(
+        f"/api/remote/v1/devices/{device_id}", {"name": "Pixel Renamed"})
+    assert status == 200, body
+    dev = json.loads(body)
+    assert dev["name"] == "Pixel Renamed"
+
+    status, body = phone.patch(
+        f"/api/remote/v1/devices/{device_id}",
+        {"requested_scopes": ["read", "control"]})
+    assert status == 200, body
+    dev = json.loads(body)
+    assert "control" in dev["requested_scopes"]
+    assert dev["upgrade_requested_at"] > 0
+
+    # a DIFFERENT device's token is rejected for this device
+    other, _ = _paired_phone(server, tmp_path)
+    status, body = other.patch(
+        f"/api/remote/v1/devices/{device_id}", {"name": "Hijack"})
+    assert status == 403
+    assert "may only update itself" in body
+
+
+def test_audit_never_contains_token_material(server, tmp_path, monkeypatch):
+    """B1 regression: audit rows attribute the registry id; the bearer
+    token (or its middle) never appears in audit.jsonl."""
+    phone, device_id = _paired_phone(server, tmp_path)
+    token = phone.headers["Authorization"][len("Bearer "):]
+
+    # drive the audited paths: approval decision + scope request
+    from tools.approval import resolve_gateway_approval  # noqa: F401 (name patched below)
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval", lambda *a, **k: 1)
+    server.adapter._approval_index["run:r1:deadbeef"] = {
+        "session_key": "sess-test", "run_id": "r1", "command_hash": "deadbeef"}
+    status, body = phone.post(
+        "/api/remote/v1/approvals/run:r1:deadbeef/decision",
+        {"decision": "approve"})
+    assert status == 200, body
+
+    status, body = phone.patch(
+        f"/api/remote/v1/devices/{device_id}",
+        {"requested_scopes": ["read", "approve"]})
+    assert status == 200, body
+
+    rows = RemoteState(tmp_path).read_audit()
+    assert any(r["action"] == "approval.decision" for r in rows)
+    assert any(r["action"] == "device.scope_requested" for r in rows)
+    blob = json.dumps(rows)
+    assert token not in blob
+    assert token.split("_", 1)[1] not in blob
+    for r in rows:
+        if r["action"] in ("approval.decision", "device.scope_requested"):
+            assert r["actor"] == device_id

--- a/tests/remote/test_remote_gateway.py
+++ b/tests/remote/test_remote_gateway.py
@@ -181,6 +181,10 @@ class Phone:
         merged = {**self.headers, **(headers or {})}
         return self._request("PATCH", path, body, headers=merged)
 
+    def delete(self, path, headers=None):
+        merged = {**self.headers, **(headers or {})}
+        return self._request("DELETE", path, None, headers=merged)
+
     def register_token(self, token):
         self.headers["Authorization"] = f"Bearer {token}"
 
@@ -494,3 +498,177 @@ def test_audit_never_contains_token_material(server, tmp_path, monkeypatch):
     for r in rows:
         if r["action"] in ("approval.decision", "device.scope_requested"):
             assert r["actor"] == device_id
+
+
+# ---------------------------------------------------------------------------
+# v1.1: session lifecycle (pin/archive/rename/delete) + projects + profiles
+# ---------------------------------------------------------------------------
+
+
+def test_session_patch_pin_archive_and_delete(server, tmp_path, home_env):
+    """PATCH /sessions/{id} {pinned|archived|title} and DELETE mirror the
+    desktop's session sidebar actions against the SAME state.db — the
+    desktop and the phone stay in sync because they share the host DB."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(home_env / "state.db")
+    phone, _ = _paired_phone(server, tmp_path)
+
+    # create via the real API route (as the app does)
+    status, body = phone.post(
+        "/api/remote/v1/sessions",
+        {"id": "phone-test-1", "title": "Phone Test", "cwd": str(home_env)})
+    assert status == 201, body
+    sid = "phone-test-1"
+
+    # pin
+    status, body = phone.patch(f"/api/remote/v1/sessions/{sid}", {"pinned": True})
+    assert status == 200, body
+    row = db.get_session(sid)
+    assert row is not None and row["pinned"] == 1
+
+    # archive
+    status, body = phone.patch(f"/api/remote/v1/sessions/{sid}", {"archived": True})
+    assert status == 200, body
+    row = db.get_session(sid)
+    assert row is not None and row["archived"] == 1
+
+    # rename
+    status, body = phone.patch(f"/api/remote/v1/sessions/{sid}", {"title": "Renamed by phone"})
+    assert status == 200, body
+    row = db.get_session(sid)
+    assert row is not None and row["title"] == "Renamed by phone"
+
+    # list excludes archived (matches desktop sidebar behaviour)
+    status, body = phone.get("/api/remote/v1/sessions")
+    assert status == 200, body
+    sessions = json.loads(body)
+    items = sessions if isinstance(sessions, list) else sessions.get("sessions", [])
+    assert all(s["id"] != sid for s in items)
+
+    # delete
+    status, body = phone.delete(f"/api/remote/v1/sessions/{sid}")
+    assert status == 200, body
+    assert db.get_session(sid) is None
+
+
+def test_session_patch_requires_chat_scope(server, tmp_path):
+    """A read-only device cannot mutate sessions (chat scope required);
+    session lifecycle is the chat surface, not control."""
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    state.update_device(result["device_id"], scopes=["read"])
+    phone.register_token(result["token"])
+
+    status, body = phone.patch("/api/remote/v1/sessions/nope", {"pinned": True})
+    assert status == 403
+    assert "insufficient_scope" in body
+
+
+def test_projects_tree_route(server, tmp_path, home_env):
+    """GET /projects returns the desktop sidebar tree: projects from
+    projects.db, sessions grouped into repos/lanes, hydrated rows."""
+    from hermes_state import SessionDB
+    from hermes_cli import projects_db as pdb
+
+    db = SessionDB(home_env / "state.db")
+    cwd = str(home_env / "work" / "repo-a")
+    # host-created sessions carry cwd (phone-created ones are unowned, as
+    # on the desktop); the tree lane groups by cwd -> project folder match
+    db.create_session("tree-session-1", source="tui", cwd=cwd)
+    db.set_session_title("tree-session-1", "Tree Session")
+    # tree only includes sessions with >= 1 message (desktop parity)
+    db.append_message("tree-session-1", role="user", content="hello")
+    sid = "tree-session-1"
+
+    phone, _ = _paired_phone(server, tmp_path)
+    with pdb.connect_closing() as conn:
+        pid = pdb.create_project(conn, name="repo-a", folders=[cwd])
+        pdb.set_active(conn, pid)
+
+    status, body = phone.get("/api/remote/v1/projects")
+    assert status == 200, body
+    tree = json.loads(body)
+    assert tree["active_project_id"] == pid
+    projects = tree.get("projects", [])
+    assert any(p.get("id") == pid for p in projects)
+    for project in projects:
+        if project.get("id") == pid:
+            assert project["sessionCount"] >= 1
+            nested = [
+                s["id"]
+                for repo in project.get("repos", [])
+                for grp in repo.get("groups", [])
+                for s in grp.get("sessions", [])
+            ]
+            assert sid in nested
+
+
+def test_profiles_list_and_switch(server, tmp_path, monkeypatch):
+    """GET /profiles mirrors `hermes profile list`; switch writes the
+    active-profile marker (the desktop reads the same file)."""
+    from hermes_cli import profiles as prof
+
+    phone, _ = _paired_phone(server, tmp_path, scopes=("read", "approve", "control", "chat"))
+
+    status, body = phone.get("/api/remote/v1/profiles")
+    assert status == 200, body
+    payload = json.loads(body)
+    assert "profiles" in payload and "active" in payload
+    names = [p["name"] for p in payload["profiles"]]
+    assert "default" in names
+
+    # switch to default (no-op safe)
+    status, body = phone.post("/api/remote/v1/profiles/default/switch", {})
+    assert status == 200, body
+    assert json.loads(body)["active"] == "default"
+
+    # unknown profile -> 404
+    status, body = phone.post("/api/remote/v1/profiles/does-not-exist/switch", {})
+    assert status == 404
+
+
+def test_profiles_create_rename_delete(server, tmp_path):
+    """Profile CRUD parity with `hermes profile create|rename|delete`."""
+    from hermes_cli import profiles as prof
+
+    phone, _ = _paired_phone(server, tmp_path, scopes=("read", "approve", "control", "chat"))
+
+    # create
+    status, body = phone.post("/api/remote/v1/profiles", {"name": "phone-created"})
+    assert status == 201, body
+    assert prof.get_profile_dir("phone-created").is_dir()
+
+    # rename
+    status, body = phone.patch("/api/remote/v1/profiles/phone-created", {"new_name": "phone-renamed"})
+    assert status == 200, body
+    assert prof.get_profile_dir("phone-renamed").is_dir()
+
+    # delete
+    status, body = phone.delete("/api/remote/v1/profiles/phone-renamed")
+    assert status == 200, body
+    assert not prof.get_profile_dir("phone-renamed").exists()
+
+    # deleting the active profile is refused
+    status, body = phone.delete("/api/remote/v1/profiles/default")
+    assert status == 409
+
+
+def test_profiles_require_control_scope(server, tmp_path):
+    """Profile mutation is host admin: chat-only devices get 403."""
+    state = RemoteState(tmp_path)
+    pairing = state.create_pairing(600)
+    phone = Phone(server)
+    phone.pair(pairing["secret_hex"])
+    result = server.adapter.confirm_pairing(
+        derive_confirmation_code(pairing["secret_hex"]))
+    state.update_device(result["device_id"], scopes=["read", "chat"])
+    phone.register_token(result["token"])
+
+    status, body = phone.post("/api/remote/v1/profiles", {"name": "sneaky"})
+    assert status == 403
+    assert "insufficient_scope" in body


### PR DESCRIPTION
# Host gateway for Hermes Remote (HRA-2026-001)

The Android app `hermes-remote` (spec digest 52d82281, v1.0.0) pairs
with a host through an `hra://` code and then talks to the host over
TLS. This PR is the host side of that contract: a delta layer over the
existing `api_server` platform, plus a `hermes remote` CLI.

## What this adds

- `gateway/platforms/remote.py` — `RemoteDeviceAdapter`, a subclass of
  `APIServerAdapter`. It mounts the existing session/run/job/approval
  handlers under `/api/remote/v1` and gates every route (inherited and
  own) with a device-token middleware + per-route scopes.
- The pairing ceremony: `hra://` QR codes, single-use secrets with TTL,
  a 6-digit HKDF confirmation code, and an ECIES token envelope. The
  app's golden vectors (717261, 802349) derive byte-identical codes.
- Self-signed TLS with SANs; the app pins the certificate SPKI (the
  `fp` field of the `hra://` code).
- A receive-only WebSocket at `/ws` (ring replay + live push + 30 s
  heartbeat) matching the app's `WsEventSource`.
- Kanban over the real board store (`hermes_cli/kanban_db.py`), the
  approval front-door, audit rows (no token material), idempotency
  keys, and a pairing rate limit.
- `hermes remote start|pair|confirm|revoke|status` CLI.
- `tests/remote/test_remote_gateway.py` — 14 end-to-end tests (real
  TLS, in-process server, full ceremony, replay rejection, revocation,
  scopes, idempotency, rate limit, WS frames, WS auth, self-service
  PATCH, audit without token material).

## Verified

- 14/14 pytest green.
- Live end-to-end on 2026-08-08: the debug APK paired against the live
  gateway on the API-34 emulator, then held a live WebSocket. The host
  card showed "connected, last seen 0 s ago".
- The gateway reports its own platform version 1.0.0 (the app gates
  connections on its MIN_HOST_VERSION) and the hermes-agent core
  version separately as `hermesVersion`.
- Single-reviewer gate: APPROVED (round 2; B1 blocker from round 1
  fixed and pinned by regression tests).
