### PR TITLE
feat(goals): orphan goal recovery

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -727,6 +727,29 @@ session_reset:
   idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
   at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
 
+# =============================================================================
+# Goals — standing /goal (Ralph loop)
+# =============================================================================
+# A goal is a free-form user objective that stays active across turns. After
+# each turn, a lightweight judge asks an auxiliary model whether the goal is
+# satisfied; if not, Hermes feeds a continuation prompt back into the same
+# session and keeps working until the goal is done, the turn budget is
+# exhausted, or the user pauses/clears it.
+#
+# goals:
+#   max_turns: 20              # Continuation budget before auto-pause
+#
+#   # Orphan goal recovery: a goal set in the desktop chat or a CLI terminal
+#   # dies with its owning process (desktop PTY reaped after detach, terminal
+#   # closed, gateway stopped) — the goal stays "active" but nothing feeds
+#   # continuation turns. The gateway and `hermes serve` scan for orphaned
+#   # goals at boot and resume them automatically, then re-sweep every
+#   # recovery_interval_minutes so a goal orphaned mid-run is recovered
+#   # without a restart. Goals whose owning process is still alive are never
+#   # double-fired; paused/cleared goals are untouched.
+#   recovery_enabled: true     # Master switch for the boot scan + periodic sweep
+#   recovery_interval_minutes: 5   # Periodic sweep cadence; 0 disables the sweep
+
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow
 # unlimited concurrent sessions. When the limit is reached, new sessions get a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11558,6 +11558,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 
+        # Orphan goal recovery: a standing /goal (Ralph loop) set by a CLI,
+        # TUI, or desktop chat dies with its owning process — the goal stays
+        # "active" in state_meta but no process feeds continuation turns.
+        # On boot (and periodically — see _start_goal_recovery_sweeper) scan
+        # the profiles this gateway serves, and for every active goal whose
+        # owner process is gone, enqueue a continuation turn through the
+        # same adapter FIFO the post-turn hook uses. Goals whose owner pid
+        # is still alive are never touched (no double-fire), and
+        # paused/cleared goals are skipped by construction.
+        try:
+            await self._run_goal_recovery_sweep()
+        except Exception:
+            logger.debug("goal recovery sweep failed at startup", exc_info=True)
+        self._start_goal_recovery_sweeper()
+
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
             from tools.process_registry import process_registry
@@ -18983,6 +18998,229 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 task.add_done_callback(_bg.discard)
         except Exception:
             logger.debug("Failed to start heartbeat poller", exc_info=True)
+
+    # ── Orphan goal recovery (supervisor sweep) ────────────────────────
+    # A standing /goal only runs inside a live process; when the owning
+    # process dies (CLI terminal closed, desktop chat PTY reaped) the goal
+    # stays "active" in state_meta but nothing feeds continuation turns.
+    # This sweep scans the profiles the gateway serves and enqueues one
+    # continuation turn per orphaned goal through the adapter FIFO — the
+    # same path _post_turn_goal_continuation uses — so message-role
+    # alternation and prompt caching are untouched. Goals whose owner pid
+    # is still alive are never claimed (no double-fire); paused/cleared
+    # goals are skipped by construction.
+
+    def _goal_recovery_enabled(self) -> bool:
+        try:
+            goals_cfg = (
+                (self.config or {}).get("goals", {})
+                if isinstance(self.config, dict)
+                else getattr(self.config, "goals", None) or {}
+            )
+            if not goals_cfg:
+                from hermes_cli.config import load_config
+
+                goals_cfg = (load_config() or {}).get("goals") or {}
+            return bool(goals_cfg.get("recovery_enabled", True))
+        except Exception:
+            return True
+
+    def _goal_recovery_interval_minutes(self) -> int:
+        try:
+            goals_cfg = (
+                (self.config or {}).get("goals", {})
+                if isinstance(self.config, dict)
+                else getattr(self.config, "goals", None) or {}
+            )
+            if not goals_cfg:
+                from hermes_cli.config import load_config
+
+                goals_cfg = (load_config() or {}).get("goals") or {}
+            value = int(goals_cfg.get("recovery_interval_minutes", 5) or 0)
+            return value if value > 0 else 0
+        except Exception:
+            return 5
+
+    def _goal_recovery_homes(self) -> List[str]:
+        """HERMES_HOMEs of the profiles this gateway serves (multiplex aware)."""
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            if getattr(self.config, "multiplex_profiles", False):
+                return [str(home) for _name, home in profiles_to_serve(multiplex=True)]
+            return [str(home) for _name, home in profiles_to_serve(multiplex=False)]
+        except Exception as exc:
+            logger.debug("goal recovery: profile resolution failed: %s", exc)
+            return []
+
+    def _goal_sweeper(self) -> Optional[Any]:
+        """Return the shared GoalRecoverySweeper for this runner (cached)."""
+        sweeper = getattr(self, "_goal_sweeper_obj", None)
+        if sweeper is not None:
+            return sweeper
+
+        def _owns_goal(session_id: str) -> bool:
+            # A live in-process gateway session means the loop is running
+            # here — never claim it. The routing index is keyed by
+            # session_key, so resolve the DB session id to its key first.
+            try:
+                store = getattr(self, "session_store", None)
+                if store is None:
+                    return False
+                with store._lock:  # noqa: SLF001
+                    store._ensure_loaded_locked()  # noqa: SLF001
+                    for _key, candidate in store._entries.items():  # noqa: SLF001
+                        if getattr(candidate, "session_id", None) == session_id:
+                            return self._is_session_running(
+                                getattr(candidate, "session_key", "") or ""
+                            )
+                return False
+            except Exception:
+                return False
+
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        sweeper = GoalRecoverySweeper(
+            self._goal_recovery_homes(),
+            owns_goal=_owns_goal,
+        )
+        self._goal_sweeper_obj = sweeper
+        return sweeper
+
+    def _goal_recovery_homes_reload(self) -> None:
+        """Re-resolve served profile homes (multiplex can change at runtime)."""
+        sweeper = getattr(self, "_goal_sweeper_obj", None)
+        if sweeper is not None:
+            sweeper.homes = self._goal_recovery_homes()
+
+    async def _run_goal_recovery_sweep(self) -> int:
+        """Scan served profiles and enqueue continuation turns for orphans.
+
+        Runs at boot and on the periodic sweep. Returns the number of
+        continuation turns enqueued. Never raises — a broken DB or missing
+        module degrades to a no-op sweep.
+
+        The claim (persisted orphaned flag) happens in the worker thread
+        (lock + SQLite); the enqueue runs back on the event loop because
+        the adapter FIFO is not thread-safe.
+        """
+        if not self._goal_recovery_enabled():
+            return 0
+        sweeper = self._goal_sweeper()
+        if sweeper is None:
+            return 0
+        self._goal_recovery_homes_reload()
+
+        claimed = await asyncio.to_thread(sweeper.sweep)
+        if not claimed:
+            return 0
+        enqueued = 0
+        for home, session_id, state in claimed:
+            try:
+                prompt = self._goal_continuation_prompt_for_state(state)
+                if not prompt:
+                    continue
+                source = self._goal_recovery_source_for_session(session_id)
+                adapter = self._adapter_for_source(source)
+                if adapter is None or source is None:
+                    logger.debug(
+                        "goal recovery: no adapter/source for orphaned session %s",
+                        session_id,
+                    )
+                    continue
+                quick_key = self._session_key_for_source(source)
+                if not quick_key:
+                    continue
+                cont_event = MessageEvent(
+                    text=prompt,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    message_id=None,
+                    channel_prompt=None,
+                )
+                self._enqueue_fifo(quick_key, cont_event, adapter)
+                sweeper.clear_claim(home, session_id)
+                enqueued += 1
+                logger.info(
+                    "goal recovery: resumed orphaned goal for session %s (%s)",
+                    session_id,
+                    getattr(state, "goal", "")[:60],
+                )
+            except Exception as exc:
+                logger.debug(
+                    "goal recovery: enqueue failed for %s: %s", session_id, exc
+                )
+        return enqueued
+
+    def _goal_continuation_prompt_for_state(self, state: Any) -> Optional[str]:
+        """Render the canonical continuation prompt from a goal state."""
+        try:
+            from hermes_cli.goals import continuation_prompt_from_state
+
+            return continuation_prompt_from_state(state)
+        except Exception:
+            return None
+
+    def _goal_recovery_source_for_session(self, session_id: str) -> Optional[Any]:
+        """Recover the SessionSource that owns an orphaned session.
+
+        The gateway persists session entries (routing index) with their
+        origin source; an orphaned goal's session is one of those entries.
+        Sessions without a persisted origin (pure CLI/TUI rows) are skipped
+        — they are not this gateway's to drive.
+        """
+        try:
+            store = getattr(self, "session_store", None)
+            if store is None:
+                return None
+            with store._lock:  # noqa: SLF001
+                store._ensure_loaded_locked()  # noqa: SLF001
+                entry = None
+                for _key, candidate in store._entries.items():  # noqa: SLF001
+                    if getattr(candidate, "session_id", None) == session_id:
+                        entry = candidate
+                        break
+            if entry is None:
+                return None
+            origin = getattr(entry, "origin", None)
+            if origin is None:
+                return None
+            return origin
+        except Exception as exc:
+            logger.debug("goal recovery: source lookup failed for %s: %s", session_id, exc)
+            return None
+
+    def _start_goal_recovery_sweeper(self) -> None:
+        """Start the periodic orphan-goal sweep (idempotent)."""
+        if getattr(self, "_goal_recovery_sweeper_started", False):
+            return
+        interval_minutes = self._goal_recovery_interval_minutes()
+        if interval_minutes <= 0:
+            return
+
+        async def _sweep_loop() -> None:
+            while True:
+                await asyncio.sleep(interval_minutes * 60)
+                try:
+                    enqueued = await self._run_goal_recovery_sweep()
+                    if enqueued:
+                        logger.info(
+                            "goal recovery sweep: enqueued %d continuation turn(s)",
+                            enqueued,
+                        )
+                except Exception:
+                    logger.debug("goal recovery sweep failed", exc_info=True)
+
+        try:
+            task = asyncio.create_task(_sweep_loop())
+            self._goal_recovery_sweeper_task = task
+            _bg = getattr(self, "_background_tasks", None)
+            if _bg is not None:
+                _bg.add(task)
+                task.add_done_callback(_bg.discard)
+            self._goal_recovery_sweeper_started = True
+        except Exception:
+            logger.debug("Failed to start goal recovery sweeper", exc_info=True)
 
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1760,6 +1760,18 @@ DEFAULT_CONFIG = {
         # negatives (goal actually done but judge says continue) and
         # unbounded model spend on fuzzy / unachievable goals.
         "max_turns": 20,
+        # Orphan goal recovery: when a goal's owning process dies (desktop
+        # chat PTY reaped, CLI terminal closed), no process feeds
+        # continuation turns and the loop goes inert while the goal still
+        # reads "active". The gateway and ``hermes serve`` boot scan for
+        # orphaned goals and resume them automatically, then re-sweep every
+        # ``recovery_interval_minutes`` so a goal orphaned mid-run is
+        # recovered without a restart. Set to 0 to disable the periodic
+        # sweep (boot-time recovery stays on).
+        "recovery_interval_minutes": 5,
+        # A goal whose stored owner pid is alive is NOT orphaned and is
+        # never double-fired. Paused/cleared goals are never touched.
+        "recovery_enabled": True,
     },
 
     # Mixture of Agents — named presets used by /moa. A preset is an execution

