### PR TITLE
fix(honcho): retire replaced clients safely across profiles

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -15,6 +15,8 @@ Config: Uses the existing Honcho config chain:
 
 from __future__ import annotations
 
+import contextvars
+
 import json
 import logging
 import re
@@ -351,7 +353,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._cron_skipped = True
                 return
 
-            from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
+            from plugins.memory.honcho.client import HonchoClientConfig
             from plugins.memory.honcho.session import HonchoSessionManager
 
             cfg = HonchoClientConfig.from_global_config()
@@ -443,6 +445,7 @@ class HonchoMemoryProvider(MemoryProvider):
             cfg = self._config
             init_kwargs = dict(self._lazy_init_kwargs)
             init_session_id = self._lazy_init_session_id or "hermes-default"
+            init_context = contextvars.copy_context()
 
             def _run() -> None:
                 try:
@@ -456,7 +459,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     logger.warning("Honcho background session init failed: %s", e)
 
             self._init_thread = threading.Thread(
-                target=_run,
+                target=lambda: init_context.run(_run),
                 daemon=True,
                 name="honcho-session-init",
             )
@@ -466,12 +469,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def _do_session_init(self, cfg, session_id: str, **kwargs) -> None:
         """Shared session initialization logic for both eager and lazy paths."""
-        from plugins.memory.honcho.client import get_honcho_client
         from plugins.memory.honcho.session import HonchoSessionManager
 
-        client = get_honcho_client(cfg)
         self._manager = HonchoSessionManager(
-            honcho=client,
             config=cfg,
             context_tokens=cfg.context_tokens,
             runtime_user_peer_name=kwargs.get("user_id") or None,

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -18,6 +18,7 @@ import os
 import logging
 import hashlib
 import ipaddress
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
@@ -854,15 +855,26 @@ class HonchoClientConfig:
         return self.workspace_id
 
 
-_honcho_client_slot: SingletonSlot = SingletonSlot()
-_cached_timeout: float | None = None
-# Memo for the honcho.json-derived timeout, keyed on the file's mtime_ns so
-# the staleness check on every get_honcho_client() call costs one stat()
-# instead of a JSON parse. mtime -1 = file absent; (None, None) = not yet
-# populated. config.yaml needs no such memo: load_config_readonly() is
+# Honcho clients are cached per config identity, not as one process-wide
+# singleton. A single slot was correct while one process served one profile,
+# but a multiplexed gateway (gateway.multiplex_profiles) serves many profiles
+# from one process, each potentially with its own honcho.json and workspace.
+# With a single slot, whichever profile built first pinned its workspace_id
+# for every other profile's memory (#69123) — the same first-config-wins
+# staleness trap as #57347, one field over. Each identity keeps its own SingletonSlot
+# so the build-once-under-race guarantee (#24759) holds per client. The maps
+# are bounded by the number of distinct identities (profiles) in the process.
+_honcho_client_slots: dict[tuple, SingletonSlot] = {}
+_honcho_client_slots_lock = threading.Lock()
+_cached_timeouts: dict[tuple, float] = {}
+# Memo for the honcho.json-derived timeout, keyed on the resolved config path
+# and its mtime_ns so the staleness check on every get_honcho_client() call
+# costs one stat() instead of a JSON parse. mtime -1 = file absent. Keyed by
+# path because multiplexed profiles resolve different honcho.json files from
+# one process. config.yaml needs no such memo: load_config_readonly() is
 # internally cached on both the user and managed files' signatures, and a
 # bespoke key here would have to duplicate that invalidation logic.
-_honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
+_honcho_json_timeout_memo: dict[str, tuple[int, float | None]] = {}
 
 
 def _config_yaml_timeout() -> float | None:
@@ -882,16 +894,17 @@ def _config_yaml_timeout() -> float | None:
 
 
 def _honcho_json_timeout() -> float | None:
-    """Read timeout/requestTimeout from honcho.json (host block wins), memoized on mtime."""
-    global _honcho_json_timeout_memo
+    """Read timeout/requestTimeout from honcho.json (host block wins), memoized on path+mtime."""
     try:
         path = resolve_config_path()
+        path_key = str(path)
         try:
             mtime_ns: int = path.stat().st_mtime_ns
         except OSError:
             mtime_ns = -1
-        if _honcho_json_timeout_memo[0] == mtime_ns:
-            return _honcho_json_timeout_memo[1]
+        memo = _honcho_json_timeout_memo.get(path_key)
+        if memo is not None and memo[0] == mtime_ns:
+            return memo[1]
 
         timeout = None
         if mtime_ns != -1:
@@ -903,7 +916,7 @@ def _honcho_json_timeout() -> float | None:
                 raw.get("timeout"),
                 raw.get("requestTimeout"),
             )
-        _honcho_json_timeout_memo = (mtime_ns, timeout)
+        _honcho_json_timeout_memo[path_key] = (mtime_ns, timeout)
         return timeout
     except Exception:
         return None
@@ -946,7 +959,9 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
         logger.warning("Honcho OAuth pre-build refresh failed", exc_info=True)
 
 
-def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -> None:
+def _refresh_cached_oauth(
+    client: "Honcho", config: HonchoClientConfig | None, slot: SingletonSlot
+) -> None:
     """Rotate the cached client's Bearer in place when its OAuth token is stale.
 
     If the SDK shape changed and the in-place rotation can't apply, the slot is
@@ -958,34 +973,78 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
         host = config.host if config is not None else resolve_active_host()
         token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            _honcho_client_slot.reset()
+            slot.reset()
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
 
 
-def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
-    """Get or create the Honcho client singleton.
+def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
+    """Cache identity for a Honcho client build.
 
-    When no config is provided, attempts to load ~/.honcho/config.json
-    first, falling back to environment variables.
+    Explicit configs key on the connection fields ``_build`` embeds in the
+    client (host, workspace, base_url, environment). ``api_key`` is
+    deliberately excluded: OAuth rotation refreshes the cached client's
+    Bearer in place (``_refresh_cached_oauth``), and keying on the token
+    would strand one client per rotation instead.
 
-    Thread-safe: the client is built exactly once even under concurrent
-    first calls (double-checked locking via ``SingletonSlot``), so racing
-    threads can't each construct a client and leak the loser's connection.
+    Ambient callers (``config=None``) key on what ``from_global_config()``
+    resolves from — the active honcho.json path and host key. Both follow
+    the multiplexer's per-turn HERMES_HOME override, so routed profiles get
+    distinct clients, and the key stays cheap (path resolution + profile
+    name, no JSON parse) on the per-memory-access hot path
+    (``HonchoSessionManager.honcho``).
     """
-    global _cached_timeout
-    cached = _honcho_client_slot.peek()
+    if config is not None:
+        return (
+            "explicit",
+            config.host,
+            config.workspace_id,
+            config.base_url or "",
+            config.environment,
+        )
+    return ("ambient", str(resolve_config_path()), resolve_active_host())
+
+
+def _client_slot_for(key: tuple) -> SingletonSlot:
+    with _honcho_client_slots_lock:
+        slot = _honcho_client_slots.get(key)
+        if slot is None:
+            slot = SingletonSlot()
+            _honcho_client_slots[key] = slot
+        return slot
+
+
+def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
+    """Get or create the Honcho client for this config identity.
+
+    When no config is provided, attempts to load the ambient honcho.json
+    (profile-local first) and falls back to environment variables.
+
+    Clients are cached per config identity (``_client_cache_key``), so a
+    multiplexed gateway serving several profiles from one process gets one
+    client per profile's workspace instead of sharing whichever profile
+    built first. Single-profile processes see one key and keep the old
+    singleton behavior.
+
+    Thread-safe: each identity's client is built exactly once even under
+    concurrent first calls (double-checked locking via ``SingletonSlot``),
+    so racing threads can't each construct a client and leak the loser's
+    connection.
+    """
+    key = _client_cache_key(config)
+    slot = _client_slot_for(key)
+    cached = slot.peek()
     if cached is not None:
         # Detect timeout config changes in long-lived processes (gateway,
         # dashboard).  If the user changed the timeout after the client was
         # built, rebuild with the new value.
         new_timeout = _resolve_timeout_from_sources(config)
-        if new_timeout != _cached_timeout:
-            _honcho_client_slot.reset()
-            _cached_timeout = None
+        if new_timeout != _cached_timeouts.get(key):
+            slot.reset()
+            _cached_timeouts.pop(key, None)
             cached = None
         else:
-            _refresh_cached_oauth(cached, config)
+            _refresh_cached_oauth(cached, config, slot)
             return cached
 
     if config is None:
@@ -1097,16 +1156,15 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        global _cached_timeout
-        _cached_timeout = resolved_timeout
+        _cached_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
-    return _honcho_client_slot.get(_build)
+    return slot.get(_build)
 
 
 def reset_honcho_client() -> None:
-    """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _honcho_json_timeout_memo
-    _honcho_client_slot.reset()
-    _cached_timeout = None
-    _honcho_json_timeout_memo = (None, None)
+    """Reset all cached Honcho clients (useful for testing)."""
+    with _honcho_client_slots_lock:
+        _honcho_client_slots.clear()
+    _cached_timeouts.clear()
+    _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -19,6 +19,7 @@ import logging
 import hashlib
 import ipaddress
 import threading
+import weakref
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
@@ -34,6 +35,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 HOST = "hermes"
+
+
+def _sync_http_transport(client: "Honcho") -> Any | None:
+    """Return the eager sync transport without touching lazy SDK properties."""
+    try:
+        private_attrs = object.__getattribute__(client, "__pydantic_private__")
+    except (AttributeError, TypeError):
+        private_attrs = None
+    if isinstance(private_attrs, dict) and "_http" in private_attrs:
+        return private_attrs["_http"]
+    try:
+        return vars(client).get("_http")
+    except TypeError:
+        return None
+
+
+def _close_sync_transport(transport: Any) -> None:
+    """Best-effort finalizer callback for a Hermes-owned sync transport."""
+    try:
+        transport.close()
+    except Exception:
+        logger.warning("Failed to close retired Honcho sync transport", exc_info=True)
+
+
+def _register_client_finalizer(client: "Honcho") -> None:
+    """Close a Hermes-owned client's sync transport after its final release."""
+    transport = _sync_http_transport(client)
+    if transport is None:
+        logger.warning("Honcho client has no eager synchronous transport to retire")
+        return
+    try:
+        weakref.finalize(client, _close_sync_transport, transport)
+    except TypeError:
+        logger.warning(
+            "Honcho client does not support reachability-based transport retirement"
+        )
 
 
 def profile_host_key(profile: str | None) -> str:
@@ -369,6 +406,13 @@ class HonchoClientConfig:
     base_url: str | None = None
     # Optional request timeout in seconds for Honcho SDK HTTP calls
     timeout: float | None = None
+    # Honcho credential/config path captured for this profile. Binding this
+    # prevents background threads from resolving OAuth against another
+    # profile's ambient HERMES_HOME during a later client rebuild.
+    config_path: Path | None = None
+    # Hermes profile home captured with the config for context-independent
+    # config.yaml fallbacks in native worker threads.
+    hermes_home: Path | None = None
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
@@ -467,6 +511,8 @@ class HonchoClientConfig:
         cls,
         workspace_id: str = "hermes",
         host: str | None = None,
+        config_path: Path | None = None,
+        hermes_home: Path | None = None,
     ) -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         resolved_host = host or resolve_active_host()
@@ -480,6 +526,8 @@ class HonchoClientConfig:
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
             timeout=timeout,
+            config_path=config_path or resolve_config_path(),
+            hermes_home=hermes_home or get_hermes_home(),
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
         )
@@ -497,15 +545,20 @@ class HonchoClientConfig:
         """
         resolved_host = host or resolve_active_host()
         path = config_path or resolve_config_path()
+        profile_home = get_hermes_home()
         if not path.exists():
             logger.debug("No global Honcho config at %s, falling back to env", path)
-            return cls.from_env(host=resolved_host)
+            return cls.from_env(
+                host=resolved_host, config_path=path, hermes_home=profile_home
+            )
 
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to read %s: %s, falling back to env", path, e)
-            return cls.from_env(host=resolved_host)
+            return cls.from_env(
+                host=resolved_host, config_path=path, hermes_home=profile_home
+            )
 
         host_block = _host_block(raw, resolved_host)
         # A hosts.hermes block or explicit enabled flag means the user
@@ -594,6 +647,8 @@ class HonchoClientConfig:
             environment=environment,
             base_url=base_url,
             timeout=timeout,
+            config_path=path,
+            hermes_home=profile_home,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
             pin_peer_name=_resolve_bool(
@@ -867,6 +922,7 @@ class HonchoClientConfig:
 _honcho_client_slots: dict[tuple, SingletonSlot] = {}
 _honcho_client_slots_lock = threading.Lock()
 _cached_timeouts: dict[tuple, float] = {}
+_cached_timeouts_lock = threading.Lock()
 # Memo for the honcho.json-derived timeout, keyed on the resolved config path
 # and its mtime_ns so the staleness check on every get_honcho_client() call
 # costs one stat() instead of a JSON parse. mtime -1 = file absent. Keyed by
@@ -877,12 +933,31 @@ _cached_timeouts: dict[tuple, float] = {}
 _honcho_json_timeout_memo: dict[str, tuple[int, float | None]] = {}
 
 
-def _config_yaml_timeout() -> float | None:
-    """Read honcho.timeout / honcho.request_timeout via the cached config loader."""
-    try:
-        from hermes_cli.config import load_config_readonly
+def _load_bound_hermes_config(
+    config: HonchoClientConfig | None,
+) -> dict[str, Any]:
+    """Load config.yaml under the profile home bound to *config*."""
+    from hermes_cli.config import load_config
 
-        honcho_cfg = load_config_readonly().get("honcho", {})
+    if config is None or config.hermes_home is None:
+        return load_config()
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(config.hermes_home)
+    try:
+        return load_config()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _config_yaml_timeout(config: HonchoClientConfig | None = None) -> float | None:
+    """Read honcho timeout from the config's bound profile."""
+    try:
+        honcho_cfg = _load_bound_hermes_config(config).get("honcho", {})
         if isinstance(honcho_cfg, dict):
             return _resolve_optional_float(
                 honcho_cfg.get("timeout"),
@@ -939,8 +1014,15 @@ def _resolve_timeout_from_sources(config: HonchoClientConfig | None) -> float:
         if timeout is None:
             timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
     if timeout is None:
-        timeout = _config_yaml_timeout()
+        timeout = _config_yaml_timeout(config)
     return timeout if timeout is not None else _DEFAULT_HTTP_TIMEOUT
+
+
+def _oauth_config_path(config: HonchoClientConfig | None) -> Path:
+    """Return the credential path bound to this client configuration."""
+    if config is not None and config.config_path is not None:
+        return config.config_path
+    return resolve_config_path()
 
 
 def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
@@ -952,7 +1034,7 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
     try:
         from plugins.memory.honcho import oauth
 
-        token, _ = oauth.ensure_fresh_token(resolve_config_path(), config.host)
+        token, _ = oauth.ensure_fresh_token(_oauth_config_path(config), config.host)
         if token:
             config.api_key = token
     except Exception:
@@ -961,31 +1043,37 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
 
 def _refresh_cached_oauth(
     client: "Honcho", config: HonchoClientConfig | None, slot: SingletonSlot
-) -> None:
-    """Rotate the cached client's Bearer in place when its OAuth token is stale.
+) -> bool:
+    """Refresh a cached Bearer and report whether the slot was reset.
 
-    If the SDK shape changed and the in-place rotation can't apply, the slot is
-    reset so the next acquisition rebuilds with the fresh token.
+    If the SDK shape changed and in-place rotation cannot apply, the current
+    acquisition must rebuild rather than returning the displaced stale-token
+    client.
     """
     try:
         from plugins.memory.honcho import oauth
 
         host = config.host if config is not None else resolve_active_host()
-        token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
+        token, refreshed = oauth.ensure_fresh_token(_oauth_config_path(config), host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            slot.reset()
+            with _honcho_client_slots_lock:
+                slot.reset()
+            return True
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
+    return False
 
 
 def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
     """Cache identity for a Honcho client build.
 
     Explicit configs key on the connection fields ``_build`` embeds in the
-    client (host, workspace, base_url, environment). ``api_key`` is
-    deliberately excluded: OAuth rotation refreshes the cached client's
-    Bearer in place (``_refresh_cached_oauth``), and keying on the token
-    would strand one client per rotation instead.
+    client, the bound profile/config paths, and the effective timeout. This
+    prevents otherwise-identical callers with different timeout requirements
+    from sharing a first-writer-wins slot. ``api_key`` is deliberately excluded
+    because OAuth rotation refreshes the cached client's Bearer in place
+    (``_refresh_cached_oauth``); keying on the token would strand one client per
+    rotation instead.
 
     Ambient callers (``config=None``) key on what ``from_global_config()``
     resolves from — the active honcho.json path and host key. Both follow
@@ -1001,8 +1089,16 @@ def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
             config.workspace_id,
             config.base_url or "",
             config.environment,
+            str(config.config_path) if config.config_path is not None else "",
+            str(config.hermes_home) if config.hermes_home is not None else "",
+            _resolve_timeout_from_sources(config),
         )
-    return ("ambient", str(resolve_config_path()), resolve_active_host())
+    return (
+        "ambient",
+        str(resolve_config_path()),
+        resolve_active_host(),
+        _resolve_timeout_from_sources(None),
+    )
 
 
 def _client_slot_for(key: tuple) -> SingletonSlot:
@@ -1014,38 +1110,34 @@ def _client_slot_for(key: tuple) -> SingletonSlot:
         return slot
 
 
-def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
-    """Get or create the Honcho client for this config identity.
-
-    When no config is provided, attempts to load the ambient honcho.json
-    (profile-local first) and falls back to environment variables.
-
-    Clients are cached per config identity (``_client_cache_key``), so a
-    multiplexed gateway serving several profiles from one process gets one
-    client per profile's workspace instead of sharing whichever profile
-    built first. Single-profile processes see one key and keep the old
-    singleton behavior.
-
-    Thread-safe: each identity's client is built exactly once even under
-    concurrent first calls (double-checked locking via ``SingletonSlot``),
-    so racing threads can't each construct a client and leak the loser's
-    connection.
-    """
-    key = _client_cache_key(config)
-    slot = _client_slot_for(key)
+def _get_honcho_client_from_slot(
+    config: HonchoClientConfig | None,
+    key: tuple,
+    slot: SingletonSlot,
+) -> Honcho:
+    """Obtain a client from one slot; the caller validates slot identity."""
     cached = slot.peek()
     if cached is not None:
         # Detect timeout config changes in long-lived processes (gateway,
         # dashboard).  If the user changed the timeout after the client was
         # built, rebuild with the new value.
         new_timeout = _resolve_timeout_from_sources(config)
