### PR TITLE
fix(display): quoted 'false' now hides show_reasoning in CLI, TUI, and the config report

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4336,7 +4336,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
-        self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
+        # is streamed. Parsed through the shared truthy set so a hand-edited
+        # YAML `show_reasoning: "false"` (quoted) actually hides reasoning —
+        # bool("false") is True and would keep displaying it.
+        from utils import is_truthy_value
+
+        self.show_reasoning = is_truthy_value(
+            CLI_CONFIG["display"].get("show_reasoning"), default=True
+        )
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)

--- a/cli.py
+++ b/cli.py
@@ -5123,7 +5123,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
-        self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
+        # is streamed. Parsed through the shared truthy set so a hand-edited
+        # YAML `show_reasoning: "false"` (quoted) actually hides reasoning —
+        # bool("false") is True and would keep displaying it.
+        from utils import is_truthy_value
+
+        self.show_reasoning = is_truthy_value(
+            CLI_CONFIG["display"].get("show_reasoning"), default=True
+        )
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4861,7 +4861,10 @@ def show_config():
     except Exception:
         _active_personality = display.get('personality') or 'none'
     print(f"  Personality:  {_active_personality}")
-    print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
+    # Same truthy-string semantics as the CLI/TUI readers: a hand-edited
+    # quoted `show_reasoning: "false"` must report off, not on.
+    from utils import is_truthy_value
+    print(f"  Reasoning:    {'on' if is_truthy_value(display.get('show_reasoning'), default=True) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4400,7 +4400,10 @@ def show_config():
     except Exception:
         _active_personality = display.get('personality') or 'none'
     print(f"  Personality:  {_active_personality}")
-    print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
+    # Same truthy-string semantics as the CLI/TUI readers: a hand-edited
+    # quoted `show_reasoning: "false"` must report off, not on.
+    from utils import is_truthy_value
+    print(f"  Reasoning:    {'on' if is_truthy_value(display.get('show_reasoning'), default=True) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5990,6 +5990,27 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     assert emitted[0][2]["approval_mode"] == "manual"
 
 
+def test_config_get_reasoning_quoted_false_hides_display(tmp_path, monkeypatch):
+    """display.show_reasoning: "false" (quoted) must report display=hide.
+
+    The old check was bool(value) — bool('false') is True, so a hand-edited
+    quoted YAML value kept reasoning visible in the TUI against the
+    operator's explicit intent.
+    """
+    import yaml
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"show_reasoning": "false"}})
+    )
+
+    response = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "reasoning"}}
+    )
+    assert response["result"]["display"] == "hide"
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8165,6 +8165,37 @@ def test_config_get_reasoning_quoted_false_hides_display(tmp_path, monkeypatch):
     assert response["result"]["display"] == "hide"
 
 
+def test_config_get_full_normalizes_quoted_false_show_reasoning(tmp_path, monkeypatch):
+    """config.get full must hand the TUI a real bool, not the quoted string.
+
+    useConfigSync hydrates showReasoning with ``!!value``, so a quoted
+    ``show_reasoning: "false"`` reaching the full payload would render as
+    truthy and keep reasoning visible in the TUI.
+    """
+    import yaml
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"show_reasoning": "false"}})
+    )
+
+    response = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "full"}}
+    )
+    assert response["result"]["config"]["display"]["show_reasoning"] is False
+    # Other display keys pass through untouched.
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"show_reasoning": True, "tui_statusbar": "fancy"}})
+    )
+    response = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "full"}}
+    )
+    cfg = response["result"]["config"]
+    assert cfg["display"]["show_reasoning"] is True
+    assert cfg["display"]["tui_statusbar"] == "fancy"
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8144,6 +8144,27 @@ def test_pet_info_known_revision_elides_spritesheet(monkeypatch):
     assert resp["result"]["spritesheetBase64"] == "A" * 1024
 
 
