### PR TITLE
fix(display): CLI display toggles honor quoted 'false' in config.yaml

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -224,7 +224,7 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches, fast_safe_load
+from utils import base_url_host_matches, fast_safe_load, is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -4246,7 +4246,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Initialize Rich console
         self.console = Console()
         self.config = CLI_CONFIG
-        self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
+        self.compact = compact if compact is not None else is_truthy_value(
+            CLI_CONFIG["display"].get("compact"), default=False
+        )
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
@@ -4256,7 +4258,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # path hides per-tool lines, and the pre-focus mode is stashed so
         # /focus off restores it. Purely cosmetic — never changes what is sent
         # to the model. See hermes_cli/focus_view.py.
-        self._focus_view_enabled = bool(CLI_CONFIG["display"].get("focus_view", False))
+        self._focus_view_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("focus_view"), default=False
+        )
         self._focus_saved_tool_progress = None
         self._focus_hidden_lines = 0
         self._focus_last_counted_tool = None
@@ -4273,14 +4277,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
-        self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        self.bell_on_complete = is_truthy_value(
+            CLI_CONFIG["display"].get("bell_on_complete"), default=False
+        )
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
-        self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        self.reasoning_full = is_truthy_value(
+            CLI_CONFIG["display"].get("reasoning_full"), default=False
+        )
         _configure_output_history(
-            enabled=CLI_CONFIG["display"].get("persistent_output", True),
+            enabled=is_truthy_value(
+                CLI_CONFIG["display"].get("persistent_output"), default=True
+            ),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
         )
         # busy_input_mode: "interrupt" (Enter redirects current run),
@@ -4302,9 +4312,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.verbose = bool(verbose) if verbose is not None else False
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
-        self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        self.streaming_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("streaming"), default=False
+        )
         # show_timestamps: prefix user and assistant labels with timestamps
-        self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
+        self.show_timestamps = is_truthy_value(
+            CLI_CONFIG["display"].get("timestamps"), default=False
+        )
         self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
         self.final_response_markdown = str(
             CLI_CONFIG["display"].get("final_response_markdown", "strip")
@@ -4313,15 +4327,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.final_response_markdown = "strip"
 
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
-        self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
+        self._inline_diffs_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("inline_diffs"), default=True
+        )
 
         # Per-turn accounting (display.turn_summary / display.spinner_token_flow).
         # Both are CLI-only, display-only chrome. The collector rides the
         # tool-progress feed this class already receives, so no agent-loop
         # bookkeeping is involved.
-        self._turn_summary_enabled = bool(CLI_CONFIG["display"].get("turn_summary", True))
-        self._spinner_token_flow_enabled = bool(
-            CLI_CONFIG["display"].get("spinner_token_flow", True)
+        self._turn_summary_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("turn_summary"), default=True
+        )
+        self._spinner_token_flow_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("spinner_token_flow"), default=True
         )
         self._turn_summary_collector = None
         self._turn_summary_start = 0.0

--- a/cli.py
+++ b/cli.py
@@ -4749,7 +4749,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._status_bar_visible = True
         # Battery read-out in the status bar (toggled via /battery, off by
         # default). Persisted to display.battery so it survives restarts.
-        self._battery_visible = bool(CLI_CONFIG["display"].get("battery", False))
+        self._battery_visible = is_truthy_value(
+            CLI_CONFIG["display"].get("battery"), default=False
+        )
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that

--- a/cli.py
+++ b/cli.py
@@ -226,7 +226,7 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches, base_url_hostname, fast_safe_load
+from utils import base_url_host_matches, base_url_hostname, fast_safe_load, is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -5094,7 +5094,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Initialize Rich console
         self.console = Console()
         self.config = CLI_CONFIG
