### PR TITLE
fix(agent): require actionable handoffs at incomplete terminal states

### DIFF
--- a/agent/boundary_handoff.py
+++ b/agent/boundary_handoff.py
@@ -22,6 +22,17 @@ _ACTIVE_STATUSES = frozenset({"pending", "in_progress"})
 _DEFAULT_MAX_ATTEMPTS = 2
 _MAX_REMAINING_IN_NUDGE = 6
 
+# Runtime-injected user turns that do not end the human turn window.
+# Keys ending in ``_synthetic`` are covered generically; these extra
+# markers use a different naming convention in the conversation loop.
+_INTERNAL_USER_MARKERS = frozenset(
+    {
+        "_dropped_toolcall_nudge",
+        "_empty_terminal_sentinel",
+        "_thinking_prefill",
+    }
+)
+
 
 def remaining_todo_items(todo_store: Any) -> list[dict[str, str]]:
     """Return pending/in_progress todo items from a TodoStore-like object."""
@@ -69,7 +80,9 @@ def _tool_call_name(tc: Any) -> str:
 
 def _is_synthetic_user_message(msg: dict) -> bool:
     """True for runtime-injected user turns (nudges), not the human user."""
-    return any(str(key).endswith("_synthetic") for key in msg)
+    if any(str(key).endswith("_synthetic") for key in msg):
+        return True
+    return any(marker in msg for marker in _INTERNAL_USER_MARKERS)
 
 
 def turn_called_clarify(messages: Iterable[dict] | None) -> bool:
@@ -127,13 +140,23 @@ def build_boundary_handoff_nudge(
 ) -> Optional[str]:
     """Return a synthetic follow-up when remaining work ends without ``clarify``.
 
-    Returns ``None`` when the guard should not fire (disabled, ``clarify`` not
-    in the toolset, no remaining todos, clarify already asked, or nudge budget
-    exhausted). Freeform reply text is ignored — terminal validity is
-    structured evidence only.
+    Returns ``None`` when the guard should not fire (disabled, kanban worker,
+    ``clarify`` not in the toolset, no remaining todos, clarify already asked,
+    or nudge budget exhausted). Freeform reply text is ignored — terminal
+    validity is structured evidence only.
     """
     if not enabled or not clarify_available or attempts >= max_attempts:
         return None
+
+    # Kanban workers must terminate with kanban_complete / kanban_block, not
+    # clarify. Defer to kanban_stop so this guard cannot steal the nudge.
+    try:
+        from agent.kanban_stop import kanban_stop_nudge_enabled
+
+        if kanban_stop_nudge_enabled():
+            return None
+    except Exception:
+        pass
 
     remaining = remaining_todo_items(todo_store)
     if not remaining:

--- a/agent/boundary_handoff.py
+++ b/agent/boundary_handoff.py
@@ -1,0 +1,216 @@
+"""Turn-end guard for incomplete work paused without a boundary handoff.
+
+Issue #80772: a pause at a permission, safety, workspace, repository, or
+external-system boundary is legitimate, but ending the turn with only a
+partial-progress summary is not. When task-tracking evidence shows remaining
+work, a final response that lacks both a clear completion claim and a clear
+blocker/clarification is an invalid terminal state. The conversation loop
+nudges once or twice so the model emits a self-contained handoff (or asks
+for the decision) before stopping.
+
+Policy-only: this module never calls tools or mutates the todo store. It
+returns a synthetic follow-up string or ``None``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Optional, Sequence
+
+_ACTIVE_STATUSES = frozenset({"pending", "in_progress"})
+_DEFAULT_MAX_ATTEMPTS = 2
+_MAX_REMAINING_IN_NUDGE = 6
+
+# A completion claim is an explicit "the job is done" signal — not mere
+# progress narration ("I finished the skill-local gate").
+_COMPLETION_CLAIM_RE = re.compile(
+    r"(?is)\b("
+    r"all\s+(?:done|complete|finished|implemented)|"
+    r"(?:task|implementation|plan|work|job|request)\s+(?:is\s+)?(?:done|complete|completed|finished)|"
+    r"(?:fully|completely)\s+(?:done|complete|finished|implemented)|"
+    r"nothing\s+(?:left|remaining|else)|"
+    r"no\s+(?:remaining|outstanding)\s+(?:work|tasks?|items?)|"
+    r"completed\s+(?:all|everything|the\s+(?:task|implementation|plan|request))"
+    r")\b"
+)
+
+# Blocker / boundary language that identifies why autonomous work stopped.
+_BLOCKER_RE = re.compile(
+    r"(?is)\b("
+    r"blocked|blocker|cannot\s+continue|can't\s+continue|"
+    r"need(?:s)?\s+(?:your\s+)?(?:approval|authorization|permission|decision|go-ahead)|"
+    r"(?:permission|approval|authorization)\s+(?:required|needed)|"
+    r"(?:workspace|repository|repo|safety|external(?:-|\s)?system)\s+boundary|"
+    r"outside\s+(?:the\s+)?(?:allowed\s+)?workspace|"
+    r"out\s+of\s+scope|"
+    r"remaining\s+(?:work|scope|items?|tasks?)|"
+    r"still\s+(?:need(?:s)?|left|outstanding|remaining)|"
+    r"not\s+(?:yet\s+)?(?:implemented|done|complete)|"
+    r"pause(?:d)?\s+(?:here|at)|"
+    r"stop(?:ping)?\s+(?:here|at\s+this)"
+    r")\b"
+)
+
+# Explicit ask for the user's decision — required for an actionable handoff.
+_DECISION_REQUEST_RE = re.compile(
+    r"(?is)("
+    r"\?|"
+    r"\b(?:should\s+i|may\s+i|can\s+i|do\s+you\s+want\s+(?:me\s+)?to|"
+    r"please\s+(?:confirm|approve|authorize|decide|choose)|"
+    r"awaiting\s+(?:your\s+)?(?:decision|approval|authorization|go-ahead)|"
+    r"let\s+me\s+know\s+(?:if|whether|how)|"
+    r"which\s+(?:option|path|approach)\b)"
+    r")"
+)
+
+
+def remaining_todo_items(todo_store: Any) -> list[dict[str, str]]:
+    """Return pending/in_progress todo items from a TodoStore-like object."""
+    if todo_store is None:
+        return []
+    read = getattr(todo_store, "read", None)
+    if not callable(read):
+        return []
+    try:
+        items = read() or []
+    except Exception:
+        return []
+    remaining: list[dict[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").strip().lower()
+        if status in _ACTIVE_STATUSES:
+            remaining.append(
+                {
+                    "id": str(item.get("id") or "?"),
+                    "content": str(item.get("content") or "").strip(),
+                    "status": status,
+                }
+            )
+    return remaining
+
+
+def has_remaining_work(todo_store: Any) -> bool:
+    """True when task-tracking evidence shows unfinished work."""
+    return bool(remaining_todo_items(todo_store))
+
+
+def response_has_completion_claim(text: str) -> bool:
+    """True when the final reply clearly claims the task is finished."""
+    return bool(_COMPLETION_CLAIM_RE.search(text or ""))
+
+
+def response_has_blocker_or_clarification(text: str) -> bool:
+    """True when the reply identifies a blocker/boundary and asks to proceed.
+
+    A self-contained handoff needs both signals: what stops autonomous work,
+    and the decision the user must make. A question alone without blocker
+    context, or a blocker summary without an ask, is not enough.
+    """
+    body = text or ""
+    return bool(_BLOCKER_RE.search(body) and _DECISION_REQUEST_RE.search(body))
+
+
+def is_valid_terminal_for_remaining_work(text: str) -> bool:
+    """Final replies are valid only with a completion claim or a handoff ask."""
+    return response_has_completion_claim(text) or response_has_blocker_or_clarification(
+        text
+    )
+
+
+def _tool_call_name(tc: Any) -> str:
+    if isinstance(tc, dict):
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            return str(fn.get("name") or "")
+        return str(tc.get("name") or "")
+    fn = getattr(tc, "function", None)
+    if fn is not None:
+        return str(getattr(fn, "name", "") or "")
+    return str(getattr(tc, "name", "") or "")
+
+
+def turn_called_clarify(messages: Iterable[dict] | None) -> bool:
+    """True if the latest assistant turn already invoked ``clarify``."""
+    if not messages:
+        return False
+    for msg in reversed(list(messages)):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if _tool_call_name(tc) == "clarify":
+                return True
+        return False
+    return False
+
+
+def _format_remaining(items: Sequence[dict[str, str]]) -> str:
+    lines: list[str] = []
+    for item in items[:_MAX_REMAINING_IN_NUDGE]:
+        label = item.get("content") or item.get("id") or "?"
+        lines.append(f"- [{item.get('status', '?')}] {label}")
+    omitted = len(items) - len(lines)
+    if omitted > 0:
+        lines.append(f"- ... and {omitted} more")
+    return "\n".join(lines)
+
+
+def build_boundary_handoff_nudge(
+    *,
+    todo_store: Any = None,
+    final_response: str | None = None,
+    messages: Iterable[dict] | None = None,
+    attempts: int = 0,
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    enabled: bool = True,
+) -> Optional[str]:
+    """Return a synthetic follow-up when remaining work ends without a handoff.
+
+    Returns ``None`` when the guard should not fire (disabled, no remaining
+    todos, clarify already asked, response already valid, or nudge budget
+    exhausted).
+    """
+    if not enabled or attempts >= max_attempts:
+        return None
+
+    remaining = remaining_todo_items(todo_store)
+    if not remaining:
+        return None
+
+    if turn_called_clarify(messages):
+        return None
+
+    if is_valid_terminal_for_remaining_work(final_response or ""):
+        return None
+
+    return (
+        "[System: Task-tracking still shows unfinished work, but your last "
+        "reply was neither a clear completion claim nor a self-contained "
+        "boundary handoff.\n\n"
+        "Outstanding items:\n"
+        f"{_format_remaining(remaining)}\n\n"
+        "A plain progress summary is not a valid terminal state here. Either:\n"
+        "1. Finish the remaining work now, OR\n"
+        "2. If you must pause at a permission, safety, workspace, repository, "
+        "or external-system boundary, rewrite the reply as an actionable "
+        "handoff that states (a) what you completed and verified, (b) what "
+        "remains, (c) the exact boundary or blocker, (d) whether any live or "
+        "external state changed, and (e) the decision or authorization needed "
+        "to continue — and ask for that decision explicitly.\n\n"
+        "Do not end with ambiguity about whether the task is complete, paused, "
+        "blocked, or abandoned.]"
+    )
+
+
+__all__ = [
+    "build_boundary_handoff_nudge",
+    "has_remaining_work",
+    "is_valid_terminal_for_remaining_work",
+    "remaining_todo_items",
+    "response_has_blocker_or_clarification",
+    "response_has_completion_claim",
+    "turn_called_clarify",
+]

--- a/agent/boundary_handoff.py
+++ b/agent/boundary_handoff.py
@@ -149,11 +149,12 @@ def build_boundary_handoff_nudge(
         return None
 
     # Kanban workers must terminate with kanban_complete / kanban_block, not
-    # clarify. Defer to kanban_stop so this guard cannot steal the nudge.
+    # clarify — even when HERMES_KANBAN_STOP_NUDGE disables the kanban stop
+    # nudge itself. Skip on worker identity, not nudge enablement.
     try:
-        from agent.kanban_stop import kanban_stop_nudge_enabled
+        from agent.kanban_stop import is_kanban_worker
 
-        if kanban_stop_nudge_enabled():
+        if is_kanban_worker():
             return None
     except Exception:
         pass

--- a/agent/boundary_handoff.py
+++ b/agent/boundary_handoff.py
@@ -3,65 +3,24 @@
 Issue #80772: a pause at a permission, safety, workspace, repository, or
 external-system boundary is legitimate, but ending the turn with only a
 partial-progress summary is not. When task-tracking evidence shows remaining
-work, a final response that lacks both a clear completion claim and a clear
-blocker/clarification is an invalid terminal state. The conversation loop
-nudges once or twice so the model emits a self-contained handoff (or asks
-for the decision) before stopping.
+work, a text-only stop (no ``clarify`` this turn) is an invalid terminal
+state. The conversation loop nudges once or twice so the model either
+finishes and clears todos or calls ``clarify`` with a self-contained handoff.
 
-Policy-only: this module never calls tools or mutates the todo store. It
-returns a synthetic follow-up string or ``None``.
+Policy-only and language-agnostic: this module never parses freeform prose,
+never calls tools, and never mutates the todo store. It returns a synthetic
+follow-up string or ``None``. Structured evidence only — remaining todos and
+whether ``clarify`` already ran — matching ``verification_stop`` /
+``kanban_stop``.
 """
 
 from __future__ import annotations
 
-import re
 from typing import Any, Iterable, Optional, Sequence
 
 _ACTIVE_STATUSES = frozenset({"pending", "in_progress"})
 _DEFAULT_MAX_ATTEMPTS = 2
 _MAX_REMAINING_IN_NUDGE = 6
-
-# A completion claim is an explicit "the job is done" signal — not mere
-# progress narration ("I finished the skill-local gate").
-_COMPLETION_CLAIM_RE = re.compile(
-    r"(?is)\b("
-    r"all\s+(?:done|complete|finished|implemented)|"
-    r"(?:task|implementation|plan|work|job|request)\s+(?:is\s+)?(?:done|complete|completed|finished)|"
-    r"(?:fully|completely)\s+(?:done|complete|finished|implemented)|"
-    r"nothing\s+(?:left|remaining|else)|"
-    r"no\s+(?:remaining|outstanding)\s+(?:work|tasks?|items?)|"
-    r"completed\s+(?:all|everything|the\s+(?:task|implementation|plan|request))"
-    r")\b"
-)
-
-# Blocker / boundary language that identifies why autonomous work stopped.
-_BLOCKER_RE = re.compile(
-    r"(?is)\b("
-    r"blocked|blocker|cannot\s+continue|can't\s+continue|"
-    r"need(?:s)?\s+(?:your\s+)?(?:approval|authorization|permission|decision|go-ahead)|"
-    r"(?:permission|approval|authorization)\s+(?:required|needed)|"
-    r"(?:workspace|repository|repo|safety|external(?:-|\s)?system)\s+boundary|"
-    r"outside\s+(?:the\s+)?(?:allowed\s+)?workspace|"
-    r"out\s+of\s+scope|"
-    r"remaining\s+(?:work|scope|items?|tasks?)|"
-    r"still\s+(?:need(?:s)?|left|outstanding|remaining)|"
-    r"not\s+(?:yet\s+)?(?:implemented|done|complete)|"
-    r"pause(?:d)?\s+(?:here|at)|"
-    r"stop(?:ping)?\s+(?:here|at\s+this)"
-    r")\b"
-)
-
-# Explicit ask for the user's decision — required for an actionable handoff.
-_DECISION_REQUEST_RE = re.compile(
-    r"(?is)("
-    r"\?|"
-    r"\b(?:should\s+i|may\s+i|can\s+i|do\s+you\s+want\s+(?:me\s+)?to|"
-    r"please\s+(?:confirm|approve|authorize|decide|choose)|"
-    r"awaiting\s+(?:your\s+)?(?:decision|approval|authorization|go-ahead)|"
-    r"let\s+me\s+know\s+(?:if|whether|how)|"
-    r"which\s+(?:option|path|approach)\b)"
-    r")"
-)
 
 
 def remaining_todo_items(todo_store: Any) -> list[dict[str, str]]:
@@ -96,29 +55,6 @@ def has_remaining_work(todo_store: Any) -> bool:
     return bool(remaining_todo_items(todo_store))
 
 
-def response_has_completion_claim(text: str) -> bool:
-    """True when the final reply clearly claims the task is finished."""
-    return bool(_COMPLETION_CLAIM_RE.search(text or ""))
-
-
-def response_has_blocker_or_clarification(text: str) -> bool:
-    """True when the reply identifies a blocker/boundary and asks to proceed.
-
-    A self-contained handoff needs both signals: what stops autonomous work,
-    and the decision the user must make. A question alone without blocker
-    context, or a blocker summary without an ask, is not enough.
-    """
-    body = text or ""
-    return bool(_BLOCKER_RE.search(body) and _DECISION_REQUEST_RE.search(body))
-
-
-def is_valid_terminal_for_remaining_work(text: str) -> bool:
-    """Final replies are valid only with a completion claim or a handoff ask."""
-    return response_has_completion_claim(text) or response_has_blocker_or_clarification(
-        text
-    )
-
-
 def _tool_call_name(tc: Any) -> str:
     if isinstance(tc, dict):
         fn = tc.get("function")
@@ -131,20 +67,42 @@ def _tool_call_name(tc: Any) -> str:
     return str(getattr(tc, "name", "") or "")
 
 
+def _is_synthetic_user_message(msg: dict) -> bool:
+    """True for runtime-injected user turns (nudges), not the human user."""
+    return any(str(key).endswith("_synthetic") for key in msg)
+
+
 def turn_called_clarify(messages: Iterable[dict] | None) -> bool:
-    """True if the latest assistant turn already invoked ``clarify``."""
+    """True if this user turn already invoked ``clarify``.
+
+    Scans assistant messages after the last real (non-synthetic) user message
+    so a later text reply does not erase an earlier clarify in the same turn.
+    """
     if not messages:
         return False
     for msg in reversed(list(messages)):
         if not isinstance(msg, dict):
             continue
-        if msg.get("role") != "assistant":
+        role = msg.get("role")
+        if role == "user" and not _is_synthetic_user_message(msg):
+            break
+        if role != "assistant":
             continue
         for tc in msg.get("tool_calls") or []:
             if _tool_call_name(tc) == "clarify":
                 return True
-        return False
     return False
+
+
+def is_valid_terminal_for_remaining_work(
+    *,
+    todo_store: Any = None,
+    messages: Iterable[dict] | None = None,
+) -> bool:
+    """True when todos are settled, or ``clarify`` already asked this turn."""
+    if not has_remaining_work(todo_store):
+        return True
+    return turn_called_clarify(messages)
 
 
 def _format_remaining(items: Sequence[dict[str, str]]) -> str:
@@ -161,19 +119,20 @@ def _format_remaining(items: Sequence[dict[str, str]]) -> str:
 def build_boundary_handoff_nudge(
     *,
     todo_store: Any = None,
-    final_response: str | None = None,
     messages: Iterable[dict] | None = None,
     attempts: int = 0,
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     enabled: bool = True,
+    clarify_available: bool = True,
 ) -> Optional[str]:
-    """Return a synthetic follow-up when remaining work ends without a handoff.
+    """Return a synthetic follow-up when remaining work ends without ``clarify``.
 
