### PR TITLE
fix(models): route GPT-5 models on opencode-go via codex_responses

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4179,6 +4179,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     if provider == "opencode-go":
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
+        if normalized.startswith("gpt-"):
+            # GPT-5 models on Go (gpt-5.6-luna) are served via /v1/responses
+            # per the published Go endpoint table.
+            return "codex_responses"
         if normalized.startswith("qwen"):
             # All Qwen models on Go (qwen3.7-max, qwen3.7-plus, qwen3.6-plus)
             # are served via /v1/messages per the published Go endpoint table.

--- a/tests/hermes_cli/test_model_switch_opencode_anthropic.py
+++ b/tests/hermes_cli/test_model_switch_opencode_anthropic.py
@@ -92,6 +92,19 @@ class TestOpenCodeGoV1Strip:
             f"Expected /v1 stripped for anthropic_messages; got {result.base_url}"
         )
 
+    def test_switch_to_gpt_uses_codex_responses_keeps_v1(self):
+        """GPT on opencode-go uses codex_responses api_mode — /v1 kept."""
+        result = _run_opencode_switch(
+            raw_input="gpt-5.6-luna",
+            current_provider="opencode-go",
+            current_model="glm-5",
+            current_base_url="https://opencode.ai/zen/go/v1",
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+        assert result.api_mode == "codex_responses"
+        assert result.base_url == "https://opencode.ai/zen/go/v1"
+
 
 class TestOpenCodeZenV1Strip:
     """OpenCode Zen: ``/model claude-*`` must strip /v1."""


### PR DESCRIPTION
## What does this PR do?

`opencode_model_api_mode()` maps `gpt-*` models to `codex_responses` only for the `opencode-zen` provider. On `opencode-go`, `gpt-*` models (e.g. `gpt-5.6-luna`) fall through to `chat_completions` — the wrong API surface per the published OpenCode Go endpoint table (`/v1/responses` for GPT-5 / Codex models).

This aligns the Go branch with the existing Zen branch: `gpt-*` on `opencode-go` now returns `codex_responses`.

## Related context

- Companion issue #75801 (OpenCode Go `gpt-5.6-luna` omits `finish_reason`): PR #76112 fixes the streaming classification half of that issue. This PR is the **api_mode routing half** — without correct `codex_responses` routing, GPT-5 models on Go hit the wrong endpoint surface.
- `tests/hermes_cli/test_model_switch_opencode_anthropic.py` previously covered Go only for `minimax-*` (anthropic_messages) and Zen for `gpt-*` (codex_responses); this adds the missing Go + `gpt-*` case.

## Changes Made

- `hermes_cli/models.py`: in `opencode_model_api_mode`, return `codex_responses` for `gpt-*` on `opencode-go` (mirrors the `opencode-zen` branch).
- `tests/hermes_cli/test_model_switch_opencode_anthropic.py`: add `test_switch_to_gpt_uses_codex_responses_keeps_v1` under `TestOpenCodeGoV1Strip`.

## Tests

```bash
venv/bin/python3 -m pytest tests/hermes_cli/test_model_switch_opencode_anthropic.py -q
# 5 passed
venv/bin/python3 -m pytest tests/hermes_cli/ -q -k "api_mode or opencode or switch"
# 209 passed
```