-        self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
+        self.compact = compact if compact is not None else is_truthy_value(
+            CLI_CONFIG["display"].get("compact"), default=False
+        )
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
@@ -5104,7 +5106,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # path hides per-tool lines, and the pre-focus mode is stashed so
         # /focus off restores it. Purely cosmetic — never changes what is sent
         # to the model. See hermes_cli/focus_view.py.
-        self._focus_view_enabled = bool(CLI_CONFIG["display"].get("focus_view", False))
+        self._focus_view_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("focus_view"), default=False
+        )
         self._focus_saved_tool_progress = None
         self._focus_hidden_lines = 0
         self._focus_last_counted_tool = None
@@ -5121,14 +5125,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
-        self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        self.bell_on_complete = is_truthy_value(
+            CLI_CONFIG["display"].get("bell_on_complete"), default=False
+        )
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
-        self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        self.reasoning_full = is_truthy_value(
+            CLI_CONFIG["display"].get("reasoning_full"), default=False
+        )
         _configure_output_history(
-            enabled=CLI_CONFIG["display"].get("persistent_output", True),
+            enabled=is_truthy_value(
+                CLI_CONFIG["display"].get("persistent_output"), default=True
+            ),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
         )
         # busy_input_mode: "interrupt" (Enter redirects current run),
@@ -5150,9 +5160,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.verbose = bool(verbose) if verbose is not None else False
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
-        self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        self.streaming_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("streaming"), default=False
+        )
         # show_timestamps: prefix user and assistant labels with timestamps
-        self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
+        self.show_timestamps = is_truthy_value(
+            CLI_CONFIG["display"].get("timestamps"), default=False
+        )
         self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
         self.final_response_markdown = str(
             CLI_CONFIG["display"].get("final_response_markdown", "strip")
@@ -5161,15 +5175,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.final_response_markdown = "strip"
 
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
-        self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
+        self._inline_diffs_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("inline_diffs"), default=True
+        )
 
         # Per-turn accounting (display.turn_summary / display.spinner_token_flow).
         # Both are CLI-only, display-only chrome. The collector rides the
         # tool-progress feed this class already receives, so no agent-loop
         # bookkeeping is involved.
-        self._turn_summary_enabled = bool(CLI_CONFIG["display"].get("turn_summary", True))
-        self._spinner_token_flow_enabled = bool(
-            CLI_CONFIG["display"].get("spinner_token_flow", True)
+        self._turn_summary_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("turn_summary"), default=True
+        )
+        self._spinner_token_flow_enabled = is_truthy_value(
+            CLI_CONFIG["display"].get("spinner_token_flow"), default=True
         )
         self._turn_summary_collector = None
         self._turn_summary_start = 0.0

--- a/cli.py
+++ b/cli.py
@@ -5670,7 +5670,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
         # Battery read-out in the status bar (toggled via /battery, off by
         # default). Persisted to display.battery so it survives restarts.
-        self._battery_visible = bool(CLI_CONFIG["display"].get("battery", False))
+        self._battery_visible = is_truthy_value(
+            CLI_CONFIG["display"].get("battery"), default=False
+        )
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that