-    Returns ``None`` when the guard should not fire (disabled, no remaining
-    todos, clarify already asked, response already valid, or nudge budget
-    exhausted).
+    Returns ``None`` when the guard should not fire (disabled, ``clarify`` not
+    in the toolset, no remaining todos, clarify already asked, or nudge budget
+    exhausted). Freeform reply text is ignored — terminal validity is
+    structured evidence only.
     """
-    if not enabled or attempts >= max_attempts:
+    if not enabled or not clarify_available or attempts >= max_attempts:
         return None
 
     remaining = remaining_todo_items(todo_store)
@@ -183,23 +142,19 @@ def build_boundary_handoff_nudge(
     if turn_called_clarify(messages):
         return None
 
-    if is_valid_terminal_for_remaining_work(final_response or ""):
-        return None
-
     return (
-        "[System: Task-tracking still shows unfinished work, but your last "
-        "reply was neither a clear completion claim nor a self-contained "
-        "boundary handoff.\n\n"
+        "[System: Task-tracking still shows unfinished work, but you stopped "
+        "without calling `clarify`.\n\n"
         "Outstanding items:\n"
         f"{_format_remaining(remaining)}\n\n"
         "A plain progress summary is not a valid terminal state here. Either:\n"
-        "1. Finish the remaining work now, OR\n"
+        "1. Finish the remaining work now and mark those todos completed, OR\n"
         "2. If you must pause at a permission, safety, workspace, repository, "
-        "or external-system boundary, rewrite the reply as an actionable "
-        "handoff that states (a) what you completed and verified, (b) what "
+        "or external-system boundary, call `clarify` with a self-contained "
+        "question that states (a) what you completed and verified, (b) what "
         "remains, (c) the exact boundary or blocker, (d) whether any live or "
         "external state changed, and (e) the decision or authorization needed "
-        "to continue — and ask for that decision explicitly.\n\n"
+        "to continue.\n\n"
         "Do not end with ambiguity about whether the task is complete, paused, "
         "blocked, or abandoned.]"
     )
@@ -210,7 +165,5 @@ __all__ = [
     "has_remaining_work",
     "is_valid_terminal_for_remaining_work",
     "remaining_todo_items",
-    "response_has_blocker_or_clarification",
-    "response_has_completion_claim",
     "turn_called_clarify",
 ]

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1913,6 +1913,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_intent_ack_synthetic",
     "_length_continuation_synthetic",
     "_codex_incomplete_synthetic",
+    "_kanban_stop_synthetic",
     "_dropped_toolcall_nudge",
 )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1910,6 +1910,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_boundary_handoff_synthetic",
+    "_intent_ack_synthetic",
     "_dropped_toolcall_nudge",
 )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1911,6 +1911,8 @@ _SYNTHETIC_USER_FLAGS = (
     "_pre_verify_synthetic",
     "_boundary_handoff_synthetic",
     "_intent_ack_synthetic",
+    "_length_continuation_synthetic",
+    "_codex_incomplete_synthetic",
     "_dropped_toolcall_nudge",
 )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1909,6 +1909,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_empty_recovery_synthetic",
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_boundary_handoff_synthetic",
     "_dropped_toolcall_nudge",
 )
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3102,6 +3102,7 @@ def run_conversation(
                                 continue_msg = {
                                     "role": "user",
                                     "content": _continue_content,
+                                    "_length_continuation_synthetic": True,
                                 }
                                 messages.append(continue_msg)
                                 agent._session_messages = messages
@@ -5923,6 +5924,7 @@ def run_conversation(
                             messages.append({
                                 "role": "user",
                                 "content": _CODEX_INCOMPLETE_NUDGE,
+                                "_codex_incomplete_synthetic": True,
                             })
                     if not agent.quiet_mode:
                         agent._vprint(f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7155,6 +7155,55 @@ def run_conversation(
                     final_response = None
                     continue
 
+                # ── Incomplete-task boundary handoff guard (#80772) ────
+                # When todos still show remaining work, a final reply that is
+                # neither a completion claim nor a blocker/clarification
+                # handoff is an invalid terminal state. Nudge for an
+                # actionable pause instead of accepting a vague summary.
+                try:
+                    from agent.boundary_handoff import build_boundary_handoff_nudge
+
+                    _handoff_nudge = build_boundary_handoff_nudge(
+                        todo_store=getattr(agent, "_todo_store", None),
+                        final_response=final_response,
+                        messages=messages + [final_msg],
+                        attempts=getattr(agent, "_boundary_handoff_nudges", 0),
+                        enabled=bool(
+                            getattr(agent, "_task_completion_guidance", True)
+                        ),
+                    )
+                except Exception:
+                    logger.debug("boundary handoff stop-loop check failed", exc_info=True)
+                    _handoff_nudge = None
+
+                if _handoff_nudge:
+                    agent._boundary_handoff_nudges = (
+                        getattr(agent, "_boundary_handoff_nudges", 0) + 1
+                    )
+                    final_msg["finish_reason"] = "boundary_handoff_required"
+                    agent._emit_interim_assistant_message(final_msg)
+                    messages.append(final_msg)
+                    try:
+                        agent._flush_messages_to_session_db(messages, conversation_history)
+                    except Exception:
+                        logger.debug("boundary handoff interim flush failed", exc_info=True)
+                    messages.append({
+                        "role": "user",
+                        "content": _handoff_nudge,
+                        "_boundary_handoff_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.debug(
+                        "boundary handoff nudge issued (attempt %d)",
+                        agent._boundary_handoff_nudges,
+                    )
+                    _pending_verification_response = final_response
+                    _pending_verification_response_previewed = (
+                        agent._interim_content_was_streamed(final_response or "")
+                    )
+                    final_response = None
+                    continue
+
                 # ── Kanban worker terminal-tool stop guard ─────────────
                 # Workers must end with kanban_complete / kanban_block.
                 # Models sometimes narrate the next step ("Let me write the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6939,6 +6939,7 @@ def run_conversation(
                             "[System: Continue now. Execute the required tool calls and only "
                             "send your final answer after completing the task.]"
                         ),
+                        "_intent_ack_synthetic": True,
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7159,7 +7159,8 @@ def run_conversation(
                 # When todos still show remaining work, a text-only stop
                 # without `clarify` this turn is an invalid terminal state.
                 # Structured evidence only (todo store + clarify tool call) —
-                # do not parse freeform prose.
+                # do not parse freeform prose. Kanban workers are skipped so
+                # kanban_stop owns the terminal contract below.
                 try:
                     from agent.boundary_handoff import build_boundary_handoff_nudge
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7156,21 +7156,22 @@ def run_conversation(
                     continue
 
                 # ── Incomplete-task boundary handoff guard (#80772) ────
-                # When todos still show remaining work, a final reply that is
-                # neither a completion claim nor a blocker/clarification
-                # handoff is an invalid terminal state. Nudge for an
-                # actionable pause instead of accepting a vague summary.
+                # When todos still show remaining work, a text-only stop
+                # without `clarify` this turn is an invalid terminal state.
+                # Structured evidence only (todo store + clarify tool call) —
+                # do not parse freeform prose.
                 try:
                     from agent.boundary_handoff import build_boundary_handoff_nudge
 
+                    _valid_tools = getattr(agent, "valid_tool_names", None) or ()
                     _handoff_nudge = build_boundary_handoff_nudge(
                         todo_store=getattr(agent, "_todo_store", None),
-                        final_response=final_response,
                         messages=messages + [final_msg],
                         attempts=getattr(agent, "_boundary_handoff_nudges", 0),
                         enabled=bool(
                             getattr(agent, "_task_completion_guidance", True)
                         ),
+                        clarify_available="clarify" in _valid_tools,
                     )
                 except Exception:
                     logger.debug("boundary handoff stop-loop check failed", exc_info=True)

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -22,6 +22,11 @@ _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 _DEFAULT_MAX_ATTEMPTS = 2
 
 
+def is_kanban_worker() -> bool:
+    """True when this process is a dispatcher-spawned kanban worker."""
+    return bool((os.environ.get("HERMES_KANBAN_TASK") or "").strip())
+
+
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
@@ -31,8 +36,7 @@ def kanban_stop_nudge_enabled() -> bool:
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
-    task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    return is_kanban_worker()
 
 
 def _tool_call_name(tc: Any) -> str:
@@ -103,6 +107,7 @@ def build_kanban_stop_nudge(
 
 __all__ = [
     "build_kanban_stop_nudge",
+    "is_kanban_worker",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",
 ]

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -338,8 +338,7 @@ TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm",
 #      the blocker.  (Observed on DeepSeek v4-flash on the same task:
 #      pushed through PEP-668 wall, then returned fabricated listings.)
 #   3. Ending with a partial-progress summary at a legitimate implementation
-#      boundary without identifying the unfinished scope or asking for the
-#      decision needed to continue.
+#      boundary without calling `clarify` (or clearing remaining todos).
 #
 # Short on purpose.  This block is shipped to every user, every session,
 # in the cached system prompt — token cost is paid once at install and
@@ -359,10 +358,10 @@ TASK_COMPLETION_GUIDANCE = (
     "is always better than inventing a result.\n"
     "If work must pause at a permission, safety, workspace, repository, or "
     "external-system boundary, do not end with a partial-progress summary alone. "
-    "Give a self-contained handoff stating what you completed and verified, what "
-    "remains, the exact boundary or blocker, whether any live or external state "
-    "changed, and the decision or authorization needed to continue. Ask for that "
-    "decision explicitly."
+    "Call `clarify` with a self-contained question stating what you completed "
+    "and verified, what remains, the exact boundary or blocker, whether any live "
+    "or external state changed, and the decision or authorization needed to "
+    "continue. Otherwise finish the remaining work and mark those todos completed."
 )
 
 # Universal parallel-tool-call guidance — applied to ALL models.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -355,7 +355,13 @@ TASK_COMPLETION_GUIDANCE = (
     "approach, ask the user). NEVER substitute plausible-looking fabricated "
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
-    "is always better than inventing a result.\n"
+    "is always better than inventing a result."
+)
+
+# Clarify-gated boundary handoff — only injected when ``clarify`` is in the
+# live toolset (see system_prompt assembly). Leaf/cron/kanban surfaces that
+# strip clarify must not be told to call a missing tool.
+TASK_COMPLETION_BOUNDARY_GUIDANCE = (
     "If work must pause at a permission, safety, workspace, repository, or "
     "external-system boundary, do not end with a partial-progress summary alone. "
     "Call `clarify` with a self-contained question stating what you completed "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -337,6 +337,9 @@ TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm",
 #      (fake addresses, fake JSON, fake numbers) instead of reporting
 #      the blocker.  (Observed on DeepSeek v4-flash on the same task:
 #      pushed through PEP-668 wall, then returned fabricated listings.)
+#   3. Ending with a partial-progress summary at a legitimate implementation
+#      boundary without identifying the unfinished scope or asking for the
+#      decision needed to continue.
 #
 # Short on purpose.  This block is shipped to every user, every session,
 # in the cached system prompt — token cost is paid once at install and
@@ -353,7 +356,13 @@ TASK_COMPLETION_GUIDANCE = (
     "approach, ask the user). NEVER substitute plausible-looking fabricated "
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
-    "is always better than inventing a result."
+    "is always better than inventing a result.\n"
+    "If work must pause at a permission, safety, workspace, repository, or "
+    "external-system boundary, do not end with a partial-progress summary alone. "
+    "Give a self-contained handoff stating what you completed and verified, what "
+    "remains, the exact boundary or blocker, whether any live or external state "
+    "changed, and the decision or authorization needed to continue. Ask for that "
+    "decision explicitly."
 )
 
 # Universal parallel-tool-call guidance — applied to ALL models.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -42,6 +42,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
+    TASK_COMPLETION_BOUNDARY_GUIDANCE,
     TASK_COMPLETION_GUIDANCE,
     TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -211,6 +212,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # users who want a leaner prompt can turn it off.
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
+        # Boundary handoff requires clarify — only steer when the tool exists.
+        if "clarify" in agent.valid_tool_names:
+            stable_parts.append(TASK_COMPLETION_BOUNDARY_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1138,6 +1138,7 @@ def build_turn_context(
     agent._turn_file_mutation_paths = set()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
+    agent._boundary_handoff_nudges = 0
 
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -50,6 +50,7 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_boundary_handoff_synthetic",
 )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -42,24 +42,25 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
-# Verification continuation scaffolding flags: verify-on-stop / pre_verify
-# inject a synthetic user nudge to keep the agent going one more turn.
-# These nudges must be stripped from returned/live history to avoid
-# role-alternation breaks and poisoning the resumed transcript. The
-# assistant response is real content and is not flagged. (#65919 §7)
+# Continuation scaffolding flags: verify-on-stop / pre_verify / boundary
+# handoff inject a synthetic user nudge (assistant candidate stays real and
+# unflagged). Kanban stop-guard flags BOTH the narrated assistant exit and
+# the user nudge — both must be stripped from returned/live history.
+# (#65919 §7, #80772)
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_boundary_handoff_synthetic",
+    "_kanban_stop_synthetic",
 )
 
 
 def _drop_verification_continuation_scaffolding(messages) -> None:
-    """Remove verification-continuation nudge messages from *messages* in place.
+    """Remove continuation-nudge scaffolding from *messages* in place.
 
-    Only the synthetic nudges carry these flags, so this strips just the
-    nudges while preserving the real attempted-final-answer that was
-    persisted to state.db.
+    Verify/pre_verify/boundary only flag the user nudge, so the attempted
+    final assistant answer is preserved. Kanban flags the narrated
+    assistant+nudge pair, so both sides are removed.
     """
     messages[:] = [
         m for m in messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -243,6 +243,13 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     # persisted and emitted as an interim message (#65919).
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    # incomplete-task boundary handoff nudge (#80772)
+    "_boundary_handoff_synthetic",
+    # intent-ack / length / Codex incomplete recovery continues — drive the
+    # next API call only; must not durable-persist as human turns on resume.
+    "_intent_ack_synthetic",
+    "_length_continuation_synthetic",
+    "_codex_incomplete_synthetic",
     # kanban worker stop-guard: narrated exit without kanban_complete/block
     "_kanban_stop_synthetic",
     # dropped tool-call re-prompt pair (finish_reason=tool_calls with an

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -179,6 +179,40 @@ def test_kanban_worker_skips_boundary_handoff_nudge(monkeypatch):
     )
 
 
