### PR TITLE
Add policy fallback delegation to local Qwen

### DIFF
--- a/agent/policy_fallback.py
+++ b/agent/policy_fallback.py
@@ -1,0 +1,214 @@
+"""Durable policy-only GPT -> local Qwen fallback state and orchestration."""
+from __future__ import annotations
+
+import contextlib, contextvars, hashlib, json, logging, os, re, sqlite3
+import threading, time, unicodedata, uuid
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
+from hermes_constants import get_hermes_home
+
+log = logging.getLogger(__name__)
+SUMMARY_MAX, RESULT_MAX = 8192, 32768
+ARTIFACT_TTL, ROW_TTL, LEASE_TTL = 7*86400, 30*86400, 3600
+EMBED_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+EMBED_REVISION = "bf3bf13ab40c3157080a7ab344c831b9ad18b5eb"
+SIMILARITY_LIMIT = .88
+TERMINAL = {"completed", "partial", "failed", "timeout"}
+_runtime = contextvars.ContextVar("policy_fallback_runtime", default=None)
+_embedder = None
+_embed_failed = False
+_cleanup_guard, _last_cleanup = threading.Lock(), 0.0
+
+def clip(x, n=SUMMARY_MAX):
+    s = x if isinstance(x, str) else json.dumps(x, ensure_ascii=False, default=str)
+    return s[:n]
+
+def sha(s): return hashlib.sha256(str(s).encode("utf-8", "replace")).hexdigest()
+def canonical(x): return json.dumps(x, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+def normalize_question(text):
+    text = unicodedata.normalize("NFKC", str(text or ""))
+    text = "".join(c for c in text if unicodedata.category(c) not in {"Cc","Cf"} or c in "\n\t").casefold()
+    def url(m):
+        try:
+            p=urlsplit(m.group(0).rstrip(".,);]}")); host=(p.hostname or "").rstrip(".").casefold()
+            return urlunsplit(((p.scheme or "https").casefold(), host+(f":{p.port}" if p.port else ""), re.sub(r"/{2,}","/",p.path or "/"), "", ""))
+        except Exception: return m.group(0)
+    return re.sub(r"\s+", " ", re.sub(r"https?://[^\s<>'\"]+", url, text, flags=re.I)).strip()
+
+def question_hashes(question, evidence):
+    norm=normalize_question(question); eh=sha(canonical(evidence or []))
+    return norm, sha(norm), eh, sha(norm+":"+eh)
+
+def embedding(norm):
+    global _embedder, _embed_failed
+    if _embed_failed: return None
+    try:
+        if _embedder is None:
+            from sentence_transformers import SentenceTransformer
+            _embedder=SentenceTransformer(EMBED_MODEL, revision=EMBED_REVISION, device="cpu")
+        return _embedder.encode([norm], normalize_embeddings=True)[0].astype("float32").tobytes()
+    except Exception:
+        _embed_failed=True; log.warning("policy embedding unavailable", exc_info=True); return None
+
+def cosine(a,b):
+    if not a or not b or len(a)!=len(b) or len(a)%4: return None
+    import array
+    x,y=array.array("f"),array.array("f"); x.frombytes(a); y.frombytes(b)
+    nx=sum(i*i for i in x)**.5; ny=sum(i*i for i in y)**.5
+    return sum(i*j for i,j in zip(x,y))/(nx*ny) if nx and ny else None
+
+class Store:
+    def __init__(self, path=None):
+        home=Path(get_hermes_home()); self.path=Path(path or home/"state/policy_fallback.sqlite3")
+        self.artifacts=home/"cache/policy-fallback"; self.path.parent.mkdir(parents=True,exist_ok=True); self.artifacts.mkdir(parents=True,exist_ok=True); self.init()
+    def db(self):
+        c=sqlite3.connect(str(self.path),timeout=15); c.row_factory=sqlite3.Row; c.execute("PRAGMA journal_mode=WAL"); c.execute("PRAGMA foreign_keys=ON"); return c
+    def init(self):
+        with self.db() as d: d.executescript("""
+        CREATE TABLE IF NOT EXISTS fallbacks(fallback_id TEXT PRIMARY KEY,parent_task_id TEXT NOT NULL,parent_task_hash TEXT NOT NULL,blocked_task_id TEXT NOT NULL,blocked_task_hash TEXT NOT NULL,attempt INTEGER NOT NULL DEFAULT 1,policy_source TEXT NOT NULL,state TEXT NOT NULL,lease_owner TEXT,lease_expires_at REAL,blocked_task_summary TEXT NOT NULL,context_summary TEXT NOT NULL,completed_summary TEXT NOT NULL,source_refs TEXT NOT NULL,qwen_result TEXT,error TEXT,created_at REAL NOT NULL,started_at REAL,finished_at REAL,UNIQUE(parent_task_id,blocked_task_id,attempt));
+        CREATE TABLE IF NOT EXISTS consultations(consultation_id TEXT PRIMARY KEY,fallback_id TEXT NOT NULL REFERENCES fallbacks(fallback_id) ON DELETE CASCADE,sequence INTEGER NOT NULL,reason TEXT NOT NULL,normalized_question_hash TEXT NOT NULL,question_hash TEXT NOT NULL,evidence_hash TEXT NOT NULL,embedding_model TEXT,embedding_vector BLOB,what_changed_summary TEXT NOT NULL,state TEXT NOT NULL,confidence REAL,verification_required INTEGER NOT NULL DEFAULT 1,verification_status TEXT NOT NULL DEFAULT 'not_run',verification_summary TEXT NOT NULL DEFAULT '',answer_summary TEXT NOT NULL DEFAULT '',answer_artifact_ref TEXT,answer_hash TEXT,created_at REAL NOT NULL,finished_at REAL,UNIQUE(fallback_id,sequence),UNIQUE(fallback_id,question_hash));
+        CREATE INDEX IF NOT EXISTS pf_state ON fallbacks(state,created_at); CREATE INDEX IF NOT EXISTS pc_parent ON consultations(fallback_id,sequence);
+        """)
+    def create(self,parent_id,goal,blocked,source,reason,completed,sources):
+        cleanup(self); bh=sha(normalize_question(blocked)); bid="blocked-"+bh[:20]; now=time.time()
+        with self.db() as d:
+            d.execute("BEGIN IMMEDIATE"); old=d.execute("SELECT * FROM fallbacks WHERE parent_task_id=? AND blocked_task_id=? AND attempt=1",(parent_id,bid)).fetchone()
+            if old:return dict(old)
+            fid="pf-"+uuid.uuid4().hex
+            d.execute("INSERT INTO fallbacks VALUES(?,?,?,?,?,1,?,'pending',NULL,NULL,?,?,?,?,NULL,NULL,?,NULL,NULL)",(fid,parent_id,sha(goal),bid,bh,source,clip(blocked),clip(reason),clip(completed),clip(sources),now))
+            return dict(d.execute("SELECT * FROM fallbacks WHERE fallback_id=?",(fid,)).fetchone())
+    def claim(self,fid,owner):
+        now=time.time()
+        with self.db() as d:return d.execute("UPDATE fallbacks SET state='running',lease_owner=?,lease_expires_at=?,started_at=? WHERE fallback_id=? AND state='pending'",(owner,now+LEASE_TTL,now,fid)).rowcount==1
+    def finish(self,fid,state,result=None,error=""):
+        assert state in TERMINAL
+        with self.db() as d:d.execute("UPDATE fallbacks SET state=?,qwen_result=?,error=?,finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE fallback_id=?",(state,clip(result,RESULT_MAX) if result is not None else None,clip(error,4096),time.time(),fid))
+    def fail_stale(self):
+        now=time.time()
+        with self.db() as d:return d.execute("UPDATE fallbacks SET state='failed',error='worker_lost',finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE state='running' AND lease_expires_at<?",(now,now)).rowcount
+    def list_consultations(self,fid):
+        with self.db() as d:return [dict(r) for r in d.execute("SELECT * FROM consultations WHERE fallback_id=? ORDER BY sequence",(fid,))]
+    def reserve_consultation(self,fid,reason,question,evidence,changed):
+        cleanup(self); prior=self.list_consultations(fid); seq=len(prior)+1
+        if seq>5:return None,"budget_exhausted"
+        if seq>=4 and (reason not in {"conflicting_evidence","failed_verification","high_impact_decision"} or len((changed or "").strip())<20):return None,"consultations 4-5 require qualifying reason and specific what_changed_since_last_consultation"
+        norm,nh,eh,qh=question_hashes(question,evidence); vec=embedding(norm)
+        if seq>=4 and prior and prior[-1]["evidence_hash"]==eh:
+            return None,"consultations 4-5 require new evidence, not only a changed explanation"
+        for old in prior:
+            if old["question_hash"]==qh:return None,"duplicate question and evidence"
+            if old["state"]=="blocked":
+                if old["normalized_question_hash"]==nh:return None,"blocked question may not be rephrased"
+                sim=cosine(old["embedding_vector"],vec)
+                if sim is not None and sim>=SIMILARITY_LIMIT:return None,f"blocked semantic duplicate ({sim:.3f})"
+                if vec is None:return None,"embedding unavailable; blocked duplicate check fails closed"
+        cid="pc-"+uuid.uuid4().hex
+        with self.db() as d:d.execute("INSERT INTO consultations(consultation_id,fallback_id,sequence,reason,normalized_question_hash,question_hash,evidence_hash,embedding_model,embedding_vector,what_changed_summary,state,created_at) VALUES(?,?,?,?,?,?,?,?,?,?, 'running',?)",(cid,fid,seq,reason,nh,qh,eh,EMBED_MODEL if vec else None,vec,clip(changed or "",2048),time.time()))
+        return {"consultation_id":cid,"sequence":seq},""
+    def finish_consultation(self,cid,state,answer,confidence,required):
+        ref=None
+        if answer:
+            p=self.artifacts/(cid+".json"); t=p.with_suffix(".tmp"); t.write_text(json.dumps({"answer":answer},ensure_ascii=False),encoding="utf-8"); os.replace(t,p); ref=str(p)
+        summary=clip(re.sub(r"\s+"," ",answer).strip(),2048)
+        with self.db() as d:d.execute("UPDATE consultations SET state=?,confidence=?,verification_required=?,answer_summary=?,answer_artifact_ref=?,answer_hash=?,finished_at=? WHERE consultation_id=?",(state,confidence,int(required),summary,ref,sha(answer) if answer else None,time.time(),cid))
+    def verify(self,cid,status,summary,evidence):
+        if status not in {"passed","failed","inconclusive"}:raise ValueError("invalid verification status")
+        refs=[str(x).strip() for x in evidence or [] if str(x).strip()]
+        if status=="passed" and not refs:raise ValueError("passed requires tool-result/artifact evidence")
+        text=clip(summary+("\nEvidence: "+"; ".join(refs) if refs else ""),4096)
+        with self.db() as d:
+            if not d.execute("SELECT 1 FROM consultations WHERE consultation_id=?",(cid,)).fetchone():raise KeyError("unknown consultation_id")
+            d.execute("UPDATE consultations SET verification_status=?,verification_summary=? WHERE consultation_id=?",(status,text,cid))
+        return {"consultation_id":cid,"verification_result":{"status":status,"summary":text}}
+    def cleanup(self,now=None,batch=100):
+        now=now or time.time(); files=bytes_=rows=0
+        with self.db() as d:
+            live={r[0] for r in d.execute("SELECT answer_artifact_ref FROM consultations WHERE answer_artifact_ref IS NOT NULL")}
+            for cid,ref in d.execute("SELECT consultation_id,answer_artifact_ref FROM consultations WHERE answer_artifact_ref IS NOT NULL AND finished_at<? LIMIT ?",(now-ARTIFACT_TTL,batch)):
+                try:p=Path(ref); size=p.stat().st_size if p.exists() else 0;p.unlink(missing_ok=True);files+=1;bytes_+=size
+                except OSError:log.warning("artifact cleanup failed id=%s",cid)
+                d.execute("UPDATE consultations SET answer_artifact_ref=NULL WHERE consultation_id=?",(cid,))
+            for p in list(self.artifacts.glob("pc-*"))[:batch]:
+                if str(p) not in live and p.stat().st_mtime<now-3600:bytes_+=p.stat().st_size;p.unlink(missing_ok=True);files+=1
+            ids=d.execute("SELECT fallback_id FROM fallbacks WHERE state IN ('completed','partial','failed','timeout') AND finished_at<? LIMIT ?",(now-ROW_TTL,batch)).fetchall()
+            for r in ids:d.execute("DELETE FROM fallbacks WHERE fallback_id=?",(r[0],))
+            rows=len(ids);d.execute("PRAGMA wal_checkpoint(PASSIVE)");d.execute("PRAGMA incremental_vacuum(64)")
+        return {"files":files,"bytes":bytes_,"rows":rows}
+
+def cleanup(store=None,force=False):
+    global _last_cleanup
+    now=time.time()
+    if not force and now-_last_cleanup<3600:return None
+    if not _cleanup_guard.acquire(False):return None
+    lock_handle = None
+    try:
+        target = store or Store()
+        # Cross-process guard: gateway, CLI and opportunistic inserts may all
+        # reach cleanup concurrently.
+        import fcntl
+        lock_path = Path(get_hermes_home()) / "state" / "policy_fallback.cleanup.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_handle = open(lock_path, "a+")
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return None
+        out=target.cleanup(now);_last_cleanup=now
+        if out and any(out.values()):log.info("policy cleanup files=%s bytes=%s rows=%s",out["files"],out["bytes"],out["rows"])
+        return out
+    finally:
+        if lock_handle is not None:
+            try: lock_handle.close()
+            except OSError: pass
+        _cleanup_guard.release()
+
+def runtime():return _runtime.get()
+@contextlib.contextmanager
+def runtime_scope(value):
+    tok=_runtime.set(value)
+    try:yield
+    finally:_runtime.reset(tok)
+
+def parse_json(text):
+    s=str(text or "").strip(); m=re.fullmatch(r"```(?:json)?\s*(\{.*\})\s*```",s,re.S|re.I); s=m.group(1) if m else s
+    try:v=json.loads(s);return v if isinstance(v,dict) else None
+    except Exception:return None
+
+def classify(result,goal):
+    err=str(result.get("error") or "")
+    if err.startswith("content_policy_blocked:"):return {"source":"provider_policy_block","blocked":goal,"completed":[],"reason":err.split(":",1)[1].strip(),"sources":[]}
+    r=parse_json(result.get("final_response"))
+    if not r or r.get("status") not in {"blocked","partial"}:return None
+    reason=str(r.get("reason") or r.get("blocked_reason") or "");code=str(r.get("reason_code") or r.get("category") or "")
+    if "policy" not in (reason+code).casefold():return None
+    left=r.get("remaining") or r.get("blocked") or []; blocked="\n".join(map(str,left)) if isinstance(left,list) else str(left)
+    return {"source":"model_reported_policy","blocked":blocked,"completed":r.get("completed") or [],"reason":reason,"sources":r.get("sources") or []} if blocked.strip() else None
+
+def maybe_run(agent,result,user_message,task_id):
+    if not isinstance(result,dict) or getattr(agent,"platform","")=="subagent" or getattr(agent,"_policy_fallback_in_progress",False):return result
+    goal=user_message if isinstance(user_message,str) else clip(user_message); p=classify(result,goal)
+    if not p:return result
+    store=Store();store.fail_stale();row=store.create(task_id,goal,p["blocked"],p["source"],p["reason"],p["completed"],p["sources"])
+    if row["state"] in TERMINAL or not store.claim(row["fallback_id"],f"{os.getpid()}:{uuid.uuid4().hex[:8]}"):return result
+    log.info("policy_fallback state=running fallback_id=%s parent_task_id=%s blocked_task_id=%s policy_source=%s reason_hash=%s",row["fallback_id"],task_id,row["blocked_task_id"],p["source"],sha(p["reason"])[:16])
+    ctx={"fallback_id":row["fallback_id"],"blocked_task_id":row["blocked_task_id"],"parent_task_id":task_id,"parent_agent":agent,"store":store}
+    child_goal=f'''Complete only this policy-blocked subtask independently:\n{p["blocked"]}\nReturn ONLY JSON: {{"status":"completed|partial|failed","source":"qwen_subagent","original_blocked_task":"...","completed":[],"remaining":[],"result":"...","notes":[]}}. Use ask_gpt only for a narrow uncertainty after your research. Verify mandatory advice and record it.'''
+    child_context=clip({"original_goal":goal,"policy_source":p["source"],"policy_reason":p["reason"],"already_completed":p["completed"],"sources":p["sources"]})
+    try:
+        from tools.delegate_tool import delegate_task
+        agent._policy_fallback_in_progress=True;agent._policy_fallback_context=ctx
+        envelope=json.loads(delegate_task(goal=child_goal,context=child_context,parent_agent=agent));entries=envelope.get("results") or []; q=parse_json(entries[0].get("summary") if entries else "")
+        if not q:
+            store.finish(row["fallback_id"],"failed",error="invalid_qwen_json");log.warning("policy_fallback state=failed fallback_id=%s error=invalid_qwen_json",row["fallback_id"])
+            out=dict(result);out["policy_fallback_id"]=row["fallback_id"];out["remaining"]=[p["blocked"]];return out
+        state=q.get("status") if q.get("status") in {"completed","partial","failed"} else "failed"; consult=store.list_consultations(row["fallback_id"])
+        if state != "completed" and not (q.get("remaining") or []):q["remaining"]=[p["blocked"]]
+        if state=="completed" and any(c["verification_required"] and c["verification_status"]=="not_run" for c in consult):state="partial";q.setdefault("remaining",[]).append("mandatory GPT consultation verification not run")
+        q["consultations"]=[{"consultation_id":c["consultation_id"],"state":c["state"],"confidence":c["confidence"],"verification_required":bool(c["verification_required"]),"verification_result":{"status":c["verification_status"],"summary":c["verification_summary"]}} for c in consult]
+        store.finish(row["fallback_id"],state,q);log.info("policy_fallback state=%s fallback_id=%s consultations=%d remaining=%d",state,row["fallback_id"],len(consult),len(q.get("remaining") or []));merged={"status":"completed" if state=="completed" else "partial","source":"gpt_qwen_policy_fallback","policy_source":p["source"],"gpt_completed":p["completed"],"qwen":q,"remaining":q.get("remaining") or []}
+        out=dict(result);out.update(final_response=json.dumps(merged,ensure_ascii=False),completed=state=="completed",failed=state=="failed",policy_fallback_id=row["fallback_id"]);out.pop("error",None);return out
+    except TimeoutError as e:store.finish(row["fallback_id"],"timeout",error=str(e));return result
+    except Exception as e:log.exception("policy fallback failed id=%s",row["fallback_id"]);store.finish(row["fallback_id"],"failed",error=str(e));return result
+    finally:agent._policy_fallback_in_progress=False;agent._policy_fallback_context=None

--- a/agent/policy_tool_policy.py
+++ b/agent/policy_tool_policy.py
@@ -1,0 +1,50 @@
+"""Mandatory pre-dispatch policy for the untrusted local fallback worker."""
+import ipaddress, json, re, socket
+from urllib.parse import urlsplit
+
+PROXMOX_MARKERS=(":8006","/api2/json","/api2/extjs","/pve2/","pveapitoken","pveauthcookie","proxmox","porx"," pvesh "," pvecm "," pvesm "," qm "," pct ")
+NETWORK_CHANGE=("iptables","nft ","ip route","ip link","nmcli","resolv.conf","wg-quick")
+SYSTEM_DELETE=("rm -rf /","rm -r /etc","rm -r /var","wipefs","mkfs")
+SSH=(" ssh ","scp ","sftp ","rsync ")
+URL_RE=re.compile(r"https?://[^\s'\"`<>]+",re.I)
+
+def _strings(value):
+    if isinstance(value,str):yield value
+    elif isinstance(value,dict):
+        for item in value.values():yield from _strings(item)
+    elif isinstance(value,(list,tuple)):
+        for item in value:yield from _strings(item)
+
+def _blocked_url(url):
+    try:
+        p=urlsplit(url); host=(p.hostname or "").casefold().rstrip(".")
+        if p.port==8006 or any(x in p.path.casefold() for x in ("/api2/json","/api2/extjs","/pve2/")):return True
+        if host in {"porx","porx.local","proxmox","pve"} or "proxmox" in host:return True
+        for info in socket.getaddrinfo(host,p.port or 443,type=socket.SOCK_STREAM):
+            ip=ipaddress.ip_address(info[4][0])
+            if ip in ipaddress.ip_network("10.50.50.0/24"):return True
+    except Exception:
+        # A malformed/suspicious Proxmox-looking target fails closed; ordinary
+        # unresolved public URLs are left for the tool's own error handling.
+        return any(x in url.casefold() for x in PROXMOX_MARKERS)
+    return False
+
+def enforce(function_name,args):
+    try:
+        from agent.policy_fallback import runtime
+        if runtime() is None:return None
+    except Exception:return None
+    text=" "+" ".join(_strings(args)).casefold()+" "
+    if any(x in text for x in PROXMOX_MARKERS):return "Denied: policy fallback cannot access Proxmox or actions outside its VM"
+    for url in URL_RE.findall(text):
+        if _blocked_url(url):return "Denied: resolved/final network target is Proxmox management infrastructure"
+    if any(x in text for x in SSH+NETWORK_CHANGE+SYSTEM_DELETE):
+        from tools.approval import request_tool_approval
+        decision = request_tool_approval(
+            function_name,
+            "Qwen policy-fallback requests an infrastructure-sensitive action",
+            rule_key="policy_fallback_sensitive_action",
+        )
+        if not decision.get("approved"):
+            return decision.get("message") or "Denied: required human confirmation was not granted"
+    return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10533,6 +10533,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
+        # Repair stale leases and service bounded policy-fallback storage on
+        # every gateway start. Failures are non-fatal to messaging startup.
+        try:
+            from agent.policy_fallback import Store as _PolicyStore, cleanup as _policy_cleanup
+            _policy_store = _PolicyStore()
+            stale = _policy_store.fail_stale()
+            _policy_cleanup(_policy_store, force=True)
+            if stale:
+                logger.warning("Policy fallback recovery marked %d stale worker(s) failed", stale)
+        except Exception:
+            logger.warning("Policy fallback startup cleanup failed", exc_info=True)
         # Enable faulthandler for stack dumps on freezes/crashes (#70344).
         # Falls back to a log file when sys.stderr is None (Windows VBS /
         # pythonw / detached service) — otherwise the gateway would die
@@ -25833,6 +25844,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
     AUTO_ARCHIVE_EVERY = 60  # ticks — poll hourly (state_meta gate owns the real cadence)
+    POLICY_FALLBACK_EVERY = 60  # ticks — bounded artifacts/rows + WAL checkpoint
     MEMORY_TRIM_EVERY = 1    # shared helper cooldown bounds actual allocator work
 
     # Every platform media cache prunes on the same hourly cadence — one loop
@@ -25887,6 +25899,13 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     )
             except Exception as e:
                 logger.debug("Paste sweep error: %s", e)