+def test_config_get_reasoning_quoted_false_hides_display(tmp_path, monkeypatch):
+    """display.show_reasoning: "false" (quoted) must report display=hide.
+
+    The old check was bool(value) — bool('false') is True, so a hand-edited
+    quoted YAML value kept reasoning visible in the TUI against the
+    operator's explicit intent.
+    """
+    import yaml
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"show_reasoning": "false"}})
+    )
+
+    response = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "reasoning"}}
+    )
+    assert response["result"]["display"] == "hide"
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -8,6 +8,7 @@ are rebound onto server.py's globals at install time — see method_ctx.py.
 """
 
 from .method_ctx import HandlerRegistry
+from utils import is_truthy_value
 
 from hermes_constants import DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES
 
@@ -245,7 +246,9 @@ def _(rid, params: dict) -> dict:
                 effort = str(raw_effort or "medium")
         display = (
             "show"
-            if bool((cfg.get("display") or {}).get("show_reasoning", True))
+            if is_truthy_value(
+                (cfg.get("display") or {}).get("show_reasoning"), default=True
+            )
             else "hide"
         )
         return _ok(rid, {"value": effort, "display": display})

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -210,7 +210,21 @@ def _(rid, params: dict) -> dict:
         cwd = _completion_cwd({"cwd": raw} if raw else {})
         return _ok(rid, {"cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
     if key == "full":
-        return _ok(rid, {"config": _load_cfg()})
+        cfg = _load_cfg()
+        display = cfg.get("display")
+        if isinstance(display, dict) and "show_reasoning" in display:
+            # The TUI hydrates showReasoning with `!!value` (useConfigSync),
+            # so a hand-edited quoted ``show_reasoning: "false"`` would render
+            # as truthy. Normalize to a real bool here, matching the
+            # `/reasoning` handler below.
+            display = {
+                **display,
+                "show_reasoning": is_truthy_value(
+                    display.get("show_reasoning"), default=True
+                ),
+            }
+            cfg = {**cfg, "display": display}
+        return _ok(rid, {"config": cfg})
     if key == "prompt":
         return _ok(rid, {"prompt": _load_cfg().get("custom_prompt", "")})
     if key == "skin":

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -8,6 +8,7 @@ are rebound onto server.py's globals at install time — see method_ctx.py.
 """
 
 from .method_ctx import HandlerRegistry
+from utils import is_truthy_value
 
 from hermes_constants import DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES
 
@@ -265,7 +266,9 @@ def _(rid, params: dict) -> dict:
                 effort = str(raw_effort or "medium")
         display = (
             "show"
-            if bool((cfg.get("display") or {}).get("show_reasoning", True))
+            if is_truthy_value(
+                (cfg.get("display") or {}).get("show_reasoning"), default=True
+            )
             else "hide"
         )
         return _ok(rid, {"value": effort, "display": display})


### PR DESCRIPTION
## Summary

`display.show_reasoning` (controls whether model reasoning is shown) was read with bare bool semantics at three sites, so a hand-edited YAML `show_reasoning: "false"` (quoted) kept reasoning **visible** against the operator's explicit intent — `bool("false")` is `True`:

1. `cli.py` — `HermesCLI.show_reasoning` (CLI display).
2. `tui_gateway/methods_config.py` — `config.get reasoning` handler (`display` field).
3. `hermes_cli/config.py` — the `hermes config` report printed `Reasoning: on` (readout contradicted effective behavior; review follow-up).

## Fix

All three sites now route through the shared `utils.is_truthy_value` (truthy set `1/true/yes/on`), default `True` — matching the historical default. The gateway status card (`_load_show_reasoning`) is intentionally untouched: it has its own per-platform override resolution.

## Tests

`tests/test_tui_gateway_server.py::test_config_get_reasoning_quoted_false_hides_display` — drives `config.get reasoning` with a quoted `"false"` config.yaml and asserts `display == "hide"`. **Verified RED on old code (`show`), GREEN here.** Full file: 524 passed.