+def test_kanban_worker_skips_even_when_stop_nudge_disabled(monkeypatch):
+    """Worker identity wins over HERMES_KANBAN_STOP_NUDGE=0."""
+    store = _store(("remaining step", "pending"))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_KANBAN_STOP_NUDGE", "0")
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            messages=[{"role": "assistant", "content": "Stopped mid-task."}],
+            clarify_available=True,
+        )
+        is None
+    )
+
+
+def test_intent_ack_continue_does_not_reset_clarify_window():
+    store = _store(("remaining step", "pending"))
+    messages = [
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {
+            "role": "user",
+            "content": (
+                "[System: Continue now. Execute the required tool calls and only "
+                "send your final answer after completing the task.]"
+            ),
+            "_intent_ack_synthetic": True,
+        },
+        {"role": "assistant", "content": "Paused pending your decision."},
+    ]
+    assert turn_called_clarify(messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
+
+
 def test_nudge_budget_disable_and_clarify_unavailable():
     store = _store(("remaining step", "pending"))
     assert (

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -1,0 +1,291 @@
+"""Regression coverage for incomplete-task boundary handoffs (#80772).
+
+Covers both implementation and planning shapes: remaining todos + a vague
+progress summary is an invalid terminal state; a self-contained handoff or
+clear completion claim is allowed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.boundary_handoff import (
+    build_boundary_handoff_nudge,
+    has_remaining_work,
+    is_valid_terminal_for_remaining_work,
+    remaining_todo_items,
+    response_has_blocker_or_clarification,
+    response_has_completion_claim,
+    turn_called_clarify,
+)
+from tools.todo_tool import TodoStore
+
+
+def _store(*items):
+    store = TodoStore()
+    store.write(
+        [
+            {"id": str(i), "content": content, "status": status}
+            for i, (content, status) in enumerate(items, start=1)
+        ]
+    )
+    return store
+
+
+# ── Policy unit tests ────────────────────────────────────────────────
+
+
+def test_remaining_work_from_active_todos_only():
+    store = _store(
+        ("done piece", "completed"),
+        ("still open", "pending"),
+        ("cancelled piece", "cancelled"),
+        ("active now", "in_progress"),
+    )
+    remaining = remaining_todo_items(store)
+    assert has_remaining_work(store) is True
+    assert [item["content"] for item in remaining] == ["still open", "active now"]
+
+
+def test_no_remaining_work_when_todos_settled():
+    store = _store(("a", "completed"), ("b", "cancelled"))
+    assert has_remaining_work(store) is False
+    assert build_boundary_handoff_nudge(todo_store=store, final_response="summary") is None
+
+
+def test_partial_progress_summary_is_invalid_terminal():
+    text = (
+        "I finished the skill-local gate and verified the unit tests. "
+        "The scheduler integration is next."
+    )
+    assert response_has_completion_claim(text) is False
+    assert response_has_blocker_or_clarification(text) is False
+    assert is_valid_terminal_for_remaining_work(text) is False
+
+
+def test_implementation_boundary_handoff_is_valid_terminal():
+    text = (
+        "Completed and verified the skill-local gate. Remaining work is the "
+        "scripts-tree scheduler write outside this workspace boundary. No live "
+        "or external state changed. Should I proceed with that write?"
+    )
+    assert response_has_blocker_or_clarification(text) is True
+    assert is_valid_terminal_for_remaining_work(text) is True
+
+
+def test_clear_completion_claim_is_valid_terminal():
+    text = "The implementation is complete. All requested work is done."
+    assert response_has_completion_claim(text) is True
+    assert is_valid_terminal_for_remaining_work(text) is True
+
+
+def test_planning_partial_summary_nudges():
+    store = _store(
+        ("outline API shape", "completed"),
+        ("choose storage backend", "pending"),
+        ("write rollout plan", "pending"),
+    )
+    partial = (
+        "I outlined the API shape. Next I will choose a storage backend and "
+        "draft the rollout plan."
+    )
+    nudge = build_boundary_handoff_nudge(
+        todo_store=store,
+        final_response=partial,
+        attempts=0,
+    )
+    assert nudge is not None
+    assert "Outstanding items" in nudge
+    assert "choose storage backend" in nudge
+    assert "decision or authorization" in nudge
+
+
+def test_planning_valid_pause_does_not_nudge():
+    store = _store(
+        ("outline API shape", "completed"),
+        ("choose storage backend", "pending"),
+    )
+    handoff = (
+        "Completed the API outline. Remaining work is choosing the storage "
+        "backend — that needs your approval before I continue. No external "
+        "state changed. Should I use Postgres or SQLite?"
+    )
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            final_response=handoff,
+            attempts=0,
+        )
+        is None
+    )
+
+
+def test_implementation_partial_summary_nudges():
+    store = _store(
+        ("skill-local gate", "completed"),
+        ("scheduler scripts write", "pending"),
+    )
+    partial = (
+        "Implemented and tested the skill-local gate. Stopping here for now."
+    )
+    nudge = build_boundary_handoff_nudge(
+        todo_store=store,
+        final_response=partial,
+        attempts=0,
+    )
+    assert nudge is not None
+    assert "scheduler scripts write" in nudge
+    assert "self-contained" in nudge.lower() or "actionable" in nudge.lower()
+
+
+def test_clarify_tool_already_asked_skips_nudge():
+    store = _store(("remaining step", "pending"))
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "clarify", "arguments": "{}"},
+                }
+            ],
+        }
+    ]
+    assert turn_called_clarify(messages) is True
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            final_response="Waiting.",
+            messages=messages,
+        )
+        is None
+    )
+
+
+def test_nudge_budget_and_disable_gates():
+    store = _store(("remaining step", "pending"))
+    partial = "Finished the first half."
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            final_response=partial,
+            attempts=2,
+        )
+        is None
+    )
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            final_response=partial,
+            attempts=0,
+            enabled=False,
+        )
+        is None
+    )
+
+
+# ── Conversation-loop integration ────────────────────────────────────
+
+
+def _response(content: str):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            session_id="boundary-handoff-test",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance._cached_system_prompt = "stable test prompt"
+    instance._session_db = None
+    instance._session_json_enabled = False
+    instance.save_trajectories = False
+    instance.compression_enabled = False
+    instance._task_completion_guidance = True
+    instance._cleanup_task_resources = lambda *_a, **_kw: None
+    instance._save_trajectory = lambda *_a, **_kw: None
+    instance._todo_store = _store(
+        ("skill-local gate", "completed"),
+        ("scheduler scripts write", "pending"),
+    )
+    return instance
+
+
+def test_loop_rejects_ambiguous_stop_then_accepts_handoff(agent):
+    partial = (
+        "I finished the skill-local gate and verified tests. "
+        "Scheduler integration is still pending."
+    )
+    handoff = (
+        "Completed and verified the skill-local gate. Remaining work is the "
+        "scheduler scripts write outside this repository boundary. No live or "
+        "external state changed. Should I proceed with that write?"
+    )
+    replies = [_response(partial), _response(handoff)]
+
+    def model_call(_api_kwargs):
+        return replies.pop(0)
+
+    agent._interruptible_api_call = model_call
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("implement the dual-repo plan")
+
+    assert result["final_response"] == handoff
+    assert agent._boundary_handoff_nudges == 1
+    # Synthetic nudge stripped from returned history; assistant handoff remains.
+    roles = [message["role"] for message in result["messages"]]
+    assert roles[0] == "user"
+    assert "assistant" in roles
+    assert not any(
+        isinstance(message, dict) and message.get("_boundary_handoff_synthetic")
+        for message in result["messages"]
+    )
+
+
+def test_loop_accepts_valid_boundary_pause_without_nudge(agent):
+    handoff = (
+        "Completed and verified the skill-local gate. Remaining work is the "
+        "scheduler scripts write at a workspace boundary. No external state "
+        "changed. Do you want me to continue with that write?"
+    )
+    agent._interruptible_api_call = lambda _kwargs: _response(handoff)
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("implement the dual-repo plan")
+
+    assert result["final_response"] == handoff
+    assert getattr(agent, "_boundary_handoff_nudges", 0) == 0

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -245,6 +245,21 @@ def test_codex_incomplete_nudge_does_not_reset_clarify_window():
     assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
 
 
+def test_kanban_stop_nudge_is_not_real_user_for_compression():
+    from agent.conversation_compression import _is_real_user_message
+
+    assert (
+        _is_real_user_message(
+            {
+                "role": "user",
+                "content": "[System: You are a Hermes kanban worker.]",
+                "_kanban_stop_synthetic": True,
+            }
+        )
+        is False
+    )
+
+
 def test_nudge_budget_disable_and_clarify_unavailable():
     store = _store(("remaining step", "pending"))
     assert (

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -1,8 +1,7 @@
 """Regression coverage for incomplete-task boundary handoffs (#80772).
 
-Covers both implementation and planning shapes: remaining todos + a vague
-progress summary is an invalid terminal state; a self-contained handoff or
-clear completion claim is allowed.
+Structured evidence only: remaining todos + whether ``clarify`` ran this
+turn. Freeform English (or any language) summaries are not a valid pause.
 """
 
 from __future__ import annotations
@@ -17,8 +16,6 @@ from agent.boundary_handoff import (
     has_remaining_work,
     is_valid_terminal_for_remaining_work,
     remaining_todo_items,
-    response_has_blocker_or_clarification,
-    response_has_completion_claim,
     turn_called_clarify,
 )
 from tools.todo_tool import TodoStore
@@ -33,6 +30,20 @@ def _store(*items):
         ]
     )
     return store
+
+
+def _clarify_assistant():
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "1",
+                "type": "function",
+                "function": {"name": "clarify", "arguments": "{}"},
+            }
+        ],
+    }
 
 
 # ── Policy unit tests ────────────────────────────────────────────────
@@ -53,61 +64,18 @@ def test_remaining_work_from_active_todos_only():
 def test_no_remaining_work_when_todos_settled():
     store = _store(("a", "completed"), ("b", "cancelled"))
     assert has_remaining_work(store) is False
-    assert build_boundary_handoff_nudge(todo_store=store, final_response="summary") is None
+    assert is_valid_terminal_for_remaining_work(todo_store=store) is True
+    assert build_boundary_handoff_nudge(todo_store=store) is None
 
 
-def test_partial_progress_summary_is_invalid_terminal():
-    text = (
-        "I finished the skill-local gate and verified the unit tests. "
-        "The scheduler integration is next."
-    )
-    assert response_has_completion_claim(text) is False
-    assert response_has_blocker_or_clarification(text) is False
-    assert is_valid_terminal_for_remaining_work(text) is False
+def test_partial_progress_summary_is_invalid_when_todos_remain():
+    store = _store(("scheduler scripts write", "pending"))
+    assert is_valid_terminal_for_remaining_work(todo_store=store, messages=[]) is False
 
 
-def test_implementation_boundary_handoff_is_valid_terminal():
-    text = (
-        "Completed and verified the skill-local gate. Remaining work is the "
-        "scripts-tree scheduler write outside this workspace boundary. No live "
-        "or external state changed. Should I proceed with that write?"
-    )
-    assert response_has_blocker_or_clarification(text) is True
-    assert is_valid_terminal_for_remaining_work(text) is True
-
-
-def test_clear_completion_claim_is_valid_terminal():
-    text = "The implementation is complete. All requested work is done."
-    assert response_has_completion_claim(text) is True
-    assert is_valid_terminal_for_remaining_work(text) is True
-
-
-def test_planning_partial_summary_nudges():
-    store = _store(
-        ("outline API shape", "completed"),
-        ("choose storage backend", "pending"),
-        ("write rollout plan", "pending"),
-    )
-    partial = (
-        "I outlined the API shape. Next I will choose a storage backend and "
-        "draft the rollout plan."
-    )
-    nudge = build_boundary_handoff_nudge(
-        todo_store=store,
-        final_response=partial,
-        attempts=0,
-    )
-    assert nudge is not None
-    assert "Outstanding items" in nudge
-    assert "choose storage backend" in nudge
-    assert "decision or authorization" in nudge
-
-
-def test_planning_valid_pause_does_not_nudge():
-    store = _store(
-        ("outline API shape", "completed"),
-        ("choose storage backend", "pending"),
-    )
+def test_english_handoff_prose_alone_is_not_valid_terminal():
+    """Prose handoffs are ignored — language-agnostic structured gate."""
+    store = _store(("choose storage backend", "pending"))
     handoff = (
         "Completed the API outline. Remaining work is choosing the storage "
         "backend — that needs your approval before I continue. No external "
@@ -116,74 +84,85 @@ def test_planning_valid_pause_does_not_nudge():
     assert (
         build_boundary_handoff_nudge(
             todo_store=store,
-            final_response=handoff,
+            messages=[{"role": "assistant", "content": handoff}],
             attempts=0,
         )
-        is None
+        is not None
     )
 
 
-def test_implementation_partial_summary_nudges():
-    store = _store(
-        ("skill-local gate", "completed"),
-        ("scheduler scripts write", "pending"),
-    )
-    partial = (
-        "Implemented and tested the skill-local gate. Stopping here for now."
-    )
+def test_non_english_summary_also_nudges():
+    store = _store(("scheduler scripts write", "pending"))
     nudge = build_boundary_handoff_nudge(
         todo_store=store,
-        final_response=partial,
+        messages=[{"role": "assistant", "content": "技能侧门已完成，调度脚本待定。"}],
         attempts=0,
     )
     assert nudge is not None
+    assert "clarify" in nudge
     assert "scheduler scripts write" in nudge
-    assert "self-contained" in nudge.lower() or "actionable" in nudge.lower()
 
 
-def test_clarify_tool_already_asked_skips_nudge():
+def test_planning_partial_summary_nudges():
+    store = _store(
+        ("outline API shape", "completed"),
+        ("choose storage backend", "pending"),
+        ("write rollout plan", "pending"),
+    )
+    nudge = build_boundary_handoff_nudge(
+        todo_store=store,
+        messages=[{"role": "assistant", "content": "Outlined the API. Next steps later."}],
+        attempts=0,
+    )
+    assert nudge is not None
+    assert "Outstanding items" in nudge
+    assert "choose storage backend" in nudge
+    assert "`clarify`" in nudge
+
+
+def test_clarify_in_same_turn_skips_nudge_even_after_text_reply():
     store = _store(("remaining step", "pending"))
     messages = [
-        {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [
-                {
-                    "id": "1",
-                    "type": "function",
-                    "function": {"name": "clarify", "arguments": "{}"},
-                }
-            ],
-        }
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {"role": "tool", "name": "clarify", "content": '{"user_response":"wait"}'},
+        {"role": "assistant", "content": "Paused pending your decision."},
     ]
     assert turn_called_clarify(messages) is True
-    assert (
-        build_boundary_handoff_nudge(
-            todo_store=store,
-            final_response="Waiting.",
-            messages=messages,
-        )
-        is None
-    )
+    assert is_valid_terminal_for_remaining_work(todo_store=store, messages=messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
 
 
-def test_nudge_budget_and_disable_gates():
+def test_synthetic_nudge_does_not_reset_clarify_window():
     store = _store(("remaining step", "pending"))
-    partial = "Finished the first half."
+    messages = [
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {
+            "role": "user",
+            "content": "[System: nudge]",
+            "_boundary_handoff_synthetic": True,
+        },
+        {"role": "assistant", "content": "Still waiting."},
+    ]
+    assert turn_called_clarify(messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
+
+
+def test_nudge_budget_disable_and_clarify_unavailable():
+    store = _store(("remaining step", "pending"))
     assert (
-        build_boundary_handoff_nudge(
-            todo_store=store,
-            final_response=partial,
-            attempts=2,
-        )
+        build_boundary_handoff_nudge(todo_store=store, attempts=2) is None
+    )
+    assert (
+        build_boundary_handoff_nudge(todo_store=store, attempts=0, enabled=False)
         is None
     )
     assert (
         build_boundary_handoff_nudge(
             todo_store=store,
-            final_response=partial,
             attempts=0,
-            enabled=False,
+            clarify_available=False,
         )
         is None
     )
@@ -231,6 +210,8 @@ def agent(tmp_path, monkeypatch):
     instance._task_completion_guidance = True
     instance._cleanup_task_resources = lambda *_a, **_kw: None
     instance._save_trajectory = lambda *_a, **_kw: None
+    # Guard only fires when clarify is in the live toolset.
+    instance.valid_tool_names = {"clarify", "todo"}
     instance._todo_store = _store(
         ("skill-local gate", "completed"),
         ("scheduler scripts write", "pending"),
@@ -238,20 +219,25 @@ def agent(tmp_path, monkeypatch):
     return instance
 
 
-def test_loop_rejects_ambiguous_stop_then_accepts_handoff(agent):
+def test_loop_rejects_ambiguous_stop_then_accepts_when_todos_settled(agent):
     partial = (
         "I finished the skill-local gate and verified tests. "
         "Scheduler integration is still pending."
     )
-    handoff = (
-        "Completed and verified the skill-local gate. Remaining work is the "
-        "scheduler scripts write outside this repository boundary. No live or "
-        "external state changed. Should I proceed with that write?"
-    )
-    replies = [_response(partial), _response(handoff)]
+    done = "All outstanding todos are complete."
 
     def model_call(_api_kwargs):
-        return replies.pop(0)
+        if not hasattr(model_call, "n"):
+            model_call.n = 0
+        model_call.n += 1
+        if model_call.n == 1:
+            return _response(partial)
+        # After the nudge, settle todos then stop — structured completion.
+        agent._todo_store = _store(
+            ("skill-local gate", "completed"),
+            ("scheduler scripts write", "completed"),
+        )
+        return _response(done)
 
     agent._interruptible_api_call = model_call
 
@@ -261,24 +247,49 @@ def test_loop_rejects_ambiguous_stop_then_accepts_handoff(agent):
     ):
         result = agent.run_conversation("implement the dual-repo plan")
 
-    assert result["final_response"] == handoff
+    assert result["final_response"] == done
     assert agent._boundary_handoff_nudges == 1
-    # Synthetic nudge stripped from returned history; assistant handoff remains.
-    roles = [message["role"] for message in result["messages"]]
-    assert roles[0] == "user"
-    assert "assistant" in roles
     assert not any(
         isinstance(message, dict) and message.get("_boundary_handoff_synthetic")
         for message in result["messages"]
     )
 
 
-def test_loop_accepts_valid_boundary_pause_without_nudge(agent):
+def test_loop_english_handoff_without_clarify_still_nudges(agent):
     handoff = (
         "Completed and verified the skill-local gate. Remaining work is the "
         "scheduler scripts write at a workspace boundary. No external state "
         "changed. Do you want me to continue with that write?"
     )
+    settled = "Marked remaining todos complete after your go-ahead path."
+
+    def model_call(_api_kwargs):
+        if not hasattr(model_call, "n"):
+            model_call.n = 0
+        model_call.n += 1
+        if model_call.n == 1:
+            return _response(handoff)
+        agent._todo_store = _store(
+            ("skill-local gate", "completed"),
+            ("scheduler scripts write", "completed"),
+        )
+        return _response(settled)
+
+    agent._interruptible_api_call = model_call
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("implement the dual-repo plan")
+
+    assert result["final_response"] == settled
+    assert agent._boundary_handoff_nudges == 1
+
+
+def test_loop_skips_guard_when_clarify_not_in_toolset(agent):
+    agent.valid_tool_names = {"todo"}
+    handoff = "Stopped at the workspace boundary without calling clarify."
     agent._interruptible_api_call = lambda _kwargs: _response(handoff)
 
     with (

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -149,6 +149,36 @@ def test_synthetic_nudge_does_not_reset_clarify_window():
     assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
 
 
+def test_dropped_toolcall_nudge_does_not_reset_clarify_window():
+    store = _store(("remaining step", "pending"))
+    messages = [
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {
+            "role": "user",
+            "content": "Your previous turn indicated a tool call but none was included.",
+            "_dropped_toolcall_nudge": True,
+        },
+        {"role": "assistant", "content": "Paused pending your decision."},
+    ]
+    assert turn_called_clarify(messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
+
+
+def test_kanban_worker_skips_boundary_handoff_nudge(monkeypatch):
+    store = _store(("remaining step", "pending"))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.delenv("HERMES_KANBAN_STOP_NUDGE", raising=False)
+    assert (
+        build_boundary_handoff_nudge(
+            todo_store=store,
+            messages=[{"role": "assistant", "content": "Stopped mid-task."}],
+            clarify_available=True,
+        )
+        is None
+    )
+
+
 def test_nudge_budget_disable_and_clarify_unavailable():
     store = _store(("remaining step", "pending"))
     assert (

--- a/tests/agent/test_boundary_handoff.py
+++ b/tests/agent/test_boundary_handoff.py
@@ -213,6 +213,38 @@ def test_intent_ack_continue_does_not_reset_clarify_window():
     assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
 
 
+def test_length_continuation_does_not_reset_clarify_window():
+    store = _store(("remaining step", "pending"))
+    messages = [
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {
+            "role": "user",
+            "content": "Continue your previous response from where it was cut off.",
+            "_length_continuation_synthetic": True,
+        },
+        {"role": "assistant", "content": "Paused pending your decision."},
+    ]
+    assert turn_called_clarify(messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
+
+
+def test_codex_incomplete_nudge_does_not_reset_clarify_window():
+    store = _store(("remaining step", "pending"))
+    messages = [
+        {"role": "user", "content": "implement the plan"},
+        _clarify_assistant(),
+        {
+            "role": "user",
+            "content": "[System: Your previous response was incomplete. Continue.]",
+            "_codex_incomplete_synthetic": True,
+        },
+        {"role": "assistant", "content": "Paused pending your decision."},
+    ]
+    assert turn_called_clarify(messages) is True
+    assert build_boundary_handoff_nudge(todo_store=store, messages=messages) is None
+
+
 def test_nudge_budget_disable_and_clarify_unavailable():
     store = _store(("remaining step", "pending"))
     assert (

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -29,6 +29,34 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
+def test_kanban_stop_pair_stripped_from_finalize_history():
+    from agent.turn_finalizer import (
+        _VERIFICATION_CONTINUATION_FLAGS,
+        _drop_verification_continuation_scaffolding,
+    )
+
+    assert "_kanban_stop_synthetic" in _VERIFICATION_CONTINUATION_FLAGS
+    messages = [
+        {"role": "user", "content": "work kanban task"},
+        {
+            "role": "assistant",
+            "content": "Let me write the report now.",
+            "_kanban_stop_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": "[System: call kanban_complete]",
+            "_kanban_stop_synthetic": True,
+        },
+        {"role": "assistant", "content": "Calling kanban_complete now."},
+    ]
+    _drop_verification_continuation_scaffolding(messages)
+    assert [m.get("content") for m in messages] == [
+        "work kanban task",
+        "Calling kanban_complete now.",
+    ]
+
+
 def test_nudge_when_no_terminal_tool(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
     messages = [

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
     drain_truncation_warnings,
+    TASK_COMPLETION_BOUNDARY_GUIDANCE,
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -56,9 +57,11 @@ class TestGuidanceConstants:
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
 
     def test_task_completion_guidance_requires_clarify_at_boundary(self):
-        guidance = TASK_COMPLETION_GUIDANCE.lower()
+        # Base block stays tool-agnostic; clarify handoff is a separate gated block.
+        assert "`clarify`" not in TASK_COMPLETION_GUIDANCE
+        guidance = TASK_COMPLETION_BOUNDARY_GUIDANCE.lower()
 
-        assert "`clarify`" in TASK_COMPLETION_GUIDANCE
+        assert "`clarify`" in TASK_COMPLETION_BOUNDARY_GUIDANCE
         assert "completed and verified" in guidance
         assert "what remains" in guidance
         assert "exact boundary or blocker" in guidance

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
     drain_truncation_warnings,
+    TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -53,6 +54,15 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_task_completion_guidance_requires_actionable_boundary_handoff(self):
+        guidance = TASK_COMPLETION_GUIDANCE.lower()
+
+        assert "completed and verified" in guidance
+        assert "what remains" in guidance
+        assert "exact boundary or blocker" in guidance
+        assert "live or external state" in guidance
+        assert "decision or authorization" in guidance
 
 
 # =========================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -55,14 +55,16 @@ class TestGuidanceConstants:
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
 
-    def test_task_completion_guidance_requires_actionable_boundary_handoff(self):
+    def test_task_completion_guidance_requires_clarify_at_boundary(self):
         guidance = TASK_COMPLETION_GUIDANCE.lower()
 
+        assert "`clarify`" in TASK_COMPLETION_GUIDANCE
         assert "completed and verified" in guidance
         assert "what remains" in guidance
         assert "exact boundary or blocker" in guidance
         assert "live or external state" in guidance
         assert "decision or authorization" in guidance
+        assert "mark those todos completed" in guidance
 
 
 # =========================================================================

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -33,6 +33,11 @@ def test_verification_flags_registered_as_ephemeral(tmp_path, monkeypatch):
 
     assert "_verification_stop_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
     assert "_pre_verify_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert "_boundary_handoff_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert "_intent_ack_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert "_length_continuation_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert "_codex_incomplete_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert "_kanban_stop_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
 
     # The nudge messages ARE scaffolding (they carry the synthetic flag).
     assert ra._is_ephemeral_scaffolding(
@@ -40,6 +45,13 @@ def test_verification_flags_registered_as_ephemeral(tmp_path, monkeypatch):
     )
     assert ra._is_ephemeral_scaffolding(
         {"role": "user", "content": "[System: run tests]", "_verification_stop_synthetic": True}
+    )
+    assert ra._is_ephemeral_scaffolding(
+        {
+            "role": "user",
+            "content": "[System: boundary handoff]",
+            "_boundary_handoff_synthetic": True,
+        }
     )
     # Real messages (including the assistant candidate) are not.
     assert not ra._is_ephemeral_scaffolding({"role": "user", "content": "hi"})


### PR DESCRIPTION
## What does this PR do?

When an agent reaches a legitimate permission, safety, workspace, repository, or external-system boundary before finishing work, it could stop with only a partial-progress summary. That left users unable to tell whether the task was complete, paused, blocked, or abandoned.

This change does two things:

1. Extends universal task-completion guidance with a compact boundary-handoff contract (completed/verified scope, remaining work, exact blocker, live/external side effects, and the decision needed to continue).
2. Adds a turn-finalization guard: when task-tracking still shows remaining work, a final reply with neither a clear completion claim nor a blocker/decision handoff is treated as an invalid terminal state and nudged (up to twice) for an actionable handoff.

Legitimate pauses and safety gates remain allowed; they must be explicit and actionable.

## Related Issue

Fixes #80772

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/prompt_builder.py` - require actionable, self-contained handoffs when implementation pauses at a legitimate boundary.
- `agent/boundary_handoff.py` - policy for remaining-todo invalid terminal detection and handoff nudge text.
- `agent/conversation_loop.py` - wire the boundary-handoff stop guard into turn finalization.
- `agent/turn_finalizer.py`, `agent/turn_context.py`, `agent/conversation_compression.py` - strip/reset synthetic handoff scaffolding like other continuation nudges.
- `tests/agent/test_prompt_builder.py` - assert the semantic fields required by the boundary-handoff contract.
- `tests/agent/test_boundary_handoff.py` - policy and loop regressions for implementation and planning shapes, including a valid boundary pause.

## How to Test

1. Run the focused prompt-builder suite and confirm all tests pass.
2. Run the boundary-handoff regressions and confirm all tests pass.

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py -q
scripts/run_tests.sh tests/agent/test_boundary_handoff.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A - this changes internal agent guidance and turn-finalization behavior covered by tests
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no contributor workflow changed
- [x] Cross-platform impact considered: prompt text, policy heuristics, and Python assertions are platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - covered by prompt contract tests and conversation-loop regressions.