-        if new_timeout != _cached_timeouts.get(key):
-            slot.reset()
-            _cached_timeouts.pop(key, None)
+        with _cached_timeouts_lock:
+            cached_timeout = _cached_timeouts.get(key)
+        if new_timeout != cached_timeout:
+            # Remove metadata before taking map → slot locks; factories hold
+            # the slot lock while publishing metadata, so this order avoids a
+            # timeout-lock/slot-lock cycle.
+            with _cached_timeouts_lock:
+                _cached_timeouts.pop(key, None)
+            with _honcho_client_slots_lock:
+                slot.reset()
             cached = None
         else:
-            _refresh_cached_oauth(cached, config, slot)
-            return cached
+            if _refresh_cached_oauth(cached, config, slot):
+                cached = None
+            else:
+                return cached
 
     if config is None:
         config = HonchoClientConfig.from_global_config()
@@ -1092,8 +1184,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         resolved_timeout = config.timeout
         if not resolved_base_url or resolved_timeout is None:
             try:
-                from hermes_cli.config import load_config
-                hermes_cfg = load_config()
+                hermes_cfg = _load_bound_hermes_config(config)
                 honcho_cfg = hermes_cfg.get("honcho", {})
                 if isinstance(honcho_cfg, dict):
                     if not resolved_base_url:
@@ -1156,15 +1247,36 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        _cached_timeouts[key] = resolved_timeout
-        return Honcho(**kwargs)
+        client = Honcho(**kwargs)
+        _register_client_finalizer(client)
+        with _cached_timeouts_lock:
+            _cached_timeouts[key] = resolved_timeout
+        return client
 
     return slot.get(_build)
+
+
+def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
+    """Get or create the client for this config identity.
+
+    Each identity builds once per current slot. If reset detaches a slot while
+    its factory is running, the completed client is discarded by reachability
+    and acquisition retries against the slot currently published in the map.
+    """
+    key = _client_cache_key(config)
+    while True:
+        slot = _client_slot_for(key)
+        client = _get_honcho_client_from_slot(config, key, slot)
+        with _honcho_client_slots_lock:
+            if _honcho_client_slots.get(key) is slot and slot.contains(client):
+                return client
+        logger.debug("Retrying Honcho acquisition after concurrent cache reset")
 
 
 def reset_honcho_client() -> None:
     """Reset all cached Honcho clients (useful for testing)."""
     with _honcho_client_slots_lock:
         _honcho_client_slots.clear()
-    _cached_timeouts.clear()
+        with _cached_timeouts_lock:
+            _cached_timeouts.clear()
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -24,6 +24,23 @@ _PEER_ID_HASH_LEN = 8
 _PEER_ID_HASH_ESCALATION_LENGTHS = (_PEER_ID_HASH_LEN, 12, 16, 24, 32, 64)
 
 
+_UNKNOWN_SDK_OWNER = object()
+
+
+def _sdk_owner(value: Any, default: Any = _UNKNOWN_SDK_OWNER) -> Any:
+    """Read the SDK's eager parent link without invoking dynamic attributes."""
+    try:
+        private_attrs = object.__getattribute__(value, "__pydantic_private__")
+    except (AttributeError, TypeError):
+        private_attrs = None
+    if isinstance(private_attrs, dict) and "_honcho" in private_attrs:
+        return private_attrs["_honcho"]
+    try:
+        return vars(value).get("_honcho", default)
+    except TypeError:
+        return default
+
+
 @dataclass
 class HonchoSession:
     """
@@ -96,14 +113,19 @@ class HonchoSessionManager:
             runtime_user_peer_name_alt: Optional stable alternate gateway identity.
         """
         self._honcho = honcho
+        self._managed_honcho = honcho is None
         self._context_tokens = context_tokens
         self._config = config
         self._runtime_user_peer_name = runtime_user_peer_name
         self._runtime_user_peer_name_alt = runtime_user_peer_name_alt
         self._cache: dict[str, HonchoSession] = {}
         self._cache_lock = threading.RLock()
+        self._client_refresh_lock = threading.Lock()
+        self._session_rotation_lock = threading.Lock()
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
+        self._peer_cache_owners: dict[str, Any] = {}
+        self._session_cache_owners: dict[str, Any] = {}
 
         # Write frequency state
         write_frequency = (config.write_frequency if config else "async")
@@ -154,32 +176,75 @@ class HonchoSessionManager:
 
     @property
     def honcho(self) -> Honcho:
-        """Get the Honcho client, refreshing a near-expiry OAuth token in place.
+        """Get the configured client and invalidate displaced SDK caches."""
+        if not self._managed_honcho:
+            return self._honcho
 
-        Routes every access through ``get_honcho_client`` (which returns the same
-        cached singleton) so a long session can't outlive its 1h access token.
-        """
-        self._honcho = get_honcho_client()
-        return self._honcho
+        # Serialize acquisitions separately from cache mutation.  This prevents
+        # an older acquisition from publishing after a newer refresh without
+        # holding ``_cache_lock`` across a potentially blocking client build.
+        with self._client_refresh_lock:
+            current = get_honcho_client(self._config)
+            with self._cache_lock:
+                if current is not self._honcho:
+                    self._honcho = current
+                    self._peers_cache.clear()
+                    self._sessions_cache.clear()
+                    self._peer_cache_owners.clear()
+                    self._session_cache_owners.clear()
+                return self._honcho
 
-    def _get_or_create_peer(self, peer_id: str) -> Any:
+    def _cached_session_for_current_client(
+        self, session_id: str, owner: Any | None = None
+    ) -> Any | None:
+        """Return only a session owned by the operation's client snapshot."""
+        current = owner if owner is not None else self.honcho
+        with self._cache_lock:
+            cached = self._sessions_cache.get(session_id)
+            if cached is None:
+                return None
+            owner = self._session_cache_owners.get(
+                session_id, _sdk_owner(cached)
+            )
+            if owner is current:
+                return cached
+            self._sessions_cache.pop(session_id, None)
+            self._session_cache_owners.pop(session_id, None)
+            return None
+
+    def _get_or_create_peer(
+        self, peer_id: str, owner: Any | None = None
+    ) -> Any:
         """
         Get or create a Honcho peer.
 
         Peers are lazy -- no API call until first use.
         Observation settings are controlled per-session via SessionPeerConfig.
         """
+        owner = owner if owner is not None else self.honcho
+        assert owner is not None
         with self._cache_lock:
             if peer_id in self._peers_cache:
-                return self._peers_cache[peer_id]
+                cached = self._peers_cache[peer_id]
+                cached_owner = self._peer_cache_owners.get(
+                    peer_id, _sdk_owner(cached)
+                )
+                if cached_owner is owner:
+                    return cached
 
-        peer = self.honcho.peer(peer_id)
+        peer = owner.peer(peer_id)
         with self._cache_lock:
-            self._peers_cache[peer_id] = peer
+            if self._honcho is owner:
+                self._peers_cache[peer_id] = peer
+                self._peer_cache_owners[peer_id] = owner
         return peer
 
     def _get_or_create_honcho_session(
-        self, session_id: str, user_peer: Any, assistant_peer: Any
+        self,
+        session_id: str,
+        user_peer: Any,
+        assistant_peer: Any,
+        owner: Any | None = None,
     ) -> tuple[Any, list]:
         """
         Get or create a Honcho session with peers configured.
@@ -187,12 +252,14 @@ class HonchoSessionManager:
         Returns:
             Tuple of (honcho_session, existing_messages).
         """
-        with self._cache_lock:
-            if session_id in self._sessions_cache:
-                logger.debug("Honcho session '%s' retrieved from cache", session_id)
-                return self._sessions_cache[session_id], []
+        owner = owner if owner is not None else self.honcho
+        assert owner is not None
+        cached = self._cached_session_for_current_client(session_id, owner)
+        if cached is not None:
+            logger.debug("Honcho session '%s' retrieved from cache", session_id)
+            return cached, []
 
-        session = self.honcho.session(session_id)
+        session = owner.session(session_id)
 
         # Configure per-peer observation from granular booleans.
         # These map 1:1 to Honcho's SessionPeerConfig toggles.
@@ -269,7 +336,10 @@ class HonchoSessionManager:
                 session_id, e,
             )
 
-        self._sessions_cache[session_id] = session
+        with self._cache_lock:
+            if self._honcho is owner:
+                self._sessions_cache[session_id] = session
+                self._session_cache_owners[session_id] = owner
         return session, existing_messages
 
     def _sanitize_id(self, id_str: str) -> str:
@@ -390,10 +460,11 @@ class HonchoSessionManager:
 
         # All expensive I/O outside the lock — Honcho's persistence is source of truth
         honcho_session_id = self._sanitize_id(key)
-        user_peer = self._get_or_create_peer(user_peer_id)
-        assistant_peer = self._get_or_create_peer(assistant_peer_id)
+        owner = self.honcho
+        user_peer = self._get_or_create_peer(user_peer_id, owner)
+        assistant_peer = self._get_or_create_peer(assistant_peer_id, owner)
         honcho_session, existing_messages = self._get_or_create_honcho_session(
-            honcho_session_id, user_peer, assistant_peer
+            honcho_session_id, user_peer, assistant_peer, owner
         )
 
         local_messages = []
