### PR TITLE
fix(discord): preserve native semantic thread rename

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20282,13 +20282,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_name,
         )
         try:
-            renamed = await rename_thread(
-                target_thread_id,
-                thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
-            )
+            if use_connector_guard:
+                # RelayAdapter owns these connector-specific guard/routing
+                # arguments.  Do not leak them into native platform adapters:
+                # DiscordAdapter.rename_thread intentionally accepts only the
+                # current-name guard, and a shared superset call raises before
+                # the Discord API is ever reached.
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    prefer_connector_created=True,
+                    parent_chat_id=parent_chat_id,
+                )
+            else:
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    only_if_current_name=guard_name,
+                )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,

--- a/tests/gateway/relay/test_relay_threads.py
+++ b/tests/gateway/relay/test_relay_threads.py
@@ -28,6 +28,7 @@ from gateway.relay.adapter import RelayAdapter
 from gateway.relay.command_manifest import build_relay_command_manifest
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
 from gateway.relay.ws_transport import _event_from_wire
+from gateway.session import SessionSource
 
 from tests.gateway.relay.stub_connector import StubConnector
 
@@ -318,6 +319,44 @@ def _relay_channel_source():
         auto_thread_created=False,
         auto_thread_initial_name=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_native_title_rename_does_not_receive_relay_only_kwargs():
+    """The shared semantic-title lane must respect the native adapter API.
+
+    Regression: relay guard/routing kwargs were passed unconditionally.  The
+    native Discord adapter rejected them with TypeError, which the best-effort
+    rename lane swallowed, leaving every native thread at its raw placeholder.
+    """
+    class NativeAdapter:
+        def __init__(self):
+            self.renames = []
+
+        async def rename_thread(
+            self, thread_id, name, *, only_if_current_name=None
+        ):
+            self.renames.append((thread_id, name, only_if_current_name))
+            return True
+
+    adapter = NativeAdapter()
+    runner = _mk_runner_stub()(adapter)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="th-native",
+        chat_type="thread",
+        thread_id="th-native",
+        auto_thread_created=True,
+        auto_thread_initial_name="raw user prompt",
+    )
+
+    await runner._rename_discord_auto_thread_for_session_title(
+        source, "sess-native", "Semantic Native Title"
+    )
+
+    assert adapter.renames == [
+        ("th-native", "Semantic Native Title", "raw user prompt")
+    ]
 
 
 def test_relay_channel_lane_shape_gate():


### PR DESCRIPTION
## Summary

- keep connector-specific Discord thread rename arguments on the relay path
- call the native Discord adapter with only its supported current-name guard
- add an exact-signature regression proving native semantic renames do not receive relay-only kwargs

## Why

Discord semantic auto-thread title generation succeeds and schedules the rename, but the shared call currently passes `prefer_connector_created` and `parent_chat_id` into native `DiscordAdapter.rename_thread(...)`. The native adapter intentionally does not accept those relay-only arguments, so it raises `TypeError` before Discord is touched. The surrounding best-effort exception handler suppresses the failure, leaving the raw placeholder title in place.

This is a regression follow-up to #56792: relay and native adapters need separate calls at the adapter boundary.

Related refactor #77733 currently moves this method into `GatewayThreadsMixin` while retaining the same shared-superset call; whichever change lands second may need a trivial relocation/conflict resolution.

## Test plan

```bash
python -m pytest -q -o addopts='' \
  tests/gateway/relay/test_relay_threads.py \
  tests/gateway/test_fast_command.py \
  tests/gateway/test_discord_slash_commands.py \
  tests/agent/test_title_generator.py
```

Result: `47 passed`.
