### PR TITLE
fix(computer_use): ignore placeholder pid/window_id ids

### DIFF
--- a/tests/tools/test_computer_use_placeholder_ids.py
+++ b/tests/tools/test_computer_use_placeholder_ids.py
@@ -1,0 +1,107 @@
+"""A zero-filled ``pid``/``window_id`` must not be read as exact targeting.
+
+Several providers emit every declared schema property on every tool call,
+filling unused optional integers with ``0``. ``capture()`` entered its
+exact-target branch for any non-``None`` id, so those calls dropped the
+caller's ``app=``, coerced both ids to ``None`` via ``_positive_int``, and
+failed with a message pointing at pid/window_id rather than the real problem.
+For that class of model ``capture(app=...)`` never worked at all.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+def _backend_with_windows(windows: List[Dict[str, Any]]):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = {
+        "data": "",
+        "images": [],
+        "structuredContent": {"windows": windows},
+        "isError": False,
+    }
+    return backend
+
+
+_WINDOWS = [
+    {"app_name": "Fuwari", "pid": 100, "window_id": 1,
+     "is_on_screen": True, "title": "menu bar", "z_index": 0},
+    {"app_name": "Comet", "pid": 200, "window_id": 2,
+     "is_on_screen": True, "title": "Comet Browser", "z_index": 1},
+]
+
+
+def test_app_scoped_capture_survives_placeholder_ids():
+    """The bug: app= was discarded and the capture failed outright."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid=0, window_id=0)
+
+    assert cap.app == "Comet", (
+        f"app= was dropped for a zero-filled call; got app={cap.app!r} "
+        f"detail={cap.window_title!r}"
+    )
+
+
+def test_frontmost_capture_survives_placeholder_ids():
+    """Frontmost capture is the same failure with no app= to drop."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", pid=0, window_id=0)
+
+    # Frontmost is the highest z_index window.
+    assert cap.app == "Comet", f"frontmost capture failed; detail={cap.window_title!r}"
+
+
+def test_real_exact_target_still_wins_over_app():
+    """Guard: a genuine pid/window pair keeps its exact-targeting behaviour."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    # Ids that match no enumerated window: only the exact branch can produce
+    # this label, so it proves discovery was bypassed rather than consulted.
+    cap = backend.capture(mode="som", app="Ghost", pid=999, window_id=99)
+
+    assert cap.app == "Ghost", f"exact targeting was bypassed; detail={cap.window_title!r}"
+
+
+def test_partial_target_still_reports_the_missing_half():
+    """Guard: one real id and one placeholder is a caller error, not discovery."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid=200, window_id=0)
+
+    assert "requires both pid and window_id" in cap.window_title
+
+
+def test_malformed_ids_are_not_treated_as_placeholders():
+    """Guard: garbage must still reach the validation error, not be ignored."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid="abc", window_id="def")
+
+    assert "positive integer" in cap.window_title
+
+
+def test_placeholder_predicate():
+    from tools.computer_use.cua_backend import _is_placeholder_id
+
+    assert _is_placeholder_id(0) is True
+    assert _is_placeholder_id("0") is True
+    assert _is_placeholder_id(-1) is True
+    assert _is_placeholder_id(200) is False
+    assert _is_placeholder_id("200") is False
+    # Garbage is not a placeholder: it must keep reaching the existing error.
+    assert _is_placeholder_id("abc") is False
+    assert _is_placeholder_id(None) is False
+    assert _is_placeholder_id(1.5) is False
+    # bools are ints in Python; False must not read as a placeholder id.
+    assert _is_placeholder_id(False) is False
+    assert _is_placeholder_id(True) is False

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1811,6 +1811,24 @@ def _positive_int(value: Any) -> Optional[int]:
     return parsed if parsed > 0 else None
 
 
