### PR TITLE
feat(cronjob): add get action and include_prompt for full prompt access

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,69 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_get_returns_full_prompt(self):
+        long_prompt = "Inspect the current job before editing. " * 8
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt=long_prompt,
+                schedule="every 1h",
+                name="Inspectable",
+            )
+        )
+        result = json.loads(cronjob(action="get", job_id=created["job_id"]))
+        assert result["success"] is True
+        assert result["job"]["job_id"] == created["job_id"]
+        assert result["job"]["name"] == "Inspectable"
+        assert result["job"]["prompt"] == long_prompt
+        assert result["job"]["prompt_preview"].endswith("...")
+
+    def test_show_alias_resolves_by_name(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Full prompt by name",
+                schedule="every 1h",
+                name="named-inspection-job",
+            )
+        )
+        result = json.loads(cronjob(action="show", job_id="named-inspection-job"))
+        assert result["success"] is True
+        assert result["job"]["job_id"] == created["job_id"]
+        assert result["job"]["prompt"] == "Full prompt by name"
+
+    def test_get_missing_job_returns_error(self):
+        result = json.loads(cronjob(action="get", job_id="nonexistent"))
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    def test_list_default_excludes_full_prompt(self):
+        long_prompt = "A prompt long enough to be truncated in preview. " * 5
+        cronjob(action="create", prompt=long_prompt, schedule="every 1h")
+        listing = json.loads(cronjob(action="list"))
+        assert "prompt" not in listing["jobs"][0]
+        assert listing["jobs"][0]["prompt_preview"].endswith("...")
+
+    def test_list_include_prompt_returns_full_text(self):
+        long_prompt = "A prompt long enough to be truncated in preview. " * 5
+        cronjob(action="create", prompt=long_prompt, schedule="every 1h")
+        listing = json.loads(cronjob(action="list", include_prompt=True))
+        assert listing["jobs"][0]["prompt"] == long_prompt
+
+    def test_update_include_prompt_echoes_full_text(self):
+        created = json.loads(cronjob(action="create", prompt="old", schedule="every 1h"))
+        new_prompt = "new full prompt text"
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                prompt=new_prompt,
+                include_prompt=True,
+            )
+        )
+        assert result["success"] is True
+        assert result["job"]["prompt"] == new_prompt
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -553,7 +553,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
-def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _format_job(job: Dict[str, Any], *, include_prompt: bool = False) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
@@ -594,6 +594,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if include_prompt:
+        result["prompt"] = prompt
     return result
 
 