--- a/tests/cli/test_cli_display_quoted_false.py
+++ b/tests/cli/test_cli_display_quoted_false.py
@@ -1,0 +1,74 @@
+"""Regression tests: CLI display toggles honor quoted YAML ``"false"``.
+
+The CLI init block read each display.* boolean with bare ``bool()`` /
+truthiness; ``bool("false")`` is ``True``, so a hand-edited config.yaml
+with a quoted value silently KEPT the feature on (focus view, bell,
+streaming, timestamps, inline diffs, turn summary, token flow, persistent
+output, reasoning recap, compact) against the operator's explicit intent.
+"""
+
+from unittest.mock import patch
+
+import cli as _cli_mod
+from cli import HermesCLI
+
+
+def _make_cli(display, **kwargs):
+    """Construct HermesCLI with a patched CLI_CONFIG display section."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": display,
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    with (
+        patch("cli.get_tool_definitions", return_value=[]),
+        patch.dict("os.environ", clean_env, clear=False),
+        patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}),
+    ):
+        return HermesCLI(model="anthropic/claude-opus-4.6", **kwargs)
+
+
+def test_display_toggles_quoted_false_disables():
+    """Quoted ``"false"`` for every display toggle must disable it."""
+    display = {
+        "compact": "false",
+        "focus_view": "false",
+        "bell_on_complete": "false",
+        "reasoning_full": "false",
+        "persistent_output": "false",
+        "streaming": "false",
+        "timestamps": "false",
+        "inline_diffs": "false",
+        "turn_summary": "false",
+        "spinner_token_flow": "false",
+    }
+    cli = _make_cli(display)
+    assert cli.compact is False
+    assert cli._focus_view_enabled is False
+    assert cli.bell_on_complete is False
+    assert cli.reasoning_full is False
+    assert cli.streaming_enabled is False
+    assert cli.show_timestamps is False
+    assert cli._inline_diffs_enabled is False
+    assert cli._turn_summary_enabled is False
+    assert cli._spinner_token_flow_enabled is False
+
+
+def test_display_toggles_quoted_true_and_defaults():
+    """Quoted ``"true"`` enables; absent keys keep the historical defaults."""
+    cli = _make_cli({"streaming": "true", "turn_summary": "true"})
+    assert cli.streaming_enabled is True
+    assert cli._turn_summary_enabled is True
+    # Historical defaults when absent.
+    assert cli._inline_diffs_enabled is True
+    assert cli.compact is False
+    assert cli._focus_view_enabled is False
+    assert cli.bell_on_complete is False
+    assert cli.show_timestamps is False
+    assert cli._spinner_token_flow_enabled is True

--- a/tests/cli/test_cli_display_quoted_false.py
+++ b/tests/cli/test_cli_display_quoted_false.py
@@ -47,6 +47,7 @@ def test_display_toggles_quoted_false_disables():
         "inline_diffs": "false",
         "turn_summary": "false",
         "spinner_token_flow": "false",
+        "battery": "false",
     }
     cli = _make_cli(display)
     assert cli.compact is False
@@ -58,6 +59,7 @@ def test_display_toggles_quoted_false_disables():
     assert cli._inline_diffs_enabled is False
     assert cli._turn_summary_enabled is False
     assert cli._spinner_token_flow_enabled is False
+    assert cli._battery_visible is False
 
 
 def test_display_toggles_quoted_true_and_defaults():


### PR DESCRIPTION
## Summary

The CLI init block read the `display.*` boolean toggles with bare `bool()` / raw truthiness. `bool("false")` is `True`, so a hand-edited config.yaml with a quoted value silently **kept the feature on** against the operator's explicit intent — the exact "quoted false" class (`bool("false")` is `True`).

Eleven toggles fixed, all now through the shared `utils.is_truthy_value` (truthy set `1/true/yes/on`) with their historical defaults preserved byte-for-byte for real bools and absent keys:

- `compact`, `focus_view`, `bell_on_complete`, `reasoning_full`, `persistent_output`, `streaming`, `timestamps`, `inline_diffs`, `turn_summary`, `spinner_token_flow`, `battery`

(`show_reasoning` is covered by its own PR — #81354.)

## Tests

`tests/cli/test_cli_display_quoted_false.py` — constructs `HermesCLI` with a patched `CLI_CONFIG` (the established `test_codex_models` pattern):
- `test_display_toggles_quoted_false_disables` — quoted `"false"` for every toggle → each attribute `False`. **Verified RED on old code, GREEN here.**
- `test_display_toggles_quoted_true_and_defaults` — quoted `"true"` enables; absent keys keep historical defaults.

Verified: new file 2/2; neighboring CLI tests (`test_busy_input_mode_command`, `test_chat_q_exit_clear`, `test_codex_models`) 16/16. Independent review: PASS (one review-fix round folded in — `battery` sibling).
