### PR TITLE
fix(delegation): stop rejecting concrete goals with structured syntax

### DIFF
--- a/tests/tools/test_delegate_batch_validation.py
+++ b/tests/tools/test_delegate_batch_validation.py
@@ -101,7 +101,6 @@ class TestBatchPlaceholderGoals(unittest.TestCase):
         # Error must tell the model HOW to fix the call.
         self.assertIn("specific", result["error"].lower())
 
-
 class TestSingleTaskBatch(unittest.TestCase):
     def test_one_task_batch_rejected_pointing_to_goal_form(self):
         result = _call([{"goal": GOOD_A}])
@@ -133,6 +132,27 @@ class TestValidBatchStillRuns(unittest.TestCase):
             }
             result = json.loads(delegate_task(goal="test", parent_agent=parent))
         self.assertNotIn("error", result)
+
+    def test_concrete_syntax_is_not_treated_as_template_marker(self):
+        concrete_goals = (
+            'Ensure JSON output is {"status": "ok"}',
+            "Compare x < y and z > zero safely",
+            "Review the <button> rendering behavior",
+            "Read the ${HOME} environment variable safely",
+        )
+        for concrete_goal in concrete_goals:
+            with self.subTest(goal=concrete_goal), patch(
+                "tools.delegate_tool._run_single_child"
+            ) as mock_run:
+                mock_run.side_effect = [
+                    {"task_index": 0, "status": "completed", "summary": "A done",
+                     "api_calls": 1, "duration_seconds": 1.0, "_child_role": None},
+                    {"task_index": 1, "status": "completed", "summary": "B done",
+                     "api_calls": 1, "duration_seconds": 1.0, "_child_role": None},
+                ]
+                result = _call([{"goal": GOOD_A}, {"goal": concrete_goal}])
+            self.assertNotIn("error", result)
+            self.assertEqual(len(result["results"]), 2)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3057,9 +3057,14 @@ def _recover_tasks_from_json_string(
 
 
 # Placeholder shapes for batch goal validation: bare 'TODO', bare 'task N'
-# labels, or goals still carrying unexpanded template markers.
+# labels, or goals still carrying conventional unexpanded template markers.
+# Keep this conservative: arbitrary braces/angle brackets are valid in concrete
+# goals that contain JSON, comparisons, HTML tags, or shell variables.
 _PLACEHOLDER_GOAL_RE = re.compile(r"^(todo|task\s*\d+)$", re.IGNORECASE)
-_TEMPLATE_MARKER_RE = re.compile(r"<[^<>]+>|\{[^{}]+\}")
+_TEMPLATE_MARKER_NAME = r"(?:[A-Z][A-Z0-9_]*|[a-z][a-z0-9]*_[a-z0-9_]+)"
+_TEMPLATE_MARKER_RE = re.compile(
+    rf"<{_TEMPLATE_MARKER_NAME}>|(?<!\$)\{{{_TEMPLATE_MARKER_NAME}\}}"
+)
 _MIN_BATCH_GOAL_LEN = 10
 
 


### PR DESCRIPTION
## What does this PR do?

Valid `delegate_task` batches can currently fail before spawning children when a concrete goal contains JSON, an HTML tag, a comparison, or a shell variable. The placeholder detector treats any brace or angle-bracket span as an unresolved template value, so callers receive a false validation error and must rewrite accurate instructions.

This change narrows placeholder recognition to conventional all-caps or snake_case marker names and excludes shell `${...}` expansion. Concrete structured syntax remains valid while `<FILE_PATH>` and `{component_name}` continue to be rejected.

## Related Issue

Fixes #81391

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - narrow batch placeholder matching to conventional marker names and preserve shell variable syntax.
- `tests/tools/test_delegate_batch_validation.py` - cover JSON, HTML, comparison, and shell syntax as valid concrete goals.

## How to Test

1. Submit a two-task batch where one goal contains JSON, an HTML tag, a comparison, or `${HOME}` and verify both children are accepted for execution.
2. Submit a batch containing `<FILE_PATH>` or `{component_name}` and verify validation still returns an actionable placeholder error.
3. Run the focused delegation suites:

```bash
scripts/run_tests.sh tests/tools/test_delegate_batch_validation.py tests/tools/test_delegate.py
```

Result: 76 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation updates are N/A; no user-facing configuration or API changed
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the change is pure Python regular-expression validation
- [x] Tool description/schema updates are N/A; the model-facing contract is unchanged
