### PR TITLE
fix(gateway): cancel pending clarify on unmatched prose reply (#74399)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14862,6 +14862,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                # The text was not resolved (arbitrary prose for a native
+                # multi-choice clarify).  Cancel the pending clarify so the
+                # agent loop does not block for up to clarify_timeout (default
+                # 1h) waiting for a button click that will never come.  The
+                # user's message falls through to normal dispatch as a new
+                # turn (#74399).
+                _clarify_mod.clear_session(_quick_key)
+                logger.info(
+                    "Gateway cancelled pending clarify after unmatched text "
+                    "reply (session=%s, id=%s)",
+                    _quick_key, _pending_clarify.clarify_id,
+                )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -341,3 +341,62 @@ class TestMultiSelectTextFallback:
         from tools import clarify_gateway as cm
         entry = cm.register("s4", "sk", "Q?", ["A", "B"])
         assert cm._coerce_text_response(entry, "b") == "B"
+
+
+class TestClarifyCancelOnUnmatchedProse:
+    """When the user replies with arbitrary prose that can't resolve a
+    native multi-choice clarify, clear_session must unblock the waiting
+    agent thread immediately instead of leaving it stuck for up to
+    clarify_timeout (default 1h).
+
+    This is the primitive-level contract the gateway fix in run.py relies
+    on (#74399): after resolve_text_response_for_session returns False,
+    the gateway calls clear_session to cancel the pending entry.
+    """
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_clear_session_unblocks_waiter(self):
+        """clear_session sets the event so wait_for_response returns ''."""
+        from tools import clarify_gateway as cm
+        cm.register("c1", "sk", "Q?", ["A", "B", "C"])
+        result_box = {}
+
+        def waiter():
+            result_box["r"] = cm.wait_for_response("c1", timeout=5)
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        time.sleep(0.05)
+
+        # The text response does not match any choice
+        assert cm.resolve_text_response_for_session("sk", "let's go with A please") is False
+        # The clarify is still pending
+        assert cm.has_pending("sk")
+
+        # Gateway cancels the pending clarify
+        cancelled = cm.clear_session("sk")
+        assert cancelled == 1
+        assert not cm.has_pending("sk")
+
+        t.join(timeout=5)
+        assert result_box["r"] == ""
+
+    def test_clear_session_no_pending_is_noop(self):
+        """clear_session on a session with no pending clarify returns 0."""
+        from tools import clarify_gateway as cm
+        assert cm.clear_session("nonexistent") == 0
+
+    def test_unmatched_prose_does_not_resolve(self):
+        """resolve_text_response_for_session returns False for arbitrary prose."""
+        from tools import clarify_gateway as cm
+        cm.register("c2", "sk", "Q?", ["staging", "prod", "cancel"])
+        # Exact match resolves
+        assert cm.resolve_text_response_for_session("sk", "staging") is True
+        # But after re-registering (the first resolve consumed the entry)
+        cm.register("c3", "sk", "Q?", ["staging", "prod", "cancel"])
+        # Arbitrary prose does not resolve
+        assert cm.resolve_text_response_for_session("sk", "let's go with staging please") is False
+        # The entry is still pending
+        assert cm.has_pending("sk")


### PR DESCRIPTION
When the clarify tool renders interactive buttons on Discord and the user replies with plain-text prose that doesn't match any choice label or number, resolve_text_response_for_session returns False and the text falls through to normal dispatch.  But the pending clarify entry was never cancelled — the blocking wait_for_response kept polling for up to agent.clarify_timeout (default 3600s / 1 hour), and the agent loop showed "Working — N min" with no way to advance.

Fix: when a pending clarify exists and the text-intercept path rejects the reply (arbitrary prose for native multi-choice), call clarify_gateway.clear_session() to cancel the pending entry and unblock the waiting agent thread immediately.  The user's message continues as a normal new turn.

This reuses the existing clear_session primitive (already used by /new, gateway shutdown, and cached-agent eviction) — no new mechanism needed.

Tests: 3 new tests in test_clarify_gateway.py covering:
- clear_session unblocks a waiter after unmatched prose (the core contract the gateway fix relies on)
- clear_session on a session with no pending clarify is a no-op
- resolve_text_response_for_session returns False for arbitrary prose but leaves the entry pending (proving the gap the fix addresses)

All 26 tests in test_clarify_gateway.py pass.

Fixes #74399

## What does this PR do?

When the clarify tool renders interactive buttons on Discord and the user replies with plain-text prose that doesn't match any choice label or number (e.g. "let's go with staging please" instead of clicking "staging" or typing "staging"), the text-intercept path rejects the reply — but the pending clarify entry was never cancelled. The blocking wait_for_response kept polling for up to agent.clarify_timeout (default 3600s / 1 hour), and the agent loop showed "Working — N min" with no way to advance.

This PR calls clarify_gateway.clear_session() to cancel the pending entry and unblock the waiting agent thread immediately when the text-intercept rejects the reply. The user's message then falls through to normal dispatch as a new turn. This reuses the existing clear_session primitive (already used by /new, gateway shutdown, and cached-agent eviction) — no new mechanism needed.



## Related Issue

[<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->](https://github.com/NousResearch/hermes-agent/issues/74399)

Fixes #74399

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/run.py (12 lines): After resolve_text_response_for_session returns False for unmatched prose, call clarify_gateway.clear_session(_quick_key) to cancel the pending clarify and unblock the agent thread
- tests/tools/test_clarify_gateway.py (59 lines): 3 new tests proving clear_session unblocks a waiter after unmatched prose, clear_session is a no-op with no pending entries, and resolve_text_response_for_session returns False for arbitrary prose while leaving the entry pending

## How to Test

1. Run the test suite: python -m pytest tests/tools/test_clarify_gateway.py -v — all 26 tests pass (23 existing + 3 new)
2. Manual scenario: trigger a clarify with multi-choice buttons on Discord, reply with arbitrary prose (e.g. "let's go with staging please" for choices ["staging", "prod", "cancel"]). Before the fix, the agent stays stuck for up to 1 hour. After the fix, the clarify is cancelled immediately and the message starts a fresh turn.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

