### PR TITLE
fix(cli): run MCP catalog bootstrap commands without a shell

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -28,6 +28,7 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 from __future__ import annotations
 
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -391,12 +392,13 @@ def _install_root() -> Path:
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
-    Each command runs through the shell (so `&&` etc. work). The output is
+    Each command is split into argv via shlex and run without a shell, so a
+    catalog entry cannot smuggle in shell metacharacters. The output is
     streamed to the user's terminal for visibility.
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(shlex.split(cmd), cwd=str(cwd))
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -636,3 +636,70 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+
+# ---------------------------------------------------------------------------
+# _run_bootstrap: no shell
+# ---------------------------------------------------------------------------
+
+
+class TestRunBootstrap:
+    """Bootstrap commands must run as argv, never through a shell."""
+
+    def test_bootstrap_passes_argv_list_without_shell(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+
+        def _fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+
+            class _Proc:
+                returncode = 0
+
+            return _Proc()
+
+        monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", _fake_run)
+        mc._run_bootstrap(tmp_path, ["npm install", "npm run build"])
+
+        assert [args for args, _ in calls] == [
+            ["npm", "install"],
+            ["npm", "run", "build"],
+        ]
+        for _, kwargs in calls:
+            assert kwargs.get("shell") is not True
+            assert kwargs.get("cwd") == str(tmp_path)
+
+    def test_bootstrap_metacharacters_stay_literal(self, tmp_path, monkeypatch):
+        """A catalog entry with shell metacharacters must not execute them."""
+        import hermes_cli.mcp_catalog as mc
+
+        captured = []
+
+        def _fake_run(args, **kwargs):
+            captured.append(args)
+
+            class _Proc:
+                returncode = 0
+
+            return _Proc()
+
+        monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", _fake_run)
+        payload = f"echo hi > {tmp_path / 'pwned'}"
+        mc._run_bootstrap(tmp_path, [payload])
+
+        # No shell, so the redirection operator is a literal argv element.
+        assert ">" in captured[0]
+        assert not (tmp_path / "pwned").exists()
+
+    def test_bootstrap_failure_raises_with_command(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        class _Proc:
+            returncode = 3
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_catalog.subprocess.run", lambda *a, **k: _Proc()
+        )
+        with pytest.raises(mc.CatalogError, match="npm install"):
+            mc._run_bootstrap(tmp_path, ["npm install"])


### PR DESCRIPTION
## What does this PR do?

Git-type MCP catalog entries can declare `install.bootstrap` commands, and `_run_bootstrap` in `hermes_cli/mcp_catalog.py:399` runs each one with `subprocess.run(cmd, shell=True)`. The catalog directory is overridable through `HERMES_OPTIONAL_MCPS` and the manifests are plain YAML, so the command strings are not guaranteed to be the copy Nous ships. Any shell metacharacters in a bootstrap entry execute during install.

This switches the call to `subprocess.run(shlex.split(cmd), cwd=...)`, no shell involved.

**Why this approach.** The docstring says the shell is intentional so `&&` works, but nothing in the shipped catalog needs that: the only bootstrap entry in `optional-mcps/` (`n8n/manifest.yaml`) is two plain argv-splittable commands (`python3 -m venv .venv`, `.venv/bin/pip install -r requirements.txt`). The shell buys nothing and turns every bootstrap string into a code execution sink. The commands are echoed to the user before running (`  $ cmd`), and the printed string still matches what runs.

**Overlap with #34973 and #35545.** #34973 makes the same change to this function but bundles an unrelated SSRF change in `agent/model_metadata.py`. #35545 sweeps `cli.py` and `mcp_catalog.py` together. This is the minimal focused version with regression tests, so it can land on its own. Happy to close if the maintainers prefer either of those.

## Related Issue

Fixes #81365

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_catalog.py`: `_run_bootstrap` now splits each command with `shlex.split` and runs it without a shell. Docstring updated to describe the new contract.
- `tests/hermes_cli/test_mcp_catalog.py`: new `TestRunBootstrap` class, three tests. Argv shape and no `shell` kwarg, shell metacharacters stay literal (a `>` payload creates no file), and a non-zero exit still raises `CatalogError` naming the original command.

## How to Test

1. Point `HERMES_OPTIONAL_MCPS` at a catalog directory containing a git-type manifest with `install.bootstrap: ["echo pwned > /tmp/pwned"]`
2. Install the entry
3. Before this change: the redirection runs through the shell and `/tmp/pwned` is created
4. After: `>` is passed to `echo` as a literal argument and nothing is created

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q
```

All 24 tests in the file pass (21 existing plus 3 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite via `scripts/run_tests.sh` (targeted files, see How to Test) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 10.0.26200, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A