### PR TITLE
fix(cli): initialize hooks for serve sessions (#81314)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10745,7 +10745,7 @@ def _resolve_deferred_platform_cli_command(command_name: str | None) -> None:
         )
 
 
-_AGENT_COMMANDS = {None, "chat", "acp", "rl"}
+_AGENT_COMMANDS = {None, "chat", "acp", "rl", "serve"}
 _AGENT_SUBCOMMANDS = {
     "cron": ("cron_command", {"run", "tick"}),
     "gateway": ("gateway_command", {"run"}),


### PR DESCRIPTION
## Summary

- Include `serve` in the agent startup command set so Desktop sessions register configured shell hooks.

Closes #81314