@@ -414,8 +485,13 @@ class HonchoSessionManager:
             messages=local_messages,
         )
 
-        # Write to cache under lock — only one writer wins
+        # Publish only if no concurrent creator won while this candidate was
+        # being built. Returning the winner prevents late candidates from
+        # replacing a session that may already contain unsynced messages.
         with self._cache_lock:
+            existing = self._cache.get(key)
+            if existing is not None:
+                return existing
             self._cache[key] = session
         return session
 
@@ -424,13 +500,16 @@ class HonchoSessionManager:
         if not session.messages:
             return True
 
-        user_peer = self._get_or_create_peer(session.user_peer_id)
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        owner = self.honcho
+        user_peer = self._get_or_create_peer(session.user_peer_id, owner)
+        assistant_peer = self._get_or_create_peer(session.assistant_peer_id, owner)
+        honcho_session = self._cached_session_for_current_client(
+            session.honcho_session_id, owner
+        )
 
         if not honcho_session:
             honcho_session, _ = self._get_or_create_honcho_session(
-                session.honcho_session_id, user_peer, assistant_peer
+                session.honcho_session_id, user_peer, assistant_peer, owner
             )
 
         new_messages = [m for m in session.messages if not m.get("_synced")]
@@ -448,14 +527,16 @@ class HonchoSessionManager:
                 msg["_synced"] = True
             logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
             with self._cache_lock:
-                self._cache[session.key] = session
+                if self._cache.get(session.key) is session:
+                    self._cache[session.key] = session
             return True
         except Exception as e:
             for msg in new_messages:
                 msg["_synced"] = False
             logger.error("Failed to sync messages to Honcho: %s", e)
             with self._cache_lock:
-                self._cache[session.key] = session
+                if self._cache.get(session.key) is session:
+                    self._cache[session.key] = session
             return False
 
     def _async_writer_loop(self) -> None:
