### PR TITLE
fix(desktop): retain ownership of pooled backends

### DIFF
--- a/apps/desktop/electron/backend-pool-state.test.ts
+++ b/apps/desktop/electron/backend-pool-state.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { cleanupFailedBackendPoolEntry, deleteBackendPoolEntryIfCurrent } from './backend-pool-state'
+import {
+  assertBackendPoolEntryCurrent,
+  cleanupFailedBackendPoolEntry,
+  deleteBackendPoolEntryIfCurrent
+} from './backend-pool-state'
 
 test('a stale backend exit cannot remove the replacement pool entry', () => {
   const staleEntry = { id: 'stale' }
@@ -31,4 +35,16 @@ test('a failed stale startup stops its child without removing the replacement', 
 
   assert.deepEqual(stopped, [staleEntry.process])
   assert.equal(entries.get('brainkit'), replacementEntry)
+})
+
+test('a startup cannot continue after its pool entry is replaced', () => {
+  const staleEntry = { id: 'stale' }
+  const replacementEntry = { id: 'replacement' }
+  const entries = new Map([['brainkit', replacementEntry]])
+
+  assert.throws(
+    () => assertBackendPoolEntryCurrent(entries, 'brainkit', staleEntry),
+    /Backend pool entry is no longer current/
+  )
+  assert.doesNotThrow(() => assertBackendPoolEntryCurrent(entries, 'brainkit', replacementEntry))
 })

--- a/apps/desktop/electron/backend-pool-state.test.ts
+++ b/apps/desktop/electron/backend-pool-state.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { cleanupFailedBackendPoolEntry, deleteBackendPoolEntryIfCurrent } from './backend-pool-state'
+
+test('a stale backend exit cannot remove the replacement pool entry', () => {
+  const staleEntry = { id: 'stale' }
+  const replacementEntry = { id: 'replacement' }
+  const entries = new Map([['brainkit', replacementEntry]])
+
+  assert.equal(deleteBackendPoolEntryIfCurrent(entries, 'brainkit', staleEntry), false)
+  assert.equal(entries.get('brainkit'), replacementEntry)
+})
+
+test('the current backend exit removes its pool entry', () => {
+  const entry = { id: 'current' }
+  const entries = new Map([['brainkit', entry]])
+
+  assert.equal(deleteBackendPoolEntryIfCurrent(entries, 'brainkit', entry), true)
+  assert.equal(entries.has('brainkit'), false)
+})
+
+test('a failed stale startup stops its child without removing the replacement', () => {
+  const staleEntry = { process: { id: 'stale-process' } }
+  const replacementEntry = { process: { id: 'replacement-process' } }
+  const entries = new Map([['brainkit', replacementEntry]])
+  const stopped: Array<{ id: string }> = []
+
+  cleanupFailedBackendPoolEntry(entries, 'brainkit', staleEntry, child => stopped.push(child))
+
+  assert.deepEqual(stopped, [staleEntry.process])
+  assert.equal(entries.get('brainkit'), replacementEntry)
+})

--- a/apps/desktop/electron/backend-pool-state.ts
+++ b/apps/desktop/electron/backend-pool-state.ts
@@ -10,6 +10,16 @@ export function deleteBackendPoolEntryIfCurrent<TKey, TEntry>(
   return entries.delete(key)
 }
 
+export function assertBackendPoolEntryCurrent<TKey, TEntry>(
+  entries: Map<TKey, TEntry>,
+  key: TKey,
+  expectedEntry: TEntry
+): void {
+  if (entries.get(key) !== expectedEntry) {
+    throw new Error('Backend pool entry is no longer current.')
+  }
+}
+
 export function cleanupFailedBackendPoolEntry<TKey, TEntry extends { process: unknown }>(
   entries: Map<TKey, TEntry>,
   key: TKey,

--- a/apps/desktop/electron/backend-pool-state.ts
+++ b/apps/desktop/electron/backend-pool-state.ts
@@ -1,0 +1,21 @@
+export function deleteBackendPoolEntryIfCurrent<TKey, TEntry>(
+  entries: Map<TKey, TEntry>,
+  key: TKey,
+  expectedEntry: TEntry
+): boolean {
+  if (entries.get(key) !== expectedEntry) {
+    return false
+  }
+
+  return entries.delete(key)
+}
+
+export function cleanupFailedBackendPoolEntry<TKey, TEntry extends { process: unknown }>(
+  entries: Map<TKey, TEntry>,
+  key: TKey,
+  failedEntry: TEntry,
+  stopProcess: (process: TEntry['process']) => void
+): void {
+  deleteBackendPoolEntryIfCurrent(entries, key, failedEntry)
+  stopProcess(failedEntry.process)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -37,6 +37,7 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
+import { cleanupFailedBackendPoolEntry, deleteBackendPoolEntryIfCurrent } from './backend-pool-state'
 import {
   canImportHermesCli,
   execProbeSync,
@@ -8050,7 +8051,7 @@ async function ensureBackend(profile) {
   }
 
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
-    backendPool.delete(key)
+    cleanupFailedBackendPoolEntry(backendPool, key, entry, stopBackendChild)
     throw error
   })
   backendPool.set(key, entry)
@@ -8232,12 +8233,12 @@ async function spawnPoolBackend(profile, entry) {
 
   child.once('error', error => {
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
-    backendPool.delete(profile)
+    deleteBackendPoolEntryIfCurrent(backendPool, profile, entry)
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
-    backendPool.delete(profile)
+    deleteBackendPoolEntryIfCurrent(backendPool, profile, entry)
 
     if (!ready) {
       rejectStart?.(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -37,7 +37,11 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
-import { cleanupFailedBackendPoolEntry, deleteBackendPoolEntryIfCurrent } from './backend-pool-state'
+import {
+  assertBackendPoolEntryCurrent,
+  cleanupFailedBackendPoolEntry,
+  deleteBackendPoolEntryIfCurrent
+} from './backend-pool-state'
 import {
   canImportHermesCli,
   execProbeSync,
@@ -8145,6 +8149,7 @@ async function spawnPoolBackend(profile, entry) {
 
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
+    assertBackendPoolEntryCurrent(backendPool, profile, entry)
 
     // Recorded on the entry so revalidation can probe this descriptor without
     // awaiting connectionPromise, which may still be pending for a sibling.
@@ -8185,6 +8190,7 @@ async function spawnPoolBackend(profile, entry) {
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
+  assertBackendPoolEntryCurrent(backendPool, profile, entry)
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
@@ -8292,15 +8298,16 @@ async function spawnPoolBackend(profile, entry) {
   }
 }
 
-function stopPoolBackend(profile) {
-  const entry = backendPool.get(profile)
+function stopPoolBackend(profile, expectedEntry = backendPool.get(profile)) {
+  const entry = expectedEntry
 
-  if (!entry) {
-    return
+  if (!entry || !deleteBackendPoolEntryIfCurrent(backendPool, profile, entry)) {
+    return false
   }
 
-  backendPool.delete(profile)
   stopBackendChild(entry.process)
+
+  return true
 }
 
 async function teardownPoolBackendAndWait(profile) {
@@ -9528,7 +9535,7 @@ function revalidatePool() {
     entries: backendPool.entries(),
     log: rememberLog,
     probe: fetchPublicJson,
-    stopBackend: stopPoolBackend,
+    stopBackend: (profile, entry) => stopPoolBackend(profile, entry),
     tracker: remoteLiveness
   })
 }

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -257,7 +257,7 @@ describe('revalidatePooledRemoteBackends', () => {
   const harness = (entries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string }]>) => {
     const unreachable = new Set<string>()
     const log = vi.fn()
-    const stopBackend = vi.fn()
+    const stopBackend = vi.fn(() => true)
 
     const probe = vi.fn(async (url: string) => {
       if ([...unreachable].some(base => url.startsWith(base))) {
@@ -309,7 +309,10 @@ describe('revalidatePooledRemoteBackends', () => {
     }
 
     await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
-    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder', {
+      process: null,
+      remoteBaseUrl: 'https://remote.example.com/'
+    })
   })
 
   it('clears the streak when the host answers again', async () => {
@@ -348,6 +351,26 @@ describe('revalidatePooledRemoteBackends', () => {
 
     await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
     expect(pool.stopBackend).toHaveBeenCalledTimes(1)
-    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder', {
+      process: null,
+      remoteBaseUrl: 'https://dead.example.com'
+    })
+  })
+
+  it('does not report a stale descriptor as dropped when its replacement is current', async () => {
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
+    pool.stopBackend.mockReturnValue(false)
+    pool.unreachable.add('https://remote.example.com')
+    const tracker = new RemoteLivenessTracker()
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await pool.run(tracker)
+    }
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder', {
+      process: null,
+      remoteBaseUrl: 'https://remote.example.com'
+    })
   })
 })

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -126,7 +126,7 @@ export interface RevalidatePooledRemoteBackendsOptions {
   entries: Iterable<[string, PooledRemoteEntry]>
   log: (message: string) => void
   probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
-  stopBackend: (profile: string) => void
+  stopBackend: (profile: string, expectedEntry: PooledRemoteEntry) => boolean
   tracker: RemoteLivenessTracker
 }
 
@@ -170,8 +170,10 @@ export async function revalidatePooledRemoteBackends({
         }
 
         log(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
-        stopBackend(profile)
-        dropped.push(profile)
+
+        if (stopBackend(profile, entry)) {
+          dropped.push(profile)
+        }
       }
     })
   )


### PR DESCRIPTION
## Summary

Prevent pooled profile backends from becoming untracked when an older backend exits after a replacement has already been installed.

The desktop pool previously deleted entries by profile key from asynchronous startup, exit, and remote-liveness callbacks. A stale callback could therefore remove a newer owner while leaving its `hermes serve` child alive. Later requests no longer saw that child in the pool and spawned another backend, causing duplicate processes and steadily increasing memory use. Failed startups could also drop tracking without stopping their owned child.

## Changes

- Delete pooled backend entries only when the map still contains the expected owner.
- Re-check ownership after asynchronous pre-spawn work so cancelled attempts cannot spawn outside the pool.
- Stop the failed attempt's child without deleting a replacement entry.
- Apply the same expected-owner guard to stale remote descriptor teardown.
- Add regression coverage for replacement, cancellation, failed startup, and stale liveness races.

## Validation

- `npx vitest run electron/backend-pool-state.test.ts electron/backend-connection-state.test.ts electron/remote-liveness.test.ts` (29 tests passed)
- `npx tsc -p tsconfig.electron.json --noEmit`
- `npx eslint electron/backend-pool-state.ts electron/backend-pool-state.test.ts electron/main.ts electron/remote-liveness.ts electron/remote-liveness.test.ts`
- `git diff --check hermes/main...HEAD`

Closes #81275
