### PR TITLE
fix(windows): converge dual gateway autostart entries to one mechanism (#80569)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -613,7 +613,7 @@ def _check_windows_gateway_launcher(issues: list[str]) -> None:
         for action in actions:
             check_info(action)
         if any(a.startswith("⚠") for a in actions):
-            check_warn("Gateway autostart reconcile incomplete — remove the listed Startup entries manually")
+            check_warn("Gateway autostart reconcile incomplete — review the warnings above")
         else:
             check_ok("Gateway autostart reconciled to a single mechanism")
     else:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -612,7 +612,10 @@ def _check_windows_gateway_launcher(issues: list[str]) -> None:
     if actions:
         for action in actions:
             check_info(action)
-        check_ok("Gateway autostart reconciled to a single mechanism")
+        if any(a.startswith("⚠") for a in actions):
+            check_warn("Gateway autostart reconcile incomplete — remove the listed Startup entries manually")
+        else:
+            check_ok("Gateway autostart reconciled to a single mechanism")
     else:
         check_ok("Gateway autostart uses a single mechanism")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -584,6 +584,39 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _check_windows_gateway_launcher(issues: list[str]) -> None:
+    """Windows: converge Scheduled Task + Startup-folder gateway autostart.
+
+    Pre-#45610 installs left a ``cmd.exe`` launcher in the Startup folder,
+    and successful Scheduled Task installs never removed Startup entries —
+    both then fire the same launcher at logon and spawn duplicate gateways
+    (#80569). Reconciles to a single mechanism and reports the outcome.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        from hermes_cli import gateway_windows
+    except Exception:
+        return
+    try:
+        if not gateway_windows.is_installed():
+            return
+    except Exception:
+        return
+    _section("Windows Gateway Autostart")
+    try:
+        actions = gateway_windows.reconcile_autostart_launchers()
+    except Exception as exc:
+        check_warn("Could not reconcile Windows gateway autostart", f"({exc})")
+        return
+    if actions:
+        for action in actions:
+            check_info(action)
+        check_ok("Gateway autostart reconciled to a single mechanism")
+    else:
+        check_ok("Gateway autostart uses a single mechanism")
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1624,6 +1657,7 @@ def run_doctor(args):
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
+    _check_windows_gateway_launcher(issues)
 
     if sys.platform != "win32":
         _section("Command Installation")

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -714,22 +714,26 @@ def _install_startup_entry(script_path: Path) -> Path:
     return entry
 
 
-def _remove_startup_entries() -> list[Path]:
+def _remove_startup_entries() -> tuple[list[Path], list[Path]]:
     """Remove both Startup-folder gateway entries (.vbs fallback + legacy .cmd).
 
     The Scheduled Task and the Startup entry are alternatives — the fallback
     is only installed when schtasks is unavailable (see ``install``). If both
     persist, logon fires the same launcher twice and spawns duplicate
-    gateways (#80569). Best-effort per path; returns the paths removed.
+    gateways (#80569). Returns (removed, failed); failures (locked or access
+    denied) are surfaced so callers warn instead of claiming convergence.
     """
     removed: list[Path] = []
+    failed: list[Path] = []
     for path in (get_startup_entry_path(), _legacy_startup_entry_path()):
         try:
             path.unlink()
             removed.append(path)
-        except OSError:
+        except FileNotFoundError:
             pass
-    return removed
+        except OSError:
+            failed.append(path)
+    return removed, failed
 
 
 def reconcile_autostart_launchers() -> list[str]:
@@ -756,8 +760,14 @@ def reconcile_autostart_launchers() -> list[str]:
     except Exception:
         return actions
     if task_registered:
-        for path in _remove_startup_entries():
+        removed, failed = _remove_startup_entries()
+        for path in removed:
             actions.append(f"Removed redundant Windows login item: {path}")
+        for path in failed:
+            actions.append(
+                f"⚠ Could not remove redundant Windows login item: {path} "
+                "(locked or access denied — duplicate autostart may persist)"
+            )
         return actions
     if _legacy_startup_entry_path().exists():
         script_path = _write_task_script()
@@ -1063,8 +1073,19 @@ def _prompt_install_choices(
 def _install_startup_fallback(script_path: Path, start_now: bool, detail: str) -> None:
     """Install the Startup-folder fallback and optionally start once."""
     print(f"↻ Scheduled Task install blocked ({detail.splitlines()[0]}) — using Startup folder fallback")
-    entry = _install_startup_entry(script_path)
-    print(f"✓ Installed Windows login item: {entry}")
+    try:
+        task_still_registered = is_task_registered()
+    except Exception:
+        task_still_registered = False
+    if task_still_registered:
+        # The task still exists (schtasks delete failed with access denied, or
+        # UAC was declined on a machine that already has a task). Installing
+        # the fallback too would fire the same launcher twice at logon and
+        # spawn duplicate gateways (#80569).
+        print("⚠ Scheduled Task is still registered — skipped Startup fallback to avoid duplicate autostart entries.")
+    else:
+        entry = _install_startup_entry(script_path)
+        print(f"✓ Installed Windows login item: {entry}")
     print(f"  Task script: {script_path}")
 
     # Re-running `hermes -p <profile> gateway install` must be safe.
@@ -1152,8 +1173,11 @@ def install(
         # Startup fallback or a legacy pre-#45610 .cmd entry still exists,
         # logon would fire the same launcher twice and spawn duplicate
         # gateways (#80569). Converge to the task only.
-        for entry in _remove_startup_entries():
+        removed, failed = _remove_startup_entries()
+        for entry in removed:
             print(f"✓ Removed redundant Windows login item: {entry}")
+        for entry in failed:
+            print(f"⚠ Could not remove redundant Windows login item: {entry} (locked or access denied — it will still fire at logon)")
         if start_now:
             running_pids = _gateway_pids()
             if running_pids:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -714,6 +714,58 @@ def _install_startup_entry(script_path: Path) -> Path:
     return entry
 
 
+def _remove_startup_entries() -> list[Path]:
+    """Remove both Startup-folder gateway entries (.vbs fallback + legacy .cmd).
+
+    The Scheduled Task and the Startup entry are alternatives — the fallback
+    is only installed when schtasks is unavailable (see ``install``). If both
+    persist, logon fires the same launcher twice and spawns duplicate
+    gateways (#80569). Best-effort per path; returns the paths removed.
+    """
+    removed: list[Path] = []
+    for path in (get_startup_entry_path(), _legacy_startup_entry_path()):
+        try:
+            path.unlink()
+            removed.append(path)
+        except OSError:
+            pass
+    return removed
+
+
+def reconcile_autostart_launchers() -> list[str]:
+    """Converge Windows gateway autostart persistence to a single mechanism.
+
+    Pre-#45610 installs left a ``cmd.exe`` launcher (``Hermes_Gateway.cmd``)
+    in the Startup folder, and successful Scheduled Task installs never
+    removed Startup entries — so both could coexist and fire the same
+    launcher at logon, spawning duplicate gateways (#80569).
+
+    Rules (idempotent):
+    * Scheduled Task registered  -> remove Startup entries (.vbs + legacy .cmd).
+    * No task, legacy .cmd present -> migrate to the console-less .vbs
+      fallback (``_install_startup_entry`` removes the legacy .cmd itself).
+    * No task, .vbs fallback present -> already converged, no-op.
+
+    File-ops only (no schtasks mutation, no elevation), safe to run from
+    install, update, and ``hermes doctor``. Returns human-readable actions
+    taken; empty when already converged or schtasks is unavailable.
+    """
+    actions: list[str] = []
+    try:
+        task_registered = is_task_registered()
+    except Exception:
+        return actions
+    if task_registered:
+        for path in _remove_startup_entries():
+            actions.append(f"Removed redundant Windows login item: {path}")
+        return actions
+    if _legacy_startup_entry_path().exists():
+        script_path = _write_task_script()
+        entry = _install_startup_entry(script_path)
+        actions.append(f"Migrated legacy Windows login item to: {entry}")
+    return actions
+
+
 def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     """Return (hidden_console_python, venv_dir, extra_pythonpath) for detached runs.
 
@@ -1096,6 +1148,12 @@ def install(
         print(f"✓ {detail}")
         print(f"  Task script: {script_path}")
         print("ℹ Gateway auto-start installed for Windows login.")
+        # The Scheduled Task and the Startup entry are alternatives — if a
+        # Startup fallback or a legacy pre-#45610 .cmd entry still exists,
+        # logon would fire the same launcher twice and spawn duplicate
+        # gateways (#80569). Converge to the task only.
+        for entry in _remove_startup_entries():
+            print(f"✓ Removed redundant Windows login item: {entry}")
         if start_now:
             running_pids = _gateway_pids()
             if running_pids:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -757,7 +757,8 @@ def reconcile_autostart_launchers() -> list[str]:
     actions: list[str] = []
     try:
         task_registered = is_task_registered()
-    except Exception:
+    except Exception as exc:
+        actions.append(f"⚠ Could not verify Scheduled Task state ({exc}) — reconcile skipped")
         return actions
     if task_registered:
         removed, failed = _remove_startup_entries()
@@ -1083,6 +1084,7 @@ def _install_startup_fallback(script_path: Path, start_now: bool, detail: str) -
         # the fallback too would fire the same launcher twice at logon and
         # spawn duplicate gateways (#80569).
         print("⚠ Scheduled Task is still registered — skipped Startup fallback to avoid duplicate autostart entries.")
+        print("  If the task is disabled or broken, run 'hermes gateway uninstall' (or delete the task) and re-run install to use the Startup fallback.")
     else:
         entry = _install_startup_entry(script_path)
         print(f"✓ Installed Windows login item: {entry}")

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -757,8 +757,9 @@ def reconcile_autostart_launchers() -> list[str]:
     actions: list[str] = []
     try:
         task_registered = is_task_registered()
-    except Exception as exc:
-        actions.append(f"⚠ Could not verify Scheduled Task state ({exc}) — reconcile skipped")
+    except Exception:
+        # Fail open: never let a wedged schtasks query block install/update/doctor.
+        actions.append("⚠ Could not verify Scheduled Task state — reconcile skipped")
         return actions
     if task_registered:
         removed, failed = _remove_startup_entries()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3338,7 +3338,10 @@ def _refresh_windows_gateway_launchers() -> None:
         # and migrate legacy pre-#45610 .cmd login items (#80569) so the next
         # logon cannot fire the same launcher twice.
         for action in gateway_windows.reconcile_autostart_launchers():
-            print(f"  ✓ {action}")
+            if action.startswith("⚠"):
+                print(f"  {action}")
+            else:
+                print(f"  ✓ {action}")
         print("  ✓ Refreshed Windows gateway launcher scripts")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3334,6 +3334,11 @@ def _refresh_windows_gateway_launchers() -> None:
         if not gateway_windows.is_installed():
             return
         gateway_windows._write_task_script()
+        # Converge dual autostart persistence (Scheduled Task + Startup entry)
+        # and migrate legacy pre-#45610 .cmd login items (#80569) so the next
+        # logon cannot fire the same launcher twice.
+        for action in gateway_windows.reconcile_autostart_launchers():
+            print(f"  ✓ {action}")
         print("  ✓ Refreshed Windows gateway launcher scripts")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1473,3 +1473,23 @@ def test_windows_gateway_launcher_check_warns_on_incomplete_reconcile(monkeypatc
     assert "Could not remove redundant Windows login item" in out
     assert "reconcile incomplete" in out
     assert "reconciled to a single mechanism" not in out
+
+
+def test_windows_gateway_launcher_check_warns_when_schtasks_wedges(monkeypatch, capsys):
+    """A schtasks query failure surfaces as a doctor warning, not a clean ok."""
+    import hermes_cli.gateway_windows as gateway_windows
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "reconcile_autostart_launchers",
+        lambda: ["⚠ Could not verify Scheduled Task state — reconcile skipped"],
+    )
+
+    doctor._check_windows_gateway_launcher([])
+
+    out = capsys.readouterr().out
+    assert "Could not verify Scheduled Task state" in out
+    assert "reconcile incomplete" in out
+    assert "reconciled to a single mechanism" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,46 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+# ---------------------------------------------------------------------------
+# Windows gateway autostart convergence — issue #80569
+# ---------------------------------------------------------------------------
+
+
+def test_windows_gateway_launcher_check_reconciles_and_reports(monkeypatch, capsys):
+    """Windows doctor applies and reports autostart convergence (#80569)."""
+    import hermes_cli.gateway_windows as gateway_windows
+
+    actions = ["Removed redundant Windows login item: C:\\Startup\\Hermes_Gateway.cmd"]
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "reconcile_autostart_launchers", lambda: actions)
+
+    doctor._check_windows_gateway_launcher([])
+
+    out = capsys.readouterr().out
+    assert "Windows Gateway Autostart" in out
+    assert "Removed redundant Windows login item" in out
+    assert "reconciled to a single mechanism" in out
+
+
+def test_windows_gateway_launcher_check_skips_off_windows(monkeypatch, capsys):
+    """The check is a no-op on non-Windows platforms."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    doctor._check_windows_gateway_launcher([])
+
+    assert "Windows Gateway Autostart" not in capsys.readouterr().out
+
+
+def test_windows_gateway_launcher_check_skips_when_not_installed(monkeypatch, capsys):
+    """No gateway autostart install -> nothing to reconcile, no section."""
+    import hermes_cli.gateway_windows as gateway_windows
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: False)
+
+    doctor._check_windows_gateway_launcher([])
+
+    assert "Windows Gateway Autostart" not in capsys.readouterr().out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1453,3 +1453,23 @@ def test_windows_gateway_launcher_check_skips_when_not_installed(monkeypatch, ca
     doctor._check_windows_gateway_launcher([])
 
     assert "Windows Gateway Autostart" not in capsys.readouterr().out
+
+
+def test_windows_gateway_launcher_check_warns_on_incomplete_reconcile(monkeypatch, capsys):
+    """A failed removal must surface as a warning, not a clean ok."""
+    import hermes_cli.gateway_windows as gateway_windows
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "reconcile_autostart_launchers",
+        lambda: ["⚠ Could not remove redundant Windows login item: C:\\Startup\\Hermes_Gateway.cmd"],
+    )
+
+    doctor._check_windows_gateway_launcher([])
+
+    out = capsys.readouterr().out
+    assert "Could not remove redundant Windows login item" in out
+    assert "reconcile incomplete" in out
+    assert "reconciled to a single mechanism" not in out

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -197,6 +197,107 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+# ---------------------------------------------------------------------------
+# Dual autostart persistence convergence — issue #80569
+# ---------------------------------------------------------------------------
+
+
+def _arrange_startup_files(monkeypatch, tmp_path):
+    """Create a Startup folder with both the .vbs fallback and legacy .cmd."""
+    vbs = tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"
+    cmd = tmp_path / "Startup" / "Hermes_Gateway_alice.cmd"
+    vbs.parent.mkdir(parents=True, exist_ok=True)
+    vbs.write_text("' fake vbs fallback", encoding="utf-8")
+    cmd.write_text("@echo off", encoding="utf-8")
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: vbs)
+    monkeypatch.setattr(gateway_windows, "_legacy_startup_entry_path", lambda: cmd)
+    return vbs, cmd
+
+
+def test_reconcile_removes_both_entries_when_task_registered(monkeypatch, tmp_path):
+    """Task + Startup entries coexisting -> both Startup entries are removed."""
+    vbs, cmd = _arrange_startup_files(monkeypatch, tmp_path)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+
+    actions = gateway_windows.reconcile_autostart_launchers()
+
+    assert not vbs.exists()
+    assert not cmd.exists()
+    assert len(actions) == 2
+    assert all("Removed redundant Windows login item" in a for a in actions)
+
+
+def test_reconcile_migrates_legacy_cmd_to_vbs_when_no_task(monkeypatch, tmp_path):
+    """No task + legacy .cmd -> .vbs fallback installed, legacy .cmd removed."""
+    cmd = tmp_path / "Startup" / "Hermes_Gateway_alice.cmd"
+    vbs = tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"
+    cmd.parent.mkdir(parents=True, exist_ok=True)
+    cmd.write_text("@echo off", encoding="utf-8")
+    script_path = tmp_path / "gateway-service" / "Hermes_Gateway_alice.cmd"
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: vbs)
+    monkeypatch.setattr(gateway_windows, "_legacy_startup_entry_path", lambda: cmd)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+
+    actions = gateway_windows.reconcile_autostart_launchers()
+
+    assert not cmd.exists()
+    assert vbs.exists()
+    assert len(actions) == 1
+    assert "Migrated legacy Windows login item" in actions[0]
+
+
+def test_reconcile_noop_when_converged(monkeypatch, tmp_path):
+    """Task-only or .vbs-fallback-only installs are already converged."""
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "get_startup_entry_path", lambda: tmp_path / "missing.vbs"
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_legacy_startup_entry_path", lambda: tmp_path / "missing.cmd"
+    )
+    assert gateway_windows.reconcile_autostart_launchers() == []
+
+    vbs = tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"
+    vbs.parent.mkdir(parents=True, exist_ok=True)
+    vbs.write_text("' fake vbs fallback", encoding="utf-8")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: vbs)
+    assert gateway_windows.reconcile_autostart_launchers() == []
+
+
+def test_install_success_removes_redundant_startup_entries(monkeypatch, tmp_path):
+    """install() with a successful Scheduled Task converges to task-only."""
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    removed_calls = []
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_prompt_install_choices",
+        lambda *args, **kwargs: (False, True),
+    )
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda task_name, script_path: (True, "Created Scheduled Task 'Hermes_Gateway_alice'"),
+    )
+
+    def fake_remove_startup_entries():
+        removed_calls.append(True)
+        return [tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"]
+
+    monkeypatch.setattr(gateway_windows, "_remove_startup_entries", fake_remove_startup_entries)
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
+
+    gateway_windows.install()
+
+    assert removed_calls == [True]
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -320,8 +320,8 @@ def test_reconcile_reports_unlink_failure(monkeypatch, tmp_path):
     assert any("Could not remove redundant Windows login item" in a for a in actions)
 
 
-def test_reconcile_noop_when_schtasks_wedges(monkeypatch, tmp_path):
-    """A schtasks query failure must not crash or remove anything."""
+def test_reconcile_warns_when_schtasks_wedges(monkeypatch, tmp_path):
+    """A schtasks query failure must warn, not crash or remove anything."""
     vbs, cmd = _arrange_startup_files(monkeypatch, tmp_path)
 
     def raise_wedge():
@@ -329,7 +329,10 @@ def test_reconcile_noop_when_schtasks_wedges(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_windows, "is_task_registered", raise_wedge)
 
-    assert gateway_windows.reconcile_autostart_launchers() == []
+    actions = gateway_windows.reconcile_autostart_launchers()
+
+    assert len(actions) == 1
+    assert "Could not verify Scheduled Task state" in actions[0]
     assert vbs.exists()
     assert cmd.exists()
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -288,7 +288,7 @@ def test_install_success_removes_redundant_startup_entries(monkeypatch, tmp_path
 
     def fake_remove_startup_entries():
         removed_calls.append(True)
-        return [tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"]
+        return ([tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"], [])
 
     monkeypatch.setattr(gateway_windows, "_remove_startup_entries", fake_remove_startup_entries)
     monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
@@ -296,6 +296,65 @@ def test_install_success_removes_redundant_startup_entries(monkeypatch, tmp_path
     gateway_windows.install()
 
     assert removed_calls == [True]
+
+
+def test_reconcile_reports_unlink_failure(monkeypatch, tmp_path):
+    """A locked Startup entry must be reported, not silently claimed removed."""
+    vbs, cmd = _arrange_startup_files(monkeypatch, tmp_path)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+
+    real_unlink = Path.unlink
+
+    def flaky_unlink(self):
+        if self.name.endswith(".vbs"):
+            raise PermissionError("file is locked")
+        return real_unlink(self)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+    actions = gateway_windows.reconcile_autostart_launchers()
+
+    assert vbs.exists()
+    assert not cmd.exists()
+    assert any("Removed redundant Windows login item" in a for a in actions)
+    assert any("Could not remove redundant Windows login item" in a for a in actions)
+
+
+def test_reconcile_noop_when_schtasks_wedges(monkeypatch, tmp_path):
+    """A schtasks query failure must not crash or remove anything."""
+    vbs, cmd = _arrange_startup_files(monkeypatch, tmp_path)
+
+    def raise_wedge():
+        raise RuntimeError("schtasks timed out")
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", raise_wedge)
+
+    assert gateway_windows.reconcile_autostart_launchers() == []
+    assert vbs.exists()
+    assert cmd.exists()
+
+
+def test_install_fallback_skips_entry_when_task_still_registered(monkeypatch, tmp_path):
+    """Startup fallback must not be installed while the Scheduled Task exists."""
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "_install_startup_entry", lambda p: calls.append(("entry", p)) or p
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_spawn_detached", lambda: calls.append(("spawn", None)) or 12345
+    )
+    monkeypatch.setattr(gateway_windows, "_report_gateway_start", lambda via: calls.append(("report", via)))
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: calls.append(("next", None)))
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway, "_profile_arg", lambda: "--profile alice")
+
+    gateway_windows._install_startup_fallback(script_path, start_now=True, detail="blocked")
+
+    assert not any(c[0] == "entry" for c in calls)
+    assert any(c[0] == "spawn" for c in calls)
 
 
 def test_gateway_vbs_script_is_console_less(monkeypatch):

--- a/tests/hermes_cli/test_update_gateway_launcher_refresh.py
+++ b/tests/hermes_cli/test_update_gateway_launcher_refresh.py
@@ -78,6 +78,25 @@ def test_restart_spec_normalizes_legacy_pythonw_argv(tmp_path):
     assert env["VIRTUAL_ENV"] == str(tmp_path / "venv")
 
 
+def test_refresh_reconciles_dual_autostart_entries(tmp_path):
+    """Post-update launcher refresh converges dual autostart persistence.
+
+    ``_refresh_windows_gateway_launchers`` must remove redundant Startup
+    entries (legacy .cmd / .vbs fallback) whenever a Scheduled Task is
+    registered, so the next logon cannot fire the same launcher twice
+    (#80569).
+    """
+    actions = ["Removed redundant Windows login item: C:\\Startup\\Hermes_Gateway.cmd"]
+    with mock.patch.object(cli_main, "_is_windows", return_value=True), mock.patch.object(
+        gateway_windows, "is_installed", return_value=True
+    ), mock.patch.object(
+        gateway_windows, "_write_task_script", return_value=tmp_path / "Hermes_Gateway.cmd"
+    ), mock.patch.object(
+        gateway_windows, "reconcile_autostart_launchers", return_value=actions
+    ):
+        cli_main._refresh_windows_gateway_launchers()
+
+
 # ---------------------------------------------------------------------------
 # _refresh_windows_gateway_launchers: hermes update regenerates launchers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows gateway dual-autostart class behind #80569: a machine can end up with **both** a Scheduled Task (`Hermes_Gateway`) and a Startup-folder entry (`Hermes_Gateway.cmd` from pre-#45610 installs, or the `.vbs` fallback), and at logon both fire the **same** launcher, spawning duplicate `gateway run` processes and orphan PIDs that `hermes gateway status` does not report.

Root cause, verified against current main:

1. `install()` never removed Startup-folder entries after a successful Scheduled Task install, so the task and the Startup entry could coexist indefinitely.
2. Nothing reconciled stale pre-#45610 `Hermes_Gateway.cmd` login items (the `.cmd` form has been legacy since #45610, 2026-06-23). Only a fallback re-install or `uninstall` removed them. The doctor-side reconciliation proposed in closed PR #53321 was never merged.
3. `install()`'s Startup-fallback path could *create* the dual state (UAC declined, or schtasks delete access-denied, on a machine that already has a task).

This PR converges persistence to a single mechanism — Scheduled Task preferred, Startup entry only when no task is registered:

- **`install()`**: after a successful Scheduled Task install, remove both Startup entries (`.vbs` fallback + legacy `.cmd`). Failures (locked/access-denied) are printed as warnings, not silently ignored.
- **`_install_startup_fallback()`**: skip installing the Startup entry when the Scheduled Task is still registered (warn instead), so install can no longer create the dual state.
- **`hermes update`**: `_refresh_windows_gateway_launchers()` now calls `reconcile_autostart_launchers()` — existing installs converge on update (removes redundant entries when a task is registered; migrates a legacy `.cmd`-only install to the console-less `.vbs` form).
- **`hermes doctor`**: new Windows-only check that runs the same reconcile and reports the outcome (warning when a removal fails).

`reconcile_autostart_launchers()` is idempotent: it performs file-system mutations only, queries `schtasks` read-only (no task mutation, no elevation needed), and is safe to run from install, update, and doctor. If the `schtasks` query hangs or fails (module-wide 15s timeout), reconcile fails open — nothing is touched and a warning is surfaced.

## Related Issue

Fixes #80569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway_windows.py`: add `_remove_startup_entries()` (returns removed+failed), `reconcile_autostart_launchers()`; wire entry removal into `install()` success; guard `_install_startup_fallback()` against an existing task.
- `hermes_cli/update_cmd.py`: `_refresh_windows_gateway_launchers()` calls `reconcile_autostart_launchers()`.
- `hermes_cli/doctor.py`: Windows-only `_check_windows_gateway_launcher` (next to `_check_gateway_service_linger` / `_check_s6_supervision`).
- `tests/hermes_cli/test_gateway_windows.py`, `test_update_gateway_launcher_refresh.py`, `test_doctor.py`: 9 new tests (reconcile dual-removal, legacy migration, no-op cases, unlink-failure reporting, schtasks wedge, fallback skip, doctor warn/skip).

## How to Test

1. `pytest tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_update_gateway_launcher_refresh.py tests/hermes_cli/test_doctor.py -q` → 71 passed (9 new tests in this PR).
2. Regression batch (test_gateway_wsl, test_update_venv_health, test_update_concurrent_quarantine, test_gateway, test_cmd_update) → 59 passed.
3. `scripts/check-windows-footguns.py <changed files>` → no new hits.

Manual (Windows): with a Scheduled Task installed, drop a `Hermes_Gateway.cmd` (or `.vbs`) into the Startup folder, then run `hermes doctor` — it reports removal of the redundant entry. Re-running `hermes gateway install` with the task present also removes it.

## Notes

- The reporter's "Startup `.cmd` reappears after update" sub-claim could not be reproduced from current main code paths: `hermes update` never writes to the Startup folder (it only regenerates `gateway-service/*.cmd|.vbs` under HERMES_HOME — which may be what the reporter saw refreshed). The stale-entry and dual-persistence classes are the real defects, fixed here.
- Out of scope (follow-up): a stale Scheduled Task whose action still runs `cmd.exe` (pre-#45610 task form) is not rewritten by this PR — `install()` already delete+creates the task, so a re-install or `hermes doctor` + re-install fixes it. Machines that never re-run install keep the task, now with the redundant Startup entry removed.
- No user-facing documentation changes needed — convergence is automatic; `hermes doctor` reports the outcome.
- **Open question:** when the task is registered but the user manually *disabled* it in Task Scheduler, this PR removes the Startup fallback — so the user's disable actually takes effect (previously the fallback would fire the gateway anyway, contradicting the disable). If maintainers prefer preserving the fallback for disabled tasks, that would require locale-aware task-status parsing; flagging for discussion.
