### PR TITLE
feat(serve): configurable PTY keep-alive TTL

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1602,6 +1602,18 @@ updates:
 # =============================================================================
 # Web Dashboard
 # =============================================================================
+# `hermes serve` is the headless backend the desktop app and remote clients
+# connect to — the same gateway as `hermes dashboard`, always headless.
+# Settings under `serve:` apply to the serve/dashboard web server.
+#
+# serve:
+#   # Keep-alive TTL (minutes) for detached desktop chat PTYs. The desktop
+#   # chat runs in a keep-alive PTY child of `hermes serve`; after the
+#   # browser detaches, the reaper kills the child once it has been
+#   # detached for this long. Default 30 (the historical hardcoded
+#   # 30-minute TTL). Set to 0 to fall back to the default.
+#   pty_ttl_minutes: 30
+#
 # OAuth gate configuration for `hermes dashboard --host <non-loopback>`.
 # The bundled Nous Portal plugin reads these on startup; settings here are
 # the canonical surface. Each can be overridden by an environment variable:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1762,6 +1762,18 @@ DEFAULT_CONFIG = {
         "max_turns": 20,
     },
 
+    # `hermes serve` — the headless backend the desktop app and remote
+    # clients connect to (same gateway as `hermes dashboard`, always
+    # headless). Settings here apply to the serve/dashboard web server.
+    "serve": {
+        # Keep-alive TTL (minutes) for detached desktop chat PTYs. The
+        # desktop chat runs in a keep-alive PTY child of `hermes serve`;
+        # after the browser detaches, the reaper kills the child once it
+        # has been detached for this long. Default 30 (the historical
+        # hardcoded 30-minute TTL). Set to 0 to fall back to the default.
+        "pty_ttl_minutes": 30,
+    },
+
     # Mixture of Agents — named presets used by /moa. A preset is an execution
     # mode around the main model, not a provider/model itself: references +
     # aggregator synthesize private guidance before each main-model iteration.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1025,6 +1025,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "approvals": "security",
     "human_delay": "display",
     "dashboard": "display",
+    # `serve.pty_ttl_minutes` is the only schema-surfaced serve field —
+    # fold it into the display tab (alongside dashboard) rather than
+    # spawning a one-field orphan category.
+    "serve": "display",
     "code_execution": "agent",
     "prompt_caching": "agent",
     "goals": "agent",
@@ -14514,8 +14518,39 @@ _PTY_READ_CHUNK_TIMEOUT = 0.2
 # bound to a process that survives disconnect/refresh and is reattachable.
 from hermes_cli.pty_session import PtySessionRegistry, RegistryFull, run_reaper  # noqa: E402
 
