### PR TITLE
fix(model-options): keep curated models visible for exhausted-pool providers in public picker payload

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -302,6 +302,7 @@ def build_model_options_payload(
         ctx,
         explicit_only=bool(explicit_only),
         include_unconfigured=bool(include_unconfigured),
+        for_picker=True,
         picker_hints=True,
         canonical_order=True,
         pricing=True,

--- a/tests/hermes_cli/test_model_options_exhausted_pool_visibility.py
+++ b/tests/hermes_cli/test_model_options_exhausted_pool_visibility.py
@@ -1,0 +1,26 @@
+"""Regression: public model-options surface keeps curated models for an
+exhausted credential pool while runtime resolution stays non-usable."""
+from unittest.mock import patch
+
+from hermes_cli.inventory import build_model_options_payload, load_picker_context
+from hermes_cli.model_switch import _credential_pool_is_usable
+
+
+class _ExhaustedPool:
+    def has_credentials(self):
+        return True
+    def has_available(self):
+        return False
+
+
+def test_model_options_keeps_curated_models_for_exhausted_pool():
+    with patch("agent.credential_pool.load_pool", return_value=_ExhaustedPool()):
+        assert _credential_pool_is_usable("openai-codex") is False
+        payload = build_model_options_payload(load_picker_context(), include_unconfigured=True)
+        rows = payload.get("providers", [])
+        codex = next((r for r in rows if r.get("slug") == "openai-codex"), None)
+        assert codex is not None, "openai-codex must remain visible in the picker"
+        models = codex.get("models") or []
+        assert len(models) > 0, "curated Codex model list must remain visible"
+        for shared in ("gpt-5.4-mini", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"):
+            assert shared in models, f"shared model {shared} missing from curated list"


### PR DESCRIPTION
## Summary

`build_model_options_payload` drives the dashboard Models page and the gateway `/api/model/options` surface. It forwards `include_unconfigured` but not `for_picker`, so a provider with an **exhausted credential pool** (e.g. `openai-codex`) keeps its provider row but **loses its curated model list** (models=0).

This forwards `for_picker=True` so the public picker surface retains the curated Codex catalog while an exhausted pool is still **not** treated as runtime-usable.

## Context

- `get_codex_model_ids(None)` returns the full curated catalog (11 models).
- `provider_model_ids("openai-codex")` returns 11.
- `build_models_payload(..., for_picker=True)` returns 11.
- `build_model_options_payload(...)` (no `for_picker`) returns 0 for the exhausted provider.

## Change

`hermes_cli/inventory.py`: forward `for_picker=True` in `build_model_options_payload`.

## Regression test

`tests/hermes_cli/test_model_options_exhausted_pool_visibility.py` — 1 passed via `uv run --extra dev -- python3 -m pytest tests/hermes_cli/test_model_options_exhausted_pool_visibility.py -q`:

- Exhausted `openai-codex` pool: provider remains visible with the curated model list containing `gpt-5.4-mini`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`.
- `_credential_pool_is_usable("openai-codex")` still `False` (runtime resolution invariant unchanged).

## Scope

No credential movement; no change to normal programmatic provider resolution; no LocalClaw-specific behavior.