### PR TITLE
feat(telegram): pin per-topic session workdir via group_topics[].workdir

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2112,6 +2112,13 @@ class MessageEvent:
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
 
+    # Per-channel working-directory pin for topic/channel bindings (e.g.
+    # Telegram group_topics[].workdir).  When set, the dispatcher runs this
+    # session with cwd pointed at the given absolute path instead of the
+    # global TERMINAL_CWD.  Lets a topic map to a git repo's directory so the
+    # agent operates on the right filesystem by default.
+    workdir: Optional[str] = None
+
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16465,8 +16465,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Build session context
         context = build_session_context(source, self.config, session_entry)
         
-        # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        # Set session context variables for tools (task-local, concurrency-safe).
+        # A per-topic workdir binding (e.g. Telegram group_topics[].workdir) pins
+        # this session's cwd onto its git repo directory; absence keeps global default.
+        _event_workdir = (getattr(event, "workdir", None) or "").strip()
+        _session_env_tokens = self._set_session_env(
+            context, cwd=_event_workdir or None
+        )
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -21380,11 +21385,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return delivered
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(self, context: SessionContext, cwd: Optional[str] = None) -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
         gateway messages cannot overwrite each other's session state.
+
+        ``cwd`` optionally pins the session's working directory (e.g. a
+        per-topic ``workdir`` binding).  When None, the session keeps the
+        global TERMINAL_CWD default.
 
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
@@ -21415,6 +21424,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
             cron_session="",
+            cwd=cwd or "",
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9677,6 +9677,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id_str = self._effective_message_thread_id(message)
         chat_topic = None
         topic_skill = None
+        topic_workdir = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
@@ -9722,6 +9723,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            topic_workdir = topic.get("workdir")
                             break
                     break
 
@@ -9805,6 +9807,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
+            workdir=topic_workdir,
             channel_prompt=_channel_prompt,
             timestamp=message.date,
         )

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -475,6 +475,90 @@ def test_group_topic_skill_binding_second_topic():
     assert event.source.chat_topic == "Sales"
 
 
