### PR TITLE
fix(mcp): clamp generated MCP tool names to 64 chars

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -430,6 +430,33 @@ class TestSchemaConversion:
         assert schema["name"] == "mcp__my_server__get_sum"
         assert "-" not in schema["name"]
 
+    def test_long_names_are_clamped_to_64_chars(self):
+        """Portable Agent Plugin names can push mcp__<server>__<tool> past the
+        64-char limit OpenAI-compatible providers enforce on function names
+        (issue #81331). The registry name must be clamped with a stable hash
+        suffix, distinct long names must not collide, and the same inputs
+        must always produce the same shortened name.
+        """
+        from tools.mcp_tool import _convert_mcp_schema, mcp_prefixed_tool_name
+
+        server_name = "agent_plugin_my_server_997167c9__my_server"
+        mcp_tool = _make_mcp_tool(name="reply_communication_todo")
+        schema = _convert_mcp_schema(server_name, mcp_tool)
+
+        assert len(schema["name"]) <= 64
+        assert schema["name"] == mcp_prefixed_tool_name(server_name, "reply_communication_todo")
+
+        other_tool = _make_mcp_tool(name="reply_communication_task")
+        other_schema = _convert_mcp_schema(server_name, other_tool)
+        assert other_schema["name"] != schema["name"]
+        assert len(other_schema["name"]) <= 64
+
+        # Deterministic across repeated calls with the same inputs.
+        assert (
+            mcp_prefixed_tool_name(server_name, "reply_communication_todo")
+            == schema["name"]
+        )
+
 
 # ---------------------------------------------------------------------------
 # Check function

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -99,6 +99,7 @@ import contextvars
 import concurrent.futures
 import errno
 import fnmatch
+import hashlib
 import inspect
 import json
 import logging
@@ -5787,15 +5788,42 @@ def sanitize_mcp_name_component(value: str) -> str:
 MCP_TOOL_NAME_PREFIX = "mcp__"
 _MCP_NAME_DELIM = "__"
 
+# OpenAI-compatible providers validate function names against
+# ``^[a-zA-Z0-9_-]{1,64}$`` and reject the whole tools array (or, in the
+# portable-plugin case, silently drop the offending tool from the catalog)
+# when a generated name exceeds 64 chars. Portable Agent Plugin names put the
+# plugin name in three times over (slug, digest, server key), so their
+# server/tool prefix routinely blows past this limit even though a plain
+# ``hermes mcp add`` of the same server stays well under it (issue #81331).
+# Clamp deterministically with a collision-safe hash suffix, mirroring the
+# property-key clamp in schema_sanitizer.sanitize_property_key.
+_MCP_TOOL_NAME_MAX_LENGTH = 64
+_MCP_TOOL_NAME_HASH_LENGTH = 8
+
 
 def mcp_prefixed_tool_name(server_name: str, tool_name: str) -> str:
     """Build the registry/wire name for an MCP tool.
 
-    Produces ``mcp__<sanitizedServer>__<sanitizedTool>``.
+    Produces ``mcp__<sanitizedServer>__<sanitizedTool>``, clamped to
+    ``_MCP_TOOL_NAME_MAX_LENGTH`` chars with a stable hash suffix when the
+    natural name would exceed it.
     """
     safe_server = sanitize_mcp_name_component(server_name)
     safe_tool = sanitize_mcp_name_component(tool_name)
-    return f"{MCP_TOOL_NAME_PREFIX}{safe_server}{_MCP_NAME_DELIM}{safe_tool}"
+    full_name = f"{MCP_TOOL_NAME_PREFIX}{safe_server}{_MCP_NAME_DELIM}{safe_tool}"
+    if len(full_name) <= _MCP_TOOL_NAME_MAX_LENGTH:
+        return full_name
+
+    digest = hashlib.sha256(full_name.encode("utf-8")).hexdigest()[:_MCP_TOOL_NAME_HASH_LENGTH]
+    suffix = f"_{digest}"
+    logger.warning(
+        "MCP tool name %r (%d chars) exceeds the %d-char provider limit; "
+        "shortened to a deterministic hash-suffixed name",
+        full_name,
+        len(full_name),
+        _MCP_TOOL_NAME_MAX_LENGTH,
+    )
+    return full_name[: _MCP_TOOL_NAME_MAX_LENGTH - len(suffix)] + suffix
 
 
 def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:


### PR DESCRIPTION
## Summary

Fixes #81331.

Portable Agent Plugins v1 packages fold the plugin name into the generated
MCP tool name three times over — as the slug, as the sha256 digest of that
same slug, and again as the server key when a package names its server
after itself (`hermes_cli/plugins.py`'s `_portable_skill_namespace()` +
`f"{manifest.skill_namespace}__{server_name}"`). The resulting
`mcp__<server>__<tool>` name built by `mcp_prefixed_tool_name()` in
`tools/mcp_tool.py` routinely lands between 75 and 88 characters for a
package with a normal-length name — well over the `^[a-zA-Z0-9_-]{1,64}$`
function-name limit OpenAI-compatible providers enforce. The same server
registered the old way (`hermes mcp add`) stays well under 64 chars because
it skips the plugin-namespace prefix entirely.

Nothing in the chain clamps or truncates the generated name, so the
failure is silent: registration logs succeed, `tool_search` activates
normally, and the tool shows up in `hermes plugins list` / `/tools`, but
the model can never actually reach it, because the provider itself has no
way to expose or accept a >64-char function name.

## Fix

Clamp `mcp_prefixed_tool_name()` (`tools/mcp_tool.py`) to 64 chars with a
deterministic, collision-safe sha256-based suffix whenever the natural
`mcp__<server>__<tool>` name would exceed the limit, mirroring the
existing property-key clamp pattern in
`tools/schema_sanitizer.py:sanitize_property_key`/`_rename_property_keys`
(as suggested in the issue). A warning is now logged whenever a name gets
shortened, so the failure is no longer silent even in edge cases this
patch doesn't fully resolve.

Dispatch to the underlying MCP server is unaffected: `_register_server_tools`
already binds each handler by closing over the tool's original, unprefixed
`mcp_tool.name` — the registry name is only ever used as the model-facing
key — so shortening it doesn't change what gets called on the wire. The
existing "ambiguous names fail closed" collision-preflight in
`_register_server_tools` also already covers the case where two long names
happen to clamp to the same string.

Short names (the common case, including plain `hermes mcp add` servers)
are completely unaffected — the clamp only triggers once the natural name
exceeds 64 chars.

## Test plan

Added `test_long_names_are_clamped_to_64_chars` to
`tests/tools/test_mcp_tool.py::TestSchemaConversion`, reproducing the
issue's exact scenario (a portable-plugin-style server name plus normal
tool names) and asserting:
- the generated name is clamped to <= 64 chars
- `_convert_mcp_schema` and `mcp_prefixed_tool_name` agree
- two distinct long names do not collide
- the shortened name is deterministic across repeated calls

Confirmed the new test fails without the fix:

```
$ git checkout HEAD~1 -- tools/mcp_tool.py && scripts/run_tests.sh tests/tools/test_mcp_tool.py -k TestSchemaConversion -q
...
>       assert len(schema["name"]) <= 64
E       AssertionError: assert 73 <= 64
E        +  where 73 = len('mcp__agent_plugin_my_server_997167c9__my_server__reply_communication_todo')
1 failed, 4 passed, 89 deselected in 0.71s
$ git checkout HEAD -- tools/mcp_tool.py
```

And passes with the fix, along with the rest of the affected suites:

```
$ scripts/run_tests.sh tests/tools/test_mcp_tool.py -q
=== Summary: 1 files, 94 tests passed, 0 failed (100% complete) in 2.6s (8 workers) ===

$ scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/tools/test_tool_search.py tests/tools/test_mcp_lazy_start.py -q
=== Summary: 3 files, 89 tests passed, 0 failed (100% complete) in 3.1s (8 workers) ===

$ ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py
All checks passed!
```

## AI-assistance disclosure

This change was implemented and tested with Claude Code (Anthropic).
