### PR TITLE
fix(telegram): keep code blocks on legacy path to preserve copy affordance

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1639,6 +1639,7 @@ class TelegramAdapter(BasePlatformAdapter):
         "\U00020000-\U000323af"  # CJK extensions and compatibility supplement
         "]"
     )
+    _RICH_CODE_FENCE_RE = re.compile(r"(?m)^[ \t]{0,3}(?:`{3,}|~{3,})")
 
     def _has_telegram_desktop_details_math_crash_shape(self, content: str) -> bool:
         """Return True for rich-message details+math content that crashes TDesktop.
@@ -1665,6 +1666,21 @@ class TelegramAdapter(BasePlatformAdapter):
         delivery up front until affected clients age out.
         """
         return bool(content and self._RICH_CJK_RE.search(content))
+
+    def _has_telegram_rich_code_copy_gap_shape(self, content: str) -> bool:
+        """Return True for fenced code blocks that lose the client copy button.
+
+        Telegram clients currently omit the standard code-block copy
+        affordance for Bot API 10.1 rich-message preformatted blocks rendered
+        from markdown fences, while the legacy MarkdownV2 path keeps it
+        (#79331). The rich endpoint is a strict downgrade for code, so skip
+        rich delivery up front and let the legacy path carry the message.
+        Matches backtick and tilde fences (3+ chars, 0-3 leading spaces, per
+        CommonMark) at line start so prose mentions of triple backticks and
+        4+-space-indented code blocks (indented code, not fences) don't force
+        the fallback.
+        """
+        return bool(content and self._RICH_CODE_FENCE_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:
         """Return True for markdown constructs that the legacy path degrades.
@@ -1709,6 +1725,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and self._needs_rich_rendering(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
             and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            and not self._has_telegram_rich_code_copy_gap_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )
@@ -2057,6 +2074,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and content.strip()
             and not self._has_telegram_desktop_details_math_crash_shape(content)
             and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            and not self._has_telegram_rich_code_copy_gap_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -124,6 +124,81 @@ async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fence",
+    [
+        "```bash\n~/.local/bin/hermes gateway status\n```",
+        "~~~bash\n~/.local/bin/hermes gateway status\n~~~",
+        "   ```bash\n~/.local/bin/hermes gateway status\n   ```",
+    ],
+)
+async def test_code_fence_content_skips_rich_send_to_preserve_copy_affordance(fence):
+    """Fenced code blocks (backtick or tilde, indented or flush) keep
+    Telegram's client copy button via the legacy MarkdownV2 path; rich
+    preformatted blocks currently omit it (#79331)."""
+    adapter = _make_adapter()
+
+    result = await adapter.send(
+        "12345",
+        f"## Results\n\n| Case | Status |\n|---|---|\n| rich | ✅ |\n\n{fence}",
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_inline_triple_backtick_mention_does_not_skip_rich():
+    """A prose mention of triple backticks (not on its own line) is not a
+    fenced block and must not force the legacy path."""
+    adapter = _make_adapter()
+
+    result = await adapter.send(
+        "12345",
+        "| Case | Status |\n|---|---|\n| rich | ✅ |\n\nWrap it with ``` for code.",
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_indented_code_block_does_not_skip_rich():
+    """A 4+-space-indented code block is indented code, not a CommonMark
+    fence — it must not force the legacy path (#79331 review feedback)."""
+    adapter = _make_adapter()
+
+    result = await adapter.send(
+        "12345",
+        "| Case | Status |\n|---|---|\n| rich | ✅ |\n\n    ```bash\n    ~/.local/bin/hermes gateway status\n    ```",
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_table_without_code_fence_still_uses_rich_send():
+    """The copy-gap guard must not over-trigger: tables alone stay rich."""
+    adapter = _make_adapter()
+
+    result = await adapter.send("12345", TABLE_ONLY_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_plain_markdown_stays_on_legacy_path():
     """Ordinary replies (no table/task-list/details/math) stay on the legacy
     MarkdownV2 path for consistent client rendering, even with rich enabled."""
@@ -374,6 +449,24 @@ async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
     adapter._bot.send_message_draft.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_code_fence_content_skips_rich_draft_to_preserve_copy_affordance():
+    """Draft previews mirror the final path: fenced code skips rich so the
+    typing preview never shows a copy-less preformatted block (#79331)."""
+    adapter = _make_adapter(extra={"rich_drafts": True})
+    adapter._bot.do_api_request = AsyncMock(return_value=True)
+
+    result = await adapter.send_draft(
+        "12345",
+        draft_id=7,
+        content="## Results\n\n| Case | Status |\n|---|---|\n| rich | ✅ |\n\n```bash\nhermes gateway status\n```",
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message_draft.assert_awaited_once()
+
+
 # ----------------------------------------------------------------------
 # prefers_fresh_final_streaming: Telegram keeps streamed finals on the edit
 # path, even when rich messages are enabled, so users do not briefly see two
@@ -430,6 +523,26 @@ async def test_finalize_edit_uses_rich_for_table_content():
     assert api_kwargs["rich_message"]["markdown"] == RICH_CONTENT
     # No fresh send / delete — the whole point of the in-place rich edit.
     adapter._bot.edit_message_text.assert_not_called()
+    adapter._bot.delete_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_with_code_fence_uses_legacy_edit():
+    """Finalizing a preview containing a fenced code block edits via the
+    legacy MarkdownV2 path so the client keeps the code copy button
+    (#79331)."""
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345",
+        "555",
+        "| Case | Status |\n|---|---|\n| rich | ✅ |\n\n```bash\nhermes gateway status\n```",
+        finalize=True,
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.edit_message_text.assert_awaited_once()
     adapter._bot.delete_message.assert_not_called()
 
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -979,6 +979,8 @@ gateway:
 
 This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
+**Code blocks always take the legacy path.** Current Telegram clients omit the standard code-block copy button for Bot API 10.1 rich-message preformatted blocks, so any reply containing a fenced code block (```` ``` ````) is delivered through the legacy MarkdownV2 path even when rich messages are enabled — preserving the copy affordance for command snippets, configs, and logs. Messages without code fences (tables, task lists, details, math) still use the rich path.
+
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 
 ```yaml


### PR DESCRIPTION
## Summary

Closes #79331 — Telegram clients omit the standard code-block copy button for Bot API 10.1 rich-message preformatted blocks rendered from markdown fences, while the legacy MarkdownV2 path keeps it.

The adapter already skips rich delivery up front for content that current Telegram clients render badly (CJK garble, issue #47653; details+math TDesktop crash, [telegramdesktop/tdesktop#30808](https://github.com/telegramdesktop/tdesktop/issues/30808)), falling back to the legacy path. This PR adds the same class of guard for fenced code blocks: any reply containing a fenced code block (backtick or tilde, 3+ chars, 0–3 leading spaces per CommonMark) is delivered via the legacy MarkdownV2 path so the client retains the copy affordance.

Wired into all three rich decision points:
- final send — `_rich_eligible()`
- streamed-preview finalize — `_rich_eligible()` (edit path)
- draft previews — `_should_attempt_rich_draft()` (mirrors how the existing CJK/details guards are wired, since the draft path does not go through `_rich_eligible`)

Messages without code fences (tables, task lists, details, math) still use the rich path unchanged. Docs updated in `website/docs/user-guide/messaging/telegram.md` (Rendering: Rich Messages, Tables and Link Previews section).

## Tests

Added to `tests/gateway/test_telegram_rich_messages.py`:
- `test_code_fence_content_skips_rich_send_to_preserve_copy_affordance` — parametrized over flush backtick, flush tilde, and 3-space-indented fences; table+fence content asserts legacy `send_message`, rich endpoint not called
- `test_inline_triple_backtick_mention_does_not_skip_rich` — prose mention of ``` mid-line does not force the legacy path (anchor regression guard)
- `test_table_without_code_fence_still_uses_rich_send` — guard must not over-trigger
- `test_code_fence_content_skips_rich_draft_to_preserve_copy_affordance` — draft path parity
- `test_finalize_edit_with_code_fence_uses_legacy_edit` — edit-finalize path parity

Full file: 33 passed. Full `tests/gateway/` suite: 4966 passed; the 7 failures reproduce identically on clean `main` (environment-dependent) or pass in isolation — no new failures introduced.

## Notes

- **Reporter environment context:** the reporter's build used a `rich_messages_all` config key added in their own fork commit; that key does not exist on `main` (zero occurrences in `plugins/` or `gateway/`). This fix targets on-main behavior: rich-eligible content that also contains a fenced code block.
- Trade-off: a reply with both a table and a fenced code block uses the legacy path, preserving the copy button at the cost of native rich table rendering. The copy affordance is the higher-value property for command snippets and logs.