+def _is_placeholder_id(value: Any) -> bool:
+    """True when *value* is a schema-filler id rather than a real target.
+
+    Several providers emit every declared schema property on every tool call,
+    filling unused optional integers with ``0``. A non-positive id cannot name
+    a window, so treating it as a targeting request drops the caller's ``app=``
+    and fails the capture. Malformed non-numeric values are deliberately NOT
+    placeholders: those still reach the existing validation error rather than
+    being silently ignored.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return False
+    try:
+        return int(value) <= 0
+    except ValueError:
+        return False
+
+
 def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Normalise cua-driver ``list_windows`` entries, dropping unusable ones.
 
@@ -2237,6 +2255,13 @@ class CuaDriverBackend(ComputerUseBackend):
         # PR's effective minimum (trycua/cua#1961 + #1908) is well past
         # that, so the fallback is gone — the wrapper now treats the
         # structured shape as the only contract.
+        # Drop schema-filler ids before they can be read as a targeting
+        # request, so `capture(app=...)` and frontmost capture still work for
+        # models that emit every optional property zero-filled.
+        if _is_placeholder_id(pid):
+            pid = None
+        if _is_placeholder_id(window_id):
+            window_id = None
         # An exact pid/window pair is both the stable capture_after target and
         # the escape hatch when app/window discovery is unavailable on X11.
         if pid is not None or window_id is not None:


### PR DESCRIPTION
## What does this PR do?

`capture()` reads **any** non-`None` `pid`/`window_id` as a request for exact-window targeting:

```python
if pid is not None or window_id is not None:
    if pid is None or window_id is None:
        return self._failed_capture(mode, "<capture targeting requires both pid and window_id>")
    target_pid = _positive_int(pid)          # _positive_int(0) -> None
    target_window_id = _positive_int(window_id)
    if target_pid is None or target_window_id is None:
        return self._failed_capture(mode, "<capture targeting requires positive integer pid and window_id>")
```

Several providers emit every declared schema property on every tool call, zero-filling unused optional integers. Those calls arrive as `pid=0, window_id=0` on **every** invocation, so:

1. the exact-target branch is entered because `0 is not None`,
2. the caller's `app=` is discarded,
3. `_positive_int(0)` returns `None` for both ids,
4. the capture fails, and the message points at `pid`/`window_id`, which is the opposite of the real problem.

For that class of model `capture(app=...)` and frontmost capture never work at all, so `computer_use` is unusable end to end.

### The fix

Drop schema-filler ids before the branch decision, so dispatch falls through to app/frontmost discovery:

```python
def _is_placeholder_id(value: Any) -> bool:
    if isinstance(value, bool) or not isinstance(value, (int, str)):
        return False
    try:
        return int(value) <= 0
    except ValueError:
        return False
```

The predicate is deliberately narrower than "anything `_positive_int` rejects":

- **Non-positive ids are placeholders.** A `0` or negative value cannot name a window, so reading it as a targeting request can only produce the failure above.
- **Malformed ids are not.** `pid="abc"` still reaches the existing `positive integer` error rather than being silently ignored, which would turn a caller mistake into a confusing silent retarget.
- **Booleans are excluded** before the numeric check, since `False` is an `int` in Python and must not read as a placeholder id.

## Related Issue

Fixes #81333 (P2, `comp/tools`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81333"                --limit 25   # 0
gh search prs --repo NousResearch/hermes-agent "computer_use pid"     --limit 25   # 0
gh search prs --repo NousResearch/hermes-agent "placeholder pid"      --limit 25   # 0
gh search prs --repo NousResearch/hermes-agent "window_id in:title"   --limit 25   # see below
gh search prs --repo NousResearch/hermes-agent "capture targeting"    --limit 25   # nothing on this path
```

The `window_id` neighbours are all about the **output** side, guarding against null `pid`/`window_id` rows coming back from `list_windows` (#58173 merged, #56707/#57426/#57392/#56709 closed). This is the **input** side: ids supplied by the model on the way in. #52142 is the opposite intent, accepting an explicit pid+window pair as a discovery bypass, which this PR preserves.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `tools/computer_use/cua_backend.py` - added `_is_placeholder_id()`; `capture()` normalizes placeholder ids to `None` before the exact-target branch.
- `tests/tools/test_computer_use_placeholder_ids.py` - new, 6 tests.

## How to Test

```
pytest tests/tools/test_computer_use_placeholder_ids.py -q
```

6 passed.

Reverting only `tools/computer_use/cua_backend.py` and rerunning:

```
FAILED test_app_scoped_capture_survives_placeholder_ids
FAILED test_frontmost_capture_survives_placeholder_ids
FAILED test_partial_target_still_reports_the_missing_half
FAILED test_placeholder_predicate
4 failed, 2 passed
```

with the reported failure verbatim:

```
E  AssertionError: app= was dropped for a zero-filled call; got app=''
E  detail='<capture targeting requires positive integer pid and window_id>'
```

Two tests pass both before and after by design and are genuine guards: `test_real_exact_target_still_wins_over_app` pins that a real pid/window pair still bypasses discovery (it uses ids matching no enumerated window, so only the exact branch can produce that result), and `test_malformed_ids_are_not_treated_as_placeholders` pins that garbage still reaches the validation error.

**One deliberate message change.** A mixed call (`pid=200, window_id=0`) previously answered `requires positive integer pid and window_id`; it now answers `requires both pid and window_id`. That is the accurate diagnosis once the placeholder is recognised as absent: the caller supplied one id, not two. `test_partial_target_still_reports_the_missing_half` pins the new wording, which is why it fails on revert rather than passing as a pure guard.

Existing suites, this branch vs `main`, same environment, run serially:

```
main:   1 failed, 116 passed
branch: 1 failed, 116 passed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The one failure is pre-existing on both sides (`TestCaptureAppFilterNoMatch::test_linux_default_capture_skips_gnome_shell_helper`, a Linux-specific case run on macOS). This PR's 6 new tests live in their own file and are additional to those counts.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(computer_use): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the helper's docstring records why non-positive ids are placeholders and why malformed ones deliberately are not
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A; the change is argument normalization ahead of any platform call
- [x] Tool descriptions/schemas are N/A; the schema already types these as optional integers

## Notes for the reviewer

I fixed the dispatch rather than the tool schema on purpose. Tightening the schema (for example a `minimum: 1` on both ids) would not help: the models in question emit the full property set regardless, and a schema constraint they ignore still arrives as `0`. Normalizing at the boundary is the only place that holds for every caller.

The same zero-filling shape may affect other optional integers on this tool (`element`, `seconds`, `max_elements` all appear zero-filled in the issue's captured payload). I did not touch them because I could not show a concrete failure for any of them the way I can for `pid`/`window_id`, and widening this beyond the reported defect would be guessing. Happy to look at them as a follow-up if you have seen it bite.
