### PR TITLE
fix(kanban): recover or block missing worktrees

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6485,6 +6485,29 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
+class _MissingWorkspaceError(FileNotFoundError):
+    pass
+
+
+def _registered_worktree_for_branch(repo_root: Path, branch_name: str) -> Optional[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    worktree = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            worktree = Path(line.removeprefix("worktree "))
+        elif line == f"branch refs/heads/{branch_name}":
+            return worktree
+    return None
+
+
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
@@ -6495,7 +6518,18 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
             return
     target.parent.mkdir(parents=True, exist_ok=True)
     if _git_branch_exists(repo_root, branch_name):
-        cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
+        force = []
+        registered = _registered_worktree_for_branch(repo_root, branch_name)
+        if (
+            not target.exists()
+            and registered is not None
+            and registered.resolve(strict=False) == target.resolve(strict=False)
+        ):
+            force = ["--force"]
+        cmd = [
+            "git", "-C", str(repo_root), "worktree", "add", *force,
+            str(target), branch_name,
+        ]
     else:
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
@@ -6596,6 +6630,8 @@ def _resolve_worktree_workspace(
 
     repo_root = _repo_root_for_worktree_target(requested.parent)
     if repo_root is None:
+        if not requested.exists():
+            raise _MissingWorkspaceError(f"missing workspace path: {requested}")
         raise ValueError(
             f"task {task.id} worktree path {task.workspace_path!r} is not inside a git repo "
             "and does not point at a git repo root"
@@ -6827,7 +6863,7 @@ class DispatchResult:
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
-    """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    """Task ids auto-blocked by workspace preflight or the spawn circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -8640,6 +8676,15 @@ def _dispatch_once_locked(
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)
+        except _MissingWorkspaceError as exc:
+            if block_task(
+                conn,
+                claimed.id,
+                reason=str(exc),
+                expected_run_id=claimed.current_run_id,
+            ):
+                result.auto_blocked.append(claimed.id)
+            continue
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -8732,6 +8777,15 @@ def _dispatch_once_locked(
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)
+        except _MissingWorkspaceError as exc:
+            if block_task(
+                conn,
+                claimed.id,
+                reason=str(exc),
+                expected_run_id=claimed.current_run_id,
+            ):
+                result.auto_blocked.append(claimed.id)
+            continue
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -16,6 +16,7 @@ Two-part fix under test:
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -124,6 +125,59 @@ def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
         capture_output=True, text=True, check=True,
     ).stdout.strip()
     assert head == "wt/sibling"
+
+
+def test_resolve_worktree_recreates_missing_registered_checkout(kanban_home, tmp_path):
+    repo = _make_repo(tmp_path)
+    target = _add_worktree(repo, repo / ".worktrees" / "reissue", "wt/reissue")
+    shutil.rmtree(target)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="reissued task",
+            workspace_kind="worktree",
+            workspace_path=str(target),
+            branch_name="wt/reissue",
+        )
+        task = kb.get_task(conn, tid)
+
+    workspace, branch = kb._resolve_worktree_workspace(task)
+    assert workspace == target.resolve()
+    assert branch == "wt/reissue"
+    assert target.is_dir()
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_dispatch_blocks_unrecoverable_missing_worktree(
+    kanban_home, tmp_path, all_assignees_spawnable, status
+):
+    missing = tmp_path / "retired-repo" / ".worktrees" / "task"
+    spawned: list[str] = []
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="stale workspace",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path=str(missing),
+        )
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, tid))
+        conn.commit()
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda _task, workspace: spawned.append(workspace),
+        )
+        task = kb.get_task(conn, tid)
+        blocked = [event for event in kb.list_events(conn, tid) if event.kind == "blocked"]
+
+    assert spawned == []
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 0
+    assert result.auto_blocked == [tid]
+    assert blocked[-1].payload["reason"] == f"missing workspace path: {missing}"
 
 
 


### PR DESCRIPTION
## Summary

- recreate a missing linked worktree when Git still registers the task branch at that exact target
- block normal and review dispatch immediately when a persisted worktree path is missing and no source repository can be discovered
- preserve the existing retry/circuit-breaker behavior for all other workspace errors

## Behavior

Reissued tasks can retain a stale `workspace_path`. Dispatch now resolves the workspace after claim and before spawn as before, but distinguishes an unrecoverable missing path from retryable workspace failures. The task transitions directly to `blocked`, the reason names the missing path, the worker is not spawned, and `consecutive_failures` is not consumed.

When the repository is still available, existing worktree provisioning remains the first choice. A missing checkout that is still registered at the same branch and target is safely recreated with `git worktree add --force`; the force flag is not used when that branch is registered at another path.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_isolation.py` — 5 passed
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worktree_isolation.py` — passed
- `git diff --check` — passed
