### PR TITLE
fix(skills): stop duplicating root skill names

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1365,9 +1365,9 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
-# org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3: root-level entries now use the general category; v2 snapshots may encode
+# them as <name>/<name> and must be rebuilt.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1487,7 +1487,7 @@ def _build_snapshot_entry(
 
     if len(parts) >= 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2]) or "general"
     else:
         category = "general"
         skill_name = skill_file.parent.name

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -280,7 +281,43 @@ class TestBuildSkillsSystemPrompt:
         yield
         clear_skills_system_prompt_cache(clear_snapshot=True)
 
+    def test_root_level_skill_is_not_repeated_as_its_category(
+        self, monkeypatch, tmp_path
+    ):
+        from agent.prompt_builder import _build_skills_manifest
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "git-worktree-discipline"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: git-worktree-discipline\n"
+            "description: Keep worktrees safe\n"
+            "---\n"
+        )
+        (tmp_path / ".skills_prompt_snapshot.json").write_text(
+            json.dumps({
+                "version": 2,
+                "manifest": _build_skills_manifest(skills_root),
+                "skills": [
+                    {
+                        "skill_name": "git-worktree-discipline",
+                        "category": "git-worktree-discipline",
+                        "frontmatter_name": "git-worktree-discipline",
+                        "description": "Keep worktrees safe",
+                        "platforms": [],
+                        "conditions": {},
+                    }
+                ],
+                "category_descriptions": {},
+            })
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "\n  general:\n    - git-worktree-discipline:" in result
+        assert "\n  git-worktree-discipline:\n" not in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- classify root-level skill directories under `general` instead of repeating the skill name as a category
- invalidate version-2 skill prompt snapshots so existing installations rebuild the corrected index
- add a regression test covering the production `git-worktree-discipline/git-worktree-discipline` failure shape and stale snapshots

## Root cause

For a root-level `skills/<name>/SKILL.md`, `_build_snapshot_entry()` treated `<name>` as both the category and skill name. The generated prompt therefore represented the skill as `<name>/<name>`, which workers passed literally to `skill_view` and could not resolve.

## Test evidence

- `scripts/run_tests.sh tests/agent/test_prompt_builder.py -- -q` — 56 passed
- `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py` — passed
- `git diff --check` — passed
- `scripts/run_tests.sh tests/tools/test_skills_tool.py -- -q` — 39 passed; 2 existing Windows-only path-separator assertions failed (`/` expected, `\\` returned)
- WSL Ubuntu rerun of those two path-separator tests — 2 passed, 39 deselected

## Notes

The repository root has no `npm run verify` script, so that project-level command is unavailable. The full WSL skills-tool file exceeded the 10-minute local `/mnt/c` runner limit; the card-relevant prompt-builder file and the two Windows-specific failures were validated separately.
