### PR TITLE
fix(installer): recover Windows setup when node-deps host exits abruptly

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -26,6 +26,8 @@ use crate::install_script::{self, Pin, ScriptKind, ScriptSource};
 use crate::powershell::{self, StreamSink};
 use crate::AppState;
 
+const MAX_STAGE_ATTEMPTS: usize = 3;
+
 // ---------------------------------------------------------------------------
 // Public Tauri commands
 // ---------------------------------------------------------------------------
@@ -621,19 +623,54 @@ async fn run_bootstrap(
             stage_args.push("-IncludeDesktop".to_string());
         }
 
-        // Each stage gets its own cancel receiver because tokio::select!
-        // in run_script consumes it. Take/return through the Arc<Mutex>.
-        let local_cancel_rx = cancel_rx_holder.lock().await.take();
+        // A Windows PowerShell host can occasionally terminate with raw status
+        // 0xffffffff while a long-running native child (npm / Playwright) is
+        // still active. That bypasses install.ps1's finally block, so there is
+        // no JSON frame to distinguish success from failure. Stage workers are
+        // required to be idempotent; retry only this exact abrupt-host shape,
+        // and keep it bounded so ordinary script failures remain immediate.
+        let mut attempt = 1;
+        let mut local_cancel_rx = cancel_rx_holder.lock().await.take();
+        let (stage_result, result_frame) = loop {
+            let result = run_install_script(
+                &app,
+                &script.path,
+                &stage_args,
+                args.hermes_home.as_deref(),
+                local_cancel_rx.take(),
+                Some(stage.name.clone()),
+            )
+            .await?;
+            let frame = powershell::parse_stage_result(&result.stdout);
 
-        let stage_result = run_install_script(
-            &app,
-            &script.path,
-            &stage_args,
-            args.hermes_home.as_deref(),
-            local_cancel_rx,
-            Some(stage.name.clone()),
-        )
-        .await?;
+            if should_retry_missing_stage_frame(result.exit_code, result.killed, attempt)
+                && frame.is_none()
+            {
+                attempt += 1;
+                let line = format!(
+                    "[bootstrap] {} stage host exited unexpectedly before its JSON result; retrying ({attempt}/{MAX_STAGE_ATTEMPTS})",
+                    stage.name
+                );
+                tracing::warn!(
+                    stage = %stage.name,
+                    exit = ?result.exit_code,
+                    attempt,
+                    "stage host exited without a result frame; retrying"
+                );
+                emit_event(
+                    &app,
+                    BootstrapEvent::Log {
+                        stage: Some(stage.name.clone()),
+                        line,
+                        stream: LogStream::Stderr,
+                    },
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                continue;
+            }
+
+            break (result, frame);
+        };
 
         let duration_ms = started.elapsed().as_millis() as u64;
 
@@ -657,8 +694,6 @@ async fn run_bootstrap(
             );
             return Err(anyhow!("cancelled by user"));
         }
