### PR TITLE
fix(cron): quoted 'false' now disables mirror_delivery and preflight

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -781,7 +781,14 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
     try:
         if cfg is None:
             cfg = load_config() or {}
-        return bool((cfg.get("cron", {}) or {}).get("mirror_delivery", False))
+        from utils import is_truthy_value
+
+        # Quoted YAML `"false"` must disable, not enable: bool("false") is
+        # True and would mirror cron output into a live chat against the
+        # operator's intent (a privacy leak, not just a misfeature).
+        return is_truthy_value(
+            (cfg.get("cron", {}) or {}).get("mirror_delivery"), default=False
+        )
     except Exception:
         return False
 
@@ -2946,13 +2953,18 @@ BLOCKED_CONFIG_SILENT_MARKER = "[blocked_config:silent]"
 def _cron_preflight_enabled(cfg: dict) -> bool:
     """Whether cron pre-dispatch configuration validation is enabled.
 
-    Default ON; only the literal boolean ``false`` under ``cron.preflight``
-    opts out (mirrors ``cron_model_drift_guard_enabled`` semantics).
+    Default ON; ``false`` under ``cron.preflight`` opts out. Parsed through
+    the shared truthy-string set so a quoted YAML ``"false"`` also disables
+    it — ``"false" is not False`` is True, so the old check kept preflight
+    on against explicit operator intent, blocking every tick with
+    ``[blocked_config]``.
     """
     cron_cfg = (cfg or {}).get("cron")
     if not isinstance(cron_cfg, dict):
         return True
-    return cron_cfg.get("preflight", True) is not False
+    from utils import is_truthy_value
+
+    return is_truthy_value(cron_cfg.get("preflight", True), default=True)
 
 
 def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -224,6 +224,23 @@ class TestHealthyJobUnaffected:
 
 
 class TestOptOut:
+    def test_quoted_false_string_disables_preflight(self):
+        """cron.preflight: "false" (quoted) must disable validation.
+
+        The old check (`value is not False`) kept preflight ON for a quoted
+        string — ``"false" is not False`` is True — blocking every tick with
+        [blocked_config] against explicit operator intent.
+        """
+        from cron.scheduler import _cron_preflight_enabled
+
+        assert _cron_preflight_enabled({"cron": {"preflight": "false"}}) is False
+        assert _cron_preflight_enabled({"cron": {"preflight": "no"}}) is False
+        assert _cron_preflight_enabled({"cron": {"preflight": False}}) is False
+        assert _cron_preflight_enabled({"cron": {"preflight": "true"}}) is True
+        assert _cron_preflight_enabled({"cron": {"preflight": True}}) is True
+        assert _cron_preflight_enabled({}) is True
+        assert _cron_preflight_enabled({"cron": {}}) is True
+
     def test_preflight_false_restores_old_behavior(self, tmp_path):
         """cron.preflight: false → job proceeds to resolution and fails the
         old way (error status, re-alerts every tick, no blocked_config)."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1621,6 +1621,20 @@ class TestCronDeliveryMirror:
     so cron uses exactly the same path interactive send_message mirroring uses.
     """
 
+    def test_quoted_false_string_does_not_enable_mirror(self):
+        """bool('false') is True — a quoted YAML value must not flip
+        cron.mirror_delivery ON (cron output appended into a live chat
+        against operator intent is a privacy leak)."""
+        from cron.scheduler import _cron_mirror_delivery_enabled
+
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": "false"}}) is False
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": "no"}}) is False
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": False}}) is False
+        assert _cron_mirror_delivery_enabled({}, {}) is False
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": True}}) is True
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": "true"}}) is True
+        assert _cron_mirror_delivery_enabled({}, {"cron": {"mirror_delivery": "1"}}) is True
+
 
     def test_mirror_writes_user_role_with_label_not_assistant(self):
         """Regression for #2221 / #2313: the cron brief must mirror as a USER


### PR DESCRIPTION
## Summary

Two bare-bool config traps in `cron/scheduler.py`, both in the "quoted `'false'`" class (`bool("false")` is `True`):

1. **`_cron_mirror_delivery_enabled`** used `bool(value)`. A hand-edited YAML `cron: mirror_delivery: "false"` flipped the feature **ON** — cron output was appended into a live chat's transcript against operator intent (a privacy leak, not just a misfeature).

2. **`_cron_preflight_enabled`** checked `value is not False`. A quoted `"false"` kept pre-dispatch config validation **ON**, blocking every tick with `[blocked_config]` against explicit opt-out intent — the job never runs.

## Fix

Both parse through the project's shared `utils.is_truthy_value` (truthy set: `1/true/yes/on`), defaulting to the same historical values (mirror: off; preflight: on). The per-job `attach_to_session` branch (already `isinstance(bool)`-guarded) is untouched.

## Tests

- `tests/cron/test_scheduler.py::test_quoted_false_string_does_not_enable_mirror`
- `tests/cron/test_preflight_config.py::test_quoted_false_string_disables_preflight`

Both **verified RED on old code, GREEN here**. Full files: 80 passed.