+# Default keep-alive TTL for detached desktop chat PTYs (seconds). The
+# desktop chat runs in a keep-alive PTY child of `hermes serve`; after the
+# browser detaches, the reaper kills the child once it has been detached
+# for this long. Configurable via `serve.pty_ttl_minutes` (see
+# _pty_keepalive_ttl_seconds).
+_DEFAULT_PTY_KEEPALIVE_TTL_SECONDS = 30 * 60
+
+
+def _pty_keepalive_ttl_seconds() -> float:
+    """Resolve the desktop PTY keep-alive TTL from config.
+
+    Reads ``serve.pty_ttl_minutes`` (default 30, matching the historical
+    hardcoded 30-minute TTL). Values <= 0 fall back to the default; a
+    non-numeric value is ignored. The registry is built at import time, so
+    this is resolved once per process — a config change takes effect on
+    the next ``hermes serve`` / dashboard start.
+    """
+    try:
+        cfg = load_config() or {}
+        serve_cfg = cfg.get("serve") or {}
+        raw = serve_cfg.get("pty_ttl_minutes")
+        if raw is None:
+            return float(_DEFAULT_PTY_KEEPALIVE_TTL_SECONDS)
+        minutes = float(raw)
+        if minutes <= 0:
+            return float(_DEFAULT_PTY_KEEPALIVE_TTL_SECONDS)
+        return minutes * 60.0
+    except Exception:
+        return float(_DEFAULT_PTY_KEEPALIVE_TTL_SECONDS)
+
+
 PTY_REGISTRY = PtySessionRegistry(
-    ttl=30 * 60,
+    ttl=_pty_keepalive_ttl_seconds(),
     max_sessions=16,
     buffer_cap=1 * 1024 * 1024,
     read_timeout=_PTY_READ_CHUNK_TIMEOUT,

--- a/tests/hermes_cli/test_web_server_pty_ttl.py
+++ b/tests/hermes_cli/test_web_server_pty_ttl.py
@@ -1,0 +1,60 @@
+"""Tests for the configurable desktop PTY keep-alive TTL.
+
+The desktop chat runs in a keep-alive PTY child of `hermes serve`; the
+reaper kills the child after it has been detached for the registry TTL.
+The TTL was hardcoded at 30 minutes; it is now configurable via
+``serve.pty_ttl_minutes`` (default 30, preserving the historical
+behavior).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestPtyKeepaliveTtl:
+
+    def test_default_ttl_is_30_minutes(self):
+        """No config → the historical 30-minute TTL."""
+        from hermes_cli import web_server
+
+        with patch("hermes_cli.web_server.load_config", return_value={}):
+            assert web_server._pty_keepalive_ttl_seconds() == 30 * 60
+
+    def test_custom_ttl_minutes(self):
+        from hermes_cli import web_server
+
+        cfg = {"serve": {"pty_ttl_minutes": 5}}
+        with patch("hermes_cli.web_server.load_config", return_value=cfg):
+            assert web_server._pty_keepalive_ttl_seconds() == 5 * 60
+
+    def test_zero_or_negative_falls_back_to_default(self):
+        from hermes_cli import web_server
+
+        for bad in (0, -10):
+            cfg = {"serve": {"pty_ttl_minutes": bad}}
+            with patch("hermes_cli.web_server.load_config", return_value=cfg):
+                assert web_server._pty_keepalive_ttl_seconds() == 30 * 60
+
+    def test_non_numeric_falls_back_to_default(self):
+        from hermes_cli import web_server
+
+        cfg = {"serve": {"pty_ttl_minutes": "soon"}}
+        with patch("hermes_cli.web_server.load_config", return_value=cfg):
+            assert web_server._pty_keepalive_ttl_seconds() == 30 * 60
+
+    def test_config_error_falls_back_to_default(self):
+        from hermes_cli import web_server
+
+        with patch(
+            "hermes_cli.web_server.load_config", side_effect=RuntimeError("boom")
+        ):
+            assert web_server._pty_keepalive_ttl_seconds() == 30 * 60
+
+    def test_registry_uses_resolved_ttl(self):
+        """The PTY_REGISTRY is built with the resolved TTL (default)."""
+        from hermes_cli import web_server
+
+        assert web_server.PTY_REGISTRY._ttl == 30 * 60


### PR DESCRIPTION
## What does this PR do?

The desktop chat runs in a keep-alive PTY child of `hermes serve`; the reaper kills the child once it has been detached for the registry TTL, which was hardcoded at `ttl=30 * 60` in `hermes_cli/web_server.py` (`PTY_REGISTRY = PtySessionRegistry(...)`).

This PR exposes that TTL as a configuration value — `serve.pty_ttl_minutes` — with the current 30-minute default preserved, and documents the new key in `cli-config.yaml.example`.

Why this approach: the registry is built at module import time, so the value is resolved once per process via a small `_pty_keepalive_ttl_seconds()` helper that reads `load_config()` and falls back to the historical default on any error, non-numeric value, or value <= 0. No behavior change for existing installs.

## Related Issue

No issue — small, focused configuration change in the same problem family as #81109 (desktop PTY keep-alive lifecycle).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/web_server.py` — `_DEFAULT_PTY_KEEPALIVE_TTL_SECONDS = 30 * 60`; new `_pty_keepalive_ttl_seconds()` resolving `serve.pty_ttl_minutes` (default 30, fallback on invalid values); `PTY_REGISTRY` now built with the resolved TTL. The `serve` config category folds into the `display` tab in the dashboard schema (`_CATEGORY_MERGE`) so it does not spawn a one-field orphan category.
- `hermes_cli/config_defaults.py` — new `serve.pty_ttl_minutes: 30` default with documentation.
- `cli-config.yaml.example` — documented `serve.pty_ttl_minutes` under the Web Dashboard section.
- Tests: `tests/hermes_cli/test_web_server_pty_ttl.py` (default, custom, invalid-value fallback, config-error fallback, registry wiring).

## How to Test

1. `pytest tests/hermes_cli/test_web_server_pty_ttl.py -q` — all pass.
2. Set `serve.pty_ttl_minutes: 5` in `~/.hermes/config.yaml`, restart `hermes serve`, detach a desktop chat: the PTY child is reaped after ~5 minutes instead of 30.
3. Omit the key (or set 0 / a non-numeric value): the historical 30-minute TTL applies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior verified by unit tests (default preserved, custom value honored, invalid values fall back).
