### PR TITLE
fix(kanban): reject live source dir workspaces

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -135,6 +135,32 @@ BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
+def _running_source_checkout_root() -> Optional[Path]:
+    """Return the git checkout containing this running Kanban module, if any."""
+    candidate = Path(__file__).resolve().parent.parent
+    return candidate if (candidate / ".git").exists() else None
+
+
+def _reject_live_source_dir_workspace(
+    workspace_kind: str, workspace_path: Optional[str]
+) -> None:
+    """Prevent a persistent ``dir`` task from editing Hermes' live checkout."""
+    if workspace_kind != "dir" or not workspace_path:
+        return
+    source_root = _running_source_checkout_root()
+    if source_root is None:
+        return
+    requested = Path(workspace_path).expanduser().resolve(strict=False)
+    try:
+        requested.relative_to(source_root)
+    except ValueError:
+        return
+    raise ValueError(
+        f"dir workspace {workspace_path!r} is inside the running Hermes source "
+        f"checkout {str(source_root)!r}; use an isolated worktree workspace instead"
+    )
+
+
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
 
@@ -3152,6 +3178,8 @@ def create_task(
         board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+
+    _reject_live_source_dir_workspace(workspace_kind, workspace_path)
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
@@ -6658,6 +6686,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
                 f"{task.workspace_path!r}; use an absolute path "
                 f"(relative paths are ambiguous against the dispatcher's CWD)"
             )
+        _reject_live_source_dir_workspace(kind, str(p))
         p.mkdir(parents=True, exist_ok=True)
         return p
     if kind == "worktree":

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1231,6 +1231,76 @@ def _make_task(**overrides) -> "kb.Task":
 # ---------------------------------------------------------------------------
 
 
+def test_create_task_rejects_dir_workspace_inside_running_source_checkout(kanban_home):
+    source_root = Path(kb.__file__).resolve().parent.parent
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="running Hermes source checkout"):
+            kb.create_task(
+                conn,
+                title="unsafe live edit",
+                workspace_kind="dir",
+                workspace_path=str(source_root / "hermes_cli"),
+            )
+
+
+def test_create_task_rejects_symlink_into_running_source_checkout(kanban_home, tmp_path):
+    source_root = Path(kb.__file__).resolve().parent.parent
+    alias = tmp_path / "source-alias"
+    alias.symlink_to(source_root, target_is_directory=True)
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="running Hermes source checkout"):
+            kb.create_task(
+                conn,
+                title="unsafe symlink edit",
+                workspace_kind="dir",
+                workspace_path=str(alias),
+            )
+
+
+def test_create_task_allows_separate_dir_and_worktree_workspace(kanban_home, tmp_path):
+    source_root = Path(kb.__file__).resolve().parent.parent
+
+    with kb.connect() as conn:
+        dir_task_id = kb.create_task(
+            conn,
+            title="safe separate directory",
+            workspace_kind="dir",
+            workspace_path=str(tmp_path / "separate-repo"),
+        )
+        worktree_task_id = kb.create_task(
+            conn,
+            title="safe isolated worktree",
+            workspace_kind="worktree",
+            workspace_path=str(source_root / ".worktrees" / "safe-task"),
+        )
+
+        dir_task = kb.get_task(conn, dir_task_id)
+        worktree_task = kb.get_task(conn, worktree_task_id)
+        assert dir_task is not None
+        assert worktree_task is not None
+        assert dir_task.workspace_kind == "dir"
+        assert worktree_task.workspace_kind == "worktree"
+
+
+def test_resolve_workspace_rejects_legacy_live_source_dir_task(kanban_home):
+    source_root = Path(kb.__file__).resolve().parent.parent
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy unsafe task")
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='dir', workspace_path=? WHERE id=?",
+            (str(source_root), task_id),
+        )
+        conn.commit()
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    with pytest.raises(ValueError, match="running Hermes source checkout"):
+        kb.resolve_workspace(task)
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prevent Kanban tasks from using the running Hermes git checkout, or any descendant/symlink into it, as a persistent `dir` workspace. Such tasks can silently dirty an active installation, block unattended updates, and couple review-gated work to the production runtime.

The guard runs at both task creation and workspace resolution. The second check fails closed for legacy rows created before this change. Isolated `worktree` workspaces remain supported, including worktrees materialized beneath the source repo's `.worktrees/` directory.

## Reproduction

Before this change, `create_task(..., workspace_kind="dir", workspace_path=<running checkout>)` succeeds and the dispatcher writes directly into the live source tree.

## Tests

- RED: 3 focused regression tests failed before implementation.
- GREEN: 4 focused workspace-guard tests passed.
- Regression: `62 passed` across `test_kanban_db.py`, `test_kanban_tools.py`, and `test_kanban_watchers_mixin.py`.

## Scope

Two files only: the Kanban DB/workspace validation and behavioral tests. No config, schema, model-tool, or runtime-service changes.