### PR TITLE
fix(skills): stop duplicating root skill names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,17 +453,19 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
-Run these commands from the repository root:
+Install from the repository root, then run TUI scripts from `ui-tui`, where
+they are declared:
 
 ```bash
-npm run install:tui                  # first time
-npm run dev --workspace ui-tui       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm run start --workspace ui-tui     # production
-npm run build --workspace ui-tui     # bundle TUI entrypoint with esbuild
-npm run typecheck --workspace ui-tui # typecheck only (tsc --noEmit)
-npm run lint --workspace ui-tui      # eslint
-npm run fmt --workspace ui-tui       # prettier
-npm run test --workspace ui-tui      # vitest
+npm run install:tui # first time
+cd ui-tui
+npm run dev         # watch mode (rebuilds hermes-ink + tsx --watch)
+npm start           # production
+npm run build       # bundle TUI entrypoint with esbuild
+npm run typecheck   # typecheck only (tsc --noEmit)
+npm run lint        # eslint
+npm run fmt         # prettier
+npm test            # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,16 +453,17 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these commands from the repository root:
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm run install:tui                  # first time
+npm run dev --workspace ui-tui       # watch mode (rebuilds hermes-ink + tsx --watch)
+npm run start --workspace ui-tui     # production
+npm run build --workspace ui-tui     # bundle TUI entrypoint with esbuild
+npm run typecheck --workspace ui-tui # typecheck only (tsc --noEmit)
+npm run lint --workspace ui-tui      # eslint
+npm run fmt --workspace ui-tui       # prettier
+npm run test --workspace ui-tui      # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -965,7 +965,7 @@ CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1044,7 +1044,7 @@ def _build_snapshot_entry(
     parts = rel_path.parts
     if len(parts) >= 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2]) or "general"
     else:
         category = "general"
         skill_name = skill_file.parent.name

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -264,6 +265,44 @@ class TestBuildSkillsSystemPrompt:
         assert "python-debug" in result
         assert "Debug Python scripts" in result
         assert "available_skills" in result
+
+    def test_root_level_skill_is_not_repeated_as_its_category(
+        self, monkeypatch, tmp_path
+    ):
+        from agent.prompt_builder import _build_skills_manifest
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "git-worktree-discipline"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: git-worktree-discipline\n"
+            "description: Keep worktrees safe\n"
+            "---\n"
+        )
+        (tmp_path / ".skills_prompt_snapshot.json").write_text(
+            json.dumps({
+                "version": 1,
+                "manifest": _build_skills_manifest(skills_root),
+                "skills": [
+                    {
+                        "skill_name": "git-worktree-discipline",
+                        "category": "git-worktree-discipline",
+                        "frontmatter_name": "git-worktree-discipline",
+                        "description": "Keep worktrees safe",
+                        "platforms": [],
+                        "conditions": {},
+                    }
+                ],
+                "category_descriptions": {},
+            })
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "\n  general:\n    - git-worktree-discipline:" in result
+        assert "\n  git-worktree-discipline:\n" not in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- classify root-level skill directories under `general` instead of repeating the skill name as a category
- invalidate version-1 skill prompt snapshots so existing installations rebuild the corrected index
- add a regression test covering the production `git-worktree-discipline/git-worktree-discipline` failure shape and stale snapshots

## Root cause

For a root-level `skills/<name>/SKILL.md`, `_build_snapshot_entry()` treated `<name>` as both the category and skill name. The generated prompt therefore represented the skill as `<name>/<name>`, which workers passed literally to `skill_view` and could not resolve.

## Test evidence

- `scripts/run_tests.sh tests/agent/test_prompt_builder.py -- -q` — 135 passed
- WSL Ubuntu: `scripts/run_tests.sh tests/tools/test_skills_tool.py -- -q` — 87 passed
- `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py` — passed
- `git diff --check` — passed

## Notes

The repository root has no `npm run verify` script, so that project-level command is unavailable.
