### PR TITLE
fix(desktop): keep-alive hidden panes can no longer paint through

### DIFF
--- a/apps/desktop/src/components/pane-shell/pane-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/pane-visibility.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { hiddenPaneProps, PANE_HIDDEN_ATTR, queryAllVisible, queryVisible } from './pane-visibility'
+
+// The live stylesheet, read directly: the painting-contract test below must
+// validate the shipped rule, not a copy of it. Tests run with cwd =
+// apps/desktop (vitest projects root).
+const cssText = readFileSync(resolve(process.cwd(), 'src/styles.css'), 'utf8')
 
 /**
  * Inactive tabs stay mounted with their layout box intact, so they answer
@@ -37,5 +44,53 @@ describe('pane visibility lookups', () => {
   it('marks a pane hidden only while it is inactive', () => {
     expect(hiddenPaneProps(true)).toEqual({ [PANE_HIDDEN_ATTR]: '' })
     expect(hiddenPaneProps(false)).toEqual({})
+  })
+})
+
+describe('hidden pane painting contract', () => {
+  // The pane-level rule from styles.css that keeps a keep-alive hidden pane
+  // opaque to painting. Third-party widget scripts (Twitter's embed) render
+  // their card with an inline `visibility: visible`, which CSS would otherwise
+  // let paint through the pane's `visibility: hidden` over the active view
+  // (#79833). The rule forces every descendant to follow the pane's
+  // visibility. Extract it from the real stylesheet so this test validates the
+  // shipped rule — if the rule disappears, the contract is broken.
+  const paneBleedRule = (): string => {
+    // Anchored on the rule's own comment + selector, so reordering adjacent
+    // rules or reformatting unrelated CSS can't break the extraction.
+    const match = cssText.match(/\/\* Keep-alive hidden panes[\s\S]*?\[data-pane-hidden\] \* \{[\s\S]*?\}/)
+
+    expect(match).not.toBeNull()
+
+    return match![0]
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.head.querySelector('style[data-pane-bleed-rule]')?.remove()
+  })
+
+  it('keeps a descendant with inline visibility:visible from painting through a hidden pane', () => {
+    const style = document.createElement('style')
+
+    style.dataset.paneBleedRule = 'true'
+    style.textContent = paneBleedRule()
+    document.head.appendChild(style)
+
+    // What the reporter saw: the widget's rendered card (inline
+    // visibility:visible) nested inside a keep-alive pane (visibility:hidden).
+    document.body.innerHTML = `
+      <div data-pane-hidden style="visibility: hidden">
+        <div style="visibility: visible" id="leaky-card">card</div>
+      </div>
+    `
+
+    expect(getComputedStyle(document.getElementById('leaky-card')!).visibility).toBe('hidden')
+  })
+
+  it('does not affect a visible pane or an inline override outside one', () => {
+    document.body.innerHTML = `<div style="visibility: visible" id="live-card">card</div>`
+
+    expect(getComputedStyle(document.getElementById('live-card')!).visibility).toBe('visible')
   })
 })

--- a/apps/desktop/src/components/pane-shell/pane-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/pane-visibility.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { hiddenPaneProps, PANE_HIDDEN_ATTR, queryAllVisible, queryVisible } from './pane-visibility'

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2264,3 +2264,14 @@ button[data-slot='aui_msg-reactions'] svg {
     opacity: 0.4;
   }
 }
+
+/* Keep-alive hidden panes (see pane-visibility.ts) hide with `visibility:
+   hidden` so the layout box — and with it scroll positions — survives a tab
+   round-trip. But `visibility` is inherited-and-overridable: third-party
+   widget scripts (Twitter's embed injects its rendered card with an inline
+   `visibility: visible`) can paint through the hidden pane over the active
+   view (#79833). Force every descendant to follow the pane's visibility; an
+   author `!important` rule beats the widget's inline non-important style. */
+[data-pane-hidden] * {
+  visibility: inherit !important;
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2981,3 +2981,14 @@ html:has([data-hud-shell]) [data-slot='popover-content'] {
 [data-hud-shell] [data-slot='composer-bounds'] *::-webkit-scrollbar {
   display: none;
 }
+
+/* Keep-alive hidden panes (see pane-visibility.ts) hide with `visibility:
+   hidden` so the layout box — and with it scroll positions — survives a tab
+   round-trip. But `visibility` is inherited-and-overridable: third-party
+   widget scripts (Twitter's embed injects its rendered card with an inline
+   `visibility: visible`) can paint through the hidden pane over the active
+   view (#79833). Force every descendant to follow the pane's visibility; an
+   author `!important` rule beats the widget's inline non-important style. */
+[data-pane-hidden] * {
+  visibility: inherit !important;
+}


### PR DESCRIPTION
## Problem

Closes #79833 — with Inline Embeds set to "Always", an X/Twitter card that auto-loads in one session keeps painting over the whole UI after switching to another session, the Artifacts view, or Settings. It also survives a renderer reload (Ctrl+R).

## Root cause

Keep-alive tabs stay **mounted** when inactive and are hidden with `visibility: hidden` (not `display: none`) so their layout box — and with it the scroll position — survives a tab round-trip (`pane-shell/tree/renderer/tree-group.tsx`). But CSS `visibility` is inherited-*and-overridable*: Twitter's embed script renders its card into a sandbox element with an **inline** `visibility: visible` (`platform.twitter.com/widgets.js`), which CSS then lets paint through the hidden pane over the active view. It returned after Ctrl+R because the tab layout and the embed mode ("always") are persisted, so the embed re-auto-loads.

Plain-iframe embeds (YouTube, Spotify, maps) do not set inline `visibility`, which is why only the X/Twitter card was affected.

## Fix

One pane-level CSS rule — every descendant of a `[data-pane-hidden]` pane follows the pane's visibility (`visibility: inherit !important`). An author `!important` rule beats the widget's inline non-important style. The fix does not require additional unmounting: the embed stays mounted and renders exactly as before when its tab is active (no re-fetch, no flicker), and scroll preservation is untouched.

## Verification

- New "hidden pane painting contract" tests in `pane-visibility.test.ts` validate the rule against the **live stylesheet** (extracted by an anchored regex, so removal/rename fails loudly): a `visibility: visible` descendant inside a hidden pane computes `hidden`; an element outside is unaffected.
- Real-Chromium (Electron 40) probes: with the rule, a widget-style card inside a hidden pane computes `hidden`; without the rule it computes `visible` (bug mechanism reproduced); cards outside hidden panes stay `visible`.
- Full desktop UI suite: 4525 tests passed (480 files, 2 skipped); `tsc --noEmit` clean.

## Notes

- **Open question:** a widget that set `visibility: visible` on elements *inside* a shadow root (rather than on the host, which is what Twitter's script does) would not be covered — CSS cannot select into shadow roots. No known provider (Twitter/Instagram/TikTok, all checked) does this; if one appears, the follow-up is gating widget embeds on pane visibility in `social-embed.tsx`.
- **Open question:** the rule cannot win against a widget that set inline `visibility: visible !important`; today's widget scripts use plain inline styles.