--- a/hermes_cli/goal_recovery.py
+++ b/hermes_cli/goal_recovery.py
@@ -1,0 +1,379 @@
+"""Orphan goal recovery — resume standing goals whose owning process died.
+
+A standing ``/goal`` (Ralph loop) only runs inside a live process. Goal
+state is persisted in ``SessionDB.state_meta`` under ``goal:<session_id>``,
+but nothing executes the loop when the owning process dies — a desktop chat
+PTY reaped after detach, a closed terminal, or a gateway that was stopped
+all leave the goal ``active`` but inert.
+
+This module is the shared supervisor used by both long-lived surfaces that
+can legitimately own a goal loop:
+
+- ``gateway/run.py`` — scans the profiles the gateway serves at boot and on
+  a periodic sweep;
+- ``hermes_cli/web_server.py`` (``hermes serve`` / dashboard) — the same
+  scan for desktop-scoped sessions.
+
+Ownership model
+---------------
+Each goal row records ``owner_pid`` + ``last_owner_seen_at`` at set time
+(and refreshes ``last_owner_seen_at`` on every evaluated turn, via
+``GoalManager.evaluate_after_turn``). A goal is orphaned when:
+
+- its status is ``active`` (paused/cleared/done are never touched), and
+- no live owner remains, where "live owner" means:
+  * the surface hosting the sweep has a live in-process session for the
+    goal (``owns_goal`` callback — e.g. the desktop chat's tui_gateway
+    session registry), or
+  * the stored ``owner_pid`` belongs to a different, still-alive process
+    (the classic double-fire guard: a surface whose goal loop is running
+    must never have its continuation re-queued by a sibling supervisor).
+  * A surface that sets goals in-process (``hermes serve``, whose
+    tui_gateway owns desktop goals in attach mode) passes ``self_pid`` so
+    its own pid is judged by the session registry instead — an alive pid
+    proves nothing about a loop that may have been reaped.
+
+Cross-process safety
+--------------------
+Gateway and ``hermes serve`` can both run on one machine, so the claim
+step is serialized with a per-``HERMES_HOME`` lock file; only the winner
+flips the goal to ``orphaned`` (the flag flip IS the claim), and a freshly
+claimed goal is not re-claimed for a short window while the winner is
+driving it. A supervisor that crashes mid-drive leaves ``orphaned=True``
+with a stale timestamp, so the next sweep after the window heals it.
+
+``/goal status`` reflects reality via the persisted flag:
+``mark_goal_orphaned`` / ``clear_goal_orphaned`` in ``hermes_cli/goals.py``
+produce the "active-orphaned" vs "active-running" distinction.
+
+The sweep is pure: ``sweep()`` returns the ``(home, session_id, state)``
+claims this process won. Each surface drives the continuation turn through
+its own machinery (adapter FIFO for the gateway, ``tui_gateway`` dispatch
+for ``hermes serve``) and calls :meth:`clear_claim` once the turn is
+handed off, so message-role alternation and prompt caching stay untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: A goal whose owner pid is dead may still be claimed immediately; the
+#: silence window only gates goals with NO owner pid at all (rows written
+#: before owner stamping existed, or a set-then-crash race).
+_OWNER_SILENCE_SECONDS = 300.0
+
+#: A claimed goal (``orphaned=True``) is not re-claimed within this window,
+#: even by another supervisor process — the winner is still driving.
+_RECENT_CLAIM_WINDOW_SECONDS = 30.0
+
+
+def _owner_alive(state: object) -> bool:
+    """True when the goal's stored owner process is still alive.
+
+    Uses the same cross-platform, footgun-safe liveness check the goal
+    wait-barrier uses (``gateway.status._pid_exists`` — avoids
+    ``os.kill(pid, 0)`` which on Windows is NOT a no-op, bpo-14484).
+    Any error resolves to False (treat unknown as dead) so a stale owner
+    can never block recovery forever.
+    """
+    pid = getattr(state, "owner_pid", None)
+    if not pid or int(pid) <= 0:
+        return False
+    try:
+        from gateway.status import _pid_exists
+
+        return bool(_pid_exists(int(pid)))
+    except Exception:
+        pass
+    try:
+        import psutil  # type: ignore
+
+        return bool(psutil.pid_exists(int(pid)))
+    except Exception:
+        return False
+
+
+def _last_owner_seen(state: object) -> float:
+    try:
+        return float(getattr(state, "last_owner_seen_at", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _goal_is_orphaned(
+    state: object,
+    now: float,
+    *,
+    surface_owns: bool = False,
+    self_pid: Optional[int] = None,
+) -> bool:
+    """True when an active goal should be claimed by this sweep.
+
+    ``surface_owns`` — True when the sweeping surface hosts a live
+    in-process session for the goal (its loop is running; never claim).
+
+    ``self_pid`` — when set, a goal whose ``owner_pid`` equals this
+    process is judged purely by the session registry (``surface_owns``):
+    the owning surface and the sweeping surface are the same process, so
+    an alive pid proves nothing about the loop. Used by ``hermes serve``,
+    which sets desktop goals in-process. Surfaces that do not set goals
+    in-process (the messaging gateway) leave it None, so a live owner pid
+    always means "loop running elsewhere — do not touch".
+    """
+    if getattr(state, "status", None) != "active":
+        return False
+    if surface_owns:
+        return False
+    owner = 0
+    try:
+        owner = int(getattr(state, "owner_pid", 0) or 0)
+    except (TypeError, ValueError):
+        owner = 0
+    if owner > 0 and owner != (self_pid or 0) and _owner_alive(state):
+        return False
+    if getattr(state, "orphaned", False):
+        # Previously claimed — the freshness gate is re-checked under the
+        # claim lock, so an orphaned flag alone means "claimable" here
+        # (heals a supervisor that crashed mid-drive).
+        return True
+    if owner > 0:
+        # Owner pid recorded but the process is gone → claim immediately.
+        return True
+    # No owner pid at all (rows written before owner stamping, or a
+    # set-then-crash race) → require the silence window.
+    return (now - _last_owner_seen(state)) > _OWNER_SILENCE_SECONDS
+
+
+def _claim_lock_path(home: str) -> str:
+    """Return the shared recovery claim-lock path for a HERMES_HOME.
+
+    One lock per home across ALL surfaces, so a gateway and a
+    ``hermes serve`` backing the same home can never both claim the same
+    goal in the same sweep.
+    """
+    import hashlib
+
+    digest = hashlib.sha1(str(home).encode("utf-8")).hexdigest()[:12]
+    return os.path.join(str(home), "runtime", f"goal-recovery-{digest}.lock")
+
+
+class _ClaimLock:
+    """Cross-process claim lock (fcntl on POSIX, msvcrt on Windows).
+
+    Mirrors ``hermes_cli.active_sessions._FileLock``: one process at a time
+    owns the claim critical section.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self._fh = None
+
+    def __enter__(self) -> "_ClaimLock":
+        try:
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            self._fh = open(self.path, "a+b")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("goal recovery: claim lock open failed: %s", exc)
+            self._fh = None
+            return self
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
+            except Exception:
+                self._fh.close()
+                self._fh = None
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+            except Exception:
+                self._fh.close()
+                self._fh = None
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        if self._fh is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        try:
+            self._fh.close()
+        finally:
+            self._fh = None
+
+
+class GoalRecoverySweeper:
+    """Scans HERMES_HOMEs for orphaned active goals and claims them.
+
+    ``sweep()`` is pure: it returns ``[(home, session_id, state), ...]``
+    for the goals this process won the claim on. The surface then drives
+    each continuation turn through its own turn machinery and calls
+    :meth:`clear_claim`. Never raises — a broken DB or missing module
+    degrades to an empty sweep.
+    """
+
+    def __init__(
+        self,
+        homes: List[str],
+        *,
+        owns_goal: Optional[Callable[[str], bool]] = None,
+        self_pid: Optional[int] = None,
+    ):
+        self.homes = [str(h) for h in homes]
+        # Surface-specific live-ownership check, e.g. "this session is
+        # currently live in my in-process session registry". Called with
+        # the goal's session_id.
+        self._owns_goal = owns_goal
+        # Process identity for the in-process-owner override (serve).
+        self._self_pid = int(self_pid) if self_pid else None
+
+    def sweep(self) -> List[Tuple[str, str, object]]:
+        """Scan every configured HERMES_HOME; return the claimed orphans.
+
+        The claim (persisted ``orphaned`` flag + timestamp) is what stops a
+        sibling supervisor from double-firing. The caller drives each claim
+        through its own turn machinery and then calls :meth:`clear_claim`
+        so ``/goal status`` flips back to active-running.
+        """
+        claimed: List[Tuple[str, str, object]] = []
+        for home in self.homes:
+            claimed.extend(self._sweep_home(home))
+        return claimed
+
+    def clear_claim(self, home: str, session_id: str) -> None:
+        """Clear the orphaned flag for a claim this process drove."""
+        try:
+            db = self._session_db_for_home(home)
+            if db is None:
+                return
+            self._clear_orphaned(db, session_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(
+                "goal recovery: orphaned-clear failed for %s: %s", session_id, exc
+            )
+
+    def _sweep_home(self, home: str) -> List[Tuple[str, str, object]]:
+        try:
+            from hermes_cli.goals import GOAL_META_PREFIX
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("goal recovery: goals module unavailable: %s", exc)
+            return []
+
+        db = self._session_db_for_home(home)
+        if db is None:
+            return []
+
+        now = time.time()
+        try:
+            keys = db.list_meta_keys(GOAL_META_PREFIX)
+        except Exception as exc:
+            logger.debug("goal recovery: meta enumeration failed for %s: %s", home, exc)
+            return []
+
+        claimed: List[Tuple[str, str, object]] = []
+        for key in keys:
+            session_id = key[len(GOAL_META_PREFIX):]
+            if not session_id:
+                continue
+            state = self._load_goal_at(db, session_id)
+            if state is None:
+                continue
+            surface_owns = bool(self._owns_goal(session_id)) if self._owns_goal else False
+            if not _goal_is_orphaned(state, now, surface_owns=surface_owns, self_pid=self._self_pid):
+                continue
+            if not self._claim(db, session_id):
+                continue
+            claimed_state = self._load_goal_at(db, session_id)
+            claimed.append((home, session_id, claimed_state or state))
+        return claimed
+
+    @staticmethod
+    def _session_db_for_home(home: str):
+        """Open a SessionDB bound to ``home`` (per-home, like goals.py)."""
+        try:
+            from pathlib import Path
+
+            from hermes_state import SessionDB
+
+            return SessionDB(db_path=Path(str(home)) / "state.db")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("goal recovery: SessionDB unavailable for %s: %s", home, exc)
+            return None
+
+    @staticmethod
+    def _load_goal_at(db, session_id: str):
+        """Load a goal row through the DB instance bound to its home.
+
+        ``goals.load_goal`` resolves the process-default HERMES_HOME, which
+        is wrong when sweeping a secondary profile. Parse directly instead.
+        """
+        from hermes_cli.goals import GoalState, _meta_key
+
+        raw = db.get_meta(_meta_key(session_id))
+        if not raw:
+            return None
+        try:
+            return GoalState.from_json(raw)
+        except Exception as exc:
+            logger.warning(
+                "GoalManager: could not parse stored goal for %s: %s", session_id, exc
+            )
+            return None
+
+    def _claim(self, db, session_id: str) -> bool:
+        """Atomically (per-home lock) claim this goal for this sweep.
+
+        The flag flip (``orphaned`` True + claim timestamp) IS the claim:
+        a goal claimed within the recent window is skipped even if a
+        sibling supervisor is mid-drive; a goal claimed long ago (winner
+        crashed) is re-claimed.
+        """
+        from hermes_cli.goals import load_goal, save_goal
+
+        lock_path = _claim_lock_path(db.db_path)
+        try:
+            with _ClaimLock(lock_path):
+                state = load_goal(session_id, db=db)
+                if state is None or getattr(state, "status", None) != "active":
+                    return False
+                now = time.time()
+                if getattr(state, "orphaned", False) and (
+                    now - _last_owner_seen(state)
+                ) <= _RECENT_CLAIM_WINDOW_SECONDS:
+                    return False
+                state.orphaned = True
+                state.last_owner_seen_at = now
+                save_goal(session_id, state, db=db)
+                return True
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("goal recovery: claim failed for %s: %s", session_id, exc)
+            return False
+
+    @staticmethod
+    def _clear_orphaned(db, session_id: str) -> None:
+        """Clear the orphaned flag once the adopted surface is driving."""
+        from hermes_cli.goals import clear_goal_orphaned
+
+        clear_goal_orphaned(session_id, db=db)
+
+
+__all__ = ["GoalRecoverySweeper"]

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -587,6 +587,15 @@ class GoalState:
     # must ALL pass before the judge may declare the goal done. Empty by
     # default — a goal with no gates behaves exactly as before.
     gates: List[GoalGate] = field(default_factory=list)
+    # Owner liveness bookkeeping for orphan recovery. The owning surface
+    # (CLI / TUI / desktop / gateway) stamps ``owner_pid`` at set time;
+    # ``last_owner_seen_at`` refreshes while the owning process runs. A
+    # supervisor marks ``orphaned=True`` when no live owner remains, so
+    # ``/goal status`` can distinguish active-running from active-orphaned
+    # without guessing. Backwards-compatible: old rows load with no owner.
+    owner_pid: Optional[int] = None
+    last_owner_seen_at: float = 0.0
+    orphaned: bool = False
 
     def to_json(self) -> str:
         data = asdict(self)
@@ -624,6 +633,9 @@ class GoalState:
                 for g in (data.get("gates") or [])
                 if isinstance(g, dict) and str(g.get("command") or "").strip()
             ],