@@ -569,25 +650,28 @@ class HonchoSessionManager:
         """
         import time
 
-        # Hold the reentrant lock across get_or_create so a concurrent caller
-        # can't observe the (old-popped, new-not-yet-inserted) gap and create
-        # its own session under the raw key.  `_cache_lock` is an RLock so
-        # nested reacquisition inside get_or_create is safe.
-        with self._cache_lock:
-            # Remove old session from caches (but don't delete from Honcho)
-            old_session = self._cache.pop(key, None)
-            if old_session:
-                self._sessions_cache.pop(old_session.honcho_session_id, None)
+        # Serialize rotations without holding the cache lock across Honcho I/O.
+        # The old session remains available under ``key`` until the replacement
+        # is complete, so concurrent readers cannot observe a missing-key gap.
+        with self._session_rotation_lock:
+            with self._cache_lock:
+                old_session = self._cache.get(key)
 
-            # Create new session with timestamp suffix
-            timestamp = int(time.time())
-            new_key = f"{key}:{timestamp}"
-
-            # get_or_create will create a fresh session
+            suffix = time.time_ns()
+            with self._cache_lock:
+                new_key = f"{key}:{suffix}"
+                while new_key in self._cache:
+                    suffix += 1
+                    new_key = f"{key}:{suffix}"
             session = self.get_or_create(new_key)
 
-            # Cache under the original key so callers find it by the expected name
-            self._cache[key] = session
+            with self._cache_lock:
+                if old_session:
+                    self._sessions_cache.pop(old_session.honcho_session_id, None)
+                    self._session_cache_owners.pop(
+                        old_session.honcho_session_id, None
+                    )
+                self._cache[key] = session
 
         logger.info("Created new session for %s (honcho: %s)", key, session.honcho_session_id)
         return session
@@ -733,7 +817,7 @@ class HonchoSessionManager:
         # return null summary — the guard below handles that gracefully.
         # Per-directory returning sessions get their accumulated summary.
         try:
-            honcho_session = self._sessions_cache.get(session.honcho_session_id)
+            honcho_session = self._cached_session_for_current_client(session.honcho_session_id)
             if honcho_session:
                 ctx = honcho_session.context(summary=True)
                 if ctx.summary and getattr(ctx.summary, "content", None):
@@ -777,12 +861,15 @@ class HonchoSessionManager:
             logger.warning("No local session cached for '%s', skipping migration", session_key)
             return False
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        owner = self.honcho
+        honcho_session = self._cached_session_for_current_client(
+            session.honcho_session_id, owner
+        )
         if not honcho_session:
             logger.warning("No Honcho session cached for '%s', skipping migration", session_key)
             return False
 
-        user_peer = self._get_or_create_peer(session.user_peer_id)
+        user_peer = self._get_or_create_peer(session.user_peer_id, owner)
 
         content_bytes = self._format_migration_transcript(session_key, messages)
         first_ts = messages[0].get("timestamp") if messages else None
@@ -856,13 +943,16 @@ class HonchoSessionManager:
             logger.warning("No local session cached for '%s', skipping memory migration", session_key)
             return False
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        owner = self.honcho
+        honcho_session = self._cached_session_for_current_client(
+            session.honcho_session_id, owner
+        )
         if not honcho_session:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
 
-        user_peer = self._get_or_create_peer(session.user_peer_id)
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+        user_peer = self._get_or_create_peer(session.user_peer_id, owner)
+        assistant_peer = self._get_or_create_peer(session.assistant_peer_id, owner)
 
         uploaded = False
         files = [
@@ -1011,7 +1101,7 @@ class HonchoSessionManager:
         if not session:
             return {}
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        honcho_session = self._cached_session_for_current_client(session.honcho_session_id)
         if not honcho_session:
             # Fall back to peer-level context, respecting the requested peer
             peer_id = self._resolve_peer_id(session, peer)
@@ -1378,8 +1468,13 @@ class HonchoSessionManager:
             logger.warning("No session cached for '%s', skipping AI seed", session_key)
             return False
 
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        owner = self.honcho
+        assistant_peer = self._get_or_create_peer(
+            session.assistant_peer_id, owner
+        )
+        honcho_session = self._cached_session_for_current_client(
+            session.honcho_session_id, owner
+        )
         if not honcho_session:
             logger.warning("No Honcho session cached for '%s', skipping AI seed", session_key)
             return False

--- a/plugins/plugin_utils.py
+++ b/plugins/plugin_utils.py
@@ -128,6 +128,11 @@ class SingletonSlot(Generic[T]):
         """Return the cached instance without building it (None if unset)."""
         return self._value if self._set else None
 
+    def contains(self, value: T) -> bool:
+        """Return whether *value* is still cached, synchronized with reset()."""
+        with self._lock:
+            return self._set and self._value is value
+
     def reset(self) -> None:
         """Drop the cached instance so the next ``get()`` rebuilds it."""
         with self._lock:

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -41,9 +41,7 @@ def _make_manager(write_frequency="turn") -> HonchoSessionManager:
         api_key="test-key",
         enabled=True,
     )
-    mgr = HonchoSessionManager(config=cfg)
-    mgr._honcho = MagicMock()
-    return mgr
+    return HonchoSessionManager(honcho=MagicMock(), config=cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -428,9 +426,12 @@ class TestMemoryFileMigrationTargets:
         ai_peer = MagicMock(name="ai-peer")
         mgr._peers_cache[session.user_peer_id] = user_peer
         mgr._peers_cache[session.assistant_peer_id] = ai_peer
+        mgr._peer_cache_owners[session.user_peer_id] = mgr._honcho
+        mgr._peer_cache_owners[session.assistant_peer_id] = mgr._honcho
 
         honcho_session = MagicMock()
         mgr._sessions_cache[session.honcho_session_id] = honcho_session
+        mgr._session_cache_owners[session.honcho_session_id] = mgr._honcho
 
         (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
         (tmp_path / "USER.md").write_text("user profile", encoding="utf-8")

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -1002,17 +1002,26 @@ class TestResolveSessionNameLengthLimit:
 
 
 class TestResetHonchoClient:
-    def test_reset_clears_singleton(self):
+    def test_reset_clears_all_cached_clients(self):
         import plugins.memory.honcho.client as mod
+        from plugins.plugin_utils import SingletonSlot
 
-        # Seed the cached client through the slot's public surface, then
-        # verify reset_honcho_client() clears it. (The client is cached in
-        # mod._honcho_client_slot, a thread-safe SingletonSlot, not a bare
-        # module global anymore — see #24759.)
-        mod._honcho_client_slot.get(lambda: MagicMock())
-        assert mod._honcho_client_slot.peek() is not None
+        # Seed cached clients for two identities through the slot map's
+        # public surface, then verify reset_honcho_client() clears them all.
+        # (Clients are cached per config identity in mod._honcho_client_slots
+        # — one thread-safe SingletonSlot per identity — so multiplexed
+        # profiles don't share whichever client built first; see #24759 for
+        # the slot primitive.)
+        for key in (("explicit", "hermes", "ws-a", "", "production"),
+                    ("explicit", "hermes", "ws-b", "", "production")):
+            slot = SingletonSlot()
+            slot.get(lambda: MagicMock())
+            with mod._honcho_client_slots_lock:
+                mod._honcho_client_slots[key] = slot
+            assert slot.peek() is not None
         reset_honcho_client()
-        assert mod._honcho_client_slot.peek() is None
+        with mod._honcho_client_slots_lock:
+            assert not mod._honcho_client_slots
 
 
 class TestDialecticDepthParsing:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -2197,15 +2197,10 @@ class TestGetSessionContextFallback:
         from plugins.memory.honcho.client import HonchoClientConfig
         from plugins.memory.honcho.session import HonchoSessionManager
 
-        cfg = HonchoClientConfig(api_key="test-key", enabled=True)
-        mgr = HonchoSessionManager.__new__(HonchoSessionManager)
-        mgr._cache = {}
-        mgr._sessions_cache = {}
-        mgr._config = cfg
-        mgr._dialectic_dynamic = True
-        mgr._dialectic_reasoning_level = "low"
-        mgr._dialectic_max_input_chars = 10000
-        mgr._ai_observe_others = True
+        cfg = HonchoClientConfig(
+            api_key="test-key", enabled=True, write_frequency="turn"
+        )
+        mgr = HonchoSessionManager(honcho=MagicMock(), config=cfg)
 
         session = HonchoSession(
             key="test",

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -25,6 +25,7 @@ class TestHonchoClientConfigAutoEnable:
         cfg = HonchoClientConfig.from_global_config(config_path=config_path)
 
         assert cfg.api_key == "test-api-key-12345"
+        assert cfg.config_path == config_path
         assert cfg.enabled is True  # Auto-enabled because API key exists
 
     def test_respects_explicit_enabled_false(self, tmp_path):

--- a/tests/test_honcho_client_multiplex_isolation.py
+++ b/tests/test_honcho_client_multiplex_isolation.py
@@ -1,0 +1,169 @@
+"""Per-profile client isolation for get_honcho_client() under multiplexing.
+
+A multiplexed gateway (``gateway.multiplex_profiles``) serves many profiles
+from one process: each turn enters ``_profile_runtime_scope``, which points
+``get_hermes_home()`` at the routed profile's home, so profile-local
+honcho.json files (and their workspaces) resolve per turn. The client cache
+must key on that identity — with a single first-config-wins slot, whichever
+profile built first pinned its ``workspace_id`` for every other profile's
+memory, silently merging tenants into one workspace (#69123).
+
+These tests pin the per-identity cache: distinct workspaces get distinct
+clients (explicit configs and ambient HERMES_HOME-override resolution alike),
+while same-identity callers keep sharing one build.
+"""
+
+import json
+import sys
+import threading
+import types
+
+import pytest
+
+from plugins.memory.honcho import client as honcho_client
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    get_honcho_client,
+    reset_honcho_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_honcho_client()
+    yield
+    reset_honcho_client()
+
+
+def _install_fake_honcho_sdk(monkeypatch, build_count, build_lock):
+    """Make `from honcho import Honcho` resolve to a counting fake."""
+
+    class _FakeHoncho:
+        def __init__(self, **kwargs):
+            with build_lock:
+                build_count["n"] += 1
+            self.kwargs = kwargs
+
+    fake_mod = types.ModuleType("honcho")
+    fake_mod.Honcho = _FakeHoncho
+    monkeypatch.setitem(sys.modules, "honcho", fake_mod)
+    # Pin the timeout axis to the default so identity keying is the only
+    # variable under test.
+    monkeypatch.setattr(
+        honcho_client, "_resolve_optional_float", lambda *a, **k: None, raising=False
+    )
+
+
+def test_distinct_workspace_configs_get_distinct_clients(monkeypatch):
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+
+    config_a = HonchoClientConfig(
+        api_key="test-key", workspace_id="brand-a", environment="production"
+    )
+    config_b = HonchoClientConfig(
+        api_key="test-key", workspace_id="brand-b", environment="production"
+    )
+
+    client_a = get_honcho_client(config_a)
+    client_b = get_honcho_client(config_b)
+
+    assert client_a is not client_b, "distinct workspaces must not share a client"
+    assert client_a.kwargs["workspace_id"] == "brand-a"
+    assert client_b.kwargs["workspace_id"] == "brand-b"
+    assert build_count["n"] == 2
+
+    # Same identity keeps sharing one build.
+    assert get_honcho_client(config_a) is client_a
+    assert get_honcho_client(config_b) is client_b
+    assert build_count["n"] == 2
+
+
+def test_concurrent_distinct_configs_build_once_each(monkeypatch):
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+
+    configs = [
+        HonchoClientConfig(
+            api_key="test-key", workspace_id=f"ws-{i}", environment="production"
+        )
+        for i in range(2)
+    ]
+
+    barrier = threading.Barrier(20)
+    results: dict[str, list] = {"ws-0": [], "ws-1": []}
+    results_lock = threading.Lock()
+
+    def worker(config):
+        barrier.wait()
+        c = get_honcho_client(config)
+        with results_lock:
+            results[config.workspace_id].append(c)
+
+    threads = [
+        threading.Thread(target=worker, args=(configs[i % 2],)) for i in range(20)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert build_count["n"] == 2, "one build per identity, even under races"
+    for workspace_id, clients in results.items():
+        assert len(clients) == 10
+        assert all(c is clients[0] for c in clients), (
+            f"all callers of {workspace_id} share one client"
+        )
+        assert clients[0].kwargs["workspace_id"] == workspace_id
+
+
+def _write_profile_home(tmp_path, name, workspace):
+    home = tmp_path / name
+    home.mkdir()
+    (home / "honcho.json").write_text(
+        json.dumps({"workspace": workspace, "apiKey": "test-key"}),
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_ambient_resolution_follows_hermes_home_override(monkeypatch, tmp_path):
+    """The multiplex scenario: config=None resolved under per-turn home overrides.
+
+    ``HonchoSessionManager.honcho`` calls ``get_honcho_client()`` with no
+    config on every memory access; under the multiplexer the ambient
+    honcho.json is profile-local. Two profiles with different workspaces
+    must get two clients — not whichever built first.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+    monkeypatch.delenv("HONCHO_TIMEOUT", raising=False)
+
+    home_a = _write_profile_home(tmp_path, "profile-a", "brand-a")
+    home_b = _write_profile_home(tmp_path, "profile-b", "brand-b")
+
+    def under_home(home):
+        token = set_hermes_home_override(home)
+        try:
+            return get_honcho_client()
+        finally:
+            reset_hermes_home_override(token)
+
+    client_a = under_home(home_a)
+    client_b = under_home(home_b)
+
+    assert client_a is not client_b, "profiles must not share the first-built client"
+    assert client_a.kwargs["workspace_id"] == "brand-a"
+    assert client_b.kwargs["workspace_id"] == "brand-b"
+    assert build_count["n"] == 2
+
+    # Re-entering a profile's scope reuses its cached client.
+    assert under_home(home_a) is client_a
+    assert under_home(home_b) is client_b
+    assert build_count["n"] == 2

--- a/tests/test_honcho_client_retirement.py
+++ b/tests/test_honcho_client_retirement.py
@@ -1,0 +1,810 @@
+"""Reachability-based Honcho retirement and identity-safe SDK cache tests."""
+
+from __future__ import annotations
+
+import gc
+import sys
+import threading
+import types
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from honcho import Honcho as RealHoncho
+from honcho.peer import Peer as RealPeer
+from honcho.session import Session as RealSession
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho import client as client_module
+from plugins.memory.honcho import session as session_module
+from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client, reset_honcho_client
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class _Transport:
+    def __init__(self):
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+
+
+class _Context:
+    messages = []
+    summary = None
+
+
+class _Peer:
+    def __init__(self, honcho, peer_id):
+        self._honcho = honcho
+        self.peer_id = peer_id
+
+    def message(self, content):
+        return content
+
+
+class _Session:
+    def __init__(self, honcho, session_id):
+        self._honcho = honcho
+        self.session_id = session_id
+
+    def add_peers(self, peers):
+        return None
+
+    def get_peer_configuration(self, peer):
+        return SimpleNamespace(observe_me=None, observe_others=None)
+
+    def context(self, **kwargs):
+        return _Context()
+
+
+class _Honcho:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._http = _Transport()
+        self._async_http = None
+
+
+    def peer(self, peer_id):
+        return _Peer(self, peer_id)
+
+    def session(self, session_id):
+        return _Session(self, session_id)
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache(monkeypatch):
+    reset_honcho_client()
+
+    fake_honcho = types.ModuleType("honcho")
+    fake_honcho.Honcho = _Honcho
+    monkeypatch.setitem(sys.modules, "honcho", fake_honcho)
+    fake_session = types.ModuleType("honcho.session")
+    fake_session.SessionPeerConfig = lambda **kwargs: SimpleNamespace(**kwargs)
+    monkeypatch.setitem(sys.modules, "honcho.session", fake_session)
+    monkeypatch.setattr(client_module, "_resolve_timeout_from_sources", lambda cfg: 30.0)
+    yield
+    reset_honcho_client()
+    gc.collect()
+
+
+def _cfg(workspace="ws"):
+    return HonchoClientConfig(
+        api_key="test", workspace_id=workspace, write_frequency="turn"
+    )
+
+
+def test_real_sdk_private_transport_is_finalized_without_async_creation():
+    client = RealHoncho(
+        base_url="http://127.0.0.1:9",
+        workspace_id="finalizer-shape-probe",
+    )
+    transport = client._http
+    client_ref = weakref.ref(client)
+
+    assert client_module._sync_http_transport(client) is transport
+    assert client._async_http is None
+    client_module._register_client_finalizer(client)
+
+    del client
+    gc.collect()
+
+    assert client_ref() is None
+    assert transport._client.is_closed
+
+
+def test_reset_waits_for_final_strong_reference_and_closes_sync_once():
+    client = get_honcho_client(_cfg())
+    transport = client._http
+    ref = weakref.ref(client)
+
+    reset_honcho_client()
+    gc.collect()
+    assert transport.close_count == 0
+    assert ref() is client
+
+    del client
+    gc.collect()
+    assert ref() is None
+    assert transport.close_count == 1
+
+
+def test_profile_finalizers_are_isolated_and_async_transport_stays_lazy():
+    first = get_honcho_client(_cfg("first"))
+    second = get_honcho_client(_cfg("second"))
+    first_transport = first._http
+    second_transport = second._http
+
+    assert first._async_http is None
+    assert second._async_http is None
+    reset_honcho_client()
+    del first
+    gc.collect()
+    assert first_transport.close_count == 1
+    assert second_transport.close_count == 0
+    assert second._async_http is None
+
+    del second
+    gc.collect()
+    assert second_transport.close_count == 1
+
+
+def test_cached_sdk_objects_delay_retirement_until_manager_refresh_and_release():
+    cfg = _cfg()
+    manager = HonchoSessionManager(config=cfg)
+    old = manager.honcho
+    old_ref = weakref.ref(old)
+    transport = old._http
+    peer = manager._get_or_create_peer("user")
+    sdk_session, _ = manager._get_or_create_honcho_session("session", peer, peer)
+
+    reset_honcho_client()
+    new = manager.honcho
+    assert new is not old
+    assert manager._peers_cache == {}
+    assert manager._sessions_cache == {}
+    del old
+    gc.collect()
+    assert transport.close_count == 0
+
+    del peer, sdk_session
+    gc.collect()
+    assert old_ref() is None
+    assert transport.close_count == 1
+    assert new._async_http is None
+
+
+def _manager_with_switchable_clients(monkeypatch, first, current):
+    cfg = _cfg()
+    monkeypatch.setattr(session_module, "get_honcho_client", lambda bound: current[0])
+    manager = HonchoSessionManager(config=cfg)
+    manager._honcho = first
+    return manager
+
+
+def test_peer_finishing_after_refresh_is_not_published(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingHoncho(_Honcho):
+        def peer(self, peer_id):
+            entered.set()
+            assert release.wait(5)
+            return super().peer(peer_id)
+
+    old = BlockingHoncho(workspace_id="old")
+    new = _Honcho(workspace_id="new")
+    current = [old]
+    manager = _manager_with_switchable_clients(monkeypatch, old, current)
+    result = []
+    worker = threading.Thread(target=lambda: result.append(manager._get_or_create_peer("p")))
+    worker.start()
+    assert entered.wait(5)
+    current[0] = new
+    assert manager.honcho is new
+    release.set()
+    worker.join(5)
+
+    assert result[0]._honcho is old
+    assert "p" not in manager._peers_cache
+
+
+def test_session_finishing_after_refresh_is_not_published(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingHoncho(_Honcho):
+        def session(self, session_id):
+            entered.set()
+            assert release.wait(5)
+            return super().session(session_id)
+
+    old = BlockingHoncho(workspace_id="old")
+    new = _Honcho(workspace_id="new")
+    current = [old]
+    manager = _manager_with_switchable_clients(monkeypatch, old, current)
+    peer = _Peer(old, "p")
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            manager._get_or_create_honcho_session("s", peer, peer)[0]
+        )
+    )
+    worker.start()
+    assert entered.wait(5)
+    current[0] = new
+    assert manager.honcho is new
+    release.set()
+    worker.join(5)
+
+    assert result[0]._honcho is old
+    assert "s" not in manager._sessions_cache
+
+
+def test_direct_session_cache_path_refreshes_before_use(monkeypatch):
+    old = _Honcho(workspace_id="old")
+    new = _Honcho(workspace_id="new")
+    current = [old]
+    manager = _manager_with_switchable_clients(monkeypatch, old, current)
+    local = HonchoSession("key", "user", "ai", "sid")
+    stale = _Session(old, "sid")
+    manager._cache["key"] = local
+    manager._sessions_cache["sid"] = stale
+    manager._session_cache_owners["sid"] = old
+
+    current[0] = new
+    result = manager.get_session_context("key")
+    assert result == {"representation": "", "card": []}
+    assert manager._sessions_cache == {}
+
+
+def test_new_session_does_not_hold_cache_lock_while_refreshing(monkeypatch):
+    old_client = _Honcho(workspace_id="old")
+    current = [old_client]
+    manager = _manager_with_switchable_clients(
+        monkeypatch, old_client, current
+    )
+    old_session = HonchoSession("key", "user", "ai", "old-sid")
+    manager._cache["key"] = old_session
+    entered_resolution = threading.Event()
+    original_resolve_user = manager._resolve_user_peer_id
+
+    def signal_resolution(key):
+        entered_resolution.set()
+        return original_resolve_user(key)
+
+    monkeypatch.setattr(manager, "_resolve_user_peer_id", signal_resolution)
+    manager._client_refresh_lock.acquire()
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(manager.new_session("key"))
+    )
+    worker.start()
+    try:
+        assert entered_resolution.wait(5)
+        assert manager._cache_lock.acquire(timeout=1)
+        try:
+            assert manager._cache["key"] is old_session
+        finally:
+            manager._cache_lock.release()
+    finally:
+        manager._client_refresh_lock.release()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert result[0] is manager._cache["key"]
+    assert result[0] is not old_session
+
+
+def test_concurrent_first_creation_returns_published_winner_with_messages(monkeypatch):
+    manager = HonchoSessionManager(
+        honcho=cast(Any, _Honcho(workspace_id="ws")), config=_cfg()
+    )
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    message_added = threading.Event()
+    call_count = 0
+    call_lock = threading.Lock()
+
+    def controlled_session_build(session_id, user_peer, assistant_peer, owner=None):
+        nonlocal call_count
+        with call_lock:
+            call_count += 1
+            call_number = call_count
+        if call_number == 1:
+            first_entered.set()
+            assert second_entered.wait(5)
+        else:
+            second_entered.set()
+            assert message_added.wait(5)
+        return _Session(owner, session_id), []
+
+    monkeypatch.setattr(
+        manager, "_get_or_create_honcho_session", controlled_session_build
+    )
+    results = []
+
+    def first_creator():
+        session = manager.get_or_create("key")
+        session.messages.append({"role": "user", "content": "preserved"})
+        results.append(session)
+        message_added.set()
+
+    def second_creator():
+        results.append(manager.get_or_create("key"))
+
+    first_thread = threading.Thread(target=first_creator)
+    first_thread.start()
+    assert first_entered.wait(5)
+    second_thread = threading.Thread(target=second_creator)
+    second_thread.start()
+    first_thread.join(5)
+    second_thread.join(5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert results[0] is results[1]
+    assert results[0].messages == [{"role": "user", "content": "preserved"}]
+    assert manager._cache["key"] is results[0]
+
+
+def test_old_flush_cannot_overwrite_completed_rotation():
+    owner = _Honcho(workspace_id="ws")
+    manager = HonchoSessionManager(honcho=cast(Any, owner), config=_cfg())
+    old = HonchoSession(
+        "key",
+        "user",
+        "assistant",
+        "old-session",
+        messages=[{"role": "user", "content": "pending", "_synced": False}],
+    )
+    manager._cache["key"] = old
+    flush_entered = threading.Event()
+    release_flush = threading.Event()
+
+    class BlockingSession(_Session):
+        def add_messages(self, messages):
+            flush_entered.set()
+            assert release_flush.wait(5)
+
+    old_sdk_session = BlockingSession(owner, old.honcho_session_id)
+    manager._sessions_cache[old.honcho_session_id] = old_sdk_session
+    manager._session_cache_owners[old.honcho_session_id] = owner
+    flush_result = []
+    flush_thread = threading.Thread(
+        target=lambda: flush_result.append(manager._flush_session(old))
+    )
+    flush_thread.start()
+    assert flush_entered.wait(5)
+
+    rotated = manager.new_session("key")
+    assert manager._cache["key"] is rotated
+    release_flush.set()
+    flush_thread.join(5)
+
+    assert not flush_thread.is_alive()
+    assert flush_result == [True]
+    assert manager._cache["key"] is rotated
+    assert manager._cache["key"] is not old
+
+
+def test_frozen_clock_rotations_use_distinct_session_keys(monkeypatch):
+    monkeypatch.setattr("time.time_ns", lambda: 123)
+    manager = HonchoSessionManager(
+        honcho=cast(Any, _Honcho(workspace_id="ws")), config=_cfg()
+    )
+    manager.get_or_create("key")
+
+    first = manager.new_session("key")
+    second = manager.new_session("key")
+
+    assert first is not second
+    assert first.key == "key:123"
+    assert second.key == "key:124"
+    assert first.honcho_session_id != second.honcho_session_id
+
+
+def test_real_sdk_private_child_owners_are_rejected_without_sidecars(monkeypatch):
+    old = RealHoncho(base_url="http://127.0.0.1:9", workspace_id="old")
+    new = _Honcho(workspace_id="new")
+    current = [new]
+
+    peer_manager = _manager_with_switchable_clients(monkeypatch, new, current)
+    stale_peer = RealPeer("peer", old)
+    peer_manager._peers_cache["peer"] = stale_peer
+    replacement_peer = peer_manager._get_or_create_peer("peer")
+    assert session_module._sdk_owner(stale_peer) is old
+    assert replacement_peer._honcho is new
+
+    session_manager = _manager_with_switchable_clients(monkeypatch, new, current)
+    stale_session = RealSession("session", old)
+    session_manager._sessions_cache["session"] = stale_session
+    replacement_session, _ = session_manager._get_or_create_honcho_session(
+        "session", new.peer("user"), new.peer("assistant")
+    )
+    assert session_module._sdk_owner(stale_session) is old
+    assert replacement_session._honcho is new
+
+    old._http.close()
+
+
+def test_failed_in_place_oauth_rotation_rebuilds_current_acquisition(monkeypatch):
+    from plugins.memory.honcho import oauth
+
+    cfg = _cfg()
+    first = get_honcho_client(cfg)
+    refresh_results = iter(
+        [("new-token", True), ("new-token", False), ("new-token", False)]
+    )
+    monkeypatch.setattr(
+        oauth, "ensure_fresh_token", lambda path, host: next(refresh_results)
+    )
+    monkeypatch.setattr(oauth, "apply_token_to_client", lambda client, token: False)
+
+    replacement = get_honcho_client(cfg)
+
+    assert replacement is not first
+    assert get_honcho_client(cfg) is replacement
+    assert getattr(replacement, "kwargs")["api_key"] == "new-token"
+
+
+def test_factory_finishing_after_global_reset_retries_current_slot(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+    built = []
+    build_lock = threading.Lock()
+
+    class BlockingHoncho(_Honcho):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            with build_lock:
+                built.append(self)
+                build_number = len(built)
+            if build_number == 1:
+                entered.set()
+                assert release.wait(5)
+
+    monkeypatch.setattr(sys.modules["honcho"], "Honcho", BlockingHoncho)
+    cfg = _cfg()
+    worker_result = []
+    worker = threading.Thread(
+        target=lambda: worker_result.append(get_honcho_client(cfg))
+    )
+    worker.start()
+    assert entered.wait(5)
+
+    reset_honcho_client()
+    replacement = get_honcho_client(cfg)
+    release.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert len(built) == 2
+    assert worker_result == [replacement]
+    assert replacement is built[1]
+    assert get_honcho_client(cfg) is replacement
+
+
+def test_explicit_configs_with_different_timeouts_use_distinct_slots(monkeypatch):
+    cfg_a = _cfg()
+    cfg_a.timeout = 10
+    cfg_b = _cfg()
+    cfg_b.timeout = 20
+    monkeypatch.setattr(
+        client_module,
+        "_resolve_timeout_from_sources",
+        lambda config: config.timeout if config is not None else 30.0,
+    )
+    start = threading.Event()
+    results = []
+    result_lock = threading.Lock()
+
+    def acquire(config):
+        assert start.wait(5)
+        client = get_honcho_client(config)
+        with result_lock:
+            results.append(client)
+
+    threads = [
+        threading.Thread(target=acquire, args=(cfg_a,)),
+        threading.Thread(target=acquire, args=(cfg_b,)),
+    ]
+    for thread in threads:
+        thread.start()
+    start.set()
+    for thread in threads:
+        thread.join(5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(results) == 2
+    assert results[0] is not results[1]
+    assert {getattr(client, "kwargs")["timeout"] for client in results} == {10, 20}
+    assert client_module._client_cache_key(cfg_a) != client_module._client_cache_key(
+        cfg_b
+    )
+
+
+def test_detached_factories_with_different_timeouts_stay_isolated(monkeypatch):
+    cfg_a = _cfg()
+    cfg_a.timeout = 10
+    cfg_b = _cfg()
+    cfg_b.timeout = 20
+    entered_first_build = threading.Event()
+    release_first_build = threading.Event()
+    build_lock = threading.Lock()
+    build_timeouts = []
+    build_count = 0
+    monkeypatch.setattr(
+        client_module,
+        "_resolve_timeout_from_sources",
+        lambda config: config.timeout if config is not None else 30.0,
+    )
+
+    class BlockingHoncho(_Honcho):
+        def __init__(self, **kwargs):
+            nonlocal build_count
+            with build_lock:
+                build_count += 1
+                number = build_count
+                build_timeouts.append(kwargs.get("timeout"))
+            if number == 1:
+                entered_first_build.set()
+                assert release_first_build.wait(5)
+            super().__init__(**kwargs)
+
+    fake_honcho = types.ModuleType("honcho")
+    setattr(fake_honcho, "Honcho", BlockingHoncho)
+    monkeypatch.setitem(sys.modules, "honcho", fake_honcho)
+    worker_result = []
+    worker = threading.Thread(
+        target=lambda: worker_result.append(get_honcho_client(cfg_a))
+    )
+    worker.start()
+    assert entered_first_build.wait(5)
+
+    reset_honcho_client()
+    replacement = get_honcho_client(cfg_b)
+    release_first_build.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert build_timeouts == [10, 20, 10]
+    assert len(worker_result) == 1
+    assert worker_result[0] is not replacement
+    assert getattr(worker_result[0], "kwargs")["timeout"] == 10
+    assert getattr(replacement, "kwargs")["timeout"] == 20
+    key_a = client_module._client_cache_key(cfg_a)
+    key_b = client_module._client_cache_key(cfg_b)
+    assert key_a != key_b
+    assert client_module._cached_timeouts[key_a] == 10
+    assert client_module._cached_timeouts[key_b] == 20
+
+
+def test_bound_oauth_path_survives_ambient_profile_change(monkeypatch):
+    from plugins.memory.honcho import oauth
+
+    cfg = _cfg()
+    bound_path = Path("/profiles/named/honcho.json")
+    cfg.config_path = bound_path
+    observed_paths = []
+    monkeypatch.setattr(
+        client_module, "resolve_config_path", lambda: Path("/profiles/default/honcho.json")
+    )
+    monkeypatch.setattr(
+        oauth,
+        "ensure_fresh_token",
+        lambda path, host: (observed_paths.append(path) or None, False),
+    )
+
+    first = get_honcho_client(cfg)
+    second = get_honcho_client(cfg)
+
+    assert first is second
+    assert observed_paths == [bound_path, bound_path]
+
+
+def test_bound_profile_home_scopes_worker_config_fallback(monkeypatch, tmp_path):
+    from hermes_constants import get_hermes_home
+    from hermes_cli import config as hermes_config
+
+    cfg = _cfg()
+    cfg.timeout = None
+    cfg.base_url = None
+    cfg.hermes_home = tmp_path / "named-profile"
+    observed_homes = []
+
+    def load_bound_config():
+        observed_homes.append(get_hermes_home())
+        return {
+            "honcho": {
+                "timeout": 17,
+                "base_url": "http://127.0.0.1:38000/v3",
+            }
+        }
+
+    monkeypatch.setattr(hermes_config, "load_config", load_bound_config)
+    result = []
+    worker = threading.Thread(target=lambda: result.append(get_honcho_client(cfg)))
+    worker.start()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert len(result) == 1
+    assert observed_homes == [cfg.hermes_home]
+    assert getattr(result[0], "kwargs")["timeout"] == 17
+    assert getattr(result[0], "kwargs")["base_url"] == "http://127.0.0.1:38000"
+
+
+def test_cached_value_reset_in_same_slot_retries_before_return(monkeypatch):
+    cfg = _cfg()
+    first = get_honcho_client(cfg)
+    key = client_module._client_cache_key(cfg)
+    slot = client_module._client_slot_for(key)
+    acquired_old = threading.Event()
+    release = threading.Event()
+    original_get_from_slot = client_module._get_honcho_client_from_slot
+    worker_result = []
+    worker_ident = []
+
+    def pause_worker_after_acquire(config, cache_key, current_slot):
+        result = original_get_from_slot(config, cache_key, current_slot)
+        if threading.get_ident() == worker_ident[0]:
+            acquired_old.set()
+            assert release.wait(5)
+        return result
+
+    monkeypatch.setattr(
+        client_module, "_get_honcho_client_from_slot", pause_worker_after_acquire
+    )
+
+    def acquire_in_worker():
+        worker_ident.append(threading.get_ident())
+        worker_result.append(get_honcho_client(cfg))
+
+    worker = threading.Thread(target=acquire_in_worker)
+    worker.start()
+    assert acquired_old.wait(5)
+    slot.reset()
+    replacement = get_honcho_client(cfg)
+    release.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert replacement is not first
+    assert worker_result == [replacement]
+
+
+def test_global_reset_cannot_split_map_and_slot_validation(monkeypatch):
+    cfg = _cfg()
+    old = get_honcho_client(cfg)
+    key = client_module._client_cache_key(cfg)
+    slot = client_module._client_slot_for(key)
+    contains_entered = threading.Event()
+    release_contains = threading.Event()
+    reset_started = threading.Event()
+    reset_done = threading.Event()
+    worker_ident = []
+    worker_result = []
+    original_contains = type(slot).contains
+
+    def blocking_contains(self, value):
+        if self is slot and threading.get_ident() == worker_ident[0]:
+            contains_entered.set()
+            assert release_contains.wait(5)
+        return original_contains(self, value)
+
+    monkeypatch.setattr(type(slot), "contains", blocking_contains)
+
+    def acquire_cached():
+        worker_ident.append(threading.get_ident())
+        worker_result.append(get_honcho_client(cfg))
+
+    def reset_cache():
+        reset_started.set()
+        reset_honcho_client()
+        reset_done.set()
+
+    worker = threading.Thread(target=acquire_cached)
+    worker.start()
+    assert contains_entered.wait(5)
+    resetter = threading.Thread(target=reset_cache)
+    resetter.start()
+    assert reset_started.wait(5)
+    assert not reset_done.wait(0.05)
+
+    release_contains.set()
+    worker.join(5)
+    resetter.join(5)
+
+    assert not worker.is_alive()
+    assert not resetter.is_alive()
+    assert worker_result == [old]
+    assert reset_done.is_set()
+    assert get_honcho_client(cfg) is not old
+
+
+def test_get_or_create_uses_one_client_snapshot_across_refresh(monkeypatch):
+    first_peer_created = threading.Event()
+    release = threading.Event()
+
+    class RecordingHoncho(_Honcho):
+        def __init__(self, *, block_first_peer=False, **kwargs):
+            super().__init__(**kwargs)
+            self.block_first_peer = block_first_peer
+            self.peers = []
+            self.sessions = []
+
+        def peer(self, peer_id):
+            peer = super().peer(peer_id)
+            self.peers.append(peer)
+            if self.block_first_peer and len(self.peers) == 1:
+                first_peer_created.set()
+                assert release.wait(5)
+            return peer
+
+        def session(self, session_id):
+            session = super().session(session_id)
+            self.sessions.append(session)
+            return session
+
+    old = RecordingHoncho(workspace_id="old", block_first_peer=True)
+    new = RecordingHoncho(workspace_id="new")
+    current = [old]
+    manager = _manager_with_switchable_clients(monkeypatch, old, current)
+    worker_result = []
+    worker = threading.Thread(
+        target=lambda: worker_result.append(manager.get_or_create("key"))
+    )
+    worker.start()
+    assert first_peer_created.wait(5)
+
+    current[0] = new
+    assert manager.honcho is new
+    release.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert len(old.peers) == 2
+    assert len(old.sessions) == 1
+    assert new.peers == []
+    assert new.sessions == []
+    assert worker_result[0].key == "key"
+
+
+def test_native_init_threads_preserve_profile_home_context(monkeypatch, tmp_path):
+    from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+
+    homes = [tmp_path / "a", tmp_path / "b"]
+    for home in homes:
+        home.mkdir()
+    configs = [_cfg("a"), _cfg("b")]
+    seen = []
+    seen_lock = threading.Lock()
+
+    def record_init(self, cfg, session_id, **kwargs):
+        with seen_lock:
+            seen.append((cfg, get_hermes_home()))
+        self._session_initialized = True
+
+    monkeypatch.setattr(HonchoMemoryProvider, "_do_session_init", record_init)
+    providers = []
+    for cfg, home in zip(configs, homes):
+        provider = HonchoMemoryProvider()
+        provider._config = cfg
+        provider._lazy_init_kwargs = {}
+        provider._lazy_init_session_id = cfg.workspace_id
+        token = set_hermes_home_override(home)
+        try:
+            provider._start_session_init_background()
+        finally:
+            reset_hermes_home_override(token)
+        providers.append(provider)
+
+    for provider in providers:
+        provider._init_thread.join(5)
+    assert sorted((cfg.workspace_id, home) for cfg, home in seen) == [
+        ("a", homes[0]),
+        ("b", homes[1]),
+    ]

--- a/tests/test_honcho_session_context.py
+++ b/tests/test_honcho_session_context.py
@@ -49,6 +49,7 @@ def _manager_with_cached_session(*, ai_observe_others=True):
     fake_honcho_session = _RecordingHonchoSession()
     mgr._cache[session.key] = session
     mgr._sessions_cache[session.honcho_session_id] = fake_honcho_session
+    mgr._session_cache_owners[session.honcho_session_id] = mgr._honcho
     return mgr, fake_honcho_session
 
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -115,6 +115,17 @@ def test_slot_reset():
     assert slot.get(lambda: "b") == "b"
 
 
+def test_slot_contains_tracks_identity_across_reset():
+    slot: SingletonSlot = SingletonSlot()
+    first = object()
+    other = object()
+    slot.get(lambda: first)
+    assert slot.contains(first)
+    assert not slot.contains(other)
+    slot.reset()
+    assert not slot.contains(first)
+
+
 def test_slot_factory_exception_not_cached():
     slot: SingletonSlot = SingletonSlot()
 


### PR DESCRIPTION
## What does this PR do?

This is a **stacked draft on #69142**. Its first commit is the exact #69142 head (`e383f39bf`), preserving NaMinhyeok's original authorship and commit. The second commit is the lifecycle/cache-coherence follow-up reviewed here.

Long-lived Hermes processes can replace Honcho clients after timeout changes, OAuth fallback, profile routing, or explicit reset. Dropping the old cache entry without lifecycle handling leaves its eager synchronous HTTP transport alive until process exit. Closing it immediately is also unsafe because in-flight SDK `Peer`/`Session` objects may still use it.

This follow-up therefore retires Hermes-owned synchronous transports **after final client reachability**, and keeps all dependent caches coherent while clients are replaced. It deliberately does not instantiate or close the Honcho SDK's lazy async transport.

## Dependency / sequencing

- Depends on #69142 (`e383f39bf`) for per-config client slots.
- #81401 remains draft until #69142 lands.
- After #69142 merges, this branch should be rebased onto the resulting `main`; the exact #69142 commit is included now only to preserve a reviewable stacked topology and contributor credit.

## Changes made

### Client lifecycle

- Register a `weakref.finalize` callback for Hermes-created Honcho clients.
- Close only the eager synchronous `_http` transport after the client is no longer reachable.
- Read Pydantic private attributes through `__pydantic_private__`, with legacy/fake-object fallback.
- Leave `_async_http` lazy and untouched.

### Atomic cache replacement

- Validate slot-map identity and slot value in one synchronized operation across reset.
- Isolate explicit clients by effective timeout, profile home, credential path, host, workspace, base URL, and environment.
- Keep timeout metadata synchronized independently from slot-map locking.
- Retry acquisitions whose slot/value was displaced by reset, timeout refresh, or OAuth fallback.
- Rebuild during the current acquisition when an OAuth token cannot be applied in place.

### Profile isolation

- Bind the resolved `honcho.json` path and Hermes profile home to `HonchoClientConfig`.
- Resolve OAuth and `config.yaml` fallbacks under that bound profile, including context-blind native worker threads.
- Bind `HonchoSessionManager` to its resolved config rather than ambient profile state.

### Peer/session cache coherence

- Reject cached SDK `Peer` and `Session` children owned by a displaced client, including real Honcho 2.2.0 Pydantic `PrivateAttr` ownership.
- Propagate one client snapshot through multi-object operations so peers and sessions cannot mix generations.
- Avoid Honcho/network acquisition while holding the local session cache lock.
- Serialize session rotation without lock inversion.
- Use compare-before-publish for concurrent first creation and old flushes.
- Prevent old in-flight flushes from undoing rotation.
- Generate collision-resistant session rotation keys.

## How to test

Canonical focused selection:

```bash
scripts/run_tests.sh tests/honcho_plugin tests/test_honcho*.py tests/test_plugin_utils.py
```

Result on macOS 26.6 / Hermes Python with `honcho-ai==2.2.0`:

- **486 passed, 0 failed**

Lint and whitespace:

```bash
uvx --from ruff==0.15.10 ruff check \
  plugins/plugin_utils.py \
  plugins/memory/honcho/__init__.py \
  plugins/memory/honcho/client.py \
  plugins/memory/honcho/session.py \
  tests/test_plugin_utils.py \
  tests/honcho_plugin/test_async_memory.py \
  tests/honcho_plugin/test_session.py \
  tests/test_honcho_client_config.py \
  tests/test_honcho_client_retirement.py \
  tests/test_honcho_session_context.py
git diff --check
```

Both passed.

Scoped `ty` output matches the exact #69142 base: 14 diagnostics in the expanded scope, with no new diagnostics introduced by this follow-up.

Two independent final reviewers evaluated exact tree `5e7070deed090c761bf0a0038eceebcbfd005fd1` and returned PASS. Critical lifecycle/race tests were repeated 30 times without failure.

## Runtime evidence

The live dashboard remained healthy during read-only verification:

- one listener on port 9119;
- 224 descriptor rows;
- zero `CLOSE_WAIT` sockets;
- HTTP response in 0.017 seconds.

The reviewed branch was not deployed into the live checkout for this verification.

## Type of change

- [x] Bug fix
- [x] Concurrency/resource-lifecycle hardening
- [x] Tests
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Preserves #69142's exact commit and author credit
- [x] No unrelated BlueBubbles changes
- [x] Real Honcho 2.2.0 behavior covered
- [x] Deterministic reset/OAuth/timeout/session race coverage
- [x] Focused canonical tests pass
- [x] Ruff and whitespace checks pass
- [x] Cross-platform implementation uses Python locks/contextvars/weakref only
- [ ] Rebase onto `main` after #69142 merges
- [ ] Mark ready after stacked dependency is resolved and GitHub CI is green
