### PR TITLE
fix(hooks): register shell hooks in profile-scoped UI runtimes

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -294,6 +294,32 @@ def register_from_current_config(
     return register_from_config(load_config(), accept_hooks=accept_hooks)
 
 
+def register_profile_scoped_child_hooks(*, runtime_name: str) -> None:
+    """Register current-profile hooks in an isolated UI child process."""
+    if os.environ.get("HERMES_PROFILE_SCOPED_UI") != "1":
+        return
+
+    # Preserve CLI security precedence: plugin policy directives run before
+    # shell-hook directives.
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        logger.debug(
+            "Plugin discovery failed at %s startup", runtime_name, exc_info=True
+        )
+
+    try:
+        register_from_current_config(accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at %s startup",
+            runtime_name,
+            exc_info=True,
+        )
+
+
 def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     """Return the parsed ``ShellHookSpec`` entries from config without
     registering anything.  Used by ``hermes hooks list`` and ``doctor``."""

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -285,6 +285,15 @@ def register_from_config(
     return registered
 
 
+def register_from_current_config(
+    *, accept_hooks: bool = False,
+) -> List[ShellHookSpec]:
+    """Load the current profile config and register its shell hooks."""
+    from hermes_cli.config import load_config
+
+    return register_from_config(load_config(), accept_hooks=accept_hooks)
+
+
 def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     """Return the parsed ``ShellHookSpec`` entries from config without
     registering anything.  Used by ``hermes hooks list`` and ``doctor``."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10508,6 +10508,24 @@ def cmd_dashboard(args):
     # fail-closed SystemExit unchanged.
     _maybe_setup_dashboard_auth_interactively(args)
 
+    # Desktop starts one backend per profile, so process-global shell hooks are
+    # scoped to that profile. The browser dashboard can serve several profiles
+    # and must not register its launch profile's hooks globally. Register after
+    # interactive auth setup because that path can force plugin rediscovery and
+    # clear the process-local hook registry.
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        # Turn-isolation children inherit this profile-scope marker.
+        os.environ["HERMES_PROFILE_SCOPED_UI"] = "1"
+        try:
+            from agent.shell_hooks import register_from_current_config
+
+            register_from_current_config(accept_hooks=False)
+        except Exception:
+            logger.debug(
+                "shell-hook registration failed at Desktop backend startup",
+                exc_info=True,
+            )
+
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.

--- a/tests/hermes_cli/test_dashboard_shell_hooks.py
+++ b/tests/hermes_cli/test_dashboard_shell_hooks.py
@@ -1,0 +1,183 @@
+"""Desktop shell-hook registration regression tests."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import types
+
+import pytest
+import yaml
+
+from agent import shell_hooks
+from hermes_cli import plugins
+from hermes_cli.plugins import get_pre_tool_call_block_message
+
+
+def _args(**overrides):
+    defaults = {
+        "headless_backend": True,
+        "host": "127.0.0.1",
+        "insecure": False,
+        "isolated": True,
+        "no_open": True,
+        "open_profile": "",
+        "port": 0,
+        "skip_build": False,
+        "ssh_owner_nonce": None,
+        "ssh_session_token_file": None,
+        "status": False,
+        "stop": False,
+    }
+    defaults.update(overrides)
+    return types.SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_hook_registry():
+    previous_manager = plugins._plugin_manager
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = previous_manager
+    os.environ.pop("HERMES_PROFILE_SCOPED_UI", None)
+
+
+def _configure_allowlisted_block_hook(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "hermes-home"
+    script = tmp_path / "block.py"
+    script.write_text(
+        "import json, sys\n"
+        "json.load(sys.stdin)\n"
+        'print(\'{"action": "block", "message": "desktop-hook-fired"}\')\n',
+        encoding="utf-8",
+    )
+    command = shlex.join([sys.executable, str(script)])
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "hooks": {
+                "pre_tool_call": [
+                    {"command": command, "matcher": "terminal"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    shell_hooks._record_approval("pre_tool_call", command)
+
+
+def _stub_dashboard_runtime(main_mod, monkeypatch, events) -> None:
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr("hermes_cli.config.apply_terminal_config_to_env", lambda: None)
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: events.append("plugins"))
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **_kwargs: events.append("mcp"),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_maybe_setup_dashboard_auth_interactively",
+        lambda _args: events.append("auth"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_logging",
+        types.SimpleNamespace(setup_logging=lambda **_kwargs: None),
+    )
+    monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **_kwargs: events.append("server")),
+    )
+
+
+def test_desktop_registers_allowlisted_hook_after_auth(tmp_path, monkeypatch):
+    import hermes_cli.main as main_mod
+
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    events = []
+    _stub_dashboard_runtime(main_mod, monkeypatch, events)
+
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    main_mod.cmd_dashboard(_args())
+
+    assert events == ["plugins", "mcp", "auth", ("hooks", False), "server"]
+    assert os.environ["HERMES_PROFILE_SCOPED_UI"] == "1"
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo should-not-run"})
+        == "desktop-hook-fired"
+    )
+
+
+def test_browser_dashboard_does_not_register_profile_hooks(tmp_path, monkeypatch):
+    import hermes_cli.main as main_mod
+
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    events = []
+    _stub_dashboard_runtime(main_mod, monkeypatch, events)
+
+    main_mod.cmd_dashboard(_args())
+
+    assert events == ["plugins", "mcp", "auth", "server"]
+    assert os.environ.get("HERMES_PROFILE_SCOPED_UI") is None
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo allowed"}) is None
+    )
+
+
+def test_desktop_registration_failure_does_not_block_server(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    events = []
+    _stub_dashboard_runtime(main_mod, monkeypatch, events)
+
+    def fail_registration(_cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        raise RuntimeError("test registration failure")
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", fail_registration)
+
+    main_mod.cmd_dashboard(_args())
+
+    assert events == ["plugins", "mcp", "auth", ("hooks", False), "server"]
+
+
+@pytest.mark.parametrize("flag", ["status", "stop"])
+def test_desktop_lifecycle_commands_do_not_register_hooks(monkeypatch, flag):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(main_mod, "_report_dashboard_status", lambda: 0)
+    monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
+
+    calls = []
+    monkeypatch.setattr(
+        shell_hooks,
+        "register_from_config",
+        lambda *_args, **_kwargs: calls.append(True),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.cmd_dashboard(_args(**{flag: True}))
+
+    assert exc_info.value.code == 0
+    assert calls == []

--- a/tests/tui_gateway/test_compute_host_shell_hooks.py
+++ b/tests/tui_gateway/test_compute_host_shell_hooks.py
@@ -1,0 +1,129 @@
+"""Turn-isolated compute-host shell-hook registration tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import shlex
+import sys
+
+import pytest
+import yaml
+
+from agent import shell_hooks
+from hermes_cli import plugins
+from hermes_cli.plugins import get_pre_tool_call_block_message
+from tui_gateway import compute_host
+
+
+@pytest.fixture(autouse=True)
+def _fresh_hook_registry(monkeypatch):
+    previous_manager = plugins._plugin_manager
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    monkeypatch.setenv("HERMES_COMPUTE_HOST_CHILD", "0")
+    monkeypatch.setenv("HERMES_COMPUTE_HOST_HEARTBEAT_SECS", "0")
+    yield
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = previous_manager
+
+
+def _configure_allowlisted_block_hook(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "hermes-home"
+    script = tmp_path / "block.py"
+    script.write_text(
+        "import json, sys\n"
+        "json.load(sys.stdin)\n"
+        'print(\'{"action": "block", "message": "compute-hook-fired"}\')\n',
+        encoding="utf-8",
+    )
+    command = shlex.join([sys.executable, str(script)])
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "hooks": {
+                "pre_tool_call": [
+                    {"command": command, "matcher": "terminal"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    shell_hooks._record_approval("pre_tool_call", command)
+
+
+def _run_host(monkeypatch, events) -> list[dict]:
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: events.append("plugins"))
+    original_emit = compute_host.ComputeHost.emit
+
+    def emit(host, frame):
+        if frame.get("type") == "hello":
+            events.append("hello")
+        return original_emit(host, frame)
+
+    monkeypatch.setattr(compute_host.ComputeHost, "emit", emit)
+    stdout = io.StringIO()
+    compute_host.run_host(stdin=io.StringIO(""), stdout=stdout)
+    return [json.loads(line) for line in stdout.getvalue().splitlines()]
+
+
+def test_compute_host_registers_allowlisted_hook_before_hello(tmp_path, monkeypatch):
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_PROFILE_SCOPED_UI", "1")
+    events = []
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    frames = _run_host(monkeypatch, events)
+
+    assert events == ["plugins", ("hooks", False), "hello"]
+    assert frames[0]["type"] == "hello"
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo should-not-run"})
+        == "compute-hook-fired"
+    )
+
+
+def test_compute_host_registration_failure_does_not_block_hello(monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE_SCOPED_UI", "1")
+    events = []
+
+    def fail_registration(_cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        raise RuntimeError("test registration failure")
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", fail_registration)
+
+    frames = _run_host(monkeypatch, events)
+
+    assert events == ["plugins", ("hooks", False), "hello"]
+    assert frames[0]["type"] == "hello"
+
+
+def test_shared_dashboard_compute_host_does_not_register_profile_hooks(
+    tmp_path, monkeypatch
+):
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_PROFILE_SCOPED_UI", raising=False)
+    events = []
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    frames = _run_host(monkeypatch, events)
+
+    assert events == ["hello"]
+    assert frames[0]["type"] == "hello"
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo allowed"}) is None
+    )

--- a/tests/tui_gateway/test_entry_shell_hooks.py
+++ b/tests/tui_gateway/test_entry_shell_hooks.py
@@ -1,0 +1,154 @@
+"""Standalone TUI shell-hook registration regression tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shlex
+import sys
+
+import pytest
+import yaml
+
+from agent import shell_hooks
+from hermes_cli import plugins
+from hermes_cli.plugins import (
+    get_pre_tool_call_block_message,
+    get_pre_tool_call_directive,
+)
+from tui_gateway import entry
+
+
+@pytest.fixture(autouse=True)
+def _fresh_hook_registry():
+    previous_manager = plugins._plugin_manager
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = previous_manager
+    os.environ.pop("HERMES_PROFILE_SCOPED_UI", None)
+
+
+def _configure_allowlisted_hook(
+    tmp_path,
+    monkeypatch,
+    *,
+    action: str = "block",
+    message: str = "tui-hook-fired",
+) -> None:
+    home = tmp_path / "hermes-home"
+    script = tmp_path / "hook.py"
+    directive = json.dumps({"action": action, "message": message})
+    script.write_text(
+        f"import json, sys\njson.load(sys.stdin)\nprint({directive!r})\n",
+        encoding="utf-8",
+    )
+    command = shlex.join([sys.executable, str(script)])
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "hooks": {
+                "pre_tool_call": [
+                    {"command": command, "matcher": "terminal"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    shell_hooks._record_approval("pre_tool_call", command)
+
+
+def _stub_tui_runtime(monkeypatch, events) -> None:
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: {})
+    monkeypatch.setattr(entry.server, "_ensure_skin_watcher", lambda: None)
+    monkeypatch.setattr(entry, "handle_spurious_eof", lambda *_args: False)
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: events.append("plugins"))
+    monkeypatch.setattr(
+        entry,
+        "write_json",
+        lambda message: events.append(message["params"]["type"]) or True,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.prewarm_picker_cache_async", lambda: None
+    )
+
+
+def test_tui_registers_allowlisted_hook_before_ready(tmp_path, monkeypatch):
+    _configure_allowlisted_hook(tmp_path, monkeypatch)
+    events = []
+    _stub_tui_runtime(monkeypatch, events)
+
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    entry.main()
+
+    assert events == ["plugins", ("hooks", False), "gateway.ready"]
+    assert os.environ["HERMES_PROFILE_SCOPED_UI"] == "1"
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo should-not-run"})
+        == "tui-hook-fired"
+    )
+
+
+def test_tui_registration_failure_does_not_block_ready(monkeypatch):
+    events = []
+    _stub_tui_runtime(monkeypatch, events)
+
+    def fail_registration(_cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        raise RuntimeError("test registration failure")
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", fail_registration)
+
+    entry.main()
+
+    assert events == ["plugins", ("hooks", False), "gateway.ready"]
+
+
+def test_plugin_approval_precedes_shell_hook_block(tmp_path, monkeypatch):
+    _configure_allowlisted_hook(
+        tmp_path,
+        monkeypatch,
+        action="block",
+        message="shell-blocked",
+    )
+    events = []
+    _stub_tui_runtime(monkeypatch, events)
+
+    def discover_plugins():
+        events.append("plugins")
+        plugins.get_plugin_manager()._hooks.setdefault("pre_tool_call", []).append(
+            lambda **_kwargs: {
+                "action": "approve",
+                "message": "plugin-approval",
+            }
+        )
+
+    monkeypatch.setattr(plugins, "discover_plugins", discover_plugins)
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    entry.main()
+
+    assert events == ["plugins", ("hooks", False), "gateway.ready"]
+    assert get_pre_tool_call_directive("terminal", {"command": "echo guarded"}) == (
+        "approve",
+        "plugin-approval",
+    )

--- a/tests/tui_gateway/test_slash_worker_shell_hooks.py
+++ b/tests/tui_gateway/test_slash_worker_shell_hooks.py
@@ -1,0 +1,149 @@
+"""Profile-scoped slash-worker shell-hook registration tests."""
+
+from __future__ import annotations
+
+import io
+import os
+import shlex
+import sys
+
+import pytest
+import yaml
+
+from agent import shell_hooks
+from hermes_cli import plugins
+from hermes_cli.plugins import get_pre_tool_call_block_message
+from tui_gateway import slash_worker
+
+
+@pytest.fixture(autouse=True)
+def _fresh_hook_registry():
+    previous_manager = plugins._plugin_manager
+    previous_session_key = os.environ.get("HERMES_SESSION_KEY")
+    previous_interactive = os.environ.get("HERMES_INTERACTIVE")
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = previous_manager
+    for key, previous in (
+        ("HERMES_SESSION_KEY", previous_session_key),
+        ("HERMES_INTERACTIVE", previous_interactive),
+    ):
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
+def _configure_allowlisted_block_hook(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "hermes-home"
+    script = tmp_path / "block.py"
+    script.write_text(
+        "import json, sys\n"
+        "json.load(sys.stdin)\n"
+        'print(\'{"action": "block", "message": "slash-hook-fired"}\')\n',
+        encoding="utf-8",
+    )
+    command = shlex.join([sys.executable, str(script)])
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "hooks": {
+                "pre_tool_call": [
+                    {"command": command, "matcher": "terminal"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    shell_hooks._record_approval("pre_tool_call", command)
+
+
+def _stub_worker_runtime(monkeypatch, events) -> None:
+    monkeypatch.setattr(
+        slash_worker.sys,
+        "argv",
+        ["slash_worker", "--session-key", "agent:main:tui:dm:shell-hook-test"],
+    )
+    monkeypatch.setattr(slash_worker.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(
+        slash_worker, "_start_parent_death_watchdog", lambda _ppid: None
+    )
+    monkeypatch.setattr(
+        slash_worker,
+        "_prepare_slash_worker_runtime",
+        lambda: events.append("mcp"),
+    )
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: events.append("plugins"))
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            events.append("cli")
+
+    monkeypatch.setattr(slash_worker, "HermesCLI", FakeCLI)
+
+
+def test_slash_worker_registers_allowlisted_hook_before_cli(tmp_path, monkeypatch):
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_PROFILE_SCOPED_UI", "1")
+    events = []
+    _stub_worker_runtime(monkeypatch, events)
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    slash_worker.main()
+
+    assert events == ["plugins", ("hooks", False), "mcp", "cli"]
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo should-not-run"})
+        == "slash-hook-fired"
+    )
+
+
+def test_slash_worker_registration_failure_does_not_block_cli(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE_SCOPED_UI", "1")
+    events = []
+    _stub_worker_runtime(monkeypatch, events)
+
+    def fail_registration(_cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        raise RuntimeError("test registration failure")
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", fail_registration)
+
+    slash_worker.main()
+
+    assert events == ["plugins", ("hooks", False), "mcp", "cli"]
+
+
+def test_shared_dashboard_slash_worker_does_not_register_profile_hooks(
+    tmp_path, monkeypatch
+):
+    _configure_allowlisted_block_hook(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_PROFILE_SCOPED_UI", raising=False)
+    events = []
+    _stub_worker_runtime(monkeypatch, events)
+    original_register = shell_hooks.register_from_config
+
+    def register(cfg, *, accept_hooks):
+        events.append(("hooks", accept_hooks))
+        return original_register(cfg, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", register)
+
+    slash_worker.main()
+
+    assert events == ["mcp", "cli"]
+    assert (
+        get_pre_tool_call_block_message("terminal", {"command": "echo allowed"}) is None
+    )

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -11,6 +11,7 @@ import argparse
 import concurrent.futures
 import contextlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -23,6 +24,9 @@ from pathlib import Path
 from typing import Any, Callable, Collection
 
 from agent.interrupt_compat import request_hard_interrupt
+
+
+logger = logging.getLogger(__name__)
 
 
 def now_ns() -> int:
@@ -826,6 +830,31 @@ def _default_workers() -> int:
 
 def run_host(stdin: Any = None, stdout: Any = None) -> None:
     os.environ["HERMES_COMPUTE_HOST_CHILD"] = "1"
+
+    # Turn-isolated sessions run entirely in this child process, so a
+    # profile-scoped parent marks the runtime before spawning it. A generic
+    # browser dashboard can serve multiple profiles through one compute host
+    # and must not register its launch profile's hooks globally.
+    if os.environ.get("HERMES_PROFILE_SCOPED_UI") == "1":
+        # Preserve CLI security precedence: plugin policy directives run before
+        # shell-hook directives.
+        try:
+            from hermes_cli.plugins import discover_plugins
+
+            discover_plugins()
+        except Exception:
+            logger.debug("Plugin discovery failed at compute-host startup", exc_info=True)
+
+        try:
+            from agent.shell_hooks import register_from_current_config
+
+            register_from_current_config(accept_hooks=False)
+        except Exception:
+            logger.debug(
+                "shell-hook registration failed at compute-host startup",
+                exc_info=True,
+            )
+
     stdin = stdin or sys.stdin
     host = ComputeHost(stdout=stdout or sys.stdout)
     shutting_down = threading.Event()

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -831,29 +831,17 @@ def _default_workers() -> int:
 def run_host(stdin: Any = None, stdout: Any = None) -> None:
     os.environ["HERMES_COMPUTE_HOST_CHILD"] = "1"
 
-    # Turn-isolated sessions run entirely in this child process, so a
-    # profile-scoped parent marks the runtime before spawning it. A generic
-    # browser dashboard can serve multiple profiles through one compute host
-    # and must not register its launch profile's hooks globally.
-    if os.environ.get("HERMES_PROFILE_SCOPED_UI") == "1":
-        # Preserve CLI security precedence: plugin policy directives run before
-        # shell-hook directives.
-        try:
-            from hermes_cli.plugins import discover_plugins
+    # Turn-isolated sessions run entirely in this child process. The shared
+    # helper's profile marker prevents launch-profile hooks from leaking into a
+    # generic multi-profile browser Dashboard.
+    try:
+        from agent.shell_hooks import register_profile_scoped_child_hooks
 
-            discover_plugins()
-        except Exception:
-            logger.debug("Plugin discovery failed at compute-host startup", exc_info=True)
-
-        try:
-            from agent.shell_hooks import register_from_current_config
-
-            register_from_current_config(accept_hooks=False)
-        except Exception:
-            logger.debug(
-                "shell-hook registration failed at compute-host startup",
-                exc_info=True,
-            )
+        register_profile_scoped_child_hooks(runtime_name="compute host")
+    except Exception:
+        logger.debug(
+            "profile-scoped hook setup failed at compute-host startup", exc_info=True
+        )
 
     stdin = stdin or sys.stdin
     host = ComputeHost(stdout=stdout or sys.stdout)

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -420,6 +420,31 @@ def ensure_mcp_discovery_started() -> None:
 
 def main():
     _install_sidecar_publisher()
+    # Turn-isolation children inherit this profile-scope marker.
+    os.environ["HERMES_PROFILE_SCOPED_UI"] = "1"
+
+    # Preserve CLI security precedence: plugin policy directives run before
+    # shell-hook directives.
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        logger.debug("Plugin discovery failed at TUI gateway startup", exc_info=True)
+
+    # The TUI gateway runs agent turns in this child process. Shell hooks
+    # registered by the parent CLI live in its process-local plugin registry,
+    # so load the current profile's approved hooks again before announcing
+    # readiness.
+    try:
+        from agent.shell_hooks import register_from_current_config
+
+        register_from_current_config(accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI gateway startup",
+            exc_info=True,
+        )
 
     # MCP tool discovery — backgrounded so a slow or unreachable MCP server
     # can't freeze TUI startup (a dead stdio/http server burns 1+2+4s of

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -423,26 +423,13 @@ def main():
     # Turn-isolation children inherit this profile-scope marker.
     os.environ["HERMES_PROFILE_SCOPED_UI"] = "1"
 
-    # Preserve CLI security precedence: plugin policy directives run before
-    # shell-hook directives.
     try:
-        from hermes_cli.plugins import discover_plugins
+        from agent.shell_hooks import register_profile_scoped_child_hooks
 
-        discover_plugins()
-    except Exception:
-        logger.debug("Plugin discovery failed at TUI gateway startup", exc_info=True)
-
-    # The TUI gateway runs agent turns in this child process. Shell hooks
-    # registered by the parent CLI live in its process-local plugin registry,
-    # so load the current profile's approved hooks again before announcing
-    # readiness.
-    try:
-        from agent.shell_hooks import register_from_current_config
-
-        register_from_current_config(accept_hooks=False)
+        register_profile_scoped_child_hooks(runtime_name="TUI gateway")
     except Exception:
         logger.debug(
-            "shell-hook registration failed at TUI gateway startup",
+            "profile-scoped hook setup failed at TUI gateway startup",
             exc_info=True,
         )
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -133,6 +133,14 @@ def main():
 
     os.environ["HERMES_SESSION_KEY"] = args.session_key
     os.environ["HERMES_INTERACTIVE"] = "1"
+    try:
+        from agent.shell_hooks import register_profile_scoped_child_hooks
+
+        register_profile_scoped_child_hooks(runtime_name="slash worker")
+    except Exception:
+        logger.debug(
+            "profile-scoped hook setup failed at slash-worker startup", exc_info=True
+        )
 
     # Start before the (hundreds-of-ms) HermesCLI build — that window is itself
     # an orphan risk if the gateway dies mid-spawn.


### PR DESCRIPTION
## Summary

- register approved config-based shell hooks in the per-profile Desktop backend after interactive auth/plugin setup
- register the same hooks in standalone TUI gateway, turn-isolation compute-host, and slash-worker child processes
- centralize profile-scoped child registration so plugins are discovered before shell hooks and plugin policy retains precedence
- keep the multi-profile browser Dashboard and its shared children free of launch-profile shell hooks
- keep `serve --status` / `--stop` side-effect free and fail open on registration errors

## Why this approach

Desktop, the standalone TUI, turn-isolated compute hosts, and slash workers execute agent work in processes that do not inherit another process's hook registry. Adding `serve` to `_AGENT_COMMANDS` fixes the immediate Desktop symptom, but also initializes agent startup for lifecycle-only commands and registers one profile's hooks globally in the browser Dashboard process.

Desktop already launches one backend per profile (`HERMES_DESKTOP=1`), and profile-scoped TUI children inherit that profile's `HERMES_HOME`. Registering at those process boundaries preserves profile isolation without changing generic Dashboard startup.

This follows the profile-aware direction in #62681 and adds the requested real-import coverage: a temporary `HERMES_HOME`, an explicitly allowlisted executable hook, the real config loader and plugin manager, and a real hook subprocess whose block result is asserted. It also covers the lifecycle-command concern behind #61844 / #81330 and the broader Dashboard proposals in #69832 / #73613 / #78805.

Fixes #81314.

## Tests

- `tests/hermes_cli/test_dashboard_shell_hooks.py`
  - real allowlisted hook registration after auth
  - browser Dashboard profile isolation
  - registration failure is non-fatal
  - `--status` / `--stop` do not register hooks
- `tests/tui_gateway/test_entry_shell_hooks.py`
  - real allowlisted hook registration before `gateway.ready`
  - plugin approval retains precedence over a conflicting shell-hook block
  - registration failure is non-fatal
- `tests/tui_gateway/test_compute_host_shell_hooks.py`
  - real allowlisted hook registration before compute-host `hello`
  - shared browser-Dashboard compute host does not register launch-profile hooks
  - registration failure is non-fatal
- `tests/tui_gateway/test_slash_worker_shell_hooks.py`
  - real allowlisted hook registration before `HermesCLI` construction
  - shared browser-Dashboard slash worker does not register launch-profile hooks
  - registration failure is non-fatal
- expanded shell-hook/Desktop/TUI/compute-host/slash-worker suite (`scripts/run_tests.sh`): 70 passed
- Ruff lint, new-test formatting and type checks, and `git diff --check`: passed
