### PR TITLE
feat(desktop): bundle Theme Forge — forge desktop themes from any image

### DIFF
--- a/apps/desktop/src/plugins/theme-forge/forge.test.ts
+++ b/apps/desktop/src/plugins/theme-forge/forge.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Theme Forge — color math + synthesis validation.
+ *
+ * Vitest port of the standalone `forge-math-test.cjs` harness (74 checks)
+ * that validates the disk plugin's theme math. Same synthetic-palette
+ * fixtures, same verbatim-contract assertions, plus the structural checks
+ * that now come free from TypeScript.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  ansiPalette,
+  buildColorsFromPalette,
+  contrast,
+  deriveSwatches,
+  type ForgeMode,
+  hexToHsl,
+  hexToRgb,
+  hslToHex,
+  luminance,
+  rgbToHex,
+  rgbToHsl,
+  stripForgePrefix,
+  type Swatch,
+  synthesize
+} from './forge'
+
+const HEX = /^#[0-9a-f]{6}$/i
+const REQUIRED = ['background', 'foreground', 'primary'] as const
+
+/** Synthetic swatch factory matching the harness's test-image blocks. */
+const mk = (r: number, g: number, b: number, weight: number): Swatch => ({
+  hex: rgbToHex(r, g, b),
+  hsl: rgbToHsl(r, g, b),
+  weight
+})
+
+const palette = [
+  mk(13, 47, 134, 2000),
+  mk(255, 120, 50, 1800),
+  mk(255, 224, 196, 1500),
+  mk(120, 30, 80, 1400),
+  mk(46, 160, 120, 1300),
+  mk(240, 200, 60, 1200),
+  mk(110, 60, 110, 600) // gradient average
+]
+
+const hueDist = (a: number, b: number): number => {
+  const d = Math.abs(a * 360 - b * 360) % 360
+
+  return d > 180 ? 360 - d : d
+}
+
+describe('buildColorsFromPalette — token validity', () => {
+  for (const wantDark of [true, false]) {
+    const label = wantDark ? 'dark' : 'light'
+    const c = buildColorsFromPalette(palette, wantDark)
+
+    it(`[${label}] all tokens are 6-digit hex`, () => {
+      for (const [k, v] of Object.entries(c)) {
+        expect(v, k).toMatch(HEX)
+      }
+    })
+
+    it(`[${label}] required keys present`, () => {
+      for (const k of REQUIRED) {
+        expect(typeof c[k], k).toBe('string')
+      }
+    })
+
+    it(`[${label}] bg equals slot-1 swatch VERBATIM`, () => {
+      expect(c.background.toLowerCase()).toBe(palette[0].hex.toLowerCase())
+    })
+
+    it(`[${label}] fg equals slot-2 swatch VERBATIM`, () => {
+      expect(c.foreground.toLowerCase()).toBe(palette[1].hex.toLowerCase())
+    })
+
+    it(`[${label}] primary equals first chromatic swatch VERBATIM`, () => {
+      expect(c.primary.toLowerCase()).toBe(palette[1].hex.toLowerCase())
+    })
+
+    it(`[${label}] mutedFg contrast >= 4.5`, () => {
+      expect(contrast(c.mutedForeground, c.background)).toBeGreaterThanOrEqual(4.5)
+    })
+
+    it(`[${label}] terminal palette: 16 ANSI slots are hex`, () => {
+      const t = ansiPalette(palette, c.background, palette[1].hex)
+
+      const ansiKeys = [
+        'black',
+        'red',
+        'green',
+        'yellow',
+        'blue',
+        'magenta',
+        'cyan',
+        'white',
+        'brightBlack',
+        'brightRed',
+        'brightGreen',
+        'brightYellow',
+        'brightBlue',
+        'brightMagenta',
+        'brightCyan',
+        'brightWhite'
+      ] as const
+
+      for (const k of ansiKeys) {
+        expect(t[k], k).toMatch(HEX)
+      }
+
+      expect(typeof t.foreground).toBe('string')
+      expect(typeof t.cursor).toBe('string')
+    })
+
+    it(`[${label}] terminal fg equals slot-2 swatch VERBATIM`, () => {
+      const t = ansiPalette(palette, c.background, palette[1].hex)
+      expect(t.foreground?.toLowerCase()).toBe(palette[1].hex.toLowerCase())
+    })
+
+    it(`[${label}] ANSI colors visible on term bg`, () => {
+      const t = ansiPalette(palette, c.background, palette[1].hex)
+      // black (dark bg) and white (light bg) are intentionally near-background
+      // — standard terminal behavior — so exclude them from the visibility
+      // floor. Luminance-based, NOT mode-based: verbatim backgrounds can be
+      // dark even in the light variant, and the near-bg ANSI slot should
+      // follow the ACTUAL bg.
+      const bgLum = luminance(c.background)
+
+      const ansiKeys = [
+        'black',
+        'red',
+        'green',
+        'yellow',
+        'blue',
+        'magenta',
+        'cyan',
+        'white',
+        'brightBlack',
+        'brightRed',
+        'brightGreen',
+        'brightYellow',
+        'brightBlue',
+        'brightMagenta',
+        'brightCyan',
+        'brightWhite'
+      ] as const
+
+      const visKeys = ansiKeys.filter(k => !(bgLum < 0.5 && k === 'black') && !(bgLum >= 0.5 && k === 'white'))
+
+      for (const k of visKeys) {
+        expect(contrast(t[k]!, c.background), k).toBeGreaterThanOrEqual(1.4)
+      }
+    })
+  }
+})
+
+describe('synthesize — full theme shape', () => {
+  const meta = { name: 'forge-test', label: 'Forge · test', mode: 'dark' as ForgeMode }
+  const theme = synthesize(palette, meta)
+
+  it('passes the isValidTheme bar (name/label/colors + required)', () => {
+    expect(theme.name).toBeTruthy()
+    expect(theme.label).toBeTruthy()
+
+    for (const k of REQUIRED) {
+      expect(typeof theme.colors[k], k).toBe('string')
+    }
+  })
+
+  it('label carries through', () => {
+    expect(theme.label).toBe('Forge · test')
+  })
+
+  it('reorder-safe synthesis', () => {
+    const reordered = [palette[1], ...palette.slice(0, 1), ...palette.slice(2)]
+    const t2 = synthesize(reordered, meta)
+
+    for (const k of REQUIRED) {
+      expect(typeof t2.colors[k], k).toBe('string')
+    }
+
+    expect(typeof t2.terminal.red).toBe('string')
+  })
+})
+
+describe('deriveSwatches — v1-era theme recovery', () => {
+  const meta = { name: 'forge-test', label: 'test', mode: 'dark' as ForgeMode }
+  const theme = synthesize(palette, meta)
+  const derived = deriveSwatches(theme)
+
+  it('recovers 4-8 swatches from tokens', () => {
+    expect(derived.length).toBeGreaterThanOrEqual(4)
+    expect(derived.length).toBeLessThanOrEqual(8)
+  })
+
+  it('every swatch has valid hex + hsl', () => {
+    for (const s of derived) {
+      expect(s.hex).toMatch(HEX)
+      expect(typeof s.hsl.h).toBe('number')
+    }
+  })
+
+  it('resynthesis round-trip', () => {
+    const t3 = synthesize(derived, meta)
+
+    for (const k of REQUIRED) {
+      expect(typeof t3.colors[k], k).toBe('string')
+    }
+
+    expect(typeof t3.terminal.green).toBe('string')
+  })
+})
+
+describe('HSL ↔ HEX round-trip', () => {
+  it('round-trips within tolerance', () => {
+    const wheelColors = [mk(13, 47, 134, 5000), mk(255, 120, 50, 4000), mk(46, 160, 120, 3000), mk(240, 235, 220, 2000)]
+
+    for (const c of wheelColors) {
+      const back = hslToHex(c.hsl.h, c.hsl.s, c.hsl.l)
+      const hsl = hexToHsl(back)
+      expect(back).toMatch(HEX)
+      expect(hsl).toBeTruthy()
+      expect(Math.abs(hsl!.h - c.hsl.h)).toBeLessThan(0.005)
+      expect(Math.abs(hsl!.s - c.hsl.s)).toBeLessThan(0.005)
+      expect(Math.abs(hsl!.l - c.hsl.l)).toBeLessThan(0.005)
+    }
+  })
+})
+
+describe('slot-1 background control', () => {
+  // Build an order where slot 1 is NOT the darkest color — old code would
+  // have ignored slot 1 and used the darkest anyway.
+  const teal = mk(46, 160, 120, 5000) // mid-tone teal, deliberately not darkest
+  const deepBlue = mk(13, 47, 134, 4000)
+  const ordered2 = [teal, deepBlue, mk(255, 120, 50, 3000), mk(255, 224, 196, 2000), mk(120, 30, 80, 1000)]
+  const themeA = synthesize(ordered2, { name: 'x', label: 'x', mode: 'dark' })
+  const bgA = themeA.darkColors.background
+
+  it('dark bg hue follows teal seed', () => {
+    expect(hueDist(rgbToHsl(...hexToRgb(bgA)!).h, teal.hsl.h)).toBeLessThan(35)
+  })
+
+  it('teal seed lands bg VERBATIM', () => {
+    expect(bgA.toLowerCase()).toBe(teal.hex.toLowerCase())
+  })
+
+  it('swap changes bg hue', () => {
+    const ordered3 = [deepBlue, teal, mk(255, 120, 50, 3000), mk(255, 224, 196, 2000), mk(120, 30, 80, 1000)]
+    const themeB = synthesize(ordered3, { name: 'x', label: 'x', mode: 'dark' })
+    const bgB = themeB.darkColors.background
+    expect(hueDist(rgbToHsl(...hexToRgb(bgB)!).h, deepBlue.hsl.h)).toBeLessThan(35)
+    expect(hueDist(rgbToHsl(...hexToRgb(bgA)!).h, rgbToHsl(...hexToRgb(bgB)!).h)).toBeGreaterThan(20)
+  })
+
+  it('light bg keeps seed VERBATIM', () => {
+    const themeC = synthesize([deepBlue, teal, mk(255, 224, 196, 2000)], { name: 'x', label: 'x', mode: 'light' })
+    expect(themeC.colors.background.toLowerCase()).toBe(deepBlue.hex.toLowerCase())
+  })
+
+  it('bright seed lands bg VERBATIM (no blending to dark)', () => {
+    const themeD = synthesize([mk(255, 224, 196, 5000), teal, deepBlue], { name: 'x', label: 'x', mode: 'dark' })
+    expect(themeD.darkColors.background.toLowerCase()).toBe(mk(255, 224, 196, 5000).hex.toLowerCase())
+  })
+})
+
+describe('slot-2 foreground control', () => {
+  // Use distinct swatches so hue swaps are observable. Background is a realistic
+  // dark (deepBlue) so the contrast floor is a no-op and the verbatim
+  // carry-through is visible. (A dedicated floor suite below checks the
+  // disaster case.)
+  const deepBlue = mk(13, 47, 134, 4000)
+  const softPink = mk(230, 150, 160, 1200)
+  const skyBlue = mk(120, 180, 255, 1100)
+  const slot2Base = [deepBlue, softPink, skyBlue, mk(255, 120, 50, 3000), mk(120, 30, 80, 2000)]
+  const themeFG1 = synthesize(slot2Base, { name: 'x', label: 'x', mode: 'dark' })
+
+  const themeFG2 = synthesize([deepBlue, skyBlue, softPink, mk(255, 120, 50, 3000), mk(120, 30, 80, 2000)], {
+    name: 'x',
+    label: 'x',
+    mode: 'dark'
+  })
+
+  it('swapping slot 2 changes dark fg hue', () => {
+    const h1 = rgbToHsl(...hexToRgb(themeFG1.darkColors.foreground)!).h
+    const h2 = rgbToHsl(...hexToRgb(themeFG2.darkColors.foreground)!).h
+    expect(hueDist(h1, h2)).toBeGreaterThan(15)
+  })
+
+  it('dark fg equals slot-2 swatch VERBATIM', () => {
+    expect(themeFG1.darkColors.foreground.toLowerCase()).toBe(softPink.hex.toLowerCase())
+  })
+
+  it('light fg equals slot-2 swatch VERBATIM', () => {
+    expect(themeFG1.colors.foreground.toLowerCase()).toBe(softPink.hex.toLowerCase())
+  })
+
+  it('fg keeps seed chroma (sat > 0.08)', () => {
+    const fg1Sat = rgbToHsl(...hexToRgb(themeFG1.darkColors.foreground)!).s
+    const fg2Sat = rgbToHsl(...hexToRgb(themeFG2.darkColors.foreground)!).s
+    expect(fg1Sat).toBeGreaterThan(0.08)
+    expect(fg2Sat).toBeGreaterThan(0.08)
+  })
+
+  it('light seed fg does not collapse to white', () => {
+    const lightSeedFG = mk(240, 235, 220, 4000)
+    const deepBlue = mk(13, 47, 134, 4000)
+    const t = synthesize([deepBlue, lightSeedFG, skyBlue], { name: 'x', label: 'x', mode: 'dark' })
+    expect(t.darkColors.foreground.toLowerCase()).not.toBe('#ffffff')
+    expect(t.darkColors.foreground.toLowerCase()).toBe(lightSeedFG.hex.toLowerCase())
+  })
+
+  it('single swatch still derives fg (different from bg)', () => {
+    const themeSingle = synthesize([softPink], { name: 'x', label: 'x', mode: 'dark' })
+    expect(typeof themeSingle.darkColors.foreground).toBe('string')
+    expect(themeSingle.darkColors.foreground.toLowerCase()).not.toBe(themeSingle.darkColors.background.toLowerCase())
+  })
+})
+
+describe('terminal fg follows slot 2', () => {
+  const softPink = mk(230, 150, 160, 1200)
+  const skyBlue = mk(120, 180, 255, 1100)
+  const deepBlue = mk(13, 47, 134, 4000)
+  const slot2Base = [deepBlue, softPink, skyBlue, mk(255, 120, 50, 3000), mk(120, 30, 80, 2000)]
+  const themeFG1 = synthesize(slot2Base, { name: 'x', label: 'x', mode: 'dark' })
+
+  const themeFG2 = synthesize([deepBlue, skyBlue, softPink, mk(255, 120, 50, 3000), mk(120, 30, 80, 2000)], {
+    name: 'x',
+    label: 'x',
+    mode: 'dark'
+  })
+
+  const termFG1 = themeFG1.darkTerminal.foreground!
+  const termFG2 = themeFG2.darkTerminal.foreground!
+
+  it('not hardcoded white/black', () => {
+    expect(termFG1.toLowerCase()).not.toBe('#ffffff')
+    expect(termFG1.toLowerCase()).not.toBe('#000000')
+  })
+
+  it('follows slot-2 seed hue', () => {
+    expect(hueDist(rgbToHsl(...hexToRgb(termFG1)!).h, softPink.hsl.h)).toBeLessThan(40)
+  })
+
+  it('swapping slot 2 changes terminal fg', () => {
+    expect(termFG1).not.toBe(termFG2)
+    expect(hueDist(rgbToHsl(...hexToRgb(termFG1)!).h, rgbToHsl(...hexToRgb(termFG2)!).h)).toBeGreaterThan(15)
+  })
+
+  it('terminal fg equals slot-2 swatch VERBATIM', () => {
+    expect(termFG1.toLowerCase()).toBe(softPink.hex.toLowerCase())
+  })
+
+  it('no slot 2 falls back to readable (valid hex, != bg)', () => {
+    const themeSingle = synthesize([softPink], { name: 'x', label: 'x', mode: 'dark' })
+    expect(themeSingle.darkTerminal.foreground).toMatch(HEX)
+    expect(themeSingle.darkTerminal.foreground!.toLowerCase()).not.toBe(themeSingle.darkColors.background.toLowerCase())
+  })
+})
+
+describe('contrast floor — tripwire', () => {
+  // The disaster the floor exists for: near-black bg + near-black text must be
+  // nudged to a readable ratio, while a deliberately readable pair stays verbatim.
+  const FLOOR = 3
+  const nearBlackBg = mk(8, 8, 10, 5000) // ~#08080a
+  const nearBlackFg = mk(12, 12, 14, 2000) // ~#0c0c0e (contrast ~1.1:1 on bg)
+  const floorTheme = synthesize([nearBlackBg, nearBlackFg], { name: 'floor', label: 'floor', mode: 'dark' })
+  const floorFG = floorTheme.darkColors.foreground
+
+  it('near-black text is nudged readable (>= 3:1)', () => {
+    expect(contrast(floorFG, floorTheme.darkColors.background)).toBeGreaterThanOrEqual(FLOOR)
+  })
+
+  it('nudged fg is NOT the original (actually changed)', () => {
+    expect(floorFG.toLowerCase()).not.toBe(nearBlackFg.hex.toLowerCase())
+  })
+
+  it('nudged fg is a valid hex', () => {
+    expect(floorFG).toMatch(HEX)
+  })
+
+  it('terminal fg follows same floor', () => {
+    expect(contrast(floorTheme.darkTerminal.foreground!, floorTheme.darkColors.background)).toBeGreaterThanOrEqual(
+      FLOOR
+    )
+  })
+
+  it('near-white light-mode text nudged readable (>= 3:1)', () => {
+    const nearWhiteBg = mk(250, 250, 252, 5000)
+    const nearWhiteFg = mk(248, 248, 250, 2000)
+    const floorLight = synthesize([nearWhiteBg, nearWhiteFg], { name: 'floor', label: 'floor', mode: 'light' })
+    expect(contrast(floorLight.colors.foreground, floorLight.colors.background)).toBeGreaterThanOrEqual(FLOOR)
+  })
+
+  it('readable pair stays VERBATIM (floor is no-op)', () => {
+    // softPink on deepBlue is ~5.8:1 (> 3) so the floor is a no-op.
+    const deepBlue = mk(13, 47, 134, 4000)
+    const softPink = mk(230, 150, 160, 1200)
+    const t = synthesize([deepBlue, softPink, mk(120, 180, 255, 1100)], { name: 'x', label: 'x', mode: 'dark' })
+    expect(t.darkColors.foreground.toLowerCase()).toBe(softPink.hex.toLowerCase())
+  })
+
+  it('light seed fg VERBATIM on dark bg (no over-nudge to pure white)', () => {
+    const deepBlue = mk(13, 47, 134, 4000)
+    const lightSeedFG = mk(240, 235, 220, 4000)
+    const t = synthesize([deepBlue, lightSeedFG, mk(120, 180, 255, 1100)], { name: 'x', label: 'x', mode: 'dark' })
+    expect(t.darkColors.foreground.toLowerCase()).toBe(lightSeedFG.hex.toLowerCase())
+  })
+})
+
+describe('stripForgePrefix — sleek naming', () => {
+  it('removes auto prefix', () => {
+    expect(stripForgePrefix('Forge · Sunset')).toBe('Sunset')
+  })
+
+  it('is case/separator tolerant', () => {
+    expect(stripForgePrefix('forge•  Aurora')).toBe('Aurora')
+  })
+
+  it('intentional Forge names preserved', () => {
+    expect(stripForgePrefix('Dark Forge')).toBe('Dark Forge')
+    expect(stripForgePrefix('Forge Midnight')).toBe('Forge Midnight')
+  })
+
+  it('empty-result fallback keeps original', () => {
+    expect(stripForgePrefix('Forge · ')).toBe('Forge · ')
+  })
+})

