### PR TITLE
fix(agent): strip images on Kimi/Moonshot 'failed to decode image' 400

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3918,6 +3918,17 @@ def run_conversation(
                     # every subsequent message queued behind the stuck turn —
                     # the P1 in issue #21160. The 404 passes the 4xx gate below.
                     "no endpoints found that support image input",
+                    # Kimi / Moonshot / other OpenAI-compatible Chinese
+                    # providers reject truncated or corrupt image bytes with
+                    # HTTP 400 "Invalid request: prepare image failed ...
+                    # failed to decode image: invalid or unsupported image
+                    # format". Like the Codex case above, the bad bytes are
+                    # baked into immutable conversation history and re-sent on
+                    # every retry, wedging the session. Strip the images so the
+                    # turn recovers instead of exhausting retries. (issue
+                    # #76884; complements the proactive full-decode validation
+                    # in tools/vision_tools._normalize_to_supported_image)
+                    "failed to decode image",
                 )
                 _err_lower = _err_body.lower()
                 _looks_like_image_rejection = any(

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -139,11 +139,20 @@ class TestImageRejectionPhraseIsolation:
         "model does not support image",
         "image_url'. expected",
         "no endpoints found that support image input",
+        "failed to decode image",
     )
 
     def _matches(self, body: str) -> bool:
         low = body.lower()
         return any(p in low for p in self._REJECTION_PHRASES)
+
+    def test_kimi_truncated_image_trips_recovery(self):
+        # Kimi/Moonshot reject truncated image bytes with this 400; the
+        # bad bytes are in immutable history so stripping must fire.
+        body = ("HTTP 400: Invalid request: prepare image failed error, "
+                "status code: 400, message: failed to decode image: invalid "
+                "or unsupported image format")
+        assert self._matches(body) is True
 
     def test_anthropic_image_too_large_does_not_trip(self):
         # From agent/error_classifier.py _IMAGE_TOO_LARGE_PATTERNS —


### PR DESCRIPTION
## Summary

Adds Kimi/Moonshot's malformed-image 400 to `_IMAGE_REJECTION_PHRASES` so already-poisoned sessions recover by stripping image parts instead of exhausting retries.

## Root cause

Truncated or corrupt image bytes pass Hermes' magic-byte MIME sniff and get embedded into immutable conversation history. Kimi/Moonshot (OpenAI-compatible Chinese providers) reject them with:

```
HTTP 400: Invalid request: prepare image failed error, status code: 400,
message: failed to decode image: invalid or unsupported image format
```

That phrase was missing from `_IMAGE_REJECTION_PHRASES` in `agent/conversation_loop.py`, so the error didn't match the image-stripping recovery path — the retry loop re-sent the same rejected request until exhaustion, permanently wedging the turn (issue #76884).

## Changes

- `agent/conversation_loop.py`: add `"failed to decode image"` to `_IMAGE_REJECTION_PHRASES` with a comment documenting the Kimi/Moonshot error shape.
- `tests/run_agent/test_image_rejection_fallback.py`: sync the phrase fixture and add `test_kimi_truncated_image_trips_recovery` asserting the exact Kimi error body trips the recovery detector, while the image-too-large bodies still do not.

## Relationship to #76896

PR #76896 (proactive full-decode validation in `tools/vision_tools`) prevents new corrupt images from entering history; this PR adds the reactive recovery for sessions already poisoned on providers whose error wording differs from Codex's "does not represent a valid image". The two are complementary.

## Verification

`python3 -m pytest tests/run_agent/test_image_rejection_fallback.py -v` → 6 passed (including the new regression test).