### PR TITLE
fix(desktop): distinguish auto-discovered repos from explicit projects in the sidebar overview

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -17,7 +17,8 @@ vi.mock('@/i18n', () => ({
         projects: {
           enter: (label: string) => `Enter ${label}`,
           reorder: (label: string) => `Reorder ${label}`,
-          toggle: (label: string, open: boolean) => `${open ? 'Show' : 'Hide'} ${label} sessions`
+          toggle: (label: string, open: boolean) => `${open ? 'Show' : 'Hide'} ${label} sessions`,
+          autoDiscovered: 'Auto-discovered'
         }
       }
     }
@@ -77,5 +78,35 @@ describe('ProjectOverviewRow', () => {
     render(<ProjectOverviewRow onNewSession={vi.fn()} project={home} />)
 
     expect(screen.queryByRole('button', { name: 'New session in Home' })).toBeNull()
+  })
+
+  it('renders the folder-library lead glyph for explicit projects', () => {
+    const explicit = { id: 'p1', label: 'Explicit', isAuto: false } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={explicit} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+    expect(container.querySelector('.codicon-repo')).toBeNull()
+  })
+
+  it('defaults to the folder-library lead glyph when isAuto is absent (explicit nodes omit it)', () => {
+    const explicit = { id: 'p1', label: 'Explicit' } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={explicit} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+    expect(container.querySelector('.codicon-repo')).toBeNull()
+  })
+
+  it('renders the repo lead glyph and an "Auto-discovered" tooltip for auto projects', () => {
+    const auto = { id: '/Users/dev/my-repo', label: 'my-repo', isAuto: true } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={auto} />)
+
+    expect(container.querySelector('.codicon-repo')).toBeTruthy()
+    expect(container.querySelector('.codicon-folder-library')).toBeNull()
+
+    const link = screen.getByRole('button', { name: 'Enter my-repo' })
+    expect(tipTrigger(link)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -28,7 +28,10 @@ import { WorkspaceAddButton } from './workspace-header'
 
 // A bare color dot (no icon) or an icon glyph — tinted by `color` when set, else
 // the lead's default tertiary. The glyph wrapper centers + caps size either way.
-export function projectIcon({ color, icon, isNoProject }: SidebarProjectTree) {
+// Auto-discovered repos (git lanes Desktop found by scanning disk, not rows in
+// projects.db) get the `repo` glyph so a glance tells explicit projects
+// (`folder-library`) apart from incidental disk/session findings.
+export function projectIcon({ color, icon, isAuto, isNoProject }: SidebarProjectTree) {
   if (color && !icon) {
     return (
       <SidebarRowLeadGlyph>
@@ -39,7 +42,10 @@ export function projectIcon({ color, icon, isNoProject }: SidebarProjectTree) {
 
   return (
     <SidebarRowLeadGlyph style={color ? { color } : undefined}>
-      <Codicon name={icon || (isNoProject ? 'home' : 'folder-library')} size={SIDEBAR_LEAD_ICON_SIZE} />
+      <Codicon
+        name={icon || (isNoProject ? 'home' : isAuto ? 'repo' : 'folder-library')}
+        size={SIDEBAR_LEAD_ICON_SIZE}
+      />
     </SidebarRowLeadGlyph>
   )
 }
@@ -112,6 +118,16 @@ export function ProjectOverviewRow({
     <SidebarRowLead>{projectIcon(project)}</SidebarRowLead>
   )
 
+  const labelLink = (
+    <SidebarRowLink
+      aria-label={s.projects.enter(project.label)}
+      labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
+      onClick={() => onEnter?.(project.id)}
+    >
+      {project.label}
+    </SidebarRowLink>
+  )
+
   const shell = (
     <SidebarRowShell
       actions={
@@ -129,13 +145,11 @@ export function ProjectOverviewRow({
     >
       <SidebarRowCluster className="min-w-0 flex-1">
         {lead}
-        <SidebarRowLink
-          aria-label={s.projects.enter(project.label)}
-          labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
-          onClick={() => onEnter?.(project.id)}
-        >
-          {project.label}
-        </SidebarRowLink>
+        {project.isAuto ? (
+          <Tip label={s.projects.autoDiscovered}>{labelLink}</Tip>
+        ) : (
+          labelLink
+        )}
         {preview.length > 0 ? (
           <Tip label={s.projects.toggle(project.label, !open)}>
             <button

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1562,6 +1562,7 @@ export const ar = defineLocale({
     projects: {
       sectionLabel: 'المشاريع',
       home: 'الرئيسية',
+      autoDiscovered: 'مكتشف تلقائيًا',
       newButton: 'مشروع جديد',
       createTitle: 'مشروع جديد',
       createDesc: 'سمِّ مساحة العمل وأضف مجلدا أو أكثر.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1858,6 +1858,7 @@ export const en: Translations = {
     projects: {
       sectionLabel: 'Projects',
       home: 'Home',
+      autoDiscovered: 'Auto-discovered',
       newButton: 'New project',
       createTitle: 'New project',
       createDesc: 'Name a workspace and add one or more folders.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1699,6 +1699,7 @@ export const ja = defineLocale({
     projects: {
       sectionLabel: 'プロジェクト',
       home: 'ホーム',
+      autoDiscovered: '自動検出',
       newButton: '新規プロジェクト',
       createTitle: '新規プロジェクト',
       createDesc: 'ワークスペースに名前を付け、1つ以上のフォルダを追加します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1555,6 +1555,7 @@ export interface Translations {
     projects: {
       sectionLabel: string
       home: string
+      autoDiscovered: string
       newButton: string
       createTitle: string
       createDesc: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1644,6 +1644,7 @@ export const zhHant = defineLocale({
     projects: {
       sectionLabel: '專案',
       home: '主頁',
+      autoDiscovered: '自動探索',
       newButton: '新增專案',
       createTitle: '新增專案',
       createDesc: '為工作區命名並新增一個或多個資料夾。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2052,6 +2052,7 @@ export const zh: Translations = {
     projects: {
       sectionLabel: '项目',
       home: '主页',
+      autoDiscovered: '自动发现',
       newButton: '新建项目',
       createTitle: '新建项目',
       createDesc: '为工作区命名并添加一个或多个文件夹。',


### PR DESCRIPTION
## Summary

The Desktop sidebar's grouped/project view rendered **explicit projects** (rows in `projects.db`, created via `hermes project create` / the UI) and **auto-discovered repos** (git repos Desktop's home-directory scan finds, backend tree Tiers 2/3) identically: both got the `folder-library` lead glyph under the same PROJECTS header. A user with one real project could see several "projects" and have no way to tell which one they created versus which ones Desktop found by scanning disk (#80383).

The backend already tags every tree node with `isAuto` (auto-discovered repos) / `isNoProject` (Home bucket); the frontend used `isAuto` for sorting, dismissal, and context-menu behavior but never surfaced it visually. This PR adds the visual layer.

## Changes

- `apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx` — auto-discovered repos render the `repo` glyph instead of `folder-library` in the overview row; auto rows carry an "Auto-discovered" tooltip on the label.
- `apps/desktop/src/i18n/{en,ar,ja,zh,zh-hant}.ts` + `types.ts` — new `sidebar.projects.autoDiscovered` key.
- `apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx` — glyph + tooltip coverage for explicit, auto, and absent-`isAuto` nodes.

Explicit projects (including the `p_<hex>` nodes, which omit `isAuto`) and the Home bucket render exactly as before.

## Why this approach

A distinct lead icon + tooltip introduces the minimal visual cue while keeping sorting, dismissal, and context-menu behavior unchanged (auto projects still sort after explicit ones and can be dismissed or adopted). A second section header or per-row badge would add chrome disproportionate to a P3 cosmetic issue.

## Notes

- **Adoption flow unaffected:** theming an auto repo (`Appearance`) creates a real `projects.db` row; on the next tree refresh the node becomes an explicit project (id `p_<hex>`, `isAuto` no longer emitted), so the auto cue disappears naturally once a user adopts a repo.
- **Out of scope:** the issue's secondary observation (collapsed project rows don't show registered folders) is a separate affordance question and is not addressed here.
- **Workspace header scope:** this change targets the sidebar overview row, where the collision occurs. The entered workspace header already displays the repo's own name, so we recommend leaving it unchanged to avoid header clutter — happy to extend if maintainers prefer cross-view consistency.

## Verification

- `vitest run` on the projects + i18n suites: **104 passed** (7 in `overview-row.test.tsx`)
- `npm run typecheck` (all three tsconfigs): clean
- `eslint` on changed files: clean

Closes #80383. Addresses the visual-distinction portion of #73888 — that issue's broader design questions (folder-ownership semantics, impact preview, Home labeling) remain open for maintainers to decide.
