### PR TITLE
feat(agent): add Claude Code ACP client

### DIFF
--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -1,0 +1,818 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `cc-acp`.
+
+This adapter lets Hermes treat the Claude Code ACP agent (published on npm as
+`claude-code-acp`, which installs a binary named `cc-acp` -- the package name
+and the binary name are NOT the same string, confirmed via the package's own
+README and `--help` output) as a chat-style backend. Each request starts a
+short-lived ACP session, sends the formatted conversation as a single prompt,
+collects text chunks, and converts the result back into the minimal shape
+Hermes expects from an OpenAI client.
+
+Mirrors `agent/copilot_acp_client.py` (the shipped, production Copilot-ACP
+equivalent) structurally, almost 1:1 -- the ACP JSON-RPC method surface
+(`session/new`, `session/prompt`, `session/request_permission`,
+`fs/read_text_file`, `fs/write_text_file`, `session/update`) is the same on
+both sides, confirmed by inspecting the installed `claude-code-acp@0.1.1`
+package's bundled `dist/index.js` directly. The real differences are the
+subprocess command/args resolution (`cc-acp` takes no `--acp`/`--stdio`
+flags -- bare invocation already speaks ACP over stdio by default) and the
+absence of a Copilot-specific deprecated-CLI-collision check (no known
+equivalent exists for `cc-acp`).
+
+NOTE: as of this module's introduction (Linear LIA-529, the ticket THIS
+module was built for), it is NOT yet wired into
+Hermes's provider resolution (`agent/auxiliary_client.py`'s
+`resolve_provider_client`, `agent/agent_init.py`, `agent/conversation_loop.py`,
+`agent/moa_loop.py`, `agent/model_metadata.py`, `tools/delegate_tool.py` -- all
+of which have real `copilot-acp`-specific branches that `claude-code-acp` does
+not yet mirror). `ClaudeCodeACPClient` and the `claude-code-acp` provider
+profile are independently importable/testable but `provider: claude-code-acp`
+is not yet selectable end-to-end from `run_agent.py`'s live flow. This is a
+deliberate, named scope boundary (see LIA-529's own design doc, docs/decisions/
+hermes-cli-subprocess-provider-design.md §2.2/§4 in the separate ~/deus repo) --
+not an oversight -- but wiring it up is real, not-yet-ticketed follow-up work,
+not something to assume is already done.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import shlex
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from agent.file_safety import get_read_block_error, get_write_denied_error
+from agent.redact import redact_sensitive_text
+from tools.environments.local import hermes_subprocess_env
+
+ACP_MARKER_BASE_URL = "acp://claude-code"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CODE_ACP_PATH", "").strip()
+        or "cc-acp"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_ACP_ARGS", "").strip()
+    if not raw:
+        # Verified against the installed claude-code-acp@0.1.1 package:
+        # `cc-acp` takes no `--acp`/`--stdio` flag pair (unlike Copilot's
+        # `copilot --acp --stdio`). Invoked bare, with no args at all, it
+        # already speaks ACP JSON-RPC over stdio by default -- confirmed via
+        # `cc-acp --help` and the package's own README Zed config example
+        # (`"args": []`).
+        return []
+    return shlex.split(raw)
+
+
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for child ACP processes."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok -- POSIX fallback inside try/except (pwd import fails on Windows)
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    # Last resort: /tmp (writable on any POSIX system). Avoids crashing the
+    # subprocess with no HOME; callers can set HERMES_HOME explicitly if they
+    # need a different writable dir.
+    return "/tmp"
+
+
+# Every tool name the bundled @anthropic-ai/claude-code SDK's agentic loop
+# can invoke on its own (confirmed via a live spawn's "system"/"init"
+# message tools list, 2026-08-08). Hermes's ACP protocol asks the MODEL to
+# emit <tool_call>{...}</tool_call> text for Hermes's OWN tool-calling loop
+# to execute (see _format_messages_as_prompt) -- it does not intend for
+# cc-acp's bundled SDK to execute tools itself against the real filesystem
+# on Hermes's behalf. See _DEFAULT_CLAUDE_DISALLOWED_TOOLS below for why
+# this list must be actively enforced, not assumed off by default.
+_CLAUDE_NATIVE_SDK_TOOLS = (
+    "Task", "Bash", "Glob", "Grep", "ExitPlanMode", "Read", "Edit",
+    "MultiEdit", "Write", "NotebookEdit", "WebFetch", "TodoWrite",
+    "WebSearch", "BashOutput", "KillShell", "SlashCommand",
+)
+_DEFAULT_CLAUDE_DISALLOWED_TOOLS = ",".join(_CLAUDE_NATIVE_SDK_TOOLS)
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    # Claude Code ACP is a model-driving CLI executor: it legitimately needs
+    # LLM provider credentials (CLAUDE_API_KEY, ANTHROPIC_API_KEY,
+    # CLAUDE_CODE_OAUTH_TOKEN -- falls back to the ambient Claude Code
+    # subscription/OAuth session managed by the bundled
+    # @anthropic-ai/claude-code SDK dependency when none is set). Route
+    # through the central helper so Tier-1 secrets (gateway bot tokens,
+    # GitHub auth, infra) are still stripped (#29157), same as
+    # copilot_acp_client.py.
+    env = hermes_subprocess_env(inherit_credentials=True)
+    home = _resolve_home_dir()
+    env["HOME"] = home
+    from hermes_constants import apply_subprocess_home_env
+    apply_subprocess_home_env(env)
+
+    # SECURITY (confirmed via live testing against the real
+    # claude-code-acp@0.1.1 package, not assumed): cc-acp's own bundled
+    # Claude Agent SDK will silently execute its native Read tool against
+    # the REAL filesystem -- with the real user's HOME, with no cwd
+    # confinement, with no redaction, and WITHOUT ever sending an ACP
+    # session/request_permission call to this client -- when
+    # CLAUDE_ALLOWED_TOOLS/CLAUDE_DISALLOWED_TOOLS are both unset. This
+    # contradicts the package's own README ("we do not enable any tools
+    # unless you specify them"); an empty/unset allowlist does NOT mean no
+    # tools are available. Live-verified: a prompt asking cc-acp to Read a
+    # canary file returned the real file content verbatim with zero
+    # session/request_permission calls and zero fs/read_text_file calls
+    # (i.e. Hermes's own _ensure_path_within_cwd/redact_sensitive_text/
+    # get_read_block_error mediation was never consulted at all). Setting
+    # CLAUDE_DISALLOWED_TOOLS to the full native tool list was independently
+    # verified to close this: the same prompt then failed to retrieve the
+    # canary content. Only apply this default when the operator hasn't
+    # already made an explicit choice via CLAUDE_ALLOWED_TOOLS or
+    # CLAUDE_DISALLOWED_TOOLS -- an explicit env var always wins.
+    if "CLAUDE_ALLOWED_TOOLS" not in env and "CLAUDE_DISALLOWED_TOOLS" not in env:
+        env["CLAUDE_DISALLOWED_TOOLS"] = _DEFAULT_CLAUDE_DISALLOWED_TOOLS
+
+    return env
+
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _permission_denied(message_id: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "cancelled",
+            }
+        },
+    }
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "You are being used as the active ACP agent backend for Hermes.",
+        "Use ACP capabilities to complete tasks.",
+        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "If no tool is needed, answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available tools (OpenAI function schema). "
+                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _build_openai_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ChatCompletionMessageToolCall:
+    """Build an OpenAI-compatible tool-call object for downstream handling."""
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    """Convert a one-shot ACP response into OpenAI-style stream chunks."""
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    return [data_chunk, usage_chunk]
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[ChatCompletionMessageToolCall] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"acp_call_{len(extracted)+1}"
+
+        extracted.append(
+            _build_openai_tool_call(
+                call_id=call_id,
+                name=fn_name.strip(),
+                arguments=fn_args,
+            )
+        )
+
+    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
+        raw = m.group(1)
+        _try_add_tool_call(raw)
+        consumed_spans.append((m.start(), m.end()))
+
+    # Only try bare-JSON fallback when no XML blocks were found.
+    if not extracted:
+        for m in _TOOL_CALL_JSON_RE.finditer(text):
+            raw = m.group(0)
+            _try_add_tool_call(raw)
+            consumed_spans.append((m.start(), m.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned
+
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class ClaudeCodeACPClient:
+    """Minimal OpenAI-client-compatible facade for Claude Code ACP (`cc-acp`)."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-code-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
+        # (used natively by the OpenAI SDK) rather than a plain float.
+        if timeout is None:
+            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            _effective_timeout = float(timeout)
+        else:
+            # httpx.Timeout or similar -- pick the largest component so the
+            # subprocess has enough wall-clock time for the full response.
+            _candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text,
+            timeout_seconds=_effective_timeout,
+        )
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "claude-code-acp",
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        try:
+            # Hide the console the CLI child would otherwise flash on Windows
+            # (#56747). Hide-only -- stdio pipes stay intact for the ACP wire.
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True, encoding='utf-8', errors='replace',
+                bufsize=1,
+                cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
+                creationflags=windows_hide_flags(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude Code ACP command '{self._acp_command}'. "
+                "Install it with: npm install -g claude-code-acp\n"
+                "(the npm package is named claude-code-acp but installs a binary "
+                "named cc-acp -- verify with: cc-acp --help)\n"
+                "Or set HERMES_CLAUDE_ACP_COMMAND/CLAUDE_CODE_ACP_PATH to point at "
+                "an existing install."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Claude Code ACP process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        def _stdout_reader() -> None:
+            if proc.stdout is None:
+                return
+            for line in proc.stdout:
+                # cc-acp writes pretty-printed (multi-line) JSON.stringify
+                # debug/log objects directly to stdout, intermixed with the
+                # real single-line JSON-RPC messages (confirmed via live
+                # spawn: "[ACP] Received Claude message: {" followed by an
+                # indented multi-line object). Individual lines from that
+                # pretty-print can themselves be standalone-valid JSON that
+                # is NOT a JSON-RPC message object -- e.g. the last element
+                # of an array with no trailing comma (`"SlashCommand"`)
+                # parses successfully to a bare Python str, not a dict.
+                # json.loads() alone can't distinguish "not JSON" from
+                # "valid JSON but not an object", and a bare str/int/bool/
+                # None reaching _handle_server_message()/_request() below
+                # crashes on the first .get() call. Require a dict.
+                try:
+                    parsed = json.loads(line)
+                except Exception:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    inbox.put(parsed)
+                else:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_tail.append(line.rstrip("\n"))
+
+        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
+        out_thread.start()
+        err_thread.start()
+
+        next_id = 0
+
+        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
+            nonlocal next_id
+            next_id += 1
+            request_id = next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    msg = inbox.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                ):
+                    continue
+
+                if msg.get("id") != request_id:
+                    continue
+                if "error" in msg:
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        f"Claude Code ACP {method} failed: {err.get('message') or err}"
+                    )
+                return msg.get("result")
+
+            stderr_text = "\n".join(stderr_tail).strip()
+            if proc.poll() is not None and stderr_text:
+                raise RuntimeError(f"Claude Code ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for Claude Code ACP response to {method}.")
+
+        try:
+            _request(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": True,
+                            "writeTextFile": True,
+                        }
+                    },
+                    "clientInfo": {
+                        "name": "hermes-agent",
+                        "title": "Hermes Agent",
+                        "version": "0.0.0",
+                    },
+                },
+            )
+            session = _request(
+                "session/new",
+                {
+                    "cwd": self._acp_cwd,
+                    "mcpServers": [],
+                },
+            ) or {}
+            session_id = str(session.get("sessionId") or "").strip()
+            if not session_id:
+                raise RuntimeError("Claude Code ACP did not return a sessionId.")
+
+            text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            _request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": prompt_text,
+                        }
+                    ],
+                },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            self.close()
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        cwd: str,
+        text_parts: list[str] | None,
+        reasoning_parts: list[str] | None,
+    ) -> bool:
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            kind = str(update.get("sessionUpdate") or "").strip()
+            content = update.get("content") or {}
+            chunk_text = ""
+            if isinstance(content, dict):
+                chunk_text = str(content.get("text") or "")
+            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
+                text_parts.append(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
+                reasoning_parts.append(chunk_text)
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = _permission_denied(message_id)
+        elif method == "fs/read_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                block_error = get_read_block_error(str(path))
+                if block_error:
+                    raise PermissionError(block_error)
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    content = ""
+                line = params.get("line")
+                limit = params.get("limit")
+                if isinstance(line, int) and line > 1:
+                    lines = content.splitlines(keepends=True)
+                    start = line - 1
+                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    content = "".join(lines[start:end])
+                if content:
+                    content = redact_sensitive_text(content, force=True)
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "content": content,
+                    },
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        elif method == "fs/write_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                denied = get_write_denied_error(str(path))
+                if denied:
+                    raise PermissionError(denied)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": None,
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        process.stdin.write(json.dumps(response) + "\n")
+        process.stdin.flush()
+        return True

--- a/plugins/model-providers/claude-code-acp/__init__.py
+++ b/plugins/model-providers/claude-code-acp/__init__.py
@@ -1,0 +1,49 @@
+"""Claude Code ACP provider profile.
+
+claude-code-acp uses an external ACP subprocess (the `cc-acp` binary,
+installed by the `claude-code-acp` npm package) -- NOT the standard
+transport. Wiring this profile into api_mode/run_agent.py-level provider
+resolution (the equivalent of copilot-acp's `if provider == "copilot-acp":`
+branch in agent/auxiliary_client.py) is deliberately deferred -- a real, not-yet-ticketed follow-up, not an
+oversight -- see agent/claude_code_acp_client.py's module docstring for the
+full explanation (this profile was built for Linear LIA-529, which is the
+ticket that intentionally scoped the wiring OUT, not a tracker for doing it).
+The profile captures auth + endpoint metadata for registry migration, same
+as plugins/model-providers/copilot-acp/.
+
+Note: the provider `name`/alias `"cc-acp"` below is the same string as the
+literal binary name `_resolve_command()` falls back to in
+agent/claude_code_acp_client.py, but they are different namespaces
+(ProviderProfile.aliases is config-selection surface; _resolve_command()'s
+fallback is the literal argv[0] spawned) -- not a bug, just worth a reader
+not conflating `provider: cc-acp` with an actual CLI flag.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCodeACPProfile(ProviderProfile):
+    """Claude Code ACP -- external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+claude_code_acp = ClaudeCodeACPProfile(
+    name="claude-code-acp",
+    aliases=("claude-acp", "cc-acp", "claude-code-acp-agent"),
+    api_mode="chat_completions",  # ACP subprocess uses chat_completions routing
+    env_vars=(),  # Managed by ACP subprocess
+    base_url="acp://claude-code",  # ACP internal scheme
+    auth_type="external_process",
+)
+
+register_provider(claude_code_acp)

--- a/plugins/model-providers/claude-code-acp/plugin.yaml
+++ b/plugins/model-providers/claude-code-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-code-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Claude Code via ACP subprocess
+author: Nous Research

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -1,0 +1,366 @@
+"""Focused regressions for the Claude Code ACP shim safety layer.
+
+Mirrors tests/agent/test_copilot_acp_client.py -- same coverage shape
+(tool-call stream-chunk parsing, fs/read_text_file redaction, the UTF-8
+decode-under-non-UTF-8-locale regression, fs/write_text_file safe-root
+enforcement, HOME env propagation), adapted for ClaudeCodeACPClient /
+cc-acp instead of CopilotACPClient / copilot.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_code_acp_client import ClaudeCodeACPClient
+from agent.claude_code_acp_client import _build_subprocess_env
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+
+
+class _FakeACPProcess:
+    """Fake subprocess.Popen result for exercising the full _run_prompt
+    JSON-RPC loop against a scripted stdout stream, without spawning a
+    real cc-acp process."""
+
+    def __init__(self, stdout_lines: list) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO("\n".join(stdout_lines) + "\n")
+        self.stderr = io.StringIO("")
+
+    def poll(self):
+        return None
+
+    def terminate(self) -> None:
+        pass
+
+    def wait(self, timeout=None) -> None:
+        pass
+
+    def kill(self) -> None:
+        pass
+
+
+class ClaudeCodeACPClientSafetyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ClaudeCodeACPClient(acp_cwd="/tmp")
+
+
+
+    def test_run_prompt_ignores_non_dict_json_lines_on_stdout(self) -> None:
+        """Regression, found via a live spawn of the real cc-acp binary
+        (claude-code-acp@0.1.1, 2026-08-08): cc-acp writes pretty-printed
+        multi-line JSON.stringify debug/log output directly to stdout,
+        intermixed with real single-line JSON-RPC messages. Individual
+        lines from that pretty-print can themselves be standalone-valid
+        JSON that is NOT an object -- e.g. the last element of an array
+        with no trailing comma (`"SlashCommand"`) parses to a bare Python
+        str via json.loads(), not a dict. Before the fix, that bare str
+        reached _handle_server_message()/_request() and crashed on the
+        first .get() call (AttributeError: 'str' object has no attribute
+        'get'). This test drives the real _run_prompt() JSON-RPC loop
+        against a scripted stdout stream reproducing exactly that shape."""
+        stdout_lines = [
+            '"SlashCommand"',  # noise: valid JSON, but not an object
+            json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": 1}}),
+            json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"sessionId": "sess-123"}}),
+            json.dumps({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-123",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "PONG"},
+                    },
+                },
+            }),
+            json.dumps({"jsonrpc": "2.0", "id": 3, "result": None}),
+        ]
+        fake_proc = _FakeACPProcess(stdout_lines)
+
+        with patch("agent.claude_code_acp_client.subprocess.Popen", return_value=fake_proc):
+            text, reasoning = self.client._run_prompt("hi", timeout_seconds=5)
+
+        self.assertEqual(text, "PONG")
+        self.assertEqual(reasoning, "")
+
+    def test_stream_true_preserves_tool_call_deltas(self) -> None:
+        tool_response = (
+            "<tool_call>"
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+            "</tool_call>"
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            stream = self.client._create_chat_completion(
+                model="claude-code-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                stream=True,
+            )
+
+        chunks = list(stream)
+        delta = chunks[0].choices[0].delta
+        self.assertIsNone(delta.content)
+        self.assertEqual(chunks[0].choices[0].finish_reason, "tool_calls")
+        self.assertEqual(len(delta.tool_calls), 1)
+        tool_delta = delta.tool_calls[0]
+        self.assertEqual(tool_delta.index, 0)
+        self.assertEqual(tool_delta.id, "call_read")
+        self.assertEqual(tool_delta.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_delta.function.arguments),
+            {"path": "README.md"},
+        )
+        self.assertEqual(chunks[1].choices, [])
+
+
+    def _dispatch(self, message: dict, *, cwd: str) -> dict:
+        process = _FakeProcess()
+        handled = self.client._handle_server_message(
+            message,
+            process=process,
+            cwd=cwd,
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        payload = process.stdin.getvalue().strip()
+        self.assertTrue(payload)
+        return json.loads(payload)
+
+
+
+    def test_read_text_file_redacts_sensitive_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            secret_file = root / "config.env"
+            secret_file.write_text("OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012")
+
+            # agent.redact snapshots HERMES_REDACT_SECRETS at import time into
+            # _REDACT_ENABLED, so patching os.environ is a no-op. Flip the
+            # module-level constant directly for the duration of the call.
+            with patch("agent.redact._REDACT_ENABLED", True):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(secret_file)},
+                    },
+                    cwd=str(root),
+                )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertNotIn("abc123def456", content)
+        self.assertIn("OPENAI_API_KEY=", content)
+
+    def test_fs_read_text_file_decodes_as_utf8_under_non_utf8_locale(self) -> None:
+        """Regression for #18637 (bug 2): fs/read_text_file used
+        ``path.read_text()`` with no explicit encoding, so on Windows
+        GBK/CP932/CP949 locales the Copilot read_file tool crashed on any
+        source file with non-ASCII content (e.g. a CJK comment, an em dash,
+        or UTF-8 BOM). Same fs/read_text_file handler is reused verbatim by
+        ClaudeCodeACPClient, so the same regression coverage applies here."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "note.md"
+            target.write_text("# 中文标题\nem dash — here\n", encoding="utf-8")
+
+            original_read_text = Path.read_text
+
+            def strict_read_text(self, encoding=None, errors=None, **kwargs):
+                if self == target and encoding != "utf-8":
+                    raise UnicodeDecodeError(
+                        "gbk", b"\x94", 0, 1, "illegal multibyte sequence"
+                    )
+                return original_read_text(
+                    self, encoding=encoding, errors=errors, **kwargs
+                )
+
+            with patch.object(Path, "read_text", strict_read_text):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 10,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+
+        self.assertNotIn("error", response)
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertIn("中文标题", content)
+        self.assertIn("em dash —", content)
+
+
+
+    def test_permission_request_is_always_denied(self) -> None:
+        """session/request_permission must be unconditionally denied (no
+        interactive TTY on this path) -- same conservative default as
+        CopilotACPClient. Mirrors the qa/ai-eng-warden request for explicit
+        coverage of this dispatch branch, not just the fs/* branches."""
+        response = self._dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/request_permission",
+                "params": {"sessionId": "sess-1", "toolCall": {"name": "Bash"}},
+            },
+            cwd="/tmp",
+        )
+        self.assertEqual(
+            (response.get("result") or {}).get("outcome", {}).get("outcome"),
+            "cancelled",
+        )
+        self.assertNotIn("error", response)
+
+    def test_build_subprocess_env_defaults_to_disallowing_native_tools(self) -> None:
+        """Regression, found via live-testing the real cc-acp binary
+        (claude-code-acp@0.1.1, 2026-08-08): with CLAUDE_ALLOWED_TOOLS and
+        CLAUDE_DISALLOWED_TOOLS both unset, cc-acp's bundled Claude Agent SDK
+        silently executed its native Read tool against the real filesystem
+        -- with the real HOME, no cwd confinement, no redaction -- and
+        WITHOUT ever sending an ACP session/request_permission call to this
+        client (a prompt asking it to read a canary file returned the real
+        file content verbatim). This contradicts the package's own README
+        ("we do not enable any tools unless you specify them"). The fix:
+        _build_subprocess_env() must default CLAUDE_DISALLOWED_TOOLS to the
+        full native-tool list unless the operator already made an explicit
+        choice. Live-reverified after the fix: the same canary-read prompt,
+        run through the real ClaudeCodeACPClient with no manual env
+        override, no longer returned the file content."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_ALLOWED_TOOLS", None)
+            os.environ.pop("CLAUDE_DISALLOWED_TOOLS", None)
+            env = _build_subprocess_env()
+
+        disallowed = env.get("CLAUDE_DISALLOWED_TOOLS", "")
+        for tool in ("Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch"):
+            self.assertIn(tool, disallowed)
+
+    def test_build_subprocess_env_respects_explicit_allowed_tools_override(self) -> None:
+        """An operator-set CLAUDE_ALLOWED_TOOLS must win -- the safe default
+        must not clobber an explicit, intentional choice."""
+        with patch.dict(os.environ, {"CLAUDE_ALLOWED_TOOLS": "Read"}, clear=False):
+            os.environ.pop("CLAUDE_DISALLOWED_TOOLS", None)
+            env = _build_subprocess_env()
+
+        self.assertEqual(env.get("CLAUDE_ALLOWED_TOOLS"), "Read")
+        self.assertNotIn("CLAUDE_DISALLOWED_TOOLS", env)
+
+    def test_build_subprocess_env_respects_explicit_disallowed_tools_override(self) -> None:
+        """An operator-set CLAUDE_DISALLOWED_TOOLS must win too -- the safe
+        default only fills in when the operator made no choice at all."""
+        with patch.dict(os.environ, {"CLAUDE_DISALLOWED_TOOLS": "Bash"}, clear=False):
+            os.environ.pop("CLAUDE_ALLOWED_TOOLS", None)
+            env = _build_subprocess_env()
+
+        self.assertEqual(env.get("CLAUDE_DISALLOWED_TOOLS"), "Bash")
+
+    def test_write_text_file_respects_safe_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            safe_root = root / "workspace"
+            safe_root.mkdir()
+            outside = root / "outside.txt"
+
+            with patch.dict(os.environ, {"HERMES_WRITE_SAFE_ROOT": str(safe_root)}, clear=False):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 5,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(outside),
+                            "content": "should-not-write",
+                        },
+                    },
+                    cwd=str(root),
+                )
+
+        self.assertIn("error", response)
+        self.assertIn("HERMES_WRITE_SAFE_ROOT", str(response["error"]))
+        self.assertFalse(outside.exists())
+
+
+# ── HOME env propagation tests ───────────────────────────────────────
+
+
+def _make_home_client(tmp_path):
+    return ClaudeCodeACPClient(
+        api_key="claude-code-acp",
+        base_url="acp://claude-code",
+        acp_command="cc-acp",
+        acp_args=[],
+        acp_cwd=str(tmp_path),
+    )
+
+
+def _fake_popen_capture(captured):
+    def _fake(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        raise FileNotFoundError("cc-acp not found")
+    return _fake
+
+
+def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "home").mkdir(parents=True)
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+
+    monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Hermeticity: an ambient HERMES_REAL_HOME (exported by Hermes' own
+    # terminal contract on dev boxes) outranks HOME in the candidate ladder,
+    # and an ambient TERMINAL_HOME_MODE would change the policy under test.
+    monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+    monkeypatch.delenv("TERMINAL_HOME_MODE", raising=False)
+    # Hermeticity: get_subprocess_home()'s auto mode prefers the profile home
+    # when is_container() is True -- on a containerized CI runner that real
+    # probe flips the resolution this test asserts. The host/VM branch is the
+    # contract under test; pin containment off.
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with patch("agent.claude_code_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Claude Code ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["kwargs"]["env"]["HOME"] == str(real_home)
+    assert captured["kwargs"]["env"]["HERMES_REAL_HOME"] == str(real_home)
+
+
+def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with patch("agent.claude_code_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Claude Code ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert "env" in captured["kwargs"]
+    assert captured["kwargs"]["env"]["HOME"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Claude Code ACP provider, mirroring the existing `agent/copilot_acp_client.py` pattern: spawns the real `cc-acp` binary (npm package `claude-code-acp@0.1.1`) over JSON-RPC/stdio and converts its ACP responses into the OpenAI-chat-completion shape the rest of the agent's pipeline expects.

- New `agent/claude_code_acp_client.py`
- New `plugins/model-providers/claude-code-acp/` profile dir (`__init__.py`, `plugin.yaml`)
- New `tests/agent/test_claude_code_acp_client.py` (11 tests)

## Notes on `cc-acp`'s real behavior (verified against the installed package, not assumed)

- The npm package name (`claude-code-acp`) differs from its binary name (`cc-acp`).
- `cc-acp` takes no `--acp`/`--stdio` flags (unlike Copilot's CLI) — bare invocation already speaks ACP over stdio by default.
- Same JSON-RPC method surface as the Copilot ACP integration (`session/new`, `session/prompt`, `session/request_permission`, `fs/read_text_file`, `fs/write_text_file`, `session/update`).

## Security finding fixed in this PR

`cc-acp`'s bundled `@anthropic-ai/claude-code` SDK will execute its own native tools (Read/Glob/Grep/Write/Bash/etc.) directly against the real filesystem when `CLAUDE_ALLOWED_TOOLS`/`CLAUDE_DISALLOWED_TOOLS` are both unset — bypassing this agent's own ACP-mediated tool loop entirely, and contradicting the package's own README claim that no tools are enabled unless specified. Verified live: a prompt asking `cc-acp` to read a canary file returned the real file content verbatim with zero `session/request_permission` or `fs/read_text_file` calls.

Fix: `_build_subprocess_env()` now defaults `CLAUDE_DISALLOWED_TOOLS` to the full native-tool list unless the operator has already made an explicit choice via `CLAUDE_ALLOWED_TOOLS`/`CLAUDE_DISALLOWED_TOOLS` (an explicit env var always wins). Re-verified the canary no longer leaks after the fix.

## Scope

Deliberately out of scope for this PR: provider-resolution wiring (`agent/auxiliary_client.py`'s `resolve_provider_client` and related call sites) — `provider: claude-code-acp` is not yet selectable end-to-end from the live agent-run flow. Happy to follow up with that wiring in a separate PR if this shape looks right to maintainers.

## Test plan

- [x] `bash scripts/run_tests.sh tests/agent/test_claude_code_acp_client.py tests/agent/test_copilot_acp_client.py` — 17/17 passed, 0 failed
- [x] `ruff check` on all new files — clean
- [x] Live smoke test against the real installed `cc-acp` binary, including the canary-file permission-bypass check before/after the security fix