### PR TITLE
fix(process): reconcile background exits during listing

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -354,6 +354,31 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
 # Orphaned-pipe reconciliation (issue #17327)
 # =========================================================================
 
+def test_list_sessions_reconciles_exit_and_enqueues_completion(registry):
+    """Desktop process.list must observe exit and wake async delivery."""
+    proc = MagicMock()
+    proc.poll.return_value = 0
+    proc.stdout = None
+
+    session = _make_session(sid="proc_list_orphan")
+    session.process = proc
+    session.session_key = "desktop-session"
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    listed = registry.list_sessions(session_key=session.session_key)
+
+    assert len(listed) == 1
+    assert listed[0]["session_id"] == session.id
+    assert listed[0]["status"] == "exited"
+    assert listed[0]["exit_code"] == 0
+
+    event = registry.completion_queue.get_nowait()
+    assert event["type"] == "completion"
+    assert event["session_id"] == session.id
+    assert event["session_key"] == session.session_key
+    assert event["exit_code"] == 0
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: uses setsid/fcntl")
 class TestOrphanedPipeReconciliation:
     """Regression tests for issue #17327.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2222,6 +2222,12 @@ class ProcessRegistry:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
+        # Desktop refreshes its status stack through process.list rather than
+        # process.poll. Reconcile direct Popen exits here too: a descendant can
+        # keep stdout open after the child exits, leaving the reader thread
+        # blocked and both the UI row and autonomous completion turn pending.
+        for session in all_sessions:
+            self._reconcile_local_exit(session)
 
         if task_id or session_key:
             all_sessions = [


### PR DESCRIPTION
## Summary

- reconcile direct local process exits when `process.list` refreshes background sessions
- move completed sessions through the existing completion path so autonomous result delivery is queued
- add a regression test covering the Desktop list-based refresh path

## User-visible impact

Desktop status rows no longer remain stuck in a running state when a direct child has exited but a descendant still holds its stdout pipe open. Completion notifications and asynchronous results can be delivered without requiring the user to send another message.

## Testing

- `scripts/run_tests.sh tests/tools/test_process_registry.py -k "list_sessions_reconciles_exit_and_enqueues_completion or list_sessions"`
- `git diff --check main...HEAD`

Closes #81114