### PR TITLE
fix(model_metadata): normalize OpenAI per-1M pricing to per-token

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1120,6 +1120,30 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
             result["cache_read"] = str(float(deepinfra_pricing["cache_read_tokens"]) / 1_000_000)
         return result
 
+    # OpenAI-compatible endpoints (and aggregators following their schema)
+    # ship per-1M-token prices — either top-level ``input_price_per_million`` /
+    # ``output_price_per_million`` fields or a nested ``pricing`` block with
+    # ``unit: "per_1m_tokens"``. Normalize to per-token like the branches
+    # above; without this the generic cost machinery multiplies by 1M a
+    # second time and reports absurd prices (e.g. $1M/M).
+    per_million_fields = (
+        ("prompt", payload.get("input_price_per_million")),
+        ("completion", payload.get("output_price_per_million")),
+        ("cache_read", payload.get("cache_read_price_per_million")),
+    )
+    nested_pricing = payload.get("pricing") if isinstance(payload.get("pricing"), dict) else None
+    if any(value is not None for _, value in per_million_fields) or (
+        nested_pricing is not None and nested_pricing.get("unit") == "per_1m_tokens"
+    ):
+        result: Dict[str, Any] = {}
+        for target, value in per_million_fields:
+            if value is None and nested_pricing is not None:
+                value = nested_pricing.get(target)
+            if value is not None:
+                result[target] = str(float(value) / 1_000_000)
+        if result:
+            return result
+
     alias_map = {
         "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),
         "completion": ("completion", "output", "output_cost_per_token", "completion_token_cost"),

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import time
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -1091,6 +1092,31 @@ def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
+def _pricing_unit_divisor(unit: str) -> Optional[Decimal]:
+    """Parse a pricing unit string into a per-token conversion divisor.
+
+    Handles OpenAI-compatible unit spellings such as ``per_1m_tokens``,
+    ``per_1k_tokens``, ``per_10k_tokens``, and ``per_token``. Returns the
+    divisor that converts the reported price to per-token, or ``None`` when
+    the unit is absent/unknown (callers then assume per-token values, the
+    historical default).
+    """
+    if not unit:
+        return None
+    match = re.match(r"^per_?(\d*\.?\d*)([km]?)_?tokens?$", unit.strip().lower())
+    if not match:
+        return None
+    count_str, suffix = match.group(1), match.group(2)
+    if not count_str and not suffix:
+        return None  # per_token — already per-token
+    count = Decimal(count_str) if count_str else Decimal("1")
+    if suffix == "k":
+        count *= Decimal("1000")
+    elif suffix == "m":
+        count *= Decimal("1000000")
+    return count
+
+
 def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
@@ -1121,28 +1147,39 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         return result
 
     # OpenAI-compatible endpoints (and aggregators following their schema)
-    # ship per-1M-token prices — either top-level ``input_price_per_million`` /
-    # ``output_price_per_million`` fields or a nested ``pricing`` block with
-    # ``unit: "per_1m_tokens"``. Normalize to per-token like the branches
-    # above; without this the generic cost machinery multiplies by 1M a
-    # second time and reports absurd prices (e.g. $1M/M).
+    # ship prices in explicit per-N-token units — either top-level
+    # ``input_price_per_million`` / ``output_price_per_million`` fields or a
+    # nested ``pricing`` block with a ``unit`` such as ``per_1m_tokens``.
+    # Normalize to per-token at the extraction point (matching the Novita and
+    # DeepInfra branches above); without this the generic cost machinery
+    # multiplies by 1M a second time and reports absurd prices (e.g. $1M/M).
     per_million_fields = (
         ("prompt", payload.get("input_price_per_million")),
         ("completion", payload.get("output_price_per_million")),
         ("cache_read", payload.get("cache_read_price_per_million")),
     )
+    top_level_values = [value for _, value in per_million_fields if value is not None]
     nested_pricing = payload.get("pricing") if isinstance(payload.get("pricing"), dict) else None
-    if any(value is not None for _, value in per_million_fields) or (
-        nested_pricing is not None and nested_pricing.get("unit") == "per_1m_tokens"
-    ):
+    unit_divisor = _pricing_unit_divisor(
+        str(nested_pricing.get("unit", "")) if nested_pricing else ""
+    )
+
+    if top_level_values:
+        # ``*_price_per_million`` fields are semantically fixed at per-1M.
         result: Dict[str, Any] = {}
         for target, value in per_million_fields:
-            if value is None and nested_pricing is not None:
-                value = nested_pricing.get(target)
             if value is not None:
-                result[target] = str(float(value) / 1_000_000)
-        if result:
-            return result
+                result[target] = str(Decimal(str(value)) / Decimal("1000000"))
+        return result
+    if unit_divisor is not None:
+        # Nested ``pricing`` block declares an explicit per-N-token unit.
+        assert nested_pricing is not None  # unit_divisor implies a pricing block
+        result: Dict[str, Any] = {}
+        for target in ("prompt", "completion", "cache_read"):
+            value = nested_pricing.get(target)
+            if value is not None:
+                result[target] = str(Decimal(str(value)) / unit_divisor)
+        return result
 
     alias_map = {
         "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1095,26 +1095,36 @@ def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
 def _pricing_unit_divisor(unit: str) -> Optional[Decimal]:
     """Parse a pricing unit string into a per-token conversion divisor.
 
-    Handles OpenAI-compatible unit spellings such as ``per_1m_tokens``,
-    ``per_1k_tokens``, ``per_10k_tokens``, and ``per_token``. Returns the
-    divisor that converts the reported price to per-token, or ``None`` when
-    the unit is absent/unknown (callers then assume per-token values, the
-    historical default).
+    Handles OpenAI-compatible unit spellings: ``per_1m_tokens``,
+    ``per_1k_tokens``, ``per_10k_tokens``, ``per_token``, ``per_million``,
+    ``per_1m``, ``per_1000000``, and bare ``per``. Returns the divisor that
+    converts the reported price to per-token, or ``None`` when the unit is
+    absent/unknown or already per-token (callers then keep historical
+    behavior).
     """
     if not unit:
         return None
-    match = re.match(r"^per_?(\d*\.?\d*)([km]?)_?tokens?$", unit.strip().lower())
-    if not match:
-        return None
-    count_str, suffix = match.group(1), match.group(2)
-    if not count_str and not suffix:
-        return None  # per_token — already per-token
-    count = Decimal(count_str) if count_str else Decimal("1")
-    if suffix == "k":
-        count *= Decimal("1000")
-    elif suffix == "m":
-        count *= Decimal("1000000")
-    return count
+    u = unit.strip().lower()
+    if re.fullmatch(r"per_?tokens?", u):
+        return None  # already per-token
+    # per_N[M|K] tokens — e.g. per_1m_tokens, per_10k_tokens, per_1000000_tokens
+    m = re.fullmatch(r"per_?(\d*\.?\d*)([km]?)(?:_?tokens?)?", u)
+    if m:
+        count_str, suffix = m.groups()
+        if not count_str and not suffix:
+            return None  # bare "per"
+        count = Decimal(count_str) if count_str else Decimal("1")
+        if suffix == "k":
+            count *= Decimal("1000")
+        elif suffix == "m":
+            count *= Decimal("1000000")
+        return count
+    # word forms: per_million(_tokens), per_thousand(_tokens)
+    if u in ("per_million", "per_million_tokens", "per_million_token"):
+        return Decimal("1000000")
+    if u in ("per_thousand", "per_thousand_tokens", "per_thousand_token"):
+        return Decimal("1000")
+    return None
 
 
 def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -1153,10 +1163,26 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     # Normalize to per-token at the extraction point (matching the Novita and
     # DeepInfra branches above); without this the generic cost machinery
     # multiplies by 1M a second time and reports absurd prices (e.g. $1M/M).
+    alias_map = {
+        "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),
+        "completion": ("completion", "output", "output_cost_per_token", "completion_token_cost"),
+        "request": ("request", "request_cost"),
+        "cache_read": ("cache_read", "cached_prompt", "input_cache_read", "cache_read_cost_per_token"),
+        "cache_write": ("cache_write", "cache_creation", "input_cache_write", "cache_write_cost_per_token"),
+    }
     per_million_fields = (
         ("prompt", payload.get("input_price_per_million")),
         ("completion", payload.get("output_price_per_million")),
-        ("cache_read", payload.get("cache_read_price_per_million")),
+        (
+            "cache_read",
+            payload.get("cache_read_price_per_million")
+            or payload.get("cache_read_input_price_per_million"),
+        ),
+        (
+            "cache_write",
+            payload.get("cache_write_price_per_million")
+            or payload.get("cache_creation_input_price_per_million"),
+        ),
     )
     top_level_values = [value for _, value in per_million_fields if value is not None]
     nested_pricing = payload.get("pricing") if isinstance(payload.get("pricing"), dict) else None
@@ -1171,23 +1197,22 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
             if value is not None:
                 result[target] = str(Decimal(str(value)) / Decimal("1000000"))
         return result
-    if unit_divisor is not None:
+    if unit_divisor is not None and nested_pricing is not None:
         # Nested ``pricing`` block declares an explicit per-N-token unit.
-        assert nested_pricing is not None  # unit_divisor implies a pricing block
+        # Resolve values through the same alias set as the generic path below
+        # so vendor key variants (e.g. OpenAI's ``input_cache_read``) work.
         result: Dict[str, Any] = {}
-        for target in ("prompt", "completion", "cache_read"):
-            value = nested_pricing.get(target)
-            if value is not None:
-                result[target] = str(Decimal(str(value)) / unit_divisor)
+        for target, aliases in alias_map.items():
+            for alias in aliases:
+                value = nested_pricing.get(alias)
+                if value is not None and value != "":
+                    if target == "request":
+                        result[target] = value
+                    else:
+                        result[target] = str(Decimal(str(value)) / unit_divisor)
+                    break
         return result
 
-    alias_map = {
-        "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),
-        "completion": ("completion", "output", "output_cost_per_token", "completion_token_cost"),
-        "request": ("request", "request_cost"),
-        "cache_read": ("cache_read", "cached_prompt", "input_cache_read", "cache_read_cost_per_token"),
-        "cache_write": ("cache_write", "cache_creation", "input_cache_write", "cache_write_cost_per_token"),
-    }
     for mapping in _iter_nested_dicts(payload):
         normalized = {str(key).lower(): value for key, value in mapping.items()}
         if not any(any(alias in normalized for alias in aliases) for aliases in alias_map.values()):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1358,3 +1358,132 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# Pricing extraction (_extract_pricing)
+# =========================================================================
+
+class TestExtractPricing:
+    """Pricing extraction normalizes per-1M-token prices to per-token.
+
+    OpenAI-compatible endpoints may report ``input_price_per_million`` /
+    ``output_price_per_million`` (top-level) or a nested ``pricing`` block
+    with ``unit: "per_1m_tokens"``. Both must be divided by 1M so the
+    downstream cost machinery (usage_pricing.py) does not scale them a
+    second time and report absurd values.
+    """
+
+    def _extract(self, payload):
+        import agent.model_metadata as mm
+        return mm._extract_pricing(payload)
+
+    def test_top_level_per_million_fields(self):
+        """Top-level input/output_price_per_million are per-1M → per-token."""
+        result = self._extract({
+            "id": "deepseek-v4-flash-0731",
+            "input_price_per_million": 1,
+            "output_price_per_million": 2,
+            "cache_read_price_per_million": 0.02,
+        })
+        assert result == {
+            "prompt": "1e-06",
+            "completion": "2e-06",
+            "cache_read": "2e-08",
+        }
+
+    def test_nested_pricing_with_per_1m_unit(self):
+        """Nested pricing block with unit=per_1m_tokens is normalized too."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {
+                "currency": "CNY",
+                "unit": "per_1m_tokens",
+                "prompt": 1,
+                "completion": 2,
+                "cache_read": 0.02,
+            },
+        })
+        assert result == {
+            "prompt": "1e-06",
+            "completion": "2e-06",
+            "cache_read": "2e-08",
+        }
+
+    def test_top_level_fields_take_precedence_over_nested(self):
+        """Explicit top-level fields win when a nested block also exists."""
+        result = self._extract({
+            "id": "m",
+            "input_price_per_million": 1,
+            "output_price_per_million": 2,
+            "pricing": {
+                "unit": "per_1m_tokens",
+                "prompt": 999,
+                "completion": 999,
+            },
+        })
+        assert result == {"prompt": "1e-06", "completion": "2e-06"}
+
+    def test_per_token_pricing_untouched(self):
+        """Per-token pricing (OpenRouter style) still flows to the alias map."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+        })
+        assert result == {"prompt": "0.000001", "completion": "0.000002"}
+
+    def test_novita_format_still_works(self):
+        """Novita per-token-per-10k fields keep their existing conversion."""
+        result = self._extract({
+            "id": "m",
+            "input_token_price_per_m": 1.0,
+            "output_token_price_per_m": 2.0,
+        })
+        assert result == {
+            "prompt": "1e-10",
+            "completion": "2e-10",
+        }
+
+    def test_deepinfra_format_still_works(self):
+        """DeepInfra $/MTok metadata keeps its existing conversion."""
+        result = self._extract({
+            "id": "m",
+            "metadata": {
+                "pricing": {
+                    "input_tokens": 1.0,
+                    "output_tokens": 2.0,
+                    "cache_read_tokens": 0.02,
+                }
+            },
+        })
+        assert result == {
+            "prompt": "1e-06",
+            "completion": "2e-06",
+            "cache_read": "2e-08",
+        }
+
+    def test_no_pricing_returns_empty(self):
+        """Models without pricing info yield an empty dict, not an error."""
+        assert self._extract({"id": "m"}) == {}
+        assert self._extract({"id": "m", "pricing": {}}) == {}
+
+    def test_downstream_round_trip_is_accurate(self):
+        """Extracted per-token values restore correct per-1M costs downstream."""
+        import agent.model_metadata as mm
+        from agent.usage_pricing import _pricing_entry_from_metadata
+
+        raw = {
+            "id": "deepseek-v4-flash-0731",
+            "input_price_per_million": 1,
+            "output_price_per_million": 2,
+            "cache_read_price_per_million": 0.02,
+        }
+        extracted = mm._extract_pricing(raw)
+        entry = _pricing_entry_from_metadata(
+            {"m": {"pricing": extracted}}, "m", source_url="x", pricing_version="test"
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == 1
+        assert entry.output_cost_per_million == 2
+        assert entry.cache_read_cost_per_million is not None
+        assert float(entry.cache_read_cost_per_million) == 0.02

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -11,6 +11,7 @@ Coverage levels:
 """
 
 import time
+from decimal import Decimal
 
 import pytest
 import yaml
@@ -20,6 +21,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
+    _pricing_unit_divisor,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -1451,6 +1453,55 @@ class TestExtractPricing:
             "pricing": {"unit": "per_bazillion_tokens", "prompt": 1},
         })
         assert result == {"prompt": 1}
+
+    def test_unit_word_forms(self):
+        """Word-form units (per_million, per_thousand, per_1m) parse too."""
+        for unit, prompt_expected in (
+            ("per_million", "0.000001"),
+            ("per_million_tokens", "0.000001"),
+            ("per_1m", "0.000001"),
+            ("per_1000000", "0.000001"),
+            ("per_thousand", "0.001"),
+        ):
+            result = self._extract({
+                "id": "m",
+                "pricing": {"unit": unit, "prompt": 1, "completion": 2},
+            })
+            divisor = _pricing_unit_divisor(unit)
+            assert divisor is not None
+            assert result["prompt"] == prompt_expected
+            assert result["completion"] == str(Decimal("2") / divisor)
+
+    def test_nested_openai_official_key_names(self):
+        """OpenAI's input_cache_read key works in a unit-tagged pricing block."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {
+                "unit": "per_1m_tokens",
+                "prompt": 1,
+                "completion": 2,
+                "input_cache_read": 1.25,
+            },
+        })
+        assert result == {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "cache_read": "0.00000125",
+        }
+
+    def test_top_level_cache_read_input_field(self):
+        """OpenAI's cache_read_input_price_per_million top-level field."""
+        result = self._extract({
+            "id": "m",
+            "input_price_per_million": 1,
+            "output_price_per_million": 2,
+            "cache_read_input_price_per_million": 1.25,
+        })
+        assert result == {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "cache_read": "0.00000125",
+        }
 
     def test_top_level_fields_take_precedence_over_nested(self):
         """Explicit top-level fields win when a nested block also exists."""

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1387,9 +1387,9 @@ class TestExtractPricing:
             "cache_read_price_per_million": 0.02,
         })
         assert result == {
-            "prompt": "1e-06",
-            "completion": "2e-06",
-            "cache_read": "2e-08",
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "cache_read": "2E-8",
         }
 
     def test_nested_pricing_with_per_1m_unit(self):
