### PR TITLE
fix(models_dev): map meta-ai provider to models.dev 'meta' id

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -182,6 +182,13 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "xai-oauth": "xai",
     "xiaomi": "xiaomi",
     "nvidia": "nvidia",
+    # Meta Model API (Muse Spark family, api.meta.ai). models.dev keys these
+    # under the "meta" provider id; Hermes' provider is "meta-ai" (and the
+    # api.meta.ai host reverse-maps to "meta-ai"), so without both aliases the
+    # context/pricing lookup misses and muse-spark-* falls back to the generic
+    # 256K default instead of its true 1M window.
+    "meta-ai": "meta",
+    "meta": "meta",
     "groq": "groq",
     "mistral": "mistral",
     "togetherai": "togetherai",

--- a/tests/agent/test_models_dev_meta_mapping.py
+++ b/tests/agent/test_models_dev_meta_mapping.py
@@ -1,0 +1,8 @@
+"""Meta Model API maps to the models.dev 'meta' provider id (context/pricing)."""
+
+from agent.models_dev import PROVIDER_TO_MODELS_DEV
+
+
+def test_meta_ai_maps_to_meta():
+    assert PROVIDER_TO_MODELS_DEV.get("meta-ai") == "meta"
+    assert PROVIDER_TO_MODELS_DEV.get("meta") == "meta"


### PR DESCRIPTION
## What does this PR do?

Fixes context-window resolution for Meta's **Muse Spark** models (served via the Meta Model API at `api.meta.ai`), which currently fall back to the generic 256K default instead of their true ~1M window.

Root cause is a provider-id mismatch. The Meta Model API reverse-maps from `api.meta.ai` to the Hermes provider id **`meta-ai`**; models.dev keys the same models under the provider id **`meta`**. `lookup_models_dev_context()` / `_get_provider_models()` resolve the models.dev id strictly via `PROVIDER_TO_MODELS_DEV.get(provider)` (no raw-id fallback — unlike `get_model_info()`, which uses `.get(id, id)`), so an unmapped `meta-ai` misses entirely and token budgeting / compression drop to the 256K default.

This adds the `meta-ai → meta` mapping (plus a defensive `meta → meta`) so context and pricing resolve live from models.dev:
`muse-spark-1.1` = 1,000,000; `muse-spark-1.2` and `muse-spark-1.2-contributor` = 1,048,576.

> Note for reviewers: a broader alternative would be to give `lookup_models_dev_context()` / `_get_provider_models()` the same raw-id fallback (`.get(provider, provider)`) that `get_model_info()` already uses, so any provider whose id already matches a models.dev key resolves without a table entry. I kept this PR minimal (add the mapping) to avoid changing shared lookup semantics; happy to switch to the broader fix if preferred.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` — add `"meta-ai": "meta"` and `"meta": "meta"` to `PROVIDER_TO_MODELS_DEV`.
- `tests/agent/test_models_dev_meta_mapping.py` — assert the mapping resolves.

## How to Test

1. With any Meta Model API endpoint (`base_url=https://api.meta.ai/v1`), resolve context:
   ```python
   from agent.model_metadata import get_model_context_length as g
   for m in ("muse-spark-1.1", "muse-spark-1.2", "muse-spark-1.2-contributor"):
       print(m, g(m, base_url="https://api.meta.ai/v1", provider="meta-ai"))
   ```
   → `1000000`, `1048576`, `1048576` (was `256000` for each before this change).
2. `pytest tests/agent/test_models_dev_meta_mapping.py tests/agent/test_models_dev.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(models_dev): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant suite (`pytest tests/agent/test_models_dev*.py -q`) and it passes <!-- full `pytest tests/` not run: large suite, unrelated areas -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: CentOS Stream 9, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no user-facing docs change (internal registry mapping)
- [x] N/A — no config keys added
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — data-only dict entry, platform-agnostic
- [x] N/A — no tool behavior changed

## Screenshots / Logs

```
# before: falls back to generic default
muse-spark-1.2  ->  256000   (WARNING: Could not determine context length ... falling back to 256,000)
# after: resolved from models.dev
muse-spark-1.2  ->  1048576
```
