### PR TITLE
fix(terminal): keep mid-command backgrounded compounds valid shell

### DIFF
--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -30,6 +30,13 @@ class TestRewrites:
         cmd = "A && B &\nfalse || C &"
         assert rewrite(cmd) == "A && { B & }\nfalse || { C & }"
 
+    def test_multiple_rewrites_on_one_line(self):
+        # Two mid-command rewrites in a single line, applied back-to-front,
+        # must both stay bash-valid ('A && B & C && D & E' backgrounds two
+        # compounds and runs E in the foreground).
+        cmd = "A && B & C && D & E"
+        assert rewrite(cmd) == "A && { B & }; C && { D & }; E"
+
 
 class TestMidCommandBackground:
     """``A && B & C``: the backgrounded compound is followed by another

--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -31,6 +31,47 @@ class TestRewrites:
         assert rewrite(cmd) == "A && { B & }\nfalse || { C & }"
 
 
+class TestMidCommandBackground:
+    """``A && B & C``: the backgrounded compound is followed by another
+    statement. The rewritten brace group needs a ``;`` separator — otherwise
+    ``A && { B & }C`` is a syntax error and the whole line dies."""
+
+    def test_background_compound_then_statement(self):
+        assert rewrite("A && B & C") == "A && { B & }; C"
+
+    def test_background_compound_then_chain(self):
+        assert rewrite("A && B & C && D") == "A && { B & }; C && D"
+
+    def test_realistic_server_pattern(self):
+        cmd = "sleep 1 && python3 -m http.server & echo started"
+        assert rewrite(cmd) == "sleep 1 && { python3 -m http.server & }; echo started"
+
+    def test_trailing_background_keeps_exact_shape(self):
+        # The documented tail case must stay byte-identical.
+        assert rewrite("A && B &") == "A && { B & }"
+        assert rewrite("A && B &  ") == "A && { B & }  "
+
+    def test_rewritten_output_is_valid_bash(self):
+        import shutil
+        import subprocess
+
+        if shutil.which("bash") is None:
+            import pytest
+
+            pytest.skip("bash required")
+        for cmd in (
+            "sleep 1 && python3 -m http.server & echo started",
+            "A && B & C && D",
+            "npm run build && node server.js & echo up",
+            "A && B & (echo c)",
+        ):
+            out = rewrite(cmd)
+            probe = subprocess.run(
+                ["bash", "-n", "-c", out], capture_output=True, text=True
+            )
+            assert probe.returncode == 0, f"invalid syntax: {out!r}: {probe.stderr}"
+
+
 class TestPreserved:
     """Commands that DON'T have the bug MUST pass through unchanged."""
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -961,7 +961,19 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        # When the `&` is mid-command (`A && B & C`), bash backgrounds the
+        # whole `A && B` list and runs `C` in the foreground. The brace group
+        # must then be separated from `C` by `;` — `A && { B & }C` is a
+        # syntax error that would kill the whole command line, including the
+        # backgrounded server the user asked for. A newline (or an existing
+        # `;`/`&`/`#`) already ends the statement, so no separator is added
+        # there — keeping the historical output byte-identical.
+        head = suffix.lstrip()
+        prefix_ws = suffix[: len(suffix) - len(head)]
+        if head and "\n" not in prefix_ws and head[0] not in (";", "&", "#"):
+            result = prefix + "{ " + middle + "& }; " + head
+        else:
+            result = prefix + "{ " + middle + "& }" + suffix
 
     return result
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -971,6 +971,11 @@ def _rewrite_compound_background(command: str) -> str:
         head = suffix.lstrip()
         prefix_ws = suffix[: len(suffix) - len(head)]
         if head and "\n" not in prefix_ws and head[0] not in (";", "&", "#"):
+            # Note: the re-joined form normalizes the inter-token whitespace
+            # ('; ' replaces the original spacing) — only tail/newline cases
+            # are byte-identical. Malformed inputs like `A && B &; C` are
+            # silently repaired into valid output; that is fine — the input
+            # was already a syntax error to bash.
             result = prefix + "{ " + middle + "& }; " + head
         else:
             result = prefix + "{ " + middle + "& }" + suffix


### PR DESCRIPTION
## Summary

`_rewrite_compound_background` (tools/terminal_tool.py) rewrites `A && B &` → `A && { B & }` to avoid the bash subshell-wait orphan leak — but when the `&` was **mid-command** (`A && B & C`), the result was `A && { B & }C` — a **bash syntax error** that killed the whole command line, including the backgrounded server the user asked for.

Realistic failure: `sleep 1 && python3 -m http.server & echo started` was rewritten to `sleep 1 && { python3 -m http.server & }echo started` → `syntax error near unexpected token 'echo'`, and the server never started. This fires on **every** terminal command by default (`execute(..., rewrite_compound_background=True)`).

Bash semantics: `A && B & C` backgrounds the entire `A && B` list and runs `C` in the foreground, so the brace group needs a `;` separator before `C`.

## Fix

Insert `; ` before the trailing statement — only when the next non-whitespace token is on the **same line** and isn't already a terminator (`;`, `&`, `#`). Newline-separated scripts and the documented tail case stay byte-identical.

## Tests

`tests/tools/test_terminal_compound_background.py::TestMidCommandBackground`:
- Mid-command shapes rewrite to valid bash (`A && B & C` → `A && { B & }; C`), including the realistic server pattern. **Verified RED on old code (syntax error), GREEN here.**
- `test_rewritten_output_is_valid_bash` syntax-checks the output with `bash -n`.
- Tail case and newline-separated scripts keep their exact historical output (existing tests unchanged, all pass).

Verified: full file 20/20.
