### PR TITLE
fix(delegation): report incurred cost for failed and timed-out children

### DIFF
--- a/tests/tools/test_delegate_cost_footer.py
+++ b/tests/tools/test_delegate_cost_footer.py
@@ -15,6 +15,7 @@ Inspired by: Perplexity Agent API result shape (idea-level)
 
 import json
 import threading
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -112,6 +113,38 @@ class TestCostInResultEntry(unittest.TestCase):
         _, result = self._run(child)
         entry = result["results"][0]
         self.assertEqual(entry["cost_usd"], 0.0)
+
+    def test_exception_entry_preserves_incurred_cost(self):
+        child = _make_mock_child(cost=0.25, cost_status="reported")
+        child.run_conversation.side_effect = RuntimeError("child crashed")
+
+        parent, result = self._run(child)
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["cost_usd"], 0.25)
+        self.assertEqual(entry["cost_status"], "reported")
+        self.assertAlmostEqual(parent.session_estimated_cost_usd, 0.25, places=6)
+
+    def test_timeout_entry_snapshots_incurred_cost(self):
+        child = _make_mock_child(cost=0.25, cost_status="estimated")
+        child.get_activity_summary.return_value = {"api_call_count": 1}
+        child.run_conversation.side_effect = lambda **_kwargs: time.sleep(0.1)
+        parent = _make_mock_parent()
+
+        with (
+            patch("run_agent.AIAgent", return_value=child),
+            patch("tools.delegate_tool._get_child_timeout", return_value=0.01),
+        ):
+            result = json.loads(
+                delegate_task(goal="Test timeout cost", parent_agent=parent)
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "timeout")
+        self.assertEqual(entry["cost_usd"], 0.25)
+        self.assertEqual(entry["cost_status"], "estimated")
+        self.assertAlmostEqual(parent.session_estimated_cost_usd, 0.25, places=6)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2073,6 +2073,20 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _attach_child_cost(entry: Dict[str, Any], child) -> Dict[str, Any]:
+    """Snapshot child spend into both host-only and serialized fields."""
+    raw_cost = getattr(child, "session_estimated_cost_usd", 0.0)
+    child_cost = float(raw_cost or 0.0) if isinstance(raw_cost, (int, float)) else 0.0
+    entry["_child_cost_usd"] = child_cost
+    entry["cost_usd"] = round(child_cost, 6)
+
+    cost_status = getattr(child, "session_cost_status", None)
+    entry["cost_status"] = (
+        cost_status if isinstance(cost_status, str) and cost_status else "unknown"
+    )
+    return entry
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2452,7 +2466,7 @@ def _run_single_child(
                     " [steer did not land before the subagent stopped: "
                     f"{_late_pending_steer}]"
                 )
-            return _error_entry
+            return _attach_child_cost(_error_entry, child)
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -2637,31 +2651,11 @@ def _run_single_child(
             # parent thread can fire subagent_stop with the correct role.
             # Stripped before the dict is serialised back to the model.
             "_child_role": getattr(child, "_delegate_role", None),
-            # Captured before child.close() so the parent aggregator can fold
-            # the child's total spend into the parent's session cost.  Port of
-            # Kilo-Org/kilocode#9448 — previously the footer only reflected the
-            # parent's direct API calls and under-counted subagent-heavy runs.
-            # Stripped before the dict is serialised back to the model.
-            "_child_cost_usd": (
-                float(getattr(child, "session_estimated_cost_usd", 0.0) or 0.0)
-                if isinstance(
-                    getattr(child, "session_estimated_cost_usd", 0.0),
-                    (int, float),
-                )
-                else 0.0
-            ),
         }