+
+        if tick_count % POLICY_FALLBACK_EVERY == 0:
+            try:
+                from agent.policy_fallback import cleanup as _policy_cleanup
+                _policy_cleanup(force=True)
+            except Exception as e:
+                logger.debug("Policy fallback cleanup error: %s", e)
 
         # Curator — piggy-back on the housekeeping loop so long-running
         # gateways get weekly skill maintenance without needing restarts.

--- a/model_tools.py
+++ b/model_tools.py
@@ -1243,6 +1243,14 @@ def handle_function_call(
         if function_name in _AGENT_LOOP_TOOLS:
             return tool_error(f"{function_name} must be handled by the agent loop")
 
+        # This host-owned guard is independent of plugin hooks and therefore
+        # still executes when the agent loop already fired pre_tool_call and
+        # passed skip_pre_tool_call_hook=True.
+        from agent.policy_tool_policy import enforce as _enforce_policy_worker
+        policy_block = _enforce_policy_worker(function_name, function_args)
+        if policy_block:
+            return tool_error(policy_block)
+
         # Check plugin hooks for a block/approve directive (unless caller
         # already checked — e.g. run_agent._invoke_tool passes skip=True to
         # avoid double-firing the hook).

--- a/run_agent.py
+++ b/run_agent.py
@@ -7638,6 +7638,15 @@ class AIAgent:
                     persist_user_display_metadata=persist_user_display_metadata,
                     moa_config=moa_config,
                 )