+            owner_pid=(int(data["owner_pid"]) if data.get("owner_pid") else None),
+            last_owner_seen_at=float(data.get("last_owner_seen_at", 0.0) or 0.0),
+            orphaned=bool(data.get("orphaned", False)),
         )
 
     # --- contract helpers -------------------------------------------------
@@ -648,6 +660,11 @@ class GoalState:
 
 def _meta_key(session_id: str) -> str:
     return f"goal:{session_id}"
+
+
+#: ``state_meta`` key prefix shared by every goal row. Recovery sweeps
+#: enumerate persisted goals with ``LIKE 'goal:%'`` via ``list_meta_keys``.
+GOAL_META_PREFIX = "goal:"
 
 
 _DB_CACHE: Dict[str, Any] = {}
@@ -683,11 +700,17 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
-def load_goal(session_id: str) -> Optional[GoalState]:
-    """Load the goal for a session, or None if none exists."""
+def load_goal(session_id: str, *, db: Optional[Any] = None) -> Optional[GoalState]:
+    """Load the goal for a session, or None if none exists.
+
+    ``db`` may be supplied by callers (recovery sweeps) that need to read a
+    different profile's store; otherwise the process-default SessionDB is
+    used.
+    """
     if not session_id:
         return None
-    db = _get_session_db()
+    if db is None:
+        db = _get_session_db()
     if db is None:
         return None
     try:
@@ -704,17 +727,48 @@ def load_goal(session_id: str) -> Optional[GoalState]:
         return None
 
 
-def save_goal(session_id: str, state: GoalState) -> None:
+def save_goal(session_id: str, state: GoalState, *, db: Optional[Any] = None) -> None:
     """Persist a goal to SessionDB. No-op if DB unavailable."""
     if not session_id:
         return
-    db = _get_session_db()
+    if db is None:
+        db = _get_session_db()
     if db is None:
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())
     except Exception as exc:
         logger.debug("GoalManager: set_meta failed: %s", exc)
+
+
+def enumerate_active_goals() -> List[Tuple[str, GoalState]]:
+    """Return ``(session_id, state)`` for every live goal row.
+
+    Scans the current HERMES_HOME's ``state_meta`` for ``goal:`` keys and
+    parses each row with the same loader the GoalManager uses, so rows that
+    fail to parse (corrupt/foreign) are skipped defensively. Cleared and
+    done rows are excluded — only goals that can still run (active or
+    paused) are returned. The scan is read-only and best-effort: any DB
+    failure degrades to ``[]`` rather than raising into callers (recovery
+    sweeps must never wedge a boot).
+    """
+    db = _get_session_db()
+    if db is None:
+        return []
+    try:
+        keys = db.list_meta_keys(GOAL_META_PREFIX)
+    except Exception as exc:
+        logger.debug("GoalManager: enumerate meta keys failed: %s", exc)
+        return []
+    out: List[Tuple[str, GoalState]] = []
+    for key in keys:
+        session_id = key[len(GOAL_META_PREFIX):]
+        if not session_id:
+            continue
+        state = load_goal(session_id)
+        if state is not None and state.status in {"active", "paused"}:
+            out.append((session_id, state))
+    return out
 
 
 def clear_goal(session_id: str) -> None:
@@ -724,6 +778,46 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+
+
+def mark_goal_orphaned(session_id: str, *, db: Optional[Any] = None) -> bool:
+    """Flag an active goal as orphaned (its owning process died).
+
+    Used by recovery sweeps to persist the ``orphaned`` marker that
+    ``/goal status`` reflects (active-running vs active-orphaned).
+    Non-destructive: paused/cleared/done goals are never touched, and a
+    goal that another supervisor already claimed (``orphaned`` already
+    True) is not re-claimed — the return value is the claim result.
+    Returns True when THIS caller flipped the marker.
+    """
+    state = load_goal(session_id, db=db)
+    if state is None or state.status != "active":
+        return False
+    if state.orphaned:
+        return False
+    state.orphaned = True
+    # Stamp the claim time so the sibling-sweep re-claim window works:
+    # a goal claimed within the window reads as "recently claimed".
+    state.last_owner_seen_at = time.time()
+    save_goal(session_id, state, db=db)
+    return True
+
+
+def clear_goal_orphaned(session_id: str, *, db: Optional[Any] = None) -> bool:
+    """Clear the orphaned marker when an owner is (re)established.
+
+    Called by an adopting surface right before it fires a continuation
+    turn, so the goal reads active-running again. Returns True when the
+    flag was actually cleared.
+    """
+    state = load_goal(session_id, db=db)
+    if state is None or state.status != "active" or not state.orphaned:
+        return False
+    state.orphaned = False
+    state.owner_pid = os.getpid()
+    state.last_owner_seen_at = time.time()
+    save_goal(session_id, state, db=db)
+    return True
 
 
 def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
@@ -1226,6 +1320,37 @@ def _extract_json_object(raw: str) -> Optional[Dict[str, Any]]:
 # ──────────────────────────────────────────────────────────────────────
 
 