@@ -1052,6 +1054,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    include_prompt: bool = False,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1166,7 +1169,10 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            jobs = [
+                _format_job(job, include_prompt=include_prompt)
+                for job in list_jobs(include_disabled=include_disabled)
+            ]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
@@ -1198,6 +1204,26 @@ def cronjob(
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
+
+        if normalized in {"get", "show"}:
+            from cron.jobs import get_job
+
+            full_job = get_job(job_id) or job
+            formatted = _format_job(full_job, include_prompt=True)
+            # Include fields that are too verbose or internal for the compact
+            # list view but useful when inspecting a single job in detail.
+            for key in (
+                "schedule",
+                "repeat",
+                "origin",
+                "context_from",
+                "created_at",
+                "last_error",
+            ):
+                val = full_job.get(key)
+                if val is not None:
+                    formatted[key] = val
+            return json.dumps({"success": True, "job": formatted}, indent=2)
 
         if normalized == "remove":
             removed = remove_job(job_id)
@@ -1430,7 +1456,10 @@ def cronjob(
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
             _notify_provider_jobs_changed_safe()
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps(
+                {"success": True, "job": _format_job(updated, include_prompt=include_prompt)},
+                indent=2,
+            )
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 
@@ -1444,7 +1473,8 @@ CRONJOB_SCHEMA = {
     "description": """Manage scheduled cron jobs with a single compressed tool.
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
-Use action='list' to inspect jobs.
+Use action='list' to inspect jobs (shows only a 100-char prompt preview).
+Use action='get' with a job_id to read one job's FULL prompt and config — use this before editing to review the exact stored text. 'show' is an alias for 'get'.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
 action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue. Optionally pass 'prompt' with action='run' to inject transient per-run context (appended to the job's stored prompt for that single fire only, never persisted).
@@ -1465,11 +1495,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, get, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED. Use action='get' to read a job's full prompt before editing."
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for get/update/pause/resume/remove/run"
             },
             "prompt": {
                 "type": "string",
@@ -1552,6 +1582,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "include_prompt": {
+                "type": "boolean",
+                "default": False,
+                "description": "When True, include the job's full prompt in the response for action='list' and action='update'. Default is False (only a 100-char prompt_preview is returned). Set to True to audit or back up the exact prompt text. action='get' always includes the full prompt regardless of this flag."
+            },
         },
         "required": ["action"]
     }
@@ -1611,6 +1646,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        include_prompt=args.get("include_prompt", False),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1206,8 +1206,6 @@ def cronjob(
         job_id = job["id"]
 
         if normalized in {"get", "show"}:
-            from cron.jobs import get_job
-
             full_job = get_job(job_id) or job
             formatted = _format_job(full_job, include_prompt=True)
             # Include fields that are too verbose or internal for the compact


### PR DESCRIPTION
## What

Add `cronjob(action="get", job_id=...)` and `include_prompt=True` on `list`/`update` so sandboxed agents can read a cron job's full stored prompt — the one capability they were missing.

## Why

Issue #18374: sandboxed agents can create/update/remove/run cron jobs but cannot retrieve the full prompt text. `action='list'` only returns a 100-char `prompt_preview`. Without the full prompt, the agent cannot audit, back up, or safely review the exact text before editing.

## Changes

**`tools/cronjob_tools.py`** (+42/−6):

1. **`action='get'` (alias `'show'`)** — returns the full job record including the complete `prompt`, plus extra metadata fields useful for single-job inspection: `schedule`, `repeat`, `origin`, `context_from`, `created_at`, `last_error`. Uses the existing `resolve_job_ref` path, so `job_id` accepts both IDs and names with the same ambiguity/not-found error handling as other actions.

2. **`include_prompt=True`** on `action='list'` and `action='update'` — opt-in flag that includes the full `prompt` field in each job entry. Default is `False` (preview-only) to avoid accidentally dumping long/sensitive prompt bodies.

3. **Schema updates** — the `action` description now lists `get` and says "Use action='get' to read a job's full prompt before editing." The `job_id` description adds `get` to the required-actions list. New `include_prompt` parameter documented in the schema. The tool description text explains that `list` shows only a preview and `get` reads the full prompt.

## Design choices

- **Both Option A and Option B** from the issue are implemented — `get` for single-job inspection and `include_prompt` for bulk list/export.
- **`get` re-fetches via `get_job()`** to ensure the freshest state, not the resolved ref (which may be stale if another process modified the job).
- **Default stays preview-only** — full prompt access requires explicit opt-in via `get` or `include_prompt=True`.
- **No CLI changes** — the issue specifically asks for the model/tool API exposed to agents. CLI `hermes cron show` is a separate concern (covered by #32772, #43031, #77876).
- **No `edit_hint` field** — the schema description already guides the agent to `get` before editing. Adding an `edit_hint` to every `get` response (as #53168 proposed) is noise.

## Community PRs

Five community PRs addressed this issue — all are `mergeable: dirty` (conflicts with current main):

| PR | Author | Approach | State |
|----|--------|----------|-------|
| #32772 | joe102084 | CLI + tool, 6 files | dirty |
| #43031 | joe102084 | rebased #32772 | dirty |
| #48107 | mgmelanson | tool only, `get` + `include_prompt` | dirty |
| #53168 | rtmoore4 | tool only, `get` + `edit_hint` | closed |
| #77876 | Moun1r1 | CLI + tool, 6 files | dirty |

This PR combines the best ideas (both `get` and `include_prompt` from #48107, clean `_format_job` extension) rebased onto current main HEAD.

## Test results

74 passed (68 existing + 6 new):
- `test_get_returns_full_prompt` — verifies full prompt is returned
- `test_show_alias_resolves_by_name` — verifies name-based lookup
- `test_get_missing_job_returns_error` — verifies error handling
- `test_list_default_excludes_full_prompt` — verifies default is preview-only
- `test_list_include_prompt_returns_full_text` — verifies opt-in
- `test_update_include_prompt_echoes_full_text` — verifies update echo

All other cron-related test suites pass (100+ tests). The only failures are pre-existing missing-dependency issues (`croniter`, `starlette`, `fastapi`) unrelated to this change.

Closes #18374