+# ── _build_message_event: group_topics workdir binding ──
+
+
+def test_group_topic_workdir_binding():
+    """Group topic with a workdir config should set event.workdir."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "aiops", "thread_id": 5, "workdir": "/Users/andrew/aiops"},
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=5,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.workdir == "/Users/andrew/aiops"
+
+
+def test_group_topic_workdir_none_without_binding():
+    """Group topic without a workdir config should leave event.workdir=None."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "General", "thread_id": 1},
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=1,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.workdir is None
+
+
+def test_group_topic_workdir_alongside_skill():
+    """A topic can bind both a skill and a workdir; both should be carried."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "aiops", "thread_id": 5,
+                 "skill": "software-development", "workdir": "/Users/andrew/aiops"},
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=5,
+        text="hello",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill == "software-development"
+    assert event.workdir == "/Users/andrew/aiops"
+    assert event.source.chat_topic == "aiops"
+
+
 # ── _build_message_event: from_user=None fallback in DMs ──
 
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -76,6 +76,55 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     runner._clear_session_env(tokens)
 
 
+def test_set_session_env_applies_cwd_override():
+    """A per-topic workdir should be applied to the session cwd."""
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="aiops",
+        chat_type="group",
+        user_id="123456",
+        user_name="andrew",
+        thread_id="5",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    from agent.runtime_cwd import _session_cwd_override
+
+    tokens = runner._set_session_env(context, cwd="/Users/andrew/aiops")
+    try:
+        assert _session_cwd_override() == "/Users/andrew/aiops"
+    finally:
+        runner._clear_session_env(tokens)
+    # After clear, the override is dropped.
+    assert _session_cwd_override() != "/Users/andrew/aiops"
+
+
+def test_set_session_env_no_cwd_override_when_unset():
+    """Without a workdir binding, session cwd override stays unset."""
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="General",
+        chat_type="group",
+        user_id="123456",
+        user_name="andrew",
+        thread_id="1",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    from agent.runtime_cwd import _session_cwd_override
+
+    tokens = runner._set_session_env(context, cwd=None)
+    try:
+        # No binding -> override resolves to "" (falls through to TERMINAL_CWD).
+        assert _session_cwd_override() == ""
+    finally:
+        runner._clear_session_env(tokens)
+
+
 def test_clear_session_env_restores_previous_state(monkeypatch):
     """_clear_session_env should restore contextvars to their pre-handler values."""
     runner = object.__new__(GatewayRunner)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -882,6 +882,7 @@ platforms:
         - name: Engineering
           thread_id: 5
           skill: software-development
+          workdir: /Users/alice/engineering-repo
         - name: Research
           thread_id: 12
           skill: arxiv
@@ -898,13 +899,15 @@ platforms:
 | `name` | No | Human-readable label for the topic (informational only) |
 | `thread_id` | Yes | Telegram forum topic ID — visible in `t.me/c/<group_id>/<thread_id>` links |
 | `skill` | No | Skill to auto-load on new sessions in this topic |
+| `workdir` | No | Absolute path to pin this topic's session working directory (e.g. a git repo). Lets the agent operate on the right filesystem by default without being told each time. |
 
 ### How it works
 
 1. When a message arrives in a mapped group topic, Hermes looks up the `chat_id` and `thread_id` in `group_topics` config
 2. If a matching entry has a `skill` field, that skill is auto-loaded for the session — identical to DM topic skill binding
-3. Topics without a `skill` key get session isolation only (existing behavior, unchanged)
-4. Unmapped `thread_id` values or `chat_id` values fall through silently — no error, no skill
+3. If a matching entry has a `workdir` field, the session's working directory is pinned to that absolute path — so tools and context-file discovery operate inside that repo by default
+4. Topics without a `skill` key get session isolation only (existing behavior, unchanged)
+5. Unmapped `thread_id` values or `chat_id` values fall through silently — no error, no skill, no workdir override
 
 ### Differences from DM Topics
 


### PR DESCRIPTION
## Summary

- Adds a config-driven way to pin a Telegram group-forum topic's session working directory to a git repo, so the agent operates in the right filesystem by default.
- New optional `workdir` field on `platforms.telegram.extra.group_topics[].topics[]`, mirroring the existing per-topic `auto_skill` mechanism.

## Motivation

When running several long-lived projects as separate Telegram forum topics, each topic is isolated at the *conversation* level but a topic didn't carry *filesystem* context — the agent defaulted to `TERMINAL_CWD`/home, not the project's repo dir. This closes that gap: a topic can bind to a directory (e.g. `/Users/alice/aiops`) so tools and context-file discovery resolve there automatically.

## Changes

- `gateway/platforms/base.py`: `MessageEvent` gains a `workdir` field (per-channel cwd pin), alongside `auto_skill` / `channel_prompt`.
- `plugins/platforms/telegram/adapter.py`: resolves `group_topics[].workdir` for a matching `chat_id`+`thread_id` and attaches it to the event.
- `gateway/run.py`: `GatewayRunner._set_session_env()` accepts a `cwd` override and applies it via `set_session_vars`/`set_session_cwd`; `_handle_message_with_agent` feeds it from `event.workdir`, falling through to the global `TERMINAL_CWD` when unset (no behavior change for existing sessions).
- `website/docs/.../telegram.md`: document the `workdir` field + behavior.
- Tests: group-topic workdir binding (with/without a skill) and session-cwd override application/absence.

## Test Plan

- [x] Unit tests pass: `tests/gateway/test_dm_topics.py` (17), `tests/gateway/test_session_env.py` (11), plus regression pass over topic/session gateway tests (40).
- [ ] Manual: bind a topic -> confirm cwd resolves to the repo in a live session.

## Notes for Reviewers

- Signals are additive: no existing session binds a `workdir`, so `event.workdir` is `None` for all current traffic and the `cwd=cwd or ""` path is byte-identical to the prior default.
- This is scoped to Telegram `group_topics` for now; the `MessageEvent.workdir` field is intentionally generic so other platforms (e.g. Discord channel bindings) can reuse it.
