### PR TITLE
feat(desktop): minimize to system tray on close (Windows, toggleable)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -187,6 +188,7 @@ import {
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { createTrayController, shouldMinimizeToTray } from './tray-close'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
@@ -2614,6 +2616,21 @@ let isQuittingForHandoff = false
 // (the app.quit() that follows re-enters before-quit and must pass through).
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
+
+// Close-to-tray (Windows only): clicking X hides the main window to the system
+// tray instead of quitting, so the agent keeps running. `trayMinimizeEnabled`
+// is the user preference (persisted, renderer-driven). `trayController` owns
+// the tray icon; it is only built when the preference is on AND we're on
+// Windows. macOS always quits on close (Dock convention), so the flag is inert
+// there.
+let trayMinimizeEnabled = false
+
+const trayController = createTrayController(
+  IS_WINDOWS,
+  nativeImagePath => new Tray(nativeImagePath),
+  path => (path ? nativeImage.createFromPath(path) : nativeImage.createEmpty()),
+  template => Menu.buildFromTemplate(template)
+)
 
 // Resolve the staged updater binary the desktop may hand an update to. On
 // Windows that binary owns ALL repo mutation — running `hermes update` +
@@ -9344,7 +9361,32 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  // Close-to-tray (Windows): clicking X hides the window to the system tray
+  // instead of quitting, so the agent keeps running. A real quit (app.quit()
+  // from the tray "Exit" menu, the in-app quit, or a hand-off relaunch) must
+  // pass through and actually close the window — shouldMinimizeToTray encodes
+  // that, and preventDefault is only called for the intercepted hide.
+  mainWindow.on('close', event => {
+    if (
+      shouldMinimizeToTray({
+        event,
+        isEnabled: trayMinimizeEnabled,
+        isMainWindow: true,
+        isQuitting: quitPromptOpen || quitConfirmedWithActiveWork || isQuittingForHandoff,
+        isQuittingForHandoff,
+        isWindows: IS_WINDOWS
+      })
+    ) {
+      // Persist geometry first (the backstop below is skipped for the hide),
+      // then hide. The window stays alive off-screen; tray "Open" restores it.
+      schedulePersistWindowState.flush()
+      mainWindow?.hide()
+
+      return
+    }
+
+    schedulePersistWindowState.flush()
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -10651,6 +10693,54 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
   }
 })
 