-        # Per-delegation spend, serialized back to the model alongside
-        # tokens/api_calls so the parent can see what each delegation cost.
-        # Mirrors _child_cost_usd (which is stripped pre-serialization and
-        # only feeds the parent session rollup).
-        # Inspired by: Perplexity Agent API result shape (idea-level).
-        entry["cost_usd"] = round(entry["_child_cost_usd"], 6)
-        _cost_status = getattr(child, "session_cost_status", None)
-        entry["cost_status"] = (
-            _cost_status if isinstance(_cost_status, str) and _cost_status
-            else "unknown"
-        )
+        # Capture spend before any return path reaches child.close(). The
+        # host-only field feeds parent rollup; the public fields let the parent
+        # model see this delegation's cost.
+        _attach_child_cost(entry, child)
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
@@ -2817,7 +2811,7 @@ def _run_single_child(
                 " [steer did not land before the subagent stopped: "
                 f"{_late_pending_steer}]"
             )
-        return _error_entry
+        return _attach_child_cost(_error_entry, child)
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity


### PR DESCRIPTION
## What does this PR do?

Failed or timed-out delegations can incur model spend while returning no `cost_usd` or `cost_status`, which also causes the parent session rollup to add zero for that child. This change snapshots child cost consistently for successful, exception, and timeout results so serialized entries and parent accounting stay aligned.

### Symptom

A child that raises after recording usage, or times out after API work, returns an error entry without its already-incurred cost. The parent model cannot see that delegation's spend, and the parent session total silently undercounts it.

### Impact

Users relying on per-delegation or parent session cost reporting receive incomplete totals for unsuccessful child runs. The timeout path reports the child counter snapshot available at the timeout boundary; it does not claim spend recorded later by an abandoned in-flight child thread.

### Bug Cause

**Trigger:** Error and timeout returns in `tools/delegate_tool.py::_run_single_child`.

**Causal chain:**
1. A delegated child records nonzero session cost, then raises or reaches its configured timeout.
2. The error path returns before the normal result builder attaches host-only and serialized cost fields.
3. The result omits per-child cost, and parent finalization treats the missing rollup field as zero.

**Why it is wrong:** Cost attachment was coupled to normal result assembly instead of every terminal child result path.

**Working sibling / contrast:** Successful child results already snapshot the same counter before cleanup and therefore report and roll up their cost correctly.

**Ruled out:** The pricing calculation is not at fault; deterministic tests set a valid child cost before failure and show that only the error-result assembly drops it.

### Fix

- Centralize safe child-cost snapshotting in `_attach_child_cost`.
- Apply the same snapshot before successful, exception, and timeout returns.
- Preserve the internal `_child_cost_usd` field for parent rollup while exposing rounded `cost_usd` and validated `cost_status` in the serialized entry.
- Add regression coverage for an exception after incurred spend and a configured timeout after child API activity.

## Related Issue

Fixes #81396

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - centralize cost snapshots and attach them to every terminal child result path.
- `tests/tools/test_delegate_cost_footer.py` - verify exception and timeout entries preserve incurred cost and parent rollup.

## How to Test

1. Run the focused delegation suites through the repository test wrapper.
2. Verify exception and timeout entries contain the expected `cost_usd` and `cost_status`.
3. Verify the parent session rollup includes the same child snapshot.

```bash
scripts/run_tests.sh tests/tools/test_delegate_cost_footer.py tests/tools/test_delegate.py tests/tools/test_delegate_subagent_timeout_diagnostic.py tests/agent/test_subagent_lifecycle.py
```

Result: 79 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the relevant tests through `scripts/run_tests.sh` and all tests pass.
- [x] I've added regression tests for the exception and timeout paths.
- [x] I've tested on Windows 10 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Documentation update is N/A; the existing public fields now work consistently on error paths.
- [x] Config example update is N/A; no config keys changed.
- [x] Contributor or architecture guide update is N/A; no workflow changed.
- [x] Cross-platform impact was considered; the change uses platform-independent result assembly.
- [x] Tool description or schema update is N/A; no tool input schema changed.

## Screenshots / Logs

N/A - automated result-shape assertions cover the regression.