+            # Policy-only recovery is post-turn and never runs for subagents or
+            # technical failures; the classifier enforces both invariants.
+            from agent.policy_fallback import maybe_run as _maybe_policy_fallback
+            result = _maybe_policy_fallback(
+                self,
+                result,
+                user_message=user_message,
+                task_id=effective_task_id,
+            )
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"

--- a/tests/agent/test_policy_fallback.py
+++ b/tests/agent/test_policy_fallback.py
@@ -1,0 +1,90 @@
+import time
+
+from agent.policy_fallback import (
+    Store,
+    classify,
+    maybe_run,
+    normalize_question,
+    question_hashes,
+)
+from agent.policy_fallback import runtime_scope
+from agent.policy_tool_policy import enforce
+
+
+def test_policy_sources_are_distinct():
+    provider = classify({"error": "content_policy_blocked: rejected"}, "goal")
+    model = classify({"final_response": '{"status":"partial","reason_code":"policy_restriction","remaining":["part"]}'}, "goal")
+    assert provider["source"] == "provider_policy_block"
+    assert model["source"] == "model_reported_policy"
+    assert classify({"error": "rate_limit: retry"}, "goal") is None
+
+
+def test_question_hash_includes_evidence_and_normalizes_urls():
+    assert normalize_question(" HTTPS://Example.COM/a?tracking=1 ") == "https://example.com/a"
+    _, normalized_a, evidence_a, question_a = question_hashes("Question", [{"source": "a"}])
+    _, normalized_b, evidence_b, question_b = question_hashes("question", [{"source": "b"}])
+    assert normalized_a == normalized_b
+    assert evidence_a != evidence_b
+    assert question_a != question_b
+
+
+def test_store_claim_is_idempotent_and_stale_worker_fails(tmp_path):
+    store = Store(tmp_path / "fallback.db")
+    row = store.create("parent", "goal", "blocked", "provider_policy_block", "reason", [], [])
+    assert store.claim(row["fallback_id"], "worker-one") is True
+    assert store.claim(row["fallback_id"], "worker-two") is False
+    with store.db() as db:
+        db.execute("UPDATE fallbacks SET lease_expires_at=? WHERE fallback_id=?", (time.time()-1, row["fallback_id"]))
+    assert store.fail_stale() == 1
+    with store.db() as db:
+        current = db.execute("SELECT state,error FROM fallbacks WHERE fallback_id=?", (row["fallback_id"],)).fetchone()
+    assert tuple(current) == ("failed", "worker_lost")
+
+
+def test_passed_verification_requires_evidence(tmp_path, monkeypatch):
+    store = Store(tmp_path / "fallback.db")
+    row = store.create("parent", "goal", "blocked", "model_reported_policy", "reason", [], [])
+    monkeypatch.setattr("agent.policy_fallback.embedding", lambda _text: b"\0\0\0\0")
+    consultation, error = store.reserve_consultation(row["fallback_id"], "low_confidence", "question", [], "")
+    assert not error
+    try:
+        store.verify(consultation["consultation_id"], "passed", "looks good", [])
+    except ValueError as exc:
+        assert "requires" in str(exc)
+    else:
+        raise AssertionError("passed verification accepted without evidence")
+    result = store.verify(consultation["consultation_id"], "inconclusive", "not enough data", [])
+    assert result["verification_result"]["status"] == "inconclusive"
+
+
+def test_untrusted_worker_tool_policy_blocks_infrastructure():
+    with runtime_scope({"fallback_id": "test"}):
+        assert enforce("terminal", {"command": "curl https://porx.local:8006/api2/json"})
+        assert enforce("terminal", {"command": "ssh external.example"})
+        assert enforce("terminal", {"command": "python local_check.py"}) is None
+
+
+def test_policy_fallback_merges_qwen_result(tmp_path, monkeypatch):
+    import agent.policy_fallback as module
+    import tools.delegate_tool as delegate
+
+    monkeypatch.setattr(module, "Store", lambda: Store(tmp_path / "fallback.db"))
+    child = {
+        "status": "partial", "source": "qwen_subagent",
+        "original_blocked_task": "goal", "completed": ["researched"],
+        "remaining": ["needs hardware"], "result": "finding", "notes": [],
+    }
+    monkeypatch.setattr(delegate, "delegate_task", lambda **_kw: __import__("json").dumps({"results": [{"summary": __import__("json").dumps(child)}]}))
+
+    class Agent:
+        platform = "telegram"
+
+    result = maybe_run(
+        Agent(),
+        {"error": "content_policy_blocked: provider refused", "final_response": "blocked", "failed": True},
+        "goal", "parent-task",
+    )
+    assert result["policy_fallback_id"].startswith("pf-")
+    merged = __import__("json").loads(result["final_response"])
+    assert merged["policy_source"] == "provider_policy_block"
+    assert merged["remaining"] == ["needs hardware"]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3014,10 +3014,16 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "error": "Blocked: URL targets a cloud metadata endpoint",
         })
 