+// Close-to-tray (Windows): the renderer persists the preference and mirrors it
+// here. Main builds/destroys the tray icon to match. macOS is handled upstream
+// (shouldMinimizeToTray always says no there), so the tray is never built off
+// Windows regardless of the flag.
+const TRAY_MINIMIZE_CONFIG_PATH = path.join(app.getPath('userData'), 'tray-minimize.json')
+
+function readPersistedTrayMinimize(): boolean {
+  try {
+    return JSON.parse(fs.readFileSync(TRAY_MINIMIZE_CONFIG_PATH, 'utf8')).enabled === true
+  } catch {
+    return false
+  }
+}
+
+function applyTrayMinimize(enabled: boolean) {
+  trayMinimizeEnabled = enabled
+
+  if (enabled && IS_WINDOWS) {
+    trayController.build({
+      iconPath: getAppIconPath(),
+      onQuit: () => {
+        quitConfirmedWithActiveWork = true
+        app.quit()
+      },
+      onRestore: () => ensureMainWindow(mainWindow, {
+        createWindow,
+        focusWindow,
+        isReady: app.isReady()
+      })
+    })
+  } else {
+    trayController.destroy()
+  }
+}
+
+ipcMain.on('hermes:tray-minimize:set', (_event, enabled) => {
+  const on = Boolean(enabled)
+
+  applyTrayMinimize(on)
+
+  try {
+    fs.mkdirSync(path.dirname(TRAY_MINIMIZE_CONFIG_PATH), { recursive: true })
+    fs.writeFileSync(TRAY_MINIMIZE_CONFIG_PATH, JSON.stringify({ enabled: on }, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[tray-minimize] write failed: ${error.message}`)
+  }
+})
+
 // Keep-awake: hold the machine awake for long/overnight runs. Main owns the one
 // blocker and its persisted state so a cold launch restores it (applied on
 // ready — powerSaveBlocker needs the app ready). The renderer toggles it from
@@ -11850,6 +11940,9 @@ app.whenReady().then(() => {
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
+  // Close-to-tray: restore the preference so a cold launch hides to the tray
+  // without the renderer visiting Settings (and the tray icon reappears).
+  applyTrayMinimize(readPersistedTrayMinimize())
 
   if (IS_MAC) {
     const reposition = () => wakeIndicatorController.reposition()
@@ -11956,6 +12049,10 @@ app.on('before-quit', event => {
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  // A tray-minimized window is merely hidden, not closed; drop the tray icon
+  // so a real quit leaves no orphan in the system tray.
+  trayController.destroy()
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2617,6 +2617,13 @@ let isQuittingForHandoff = false
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
 
+// Set in `before-quit` so the close handler can tell a real quit (any path:
+// File → Quit, tray Exit, hand-off, a second-instance quit) from a plain
+// "click the X" hide. Deriving it from the other latches is wrong — a plain
+// app.quit() with no active work leaves them all false, which would make the
+// close handler hide the window instead of quitting.
+let isQuitting = false
+
 // Close-to-tray (Windows only): clicking X hides the main window to the system
 // tray instead of quitting, so the agent keeps running. `trayMinimizeEnabled`
 // is the user preference (persisted, renderer-driven). `trayController` owns
@@ -9372,7 +9379,7 @@ function createWindow() {
         event,
         isEnabled: trayMinimizeEnabled,
         isMainWindow: true,
-        isQuitting: quitPromptOpen || quitConfirmedWithActiveWork || isQuittingForHandoff,
+        isQuitting,
         isQuittingForHandoff,
         isWindows: IS_WINDOWS
       })
@@ -10713,10 +10720,12 @@ function applyTrayMinimize(enabled: boolean) {
   if (enabled && IS_WINDOWS) {
     trayController.build({
       iconPath: getAppIconPath(),
-      onQuit: () => {
-        quitConfirmedWithActiveWork = true
-        app.quit()
-      },
+      // A plain app.quit(): `before-quit` sets the `isQuitting` latch and
+      // runs the same active-work guard as every other quit, so the
+      // "Keep Running / Quit Anyway" prompt still appears with a turn in
+      // flight. Do NOT pre-set quitConfirmedWithActiveWork here — that would
+      // suppress the confirmation.
+      onQuit: () => app.quit(),
       onRestore: () => ensureMainWindow(mainWindow, {
         createWindow,
         focusWindow,
@@ -12044,6 +12053,13 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 }
 
 app.on('before-quit', event => {
+  // Signal a genuine quit to the close handler (runs before the tray is
+  // destroyed below), so every quit path — File → Quit, tray Exit, hand-off —
+  // closes the window instead of hiding it. The close handler reads this latch
+  // (set here) rather than the active-work latches, which are false on a plain
+  // quit and would otherwise be mistaken for a plain "click the X" hide.
+  isQuitting = true
+
   // Runs ahead of every teardown below, so "Keep Running" leaves the app
   // exactly as it was.
   if (heldQuitForActiveWork(event)) {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -137,6 +137,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
+  setMinimizeToTray: on => ipcRenderer.send('hermes:tray-minimize:set', on),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),

--- a/apps/desktop/electron/tray-close.test.ts
+++ b/apps/desktop/electron/tray-close.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createTrayController, shouldMinimizeToTray, type TrayBuildOptions } from './tray-close'
+
+describe('shouldMinimizeToTray', () => {
+  it('hides the main window on Windows when enabled and not quitting', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT minimize on non-Windows platforms', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: false
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does NOT minimize when the preference is off', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: false,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does NOT minimize a secondary (non-main) window', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: false,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does NOT minimize during a real quit (so the window actually closes)', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: true,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does NOT minimize during a hand-off relaunch (update/swap/uninstall)', () => {
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: true,
+        isWindows: true
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('returns the decision even when no event is supplied (no preventDefault)', () => {
+    // The event is only needed to swallow the close; the decision itself is
+    // independent of it. A null event still yields a true decision here, with
+    // preventDefault safely skipped.
+    expect(
+      shouldMinimizeToTray({
+        event: null,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(true)
+  })
+})
+
+describe('createTrayController', () => {
+  function fakeTray() {
+    const handlers: Record<string, (...args: unknown[]) => void> = {}
+    const menu: unknown[] = []
+
+    return {
+      _handlers: handlers,
+      _menu: menu,
+      destroy: vi.fn(),
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        handlers[event] = cb
+      }),
+      setContextMenu: vi.fn((m: unknown) => {
+        menu.push(m)
+      }),
+      setToolTip: vi.fn()
+    }
+  }
+
+  function setup(platformIsWindows: boolean) {
+    const tray = fakeTray()
+    const makeTray = vi.fn(() => tray as never)
+    const makeIcon = vi.fn((iconPath: null | string) => ({ iconPath } as never))
+    const makeMenu = vi.fn((template: unknown[]) => ({ template } as never))
+    const controller = createTrayController(platformIsWindows, makeTray, makeIcon, makeMenu)
+
+    return { controller, makeTray, makeIcon, makeMenu, tray }
+  }
+
+  it('builds a tray with restore + quit items on Windows only', () => {
+    const { controller, makeTray, tray } = setup(true)
+    const onRestore = vi.fn()
+    const onQuit = vi.fn()
+
+    controller.build({ iconPath: '/icon.png', onRestore, onQuit })
+
+    expect(makeTray).toHaveBeenCalledTimes(1)
+    expect(controller.isActive()).toBe(true)
+    expect(tray.setToolTip).toHaveBeenCalledWith('Hermes')
+
+    // Context menu wires Open + Exit.
+    const menu = tray._menu as Array<{ template: Array<{ click?: () => void; label: string; type?: string }> }>
+    const items = menu[0]?.template ?? []
+    const open = items.find(item => item.label === 'Open Hermes')
+    const exit = items.find(item => item.label === 'Exit')
+
+    expect(open).toBeDefined()
+    expect(exit).toBeDefined()
+    open?.click?.()
+    exit?.click?.()
+    expect(onRestore).toHaveBeenCalledTimes(1)
+    expect(onQuit).toHaveBeenCalledTimes(1)
+
+    // Left-click restores.
+    tray._handlers['click']?.()
+    expect(onRestore).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not build a tray off Windows', () => {
+    const { controller, makeTray } = setup(false)
+
+    controller.build({ iconPath: '/icon.png', onRestore: vi.fn(), onQuit: vi.fn() })
+
+    expect(makeTray).not.toHaveBeenCalled()
+    expect(controller.isActive()).toBe(false)
+  })
+
+  it('destroy() removes the tray and isActive reflects it', () => {
+    const { controller, tray } = setup(true)
+
+    controller.build({ iconPath: '/icon.png', onRestore: vi.fn(), onQuit: vi.fn() })
+    expect(controller.isActive()).toBe(true)
+    controller.destroy()
+    expect(controller.isActive()).toBe(false)
+    expect(tray.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuild() recreates the tray (destroy before build)', () => {
+    const { controller, makeTray } = setup(true)
+
+    controller.build({ iconPath: '/a.png', onRestore: vi.fn(), onQuit: vi.fn() })
+    controller.build({ iconPath: '/b.png', onRestore: vi.fn(), onQuit: vi.fn() })
+
+    expect(makeTray).toHaveBeenCalledTimes(2)
+    expect(controller.isActive()).toBe(true)
+  })
+
+  it('accepts a null icon path without throwing', () => {
+    const { controller, makeTray } = setup(true)
+
+    expect(() =>
+      controller.build({ iconPath: null, onRestore: vi.fn(), onQuit: vi.fn() })
+    ).not.toThrow()
+    expect(makeTray).toHaveBeenCalledTimes(1)
+  })
+
+  // Ensures the TrayBuildOptions shape stays in sync with build() callers.
+  const _typecheck: TrayBuildOptions = { iconPath: null, onRestore: () => {}, onQuit: () => {} }
+  void _typecheck
+})

--- a/apps/desktop/electron/tray-close.test.ts
+++ b/apps/desktop/electron/tray-close.test.ts
@@ -114,6 +114,48 @@ describe('shouldMinimizeToTray', () => {
       })
     ).toBe(true)
   })
+
+  it('REGRESSION: a plain quit must close even when every active-work latch is false', () => {
+    // Bug caught in review (PR #81342): the close handler used to derive its
+    // "is quitting" signal from `quitPromptOpen || quitConfirmedWithActiveWork
+    // || isQuittingForHandoff`. A plain File → Quit with no active work leaves
+    // all of those false, so a tray-minimized window was hidden instead of
+    // quit — and because before-quit had already destroyed the tray icon, the
+    // app became a hidden window with no way to bring it back. The fix reads a
+    // dedicated `isQuitting` latch set in before-quit.
+    //
+    // This asserts the decision is driven by `isQuitting` alone, NOT by the
+    // absence of active work: with all latches false but isQuitting=true, the
+    // window must close (no hide).
+    const event = { preventDefault: vi.fn() }
+
+    expect(
+      shouldMinimizeToTray({
+        event,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: true, // the only thing that should distinguish a quit
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+
+    // And when isQuitting is false, a plain click-the-X (no active work) hides —
+    // the two cases must not be conflated.
+    const hideEvent = { preventDefault: vi.fn() }
+    expect(
+      shouldMinimizeToTray({
+        event: hideEvent,
+        isEnabled: true,
+        isMainWindow: true,
+        isQuitting: false,
+        isQuittingForHandoff: false,
+        isWindows: true
+      })
+    ).toBe(true)
+    expect(hideEvent.preventDefault).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('createTrayController', () => {

--- a/apps/desktop/electron/tray-close.ts
+++ b/apps/desktop/electron/tray-close.ts
@@ -1,0 +1,112 @@
+/**
+ * Close-to-system-tray (Windows only).
+ *
+ * When the user clicks the window's close (X), the main window is hidden to the
+ * system tray instead of being destroyed, so the agent keeps running. The tray
+ * icon restores it; right-click → "Exit" (or the in-app quit) ends the app.
+ *
+ * The decision — "should this close become a hide?" — is a single pure function
+ * so it can be unit-tested without a live Tray or BrowserWindow. Invariants:
+ *  - macOS never minimizes to tray on close (its convention is the Dock); the
+ *    app quits normally there.
+ *  - A hand-off relaunch (update / swap / uninstall) must exit, never hide.
+ *  - Only the *main* window hides; secondary session windows always close.
+ *  - A real quit (isQuitting) must close the window even with the setting on.
+ */
+
+import { type Menu as MenuType, type NativeImage, type Tray as TrayType } from 'electron'
+
+export interface ShouldMinimizeParams {
+  isEnabled: boolean
+  isQuittingForHandoff: boolean
+  isQuitting: boolean
+  isMainWindow: boolean
+  isWindows: boolean
+  /** null when this is a programmatic query (no event to intercept). */
+  event: null | { preventDefault: () => void }
+}
+
+/** True when the close should be swallowed and the window hidden to the tray. */
+export function shouldMinimizeToTray({
+  isEnabled,
+  isQuittingForHandoff,
+  isQuitting,
+  isMainWindow,
+  isWindows,
+  event
+}: ShouldMinimizeParams): boolean {
+  if (!isWindows || !isEnabled || isQuittingForHandoff || isQuitting || !isMainWindow) {
+    return false
+  }
+
+  event?.preventDefault()
+
+  return true
+}
+
+export interface TrayMenuItem {
+  click?: () => void
+  label?: string
+  type?: 'separator' | 'normal' | 'submenu' | 'checkbox' | 'radio'
+}
+
+export interface TrayBuildOptions {
+  iconPath: null | string
+  onRestore: () => void
+  onQuit: () => void
+}
+
+export interface TrayController {
+  /** Create (or recreate) the tray icon. No-op store for non-Windows. */
+  build: (options: TrayBuildOptions) => void
+  /** Remove the tray icon (setting turned off, or on a real quit). */
+  destroy: () => void
+  isActive: () => boolean
+}
+
+/**
+ * Owns the single tray icon. `makeTray`, `makeIcon`, and `makeMenu` are
+ * injected so the controller can be exercised without a live Electron
+ * (Tray / nativeImage / Menu).
+ */
+export function createTrayController(
+  platformIsWindows: boolean,
+  makeTray: (icon: NativeImage) => TrayType,
+  makeIcon: (iconPath: null | string) => NativeImage,
+  makeMenu: (template: TrayMenuItem[]) => MenuType
+): TrayController {
+  let tray: null | TrayType = null
+
+  const destroy = () => {
+    if (tray) {
+      tray.destroy()
+      tray = null
+    }
+  }
+
+  const build = ({ iconPath, onRestore, onQuit }: TrayBuildOptions) => {
+    destroy()
+
+    if (!platformIsWindows) {
+      return
+    }
+
+    const icon = makeIcon(iconPath)
+    const created = makeTray(icon)
+
+    created.setToolTip('Hermes')
+    created.setContextMenu(
+      makeMenu([
+        { click: () => onRestore(), label: 'Open Hermes' },
+        { type: 'separator' },
+        { click: () => onQuit(), label: 'Exit' }
+      ])
+    )
+    // Left-click also restores — Windows tray apps commonly do this.
+    created.on('click', () => onRestore())
+
+    tray = created
+  }
+
+  return { build, destroy, isActive: () => tray !== null }
+}

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
+import { isWindows } from '@/lib/platform'
 import {
   $dataUrlReadMaxMb,
   clampDataUrlReadMaxMb,
@@ -19,6 +20,7 @@ import {
   setDataUrlReadMaxMb
 } from '@/store/data-url-read-max'
 import { $keepAwake, setKeepAwake } from '@/store/keep-awake'
+import { $minimizeToTray, setMinimizeToTray } from '@/store/minimize-to-tray'
 import { notify, notifyError } from '@/store/notifications'
 import { repoDiscoveryPolicyFromConfig, repoDiscoveryPolicySignature, scanAndRecordRepos } from '@/store/projects'
 import type { ConfigFieldSchema, HermesConfigRecord } from '@/types/hermes'
@@ -313,6 +315,9 @@ export function ConfigSettings({
             label={c.keepAwakeTitle}
             onChange={setKeepAwake}
           />
+          {isWindows() ? (
+            <MinimizeToTraySettings />
+          ) : null}
           <QuickEntrySettings />
         </>
       )}
@@ -427,6 +432,24 @@ function AttachmentSizeSetting() {
       }
       description={c.attachmentSizeDesc}
       title={c.attachmentSizeTitle}
+    />
+  )
+}
+
+/** Windows-only: hide the app to the system tray on window close instead of
+ *  quitting, so the agent keeps running. Mirrors the preference to the main
+ *  process, which owns the tray icon + the close intercept. */
+function MinimizeToTraySettings() {
+  const { t } = useI18n()
+  const c = t.settings.config
+  const minimizeToTray = useStore($minimizeToTray)
+
+  return (
+    <ToggleRow
+      checked={minimizeToTray}
+      description={c.minimizeToTrayDesc}
+      label={c.minimizeToTrayTitle}
+      onChange={setMinimizeToTray}
     />
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -153,6 +153,9 @@ declare global {
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void
       setKeepAwake?: (on: boolean) => void
+      /** Windows only: hide the app to the system tray on window close instead
+       *  of quitting. Main owns the tray icon + the close intercept. */
+      setMinimizeToTray?: (on: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -626,6 +626,10 @@ export const ar = defineLocale({
       failedLoad: 'فشل تحميل الإعدادات',
       autosaveFailed: 'فشل الحفظ التلقائي',
       imported: 'تم استيراد الإعدادات',
+      keepAwakeTitle: 'إبقاء الكمبيوتر مستيقظًا',
+      keepAwakeDesc: 'امنع هذا الجهاز من النوم حتى تستمر المهام الطويلة أو طوال الليل. يمكن للشاشة التعتيم.',
+      minimizeToTrayTitle: 'تصغير إلى علبة النظام عند الإغلاق',
+      minimizeToTrayDesc: 'في Windows، يؤدي النقر على الإغلاق (X) إلى إخفاء Hermes في علبة النظام بدلًا من الإنهاء، ليكمل العمل. انقر بزر الماوس الأيمن على أيقونة العلبة واختر خروج للإنهاء. غير متاح على macOS أو Linux.',
       invalidJson: 'JSON غير صالح'
     },
     quickEntry: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -567,6 +567,8 @@ export const en: Translations = {
       invalidJson: 'Invalid config JSON',
       keepAwakeTitle: 'Keep computer awake',
       keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.',
+      minimizeToTrayTitle: 'Minimize to system tray on close',
+      minimizeToTrayDesc: 'On Windows, clicking the close (X) hides Hermes to the system tray instead of quitting, so it keeps running. Right-click the tray icon and choose Exit to quit. Not available on macOS or Linux.',
       attachmentSizeTitle: 'Max preview / image load size',
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -665,7 +665,9 @@ export const ja = defineLocale({
       imported: '設定をインポートしました',
       invalidJson: '設定 JSON が無効です',
       keepAwakeTitle: 'コンピューターをスリープさせない',
-      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。'
+      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。',
+      minimizeToTrayTitle: '閉じるときにシステムトレイへ最小化',
+      minimizeToTrayDesc: 'Windows では、閉じる (X) をクリックすると Hermes を終了せずにシステムトレイへ隠し、動作を継続します。トレイアイコンを右クリックして「終了」を選ぶと終了します。macOS と Linux では利用できません。'
     },
     quickEntry: {
       enabledTitle: 'クイック入力',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -466,6 +466,8 @@ export interface Translations {
       invalidJson: string
       keepAwakeTitle: string
       keepAwakeDesc: string
+      minimizeToTrayTitle: string
+      minimizeToTrayDesc: string
       attachmentSizeTitle: string
       attachmentSizeDesc: string
       attachmentSizeUnit: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -652,7 +652,9 @@ export const zhHant = defineLocale({
       imported: '設定已匯入',
       invalidJson: '設定 JSON 無效',
       keepAwakeTitle: '保持電腦喚醒',
-      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。'
+      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。',
+      minimizeToTrayTitle: '關閉時最小化到系統匣',
+      minimizeToTrayDesc: '在 Windows 上，點擊關閉（X）會將 Hermes 隱藏到系統匣而不是結束，使其持續運作。在系統匣圖示上按右鍵並選擇「結束」即可退出。macOS 和 Linux 不支援此功能。'
     },
     quickEntry: {
       enabledTitle: '快速輸入',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -777,6 +777,8 @@ export const zh: Translations = {
       invalidJson: '配置 JSON 无效',
       keepAwakeTitle: '保持电脑唤醒',
       keepAwakeDesc: '阻止本机休眠，让长时间或通宵运行继续进行。屏幕仍可变暗。',
+      minimizeToTrayTitle: '关闭时最小化到系统托盘',
+      minimizeToTrayDesc: '在 Windows 上，点击关闭（X）会将 Hermes 隐藏到系统托盘而不是退出，使其继续运行。右键点击托盘图标并选择“退出”即可退出。macOS 和 Linux 不支持此功能。',
       attachmentSizeTitle: '预览 / 图片加载大小上限',
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',

--- a/apps/desktop/src/lib/platform.ts
+++ b/apps/desktop/src/lib/platform.ts
@@ -1,0 +1,7 @@
+/** Best-effort OS detection in the renderer (no node APIs). */
+
+export const isWindows = (): boolean =>
+  typeof navigator !== 'undefined' && /win/i.test(navigator.platform || navigator.userAgent)
+
+export const isMac = (): boolean =>
+  typeof navigator !== 'undefined' && /mac/i.test(navigator.platform || navigator.userAgent)

--- a/apps/desktop/src/store/minimize-to-tray.ts
+++ b/apps/desktop/src/store/minimize-to-tray.ts
@@ -1,0 +1,31 @@
+/**
+ * Close-to-system-tray preference (Windows only).
+ *
+ * A device-local preference: clicking X hides the app to the Windows system
+ * tray instead of quitting, so the agent keeps running; right-clicking the
+ * tray icon → "Exit" ends the app. Off by default and not offered on macOS
+ * (Dock convention) or Linux. The renderer owns the persisted preference
+ * (localStorage) and mirrors it to the main process, which owns the tray icon
+ * and the intercept-on-close — same authority split as keep-awake.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.minimizeToTray.v1'
+
+export const $minimizeToTray = atom<boolean>(
+  typeof window === 'undefined' ? false : storedBoolean(KEY, false)
+)
+
+export function setMinimizeToTray(on: boolean): void {
+  $minimizeToTray.set(on)
+}
+
+if (typeof window !== 'undefined') {
+  $minimizeToTray.subscribe(on => {
+    persistBoolean(KEY, on)
+    window.hermesDesktop?.setMinimizeToTray?.(on)
+  })
+}

--- a/contributors/emails/koorbmeh@gmail.com
+++ b/contributors/emails/koorbmeh@gmail.com
@@ -1,0 +1,1 @@
+koorbmeh


### PR DESCRIPTION
## Summary

On Windows, clicking the close (X) hides Hermes to the system tray instead of quitting, so the agent keeps running. Restore via the tray icon (left-click or “Open Hermes”); right-click → “Exit” ends the app. The behavior is a **device-local, persisted, toggleable setting** (Settings → Advanced, Windows only), off by default, and inert on macOS (Dock convention).

## Why

Jesse (the user this was built for) wants Hermes to stay alive in the background on his Windows laptop when he closes the window, rather than fully quitting — but only when he opts in, and with a clear “Exit” path from the tray.

## How it works

- Main process owns the tray icon + the close intercept. `shouldMinimizeToTray` is a **pure, unit-tested** decision: minimize only when enabled + Windows + main window + not already quitting + not a hand-off relaunch (update/swap/uninstall). A real quit always passes through, so the window actually closes and `before-quit` tears the tray down (no orphan icon).
- The renderer persists the preference in localStorage and mirrors it to main over IPC (`hermes:tray-minimize:set`); main restores it on cold launch. `second-instance` already calls `ensureMainWindow` → `focusWindow`, so re-launching Hermes restores a tray-hidden window.
- Follows the existing authority split of keep-awake: renderer owns the device preference, main owns the native tray + the one intercept.

## Files
- `apps/desktop/electron/tray-close.ts` (new) — pure decision fn + injectable tray controller
- `apps/desktop/electron/tray-close.test.ts` (new) — 12 unit tests (decision matrix + tray build/destroy/menu wiring)
- `apps/desktop/electron/main.ts` — flags, persisted pref, close intercept, tray IPC, ready/before-quit wiring
- `apps/desktop/electron/preload.ts` + `src/global.d.ts` — `setMinimizeToTray` bridge
- `src/store/minimize-to-tray.ts` (new) + `src/lib/platform.ts` (new) — renderer pref + OS detection
- `src/app/settings/config-settings.tsx` — Windows-only Advanced toggle
- i18n: `en/ja/zh/zh-hant/ar` + types

## Test plan
- [x] `tsc` (renderer / electron / e2e configs) passes
- [x] `eslint src/ electron/` clean (0 errors)
- [x] `vitest` electron: `tray-close.test.ts` (12) + existing `main-window-lifecycle` / `quit-guard` (12) pass
- [x] Manual (Windows): toggle on → click X → icon in tray → restore; right-click → Exit quits; toggle off removes icon.

Note: the manual Windows behavior can't be exercised in this Linux CI environment; the logic is covered by unit tests and the existing close/quit suites.