### PR TITLE
fix(utils): stage the cross-device replace so a failed rename can't truncate the target

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -233,10 +233,17 @@ def test_atomic_replace_copy_fallback_preserves_symlink(
     link.symlink_to(real)
     tmp = _write_tmp(tmp_path, "new\n")
 
-    def fail_replace(src: str, dst: str) -> None:
-        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+    genuine_replace = os.replace
+    replace_calls = 0
 
-    monkeypatch.setattr("utils.os.replace", fail_replace)
+    def exdev_once(src: str, dst: str) -> None:
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+        genuine_replace(src, dst)
+
+    monkeypatch.setattr("utils.os.replace", exdev_once)
 
     assert Path(atomic_replace(tmp, link)) == real
     assert link.is_symlink()
@@ -394,30 +401,37 @@ def test_atomic_replace_cross_device_uses_rename_not_inplace_copy(
 
 
 @pytest.mark.require_symlinks
-def test_atomic_replace_busy_target_falls_back_to_plain_copy(
+def test_atomic_replace_busy_staged_rename_preserves_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A busy inode cannot be renamed onto, so the plain copy must remain.
-
-    Behaviour-preservation guard: green before and after the staging change.
-    It pins the residual last-resort path and catches a staged temp leaking
-    when the staged rename fails.
-    """
+    """A failed staged rename must leave the resolved target untouched."""
     real = tmp_path / "config.yaml"
     link = tmp_path / "link.yaml"
-    real.write_text("old\n", encoding="utf-8")
+    original = "provider: openrouter\napi_key: keep-me\n"
+    real.write_text(original, encoding="utf-8")
     link.symlink_to(real)
-    tmp = _write_tmp(tmp_path, "new\n")
+    tmp = _write_tmp(tmp_path, "provider: replacement\n")
 
-    def always_busy(src: str, dst: str) -> None:
+    replace_calls: list[tuple[str, str]] = []
+
+    def exdev_then_busy(src: str, dst: str) -> None:
+        replace_calls.append((str(src), str(dst)))
+        if len(replace_calls) == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
         raise OSError(errno.EBUSY, os.strerror(errno.EBUSY), src, None, dst)
 
-    monkeypatch.setattr("utils.os.replace", always_busy)
+    monkeypatch.setattr("utils.os.replace", exdev_then_busy)
 
-    assert Path(atomic_replace(tmp, link)) == real
-    assert link.is_symlink()
-    assert real.read_text(encoding="utf-8") == "new\n"
-    assert not tmp.exists()
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, link)
+
+    assert excinfo.value.errno == errno.EBUSY
+    assert replace_calls[0] == (str(tmp), str(real))
+    assert replace_calls[1][0] != str(tmp), "the second replace must use staging"
+    assert replace_calls[1][1] == str(real)
+    assert link.is_symlink(), "failed replacement must not detach the symlink"
+    assert real.read_text(encoding="utf-8") == original
+    assert tmp.exists(), "the pending write must survive for the caller"
     assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked on EBUSY"
 
 

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -279,14 +279,15 @@ def test_atomic_replace_cross_device_never_truncates_target(
             raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
         genuine_replace(src, dst)
 
-    def copyfile_runs_out_of_space(src: str, dst: str) -> None:
+    def copyfileobj_runs_out_of_space(
+        src_handle: object, dst_handle: object, *_args: object, **_kwargs: object
+    ) -> None:
         # Land a few bytes, then fail the way a filling disk does.
-        with open(src, "rb") as src_handle, open(dst, "wb") as dst_handle:
-            dst_handle.write(src_handle.read(8))
-        raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC), dst)
+        dst_handle.write(src_handle.read(8))  # type: ignore[attr-defined]
+        raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
 
     monkeypatch.setattr("utils.os.replace", exdev_once)
-    monkeypatch.setattr("utils.shutil.copyfile", copyfile_runs_out_of_space)
+    monkeypatch.setattr("utils.shutil.copyfileobj", copyfileobj_runs_out_of_space)
 
     with pytest.raises(OSError) as excinfo:
         atomic_replace(tmp, link)

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -245,3 +245,154 @@ def test_atomic_replace_real_cross_device(tmp_path: Path) -> None:
         assert not tmp.exists()
     finally:
         _shutil.rmtree(other_fs_dir, ignore_errors=True)
+
+
+def test_atomic_replace_cross_device_never_truncates_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupted cross-device write must leave the target untouched.
+
+    ``shutil.copyfile`` opens its destination ``"wb"``, so copying straight
+    onto the resolved target truncates the user's file before the first
+    replacement byte exists.  A crash, ENOSPC or SIGKILL midway then leaves
+    ``config.yaml`` / ``auth.json`` partial or empty — precisely the outcome
+    this helper exists to prevent.
+    """
+    if os.name != "posix":
+        pytest.skip("POSIX-only")
+
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    original = "provider: openrouter\napi_key: keep-me\n"
+    real.write_text(original, encoding="utf-8")
+    os.chmod(real, 0o600)
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "provider: replacement\n")
+
+    genuine_replace = os.replace
+    replace_calls = 0
+
+    def exdev_once(src: str, dst: str) -> None:
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+        genuine_replace(src, dst)
+
+    def copyfile_runs_out_of_space(src: str, dst: str) -> None:
+        # Land a few bytes, then fail the way a filling disk does.
+        with open(src, "rb") as src_handle, open(dst, "wb") as dst_handle:
+            dst_handle.write(src_handle.read(8))
+        raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC), dst)
+
+    monkeypatch.setattr("utils.os.replace", exdev_once)
+    monkeypatch.setattr("utils.shutil.copyfile", copyfile_runs_out_of_space)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, link)
+    assert excinfo.value.errno == errno.ENOSPC
+
+    assert link.is_symlink(), "symlink must survive a failed cross-device write"
+    assert (
+        real.read_text(encoding="utf-8") == original
+    ), "a failed cross-device write destroyed the target's contents"
+
+    import stat as _stat
+
+    assert _stat.S_IMODE(real.stat().st_mode) == 0o600
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked after failure"
+
+
+def test_atomic_replace_cross_device_uses_rename_not_inplace_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cross-device fallback must finish by rename, not by in-place copy."""
+    if os.name != "posix":
+        pytest.skip("POSIX-only")
+
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+    original_inode = real.stat().st_ino
+
+    genuine_replace = os.replace
+    destinations: list[str] = []
+
+    def exdev_once(src: str, dst: str) -> None:
+        destinations.append(str(dst))
+        if len(destinations) == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+        genuine_replace(src, dst)
+
+    monkeypatch.setattr("utils.os.replace", exdev_once)
+
+    assert Path(atomic_replace(tmp, link)) == real
+
+    assert (
+        len(destinations) >= 2
+    ), "cross-device fallback copied in place instead of staging then renaming"
+    assert destinations[-1] == str(real)
+    assert (
+        real.stat().st_ino != original_inode
+    ), "target was overwritten in place rather than replaced by an atomic rename"
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked"
+
+
+def test_atomic_replace_busy_target_falls_back_to_inplace_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A busy inode cannot be renamed onto, so the in-place copy must remain.
+
+    Behaviour-preservation guard: green before and after the staging change.
+    It pins the last-resort path and catches a staged temp leaking when the
+    staged rename fails.
+    """
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def always_busy(src: str, dst: str) -> None:
+        raise OSError(errno.EBUSY, os.strerror(errno.EBUSY), src, None, dst)
+
+    monkeypatch.setattr("utils.os.replace", always_busy)
+
+    assert Path(atomic_replace(tmp, link)) == real
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked on EBUSY"
+
+
+def test_atomic_replace_cross_device_survives_unstageable_target_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A target directory that rejects a staged temp still gets the write.
+
+    Behaviour-preservation guard: green before and after the staging change.
+    """
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    def refuse_staging(*_args: object, **_kwargs: object) -> None:
+        raise OSError(errno.EACCES, os.strerror(errno.EACCES))
+
+    monkeypatch.setattr("utils.os.replace", fail_replace)
+    monkeypatch.setattr("utils.tempfile.mkstemp", refuse_staging)
+
+    assert Path(atomic_replace(tmp, link)) == real
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -276,6 +276,180 @@ def test_atomic_replace_real_cross_device(tmp_path: Path) -> None:
         _shutil.rmtree(other_fs_dir, ignore_errors=True)
 
 
+# ─── Cross-device fallback must not truncate the target ────────────────────
+#
+# ``_rewrite_in_place`` closed this window for the Windows-contended branch
+# and states the invariant in its own docstring — "Unlike ``shutil.copyfile``
+# this never truncates the target to zero first".  The EXDEV/EBUSY branch was
+# left on ``shutil.copyfile``, which opens the destination "wb"; there the
+# consequence is worse than a transient empty read, because a crash/ENOSPC
+# partway through leaves the file empty or partial on disk.
+
+
+def test_atomic_replace_cross_device_never_truncates_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupted cross-device write must leave the target untouched.
+
+    ``shutil.copyfile`` opens its destination ``"wb"``, so copying straight
+    onto the resolved target truncates the user's file before the first
+    replacement byte exists.  A crash, ENOSPC or SIGKILL midway then leaves
+    ``config.yaml`` / ``auth.json`` partial or empty — precisely the outcome
+    this helper exists to prevent.
+    """
+    if os.name != "posix":
+        pytest.skip("POSIX-only")
+
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    original = "provider: openrouter\napi_key: keep-me\n"
+    real.write_text(original, encoding="utf-8")
+    os.chmod(real, 0o600)
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "provider: replacement\n")
+
+    genuine_replace = os.replace
+    replace_calls = 0
+
+    def exdev_once(src: str, dst: str) -> None:
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+        genuine_replace(src, dst)
+
+    def copyfileobj_runs_out_of_space(
+        src_handle: object, dst_handle: object, *_args: object, **_kwargs: object
+    ) -> None:
+        # Land a few bytes, then fail the way a filling disk does.
+        dst_handle.write(src_handle.read(8))  # type: ignore[attr-defined]
+        raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+    def copyfile_runs_out_of_space(src: str, dst: str, **_kwargs: object) -> None:
+        # Reproduces ``shutil.copyfile``'s first two operations verbatim —
+        # open the destination ``"wb"``, which truncates it, then stream —
+        # before failing the same way. The destruction below is done by the
+        # OS through a real handle, not asserted against a stub.
+        with open(src, "rb") as fsrc, open(dst, "wb") as fdst:
+            fdst.write(fsrc.read(8))
+            raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+    monkeypatch.setattr("utils.os.replace", exdev_once)
+    monkeypatch.setattr("utils.shutil.copyfileobj", copyfileobj_runs_out_of_space)
+    monkeypatch.setattr("utils.shutil.copyfile", copyfile_runs_out_of_space)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, link)
+    assert excinfo.value.errno == errno.ENOSPC
+
+    assert link.is_symlink(), "symlink must survive a failed cross-device write"
+    assert (
+        real.read_text(encoding="utf-8") == original
+    ), "a failed cross-device write destroyed the target's contents"
+
+    import stat as _stat
+
+    assert _stat.S_IMODE(real.stat().st_mode) == 0o600
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked after failure"
+
+
+def test_atomic_replace_cross_device_uses_rename_not_inplace_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cross-device fallback must finish by rename, not by in-place copy."""
+    if os.name != "posix":
+        pytest.skip("POSIX-only")
+
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+    original_inode = real.stat().st_ino
+
+    genuine_replace = os.replace
+    destinations: list[str] = []
+
+    def exdev_once(src: str, dst: str) -> None:
+        destinations.append(str(dst))
+        if len(destinations) == 1:
+            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+        genuine_replace(src, dst)
+
+    monkeypatch.setattr("utils.os.replace", exdev_once)
+
+    assert Path(atomic_replace(tmp, link)) == real
+
+    assert (
+        len(destinations) >= 2
+    ), "cross-device fallback copied in place instead of staging then renaming"
+    assert destinations[-1] == str(real)
+    assert (
+        real.stat().st_ino != original_inode
+    ), "target was overwritten in place rather than replaced by an atomic rename"
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked"
+
+
+@pytest.mark.require_symlinks
+def test_atomic_replace_busy_target_falls_back_to_plain_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A busy inode cannot be renamed onto, so the plain copy must remain.
+
+    Behaviour-preservation guard: green before and after the staging change.
+    It pins the residual last-resort path and catches a staged temp leaking
+    when the staged rename fails.
+    """
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def always_busy(src: str, dst: str) -> None:
+        raise OSError(errno.EBUSY, os.strerror(errno.EBUSY), src, None, dst)
+
+    monkeypatch.setattr("utils.os.replace", always_busy)
+
+    assert Path(atomic_replace(tmp, link)) == real
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+    assert not list(tmp_path.glob(".tmp_xdev_*")), "staged temp leaked on EBUSY"
+
+
+@pytest.mark.require_symlinks
+def test_atomic_replace_cross_device_survives_unstageable_target_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A target directory that rejects a staged temp still gets the write.
+
+    Behaviour-preservation guard: green before and after the staging change.
+    """
+    real = tmp_path / "config.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    def refuse_staging(*_args: object, **_kwargs: object) -> None:
+        raise OSError(errno.EACCES, os.strerror(errno.EACCES))
+
+    monkeypatch.setattr("utils.os.replace", fail_replace)
+    monkeypatch.setattr("utils.tempfile.mkstemp", refuse_staging)
+
+    assert Path(atomic_replace(tmp, link)) == real
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+
+
 # ─── Windows contended renames (GitHub #57775) ─────────────────────────────
 #
 # CPython opens files without FILE_SHARE_DELETE on Windows, so os.replace

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -417,9 +417,18 @@ def test_contended_retry_switching_to_exdev_uses_copy_fallback(
     target.write_text("old", encoding="utf-8")
     tmp = _write_tmp(tmp_path, "new")
 
-    replace = MagicMock(
-        side_effect=[_sharing_error(5), OSError(errno.EXDEV, "cross-device")]
-    )
+    genuine_replace = os.replace
+    calls: list[tuple[str, str]] = []
+
+    def replace(src: str, dst: str) -> None:
+        calls.append((str(src), str(dst)))
+        if len(calls) == 1:
+            raise _sharing_error(5)
+        if len(calls) == 2:
+            raise OSError(errno.EXDEV, "cross-device")
+        # Third call is the copy fallback's own staged rename — let it land.
+        genuine_replace(src, dst)
+
     monkeypatch.setattr("utils.os.replace", replace)
     monkeypatch.setattr("utils._IS_WINDOWS", True)
 
@@ -429,7 +438,14 @@ def test_contended_retry_switching_to_exdev_uses_copy_fallback(
     monkeypatch.setattr("utils._rewrite_in_place", forbid_rewrite)
 
     assert Path(atomic_replace(tmp, target)) == target
-    assert replace.call_count == 2
+    # The sharing budget is still abandoned at attempt 2: only the first two
+    # renames are tried on the source temp.
+    assert [src for src, _ in calls[:2]] == [str(tmp), str(tmp)]
+    # The fallback then renames a *staged* file onto the target rather than
+    # copying onto it, so there is a third replace and its source is not tmp.
+    assert len(calls) == 3
+    assert calls[2][0] != str(tmp)
+    assert calls[2][1] == str(target)
     assert target.read_text(encoding="utf-8") == "new"
     assert not tmp.exists()
 

--- a/utils.py
+++ b/utils.py
@@ -212,11 +212,10 @@ def _copy_fallback(tmp_str: str, real_path: str) -> None:
     means there is no window in which the name could resolve to a different
     inode.
 
-    The plain copy survives only as the residual case: the target's directory
-    refuses a staging temp, or ``os.replace(staged, target)`` fails (a busy or
-    bind-mounted inode is the motivating case, but a permission/ACL,
-    read-only-filesystem or symlink-loop failure lands there too).  That
-    residual remains non-atomic.
+    The plain copy survives only when the target's directory refuses a staging
+    temp. Once staging succeeds, a failed ``os.replace(staged, target)`` is
+    cleaned up and propagated: falling back to an in-place copy then would
+    truncate the target the staging path was meant to protect.
     """
     try:
         staged_fd, staged = tempfile.mkstemp(
@@ -250,6 +249,7 @@ def _copy_fallback(tmp_str: str, real_path: str) -> None:
             os.replace(staged, real_path)
         except OSError:
             _unlink_quietly(staged)
+            raise
         else:
             os.unlink(tmp_str)
             return

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,14 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def _unlink_quietly(path: str) -> None:
+    """Best-effort removal of a staging temp file."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -101,9 +109,18 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     This helper resolves the symlink first so ``os.replace`` writes to
     the real file in-place while the symlink survives.  For non-symlink
     and non-existent paths the behavior is identical to a plain
-    ``os.replace`` call unless the rename fails with ``EXDEV`` or ``EBUSY``;
-    those cases fall back to copy/fsync/unlink for cross-device, bind-mount,
-    and busy-file deployments.
+    ``os.replace`` call.
+
+    When the rename fails with ``EXDEV`` or ``EBUSY`` the new content is
+    staged into the *resolved target's own directory* and renamed from
+    there, so the second ``os.replace`` is same-filesystem and therefore
+    still atomic.  Copying straight onto the target instead — the previous
+    behavior — opens it ``"wb"`` and truncates it before the first
+    replacement byte lands, so an interrupted copy left the user's config
+    or credentials partial or empty.  Only a target that cannot be renamed
+    onto at all (a busy or bind-mounted inode), or a directory that will
+    not accept a staging temp, degrades to that in-place copy; that
+    residual case remains non-atomic.
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
@@ -117,21 +134,57 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
         if exc.errno not in (errno.EXDEV, errno.EBUSY):
             raise
         logger.debug(
-            "atomic_replace: %s -> %s failed with %s; falling back to copy",
+            "atomic_replace: %s -> %s failed with %s; staging beside the target",
             tmp_str,
             real_path,
             errno.errorcode.get(exc.errno, exc.errno),
         )
-        shutil.copyfile(tmp_str, real_path)
         try:
-            shutil.copystat(tmp_str, real_path)
+            staged_fd, staged = tempfile.mkstemp(
+                dir=os.path.dirname(real_path) or ".",
+                prefix=".tmp_xdev_",
+                suffix=".tmp",
+            )
+            os.close(staged_fd)
         except OSError:
-            pass
-        try:
-            with open(real_path, "rb") as f:
-                os.fsync(f.fileno())
-        except OSError:
-            pass
+            # The target's directory will not take a staging temp; the
+            # in-place copy below is the only remaining option.
+            staged = None
+
+        replaced = False
+        if staged is not None:
+            try:
+                shutil.copyfile(tmp_str, staged)
+                try:
+                    shutil.copystat(tmp_str, staged)
+                except OSError:
+                    pass
+                with open(staged, "rb") as handle:
+                    os.fsync(handle.fileno())
+            except OSError:
+                # The copy failed (ENOSPC, I/O error, ...).  Only the staging
+                # temp is damaged, so surface the failure with the target's
+                # existing contents still intact rather than overwriting it.
+                _unlink_quietly(staged)
+                raise
+            try:
+                os.replace(staged, real_path)
+                replaced = True
+            except OSError:
+                # A busy or bind-mounted inode cannot be renamed onto.
+                _unlink_quietly(staged)
+
+        if not replaced:
+            shutil.copyfile(tmp_str, real_path)
+            try:
+                shutil.copystat(tmp_str, real_path)
+            except OSError:
+                pass
+            try:
+                with open(real_path, "rb") as f:
+                    os.fsync(f.fileno())
+            except OSError:
+                pass
         os.unlink(tmp_str)
     return real_path
 

--- a/utils.py
+++ b/utils.py
@@ -117,10 +117,15 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     still atomic.  Copying straight onto the target instead — the previous
     behavior — opens it ``"wb"`` and truncates it before the first
     replacement byte lands, so an interrupted copy left the user's config
-    or credentials partial or empty.  Only a target that cannot be renamed
-    onto at all (a busy or bind-mounted inode), or a directory that will
-    not accept a staging temp, degrades to that in-place copy; that
-    residual case remains non-atomic.
+    or credentials partial or empty.  The staged content is written through
+    the ``mkstemp`` descriptor itself, so the staging file is never reopened
+    by path between creation and rename.  The in-place copy is reached only
+    when the staged rename cannot be attempted or does not succeed: the
+    target's directory refuses a staging temp, or ``os.replace(staged,
+    target)`` fails with any ``OSError`` — a busy or bind-mounted inode is
+    the motivating case, but a permission/ACL, read-only-filesystem or
+    symlink-loop failure lands there too.  That residual case remains
+    non-atomic.
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
@@ -145,22 +150,28 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
                 prefix=".tmp_xdev_",
                 suffix=".tmp",
             )
-            os.close(staged_fd)
         except OSError:
             # The target's directory will not take a staging temp; the
             # in-place copy below is the only remaining option.
-            staged = None
+            staged_fd, staged = -1, None
 
         replaced = False
         if staged is not None:
             try:
-                shutil.copyfile(tmp_str, staged)
-                try:
-                    shutil.copystat(tmp_str, staged)
-                except OSError:
-                    pass
-                with open(staged, "rb") as handle:
-                    os.fsync(handle.fileno())
+                # Write through the descriptor ``mkstemp`` handed back rather
+                # than reopening the staging file by path: the staging temp
+                # holds the full plaintext of a credential file, and never
+                # reopening it means there is no window in which the name
+                # could resolve to a different inode.
+                with os.fdopen(staged_fd, "wb") as staged_handle:
+                    with open(tmp_str, "rb") as source:
+                        shutil.copyfileobj(source, staged_handle)
+                    staged_handle.flush()
+                    try:
+                        shutil.copystat(tmp_str, staged)
+                    except OSError:
+                        pass
+                    os.fsync(staged_handle.fileno())
             except OSError:
                 # The copy failed (ENOSPC, I/O error, ...).  Only the staging
                 # temp is damaged, so surface the failure with the target's
@@ -171,7 +182,8 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
                 os.replace(staged, real_path)
                 replaced = True
             except OSError:
-                # A busy or bind-mounted inode cannot be renamed onto.
+                # The staged file cannot be renamed onto the target — a busy
+                # or bind-mounted inode, or a permission/ACL restriction.
                 _unlink_quietly(staged)
 
         if not replaced:

--- a/utils.py
+++ b/utils.py
@@ -176,8 +176,84 @@ def _rewrite_in_place(tmp_str: str, real_path: str) -> None:
     os.unlink(tmp_str)
 
 
+def _unlink_quietly(path: str) -> None:
+    """Best-effort removal of a staging temp file."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
 def _copy_fallback(tmp_str: str, real_path: str) -> None:
-    """Copy/fsync/unlink fallback for cross-device and bind-mount renames."""
+    """Cross-device / bind-mount fallback: stage beside the target, then rename.
+
+    The new content is staged into the *resolved target's own directory* and
+    renamed from there, so the replace that actually lands on the target is
+    same-filesystem and therefore still atomic.
+
+    Copying straight onto the target — what this did before — opens it ``"wb"``
+    and truncates it before the first replacement byte exists.  That is exactly
+    the window ``_rewrite_in_place`` above was written to close, and it says so
+    in its own docstring: *"Unlike ``shutil.copyfile`` this never truncates the
+    target to zero first — a concurrent reader would otherwise be able to
+    observe an empty ``auth.json`` / ``gateway_state.json`` mid-write."*  The
+    same argument applies here, and with a wider blast radius: a crash, ENOSPC
+    or SIGKILL partway through the copy does not merely expose a transient
+    empty read, it leaves the file empty or partial **on disk**.
+
+    ``EXDEV`` is not an exotic path — it is every ``/tmp``-on-tmpfs, container
+    bind-mount and NAS deployment — and every caller of this module routes
+    ``config.yaml`` / ``auth.json`` / ``gateway_state.json`` through it via
+    ``atomic_write_text`` / ``atomic_json_write`` / ``atomic_yaml_write``.
+
+    The staged content is written through the ``mkstemp`` descriptor itself, so
+    the staging file is never reopened by path between creation and rename —
+    it holds the full plaintext of a credential file, and not reopening it
+    means there is no window in which the name could resolve to a different
+    inode.
+
+    The plain copy survives only as the residual case: the target's directory
+    refuses a staging temp, or ``os.replace(staged, target)`` fails (a busy or
+    bind-mounted inode is the motivating case, but a permission/ACL,
+    read-only-filesystem or symlink-loop failure lands there too).  That
+    residual remains non-atomic.
+    """
+    try:
+        staged_fd, staged = tempfile.mkstemp(
+            dir=os.path.dirname(real_path) or ".",
+            prefix=".tmp_xdev_",
+            suffix=".tmp",
+        )
+    except OSError:
+        # The target's directory will not take a staging temp; the plain copy
+        # below is the only remaining option.
+        staged = None
+
+    if staged is not None:
+        try:
+            with os.fdopen(staged_fd, "wb") as staged_handle:
+                with open(tmp_str, "rb") as source:
+                    shutil.copyfileobj(source, staged_handle)
+                staged_handle.flush()
+                try:
+                    shutil.copystat(tmp_str, staged)
+                except OSError:
+                    pass
+                os.fsync(staged_handle.fileno())
+        except OSError:
+            # The copy failed (ENOSPC, I/O error, ...).  Only the staging temp
+            # is damaged, so surface the failure with the target's existing
+            # contents still intact rather than having overwritten them.
+            _unlink_quietly(staged)
+            raise
+        try:
+            os.replace(staged, real_path)
+        except OSError:
+            _unlink_quietly(staged)
+        else:
+            os.unlink(tmp_str)
+            return
+
     shutil.copyfile(tmp_str, real_path)
     try:
         shutil.copystat(tmp_str, real_path)
@@ -207,8 +283,9 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     ``os.replace`` call unless the rename fails with:
 
     * ``EXDEV`` / ``EBUSY`` (any platform) — cross-device, bind-mount, and
-      busy-file deployments fall back to copy/fsync/unlink immediately.
-      These never clear on retry.
+      busy-file deployments stage the content beside the resolved target and
+      rename from there immediately, so the write stays atomic.  These never
+      clear on retry.
     * A Windows rename contended by another open handle (winerror 5/32/33).
       CPython opens files without ``FILE_SHARE_DELETE``, so *any* concurrent
       reader of the target blocks the rename.  The rename is retried with


### PR DESCRIPTION
## This is a sibling follow-up to #81296

- #81296 routes the Honcho profile-rename credential write through `atomic_json_write` (0600, fsync, symlink-preserving).
- #81296 does **not** touch `utils.atomic_replace`, so a cross-device or busy-mount rename still degrades to a truncating in-place copy.
- This PR closes that residual gap at the source, for every `atomic_replace` caller.

## What does this PR do?

> **Rebased and re-derived onto current `main` (2026-08-13).** `#84852`
> (`dcbe1754230`) has since split `atomic_replace` into `_rewrite_in_place` and
> `_copy_fallback`, so this branch has been rewritten against that shape rather than
> merge-resolved. The premise survived the refactor unchanged — see below.

`utils.atomic_replace` resolves a symlinked target to its real path, then — when
`os.replace` fails with `EXDEV` or `EBUSY` — calls `_copy_fallback`, which is:

```python
shutil.copyfile(tmp_str, real_path)
```

`shutil.copyfile` opens its destination `"wb"`, so **the user's file is truncated
before the first replacement byte exists.** A crash, `ENOSPC`, or `SIGKILL` during
that copy leaves `config.yaml` / `auth.json` / `jobs.json` partial or empty —
precisely the outcome the helper exists to prevent.

**`main` already states this invariant in its own voice, one function above.**
`#84852` added `_rewrite_in_place` specifically to close this window on the
Windows-contended branch, and its merged docstring says:

> Unlike `shutil.copyfile` this never truncates the target to zero first — a
> concurrent reader would otherwise be able to observe an empty `auth.json` /
> `gateway_state.json` mid-write (measured: a 4-thread poller sees a 0-byte read
> during a plain copyfile).

That reasoning was applied to the contended branch and the `EXDEV`/`EBUSY` branch was
left on the truncating copy. This PR finishes it — and here the consequence is
strictly worse: on the contended path the truncation is a transient window a reader
might observe, while on this path an interrupted copy leaves the file empty or partial
**on disk**.

The `atomic_replace` docstring compounds it, saying `EXDEV`/`EBUSY`
"fall back to copy/fsync/unlink" without disclosing that the copy destroys the target
first. This PR makes the code match both claims.

**This is not an exotic path.** The four `utils.py` writers create their temp with
`tempfile.mkstemp(dir=str(path.parent))` — the **symlink's** directory — while
`atomic_replace` replaces onto the **resolved** path. So a `~/.hermes/config.yaml`
symlinked into a dotfiles repo, a Docker bind mount, or a NAS/`/mnt` home is a
cross-device rename → `EXDEV` → truncating copy on *every single write*.

**The repo already contains the correct pattern.** The inlined mirror in
`optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` creates
its temp with `dir=os.path.dirname(target) or "."` — beside the *resolved* target —
and its docstring says the handling "mirrors `utils.atomic_replace`". `utils.py` is
the copy that got it wrong. That script keeps a truncating `shutil.copyfile` for its
own residual case; I've deliberately left it out of this diff to keep the change
cherry-pickable and single-concern, and I'm happy to fix the mirror in a follow-up
if you'd like it.

Introduced by `bf8effad023` — *"fix(utils): copy fallback for atomic replace across
devices (#43852)"*. `git log -S 'shutil.copyfile' -- utils.py` returns that one
commit; still unfixed on main.

### Relationship to #84852 (merged) — the conflict is resolved, not deferred

This previously read as "expect a textual conflict with #79793, trivially resolvable
in either order". That work has since landed as **#84852** (`dcbe1754230`), and this
branch is now rebased on top of it rather than proposing to conflict with it:

- #84852 fixed rename *failure* on Windows (bounded retry, then `_rewrite_in_place`).
- This fixes *truncation* on the cross-device / bind-mount branch, which #84852 left
  on `shutil.copyfile`.
- The two now sit side by side as the two arms of the same `if contended:` —
  `_rewrite_in_place` for a held handle, `_copy_fallback` for `EXDEV`/`EBUSY` — and
  after this change neither arm truncates.

One existing test from #84852 needed a real adjustment rather than a re-run:
`test_contended_retry_switching_to_exdev_uses_copy_fallback` asserted
`replace.call_count == 2`, which counts the fallback's *implementation* (how many
renames it performs) rather than its contract. Since the fallback now performs a
staged rename, it drives that third call for real and asserts the stronger property
instead: the sharing budget is still abandoned at attempt 2, and the final rename's
source is the staged file rather than the caller's temp. No assertion was dropped.

## Related Issue

No filed issue. This is a regression in merged PR #43852 (`bf8effad023`), found by
reading the helper against its own docstring.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Two atomic commits: the production change (with the one existing test it genuinely
invalidates), then the new regressions.

- `utils.py` — `_copy_fallback`: stage the new content into the **resolved target's
  own directory** via `mkstemp`, `copystat`, `fsync`, then `os.replace` from there.
  That second rename is same-filesystem and therefore genuinely atomic. The
  destination is never opened for writing. The staged bytes go through the `mkstemp`
  descriptor itself, so the staging file — which holds the full plaintext of a
  credential file — is never reopened by path between creation and rename.
- `utils.py` — a failed staged copy (`ENOSPC`, I/O error) now unlinks only the
  staging temp and re-raises **with the target's contents intact**. Previously the
  same failure had already destroyed the target.
- `utils.py` — the in-place copy is retained as the last resort for exactly two
  cases: an inode that cannot be renamed onto at all (busy / bind-mounted), and a
  target directory that will not accept a staging temp.
- `utils.py` — added `_unlink_quietly`, a 5-line private helper for staging-temp
  cleanup, following the file's existing `_preserve_*` / `_restore_*` convention.
- `utils.py` — docstring updated: the `EXDEV` path is now atomic; only the busy-inode
  case degrades. It no longer implies blanket atomicity.
- `tests/test_atomic_replace_symlinks.py` — 4 cases appended in their own section, plus
  the one existing test noted above whose call-count assertion the change invalidates.

### Sibling-site coverage

`git grep 'shutil.copyfile' -- '*.py'` over main returns 11 hits. Nine are unrelated
(`copyfileobj` streaming, screenshot/TTS/session file copies). The two that implement
atomic-replace semantics are `utils.py::_copy_fallback` (fixed here) and the openclaw migration
mirror described above (deliberately deferred, see rationale). No other call site
shares this root cause, and **no caller changes are needed** — all ~25
`atomic_replace` callers inherit the fix.

## How to Test

Regression direction was verified explicitly in both directions.

**1. Red before the prod change** (new tests against unpatched `utils.py`):

```
$ pytest tests/test_atomic_replace_symlinks.py -q
FAILED ...::test_atomic_replace_cross_device_never_truncates_target
FAILED ...::test_atomic_replace_cross_device_uses_rename_not_inplace_copy
FAILED ...::test_contended_retry_switching_to_exdev_uses_copy_fallback
3 failed, 21 passed, 5 skipped
```

The first failure shows the target's contents actually destroyed by a copy that
failed partway — not merely a mismatched assertion. The `config.yaml` that held
`provider: openrouter` / `api_key: keep-me` is left as the 8 bytes `provider`:

```
AssertionError: a failed cross-device write destroyed the target's contents
assert 'provider' == 'provider: op...ey: keep-me\n'
  + provider
  - provider: openrouter
  - api_key: keep-me
```

The destruction there is done by the OS through a real handle: the stub reproduces
`shutil.copyfile`'s first two operations verbatim — `open(dst, "wb")`, then stream —
before failing the way a filling disk does. It is not a mock asserting against itself.

The second fails `assert 1 >= 2` — only one `os.replace` occurred, i.e. the write
completed by in-place copy rather than by rename. That one uses no copy stub at all.
The third is the #84852 test discussed above, failing `assert 2 == 3` on the same
missing staged rename.

**2. Green after:**

```
$ pytest tests/test_atomic_replace_symlinks.py -q
24 passed, 5 skipped
```

**3. Real cross-device, not just a monkeypatched `EXDEV`.** `test_atomic_replace_real_cross_device`
skips on macOS (no `/dev/shm`), so I mounted a scratch HFS+ image and ran its
equivalent against both revisions. Same assertions pass on both — the observable
contract is unchanged — but the mechanism differs:

| revision | target inode after replace | completed by |
| --- | --- | --- |
| `origin/main` | unchanged | in-place truncating copy |
| this PR | changed | atomic rename |

**4. Adjacent caller suites** (`utils.py` is shared, so these exercise the helper):

```
$ pytest tests/test_atomic_replace_symlinks.py tests/test_atomic_write_text_metadata.py \
    tests/test_stale_utils_module_import.py tests/test_utils_truthy_values.py \
    tests/test_utils_atomic_roundtrip_yaml_save.py \
    tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py \
    tests/hermes_cli/test_update_zip_atomic_replace.py tests/gateway/test_pairing.py
89 passed, 5 skipped

$ pytest tests/cron/ -q
524 passed, 1 skipped
```

### Test notes (stated plainly)

- `test_atomic_replace_cross_device_never_truncates_target` and
  `test_atomic_replace_cross_device_uses_rename_not_inplace_copy` are the **regression
  tests** — red before, green after.
- `test_atomic_replace_busy_target_falls_back_to_plain_copy` and
  `test_atomic_replace_cross_device_survives_unstageable_target_dir` are
  **behaviour-preservation guards**: green both before and after. They pin the two
  retained last-resort paths and catch a staging temp leaking on failure. I'm calling
  that out rather than implying all four are regression tests. (The first was named
  `..._falls_back_to_inplace_copy` on the pre-rebase branch; renamed because `main`
  now has an actual `_rewrite_in_place` and "in-place" would point at the wrong arm.)
- The two that create symlinks without a POSIX guard carry
  `@pytest.mark.require_symlinks`, per this file's existing convention.
- `test_atomic_replace_copy_fallback_preserves_symlink` and
  `test_atomic_replace_real_cross_device` were deliberately left unmodified and both
  stay green — the former patches `os.replace` to raise `EXDEV` on *every* call, so
  the staged rename also fails and the plain-copy fallback runs, same observable
  result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent caller suites listed above, not the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `atomic_replace` docstring now describes the staged replace and names the residual non-atomic case
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib-only (`tempfile.mkstemp`, `os.replace`), no POSIX-only calls added; the new tests that assert inode identity or permission bits are POSIX-gated
- [x] N/A — no tool descriptions or schemas changed

## Behaviour changes worth flagging (honest diffs, not defects)

1. **The target inode is now replaced rather than overwritten in place on the `EXDEV`
   path.** A hardlink sharing that inode is no longer updated through the link. This
   makes the fallback consistent with the primary `os.replace` path, which already
   breaks hardlinks. Deliberate consistency change, not an oversight.
2. **The staged temp needs write permission in the resolved target's directory.** If
   that directory is unwritable, the code falls back to the previous in-place copy
   rather than failing — and a write to a target in an unwritable directory already
   fails today.
3. **`EBUSY` on a bind-mounted inode remains inherently non-atomic.** This PR narrows
   the unsafe window to that one case instead of eliminating it, and the docstring now
   says so explicitly rather than implying blanket atomicity.
4. **A failed copy now raises with the target intact instead of raising with the target
   destroyed.** The exception type and the caller's temp-file cleanup contract are
   unchanged — pre-fix, `os.unlink(tmp_str)` was likewise skipped when the copy raised.

