### PR TITLE
feat(webhook): plain shared-secret header auth (X-Webhook-Secret)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1067,6 +1067,15 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
 
+        # Plain shared-secret header (PostHog, n8n, Zapier, etc.): the
+        # service is configured with a custom header whose value IS the
+        # secret.  Unlike HMAC, no signing is done — the header is a bearer
+        # token.  TLS (in production) provides the confidentiality that the
+        # shared secret isn't sniffed in transit.
+        plain_token = _header("X-Webhook-Secret")
+        if plain_token:
+            return _hmac_str_equal(plain_token, secret)
+
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
         # Checked independently of (and before) legacy V1 below — a sender

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -27,6 +27,9 @@ Security:
     binds a timestamp into the signed data for replay protection; the
     legacy body-only V1 (X-Webhook-Signature) is deprecated but still
     accepted with a warning, since it has no replay protection
+  - X-Webhook-Secret plain shared-secret header (PostHog, n8n, Zapier,
+    Make.com): bearer-token pattern — the header value IS the secret,
+    TLS provides confidentiality in transit (same model as X-Gitlab-Token)
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -140,3 +140,84 @@ class TestSignatureBeforeRateLimit:
         assert len(captured_events) == 1
 
 
+class TestPlainSharedSecretHeader:
+    """Verify X-Webhook-Secret plain shared-secret header auth.
+
+    Many services (PostHog, n8n, Zapier, Make.com) authenticate by sending
+    a custom header whose value IS the secret — no HMAC signing.  This is
+    a bearer-token pattern; TLS provides confidentiality in transit.
+    """
+
+    @pytest.mark.asyncio
+    async def test_valid_plain_secret_header_accepted(self):
+        """X-Webhook-Secret matching the route secret → 202."""
+        secret = "my-shared-secret"
+        route_name = "posthog-test"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "events": [],
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+
+        async def _noop(event):
+            pass
+
+        adapter.handle_message = _noop
+        app = _create_app(adapter)
+
+        body = json.dumps({"event": "alert", "data": "hello"}).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Secret": secret,
+                },
+            )
+            assert resp.status == 202, (
+                f"Expected 202 for valid plain-secret header, got {resp.status}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_plain_secret_header_rejected(self):
+        """X-Webhook-Secret NOT matching the route secret → 401."""
+        secret = "my-shared-secret"
+        route_name = "posthog-test"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "events": [],
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+
+        async def _noop(event):
+            pass
+
+        adapter.handle_message = _noop
+        app = _create_app(adapter)
+
+        body = json.dumps({"event": "alert", "data": "hello"}).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Secret": "wrong-secret",
+                },
+            )
+            assert resp.status == 401, (
+                f"Expected 401 for invalid plain-secret header, got {resp.status}"
+            )
+
+


### PR DESCRIPTION
## What does this PR do?

Adds support for plain shared-secret header authentication (`X-Webhook-Secret`) to the webhook adapter. Many services — PostHog, n8n, Zapier, Make.com — authenticate webhooks by sending a custom header whose value **is** the secret, with no HMAC signing. This is a bearer-token pattern where TLS provides confidentiality in transit.

Hermes currently supports HMAC-based auth only:
- GitHub (`X-Hub-Signature-256`)
- GitLab (`X-Gitlab-Token` — plain token, same pattern as this!)
- Svix (`svix-signature`)
- Generic HMAC V1/V2 (`X-Webhook-Signature` / `X-Webhook-Signature-V2`)

This fills the gap. The implementation mirrors the existing `X-Gitlab-Token` approach — both compare a plain header value against the configured secret via `hmac.compare_digest`.

## Related Issue

No existing issue. Discovered while configuring PostHog error-tracking webhooks — PostHog sends `X-Webhook-Secret` (a custom header), which Hermes rejected with 401.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**`gateway/platforms/webhook.py`** (+9 lines):
- Added `X-Webhook-Secret` header check in `_validate_signature()`, placed after the GitLab token check and before the generic HMAC V2/V1 fallback
- Uses the existing `_header()` helper (case-insensitive)
- Uses `hmac.compare_digest` for constant-time comparison, same as every other auth method

**`tests/gateway/test_webhook_signature_rate_limit.py`** (+73 lines):
- `test_valid_plain_secret_header_accepted` — correct secret → 202 accepted
- `test_invalid_plain_secret_header_rejected` — wrong secret → 401 rejected

## How to Test

```bash
python -m pytest tests/gateway/test_webhook_signature_rate_limit.py -v


All 51 existing webhook tests pass + 2 new tests pass. Also verified against a live PostHog webhook.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits format
- [x] Checked for duplicate PRs
- [x] Only related changes, no unrelated commits
- [x] All tests pass
- [x] Tests added for the new feature
- [x] Tested on Linux (Oracle Cloud ARM64)