### PR TITLE
fix(kanban): exempt delegated children from the kanban stop-guard nudge (#80507)

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -26,13 +26,31 @@ def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
     On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it or the current
+    execution is not the lifecycle-owning worker.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    # #80507: delegated children (and cron jobs fired in-process from a
+    # worker) inherit HERMES_KANBAN_TASK but are denied the terminal kanban
+    # tools (#69837), so the stop-guard nudge would be unsatisfiable for them
+    # and would burn the parent's turn budget. The guard applies only to the
+    # dispatcher-owned worker context; subprocesses of a delegated child carry
+    # the HERMES_DELEGATED_CHILD_CONTEXT lineage marker.
+    child_marker = (os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT") or "").strip().lower()
+    if child_marker not in {"", "0", "false", "no", "off"}:
+        return False
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        return is_dispatcher_owned_worker_context()
+    except ImportError:
+        # Unknown context — keep the pre-existing behavior (guard on).
+        return True
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -78,6 +78,61 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 
 
 
+def test_no_nudge_in_delegated_child_context(clear_kanban_env):
+    """#80507 — a delegate_task child inherits the worker's HERMES_KANBAN_TASK
+    but cannot call kanban_complete/kanban_block (toolstrip + DB denial from
+    #69837); the stop-guard must not nudge it into an unsatisfiable loop."""
+    from agent.delegation_context import delegated_child_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with delegated_child_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert (
+            build_kanban_stop_nudge(
+                messages=[{"role": "assistant", "content": "review complete"}]
+            )
+            is None
+        )
+
+
+def test_no_nudge_in_inprocess_cron_context(clear_kanban_env):
+    """Sibling of #80507 — a cron job fired in-process from a worker is not
+    the lifecycle owner either, so the guard must not nudge it."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+
+
+def test_no_nudge_with_child_lineage_env_marker(clear_kanban_env):
+    """Subprocesses spawned by a delegated child carry the
+    HERMES_DELEGATED_CHILD_CONTEXT lineage marker; the guard must stay off."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    assert kanban_stop_nudge_enabled() is False
+
+
+def test_falsy_child_lineage_marker_keeps_guard_on(clear_kanban_env):
+    """A lifecycle-owning worker that merely carries a falsy spelling of the
+    lineage marker (e.g. HERMES_DELEGATED_CHILD_CONTEXT=0) must still be
+    nudged — the #80507 exemption only applies to a set marker."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "0")
+    assert kanban_stop_nudge_enabled() is True
+
+
+def test_worker_still_nudged_outside_child_context(clear_kanban_env):
+    """Regression guard: the real dispatcher worker (the lifecycle owner)
+    must still be nudged — the #80507 exemption must not weaken the guard."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    assert kanban_stop_nudge_enabled() is True
+    assert (
+        build_kanban_stop_nudge(messages=[{"role": "assistant", "content": "done"}])
+        is not None
+    )
+
+
 # ── Integration: agent nudge + dispatcher bounded retry ──────────────
 # These tests verify the two layers compose correctly: the agent-side
 # nudge fires first (up to 2 attempts), and if the worker still exits


### PR DESCRIPTION
## What does this PR do?

Fixes #80507. The Kanban terminal-tool stop guard (`agent/kanban_stop.py`) fired for any in-process agent whose environment carried `HERMES_KANBAN_TASK`. A `delegate_task` child running inside a Kanban worker inherits that env, so on a plain-text exit it was nudged to call `kanban_complete` / `kanban_block` — but delegated children are denied those tools by the child-isolation policy from #69837 (tool schema strip + DB-layer `PermissionError`). The nudge was unsatisfiable, and the resulting retry loop could exhaust the parent worker's turn budget (observed: `gave_up` at 100/100 turns).

This gates the stop-guard on the repo's canonical ownership predicate, `agent.delegation_context.is_dispatcher_owned_worker_context()` — the same predicate already used by `tools/kanban_tools.py` for the child-isolation denials — plus the `HERMES_DELEGATED_CHILD_CONTEXT` lineage env marker for child-spawned subprocesses. Real workers (the lifecycle owners) are unaffected: the guard still nudges them to complete/block, preserving the #56647 protocol protection.

## Related Issue

Fixes #80507

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/kanban_stop.py`: `kanban_stop_nudge_enabled()` now returns `False` when the current execution is not the dispatcher-owned worker — delegated-child ContextVar, in-process cron job executing outside dispatcher ownership (via `non_dispatcher_owned_context`), or a subprocess carrying the `HERMES_DELEGATED_CHILD_CONTEXT` lineage marker (empty/unset/falsy marker values do not disable the guard).
- `tests/agent/test_kanban_stop.py`: regression tests for delegated-child context, in-process cron context, lineage env marker set/absent-falsy, and the worker-still-nudged invariant.

## How to Test

1. `pytest tests/agent/test_kanban_stop.py -q` → 8 passed
2. `pytest tests/cron/test_cron_kanban_env_isolation.py tests/tools/test_delegate_kanban_isolation.py -q` → 31 passed
3. `pytest tests/hermes_cli/test_kanban_goal_mode.py tests/tools/test_kanban_tools.py -q` → 49 passed (incl. cron env isolation)
4. `pytest tests/hermes_cli/test_kanban_core_functionality.py -q -k "protocol_violation or complete or block"` → 4 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused suites run locally (see How to Test); full suite runs in CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
