### PR TITLE
fix(vision): keep region zoom accurate for EXIF-rotated images

### DIFF
--- a/tests/tools/test_vision_region.py
+++ b/tests/tools/test_vision_region.py
@@ -59,6 +59,32 @@ class TestCropImageRegion:
         with Image.open(cropped_path) as img:
             assert img.size == (100, 50)
 
+    def test_crop_uses_display_orientation_for_exif_rotated_jpeg(self, tmp_path):
+        from PIL import ImageOps
+
+        from tools.vision_tools import _crop_image_region
+
+        src = tmp_path / "oriented.jpg"
+        image = Image.new("RGB", (80, 40))
+        for x in range(image.width):
+            for y in range(image.height):
+                image.putpixel((x, y), (x * 3, y * 6, (x + y) * 2))
+        exif = Image.Exif()
+        exif[274] = 6  # Rotate 90 degrees clockwise for display.
+        image.save(src, format="JPEG", quality=95, exif=exif)
+
+        region = [0, 0, 40, 60]
+        with Image.open(src) as encoded:
+            expected = ImageOps.exif_transpose(encoded).crop(region).convert("RGB")
+
+        cropped_path, mime, err = _crop_image_region(src, region)
+
+        assert err is None
+        assert mime == "image/png"
+        with Image.open(cropped_path) as actual:
+            assert actual.size == (40, 60)
+            assert list(actual.convert("RGB").getdata()) == list(expected.getdata())
+
     def test_zero_area_rejected_with_actual_dims_in_error(self, tmp_path):
         from tools.vision_tools import _crop_image_region
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -697,7 +697,7 @@ def _crop_image_region(
         cleanup of the temp file — or (None, None, error_message) on failure.
     """
     try:
-        from PIL import Image
+        from PIL import Image, ImageOps
     except ImportError:
         return None, None, (
             "region cropping requires Pillow (`pip install Pillow`); "
@@ -715,7 +715,9 @@ def _crop_image_region(
         )
 
     try:
-        with Image.open(image_path) as img:
+        with Image.open(image_path) as source_img, ImageOps.exif_transpose(
+            source_img
+        ) as img:
             width, height = img.size
             x1, y1, x2, y2 = (int(v) for v in region)
             # Clamp to image bounds.


### PR DESCRIPTION
## What does this PR do?

Region zoom on an EXIF-rotated JPEG currently selects coordinates from the encoded pixel matrix rather than the displayed image. This can silently send unrelated pixels to vision analysis for rotated phone photos and scans.

### Symptom

For an 80x40 JPEG with EXIF orientation 6, a displayed-image region of `[0, 0, 40, 60]` is clamped against the encoded 80x40 dimensions. The generated crop is 40x40 and contains the wrong displayed area instead of the requested 40x60 region.

### Impact

Users can receive incorrect visual answers because region zoom analyzes a different part of an EXIF-rotated image than the part they selected. The affected input frequency was not measured.

### Bug Cause

**Trigger:** `tools/vision_tools.py` in `_crop_image_region`, when Pillow opens a file with a non-identity EXIF orientation.

**Causal chain:**
1. A user requests region zoom using coordinates from the displayed image.
2. `_crop_image_region` clamps and crops against the untransposed encoded dimensions, then saves a PNG without the orientation metadata.
3. The vision model receives the wrong area and shape.

**Why it is wrong:** Pillow keeps encoded pixel order until EXIF orientation is applied. The crop path converts selected pixels into a new PNG, so downstream consumers cannot recover the intended orientation from the original metadata.

**Working sibling / contrast:** The no-region path keeps the original JPEG and its EXIF metadata, allowing downstream image consumers to display the intended orientation.

**Ruled out:** Coordinate clamping itself is not defective. It produces the documented bounds result, but uses encoded dimensions instead of displayed dimensions.

### Fix

Apply `ImageOps.exif_transpose` before reading dimensions, clamping coordinates, and cropping. A regression test uses EXIF orientation 6 and compares the generated PNG with a crop from the display-oriented image.

## Related Issue

Fixes #81377

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` - transpose EXIF orientation before region validation and cropping.
- `tests/tools/test_vision_region.py` - cover displayed-coordinate cropping for an EXIF-rotated JPEG.

## How to Test

1. Create a JPEG with encoded dimensions 80x40 and EXIF orientation 6.
2. Crop `[0, 0, 40, 60]` through `_crop_image_region` and verify the PNG is 40x60 with display-oriented pixels.
3. Run the relevant vision suites:

```bash
scripts/run_tests.sh tests/tools/test_vision_region.py tests/tools/test_vision_tools.py
```

Result: 46 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry point on the relevant test suites and all 46 tests pass
- [x] I've added a regression test for the fix
- [x] I've tested on Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; the existing region contract remains unchanged
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; Pillow EXIF transpose behavior is platform-independent
- [x] Tool description and schema updates are N/A; the documented displayed-image region behavior remains unchanged

## Screenshots / Logs

```text
46 tests passed, 0 failed
```
