### PR TITLE
fix(petdex): quoted 'false' now disables display.pet.enabled on every surface

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5640,7 +5640,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
             pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
 
-            enabled = bool(pet_cfg.get("enabled"))
+            from utils import is_truthy_value
+
+            enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
             slug = str(pet_cfg.get("slug", "") or "")
             scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
             cols = constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))

--- a/hermes_cli/pets.py
+++ b/hermes_cli/pets.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from utils import is_truthy_value
+
 
 def _print(msg: str = "") -> None:
     print(msg)
@@ -249,7 +251,7 @@ def _cmd_doctor(args) -> int:
     from agent.pet.render import detect_terminal_graphics, resolve_mode
 
     cfg = _pet_config()
-    enabled = bool(cfg.get("enabled"))
+    enabled = is_truthy_value(cfg.get("enabled"), default=False)
     configured_slug = str(cfg.get("slug", "") or "")
     mode_cfg = str(cfg.get("render_mode", "auto") or "auto")
 
@@ -300,7 +302,9 @@ def _pet_config() -> dict:
 
 
 def _has_active_pet() -> bool:
-    return bool(_pet_config().get("enabled")) and bool(_pet_config().get("slug"))
+    return is_truthy_value(_pet_config().get("enabled"), default=False) and bool(
+        _pet_config().get("slug")
+    )
 
 
 def _set_active(slug: str) -> None:
@@ -364,7 +368,7 @@ def toggle_pet_display() -> tuple[bool, str | None, str | None]:
     slug = str(cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(slug)
 
-    if bool(cfg.get("enabled")):
+    if is_truthy_value(cfg.get("enabled"), default=False):
         _set_enabled(False)
         return False, pet.display_name if pet else None, None
 

--- a/tests/hermes_cli/test_pet_toggle.py
+++ b/tests/hermes_cli/test_pet_toggle.py
@@ -50,6 +50,35 @@ def test_toggle_pet_display_errors_with_no_installed_pets(tmp_path, monkeypatch)
     assert err is not None
 
 
+def test_pets_cli_quoted_false_disables_and_toggle_enables(tmp_path, monkeypatch):
+    """Quoted `display.pet.enabled: "false"` must read as disabled.
+
+    bool('false') is True — before the is_truthy_value fix, _has_active_pet
+    reported an active pet and /pet toggle DISABLED instead of enabling.
+    """
+    import yaml
+
+    from hermes_cli.pets import _has_active_pet, toggle_pet_display
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"display": {"pet": {"enabled": "false", "slug": "", "scale": 0.33}}}
+        ),
+        encoding="utf-8",
+    )
+
+    assert _has_active_pet() is False
+    # Toggle must take the ENABLE branch (reaching the "no pets installed"
+    # error), not the disable branch (which would return err=None).
+    enabled, name, err = toggle_pet_display()
+    assert err is not None and "no pets installed" in err
+    assert enabled is False
+    assert name is None
+
+
 @pytest.fixture
 def empty_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5802,6 +5802,27 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     assert emitted[0][2]["approval_mode"] == "manual"
 
 
+def test_pet_gallery_quoted_false_enabled_reports_disabled(tmp_path, monkeypatch):
+    """display.pet.enabled: "false" (quoted) must report enabled=False.
+
+    The old check was bool(value) — bool('false') is True, so a hand-edited
+    quoted YAML value kept the petdex mascot enabled against the operator's
+    explicit intent.
+    """
+    import yaml
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"pet": {"enabled": "false"}}})
+    )
+
+    response = server.handle_request(
+        {"id": "1", "method": "pet.gallery", "params": {}}
+    )
+    assert response["result"]["enabled"] is False
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1451,7 +1451,7 @@ def _(rid, params: dict) -> dict:
         except Exception:
             pet_cfg = {}
 
-        if not bool(pet_cfg.get("enabled")):
+        if not is_truthy_value(pet_cfg.get("enabled"), default=False):
             return _ok(rid, {"enabled": False})
 
         pet = store.resolve_active_pet(str(pet_cfg.get("slug", "") or ""))
@@ -1604,7 +1604,7 @@ def _(rid, params: dict) -> dict:
         return _ok(
             rid,
             {
-                "enabled": bool(pet_cfg.get("enabled")),
+                "enabled": is_truthy_value(pet_cfg.get("enabled"), default=False),
                 "active": str(pet_cfg.get("slug", "") or ""),
                 "pets": gallery,
             },

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8279,7 +8279,7 @@ def _pet_active_selection():
     except Exception:
         pet_cfg = {}
 
-    enabled = bool(pet_cfg.get("enabled"))
+    enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
     configured_slug = str(pet_cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(configured_slug) if enabled else None
     scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3347,7 +3347,7 @@ def _pet_sig() -> tuple:
     hatch flow rebuilds a sheet, or the scale changes."""
     display = _load_cfg().get("display") or {}
     pet_cfg = display.get("pet") if isinstance(display.get("pet"), dict) else {}
-    if not pet_cfg or not pet_cfg.get("enabled"):
+    if not pet_cfg or not is_truthy_value(pet_cfg.get("enabled"), default=False):
         return ("off",)
     try:
         enabled, pet, scale = _pet_active_selection()


### PR DESCRIPTION
## Summary

`display.pet.enabled` (petdex mascot, default `False` in `DEFAULT_CONFIG`) was read with bare `bool()`/truthiness at **eight** sites, so a hand-edited YAML `display.pet.enabled: "false"` (quoted — preserved as the string through the deep-merged config) kept the mascot **enabled** against the operator's explicit intent: `bool("false")` is `True`.

Sites fixed (all now through the shared `utils.is_truthy_value`, default `False`):
1. `tui_gateway/methods_session.py` — `pet.cells` gate (~1454).
2. `tui_gateway/methods_session.py` — `pet.gallery` enabled echo (~1607).
3. `tui_gateway/server.py` — shared pet-state helper (~8282).
4. `tui_gateway/server.py` — `_pet_sig` status-line signature (~3350) — quoted `"false"` showed the mascot as ON.
5. `cli.py` — `_pet_resolve_config` (CLI pet pane gate, ~5645).
6. `hermes_cli/pets.py` — `_cmd_doctor` (`hermes pets doctor` misreported quoted `"false"` as enabled).
7. `hermes_cli/pets.py` — `_has_active_pet` (quoted `"false"` treated as active, so `/pet install` skipped the selection prompt).
8. `hermes_cli/pets.py` — `toggle_pet_display` (`/pet toggle` flipped the **wrong** way with quoted `"false"`).

## Tests

`tests/test_tui_gateway_server.py::test_pet_gallery_quoted_false_enabled_reports_disabled` — drives `pet.gallery` with a quoted `"false"` config.yaml and asserts `enabled is False`. **Verified RED on old code (`True`), GREEN here.** Full file: 524 passed. `tests/hermes_cli/test_pet_toggle.py`: 2 passed.

Two independent review rounds caught and closed sibling sites (CLI pane, pets CLI); the final sweep confirms no bare read of `display.pet.enabled` remains.
