### PR TITLE
fix(verify): reap the whole process group when a phase command times out

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -108,26 +108,32 @@ def _run_phase_command(
     on_output: Callable[[str], None] | None = None,
 ) -> PhaseResult:
     started = time.monotonic()
+    # start_new_session puts the command (and every process it spawns) in its
+    # own process group, so a timeout can terminate the WHOLE tree. Plain
+    # ``subprocess.run(..., shell=True, timeout=...)`` only kills the sh
+    # wrapper — a phase that spawned children (jest workers, npm build
+    # chains, dev servers) leaves them orphaned and still running, holding
+    # ports, fds, and CI machines hostage (#sibling of the start-phase fix).
+    proc = subprocess.Popen(
+        command,
+        shell=True,  # project-authored commands; see module docstring
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,  # own process group for clean teardown
+        text=True,
+        errors="replace",
+    )
     try:
-        proc = subprocess.run(
-            command,
-            shell=True,  # project-authored commands; see module docstring
-            cwd=str(root),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=timeout,
-            text=True,
-            errors="replace",
-        )
-        output = proc.stdout or ""
+        output, _ = proc.communicate(timeout=timeout)
         exit_code: int | None = proc.returncode
         timed_out = False
-    except subprocess.TimeoutExpired as exc:
-        raw = exc.output
-        if isinstance(raw, bytes):
-            output = raw.decode("utf-8", errors="replace")
-        else:
-            output = raw or ""
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(proc)
+        try:
+            output, _ = proc.communicate()  # drain whatever the tree produced
+        except (OSError, ValueError):
+            output = ""
         exit_code = None
         timed_out = True
     duration = time.monotonic() - started

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -2,6 +2,8 @@
 
 import http.server
 import json
+import os
+import shutil
 import threading
 import time
 
@@ -12,7 +14,45 @@ from agent.verify.environment import (
     save_manifest,
 )
 from agent.verify.recipes import Recipe
-from agent.verify.runner import run_verify
+from agent.verify.runner import _run_phase_command, run_verify
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def test_phase_timeout_reaps_whole_process_tree(tmp_path):
+    """A timed-out phase must not orphan the command's children.
+
+    ``subprocess.run(shell=True, timeout=...)`` kills only the sh wrapper —
+    a phase that spawned children (jest workers, npm build chains) leaves
+    them running and holding ports/fds. The runner kills the whole group.
+    """
+    if shutil.which("bash") is None:
+        import pytest
+
+        pytest.skip("bash required")
+    pidfile = tmp_path / "child.pid"
+    cmd = f"bash -c 'sleep 30 & echo $! > {pidfile}; wait'"
+    result = _run_phase_command("test", cmd, tmp_path, timeout=1.0)
+    assert result.timed_out
+    child_pid = int(pidfile.read_text().strip())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _pid_alive(child_pid):
+        time.sleep(0.1)
+    assert not _pid_alive(child_pid), "phase child survived the timeout"
+
+
+def test_phase_success_still_returns_output(tmp_path):
+    result = _run_phase_command("test", "printf hello", tmp_path, timeout=10.0)
+    assert not result.timed_out
+    assert result.exit_code == 0
+    assert result.ok
+    assert "hello" in result.output_tail
 
 
 class TestManifest:


### PR DESCRIPTION
## Summary

The verify subsystem's phase runner (`agent/verify/runner.py`) used `subprocess.run(shell=True, timeout=...)` for bootstrap/build/test commands. On timeout, `subprocess.run` kills only the `sh` wrapper — a phase that spawned children (jest workers, npm build chains, dev servers) left them **orphaned and still running**, holding ports, fds, and CI machines. The `start` phase already handled this correctly via `start_new_session` + `killpg`; the phase commands were the gap.

## Fix

Run phases in their own process group (`Popen(start_new_session=True)`) and reuse `_terminate_process_group` on timeout, then drain remaining output. The normal success path is unchanged (same exit code, output, and `on_output` callback semantics).

## Tests

`tests/verify/test_environment_and_runner.py`:
- `test_phase_timeout_reaps_whole_process_tree` — spawns `bash -c 'sleep 30 & echo $! > pidfile; wait'` with a 1s timeout and asserts the backgrounded child is dead afterward. **Verified RED on the old `subprocess.run` path (child survives), GREEN here.**
- `test_phase_success_still_returns_output` — success path unaffected.

Verified: full file 21/21.
