### PR TITLE
fix(memory): restore hindsight-all for local_external updates

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -38,7 +38,7 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
             cfg = json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
             mode = cfg.get("mode", "")
             # "local" is a legacy alias for "local_embedded"
-            if mode in {"local", "local_embedded"}:
+            if mode in {"local", "local_embedded", "local_external"}:
                 deps.append("hindsight-all")
         except Exception:
             pass

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -67,6 +67,17 @@ def test_write_env_vars_strips_line_separators_and_nul(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_hindsight_local_external_expands_to_hindsight_all(tmp_path, monkeypatch):
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text("{\"mode\": \"local_external\"}", encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+
+    dependencies = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client==0.6.1"]
+    )
+
+    assert dependencies == ["hindsight-client==0.6.1", "hindsight-all"]
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #78064.

`hermes update` refreshes active Hindsight dependencies after a runtime rebuild.
For `local_external`, the dependency expansion restored only `hindsight-client`,
leaving the local `hindsight-api` stack unavailable.

Treat `local_external` like the other local Hindsight modes so the refresh also
installs `hindsight-all`.

## Related Issue

Fixes #78064

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/memory_setup.py`: include `local_external` in local Hindsight dependency expansion.
- `tests/hermes_cli/test_memory_setup.py`: add regression coverage for `local_external -> hindsight-all`.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_memory_setup.py -q`.
2. Confirm the `local_external` regression test passes.
3. Run `ruff check hermes_cli/memory_setup.py tests/hermes_cli/test_memory_setup.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the focused test path on Ubuntu 26.04

### Documentation & Housekeeping

- [x] Documentation update is not required
- [x] `cli-config.yaml.example` update is not required
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is not required
- [x] Cross-platform impact considered: this is platform-neutral dependency resolution for an already supported mode
- [x] Tool descriptions and schemas are not affected
