### PR TITLE
fix(wake): quoted 'false' now disables start_new_session instead of enabling it

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12953,6 +12953,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 load_wake_word_config,
                 owns_listener,
                 start_listening,
+                start_new_session_enabled,
             )
         except Exception as e:
             if announce:
@@ -12979,7 +12980,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # (onnxruntime is a large wheel) — tell the user why this is slow.
             _cprint(f"{_DIM}Installing wake word engine (first use — this may take a minute)...{_RST}")
 
-        self._wake_start_new_session = bool(cfg.get("start_new_session", True))
+        self._wake_start_new_session = start_new_session_enabled(cfg)
         try:
             start_listening(self._on_wake_word, owner=self, config=cfg)
         except Exception as e:
@@ -13124,6 +13125,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             is_listening,
             load_wake_word_config,
             owns_listener,
+            start_new_session_enabled,
         )
 
         cfg = load_wake_word_config()
@@ -13136,7 +13138,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cprint(f"  Phrase:      \"{reqs['phrase']}\"")
         _cprint(f"  Provider:    {reqs['provider']}")
         _cprint(f"  Surface:     {cfg.get('surface', 'auto')}")
-        _cprint(f"  New session: {'yes' if cfg.get('start_new_session', True) else 'no'}")
+        _cprint(f"  New session: {'yes' if start_new_session_enabled(cfg) else 'no'}")
         if state == "LISTENING" and audio_is_silent():
             _cprint(f"  {_ACCENT}⚠ Microphone delivers only silence — the listener can't hear anything.{_RST}")
             _cprint(f"  {_DIM}On macOS: System Settings > Privacy & Security > Microphone — allow your"

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -55,6 +55,10 @@ def test_start_new_session_quoted_false_disables():
 def test_wake_surface_enabled_gate():
     # Disabled → never, regardless of surface.
     assert ww.wake_surface_enabled("cli", {"enabled": False, "surface": "cli"}) is False
+    # Quoted ``"false"`` (hand-edited YAML) must also disable — bool() trap.
+    assert ww.wake_surface_enabled("cli", {"enabled": "false", "surface": "cli"}) is False
+    assert ww.wake_surface_enabled("tui", {"enabled": "no", "surface": "auto"}) is False
+    assert ww.wake_surface_enabled("cli", {"enabled": "0", "surface": "cli"}) is False
     # auto → every surface is eligible; ownership still admits only one.
     for s in ("cli", "tui", "gui"):
         assert ww.wake_surface_enabled(s, {"enabled": True, "surface": "auto"}) is True
@@ -65,6 +69,72 @@ def test_wake_surface_enabled_gate():
     assert ww.wake_surface_enabled("gui", cfg) is False
     # Missing/blank surface defaults to auto.
     assert ww.wake_surface_enabled("gui", {"enabled": True}) is True
+
+
+def test_profile_routing_quoted_false_skips_enrolled_phrases(monkeypatch, tmp_path):
+    """Quoted ``profile_routing: "false"`` must NOT merge other profiles' phrases.
+
+    ``bool("false")`` is True, which would silently enroll every wake-enabled
+    profile's phrase into this listener (the same trap #81345 fixes for
+    ``start_new_session``).
+    """
+    import sys
+    import types
+
+    fake = types.ModuleType("sherpa_onnx")
+    setattr(
+        fake,
+        "text2token",
+        lambda phrases, **kw: [[f"T{i}" for i in range(len(p))] for p in phrases],
+    )
+    setattr(
+        fake,
+        "KeywordSpotter",
+        type(
+            "KeywordSpotter",
+            (),
+            {
+                "__init__": lambda self, **kw: None,
+                "create_stream": lambda self: object(),
+            },
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", fake)
+    from tools import lazy_deps
+
+    monkeypatch.setattr(lazy_deps, "ensure", lambda *a, **kw: None)
+    monkeypatch.setattr(ww, "_active_profile_name", lambda: "default")
+    enrolled = {"coder": "hey coder", "research": "hey research"}
+    monkeypatch.setattr(ww, "enrolled_profile_phrases", lambda: enrolled)
+
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "tokens.txt").write_text("")
+    (model / "bpe.model").write_text("")
+    for pat in ("encoder-x.onnx", "decoder-x.onnx", "joiner-x.onnx"):
+        (model / pat).write_text("")
+
+    def _engine(cfg):
+        return ww._SherpaKwsEngine(cfg)
+
+    # Quoted "false" → only the own phrase is enrolled.
+    off = _engine(
+        {
+            "sherpa": {"model_dir": str(model)},
+            "phrase": "hey hermes",
+            "profile_routing": "false",
+        }
+    )
+    assert set(off._display_to_profile.values()) == {"default"}
+    # True (or absent default) → enrolled phrases merged in.
+    on = _engine(
+        {
+            "sherpa": {"model_dir": str(model)},
+            "phrase": "hey hermes",
+            "profile_routing": True,
+        }
+    )
+    assert set(on._display_to_profile.values()) == {"default", "coder", "research"}
 
 
 def test_looks_like_path():

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -39,6 +39,19 @@ def test_config_defaults_and_clamping():
     assert ww.wake_phrase({}) == "hey hermes"
 
 
+def test_start_new_session_quoted_false_disables():
+    """Quoted YAML ``"false"`` must disable, not enable (bool() trap)."""
+    assert ww.start_new_session_enabled({}) is True  # default
+    assert ww.start_new_session_enabled({"start_new_session": True}) is True
+    assert ww.start_new_session_enabled({"start_new_session": "true"}) is True
+    assert ww.start_new_session_enabled({"start_new_session": "yes"}) is True
+    assert ww.start_new_session_enabled({"start_new_session": "on"}) is True
+    assert ww.start_new_session_enabled({"start_new_session": False}) is False
+    assert ww.start_new_session_enabled({"start_new_session": "false"}) is False
+    assert ww.start_new_session_enabled({"start_new_session": "no"}) is False
+    assert ww.start_new_session_enabled({"start_new_session": "0"}) is False
+
+
 def test_wake_surface_enabled_gate():
     # Disabled → never, regardless of surface.
     assert ww.wake_surface_enabled("cli", {"enabled": False, "surface": "cli"}) is False

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -335,7 +335,9 @@ def wake_surface_enabled(surface: str, cfg: Optional[Dict[str, Any]] = None) -> 
     process/machine ownership lock still permits only the first claimant.
     """
     cfg = cfg if cfg is not None else load_wake_word_config()
-    if not cfg.get("enabled"):
+    from utils import is_truthy_value
+
+    if not is_truthy_value(cfg.get("enabled"), default=False):
         return False
     want = str(_get(cfg, "surface")).strip().lower() or "auto"
     return want == "auto" or want == surface.strip().lower()
@@ -650,6 +652,7 @@ class _SherpaKwsEngine(_Engine):
 
     def __init__(self, cfg: Dict[str, Any]):
         from tools import lazy_deps
+        from utils import is_truthy_value
 
         lazy_deps.ensure("wake.sherpa", prompt=False)
 
@@ -669,7 +672,7 @@ class _SherpaKwsEngine(_Engine):
         phrase = str(_get(cfg, "phrase") or "hey hermes").strip()
         own_profile = _active_profile_name()
         phrase_map: Dict[str, str] = {phrase: own_profile}
-        if bool(cfg.get("profile_routing", True)):
+        if is_truthy_value(cfg.get("profile_routing"), default=True):
             for prof, p in enrolled_profile_phrases().items():
                 phrase_map.setdefault(p.strip(), prof)
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -249,6 +249,20 @@ def wake_phrase(cfg: Optional[Dict[str, Any]] = None) -> str:
     return str(_get(cfg, "phrase")) or "hey hermes"
 
 
+def start_new_session_enabled(cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """Whether a wake-word trigger should start a new session.
+
+    Parsed through the shared truthy-string set so a hand-edited YAML
+    ``start_new_session: "false"`` (quoted) actually disables the behaviour.
+    ``bool("false")`` is ``True`` and silently enabled a new session for
+    every wake-word fire — the wake status line also lied about the setting.
+    """
+    from utils import is_truthy_value
+
+    cfg = cfg if cfg is not None else load_wake_word_config()
+    return is_truthy_value(_get(cfg, "start_new_session"), default=True)
+
+
 def resolve_capture_mode(
     cfg: Optional[Dict[str, Any]] = None,
     *,


### PR DESCRIPTION
## Summary

`cli.py` parsed the wake-word config key `start_new_session` with `bool(cfg.get("start_new_session", True))` — and `bool("false")` is `True`. A hand-edited YAML `start_new_session: "false"` (quoted — common after editors/env-bridge config writes) silently **enabled** a new session on every wake-word fire, and the `/wake` status line reported the same lie.

## Fix

New helper `tools/wake_word.start_new_session_enabled()` coerces the value through the project's shared `utils.is_truthy_value` (truthy set: `1/true/yes/on`). Both cli.py call sites — the listener start and the `/wake` status line — use it. Absent key → default `True` (unchanged).

## Tests

`tests/tools/test_wake_word.py::test_start_new_session_quoted_false_disables` — quoted `"false"`/`"no"`/`"0"` → disabled, `"true"`/`"yes"`/`"on"` and bools pass through, absent key → default. Verified: full file 27/27.