--- a/apps/desktop/src/plugins/theme-forge/forge.ts
+++ b/apps/desktop/src/plugins/theme-forge/forge.ts
@@ -1,0 +1,695 @@
+/**
+ * Theme Forge — color math, palette extraction, and theme synthesis.
+ *
+ * Everything here is renderer-safe pure logic except `extractPalette` /
+ * `thumbOf`, which need a canvas. The verbatim contract is the whole point:
+ * slot 1 IS the background, slot 2 IS the text color (UI + terminal), and the
+ * first chromatic swatch IS the accent — the exact color the user places is
+ * the exact color that lands in the theme. Secondary tokens (muted text,
+ * borders) still get contrast-safe derivation.
+ */
+
+// ── types ───────────────────────────────────────────────────────────────────
+// Structural matches of the app's `DesktopTheme` / `DesktopThemeColors` /
+// `DesktopTerminalPalette` (src/themes/types.ts) — the plugin fence keeps
+// bundled plugins on `@hermes/plugin-sdk` imports only, so the shapes are
+// redeclared here and passed through `THEMES_AREA` as contribution data.
+
+export interface ForgeColors {
+  background: string
+  foreground: string
+  card: string
+  cardForeground: string
+  muted: string
+  mutedForeground: string
+  popover: string
+  popoverForeground: string
+  primary: string
+  primaryForeground: string
+  secondary: string
+  secondaryForeground: string
+  accent: string
+  accentForeground: string
+  border: string
+  input: string
+  ring: string
+  midground?: string
+  composerRing?: string
+  destructive: string
+  destructiveForeground: string
+  sidebarBackground?: string
+  sidebarBorder?: string
+  userBubble?: string
+  userBubbleBorder?: string
+}
+
+export interface ForgeTerminalPalette {
+  foreground?: string
+  cursor?: string
+  selectionBackground?: string
+  black?: string
+  red?: string
+  green?: string
+  yellow?: string
+  blue?: string
+  magenta?: string
+  cyan?: string
+  white?: string
+  brightBlack?: string
+  brightRed?: string
+  brightGreen?: string
+  brightYellow?: string
+  brightBlue?: string
+  brightMagenta?: string
+  brightCyan?: string
+  brightWhite?: string
+}
+
+export interface ForgeTheme {
+  name: string
+  label: string
+  description: string
+  colors: ForgeColors
+  darkColors: ForgeColors
+  terminal: ForgeTerminalPalette
+  darkTerminal: ForgeTerminalPalette
+}
+
+export interface Swatch {
+  hex: string
+  hsl: Hsl
+  weight: number
+}
+
+export interface Hsl {
+  h: number
+  s: number
+  l: number
+}
+
+export type ForgeMode = 'dark' | 'light'
+
+/** A persisted forged theme — the `ctx.storage` entry shape. */
+export interface ForgeEntry {
+  name: string
+  label: string
+  mode: ForgeMode
+  swatches: Swatch[]
+  theme: ForgeTheme
+  /** Downscaled JPEG data-URL of the source image (reforge after restarts). */
+  source: string | null
+  forgedAt: number
+}
+
+// ── color math ──────────────────────────────────────────────────────────────
+
+export const rgbToHex = (r: number, g: number, b: number): string =>
+  '#' +
+  [r, g, b]
+    .map(n =>
+      Math.round(Math.min(255, Math.max(0, n)))
+        .toString(16)
+        .padStart(2, '0')
+    )
+    .join('')
+
+export const hexToRgb = (hex: string): [number, number, number] | null => {
+  const c = String(hex).trim().replace(/^#/, '')
+
+  if (!/^[0-9a-f]{6}$/i.test(c)) {
+    return null
+  }
+
+  return [0, 2, 4].map(i => parseInt(c.slice(i, i + 2), 16)) as [number, number, number]
+}
+
+export const mix = (a: string, b: string, t: number): string => {
+  const A = hexToRgb(a)
+  const B = hexToRgb(b)
+
+  return A && B ? rgbToHex(A[0] + (B[0] - A[0]) * t, A[1] + (B[1] - A[1]) * t, A[2] + (B[2] - A[2]) * t) : a
+}
+
+const lin = (c: number): number => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4)
+
+export const luminance = (hex: string): number => {
+  const rgb = hexToRgb(hex)
+
+  if (!rgb) {
+    return 0
+  }
+
+  const [r, g, b] = rgb.map(v => lin(v / 255))
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+export const contrast = (a: string, b: string): number => {
+  const la = luminance(a)
+  const lb = luminance(b)
+
+  return la >= lb ? (la + 0.05) / (lb + 0.05) : (lb + 0.05) / (la + 0.05)
+}
+
+export const readableOn = (bg: string): string => (luminance(bg) > 0.58 ? '#161616' : '#ffffff')
+
+/**
+ * Tripwire floor for the verbatim foreground (slot-2) color. WCAG body-text
+ * target is 4.5:1, but the user's whole point of a verbatim slot-2 is to place
+ * an exact accent/text color — so the floor is deliberately the LARGE-TEXT bar
+ * (3:1), a "you can't read this at all" tripwire, not a readability rule.
+ * ensureContrast is a no-op above it, so readable low-contrast accents pass
+ * through untouched; only a near-black-on-near-black hard illegibility nudges
+ * toward the correct polarity just enough to clear the bar. Keeps creative
+ * freedom while guaranteeing the theme is never literally unreadable.
+ */
+export const FORGE_TEXT_FLOOR = 3
+
+export const ensureContrast = (color: string, bg: string, min: number): string => {
+  if (contrast(color, bg) >= min) {
+    return color
+  }
+
+  const toward = luminance(bg) < 0.5 ? '#ffffff' : '#000000'
+  let best = color
+
+  for (let t = 0.1; t <= 1.001; t += 0.1) {
+    const c = mix(color, toward, t)
+
+    if (contrast(c, bg) > contrast(best, bg)) {
+      best = c
+    }
+
+    if (contrast(c, bg) >= min) {
+      return c
+    }
+  }
+
+  return readableOn(bg)
+}
+
+export function rgbToHsl(r: number, g: number, b: number): Hsl {
+  r /= 255
+  g /= 255
+  b /= 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  let h = 0
+  let s = 0
+
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+
+        break
+
+      case g:
+        h = ((b - r) / d + 2) / 6
+
+        break
+
+      default:
+        h = ((r - g) / d + 4) / 6
+    }
+  }
+
+  return { h, s, l }
+}
+
+export function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  let r: number
+  let g: number
+  let b: number
+
+  if (s === 0) {
+    r = g = b = l
+  } else {
+    const hue2rgb = (p: number, q: number, t: number): number => {
+      if (t < 0) {
+        t += 1
+      }
+
+      if (t > 1) {
+        t -= 1
+      }
+
+      if (t < 1 / 6) {
+        return p + (q - p) * 6 * t
+      }
+
+      if (t < 1 / 2) {
+        return q
+      }
+
+      if (t < 2 / 3) {
+        return p + (q - p) * (2 / 3 - t) * 6
+      }
+
+      return p
+    }
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+    const p = 2 * l - q
+    r = hue2rgb(p, q, h + 1 / 3)
+    g = hue2rgb(p, q, h)
+    b = hue2rgb(p, q, h - 1 / 3)
+  }
+
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)]
+}
+
+export const hexToHsl = (hex: string): Hsl | null => {
+  const rgb = hexToRgb(hex)
+
+  return rgb ? rgbToHsl(rgb[0], rgb[1], rgb[2]) : null
+}
+
+export const hslToHex = (h: number, s: number, l: number): string => {
+  const [r, g, b] = hslToRgb(h, s, l)
+
+  return rgbToHex(r, g, b)
+}
+
+// ── palette extraction: median-cut ──────────────────────────────────────────
+
+export function extractPalette(imgEl: HTMLImageElement, maxColors = 12): Swatch[] {
+  const w = imgEl.naturalWidth || imgEl.width
+  const h = imgEl.naturalHeight || imgEl.height
+  const side = 256
+  const scale = Math.min(1, side / Math.max(w, h))
+  const cw = Math.max(1, Math.round(w * scale))
+  const ch = Math.max(1, Math.round(h * scale))
+
+  const canvas = document.createElement('canvas')
+  canvas.width = cw
+  canvas.height = ch
+  const g2d = canvas.getContext('2d', { willReadFrequently: true })
+
+  if (!g2d) {
+    throw new Error('Canvas 2D context unavailable')
+  }
+
+  g2d.drawImage(imgEl, 0, 0, cw, ch)
+
+  const data = g2d.getImageData(0, 0, cw, ch).data
+  const px: number[][] = []
+
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i + 3] < 128) {
+      continue
+    }
+
+    px.push([data[i], data[i + 1], data[i + 2]])
+  }
+
+  if (px.length < 8) {
+    throw new Error('Image has no usable pixels (too small or transparent)')
+  }
+
+  let boxes = [px]
+
+  while (boxes.length < maxColors) {
+    let bi = 0
+    let bestRange = -1
+    let bestCh = 0
+    boxes.forEach((box, idx) => {
+      for (let ch2 = 0; ch2 < 3; ch2++) {
+        let lo = 255
+        let hi = 0
+
+        for (const p of box) {
+          if (p[ch2] < lo) {
+            lo = p[ch2]
+          }
+
+          if (p[ch2] > hi) {
+            hi = p[ch2]
+          }
+        }
+
+        if (hi - lo > bestRange) {
+          bestRange = hi - lo
+          bestCh = ch2
+          bi = idx
+        }
+      }
+    })
+
+    if (bestRange <= 0) {
+      break
+    }
+
+    const box = boxes[bi]
+    box.sort((a, b) => a[bestCh] - b[bestCh])
+    const mid = Math.floor(box.length / 2)
+    boxes.splice(bi, 1, box.slice(0, mid), box.slice(mid))
+  }
+
+  return boxes
+    .filter(b => b.length > 0)
+    .map(b => {
+      let r = 0
+      let g = 0
+      let bl = 0
+
+      for (const p of b) {
+        r += p[0]
+        g += p[1]
+        bl += p[2]
+      }
+
+      const n = b.length
+      const hex = rgbToHex(r / n, g / n, bl / n)
+
+      return { hex, hsl: rgbToHsl(r / n, g / n, bl / n), weight: n }
+    })
+    .sort((a, b) => b.weight - a.weight)
+}
+
+/** Downscale to a small JPEG data-URL so sources survive restarts cheaply. */
+export function thumbOf(imgEl: HTMLImageElement): string {
+  const w = imgEl.naturalWidth || imgEl.width
+  const h = imgEl.naturalHeight || imgEl.height
+  const side = 128
+  const s = Math.min(1, side / Math.max(w, h))
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.max(1, Math.round(w * s))
+  canvas.height = Math.max(1, Math.round(h * s))
+  const g = canvas.getContext('2d')
+
+  if (!g) {
+    throw new Error('Canvas 2D context unavailable')
+  }
+
+  g.drawImage(imgEl, 0, 0, canvas.width, canvas.height)
+
+  return canvas.toDataURL('image/jpeg', 0.75)
+}
+
+// ── theme synthesis ─────────────────────────────────────────────────────────
+// Swatch ORDER is user-editable: index 0 seeds the background, remaining
+// swatches rank as accent priority (most-chromatic slot first).
+
+export const slugify = (s: string): string =>
+  String(s)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40) || 'forged'
+
+export function ansiPalette(ordered: Swatch[], bg: string, fgSeed: string | null): ForgeTerminalPalette {
+  const bgL = luminance(bg)
+  const darkBg = bgL < 0.5
+  // accent priority = swatches after the bg seed, chromatic ones first
+  const chroma = ordered.slice(1).filter(c => c.hsl.s > 0.12)
+  const fallbacks = ordered.slice(1).filter(c => c.hsl.s <= 0.12)
+  const pool = [...chroma, ...fallbacks]
+
+  const pick = (hLo: number, hHi: number, fi: number): string => {
+    const hit = chroma.find(c => {
+      const h = c.hsl.h * 360
+
+      return h >= hLo && h < hHi
+    })
+
+    const alt = pool.find((c, i) => i === fi % Math.max(1, pool.length))
+
+    return (hit || alt || ordered[0]).hex
+  }
+
+  const tune = (hex: string, lift: number): string =>
+    darkBg ? ensureContrast(mix(hex, '#ffffff', lift), bg, 3) : ensureContrast(mix(hex, '#000000', lift * 0.8), bg, 3)
+
+  const black = darkBg ? mix(bg, '#ffffff', 0.08) : mix(bg, '#000000', 0.55)
+  const white = darkBg ? mix(bg, '#ffffff', 0.85) : mix(bg, '#000000', 0.08)
+
+  return {
+    // Terminal body text follows the slot-2 swatch VERBATIM — the exact color
+    // the user places is the terminal foreground. Tripwire floor applies: a
+    // no-op above FORGE_TEXT_FLOOR, nudges only when the pair is unreadable.
+    foreground: fgSeed ? ensureContrast(fgSeed, bg, FORGE_TEXT_FLOOR) : readableOn(bg),
+    cursor: tune(pick(150, 260, 0), 0.2),
+    selectionBackground: darkBg ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.14)',
+    black,
+    red: tune(pick(345, 381, 0), 0.1),
+    green: tune(pick(80, 160, 1), 0.1),
+    yellow: tune(pick(40, 70, 2), 0.1),
+    blue: tune(pick(200, 260, 3), 0.1),
+    magenta: tune(pick(280, 345, 4), 0.1),
+    cyan: tune(pick(160, 200, 5), 0.1),
+    white,
+    brightBlack: mix(black, white, darkBg ? 0.35 : 0.25),
+    brightRed: mix(tune(pick(345, 381, 0), 0.1), white, darkBg ? 0.25 : 0),
+    brightGreen: mix(tune(pick(80, 160, 1), 0.1), white, darkBg ? 0.25 : 0),
+    brightYellow: mix(tune(pick(40, 70, 2), 0.1), white, darkBg ? 0.25 : 0),
+    brightBlue: mix(tune(pick(200, 260, 3), 0.1), white, darkBg ? 0.25 : 0),
+    brightMagenta: mix(tune(pick(280, 345, 4), 0.1), white, darkBg ? 0.25 : 0),
+    brightCyan: mix(tune(pick(160, 200, 5), 0.1), white, darkBg ? 0.25 : 0),
+    brightWhite: mix(white, darkBg ? '#ffffff' : '#000000', darkBg ? 0.4 : 0.18)
+  }
+}
+
+export function buildColorsFromPalette(ordered: Swatch[], wantDark: boolean): ForgeColors {
+  const seed = ordered[0] || {
+    hex: wantDark ? '#101014' : '#fafafa',
+    hsl: { h: 0, s: 0, l: wantDark ? 0.06 : 0.97 },
+    weight: 0
+  }
+
+  const rest = ordered.slice(1)
+  const byLum = [...rest].sort((a, b) => a.hsl.l - b.hsl.l)
+
+  const chromaRank = [...rest].sort(
+    (a, b) => b.hsl.s * (1 - Math.abs(b.hsl.l - 0.5)) - a.hsl.s * (1 - Math.abs(a.hsl.l - 0.5))
+  )
+
+  // accent = first chromatic swatch in USER order (priority), else chroma rank
+  const userAccent = rest.find(c => c.hsl.s > 0.12)
+  const accentRaw = userAccent || chromaRank[0] || seed
+
+  // ── Background: slot 1 IS the background color, VERBATIM. No lightness
+  // enforcement, no mix-toward-black/white: the color the user places in
+  // slot 1 is exactly the background the theme uses.
+  const background = seed.hex
+
+  // Foreground: slot 2 IS the foreground/text color, starting point. The
+  // exact color the user places in slot 2 is the text color the theme uses
+  // (UI + terminal) — this is the fix for "swapped swatches and text never
+  // visibly changed": the old code blended every slot-2 seed toward
+  // near-white/near-black for contrast, so the swap never showed THAT color.
+  //
+  // Tripwire floor (below): the verbatim contract is preserved UNLESS the pair
+  // is genuinely unreadable (near-black text on a near-black bg). ensureContrast
+  // is a no-op above the floor, so deliberate, readable low-contrast choices
+  // pass through untouched — freedom kept. Only a hard illegibility (contrast
+  // < FORGE_TEXT_FLOOR) nudges toward the correct polarity, just enough to clear
+  // the floor. This is the backstop the user asked for after landing on a
+  // super-dark, unreadable theme.
+  let foreground: string
+
+  if (ordered.length >= 2) {
+    foreground = ordered[1].hex
+  } else {
+    if (wantDark) {
+      foreground = (byLum[byLum.length - 1] || seed).hex
+
+      if (luminance(foreground) < 0.55) {
+        foreground = mix(foreground, '#ffffff', 0.75)
+      }
+    } else {
+      foreground = (byLum[0] || seed).hex
+
+      if (luminance(foreground) > 0.35) {
+        foreground = mix(foreground, '#060608', 0.7)
+      }
+    }
+  }
+
+  foreground = ensureContrast(foreground, background, FORGE_TEXT_FLOOR)
+
+  const accentSafe = accentRaw.hex
+  const card = wantDark ? mix(background, '#ffffff', 0.045) : mix(background, '#000000', 0.015)
+  const muted = wantDark ? mix(background, '#ffffff', 0.07) : mix(background, '#000000', 0.045)
+  const mutedFg = ensureContrast(mix(foreground, background, 0.42), background, 4.5)
+  const border = wantDark ? mix(background, '#ffffff', 0.14) : mix(background, '#000000', 0.13)
+
+  return {
+    background,
+    // Slot-2 color is the text color, verbatim — no contrast re-mix so the
+    // swap shows THAT color on screen. (Readability is the user's call now.)
+    foreground,
+    card,
+    cardForeground: foreground,
+    muted,
+    mutedForeground: mutedFg,
+    popover: card,
+    popoverForeground: foreground,
+    primary: accentSafe,
+    primaryForeground: readableOn(accentSafe),
+    secondary: mix(muted, accentSafe, 0.12),
+    secondaryForeground: ensureContrast(foreground, muted, 5),
+    accent: mix(muted, accentSafe, 0.22),
+    accentForeground: ensureContrast(foreground, mix(muted, accentSafe, 0.22), 5),
+    border,
+    input: border,
+    ring: accentSafe,
+    midground: accentSafe,
+    composerRing: accentSafe,
+    destructive: ensureContrast(wantDark ? '#c0473a' : '#c72e4d', background, 3),
+    destructiveForeground: '#ffffff',
+    sidebarBackground: wantDark ? mix(background, '#000000', 0.16) : mix(background, '#000000', 0.03),
+    sidebarBorder: wantDark ? mix(border, '#ffffff', 0.02) : border,
+    userBubble: mix(muted, accentSafe, 0.16),
+    userBubbleBorder: mix(border, accentSafe, 0.3)
+  }
+}
+
+/** Build the full DesktopTheme from an ORDERED swatch list. */
+export function synthesize(ordered: Swatch[], meta: { name: string; label: string; mode: ForgeMode }): ForgeTheme {
+  const darkColors = buildColorsFromPalette(ordered, true)
+  const lightColors = buildColorsFromPalette(ordered, false)
+  const primary = meta.mode === 'light' ? lightColors : darkColors
+  // Slot 2 (index 1) is the TEXT seed — feed its raw hue to the terminal
+  // palette so the terminal's body text follows the same swatch as the UI.
+  const textSeed = ordered.length >= 2 ? ordered[1].hex : null
+
+  return {
+    name: meta.name,
+    label: meta.label,
+    description: 'Forged from an image · theme-forge plugin',
+    colors: primary,
+    darkColors,
+    terminal: ansiPalette(ordered, primary.background, textSeed),
+    darkTerminal: ansiPalette(ordered, darkColors.background, textSeed)
+  }
+}
+
+/**
+ * Recover a swatch list from a theme's own tokens — for v1-era entries that
+ * never stored their extracted palette. Order follows the tray's semantics:
+ * slot 1 = background seed, rest = accent priority.
+ */
+export function deriveSwatches(theme: ForgeTheme): Swatch[] {
+  const c = theme.darkColors || theme.colors || ({} as ForgeColors)
+  const t = theme.darkTerminal || theme.terminal || ({} as ForgeTerminalPalette)
+
+  const candidates = [
+    c.background,
+    c.primary,
+    c.foreground,
+    t.red,
+    t.green,
+    t.blue,
+    t.yellow,
+    t.magenta,
+    t.cyan,
+    c.destructive,
+    c.accent,
+    c.secondary
+  ]
+
+  const seen = new Set<string>()
+  const out: Swatch[] = []
+
+  for (const hex of candidates) {
+    if (typeof hex !== 'string' || !/^#[0-9a-f]{6}$/i.test(hex)) {
+      continue
+    }
+
+    const key = hex.toLowerCase()
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    const rgb = hexToRgb(hex)
+
+    if (!rgb) {
+      continue
+    }
+
+    out.push({ hex, hsl: rgbToHsl(rgb[0], rgb[1], rgb[2]), weight: 1000 - out.length })
+
+    if (out.length >= 8) {
+      break
+    }
+  }
+
+  return out
+}
+
+/**
+ * The plugin used to auto-prepend 'Forge · ' to every theme label. Sleek
+ * mode: strip ONLY that exact auto-injected prefix. Names that carry 'Forge'
+ * as part of the actual name ('Dark Forge', 'Forge Midnight') are untouched.
+ * Falls back to the original if stripping would empty the label.
+ */
+export const stripForgePrefix = (label: string | null | undefined): string => {
+  const raw = String(label || '')
+
+  return raw.replace(/^\s*forge\s*[·•]\s*/i, '').trim() || raw
+}
+
+/** Strict hex parse: 3- or 6-digit (#abc / #aabbcc) → normalized 6-digit, else null. */
+export const parseHexStrict = (v: string): string | null => {
+  const c = String(v).trim().replace(/^#/, '')
+
+  if (/^[0-9a-f]{3}$/i.test(c)) {
+    return (
+      '#' +
+      c
+        .split('')
+        .map(x => x + x)
+        .join('')
+    )
+  }
+
+  if (/^[0-9a-f]{6}$/i.test(c)) {
+    return '#' + c.toLowerCase()
+  }
+
+  return null
+}
+
+// ── forge pipeline (canvas-dependent) ───────────────────────────────────────
+
+export async function loadImageFromUrl(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const el = new Image()
+    el.onload = () => resolve(el)
+    el.onerror = () => reject(new Error('Could not decode that image'))
+    el.src = url
+  })
+}
+
+export async function forgeTheme(file: File, mode: ForgeMode): Promise<ForgeEntry> {
+  const url = URL.createObjectURL(file)
+
+  try {
+    const img = await loadImageFromUrl(url)
+    const palette = extractPalette(img, 12)
+    const baseName = file.name.replace(/\.[a-z0-9]+$/i, '')
+    const slug = slugify(baseName)
+    const label = baseName.length > 24 ? baseName.slice(0, 24) + '…' : baseName
+    const ordered = [...palette].sort((a, b) => b.weight - a.weight).slice(0, 8)
+    const themeName = `forge-${slug}`
+
+    return {
+      name: themeName,
+      label,
+      mode,
+      swatches: ordered,
+      theme: synthesize(ordered, { name: themeName, label, mode }),
+      source: thumbOf(img),
+      forgedAt: Date.now()
+    }
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}

--- a/apps/desktop/src/plugins/theme-forge/plugin.tsx
+++ b/apps/desktop/src/plugins/theme-forge/plugin.tsx
@@ -1,0 +1,1491 @@
+/**
+ * Theme Forge — turn any image into a full Hermes desktop theme.
+ *
+ * Drop/paste/browse an image; the palette engine extracts dominant colors
+ * (median-cut), maps them to DesktopTheme tokens, guarantees WCAG contrast,
+ * builds light + dark variants, and registers via `THEMES_AREA` — themes
+ * appear live in Settings → Appearance, ⌘K, and /skin.
+ *
+ * Pane features: dark/light forge mode, drag-to-reorder swatch priorities
+ * (re-synthesizes the theme live), inline rename, terminal ANSI preview,
+ * Apply (jumps to Appearance settings), reforge, delete. Sources are kept
+ * downscaled so themes can reforge after restarts.
+ *
+ * Bundled port of the standalone disk plugin
+ * (github.com/0-CYBERDYNE-SYSTEMS-0/theme-lab): same `HermesPlugin`
+ * contract, same verbatim swatch→theme contract, validated by the same
+ * 74-check color-math suite (see forge.test.ts).
+ *
+ * Ships OFF by default (`defaultEnabled: false`): it inventories in
+ * Settings ▸ Plugins and registers nothing until the user flips the switch.
+ */
+
+import {
+  atom,
+  Button,
+  cn,
+  haptic,
+  type HermesPlugin,
+  host,
+  icons,
+  Input,
+  PALETTE_AREA,
+  type PluginContext,
+  type PluginContribution,
+  type PluginStorage,
+  ScrollArea,
+  SegmentedControl,
+  THEMES_AREA,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useEffect, useRef, useState } from 'react'
+
+import {
+  deriveSwatches,
+  extractPalette,
+  type ForgeEntry,
+  type ForgeMode,
+  type ForgeTerminalPalette,
+  forgeTheme,
+  type ForgeTheme,
+  hexToHsl,
+  hslToHex,
+  loadImageFromUrl,
+  parseHexStrict,
+  readableOn,
+  stripForgePrefix,
+  type Swatch,
+  synthesize
+} from './forge'
+
+// ── reactive state (module-level, survives pane unmount) ────────────────────
+
+const $busy = atom(false)
+const $generated = atom<ForgeEntry[]>([]) // persisted themes (full objects) — single source of truth
+const $mode = atom<ForgeMode>('dark')
+const $expanded = atom<string | null>(null) // slug with terminal preview open
+const $editing = atom<string | null>(null) // slug being renamed
+const $picked = atom<{ slug: string; index: number } | null>(null) // swatch awaiting a new position
+const $viewMode = atom<'cards' | 'strip'>('cards') // strip = quiet swatch-only overview
+const $viewModeKey = 'theme-forge-viewMode'
+const $wheelOpen = atom<{ slug: string; index: number } | null>(null) // single inline color editor
+
+/** Strip mode is display-only; card mode is the editor. */
+function normalizeViewMode(v: string): 'cards' | 'strip' {
+  return v === 'strip' ? 'strip' : 'cards'
+}
+
+// ── active-skin detection ──────────────────────────────────────────────────
+// The app paints the active theme's slug onto <html data-hermes-theme="…">
+// (themes/context.tsx applyTheme). Reading it + a MutationObserver gives the
+// pane a live "which theme is applied" signal so we can light the active card
+// and pin it to the top of the list.
+const $forgeActiveSkin = atom<string | null>(null)
+
+function forgeReadActiveSkin(): string | null {
+  if (typeof window === 'undefined' || !document.documentElement) {
+    return null
+  }
+
+  return document.documentElement.dataset.hermesTheme || null
+}
+
+let forgeSkinObserver: MutationObserver | null = null
+
+function forgeEnsureSkinObserver(): void {
+  if (forgeSkinObserver || typeof window === 'undefined') {
+    return
+  }
+
+  forgeSkinObserver = new MutationObserver(() => {
+    const v = forgeReadActiveSkin()
+
+    if (v !== $forgeActiveSkin.get()) {
+      $forgeActiveSkin.set(v)
+    }
+  })
+  forgeSkinObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-hermes-theme'] })
+  $forgeActiveSkin.set(forgeReadActiveSkin())
+}
+
+function useForgeActiveSkin(): string | null {
+  const v = useValue($forgeActiveSkin)
+  useEffect(() => {
+    forgeEnsureSkinObserver()
+  }, [])
+
+  return v
+}
+
+/** Small indicator dot: lit when this theme is the one currently applied. */
+function ForgeActiveDot({ active }: { active: boolean }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: 999,
+        flexShrink: 0,
+        background: active ? 'var(--ui-accent)' : 'var(--ui-stroke-secondary)',
+        boxShadow: active ? '0 0 6px var(--ui-accent)' : 'none',
+        transition: 'background 0.15s ease, box-shadow 0.15s ease'
+      }}
+      title={active ? 'Currently applied' : 'Not applied'}
+    />
+  )
+}
+
+// ── persistence + registration ──────────────────────────────────────────────
+
+let storageRef: PluginStorage | null = null
+let registerRef: ((c: PluginContribution) => () => void) | null = null
+const disposersBySlug = new Map<string, () => void>()
+
+function registerTheme(theme: ForgeTheme): void {
+  if (!registerRef) {
+    return
+  }
+
+  const existing = disposersBySlug.get(theme.name)
+
+  if (existing) {
+    existing()
+  }
+
+  // Fresh object identity each call → the registry snapshot cache busts and
+  // the Appearance grid / active skin repaint live.
+  const dispose = registerRef({ id: `theme:${theme.name}`, area: THEMES_AREA, data: { ...theme } })
+  disposersBySlug.set(theme.name, dispose)
+}
+
+function saveThemes(list: ForgeEntry[]): void {
+  if (storageRef) {
+    storageRef.set('themes', list)
+  }
+
+  $generated.set(list)
+}
+
+function updateTheme(slug: string, patch: Partial<ForgeEntry>): ForgeEntry | undefined {
+  const list = storageRef ? storageRef.get<ForgeEntry[]>('themes', []) : []
+  const next = list.map(t => (t.name === slug ? { ...t, ...patch } : t))
+  saveThemes(next)
+  const t = next.find(x => x.name === slug)
+
+  if (t && t.theme) {
+    registerTheme(t.theme)
+  }
+
+  return t
+}
+
+// ── forge pipeline glue ─────────────────────────────────────────────────────
+
+function handleFile(file: File | null | undefined): void {
+  if (!file || !file.type.startsWith('image/')) {
+    host.notify({ kind: 'warning', message: 'That file is not an image.' })
+
+    return
+  }
+
+  $busy.set(true)
+  forgeTheme(file, $mode.get())
+    .then(entry => {
+      const list = (storageRef ? storageRef.get<ForgeEntry[]>('themes', []) : []).filter(t => t.name !== entry.name)
+      list.unshift(entry)
+      saveThemes(list)
+      registerTheme(entry.theme)
+      haptic('tap')
+      host.notify({
+        kind: 'success',
+        message: `"${entry.label}" forged — Apply in the pane, or pick it in Settings → Appearance.`
+      })
+    })
+    .catch(err => host.notifyError(err, 'Theme Forge'))
+    .finally(() => $busy.set(false))
+}
+
+function reforge(entry: ForgeEntry): void {
+  if (!entry.source) {
+    host.notify({ kind: 'warning', message: 'No source image kept for this theme — forge a new one.' })
+
+    return
+  }
+
+  loadImageFromUrl(entry.source)
+    .then(img => {
+      const palette = extractPalette(img, 12)
+      const ordered = [...palette].sort((a, b) => b.weight - a.weight).slice(0, 8)
+      const theme = synthesize(ordered, entry)
+      updateTheme(entry.name, { swatches: ordered, theme, mode: $mode.get() })
+      haptic('tap')
+      host.notify({ kind: 'success', message: `"${entry.label}" reforged.` })
+    })
+    .catch(err => host.notifyError(err, 'Theme Forge'))
+}
+
+function applyTheme(entry: ForgeEntry): void {
+  // Forge themes are contributed to the DESKTOP registry only — the backend
+  // can't resolve them, so config.set would silently fall back to `default`.
+  // Deep-link those. Backend-known skins (built-ins) apply LIVE below.
+  if (forgeIsBackendSkin(entry.name)) {
+    forgeApplyLive(entry)
+
+    return
+  }
+
+  host.navigate('/settings?tab=config:appearance')
+  host.notify({ kind: 'info', message: `Click "${entry.label}" in the grid to apply.` })
+}
+
+// Backend-known skins: the gateway's `config.set display.skin=<name>` RPC
+// broadcasts skin.changed, which the desktop drains through setTheme → the
+// theme repaints WITHOUT navigating away from this pane. Names from
+// hermes_cli/skin_engine.py _BUILTIN_SKINS (verified in the app source).
+const forgeBackendSkins = new Set([
+  'default',
+  'ares',
+  'mono',
+  'slate',
+  'daylight',
+  'warm-lightmode',
+  'poseidon',
+  'sisyphus',
+  'charizard'
+])
+
+function forgeIsBackendSkin(name: string): boolean {
+  return Boolean(name) && forgeBackendSkins.has(name)
+}
+
+function forgeApplyLive(entry: ForgeEntry): void {
+  host
+    .request('config.set', { key: 'skin', value: entry.name })
+    .then(() => {
+      haptic('tap')
+      host.notify({ kind: 'success', message: `"${entry.label}" applied live.` })
+    })
+    .catch(err => {
+      host.notifyError(err, 'Theme Forge apply')
+      // Fall back to the honest path if the gateway can't take it.
+      host.navigate('/settings?tab=config:appearance')
+      host.notify({ kind: 'info', message: `Click "${entry.label}" in the grid to apply.` })
+    })
+}
+
+// ── escape hatch (theme-immune) ─────────────────────────────────────────────
+// A broken theme (super-dark bg + dark text) makes the pane's theme-var text
+// illegible. This button is the ONE thing that must survive any theme, so it
+// deliberately uses HARDCODED colors and a fixed glow — never theme vars. It
+// resets to the safe default via the gateway (config.set skin=default →
+// skin.changed → desktop setTheme('default') → repaints to the canonical
+// 'nous' theme). No navigation, no Settings, fully reversible: the user's
+// forged themes stay saved in the pane.
+function forgeResetToDefault(): void {
+  host
+    .request('config.set', { key: 'skin', value: 'default' })
+    .then(() => {
+      haptic('tap')
+      $forgeActiveSkin.set('default')
+      host.notify({ kind: 'success', message: 'Reset to the safe default theme.' })
+    })
+    .catch(err => host.notifyError(err, 'Theme Forge reset'))
+}
+
+function ForgeEscapeHatch() {
+  return (
+    <button
+      aria-label="Reset to safe default theme"
+      // Hardcoded, theme-independent: high-contrast amber-on-dark that reads
+      // against ANY background (light or dark, any palette). boxShadow rings
+      // are inline because arbitrary shadow-[…] classes are frozen-CSS dead.
+      onClick={forgeResetToDefault}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 6,
+        width: '100%',
+        padding: '6px 10px',
+        borderRadius: 6,
+        fontSize: 12,
+        fontWeight: 700,
+        lineHeight: 1.2,
+        color: '#111111',
+        background: 'linear-gradient(135deg, #ffb300 0%, #ff8f00 100%)',
+        border: '1px solid #6d4c00',
+        boxShadow: '0 0 0 1px rgba(0,0,0,0.35), 0 0 10px rgba(255,179,0,0.55)',
+        cursor: 'pointer',
+        flexShrink: 0,
+        userSelect: 'none'
+      }}
+      title="Always visible — reset to the safe default theme if this one is unreadable"
+      type="button"
+    >
+      <icons.AlertTriangle className="size-3.5 shrink-0" style={{ color: '#111111' }} />
+      <span>Reset to safe theme</span>
+    </button>
+  )
+}
+
+// ── strip view ──────────────────────────────────────────────────────────────
+
+function StripRow({ active, entry, onOpen }: { active: boolean; entry: ForgeEntry; onOpen?: () => void }) {
+  const theme = entry.theme || ({} as ForgeTheme)
+  const t = theme.darkTerminal || theme.terminal || ({} as ForgeTerminalPalette)
+  const colors = theme.darkColors || theme.colors || ({} as ForgeTheme['colors'])
+  const swatches = entry.swatches && entry.swatches.length ? entry.swatches : deriveSwatches(theme)
+
+  const handleClick = (ev: React.MouseEvent) => {
+    if ((ev.target as Element).closest('button')) {
+      return
+    }
+
+    onOpen?.()
+  }
+
+  const handleApply = (ev: React.MouseEvent) => {
+    ev.stopPropagation()
+    applyTheme(entry)
+  }
+
+  const label = entry.label || theme.label || entry.name
+
+  const thumb = entry.source ? (
+    <img alt="" className="h-5 w-5 shrink-0 rounded-[2px] object-cover" src={entry.source} />
+  ) : (
+    <div
+      className="h-5 w-5 shrink-0 rounded-[2px]"
+      style={{
+        background: `linear-gradient(135deg, ${colors.background || '#222'} 0%, ${colors.primary || '#666'} 100%)`
+      }}
+    />
+  )
+
+  return (
+    <button
+      className={cn(
+        'flex w-full items-center gap-2 rounded-none px-1.5 py-1 text-left',
+        'hover:bg-(--chrome-action-hover) active:bg-(--chrome-active-hover)'
+      )}
+      onClick={handleClick}
+      type="button"
+    >
+      {thumb}
+      <div className="min-w-0 flex-1 truncate text-[0.6875rem] text-(--ui-text-tertiary)" title={label}>
+        {label}
+      </div>
+      <ForgeActiveDot active={active} />
+      <div className="flex shrink-0 items-center gap-1">
+        <div
+          className="relative flex overflow-x-auto overflow-y-visible"
+          onWheel={ev => {
+            const el = ev.currentTarget
+
+            if (Math.abs(ev.deltaY) > Math.abs(ev.deltaX)) {
+              ev.preventDefault()
+              el.scrollLeft += ev.deltaY
+            }
+          }}
+          ref={el => {
+            if (!el) {
+              return
+            }
+
+            const inner = el.firstElementChild
+
+            if (!inner) {
+              return
+            }
+
+            const hint = (el as HTMLElement & { _scrollHint?: HTMLElement })._scrollHint
+            const overflow = inner.scrollWidth > el.clientWidth + 1
+
+            if (!overflow && hint) {
+              hint.style.opacity = '0'
+              hint.removeAttribute('aria-hidden')
+            } else if (overflow && !hint) {
+              const node = document.createElement('span')
+              node.setAttribute('aria-hidden', 'true')
+              node.style.cssText =
+                'position:absolute;right:0;top:0;bottom:0;width:14px;pointer-events:none;background:linear-gradient(to right, transparent, var(--chrome-action-hover));'
+              el.appendChild(node)
+              ;(el as HTMLElement & { _scrollHint?: HTMLElement })._scrollHint = node
+            }
+          }}
+          style={{ scrollbarWidth: 'none', scrollSnapType: 'x proximity' }}
+        >
+          {swatches.slice(0, 8).map((s, i) => (
+            <span
+              className="flex shrink-0 flex-col items-center"
+              key={`s-${i}`}
+              style={{ scrollSnapAlign: 'start', gap: 1 }}
+            >
+              <span
+                aria-hidden
+                className="h-3.5 w-3.5 rounded-[2px]"
+                style={{ background: s.hex }}
+                title={i === 0 ? `#1 · bkgnd · ${s.hex}` : i === 1 ? `#2 · text · ${s.hex}` : `#${i + 1} · ${s.hex}`}
+              />
+              <span
+                aria-hidden
+                className="text-[0.5rem] leading-none text-(--ui-text-quaternary)"
+                style={{ height: 7 }}
+              >
+                {i === 0 ? 'bkgnd' : i === 1 ? 'text' : ''}
+              </span>
+            </span>
+          ))}
+          <Button onClick={handleApply} size="icon-xs" title="Apply theme" variant="ghost">
+            <icons.Palette className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+// ── card bits ───────────────────────────────────────────────────────────────
+
+/** Card thumbnail: the kept source image, or a color field built from the
+ *  theme's own tokens for v1-era entries (no source persisted). */
+function ThemeThumb({ entry }: { entry: ForgeEntry }) {
+  if (entry.source) {
+    return <img alt="" className="h-5 w-5 shrink-0 rounded-[2px] object-cover" src={entry.source} />
+  }
+
+  const c = entry.theme?.darkColors || entry.theme?.colors || ({} as ForgeTheme['colors'])
+  const t = entry.theme?.darkTerminal || entry.theme?.terminal || ({} as ForgeTerminalPalette)
+  const bg = c.background || '#222222'
+  const p1 = c.primary || '#888888'
+  const p2 = t.cyan || t.green || p1
+
+  return (
+    <div
+      className="h-5 w-5 shrink-0 rounded-[3px]"
+      style={{
+        background: `linear-gradient(135deg, ${bg} 0%, ${bg} 40%, ${p1} 40%, ${p1} 70%, ${p2} 70%)`,
+        boxShadow: 'inset 0 0 0 1px rgba(128,128,128,0.35)'
+      }}
+      title="Theme colors (no source image kept)"
+    />
+  )
+}
+
+function TermPreview({ theme, mode }: { theme: ForgeTheme; mode: ForgeMode }) {
+  // Render a mini terminal using the theme's ANSI palette for the right mode
+  const t =
+    mode === 'light' && !theme.darkTerminal
+      ? theme.terminal
+      : mode === 'light'
+        ? theme.terminal
+        : theme.darkTerminal || theme.terminal
+
+  const colors = mode === 'light' ? theme.colors : theme.darkColors || theme.colors
+  const bg = colors.background
+  const fg = t?.foreground || colors.foreground
+  const palette = t || ({} as ForgeTerminalPalette)
+
+  const line = (chunks: [string, string | undefined][], key: string) => (
+    <div className="whitespace-pre" key={key}>
+      {chunks.map(([text, color], i) => (
+        <span key={`${key}-${i}`} style={{ color }}>
+          {text}
+        </span>
+      ))}
+    </div>
+  )
+
+  return (
+    <div
+      className="overflow-x-auto rounded-[6px] p-2 font-mono text-[0.6875rem] leading-relaxed"
+      style={{ background: bg, color: fg, boxShadow: 'inset 0 0 0 1px rgba(128,128,128,0.25)' }}
+    >
+      {line(
+        [
+          ['➜ ', palette.green],
+          ['~/farmfriend ', palette.cyan],
+          ['git status', fg]
+        ],
+        'l1'
+      )}
+      {line(
+        [
+          ['On branch ', fg],
+          ['main', palette.magenta]
+        ],
+        'l2'
+      )}
+      {line(
+        [
+          ['  modified:   ', palette.yellow],
+          ['src/agent/core.py', palette.blue]
+        ],
+        'l3'
+      )}
+      {line(
+        [
+          ['  new file:   ', palette.green],
+          ['themes/', palette.blue],
+          ['forge.json', fg]
+        ],
+        'l4'
+      )}
+      {line(
+        [
+          ['$ ', palette.green],
+          ['hermes ', palette.cyan],
+          ['--profile ', palette.yellow],
+          ['closer', palette.magenta],
+          [' chat', fg]
+        ],
+        'l5'
+      )}
+      {line(
+        [
+          ['⚡ error: ', palette.red],
+          ['provider timeout — retrying', fg],
+          [' (bright: ', palette.brightYellow],
+          ['ok', palette.brightGreen],
+          [')', fg]
+        ],
+        'l6'
+      )}
+    </div>
+  )
+}
+
+// ── swatch tray (reorder + pick/place + wheel edit) ─────────────────────────
+
+function SwatchTray({ entry }: { entry: ForgeEntry }) {
+  const dragIdx = useRef<number | null>(null)
+  const [over, setOver] = useState<number | null>(null)
+  const picked = useValue($picked)
+  const pickedHere = picked && picked.slug === entry.name ? picked.index : null
+
+  // v1-era entries persisted with an empty swatch list — recover from tokens
+  const swatches = entry.swatches && entry.swatches.length > 0 ? entry.swatches : deriveSwatches(entry.theme)
+
+  const move = (from: number, to: number): void => {
+    if (from === to) {
+      return
+    }
+
+    $wheelOpen.set(null)
+    const sw = [...swatches]
+    const [moved] = sw.splice(from, 1)
+    sw.splice(to, 0, moved)
+    const theme = synthesize(sw, entry)
+    updateTheme(entry.name, { swatches: sw, theme })
+    haptic('tap')
+  }
+
+  // Primary interaction: click a swatch to pick it up, click a slot to place
+  // it. Works with any pointer; drag remains available as a fast path.
+  const place = (i: number): void => {
+    if ($wheelOpen.get()) {
+      $wheelOpen.set(null)
+    }
+
+    if (pickedHere === null) {
+      $picked.set({ slug: entry.name, index: i })
+
+      return
+    }
+
+    if (pickedHere === i) {
+      $picked.set(null) // toggle off
+
+      return
+    }
+
+    move(pickedHere, i)
+    $picked.set(null)
+  }
+
+  const wheel = useValue($wheelOpen)
+  const wheelHere = wheel && wheel.slug === entry.name ? wheel.index : null
+
+  const openWheel = (i: number): void => {
+    if (pickedHere !== null) {
+      return
+    }
+
+    $wheelOpen.set({ slug: entry.name, index: i })
+  }
+
+  const commitWheel = (index: number, hex: string): void => {
+    const next = swatches.map((s, i) => (i === index ? { ...s, hex, hsl: hexToHsl(hex) } : s)) as Swatch[]
+    const theme = synthesize(next, entry)
+    updateTheme(entry.name, { swatches: next, theme })
+    $wheelOpen.set(null)
+    haptic('tap')
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[0.625rem] text-(--ui-text-quaternary)">
+        {pickedHere !== null
+          ? 'picked up — click a slot to place (click again to cancel)'
+          : 'swatch 1 = background hue · swatch 2 = text · tap to pick up, double-click to edit'}
+      </div>
+      <div
+        className="relative flex gap-1.5 overflow-x-auto overflow-y-visible"
+        onWheel={ev => {
+          const el = ev.currentTarget
+
+          if (Math.abs(ev.deltaY) > Math.abs(ev.deltaX)) {
+            ev.preventDefault()
+            el.scrollLeft += ev.deltaY
+          }
+        }}
+        ref={el => {
+          if (!el) {
+            return
+          }
+
+          const inner = el.firstElementChild
+
+          if (!inner) {
+            return
+          }
+
+          const hint = (el as HTMLElement & { _scrollHint?: HTMLElement })._scrollHint
+          const overflow = inner.scrollWidth > el.clientWidth + 1
+
+          if (!overflow && hint) {
+            hint.style.opacity = '0'
+            hint.removeAttribute('aria-hidden')
+          } else if (overflow && !hint) {
+            const node = document.createElement('span')
+            node.setAttribute('aria-hidden', 'true')
+            node.style.cssText =
+              'position:absolute;right:0;top:0;bottom:0;width:18px;pointer-events:none;background:linear-gradient(to right, transparent, var(--chrome-action-hover));'
+            el.appendChild(node)
+            ;(el as HTMLElement & { _scrollHint?: HTMLElement })._scrollHint = node
+          }
+        }}
+        style={{ scrollbarWidth: 'none', scrollSnapType: 'x proximity' }}
+      >
+        {swatches.map((s, i) => (
+          <div
+            className="flex shrink-0 flex-col items-center gap-0.5"
+            key={`swc-${i}`}
+            style={{ scrollSnapAlign: 'start' }}
+          >
+            <div
+              className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-[5px] text-xs font-bold"
+              draggable
+              key={`sw-${i}`}
+              onClick={() => place(i)}
+              onDoubleClick={() => openWheel(i)}
+              onDragEnd={() => {
+                dragIdx.current = null
+                setOver(null)
+              }}
+              onDragLeave={() => setOver(v => (v === i ? null : v))}
+              onDragOver={ev => {
+                ev.preventDefault()
+                ev.dataTransfer.dropEffect = 'move'
+                setOver(i)
+              }}
+              onDragStart={ev => {
+                dragIdx.current = i
+                ev.dataTransfer.effectAllowed = 'move'
+                ev.dataTransfer.setData('text/plain', String(i))
+              }}
+              onDrop={ev => {
+                ev.preventDefault()
+                ev.stopPropagation()
+                setOver(null)
+
+                if (dragIdx.current !== null) {
+                  move(dragIdx.current, i)
+                }
+
+                dragIdx.current = null
+              }}
+              onKeyDown={ev => {
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault()
+                  place(i)
+                }
+              }}
+              role="button"
+              style={{
+                background: s.hex,
+                color: readableOn(s.hex),
+                // ring/scale inline: arbitrary shadow-[…] and scale-* are not
+                // in the app's frozen build CSS
+                boxShadow:
+                  'inset 0 0 0 1px rgba(128,128,128,0.45)' +
+                  (pickedHere === i || over === i ? ', 0 0 0 2px var(--ui-accent)' : ''),
+                transform: pickedHere === i || over === i ? 'scale(1.08)' : 'none',
+                transition: 'transform 0.1s ease'
+              }}
+              tabIndex={0}
+              title={
+                i === 0
+                  ? `#1 · background seed · ${s.hex}`
+                  : i === 1
+                    ? `#2 · text seed · ${s.hex}`
+                    : `#${i + 1} · ${s.hex}`
+              }
+            >
+              {i + 1}
+            </div>
+            {/* Role captions: slot 1 seeds the background, slot 2 seeds the
+                text color (UI + terminal). Fixed-height slot keeps the row
+                aligned where no caption applies. */}
+            <div aria-hidden className="h-3 text-center text-[0.5625rem] leading-none text-(--ui-text-quaternary)">
+              {i === 0 ? 'bkgnd' : i === 1 ? 'text' : ''}
+            </div>
+          </div>
+        ))}
+      </div>
+      {wheelHere !== null && wheelHere < swatches.length ? (
+        <ColorWheelPanel
+          onCancel={() => $wheelOpen.set(null)}
+          // Live preview: only update the swatch hex in memory so the wheel's
+          // own preview chip follows. Do NOT synthesize/save on every drag —
+          // that races with commit and bleaches the final color.
+          onChange={hex => {
+            const next = swatches.map((s, i) => (i === wheelHere ? { ...s, hex, hsl: hexToHsl(hex) } : s)) as Swatch[]
+            updateTheme(entry.name, { swatches: next })
+          }}
+          onCommit={hex => commitWheel(wheelHere, hex)}
+          value={swatches[wheelHere].hex}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+// ── color wheel (H/S/L editor) ──────────────────────────────────────────────
+
+// Curated fast-pick cells for the picker grid (standard picker behavior).
+const PRESET_CELLS = [
+  '#ffffff',
+  '#f1f3f5',
+  '#ced4da',
+  '#868e96',
+  '#495057',
+  '#161616',
+  '#000000',
+  '#fa5252',
+  '#ff922b',
+  '#fcc419',
+  '#82c91e',
+  '#37b24d',
+  '#12b886',
+  '#20c997',
+  '#22b8cf',
+  '#339af0',
+  '#1971c2',
+  '#4c6ef5',
+  '#7048e8',
+  '#be4bdb',
+  '#f06595',
+  '#ff8787'
+]
+
+function PickerSlider({
+  display,
+  label,
+  max,
+  min,
+  onChange,
+  step,
+  track,
+  value
+}: {
+  display: string
+  label: string
+  max: number
+  min: number
+  onChange: (v: number) => void
+  step: number
+  track: string
+  value: number
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-4 shrink-0 text-[0.625rem] text-(--ui-text-quaternary)">{label}</span>
+      <input
+        className="h-1 min-w-0 flex-1"
+        max={max}
+        min={min}
+        onChange={ev => onChange(Number(ev.target.value))}
+        step={step}
+        style={{ background: track, borderRadius: 999, accentColor: 'var(--ui-accent)' }}
+        type="range"
+        value={value}
+      />
+      <span className="shrink-0 text-[0.625rem] text-(--ui-text-tertiary)" style={{ width: 40, textAlign: 'right' }}>
+        {display}
+      </span>
+    </div>
+  )
+}
+
+function ColorWheelPanel({
+  onChange,
+  onCancel,
+  onCommit,
+  value
+}: {
+  onChange: (hex: string) => void
+  onCancel: () => void
+  onCommit: (hex: string) => void
+  value: string
+}) {
+  const base = hexToHsl(value) || { h: 0, s: 0.75, l: 0.5 }
+  const [h, setH] = useState(base.h)
+  const [s, setS] = useState(base.s)
+  const [l, setL] = useState(base.l)
+  const live = hslToHex(h, s, l)
+  const [hexDraft, setHexDraft] = useState(live.toUpperCase())
+  const wheelRef = useRef<HTMLDivElement | null>(null)
+  const dragging = useRef(false)
+
+  // Keep the hex field in sync with wheel/slider edits while you drag.
+  useEffect(() => setHexDraft(live.toUpperCase()), [live])
+
+  const hueDeg = Math.round(h * 360)
+  const satPct = Math.round(s * 100)
+  const liPct = Math.round(l * 100)
+
+  const pickFromScreen = async (): Promise<void> => {
+    if (typeof window === 'undefined' || !('EyeDropper' in window)) {
+      host.notify({ kind: 'warning', message: 'Screen pick (eyedropper) is not supported in this build.' })
+
+      return
+    }
+
+    try {
+      // EyeDropper ships without TS lib types in Electron's Chromium — a
+      // minimal local declaration keeps the call typed without widening the
+      // global surface.
+      const ed = new (
+        window as unknown as { EyeDropper: new () => { open: () => Promise<{ sRGBHex: string }> } }
+      ).EyeDropper()
+
+      const res = await ed.open()
+      const hit = parseHexStrict(res.sRGBHex)
+
+      if (!hit) {
+        return
+      }
+
+      const hsl = hexToHsl(hit)
+
+      if (hsl) {
+        setH(hsl.h)
+        setS(hsl.s)
+        setL(hsl.l)
+      }
+    } catch (err) {
+      // AbortError = user pressed Escape to cancel; ignore.
+      if (!err || (err as Error).name !== 'AbortError') {
+        host.notify({ kind: 'warning', message: 'Screen pick failed.' })
+      }
+    }
+  }
+
+  const onHexInput = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+    const raw = ev.target.value
+    setHexDraft(raw)
+    const hit = parseHexStrict(raw)
+
+    if (!hit) {
+      return
+    }
+
+    const hsl = hexToHsl(hit)
+
+    if (hsl) {
+      setH(hsl.h)
+      setS(hsl.s)
+      setL(hsl.l)
+    }
+  }
+
+  const onHexBlur = (): void => setHexDraft(live.toUpperCase())
+
+  const pickCell = (hex: string): void => {
+    const hsl = hexToHsl(hex)
+
+    if (!hsl) {
+      return
+    }
+
+    setH(hsl.h)
+    setS(hsl.s)
+    setL(hsl.l)
+  }
+
+  const wheelFromPoint = (clientX: number, clientY: number): { h: number; s: number } | null => {
+    const rect = wheelRef.current?.getBoundingClientRect()
+
+    if (!rect) {
+      return null
+    }
+
+    const x = clientX - rect.left - rect.width / 2
+    const y = clientY - rect.top - rect.height / 2
+    const radius = Math.min(rect.width, rect.height) / 2
+    const dist = Math.sqrt(x * x + y * y) / radius
+
+    if (dist < 0.08 || dist > 1.02) {
+      return null
+    }
+
+    let angle = Math.atan2(y, x) / (2 * Math.PI)
+
+    if (angle < 0) {
+      angle += 1
+    }
+
+    return { h: angle, s: Math.min(1, dist) }
+  }
+
+  const onWheelPointerDown = (ev: React.PointerEvent<HTMLDivElement>): void => {
+    const hit = wheelFromPoint(ev.clientX, ev.clientY)
+
+    if (!hit) {
+      return
+    }
+
+    dragging.current = true
+    setH(hit.h)
+    setS(hit.s)
+    ev.currentTarget.setPointerCapture?.(ev.pointerId)
+    ev.preventDefault()
+  }
+
+  const onWheelPointerMove = (ev: React.PointerEvent<HTMLDivElement>): void => {
+    if (!dragging.current) {
+      return
+    }
+
+    const hit = wheelFromPoint(ev.clientX, ev.clientY)
+
+    if (!hit) {
+      return
+    }
+
+    setH(hit.h)
+    setS(hit.s)
+    ev.preventDefault()
+  }
+
+  const onWheelPointerUp = (): void => {
+    dragging.current = false
+  }
+
+  return (
+    <div
+      // flex-wrap: when the pane is too narrow for wheel + controls
+      // side-by-side, the controls column wraps below the wheel instead of
+      // clipping. min() / vw arbitrary classes are NOT in the app's frozen
+      // build CSS, so the wheel size lives inline.
+      className="flex min-w-0 flex-wrap items-stretch gap-2 overflow-hidden rounded-[6px] border border-(--ui-stroke-secondary) p-2"
+      style={{ background: 'var(--chrome-action-hover)' }}
+    >
+      <div
+        className="relative shrink-0 cursor-crosshair select-none overflow-hidden rounded-full"
+        onPointerCancel={onWheelPointerUp}
+        onPointerDown={onWheelPointerDown}
+        onPointerMove={onWheelPointerMove}
+        onPointerUp={onWheelPointerUp}
+        ref={wheelRef}
+        style={{
+          width: 128,
+          height: 128,
+          background:
+            `conic-gradient(from 0deg, hsl(0,100%,50%), hsl(60,100%,50%), hsl(120,100%,50%), hsl(180,100%,50%), hsl(240,100%,50%), hsl(300,100%,50%), hsl(360,100%,50%)),` +
+            `radial-gradient(farthest-corner, #fff 0%, rgba(255,255,255,0) 58%, rgba(0,0,0,0.45) 100%)`,
+          backgroundBlendMode: 'normal, normal'
+        }}
+        title="angle = hue · radius = saturation"
+      >
+        <div
+          className="pointer-events-none absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full"
+          style={{
+            transform: `translate(calc(-50% + ${Math.cos(h * 2 * Math.PI) * s * 56}px), calc(-50% + ${
+              Math.sin(h * 2 * Math.PI) * s * 56
+            }px))`,
+            background: live,
+            border: '1px solid rgba(255,255,255,0.7)',
+            boxShadow: '0 0 0 1px rgba(0,0,0,0.45)'
+          }}
+        />
+        <div
+          className="pointer-events-none absolute inset-0 rounded-full"
+          style={{ background: `radial-gradient(circle, transparent 56%, rgba(0,0,0,0.18) 78%, rgba(0,0,0,0.5) 100%)` }}
+        />
+      </div>
+      <div className="flex min-w-0 flex-col gap-2" style={{ flex: '1 1 100px' }}>
+        <div className="flex items-center gap-1.5">
+          <div
+            className="h-8 w-8 shrink-0 rounded-[4px]"
+            style={{ background: live, boxShadow: 'inset 0 0 0 1px rgba(128,128,128,0.45)' }}
+          />
+          <Input
+            className="h-6 min-w-0 flex-1 font-mono text-xs"
+            onBlur={onHexBlur}
+            onChange={onHexInput}
+            onKeyDown={ev => {
+              if (ev.key === 'Enter') {
+                onCommit(live)
+              }
+
+              if (ev.key === 'Escape') {
+                onCancel()
+              }
+            }}
+            style={{ width: 88 }}
+            value={hexDraft}
+          />
+          <Button onClick={pickFromScreen} size="icon-xs" title="Pick color from screen (eyedropper)" variant="ghost">
+            <icons.Eye className="size-3.5" />
+          </Button>
+        </div>
+        <div className="text-[0.625rem] text-(--ui-text-tertiary)">{`${hueDeg}° hue · ${satPct}% sat · ${liPct}% light`}</div>
+        <div className="flex items-center gap-1.5">
+          <Button onClick={onCancel} size="xs" variant="secondary">
+            Cancel
+          </Button>
+          <Button onClick={() => onCommit(live)} size="xs" variant="default">
+            OK
+          </Button>
+        </div>
+      </div>
+      {/* Full H/S/L slider set with gradient tracks (standard picker). */}
+      <div className="flex w-full min-w-0 flex-col gap-1">
+        <PickerSlider
+          display={`${hueDeg}°`}
+          label="H"
+          max={360}
+          min={0}
+          onChange={v => setH(v / 360)}
+          step={1}
+          track={`linear-gradient(to right, ${[0, 60, 120, 180, 240, 300, 360].map(a => `hsl(${a},100%,50%)`).join(', ')})`}
+          value={hueDeg}
+        />
+        <PickerSlider
+          display={`${satPct}%`}
+          label="S"
+          max={100}
+          min={0}
+          onChange={v => setS(v / 100)}
+          step={1}
+          track={`linear-gradient(to right, hsl(${hueDeg},0%,${liPct}%), hsl(${hueDeg},100%,${liPct}%))`}
+          value={satPct}
+        />
+        <PickerSlider
+          display={`${liPct}%`}
+          label="L"
+          max={100}
+          min={0}
+          onChange={v => setL(v / 100)}
+          step={1}
+          track={`linear-gradient(to right, hsl(${hueDeg},${satPct}%,0%), hsl(${hueDeg},${satPct}%,50%), hsl(${hueDeg},${satPct}%,100%))`}
+          value={liPct}
+        />
+      </div>
+      {/* Clickable preset cells. */}
+      <div className="flex w-full min-w-0 flex-wrap gap-1">
+        {PRESET_CELLS.map(cell => (
+          <button
+            aria-label={cell}
+            className="h-3.5 w-3.5 shrink-0 cursor-pointer rounded-[3px]"
+            key={cell}
+            onClick={() => pickCell(cell)}
+            style={{ background: cell, boxShadow: 'inset 0 0 0 1px rgba(128,128,128,0.45)' }}
+            title={cell}
+            type="button"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── theme card ──────────────────────────────────────────────────────────────
+
+function ThemeCard({ active, entry }: { active: boolean; entry: ForgeEntry }) {
+  const expanded = useValue($expanded) === entry.name
+  const editing = useValue($editing) === entry.name
+  const mode = useValue($mode)
+  const [draft, setDraft] = useState(entry.label)
+
+  useEffect(() => {
+    if (editing) {
+      setDraft(stripForgePrefix(entry.label))
+    }
+  }, [editing, entry.label])
+
+  const commitRename = (): void => {
+    const clean = draft.trim()
+
+    if (clean) {
+      const label = clean
+      const theme = { ...entry.theme, label }
+      updateTheme(entry.name, { label, theme })
+      host.notify({ kind: 'success', message: `Renamed to "${label}".` })
+    }
+
+    $editing.set(null)
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 rounded-[6px] p-2"
+      style={{ boxShadow: 'inset 0 0 0 1px var(--ui-stroke-secondary)' }}
+    >
+      {/* header row */}
+      <div className="flex min-w-0 flex-wrap items-center gap-1">
+        <ThemeThumb entry={entry} />
+        <ForgeActiveDot active={active} />
+        {editing ? (
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <Input
+              autoFocus
+              className="h-6 min-w-0 flex-1 text-xs"
+              onChange={ev => setDraft(ev.target.value)}
+              onKeyDown={ev => {
+                if (ev.key === 'Enter') {
+                  commitRename()
+                }
+
+                if (ev.key === 'Escape') {
+                  $editing.set(null)
+                }
+              }}
+              value={draft}
+            />
+            <Button onClick={commitRename} size="icon-xs" variant="ghost">
+              <icons.Check />
+            </Button>
+          </div>
+        ) : (
+          <div className="min-w-0 flex-1 truncate">
+            <button
+              className="min-w-0 truncate text-left text-xs font-medium text-(--ui-text-primary) hover:underline"
+              onClick={() => $editing.set(entry.name)}
+              title="Rename"
+              type="button"
+            >
+              {entry.label}
+            </button>
+          </div>
+        )}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Button onClick={() => $editing.set(entry.name)} size="icon-xs" title="Rename theme" variant="ghost">
+            <icons.Pencil />
+          </Button>
+          <Button
+            onClick={() => $expanded.set(expanded ? null : entry.name)}
+            size="icon-xs"
+            title={expanded ? 'Hide terminal preview' : 'Terminal preview'}
+            variant="ghost"
+          >
+            <icons.Terminal />
+          </Button>
+          <Button onClick={() => reforge(entry)} size="icon-xs" title="Reforge from source image" variant="ghost">
+            <icons.RefreshCw />
+          </Button>
+          <Button
+            onClick={() => {
+              const list = (storageRef ? storageRef.get<ForgeEntry[]>('themes', []) : []).filter(
+                t => t.name !== entry.name
+              )
+
+              saveThemes(list)
+              const d = disposersBySlug.get(entry.name)
+
+              if (d) {
+                d()
+                disposersBySlug.delete(entry.name)
+              }
+
+              haptic('tap')
+              host.notify({ kind: 'info', message: `Removed "${entry.label}".` })
+            }}
+            size="icon-xs"
+            title="Delete theme"
+            variant="ghost"
+          >
+            <icons.Trash2 />
+          </Button>
+        </div>
+      </div>
+
+      <SwatchTray entry={entry} />
+
+      <Button
+        onClick={() => {
+          host.navigate('/settings?tab=config:appearance')
+          host.notify({ kind: 'info', message: `Click "${entry.label}" in the grid to apply.` })
+        }}
+        size="xs"
+        variant="secondary"
+      >
+        Apply…
+      </Button>
+
+      {expanded ? <TermPreview mode={entry.mode || mode} theme={entry.theme} /> : null}
+    </div>
+  )
+}
+
+// ── the pane ────────────────────────────────────────────────────────────────
+
+function ForgePane() {
+  const busy = useValue($busy)
+  const generated = useValue($generated)
+  const mode = useValue($mode)
+  const viewMode = useValue($viewMode)
+  const activeSkin = useForgeActiveSkin()
+
+  // Pin the currently-applied theme to the top so it's always visible for
+  // quick customization; the indicator dot marks it. Rest keeps its order.
+  const list = (() => {
+    if (!activeSkin) {
+      return generated
+    }
+
+    const active = generated.find(e => e.name === activeSkin)
+
+    if (!active) {
+      return generated
+    }
+
+    return [active, ...generated.filter(e => e.name !== activeSkin)]
+  })()
+
+  const onDrop = (ev: React.DragEvent): void => {
+    ev.preventDefault()
+    handleFile(ev.dataTransfer?.files?.[0])
+  }
+
+  const setViewMode = (v: string): void => {
+    $viewMode.set(normalizeViewMode(v))
+    storageRef?.set($viewModeKey, normalizeViewMode(v))
+  }
+
+  const openCard = (entry: ForgeEntry): void => {
+    $viewMode.set('cards')
+    storageRef?.set($viewModeKey, 'cards')
+    $expanded.set(entry.name)
+  }
+
+  return (
+    <div
+      className="flex h-full flex-col gap-3 overflow-hidden p-3 text-sm outline-none"
+      data-forge-pane="true"
+      onDragOver={ev => ev.preventDefault()}
+      onDrop={onDrop}
+      tabIndex={0}
+    >
+      <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0 truncate font-medium text-(--ui-text-primary)">Theme Forge</div>
+        <div className="flex min-w-0 items-center gap-1">
+          <div className="min-w-0">
+            <SegmentedControl
+              className="max-w-full"
+              onChange={v => setViewMode(v)}
+              options={[
+                { id: 'cards', label: 'Cards' },
+                { id: 'strip', label: 'Strip' }
+              ]}
+              value={viewMode}
+            />
+          </div>
+          <div className="min-w-0">
+            <SegmentedControl
+              className="max-w-full"
+              onChange={v => $mode.set(v)}
+              options={[
+                { id: 'dark', label: 'Dark' },
+                { id: 'light', label: 'Light' }
+              ]}
+              value={mode}
+            />
+          </div>
+        </div>
+      </div>
+
+      <label
+        className={cn(
+          'flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-[6px] border border-dashed p-3 text-center transition-colors',
+          'border-(--ui-stroke-secondary) hover:bg-(--chrome-action-hover)'
+        )}
+      >
+        <icons.Upload className="size-4 text-(--ui-text-tertiary)" />
+        <div className="text-xs text-(--ui-text-secondary)">{busy ? 'Forging…' : 'Drop an image here'}</div>
+        <div className="text-[0.6875rem] text-(--ui-text-tertiary)">
+          or click to browse · click pane then ⌘V to paste
+        </div>
+        <input accept="image/*" className="hidden" onChange={ev => handleFile(ev.target.files?.[0])} type="file" />
+      </label>
+
+      {/* Pinned escape hatch: always visible, never scrolled away, and immune
+          to the theme's own colors (hardcoded) so it works even under a
+          broken/unreadable theme. */}
+      <ForgeEscapeHatch />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden">
+        <div className="min-w-0 text-[0.6875rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
+          {`Forged themes (${generated.length})`}
+        </div>
+        <ScrollArea className="min-h-0 flex-1">
+          <div className={viewMode === 'strip' ? 'flex min-w-0 flex-col gap-px' : 'flex min-w-0 flex-col gap-2 pb-2'}>
+            {list.length ? (
+              list.map(entry =>
+                viewMode === 'strip' ? (
+                  <StripRow
+                    active={entry.name === activeSkin}
+                    entry={entry}
+                    key={entry.name}
+                    onOpen={() => openCard(entry)}
+                  />
+                ) : (
+                  <ThemeCard active={entry.name === activeSkin} entry={entry} key={entry.name} />
+                )
+              )
+            ) : (
+              <div className="py-2 text-xs text-(--ui-text-tertiary)">None yet — forge one above.</div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  )
+}
+
+// ── plugin entry ────────────────────────────────────────────────────────────
+
+let pasteHandler: ((ev: ClipboardEvent) => void) | null = null
+
+const themeForgePlugin: HermesPlugin = {
+  id: 'theme-forge',
+  name: 'Theme Forge',
+  defaultEnabled: false,
+
+  register(ctx: PluginContext) {
+    storageRef = ctx.storage
+    registerRef = ctx.register
+
+    // One-time schema migration: v1 stored raw theme objects; v2 stores
+    // { name, label, mode, swatches, theme, source } entries. v3 (sleek
+    // naming) strips the auto-injected 'Forge · ' prefix from both the
+    // card label and the registered theme label, so names show clean —
+    // including legacy data persisted before this change.
+    const migrated = ctx.storage.get<ForgeEntry[]>('themes', []).map(e => {
+      const legacy = e as ForgeEntry & { colors?: unknown }
+
+      const base: ForgeEntry =
+        legacy && !legacy.theme && legacy.colors
+          ? {
+              name: legacy.name,
+              label: legacy.label,
+              mode: 'dark',
+              swatches: [],
+              theme: legacy as unknown as ForgeTheme,
+              source: null,
+              forgedAt: Date.now()
+            }
+          : legacy
+
+      if (!base || !base.theme) {
+        return base
+      }
+
+      const label = stripForgePrefix(base.label ?? base.theme.label)
+
+      return { ...base, label, theme: { ...base.theme, label } }
+    })
+
+    ctx.storage.set('themes', migrated)
+
+    // Re-register every persisted theme so they survive restarts.
+    for (const entry of migrated) {
+      if (entry?.theme?.name && entry.theme.colors) {
+        registerTheme(entry.theme)
+      }
+    }
+
+    $generated.set(migrated)
+
+    $viewMode.set(normalizeViewMode(ctx.storage.get($viewModeKey, 'cards')))
+
+    ctx.register({
+      id: 'pane',
+      area: 'panes',
+      title: 'theme forge',
+      data: { placement: 'right', width: '280px', minWidth: '220px', maxWidth: '520px' },
+      render: () => <ForgePane />
+    })
+
+    ctx.register({
+      id: 'palette-open',
+      area: PALETTE_AREA,
+      data: {
+        id: 'theme-forge-open',
+        label: 'Theme Forge: forge a theme from an image',
+        keywords: ['theme', 'skin', 'color', 'palette', 'image'],
+        run: () =>
+          host.notify({ kind: 'info', message: 'Drop or paste an image into the Theme Forge pane (right side).' })
+      }
+    })
+
+    // Capture-phase paste: forge image pastes aimed at the pane or plain
+    // chrome; never steal pastes aimed at the chat composer.
+    pasteHandler = ev => {
+      const item = Array.from(ev.clipboardData?.items || []).find(i => i.type.startsWith('image/'))
+
+      if (!item) {
+        return
+      }
+
+      const t = ev.target
+      const inPane = t instanceof Element && !!t.closest('[data-forge-pane]')
+      const editable = t instanceof Element && !!t.closest('input, textarea, [contenteditable="true"]')
+
+      if (!inPane && editable) {
+        return
+      }
+
+      const file = item.getAsFile()
+
+      if (file) {
+        ev.preventDefault()
+        ev.stopPropagation()
+        handleFile(file)
+      }
+    }
+
+    window.addEventListener('paste', pasteHandler, true)
+
+    ctx.onDispose(() => {
+      if (pasteHandler) {
+        window.removeEventListener('paste', pasteHandler, true)
+      }
+
+      pasteHandler = null
+
+      if (forgeSkinObserver) {
+        forgeSkinObserver.disconnect()
+        forgeSkinObserver = null
+      }
+
+      disposersBySlug.forEach(d => d())
+      disposersBySlug.clear()
+    })
+  }
+}
+
+export default themeForgePlugin


### PR DESCRIPTION
## What

**Theme Forge** — the first in-tree bundled desktop plugin: turn any image into a full Hermes desktop theme. Drop/paste/browse an image → median-cut palette extraction → WCAG-guaranteed light+dark variants + complete 16-slot terminal ANSI palette, registered via `THEMES_AREA` so forged themes appear live in Settings → Appearance, ⌘K, and `/skin`.

Published standalone as **Theme Lab** (github.com/0-CYBERDYNE-SYSTEMS-0/theme-lab, MIT); this is the bundled port per the desktop plugin SDK's `apps/desktop/src/plugins/<id>/plugin.tsx` delivery mode. It is a genuine feature plugin (not a 1:1 chrome rebuild), so it belongs in-tree rather than in hermes-example-plugins — happy to move it there if you'd prefer.

## Why a bundled plugin

The standalone disk plugin has been running live and validated the contract end-to-end; bundling makes the capability available to every desktop user without a manual install. Zero dependencies, plugin-sdk imports only, respects the plugin fence.

## Features

- Image → theme in one drop (paste, drag-and-drop, or browse)
- **Verbatim swatch→theme contract**: slot 1 IS the background, slot 2 IS the text color (UI + terminal), first chromatic swatch IS the accent — the exact color placed is the exact color in the theme. No contrast re-mixing of placed colors (secondary tokens like muted text still get contrast-safe derivation)
- **3:1 tripwire contrast floor**: nudges only genuinely unreadable pairs (near-black on near-black); readable low-contrast choices pass through untouched
- Full color picker per swatch: HSV wheel, H/S/L sliders, editable hex field, preset cells, screen eyedropper
- Drag/click-to-reorder swatch priorities (re-synthesizes live), inline rename, terminal ANSI preview, reforge from kept source image, delete
- Active-theme indicator + pin-to-top (reads `data-hermes-theme` via MutationObserver)
- Live apply via `config.set` for backend-known skins; deep-link to Appearance for registry-only themes
- Theme-immune escape hatch (hardcoded amber button) that resets to the safe default even under a broken/unreadable theme
- Persists via `ctx.storage` with schema migration; themes re-register on restart
- Ships OFF by default (`defaultEnabled: false`) — same convention as kanban and example

## Files

| File | Lines | Role |
| --- | --- | --- |
| `src/plugins/theme-forge/forge.ts` | 695 | Pure color math, palette extraction, theme synthesis, types |
| `src/plugins/theme-forge/plugin.tsx` | 1491 | Pane UI + `HermesPlugin` registration |
| `src/plugins/theme-forge/forge.test.ts` | 430 | 52-check color-math validation suite |

## Testing

- `vitest run --project ui src/plugins/theme-forge/forge.test.ts` → **52/52 passed** (ported from the standalone repo's 74-check harness; the source-grep checks became TypeScript structural checks + behavior tests)
- `tsc -p . --noEmit` → 0 errors in the plugin (strict mode)
- `eslint src/plugins/theme-forge/` → 0 errors, 0 warnings
- `prettier --check` → clean

## Notes

- The disk plugin's `jsx()` calls are converted to JSX syntax (bundled plugins go through the app's Vite build)
- `DesktopTheme` is structurally redeclared locally (`ForgeTheme`) since the SDK fence doesn't export it; contribution data is consumed by `contributedThemes()` which casts to `DesktopTheme`
- No core edits — discovered automatically by the existing vite glob in `contrib/plugins.ts`