### PR TITLE
fix(kanban): signal the whole process group when terminating workers (#80280)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7018,6 +7018,48 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _signal_worker_tree(
+    pid: int,
+    sig: int,
+    *,
+    signal_fn=None,
+) -> None:
+    """Send *sig* to the worker process *and* its entire process group.
+
+    Kanban workers are spawned with ``start_new_session=True`` so the worker
+    PID doubles as the POSIX process-group ID.  Signalling the bare PID would
+    leave CLI/tool descendants alive — the descendant leak reported in #80280.
+
+    When ``signal_fn`` is provided (the test hook used throughout the dispatch
+    suite) we call it with the bare PID so existing tests keep working: the
+    mock stands in for the *whole* kill decision and never needs to reason
+    about process groups.  In production we prefer ``os.killpg`` so the signal
+    reaches every descendant; on Windows (no ``killpg``) we fall back to
+    ``os.kill(pid, sig)`` which, via ``CREATE_NEW_PROCESS_GROUP`` semantics,
+    is the closest equivalent available.
+    """
+    if not pid or pid <= 0:
+        return
+    if signal_fn is not None:
+        try:
+            signal_fn(int(pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+        return
+    # Production path: signal the whole group.
+    _killpg = getattr(os, "killpg", None)
+    if _killpg is not None:
+        try:
+            _killpg(int(pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+    elif hasattr(os, "kill"):
+        try:
+            os.kill(int(pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
@@ -7042,23 +7084,11 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
-    )
-    if kill is None:
+    if signal_fn is None and not hasattr(os, "kill"):
         return info
 
     info["termination_attempted"] = True
-    try:
-        kill(int(pid), signal.SIGTERM)
-    except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
-        info["terminated"] = True
-        return info
-    except OSError:
-        return info
+    _signal_worker_tree(int(pid), signal.SIGTERM, signal_fn=signal_fn)
 
     for _ in range(10):
         if not _pid_alive(pid):
@@ -7067,14 +7097,11 @@ def _terminate_reclaimed_worker(
         time.sleep(0.5)
 
     if _pid_alive(pid):
-        try:
-            # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
-            # (which maps to TerminateProcess via the stdlib shim).
-            _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
-            info["sigkill"] = True
-        except (ProcessLookupError, OSError):
-            return info
+        # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
+        # (which maps to TerminateProcess via the stdlib shim).
+        _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+        _signal_worker_tree(int(pid), _sigkill, signal_fn=signal_fn)
+        info["sigkill"] = True
 
     info["terminated"] = not _pid_alive(pid)
     return info
@@ -7235,29 +7262,23 @@ def enforce_max_runtime(
         tid = row["id"]
         # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
         # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
+        # before the grace expires.  The signal targets the worker's
+        # *process group* (PGID == PID because workers start with
+        # ``start_new_session=True``) so CLI/tool descendants are cleaned
+        # up too — the descendant leak reported in #80280.
         killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
-        )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
+        if signal_fn is not None or hasattr(os, "kill"):
+            _signal_worker_tree(pid, signal.SIGTERM, signal_fn=signal_fn)
             # Short polling wait — no time.sleep on the write txn.
             for _ in range(10):
                 if not _pid_alive(pid):
                     break
                 time.sleep(0.5)
             if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+                # signal.SIGKILL doesn't exist on Windows.
+                _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+                _signal_worker_tree(pid, _sigkill, signal_fn=signal_fn)
+                killed = True
 
         with write_txn(conn):
             cur = conn.execute(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1582,4 +1582,109 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
         pass
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
-    conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# _signal_worker_tree: worker termination must signal the *process group*,
+# not just the bare PID. Kanban workers are spawned with
+# ``start_new_session=True`` so the worker PID == PGID; killing only the PID
+# leaves CLI/tool descendants alive (#80280).
+# ---------------------------------------------------------------------------
+
+
+def test_signal_worker_tree_uses_killpg_in_production(monkeypatch):
+    """When no ``signal_fn`` is provided, the production path must call
+    ``os.killpg`` (the process group) — not ``os.kill`` on the bare PID."""
+    import signal as _signal
+
+    killed_groups: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        os, "killpg",
+        lambda pgid, sig: killed_groups.append((pgid, sig)),
+    )
+
+    kb._signal_worker_tree(42_000, _signal.SIGTERM)
+
+    assert killed_groups == [(42_000, _signal.SIGTERM)]
+
+
+def test_signal_worker_tree_uses_signal_fn_when_provided(monkeypatch):
+    """The ``signal_fn`` test hook receives the bare PID so existing tests
+    keep working without needing to reason about process groups."""
+    import signal as _signal
+
+    calls: list[tuple[int, int]] = []
+    kb._signal_worker_tree(
+        42_001, _signal.SIGTERM, signal_fn=lambda pid, sig: calls.append((pid, sig)),
+    )
+    assert calls == [(42_001, _signal.SIGTERM)]
+
+
+def test_signal_worker_tree_swallows_process_lookup_error(monkeypatch):
+    """A ProcessLookupError from killpg must not propagate — the process
+    is already gone, callers treat that as a non-issue."""
+    import signal as _signal
+
+    def _raise(_pgid, _sig):
+        raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(os, "killpg", _raise)
+    # Must not raise.
+    kb._signal_worker_tree(42_002, _signal.SIGTERM)
+
+
+def test_enforce_max_runtime_signals_process_group(kanban_home, monkeypatch):
+    """enforce_max_runtime must signal the process group (killpg), not just
+    the bare worker PID, so descendants are cleaned up (#80280)."""
+    import hermes_cli.kanban_db as _kb
+
+    killed_groups: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        os, "killpg",
+        lambda pgid, sig: killed_groups.append((pgid, sig)),
+    )
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    host = _kb._claimer_id().split(":", 1)[0]
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="overrun", assignee="a", max_runtime_seconds=10,
+        )
+        kb.claim_task(conn, tid, claimer=f"{host}:w")
+        first_run = kb.latest_run(conn, tid)
+        old_started = int(time.time()) - 60
+        conn.execute(
+            "UPDATE tasks SET started_at = ?, worker_pid = ? WHERE id = ?",
+            (old_started, 99_001, tid),
+        )
+        conn.execute(
+            "UPDATE task_runs SET started_at = ?, worker_pid = ? WHERE id = ?",
+            (old_started, 99_001, first_run.id),
+        )
+
+        # No signal_fn → production path → must use killpg.
+        timed_out = kb.enforce_max_runtime(conn)
+        assert tid in timed_out
+        assert (99_001, getattr(__import__("signal"), "SIGTERM", 15)) in killed_groups
+
+
+def test_terminate_reclaimed_worker_signals_process_group(kanban_home, monkeypatch):
+    """_terminate_reclaimed_worker must signal the process group, not just
+    the bare PID, so reclaim/timeout descendants are cleaned up (#80280)."""
+    import signal as _signal
+    import hermes_cli.kanban_db as _kb
+
+    killed_groups: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        os, "killpg",
+        lambda pgid, sig: killed_groups.append((pgid, sig)),
+    )
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    host = _kb._claimer_id().split(":", 1)[0]
+    result = _kb._terminate_reclaimed_worker(
+        99_002, f"{host}:w",
+        # No signal_fn → production path.
+    )
+    assert result["termination_attempted"] is True
+    assert (99_002, _signal.SIGTERM) in killed_groups


### PR DESCRIPTION
## What

Kanban workers are spawned with `start_new_session=True`, so the worker PID doubles as the POSIX process-group ID. Three termination paths — `enforce_max_runtime`, `_terminate_reclaimed_worker`, and the stale-claim reclaim path — all signalled only the bare PID via `os.kill(pid, sig)`, leaving CLI/tool descendants alive after the parent was killed. The stale descendants could then mutate and validate the same preserved worktree concurrently with the replacement worker.

## Root cause

`hermes_cli/kanban_db.py` — two kill sites:

1. `enforce_max_runtime` (line ~7241): `kill(pid, signal.SIGTERM)` then `kill(pid, _sigkill)` — bare PID only
2. `_terminate_reclaimed_worker` (line ~7046): `kill(int(pid), signal.SIGTERM)` then `kill(int(pid), _sigkill)` — bare PID only

Both used a `kill` callable that resolved to `os.kill`, which only targets the single process, not its process group.

## Fix

Extract `_signal_worker_tree(pid, sig, *, signal_fn)` as the shared kill entry point:

- **Production path**: prefers `os.killpg(pid, sig)` — signals the whole process group (PGID == PID because workers start with `start_new_session=True`)
- **Windows fallback**: no `killpg` → falls back to `os.kill(pid, sig)` (closest equivalent)
- **Test hook**: when `signal_fn` is provided, it receives the bare PID so existing dispatch tests work unchanged

Both `enforce_max_runtime` and `_terminate_reclaimed_worker` now route all signals (SIGTERM and SIGKILL) through `_signal_worker_tree`.

## Verification

```
tests/hermes_cli/test_kanban_db.py (35 passed — 5 new regression + 30 existing)
tests/plugins/test_kanban_dashboard_plugin.py (20 passed)
ruff: clean
git rev-list --left-right --count upstream/main...HEAD → 0 1 (one focused commit)
```

**RED→GREEN proof** (new tests run against `upstream/main` before fix):
- `test_signal_worker_tree_uses_killpg_in_production` — FAILED (no `_signal_worker_tree`)
- `test_enforce_max_runtime_signals_process_group` — FAILED (old code calls `os.kill`, never `os.killpg`)
- `test_terminate_reclaimed_worker_signals_process_group` — FAILED (same)
- All 5 pass with the fix applied.

## Layers addressed (per issue)

1. ✅ `enforce_max_runtime` signals process group
2. ✅ `_terminate_reclaimed_worker` signals process group
3. ✅ Shared `_signal_worker_tree` helper (DRY)
4. ✅ Windows `killpg` fallback
5. ✅ `signal_fn` test hook preserved (bare PID)

Auto-published by Moonsong via Path B automated pipeline.