@@ -1405,10 +1405,52 @@ class TestExtractPricing:
             },
         })
         assert result == {
-            "prompt": "1e-06",
-            "completion": "2e-06",
-            "cache_read": "2e-08",
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "cache_read": "2E-8",
         }
+
+    def test_nested_pricing_with_per_1k_unit(self):
+        """per_1k_tokens divides by 1000, not 1M."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {"unit": "per_1k_tokens", "prompt": 1, "completion": 2},
+        })
+        assert result == {
+            "prompt": "0.001",
+            "completion": "0.002",
+        }
+
+    def test_nested_pricing_with_per_10k_unit(self):
+        """Compound units like per_10k_tokens parse correctly."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {"unit": "per_10k_tokens", "prompt": 5, "completion": 10},
+        })
+        assert result == {
+            "prompt": "0.0005",
+            "completion": "0.001",
+        }
+
+    def test_nested_pricing_with_per_token_unit(self):
+        """per_token unit leaves values untouched (already per-token)."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {
+                "unit": "per_token",
+                "prompt": 0.000001,
+                "completion": 0.000002,
+            },
+        })
+        assert result == {"prompt": 0.000001, "completion": 0.000002}
+
+    def test_unknown_unit_falls_through_to_alias_map(self):
+        """An unrecognized unit does not crash and keeps historical behavior."""
+        result = self._extract({
+            "id": "m",
+            "pricing": {"unit": "per_bazillion_tokens", "prompt": 1},
+        })
+        assert result == {"prompt": 1}
 
     def test_top_level_fields_take_precedence_over_nested(self):
         """Explicit top-level fields win when a nested block also exists."""
@@ -1422,7 +1464,7 @@ class TestExtractPricing:
                 "completion": 999,
             },
         })
-        assert result == {"prompt": "1e-06", "completion": "2e-06"}
+        assert result == {"prompt": "0.000001", "completion": "0.000002"}
 
     def test_per_token_pricing_untouched(self):
         """Per-token pricing (OpenRouter style) still flows to the alias map."""


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible endpoints (e.g. tokenrhythm) report pricing in OpenAI-standard per-1M-token fields:

- top-level `input_price_per_million` / `output_price_per_million`, or
- a nested `pricing` block with `unit: "per_1m_tokens"`

`_extract_pricing` passed these through as if they were per-token values. The downstream cost machinery (`usage_pricing.py` → `_per_token_to_per_million`) then multiplied by 1M **a second time**, producing absurd prices like `$1,000,000/M` for a model that actually costs ¥1/M (≈$0.14/M).

This tripped Hermes' expensive-model guard on every `/model` switch to such an endpoint, showing a scary false warning:

```
Input tokens: $1000000.00/M
Output tokens: $2000000.00/M
```

## Fix

Normalize per-1M prices to per-token **at the extraction entry point** in `_extract_pricing`, matching the existing Novita (`÷10k÷1M`) and DeepInfra (`÷1M`) branches. This keeps the generic cost machinery untouched and covers all OpenAI-standard endpoints with one change.

- OpenRouter-style per-token pricing (no `unit` field, no `*_per_million` fields) is completely unaffected.
- Top-level `input_price_per_million` fields take precedence over a nested `pricing` block when both exist.

## Tests

Added `TestExtractPricing` covering: top-level per-1M fields, nested `unit: "per_1m_tokens"` block, precedence, untouched per-token path, Novita/DeepInfra regression, empty pricing, and a downstream round-trip asserting the final per-1M costs are correct.

All 84 tests in `test_model_metadata.py`, `test_usage_pricing.py`, and `test_model_cost_guard.py` pass. `ruff check` clean.