### PR TITLE
fix(test-runner): capture Windows pytest output in a file

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -44,11 +44,12 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import BinaryIO, Dict, List, Tuple
 
 
 # Default test discovery roots.
@@ -305,14 +306,39 @@ def _run_one_file_once(
     file_timeout: float,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
+    if sys.platform == "win32":
+        # A gateway/pythonw parent may not have a usable console handle.
+        # Give pytest a real file so its terminal writer never inherits one.
+        with tempfile.TemporaryFile() as output_file:
+            return _run_one_file_once_captured(
+                file, pytest_args, repo_root, file_timeout, output_file
+            )
+    return _run_one_file_once_captured(
+        file, pytest_args, repo_root, file_timeout, None
+    )
+
+
+def _run_one_file_once_captured(
+    file: Path,
+    pytest_args: List[str],
+    repo_root: Path,
+    file_timeout: float,
+    output_file: BinaryIO | None,
+) -> Tuple[Path, int, str, dict[str, int], float]:
     cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
+
+    def captured_output(pipe_output: str | None) -> str:
+        if output_file is None:
+            return pipe_output or ""
+        output_file.seek(0)
+        return output_file.read().decode("utf-8", errors="replace")
     
     subproc_start = time.monotonic()
     # launch the pytest process
     proc = subprocess.Popen(
         cmd,
         cwd=repo_root,
-        stdout=subprocess.PIPE,
+        stdout=output_file if output_file is not None else subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True, encoding="utf-8", errors="replace",
         env=os.environ,
@@ -343,6 +369,8 @@ def _run_one_file_once(
             output, _ = proc.communicate(timeout=10)
         except subprocess.TimeoutExpired:
             output = "(file timeout exceeded; output unavailable)"
+        else:
+            output = captured_output(output)
         rc = 124  # de facto convention for "killed by timeout".
         output = (
             f"({file_timeout:.0f}s exceeded; "
@@ -357,6 +385,7 @@ def _run_one_file_once(
         # Happy path: pytest exited on its own. Kill the group anyway in
         # case it left grandchildren behind; already-dead is a no-op.
         _kill_tree(proc, pgid=pgid)
+        output = captured_output(output)
 
         output +=  "\n"
 

--- a/tests/test_run_tests_parallel_stdio.py
+++ b/tests/test_run_tests_parallel_stdio.py
@@ -1,16 +1,19 @@
-"""The runner's status glyphs must not crash narrow console encodings.
+"""The runner's stdio must survive native Windows console edge cases.
 
 On native Windows, piped or legacy-console stdio defaults to cp1252, which
 cannot encode the runner's ✓/✗ progress glyphs — before the fix, the first
 per-file status line killed the whole run with UnicodeEncodeError. The
 failure depends only on the stream's encoding, so these tests pin it on
-every OS by building a cp1252 stream explicitly.
+every OS by building a cp1252 stream explicitly. Gateway/pythonw processes
+also need pytest output captured to a real file because their inherited
+console handles may be invalid.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import io
+import subprocess
 import sys
 from pathlib import Path
 
@@ -67,3 +70,42 @@ def test_glyph_safe_stdio_noop_without_reconfigure(monkeypatch) -> None:
     print("✓ still fine")
 
     assert "✓ still fine" in plain.getvalue()
+
+
+def test_windows_pytest_output_uses_a_file_not_a_console_pipe(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A pythonw worker can expose an unusable inherited console pipe."""
+    mod = _load_runner()
+    test_file = tmp_path / "test_probe.py"
+    test_file.write_text("def test_ok(): pass\n", encoding="utf-8")
+
+    class FakeProcess:
+        pid = 123
+        returncode = 0
+
+        def __init__(self, _cmd, **kwargs):
+            output = kwargs["stdout"]
+            if output == subprocess.PIPE:
+                raise OSError(22, "Invalid argument")
+            assert kwargs["stderr"] == subprocess.STDOUT
+            output.write(b"1 passed in 0.01s\n")
+            output.flush()
+
+        def communicate(self, timeout=None):
+            return None, None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(mod.sys, "platform", "win32")
+    monkeypatch.setattr(mod.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(mod, "_kill_tree", lambda *_args, **_kwargs: None)
+
+    _file, rc, output, summary, _duration = mod._run_one_file_once(
+        test_file, ["-q"], tmp_path, 10
+    )
+
+    assert rc == 0
+    assert "1 passed" in output
+    assert summary == {"passed": 1}


### PR DESCRIPTION
## Summary

- Capture per-file pytest stdout and stderr in a real temporary file on Windows so gateway/pythonw workers never pass an invalid inherited console handle to pytest's terminal writer.
- Read the captured bytes back with the runner's existing UTF-8 replacement semantics, preserving summaries, retries, timeout diagnostics, and process-tree cleanup.
- Add a regression test that rejects pipe capture on simulated Windows and verifies combined output remains parseable.

## Test Coverage

All new Windows output-capture behavior is covered by `test_windows_pytest_output_uses_a_file_not_a_console_pipe`; existing runner tests continue to exercise the non-Windows pipe path.

## Pre-Landing Review

No issues found.

## Plan Completion

No plan file detected.

## Documentation

No user-facing documentation changes are needed for this internal test-runner fix.

## Test plan

- [x] `scripts/run_tests.sh tests/test_run_tests_parallel_stdio.py -q -j 1 --file-timeout 300` — 4 passed
- [x] Gateway-parented scoped run of `tests/test_run_tests_parallel_stdio.py` and `tests/tui_gateway/test_kanban_notify_poller.py` — 18 passed; no crash-log growth
- [x] No-console `pythonw.exe` smoke run of the per-file runner — runner exited 0; 4 passed
- [x] `ruff check scripts/run_tests_parallel.py tests/test_run_tests_parallel_stdio.py`
- [x] `python -m py_compile scripts/run_tests_parallel.py tests/test_run_tests_parallel_stdio.py`
- [x] `git diff --check`

`npm run verify` is not defined in this repository. The fallback `npm run check` could not start because this scratch worktree has no installed TypeScript toolchain (`tsc`/`esbuild` missing); no JavaScript files changed.