+def continuation_prompt_from_state(state: "GoalState") -> Optional[str]:
+    """Build the canonical continuation prompt from a goal state.
+
+    Extracted from ``GoalManager.next_continuation_prompt`` so recovery
+    drivers (gateway / ``hermes serve``) can render the continuation for a
+    goal they adopted from the DB without constructing a GoalManager bound
+    to a session they do not own. Contract takes priority (it carries the
+    verification surface), subgoals fold in as extra criteria.
+    """
+    if state is None or state.status != "active":
+        return None
+    if state.has_contract():
+        contract_block = state.contract.render_block()
+        if state.subgoals:
+            extra = "\n".join(
+                f"- Extra criterion {i}: {text}"
+                for i, text in enumerate(state.subgoals, start=1)
+            )
+            contract_block = f"{contract_block}\n{extra}"
+        return CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
+            goal=state.goal,
+            contract_block=contract_block,
+        )
+    if state.subgoals:
+        return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+            goal=state.goal,
+            subgoals_block=state.render_subgoals_block(),
+        )
+    return CONTINUATION_PROMPT_TEMPLATE.format(goal=state.goal)
+
+
 class GoalManager:
     """Per-session goal state + continuation decisions.
 
@@ -1283,7 +1408,9 @@ class GoalManager:
                 remaining = int(s.waiting_until - time.time())
                 wr = s.waiting_reason or f"{remaining}s"
                 return f"⏳ Goal (parked {remaining}s — {wr}, {meta}): {s.goal}"
-            return f"⊙ Goal (active, {meta}): {s.goal}"
+            if s.orphaned:
+                return f"⚠ Goal (active-orphaned, {meta}): {s.goal}"
+            return f"⊙ Goal (active-running, {meta}): {s.goal}"
         if s.status == "paused":
             extra = f" — {s.paused_reason}" if s.paused_reason else ""
             return f"⏸ Goal (paused, {meta}{extra}): {s.goal}"
@@ -1306,6 +1433,13 @@ class GoalManager:
             last_turn_at=0.0,
             contract=contract if contract is not None else GoalContract(),
         )
+        # Stamp this process as the goal's owner so a supervisor elsewhere
+        # (gateway / ``hermes serve``) can tell a live loop from an orphaned
+        # one without racing the setter (see orphan recovery in
+        # hermes_cli/goal_recovery.py).
+        state.owner_pid = os.getpid()
+        state.last_owner_seen_at = time.time()
+        state.orphaned = False
         self._state = state
         save_goal(self.session_id, state)
         return state
@@ -1741,6 +1875,13 @@ class GoalManager:
         # Count the turn that just finished.
         state.turns_used += 1
         state.last_turn_at = time.time()
+        # This turn proves a live owner is running the loop (CLI, TUI,
+        # desktop chat, or gateway). Stamp ownership so orphan recovery
+        # elsewhere can tell active-running from active-orphaned, and
+        # clear any orphaned marker left by a previous recovery claim.
+        state.owner_pid = os.getpid()
+        state.last_owner_seen_at = time.time()
+        state.orphaned = False
 
         # Quality gates run BEFORE the LLM judge: a failing gate is
         # deterministic evidence the goal is not done, so the judge call is
@@ -1922,27 +2063,7 @@ class GoalManager:
     def next_continuation_prompt(self) -> Optional[str]:
         if not self._state or self._state.status != "active":
             return None
-        # Contract takes priority: it carries the verification surface and
-        # constraints the agent must target. Subgoals fold in as extra
-        # criteria appended to the contract block.
-        if self._state.has_contract():
-            contract_block = self._state.contract.render_block()
-            if self._state.subgoals:
-                extra = "\n".join(
-                    f"- Extra criterion {i}: {text}"
-                    for i, text in enumerate(self._state.subgoals, start=1)
-                )
-                contract_block = f"{contract_block}\n{extra}"
-            return CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
-                goal=self._state.goal,
-                contract_block=contract_block,
-            )
-        if self._state.subgoals:
-            return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
-                goal=self._state.goal,
-                subgoals_block=self._state.render_subgoals_block(),
-            )
-        return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+        return continuation_prompt_from_state(self._state)
 
     def render_contract(self) -> str:
         """Public helper for the /goal show + /goal draft slash commands."""
@@ -2127,7 +2248,11 @@ __all__ = [
     "load_goal",
     "save_goal",
     "clear_goal",
+    "enumerate_active_goals",
+    "mark_goal_orphaned",
+    "clear_goal_orphaned",
     "migrate_goal_to_session",
+    "continuation_prompt_from_state",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -251,6 +251,22 @@ async def _lifespan(app: "FastAPI"):
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
 
+    # Orphan goal recovery: a standing /goal set in the desktop chat dies
+    # with its keep-alive PTY child (the reaper above kills it after the
+    # TTL once the browser detaches). The goal stays "active" in state_meta
+    # but no process feeds continuation turns. On boot (and periodically —
+    # see _goal_recovery_sweep_loop) scan the desktop-scoped session
+    # store and re-queue a continuation turn for every orphaned goal via
+    # the embedded tui_gateway dispatch. Goals with a live owner (a live
+    # tui_gateway session here, or a live owner pid elsewhere) are never
+    # touched; paused/cleared goals are skipped by construction.
+    goal_recovery_task = None
+    try:
+        await _run_goal_recovery_sweep()
+        goal_recovery_task = asyncio.create_task(_goal_recovery_sweep_loop())
+    except Exception:
+        _log.debug("goal recovery boot sweep failed", exc_info=True)
+
     # Periodic authenticated self-test (feeds the ``dashboard`` component on
     # /api/status).  The loop exits immediately when httpx is unavailable.
     selftest_task = asyncio.create_task(_dashboard_selftest_loop())
@@ -263,6 +279,8 @@ async def _lifespan(app: "FastAPI"):
         yield
     finally:
         pty_reaper_task.cancel()
+        if goal_recovery_task is not None:
+            goal_recovery_task.cancel()
         selftest_task.cancel()
         auto_archive_task.cancel()
         await PTY_REGISTRY.close_all()
@@ -285,6 +303,210 @@ def _get_event_state(app: "FastAPI"):
         app.state.event_channels = {}
         app.state.event_lock = asyncio.Lock()
         return app.state.event_channels, app.state.event_lock
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Orphan goal recovery (desktop / serve)
+# ──────────────────────────────────────────────────────────────────────
+# A standing /goal set in the desktop chat runs inside the chat's
+# keep-alive PTY child, whose tui_gateway sessions live IN this process
+# (in attach mode). When the browser detaches, the PTY reaper kills the
+# child after the TTL and the goal stays "active" in state_meta with no
+# process feeding continuation turns. The recovery sweep below re-drives
+# orphaned goals through the embedded tui_gateway dispatch — the same
+# JSON-RPC surface the desktop uses — so message-role alternation and
+# prompt caching are untouched.
+
+
+def _goal_recovery_config() -> Dict[str, Any]:
+    """Resolve the goals.recovery_* config knobs (fail-open defaults)."""
+    try:
+        from hermes_cli.config import load_config
+
+        goals_cfg = (load_config() or {}).get("goals") or {}
+    except Exception:
+        goals_cfg = {}
+    return goals_cfg
+
+
+def _goal_recovery_enabled() -> bool:
+    try:
+        return bool(_goal_recovery_config().get("recovery_enabled", True))
+    except Exception:
+        return True
+
+
+def _goal_recovery_interval_minutes() -> int:
+    try:
+        value = int(_goal_recovery_config().get("recovery_interval_minutes", 5) or 0)
+        return value if value > 0 else 0
+    except Exception:
+        return 5
+
+
+def _goal_recovery_homes() -> List[str]:
+    """HERMES_HOMEs whose desktop-scoped sessions this server can drive.
+
+    Only the launch profile's home is driveable in-process: profile-scoped
+    chats spawn their own gateway child (see ``_resolve_chat_argv``), and
+    in desktop pool mode each profile runs its own backend whose own
+    lifespan sweeps that profile's home. Sweeping only the launch home
+    keeps recovery exactly where the embedded tui_gateway can actually
+    drive the session.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli import profiles as profiles_mod
+
+        name = get_active_profile_name() or "default"
+        return [str(profiles_mod.get_profile_dir(name))]
+    except Exception:
+        try:
+            from hermes_constants import get_hermes_home
+
+            return [str(get_hermes_home())]
+        except Exception:
+            return []
+
+
+def _goal_sweeper() -> Optional[Any]:
+    """Return the shared GoalRecoverySweeper for this server (cached)."""
+    sweeper = getattr(app.state, "_goal_sweeper_obj", None)
+    if sweeper is not None:
+        return sweeper
+
+    def _owns_goal(session_id: str) -> bool:
+        # A live tui_gateway session in THIS process means the desktop
+        # loop is running here — never claim it.
+        try:
+            from tui_gateway.server import _find_live_session_by_key
+
+            return _find_live_session_by_key(session_id) is not None
+        except Exception:
+            return False
+
+    from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+    sweeper = GoalRecoverySweeper(
+        _goal_recovery_homes(),
+        owns_goal=_owns_goal,
+        self_pid=os.getpid(),
+    )
+    app.state._goal_sweeper_obj = sweeper
+    return sweeper
+
+
+def _goal_recovery_drive_session(session_id: str, goal_text: str) -> bool:
+    """Drive one continuation turn for an orphaned desktop session.
+
+    Re-creates the session through the embedded tui_gateway (resume +
+    prompt.submit) — the same path the desktop uses when the user reopens
+    the chat — then queues the goal text as the next user turn. The
+    post-turn judge hook in ``_run_prompt_submit`` takes over from there,
+    so the loop continues across turns exactly as if the user had come
+    back.
+
+    The handlers are invoked directly (not via ``handle_request``) because
+    ``session.resume`` is a long handler that ``handle_request`` would
+    dispatch to the RPC pool and return ``None`` for. We are already off
+    the event loop (the sweep runs in a worker thread), so running inline
+    is safe.
+    """
+    try:
+        from tui_gateway import server as tui
+
+        live = tui._find_live_session_by_key(session_id)
+        if live is not None:
+            sid = live[0]
+        else:
+            resume = tui._methods["session.resume"](
+                "goal-recovery",
+                {"session_id": session_id},
+            )
+            if not isinstance(resume, dict) or "error" in resume:
+                _log.debug(
+                    "goal recovery: session.resume failed for %s: %s",
+                    session_id,
+                    resume,
+                )
+                return False
+            sid = (resume.get("result") or {}).get("session_id") or ""
+            if not sid or sid not in tui._sessions:
+                return False
+
+        submit = tui._methods["prompt.submit"](
+            "goal-recovery",
+            {"session_id": sid, "text": goal_text},
+        )
+        if not isinstance(submit, dict) or "error" in submit:
+            _log.debug(
+                "goal recovery: prompt.submit failed for %s: %s",
+                session_id,
+                submit,
+            )
+            return False
+        _log.info(
+            "goal recovery: resumed orphaned desktop goal for session %s (%s)",
+            session_id,
+            goal_text[:60],
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.debug("goal recovery: drive failed for %s: %s", session_id, exc)
+        return False
+
+
+async def _run_goal_recovery_sweep() -> int:
+    """Boot scan + periodic sweep: resume orphaned desktop goals.
+
+    The claim (persisted orphaned flag) happens in the worker thread
+    (lock + SQLite); the drive (tui_gateway resume + prompt.submit, which
+    can block on DB reads) also runs in a worker thread; the orphaned
+    flag is cleared once the continuation turn is handed off.
+    """
+    if not _goal_recovery_enabled():
+        return 0
+    sweeper = _goal_sweeper()
+    if sweeper is None:
+        return 0
+
+    claimed = await asyncio.to_thread(sweeper.sweep)
+    if not claimed:
+        return 0
+    driven = 0
+    for home, session_id, state in claimed:
+        try:
+            from hermes_cli.goals import continuation_prompt_from_state
+
+            prompt = continuation_prompt_from_state(state)
+            if not prompt:
+                continue
+            ok = await asyncio.to_thread(
+                _goal_recovery_drive_session, session_id, prompt
+            )
+            if ok:
+                sweeper.clear_claim(home, session_id)
+                driven += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            _log.debug("goal recovery: drive failed for %s: %s", session_id, exc)
+    return driven
+
+
+async def _goal_recovery_sweep_loop() -> None:
+    """Periodic sweep so a goal orphaned mid-run recovers without a restart."""
+    interval_minutes = _goal_recovery_interval_minutes()
+    if interval_minutes <= 0:
+        return
+    while True:
+        await asyncio.sleep(interval_minutes * 60)
+        try:
+            driven = await _run_goal_recovery_sweep()
+            if driven:
+                _log.info(
+                    "goal recovery sweep: resumed %d orphaned goal(s)", driven
+                )
+        except Exception:
+            _log.debug("goal recovery sweep failed", exc_info=True)
 
 
 def _get_chat_argv_lock(app: "FastAPI") -> asyncio.Lock:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9091,6 +9091,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return row["value"] if isinstance(row, sqlite3.Row) else row[0]
 
+    def list_meta_keys(self, prefix: str = "") -> List[str]:
+        """Return every ``state_meta`` key matching ``prefix`` (ordered).
+
+        Powers cross-process sweeps (orphan goal recovery, heartbeat
+        resumption) that need to enumerate persisted per-session state
+        without knowing the session ids up front. ``prefix`` is matched
+        with ``LIKE 'prefix%'`` after escaping ``%``/``_`` so literal
+        prefix characters are honored. Cheap scan; bounded by the number
+        of meta rows.
+        """
+        escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT key FROM state_meta WHERE key LIKE ? ESCAPE '\\' ORDER BY key",
+                (f"{escaped}%",),
+            ).fetchall()
+        return [r["key"] if isinstance(r, sqlite3.Row) else r[0] for r in rows]
+
     def set_meta(
         self, key: str, value: str, *, cursor: Optional[sqlite3.Cursor] = None
     ) -> None:

--- a/tests/gateway/test_goal_recovery_sweep.py
+++ b/tests/gateway/test_goal_recovery_sweep.py
@@ -1,0 +1,256 @@
+"""Tests for the gateway's orphan goal recovery sweep (#81109).
+
+On boot (and periodically) the gateway scans the profiles it serves and
+enqueues continuation turns for orphaned active goals through the adapter
+FIFO — the same path the post-turn goal hook uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _set_goal(home, session_id: str, *, owner_pid=None):
+    from hermes_state import SessionDB
+    from hermes_cli.goals import GoalState, save_goal
+
+    db = SessionDB(db_path=Path(home) / "state.db")
+    state = GoalState(
+        goal=f"goal for {session_id}",
+        status="active",
+        turns_used=0,
+        max_turns=5,
+        created_at=time.time() - 600,
+        last_turn_at=time.time() - 600,
+    )
+    if owner_pid is not None:
+        state.owner_pid = owner_pid
+        state.last_owner_seen_at = time.time() - 60
+    else:
+        state.last_owner_seen_at = time.time() - 3600
+    save_goal(session_id, state, db=db)
+    db.close()
+
+
+class _RecordingAdapter:
+    """Minimal adapter that records pending-message FIFO writes."""
+
+    def __init__(self) -> None:
+        self._pending_messages: dict = {}
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None):
+        class _R:
+            success = True
+
+        return _R()
+
+
+def _make_runner(hermes_home, session_id: str, src):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={src.platform: PlatformConfig(enabled=True, token="***")},
+    )
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._queued_events = {}
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(src),
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=src.platform,
+        chat_type="dm",
+        # The routing index persists origin via origin_json; a recovered
+        # entry has it populated (this is what the sweep needs to find the
+        # adapter + FIFO key for an orphaned session).
+        origin=src,
+    )
+
+    store = MagicMock()
+    store.get_or_create_session.return_value = session_entry
+    store._generate_session_key.return_value = build_session_key(src)
+    store._entries = {build_session_key(src): session_entry}
+    store._lock = MagicMock()
+
+    def _ensure_loaded_locked():
+        return None
+
+    store._ensure_loaded_locked = _ensure_loaded_locked
+    runner.session_store = store
+    runner._session_db = None
+
+    adapter = _RecordingAdapter()
+    runner.adapters[src.platform] = adapter
+    return runner, adapter, session_entry
+
+
+def _telegram_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_sweep_enqueues_continuation_for_orphaned_goal(
+    hermes_home, monkeypatch
+):
+    """An orphaned goal (dead owner pid) with a persisted gateway session is
+    enqueued through the adapter FIFO on boot."""
+    src = _telegram_source()
+    session_key = build_session_key(src)
+    runner, adapter, session_entry = _make_runner(hermes_home, "goal-sess-1", src)
+
+    _set_goal(hermes_home, "goal-sess-1", owner_pid=4_000_000)
+
+    # Serve only this home.
+    monkeypatch.setattr(
+        runner, "_goal_recovery_homes", lambda: [str(hermes_home)]
+    )
+
+    enqueued = await runner._run_goal_recovery_sweep()
+    assert enqueued == 1
+    event = adapter._pending_messages.get(session_key)
+    assert event is not None
+    assert "[Continuing toward your standing goal]" in event.text
+    assert "goal for goal-sess-1" in event.text
+    # The claim was cleared once enqueued — the loop is now active-running.
+    from hermes_cli.goals import load_goal
+
+    assert load_goal("goal-sess-1").orphaned is False
+
+
+@pytest.mark.asyncio
+async def test_boot_sweep_skips_goal_with_live_owner(hermes_home, monkeypatch):
+    """A goal whose owner pid is still alive is never enqueued (no
+    double-fire)."""
+    src = _telegram_source()
+    session_key = build_session_key(src)
+    runner, adapter, _entry = _make_runner(hermes_home, "goal-live-1", src)
+
+    _set_goal(hermes_home, "goal-live-1", owner_pid=os.getpid())
+
+    monkeypatch.setattr(
+        runner, "_goal_recovery_homes", lambda: [str(hermes_home)]
+    )
+
+    enqueued = await runner._run_goal_recovery_sweep()
+    assert enqueued == 0
+    assert adapter._pending_messages.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_boot_sweep_skips_paused_goal(hermes_home, monkeypatch):
+    """A paused goal is untouched even with a dead owner pid."""
+    src = _telegram_source()
+    runner, adapter, _entry = _make_runner(hermes_home, "goal-paused-1", src)
+
+    from hermes_state import SessionDB
+    from hermes_cli.goals import GoalState, save_goal
+
+    db = SessionDB(db_path=Path(hermes_home) / "state.db")
+    state = GoalState(
+        goal="paused goal",
+        status="paused",
+        turns_used=0,
+        max_turns=5,
+        created_at=time.time() - 600,
+        last_turn_at=time.time() - 600,
+    )
+    state.owner_pid = 4_000_000
+    state.last_owner_seen_at = time.time() - 60
+    save_goal("goal-paused-1", state, db=db)
+    db.close()
+
+    monkeypatch.setattr(
+        runner, "_goal_recovery_homes", lambda: [str(hermes_home)]
+    )
+
+    enqueued = await runner._run_goal_recovery_sweep()
+    assert enqueued == 0
+    from hermes_cli.goals import load_goal
+
+    loaded = load_goal("goal-paused-1")
+    assert loaded is not None
+    assert loaded.status == "paused"
+    assert loaded.orphaned is False
+
+
+@pytest.mark.asyncio
+async def test_boot_sweep_skips_session_without_gateway_origin(
+    hermes_home, monkeypatch
+):
+    """A goal whose session has no persisted gateway origin (pure CLI/TUI
+    row) is not this gateway's to drive — skipped."""
+    src = _telegram_source()
+    runner, adapter, _entry = _make_runner(hermes_home, "goal-cli-1", src)
+
+    _set_goal(hermes_home, "goal-cli-1", owner_pid=4_000_000)
+
+    # No matching entry in the routing index for this session id.
+    runner.session_store._entries = {}
+
+    monkeypatch.setattr(
+        runner, "_goal_recovery_homes", lambda: [str(hermes_home)]
+    )
+
+    enqueued = await runner._run_goal_recovery_sweep()
+    assert enqueued == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_loop_interval_from_config(hermes_home, monkeypatch):
+    """The sweep interval resolves from goals.recovery_interval_minutes
+    (0 disables the periodic loop)."""
+    runner, _adapter, _entry = _make_runner(
+        hermes_home, "goal-cfg-1", _telegram_source()
+    )
+    # Runner.config is a GatewayConfig dataclass; the goals.* knobs come
+    # from the user config via hermes_cli.config.load_config.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"goals": {"recovery_interval_minutes": 0, "recovery_enabled": True}},
+    )
+    assert runner._goal_recovery_interval_minutes() == 0
+    assert runner._goal_recovery_enabled() is True
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"goals": {"recovery_interval_minutes": 7, "recovery_enabled": False}},
+    )
+    assert runner._goal_recovery_interval_minutes() == 7
+    assert runner._goal_recovery_enabled() is False