-
-        let result_frame = powershell::parse_stage_result(&stage_result.stdout);
 
         match result_frame {
             None => {
@@ -783,6 +818,14 @@ async fn run_bootstrap(
     );
 
     Ok(install_root.to_string_lossy().into_owned())
+}
+
+fn should_retry_missing_stage_frame(
+    exit_code: Option<i32>,
+    killed: bool,
+    attempt: usize,
+) -> bool {
+    !killed && exit_code == Some(-1) && attempt < MAX_STAGE_ATTEMPTS
 }
 
 async fn cancellation_signalled(holder: &Arc<Mutex<Option<mpsc::Receiver<()>>>>) -> bool {
@@ -1116,5 +1159,23 @@ mod tests {
             "failed write must not leave a temp marker sibling either"
         );
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn abrupt_windows_stage_exit_is_retried_but_never_forever() {
+        assert!(should_retry_missing_stage_frame(Some(-1), false, 1));
+        assert!(should_retry_missing_stage_frame(Some(-1), false, 2));
+        assert!(
+            !should_retry_missing_stage_frame(Some(-1), false, MAX_STAGE_ATTEMPTS),
+            "the retry policy must stay bounded"
+        );
+    }
+
+    #[test]
+    fn ordinary_failure_or_cancellation_is_not_retried_without_a_frame() {
+        assert!(!should_retry_missing_stage_frame(Some(1), false, 1));
+        assert!(!should_retry_missing_stage_frame(Some(0), false, 1));
+        assert!(!should_retry_missing_stage_frame(None, false, 1));
+        assert!(!should_retry_missing_stage_frame(Some(-1), true, 1));
     }
 }

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -520,12 +520,13 @@ async fn run_bootstrap(
         manifest_args_full.push("-IncludeDesktop".to_string());
     }
 
+    let mut manifest_cancel_rx = None;
     let manifest_result = run_install_script(
         &app,
         &script.path,
         &manifest_args_full,
         args.hermes_home.as_deref(),
-        None,
+        &mut manifest_cancel_rx,
         Some("__manifest__".to_string()),
     )
     .await?;
@@ -632,12 +633,12 @@ async fn run_bootstrap(
         let mut attempt = 1;
         let mut local_cancel_rx = cancel_rx_holder.lock().await.take();
         let (stage_result, result_frame) = loop {
-            let result = run_install_script(
+            let mut result = run_install_script(
                 &app,
                 &script.path,
                 &stage_args,
                 args.hermes_home.as_deref(),
-                local_cancel_rx.take(),
+                &mut local_cancel_rx,
                 Some(stage.name.clone()),
             )
             .await?;
@@ -646,6 +647,10 @@ async fn run_bootstrap(
             if should_retry_missing_stage_frame(result.exit_code, result.killed, attempt)
                 && frame.is_none()
             {
+                if retry_backoff_cancelled(local_cancel_rx.as_mut()).await {
+                    result.killed = true;
+                    break (result, frame);
+                }
                 attempt += 1;
                 let line = format!(
                     "[bootstrap] {} stage host exited unexpectedly before its JSON result; retrying ({attempt}/{MAX_STAGE_ATTEMPTS})",
@@ -665,12 +670,12 @@ async fn run_bootstrap(
                         stream: LogStream::Stderr,
                     },
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
 
             break (result, frame);
         };
+        *cancel_rx_holder.lock().await = local_cancel_rx;
 
         let duration_ms = started.elapsed().as_millis() as u64;
 
@@ -828,6 +833,23 @@ fn should_retry_missing_stage_frame(
     !killed && exit_code == Some(-1) && attempt < MAX_STAGE_ATTEMPTS
 }
 
+async fn retry_backoff_cancelled(cancel_rx: Option<&mut mpsc::Receiver<()>>) -> bool {
+    let backoff = tokio::time::sleep(std::time::Duration::from_millis(500));
+    tokio::pin!(backoff);
+
+    match cancel_rx {
+        Some(rx) => tokio::select! {
+            biased;
+            signal = rx.recv() => signal.is_some(),
+            _ = &mut backoff => false,
+        },
+        None => {
+            backoff.await;
+            false
+        }
+    }
+}
+
 async fn cancellation_signalled(holder: &Arc<Mutex<Option<mpsc::Receiver<()>>>>) -> bool {
     let mut guard = holder.lock().await;
     if let Some(rx) = guard.as_mut() {
@@ -842,7 +864,7 @@ async fn run_install_script(
     script_path: &std::path::Path,
     args: &[String],
     hermes_home_override: Option<&str>,
-    cancel_rx: Option<mpsc::Receiver<()>>,
+    cancel_rx: &mut Option<mpsc::Receiver<()>>,
     stage_name: Option<String>,
 ) -> Result<powershell::ScriptResult> {
     let app_for_stdout = app.clone();
@@ -1177,5 +1199,13 @@ mod tests {
         assert!(!should_retry_missing_stage_frame(Some(0), false, 1));
         assert!(!should_retry_missing_stage_frame(None, false, 1));
         assert!(!should_retry_missing_stage_frame(Some(-1), true, 1));
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_retry_backoff_stops_the_retry() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(()).await.unwrap();
+
+        assert!(retry_backoff_cancelled(Some(&mut rx)).await);
     }
 }

--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -138,7 +138,7 @@ pub async fn run_script(
     args: &[String],
     sink: StreamSink,
     hermes_home_override: Option<&str>,
-    mut cancel_rx: Option<CancelRx>,
+    cancel_rx: &mut Option<CancelRx>,
 ) -> Result<ScriptResult> {
     let mut cmd = build_command(script_path, args);
 
@@ -221,7 +221,7 @@ pub async fn run_script(
                     }
                 }
             }
-            _ = recv_cancel(&mut cancel_rx) => {
+            _ = recv_cancel(cancel_rx) => {
                 tracing::warn!("cancellation received — killing child");
                 killed = true;
                 // best-effort kill; don't propagate errors


### PR DESCRIPTION
## What does this PR do?

Windows bootstrap installs can stop at the `node-deps` stage with `node-deps produced no JSON result frame` when the PowerShell host exits abruptly with status `0xffffffff`. This leaves Desktop setup incomplete even though the stage is resumable. The installer now retries only that exact unstructured host-exit shape, keeps retries bounded, and preserves user cancellation across attempts.

### Symptom

The bootstrap installer reports `Install didn't finish` and `node-deps produced no JSON result frame` during npm or Playwright setup.

### Impact

Affected Windows users cannot complete Desktop setup through the bootstrap installer without starting the installation again.

### Bug Cause

**Trigger:** `apps/bootstrap-installer/src-tauri/src/bootstrap.rs` in the per-stage `run_install_script` result handling when PowerShell returns exit code `-1` and stdout contains no stage result frame.

**Causal chain:**
1. The bootstrap installer runs the idempotent `node-deps` stage through Windows PowerShell.
2. PowerShell terminates with raw status `0xffffffff` while native npm or Playwright work is active, bypassing the script's JSON result emission.
3. Rust receives no structured stage frame and immediately marks the installation failed.

**Why it is wrong:** The host-level termination is handled like an ordinary structured stage failure even though the stage can safely resume and the script had no opportunity to report its result.

**Working sibling / contrast:** Ordinary nonzero exits that include a structured JSON result continue to report their stage-specific failure without retrying.

**Ruled out:** This is not the indefinite Playwright timeout path because the captured runs terminate after 41 to 75 seconds with raw Windows status `0xffffffff`; no Rust timeout fires at that boundary.

### Fix

Retry a stage up to three total attempts only when it exits with code `-1`, was not killed by the user, and emitted no JSON result frame. Keep the cancellation receiver alive across attempts and make the retry backoff cancellation-aware so Cancel still stops the active bootstrap promptly. Returns the cancel receiver to the holder after each stage, so Cancel works for stages after the first.

## Related Issue

Closes #81167

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/bootstrap.rs` - add bounded retry classification, cancellation-aware backoff, return the cancel receiver to the holder after each stage, and policy tests.
- `apps/bootstrap-installer/src-tauri/src/powershell.rs` - preserve the cancellation receiver across repeated stage process launches via `&mut` threading.

## How to Test

1. On Windows, run the bootstrap installer and begin the Desktop setup path.
2. Verify an abrupt `-1` stage host exit without a JSON frame is retried up to the bounded limit.
3. Verify ordinary failures are not retried and Cancel remains effective during retry backoff and for stages after the first.
4. Run:

```bash
cargo test --lib
```

Result: 54 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant Rust test suite and all tests pass
- [x] I've added tests for the retry and cancellation behavior
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update is not required for this internal error-path fix
- [x] Config example update is not applicable
- [x] Architecture or workflow documentation update is not applicable
- [x] I've considered cross-platform impact; retry classification is platform-specific by exit status and ordinary paths are unchanged
- [x] Tool schema updates are not applicable