+    try:
+        from agent.policy_fallback import runtime as _policy_runtime
+        policy_network_guard = _policy_runtime() is not None
+    except Exception:
+        policy_network_guard = False
+
     if (
-        not _is_local_backend()
-        and not auto_local_this_nav
-        and not _allow_private_urls()
+        (policy_network_guard or not _is_local_backend())
+        and (policy_network_guard or not auto_local_this_nav)
+        and (policy_network_guard or not _allow_private_urls())
         and not _is_safe_url(url)
     ):
         return json.dumps({
@@ -3091,9 +3097,9 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             })
 
         if (
-            not _is_local_backend()
-            and not auto_local_this_nav
-            and not _allow_private_urls()
+            (policy_network_guard or not _is_local_backend())
+            and (policy_network_guard or not auto_local_this_nav)
+            and (policy_network_guard or not _allow_private_urls())
             and final_url and final_url != url and not _is_safe_url(final_url)
         ):
             # Navigate away to a blank page to prevent snapshot leaks
@@ -3604,6 +3610,12 @@ def _eval_ssrf_guard_active(effective_task_id: str) -> bool:
     can reach internal networks the terminal can't), and is skipped for local
     sidecar sessions and when ``allow_private_urls`` is set.
     """
+    try:
+        from agent.policy_fallback import runtime as _policy_runtime
+        if _policy_runtime() is not None:
+            return True
+    except Exception:
+        pass
     return (
         not _is_local_backend()
         and not _is_local_sidecar_key(effective_task_id)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -100,6 +100,24 @@ def _subagent_auto_approve(command: str, description: str, **kwargs) -> str:
     return "once"
 
 
+_POLICY_PROXMOX_PATTERNS = (
+    "10.50.50.", ":8006", "/api2/json", "/api2/extjs", "/pve2/",
+    "pveapitoken", "pveauthcookie", "proxmox", " porx", "porx.",
+    " qm ", " pct ", " pvesh ", " pvecm ", " pvesm ",
+    "proxmox-backup-client",
+)
+def _policy_subagent_approval(command: str, description: str, **kwargs) -> str:
+    """Approve isolated-VM work and fail closed for infra-sensitive work."""
+    haystack = f" {command} {description} ".casefold()
+    if any(pattern in haystack for pattern in _POLICY_PROXMOX_PATTERNS):
+        logger.error("Policy fallback denied Proxmox/out-of-VM action: %s", command)
+        return "deny"
+    # Confirmation categories were already gated by policy_tool_policy before
+    # terminal dispatch. Reaching this callback means that gate approved them.
+    logger.warning("Policy fallback auto-approved isolated-VM action: %s", command)
+    return "once"
+
+
 def _get_subagent_approval_callback():
     """Return the callback to install into subagent worker threads.
 