--- a/tests/hermes_cli/test_goal_recovery.py
+++ b/tests/hermes_cli/test_goal_recovery.py
@@ -1,0 +1,245 @@
+"""Tests for orphan goal recovery — resuming active goals whose owning
+process died (issue #81109).
+
+A standing /goal only runs inside a live process; when the owner dies
+(CLI terminal closed, desktop chat PTY reaped, gateway stopped) the goal
+stays "active" in state_meta but nothing feeds continuation turns. The
+recovery sweep (hermes_cli/goal_recovery.py) detects these goals and
+hands them back to a live surface (gateway / hermes serve) to resume.
+
+Covered here:
+- orphan detection (dead owner pid → claimable; live owner pid → skipped)
+- sweep claims goals (resume-on-boot data path)
+- no double-fire for goals whose owning process is still alive
+- paused/cleared goals are excluded
+- /goal status distinguishes active-running from active-orphaned
+- claim lock prevents a sibling sweep from re-claiming within the window
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so SessionDB.state_meta writes don't clobber the real one."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _set_goal(home, session_id: str, *, status: str = "active", owner_pid=None):
+    """Write a goal row directly (bypassing owner stamping) for sweep tests."""
+    from hermes_state import SessionDB
+    from hermes_cli.goals import GoalState, save_goal
+
+    db = SessionDB(db_path=Path(home) / "state.db")
+    state = GoalState(
+        goal=f"goal for {session_id}",
+        status=status,
+        turns_used=0,
+        max_turns=5,
+        created_at=time.time() - 600,
+        last_turn_at=time.time() - 600,
+    )
+    if owner_pid is not None:
+        state.owner_pid = owner_pid
+        state.last_owner_seen_at = time.time() - 60
+    else:
+        # No owner pid + stale owner stamp → past the silence window.
+        state.last_owner_seen_at = time.time() - 3600
+    save_goal(session_id, state, db=db)
+    db.close()
+    return state
+
+
+class TestOrphanDetection:
+
+    def test_dead_owner_pid_is_orphaned(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        # A pid that can never be alive (max sys.pid_max on Linux is ~4M).
+        _set_goal(hermes_home, "orphan-s1", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        claims = sweeper.sweep()
+        assert len(claims) == 1
+        assert claims[0][1] == "orphan-s1"
+
+    def test_live_owner_pid_is_not_claimed(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        # Our own pid is definitely alive — never claim.
+        _set_goal(hermes_home, "live-s1", owner_pid=os.getpid())
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        assert sweeper.sweep() == []
+
+    def test_no_owner_pid_past_silence_window_is_orphaned(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "noowner-s1")  # no owner_pid, stale stamp
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        assert len(sweeper.sweep()) == 1
+
+    def test_surface_owns_goal_skips_it(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "owned-s1", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper(
+            [str(hermes_home)],
+            owns_goal=lambda sid: sid == "owned-s1",
+        )
+        assert sweeper.sweep() == []
+
+
+class TestPausedAndClearedExcluded:
+
+    def test_paused_goal_not_claimed(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "paused-s1", status="paused", owner_pid=4_000_000)
+        _set_goal(hermes_home, "cleared-s1", status="cleared", owner_pid=4_000_000)
+        _set_goal(hermes_home, "done-s1", status="done", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        assert sweeper.sweep() == []
+
+    def test_mixed_goals_only_orphaned_active_claimed(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "mix-paused", status="paused", owner_pid=4_000_000)
+        _set_goal(hermes_home, "mix-live", owner_pid=os.getpid())
+        _set_goal(hermes_home, "mix-orphan", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        claims = sweeper.sweep()
+        assert [c[1] for c in claims] == ["mix-orphan"]
+
+
+class TestSweepClaims:
+
+    def test_claim_carries_goal_state(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "claim-s1", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        claims = sweeper.sweep()
+        assert len(claims) == 1
+        home, session_id, state = claims[0]
+        assert session_id == "claim-s1"
+        assert getattr(state, "goal", "") == "goal for claim-s1"
+        assert getattr(state, "orphaned", False) is True
+
+    def test_clear_claim_flips_back_to_running(self, hermes_home):
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+        from hermes_cli.goals import load_goal
+
+        _set_goal(hermes_home, "clear-s1", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        claims = sweeper.sweep()
+        assert len(claims) == 1
+        sweeper.clear_claim(claims[0][0], claims[0][1])
+        assert load_goal("clear-s1").orphaned is False
+
+    def test_uncleared_claim_not_reclaimed_within_window(self, hermes_home):
+        """A claimed goal whose flag was never cleared (drive crashed) is
+        not re-claimed within the recent-claim window — the next sweep after
+        the window heals it."""
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "uncleared-s1", owner_pid=4_000_000)
+        sweeper_a = GoalRecoverySweeper([str(hermes_home)])
+        sweeper_b = GoalRecoverySweeper([str(hermes_home)])
+        assert len(sweeper_a.sweep()) == 1
+        # Fresh claim → sibling skips it.
+        assert sweeper_b.sweep() == []
+
+
+class TestStatusLineDistinguishes:
+
+    def test_orphaned_flag_reflected_in_status(self, hermes_home):
+        from hermes_cli.goals import GoalManager, mark_goal_orphaned
+
+        mgr = GoalManager(session_id="status-s1")
+        mgr.set("ship it")
+        assert "active-running" in mgr.status_line()
+
+        assert mark_goal_orphaned("status-s1") is True
+        # A fresh manager reloads from the DB and sees the flag.
+        fresh = GoalManager(session_id="status-s1")
+        line = fresh.status_line()
+        assert "active-orphaned" in line
+
+        # A live turn clears the flag back to running.
+        from hermes_cli.goals import clear_goal_orphaned
+
+        assert clear_goal_orphaned("status-s1") is True
+        fresh2 = GoalManager(session_id="status-s1")
+        assert "active-running" in fresh2.status_line()
+
+    def test_orphaned_flag_cleared_by_evaluate_after_turn(self, hermes_home):
+        """The post-turn judge path (the loop actually running) restamps
+        ownership, so /goal status flips back to active-running."""
+        from hermes_cli.goals import GoalManager, mark_goal_orphaned
+        from hermes_cli import goals as goals_mod
+
+        with patch("agent.auxiliary_client.call_llm") as call_llm:
+            call_llm.return_value = type(
+                "R", (), {"choices": [type("C", (), {"message": type(
+                    "M", (), {"content": '{"done": false, "reason": "keep going"}'}
+                )()})()]}
+            )()
+            mgr = GoalManager(session_id="eval-s1")
+            mgr.set("keep working")
+            mark_goal_orphaned("eval-s1")
+            decision = mgr.evaluate_after_turn("some response")
+        assert decision["should_continue"] is True
+        assert "active-running" in mgr.status_line()
+        assert goals_mod.load_goal("eval-s1").orphaned is False
+
+
+class TestEnumeration:
+
+    def test_enumerate_active_goals_scans_meta(self, hermes_home):
+        from hermes_cli.goals import enumerate_active_goals
+
+        _set_goal(hermes_home, "enum-1", owner_pid=os.getpid())
+        _set_goal(hermes_home, "enum-2", owner_pid=os.getpid())
+        rows = enumerate_active_goals()
+        assert {sid for sid, _state in rows} == {"enum-1", "enum-2"}
+
+    def test_enumerate_skips_cleared(self, hermes_home):
+        from hermes_cli.goals import enumerate_active_goals
+
+        _set_goal(hermes_home, "enum-c", status="cleared")
+        rows = enumerate_active_goals()
+        assert rows == []
+
+
+class TestClaimLock:
+
+    def test_cross_process_lock_serializes_claims(self, hermes_home):
+        """Two sweeper instances share the same lock file; the second sees
+        the flag already set and skips."""
+        from hermes_cli.goal_recovery import GoalRecoverySweeper
+
+        _set_goal(hermes_home, "lock-s1", owner_pid=4_000_000)
+        sweeper = GoalRecoverySweeper([str(hermes_home)])
+        assert len(sweeper.sweep()) == 1
+        # A sibling instance (same home) respects the persisted claim.
+        sibling = GoalRecoverySweeper([str(hermes_home)])
+        assert sibling.sweep() == []

--- a/tests/hermes_cli/test_web_server_goal_recovery.py
+++ b/tests/hermes_cli/test_web_server_goal_recovery.py
@@ -1,0 +1,168 @@
+"""Tests for orphan goal recovery on the serve/web_server surface (#81109).
+
+``hermes serve`` hosts the desktop chat's tui_gateway in-process. When the
+browser detaches, the PTY reaper kills the chat child after the TTL, orphaning
+any standing /goal. The server's recovery sweep re-drives the goal through the
+embedded tui_gateway (session.resume + prompt.submit).
+
+Covered here:
+- the sweep's owns_goal callback treats a LIVE tui_gateway session as owned
+  (no claim → no double-fire)
+- _goal_recovery_drive_session drives a continuation through prompt.submit
+  for a session that is no longer live (resume path)
+- the periodic sweep loop is gated by config (0 disables)
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+@pytest.fixture()
+def server(hermes_home, monkeypatch):
+    from hermes_cli import web_server
+
+    # The sweeper is cached on app.state — clear between tests.
+    if hasattr(web_server.app.state, "_goal_sweeper_obj"):
+        del web_server.app.state._goal_sweeper_obj
+    yield web_server
+
+
+@pytest.fixture()
+def tui_server(hermes_home, monkeypatch):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+    # patch.dict restores sys.modules on exit, dropping modules imported
+    # inside the block. Re-register this instance so the web_server sweep
+    # (which imports tui_gateway.server lazily) resolves to the SAME module
+    # and sees the sessions this fixture populates.
+    sys.modules["tui_gateway.server"] = mod
+    monkeypatch.setattr(mod, "_hermes_home", hermes_home)
+    monkeypatch.setattr(mod, "_cfg_cache", None)
+    monkeypatch.setattr(mod, "_cfg_mtime", None)
+    monkeypatch.setattr(mod, "_cfg_path", None)
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+
+
+def _set_goal(home, session_id: str, *, owner_pid=None):
+    from hermes_state import SessionDB
+    from hermes_cli.goals import GoalState, save_goal
+
+    db = SessionDB(db_path=Path(home) / "state.db")
+    state = GoalState(
+        goal=f"goal for {session_id}",
+        status="active",
+        turns_used=0,
+        max_turns=5,
+        created_at=time.time() - 600,
+        last_turn_at=time.time() - 600,
+    )
+    if owner_pid is not None:
+        state.owner_pid = owner_pid
+        state.last_owner_seen_at = time.time() - 60
+    else:
+        state.last_owner_seen_at = time.time() - 3600
+    save_goal(session_id, state, db=db)
+    db.close()
+
+
+class TestServeSweep:
+
+    def test_sweep_homes_resolve_launch_profile(self, server, hermes_home):
+        homes = server._goal_recovery_homes()
+        assert str(hermes_home) in homes
+
+    def test_live_tui_session_not_claimed(self, server, tui_server, hermes_home):
+        """A session live in the in-process tui_gateway is owned — the sweep
+        must not claim (and thus must not double-fire) its goal."""
+        _set_goal(hermes_home, "live-tui-s1", owner_pid=4_000_000)
+        tui_server._sessions["sid-live"] = {
+            "session_key": "live-tui-s1",
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": False,
+            "attached_images": [],
+            "cols": 120,
+        }
+        sweeper = server._goal_sweeper()
+        assert sweeper.sweep() == []
+
+    def test_orphaned_session_claimed_when_not_live(
+        self, server, tui_server, hermes_home
+    ):
+        """A goal whose session is NOT live in the registry is claimed."""
+        _set_goal(hermes_home, "orphan-tui-s1", owner_pid=4_000_000)
+        sweeper = server._goal_sweeper()
+        claims = sweeper.sweep()
+        assert [c[1] for c in claims] == ["orphan-tui-s1"]
+
+    def test_drive_session_calls_prompt_submit(
+        self, server, tui_server, hermes_home
+    ):
+        """_goal_recovery_drive_session drives a continuation turn via the
+        tui_gateway prompt.submit handler."""
+        # A session that IS live — drive should reuse it (fast path) and
+        # submit the continuation.
+        tui_server._sessions["sid-drive"] = {
+            "session_key": "drive-s1",
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": False,
+            "attached_images": [],
+            "cols": 120,
+        }
+        with patch.object(
+            tui_server, "_find_live_session_by_key", return_value=("sid-drive", None)
+        ) as find_live, patch.object(
+            tui_server, "_start_agent_build", return_value=None
+        ):
+            ok = server._goal_recovery_drive_session("drive-s1", "keep going")
+        assert ok is True
+        find_live.assert_called_once_with("drive-s1")
+
+    def test_sweep_loop_disabled_by_config(self, server, monkeypatch):
+        monkeypatch.setattr(server, "_goal_recovery_interval_minutes", lambda: 0)
+        # The loop returns immediately when disabled — no sleep, no sweep.
+        import asyncio
+
+        async def _run():
+            await server._goal_recovery_sweep_loop()
+
+        asyncio.run(_run())


### PR DESCRIPTION
## What does this PR do?

A standing `/goal` (Ralph loop) only runs inside a live process. Goal state is persisted in `SessionDB.state_meta` under `goal:<session_id>`, but nothing executes the loop when the owning process dies — a desktop chat PTY reaped after detach, a closed terminal, or a stopped gateway all leave the goal `active` but inert.

This PR adds **orphan goal recovery**: a supervisor that detects active goals whose owning process is gone and resumes the loop automatically, shared by the two long-lived surfaces that can legitimately own a goal loop:

- **`hermes_cli/goals.py`** — owner-liveness bookkeeping on `GoalState` (`owner_pid` / `last_owner_seen_at` / `orphaned`), `enumerate_active_goals()`, `mark_goal_orphaned()` / `clear_goal_orphaned()`, and a `continuation_prompt_from_state()` helper (extracted from `GoalManager.next_continuation_prompt` so recovery drivers can render the continuation without owning the session).
- **`hermes_cli/goal_recovery.py`** (new) — `GoalRecoverySweeper`: scans HERMES_HOMEs for orphaned active goals and claims them under a per-home cross-process lock (fcntl/msvcrt, mirroring `active_sessions._FileLock`), so a gateway and a `hermes serve` backing the same home can never both fire the same goal's continuation turn.
- **`gateway/run.py`** — boot scan + periodic sweep (`goals.recovery_interval_minutes`, default 5) that enqueues continuation turns through the adapter FIFO — the same path `_post_turn_goal_continuation` uses — for the profiles the gateway serves (multiplex-aware).
- **`hermes_cli/web_server.py`** — the same scan on `hermes serve` boot + periodic sweep, driving orphaned desktop sessions through the embedded `tui_gateway` (`session.resume` + `prompt.submit`), the same JSON-RPC surface the desktop uses.

Why this approach: the continuation prompt is a plain user-role message, so driving recovery through the existing turn machinery (adapter FIFO / tui_gateway dispatch) keeps message-role alternation and prompt caching untouched. The persisted `orphaned` flag makes `/goal status` truthful without guessing, and the claim lock + freshness window makes the no-double-fire guarantee hold across processes.

## Related Issue

Fixes #81109

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/goals.py` — `GoalState` gains `owner_pid` / `last_owner_seen_at` / `orphaned` (backwards-compatible: old rows load with no owner); `GoalManager.set()` stamps the owner pid; `evaluate_after_turn()` restamps ownership + clears the orphaned flag on every live turn; `status_line()` renders `active-running` vs `active-orphaned`; new `enumerate_active_goals()`, `mark_goal_orphaned()`, `clear_goal_orphaned()`, `continuation_prompt_from_state()`; `load_goal`/`save_goal` accept a bound `db` for cross-profile sweeps.
- `hermes_state.py` — `SessionDB.list_meta_keys(prefix)` for enumerating `goal:` rows.
- `hermes_cli/goal_recovery.py` — new `GoalRecoverySweeper` (scan → claim under per-home lock → surface drives → clear claim).
- `gateway/run.py` — `_run_goal_recovery_sweep()` at boot + `_start_goal_recovery_sweeper()` periodic loop; `_goal_recovery_source_for_session()` resolves the persisted origin for an orphaned session; `owns_goal` skips sessions with a live in-process turn.
- `hermes_cli/web_server.py` — `_run_goal_recovery_sweep()` at lifespan boot + `_goal_recovery_sweep_loop()`; `_goal_recovery_drive_session()` resumes orphaned desktop sessions via the embedded tui_gateway; `owns_goal` skips live tui_gateway sessions.
- `hermes_cli/config_defaults.py` + `cli-config.yaml.example` — `goals.recovery_enabled` (default true) and `goals.recovery_interval_minutes` (default 5; 0 disables the periodic sweep).
- Tests: `tests/hermes_cli/test_goal_recovery.py`, `tests/hermes_cli/test_web_server_goal_recovery.py`, `tests/gateway/test_goal_recovery_sweep.py`.

## How to Test

1. `pytest tests/hermes_cli/test_goal_recovery.py tests/hermes_cli/test_web_server_goal_recovery.py tests/gateway/test_goal_recovery_sweep.py -q` — all pass.
2. Set a goal in the desktop chat (`/goal <text>`), close the app, wait for the PTY reaper TTL (or restart `hermes serve`): the goal is resumed automatically on the next serve boot or periodic sweep.
3. `hermes chat` → `/goal status` on an orphaned goal shows `active-orphaned`; once the loop runs again it shows `active-running`.
4. With a live owning process (CLI running the loop), restart the gateway: the goal is NOT double-fired (owner pid alive → skipped).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior verified by unit tests (orphan detection, resume-on-boot, no-double-fire, paused-goal exclusion, status-line distinction).