@@ -1315,6 +1333,20 @@ def _build_child_agent(
     if effective_role == "orchestrator" and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
 
+    # Only internal policy workers receive this host-owned toolset.  It never
+    # enters the parent GPT schema or ordinary delegated children.
+    _policy_context = getattr(parent_agent, "_policy_fallback_context", None)
+    if (
+        isinstance(_policy_context, dict)
+        and _policy_context.get("fallback_id")
+        and "policy_consultation" not in child_toolsets
+    ):
+        child_toolsets.append("policy_consultation")
+        child_disabled_toolsets = [
+            name for name in child_disabled_toolsets
+            if name != "policy_consultation"
+        ]
+
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(
         goal,
@@ -1558,6 +1590,7 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._policy_fallback_context = _policy_context
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
@@ -2157,7 +2190,11 @@ def _run_single_child(
             # input() and deadlock the parent's prompt_toolkit TUI.
             # Callback (deny vs approve) is governed by delegation.subagent_auto_approve.
             initializer=_set_subagent_approval_cb,
-            initargs=(_get_subagent_approval_callback(),),
+            initargs=((
+                _policy_subagent_approval
+                if getattr(child, "_policy_fallback_context", None)
+                else _get_subagent_approval_callback()
+            ),),
         )
         # Capture the worker thread so the timeout diagnostic can dump its
         # Python stack (see #14726 — 0-API-call hangs are opaque without it).
@@ -2178,12 +2215,20 @@ def _run_single_child(
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
-                    user_message=goal,
-                    task_id=child_task_id,
-                    stream_callback=_relay_child_text,
-                )
+            def _invoke():
+                with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+                    return child.run_conversation(
+                        user_message=goal,
+                        task_id=child_task_id,
+                        stream_callback=_relay_child_text,
+                    )
+
+            policy_context = getattr(child, "_policy_fallback_context", None)
+            if not policy_context:
+                return _invoke()
+            from agent.policy_fallback import runtime_scope
+            with runtime_scope(policy_context):
+                return _invoke()
 
         _child_context = contextvars.copy_context()
         _child_future = _timeout_executor.submit(
@@ -2838,6 +2883,13 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
+    # Policy fallback has an independent provider/model budget. This avoids
+    # silently rerouting ordinary model-requested delegation to the local
+    # policy worker (or vice versa).
+    if isinstance(getattr(parent_agent, "_policy_fallback_context", None), dict):
+        policy_cfg = cfg.get("policy_fallback")
+        if isinstance(policy_cfg, dict):
+            cfg = {**cfg, **policy_cfg}
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers

--- a/tools/policy_consultation.py
+++ b/tools/policy_consultation.py
@@ -1,0 +1,76 @@
+"""Host-owned consultation tools exposed only to policy-fallback workers."""
+import json, logging
+from agent.policy_fallback import runtime
+from tools.registry import registry, tool_error
+
+log=logging.getLogger(__name__)
+REASONS={"low_confidence","conflicting_evidence","failed_verification","high_impact_decision"}
+
+def available():
+    # Availability is decided by the internal toolset, which is attached while
+    # the child is constructed (before its runtime ContextVar is bound).
+    # Handlers still enforce the runtime capability token on every call.
+    return True
+
+def _content(response):
+    choice=response.choices[0]; msg=choice.message
+    value=getattr(msg,"content","") or ""
+    if isinstance(value,list):
+        value="".join(str(getattr(p,"text",None) or (p.get("text","") if isinstance(p,dict) else "")) for p in value)
+    return str(value)
+
+def ask_gpt(question,context,evidence,reason,what_changed_since_last_consultation=None):
+    rt=runtime()
+    if not rt:return tool_error("ask_gpt is available only inside a policy-fallback Qwen worker")
+    question=str(question or "").strip(); context=str(context or "").strip(); evidence=evidence or []
+    if not question:return tool_error("question is required")
+    if reason not in REASONS:return tool_error("invalid consultation reason")
+    if not isinstance(evidence,list):return tool_error("evidence must be an array")
+    store=rt["store"]
+    reserved,error=store.reserve_consultation(rt["fallback_id"],reason,question,evidence,what_changed_since_last_consultation or "")
+    if not reserved:return json.dumps({"status":"budget_exhausted" if error=="budget_exhausted" else "failed","error":error},ensure_ascii=False)
+    cid=reserved["consultation_id"]; parent=rt["parent_agent"]
+    log.info("policy_consultation state=running fallback_id=%s consultation_id=%s sequence=%s reason=%s",rt["fallback_id"],cid,reserved["sequence"],reason)
+    bounded_evidence=[]
+    for item in evidence[:8]:
+        if isinstance(item,dict):
+            bounded_evidence.append({"source":str(item.get("source") or "")[:512],"excerpt":str(item.get("excerpt") or "")[:1024]})
+    prompt={"question":question[:2048],"context":context[:4096],"evidence":bounded_evidence,"reason":reason}
+    system="""You are a stateless technical consultant. Answer only the narrow question using the supplied facts. Do not call tools, delegate, or propose actions outside the question. Return ONLY JSON: {"status":"answered","answer":"...","confidence":0.0,"verification_required":true,"caveats":[],"suggested_checks":[]}. Confidence is only your subjective signal. Separate facts from assumptions."""
+    try:
+        kwargs={"model":parent.model,"messages":[{"role":"system","content":system},{"role":"user","content":json.dumps(prompt,ensure_ascii=False)}],"max_tokens":2048}
+        response=parent.client.chat.completions.create(**kwargs)
+        raw=_content(response); data=json.loads(raw.strip().removeprefix("```json").removesuffix("```").strip())
+        if not isinstance(data,dict):raise ValueError("consultation response is not an object")
+        status=str(data.get("status") or "answered")
+        if status=="blocked":
+            store.finish_consultation(cid,"blocked",str(data.get("answer") or data.get("reason") or "provider/model blocked consultation"),None,True)
+            log.warning("policy_consultation state=blocked fallback_id=%s consultation_id=%s",rt["fallback_id"],cid)
+            return json.dumps({"consultation_id":cid,"status":"blocked","reason":str(data.get("reason") or "policy block"),"verification_result":{"status":"not_run","summary":""}},ensure_ascii=False)
+        confidence=data.get("confidence")
+        try:confidence=max(0.0,min(1.0,float(confidence)))
+        except Exception:confidence=None
+        required=bool(data.get("verification_required")) or confidence is None or confidence<.75 or reason in {"high_impact_decision","failed_verification","conflicting_evidence"}
+        answer=str(data.get("answer") or "")
+        store.finish_consultation(cid,"answered",answer,confidence,required)
+        log.info("policy_consultation state=answered fallback_id=%s consultation_id=%s confidence=%s verification_required=%s",rt["fallback_id"],cid,confidence,required)
+        return json.dumps({"consultation_id":cid,"status":"answered","answer":answer,"confidence":confidence,"verification_required":required,"caveats":data.get("caveats") or [],"suggested_checks":data.get("suggested_checks") or [],"verification_result":{"status":"not_run","summary":""}},ensure_ascii=False)
+    except Exception as exc:
+        text=str(exc)
+        blocked="policy" in text.casefold() or "safety" in text.casefold()
+        state="blocked" if blocked else "failed"
+        store.finish_consultation(cid,state,text,None,True)
+        return json.dumps({"consultation_id":cid,"status":state,"reason":text[:1000],"verification_result":{"status":"not_run","summary":""}},ensure_ascii=False)
+
+def record_gpt_verification(consultation_id,status,summary,evidence):
+    rt=runtime()
+    if not rt:return tool_error("record_gpt_verification is available only inside policy fallback")
+    try:return json.dumps(rt["store"].verify(str(consultation_id),str(status),str(summary),evidence or []),ensure_ascii=False)
+    except Exception as exc:return tool_error(str(exc))
+
+registry.register(name="ask_gpt",toolset="policy_consultation",check_fn=available,emoji="🧭",
+ schema={"name":"ask_gpt","description":"Ask the parent GPT one narrow technical question after independent research. Never retry a blocked consultation.","parameters":{"type":"object","properties":{"question":{"type":"string"},"context":{"type":"string"},"evidence":{"type":"array","items":{"type":"object","properties":{"source":{"type":"string"},"excerpt":{"type":"string"}},"required":["source","excerpt"]}},"reason":{"type":"string","enum":sorted(REASONS)},"what_changed_since_last_consultation":{"type":["string","null"]}},"required":["question","context","evidence","reason"]}},
+ handler=lambda a,**kw:ask_gpt(a.get("question"),a.get("context"),a.get("evidence"),a.get("reason"),a.get("what_changed_since_last_consultation")))
+registry.register(name="record_gpt_verification",toolset="policy_consultation",check_fn=available,emoji="✅",
+ schema={"name":"record_gpt_verification","description":"Record an instrument-backed verification of a GPT consultation.","parameters":{"type":"object","properties":{"consultation_id":{"type":"string"},"status":{"type":"string","enum":["passed","failed","inconclusive"]},"summary":{"type":"string"},"evidence":{"type":"array","items":{"type":"string"}}},"required":["consultation_id","status","summary","evidence"]}},
+ handler=lambda a,**kw:record_gpt_verification(a.get("consultation_id"),a.get("status"),a.get("summary"),a.get("evidence")))

--- a/toolsets.py
+++ b/toolsets.py
@@ -99,6 +99,11 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
 TOOLSETS = {
+    "policy_consultation": {
+        "description": "Host-owned GPT consultation tools for policy fallback workers",
+        "tools": ["ask_gpt", "record_gpt_verification"],
+        "includes": [],
+    },
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",


### PR DESCRIPTION
## What changed

- add policy-only fallback routing from the primary orchestrator to a local Qwen subagent
- distinguish model-reported policy restrictions from provider policy blocks
- persist idempotent fallback jobs, leases, consultation state, verification results, hashes, and bounded summaries
- add host-owned ask_gpt and record_gpt_verification tools with consultation budgets and semantic blocked-question deduplication
- enforce Proxmox/network/tool restrictions for fallback workers
- add startup, hourly, and opportunistic retention cleanup
- merge Qwen completed and remaining work back into the primary result without dropping unresolved items

## Why

This lets Hermes recover the precise policy-blocked portion of a task without resending the full request, while keeping local-agent output untrusted and subject to normal execution controls.

## Validation

- scripts/run_tests.sh tests/agent/test_policy_fallback.py — 6 passed
- scripts/run_tests.sh tests/tools/test_delegate.py — 62 passed
- scripts/run_tests.sh tests/tools/test_browser_ssrf_local.py — 20 passed
- scripts/run_tests.sh tests/tools/test_browser_private_page_action_guard.py — 9 passed
- git diff --check
- live Qwen API smoke
