### PR TITLE
feat: add background review config gate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -456,6 +456,34 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _background_review_enabled_from_config() -> bool:
+    """Return the fail-open user gate for post-turn background review.
+
+    ``load_config_readonly`` includes ``DEFAULT_CONFIG``, so an absent setting
+    preserves the historical enabled behavior. Only a literal YAML boolean is
+    accepted here; malformed/manual values fail open rather than silently
+    disabling self-improvement.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+        agent_config = config.get("agent") if isinstance(config, dict) else None
+        review_config = (
+            agent_config.get("background_review")
+            if isinstance(agent_config, dict)
+            else None
+        )
+        enabled = (
+            review_config.get("enabled", True)
+            if isinstance(review_config, dict)
+            else True
+        )
+        return enabled if isinstance(enabled, bool) else True
+    except Exception:
+        return True
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -611,7 +639,11 @@ def init_agent(
     agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
-    # Background review (memory/skill) opt-out switch. When True, skips the
+    # User-facing master gate for the post-turn memory/skill review fork.
+    # This is baked into the agent at construction so gateway cache signatures
+    # can rebuild the instance atomically after a live config edit.
+    agent.background_review_enabled = _background_review_enabled_from_config()
+    # Internal/call-site opt-out switch. When True, skips the
     # _spawn_background_review fork at end-of-turn -- avoids ~30K tokens /
     # event of extra LLM cost on cron-style sessions where review forks
     # provide no value (no human in the loop, no skill-creation pressure).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -848,6 +848,8 @@ def run_codex_app_server_turn(
     if (
         turn.final_text
         and not turn.interrupted
+        and getattr(agent, "background_review_enabled", True)
+        and not getattr(agent, "skip_background_review", False)
         and (should_review_memory or should_review_skills)
     ):
         try:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -727,6 +727,7 @@ def finalize_turn(
     if (
         final_response
         and not interrupted
+        and getattr(agent, "background_review_enabled", True)
         and not getattr(agent, "skip_background_review", False)
         and (_should_review_memory or _should_review_skills)
     ):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -821,6 +821,13 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Master gate for the automatic post-turn memory/skill review fork.
+  # Defaults to true for backward compatibility. The memory.nudge_interval and
+  # skills.creation_nudge_interval settings above still control each trigger's
+  # cadence; set enabled false to suppress both forks with one switch.
+  background_review:
+    enabled: true
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22836,6 +22836,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "proactive_prune_min_reclaim_tokens"),
         ("compression", "min_tail_user_messages"),
         ("agent", "disabled_toolsets"),
+        ("agent", "background_review.enabled"),
         ("memory", "provider"),
         ("checkpoints", "enabled"),
         ("checkpoints", "max_snapshots"),
@@ -22909,7 +22910,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # toggle must still rebuild the cached agent.
                 out[f"{section}.{key}"] = section_val if key == "enabled" else None
             elif isinstance(section_val, dict):
-                out[f"{section}.{key}"] = section_val.get(key)
+                value: Any = section_val
+                for key_part in key.split("."):
+                    if not isinstance(value, dict):
+                        value = None
+                        break
+                    value = value.get(key_part)
+                out[f"{section}.{key}"] = value
             else:
                 out[f"{section}.{key}"] = None
         try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -30,6 +30,12 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 500,
+        # Post-turn self-improvement fork. The memory.nudge_interval and
+        # skills.creation_nudge_interval settings still control cadence; this
+        # is the single master gate for spawning either review path.
+        "background_review": {
+            "enabled": True,
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_skip_background_review.py
+++ b/tests/agent/test_skip_background_review.py
@@ -85,6 +85,32 @@ def test_default_skip_background_review_is_false() -> None:
     assert agent.skip_background_review is False
 
 
+def test_background_review_config_defaults_enabled(monkeypatch) -> None:
+    """The user-facing config gate preserves the historical enabled default."""
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"agent": {"background_review": {"enabled": True}}},
+    )
+    agent = _make_agent()
+    assert agent.background_review_enabled is True
+
+
+def test_background_review_config_can_disable_constructor_gate(monkeypatch) -> None:
+    """agent.background_review.enabled=false reaches every AIAgent instance."""
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"agent": {"background_review": {"enabled": False}}},
+    )
+    agent = _make_agent()
+    assert agent.background_review_enabled is False
+
+
 def test_skip_background_review_flag_persists() -> None:
     """Passing skip_background_review=True records the flag on the instance."""
     agent = _make_agent(skip_background_review=True)
@@ -109,6 +135,17 @@ def test_finalize_turn_fires_review_when_flag_unset() -> None:
     _stub_agent_for_finalize(agent)
     _run_finalize(agent)
     agent._spawn_background_review.assert_called_once()
+
+
+def test_finalize_turn_skips_review_when_config_gate_disabled() -> None:
+    """The normal runtime must honor the user-facing background-review gate."""
+    agent = _make_agent(skip_background_review=False)
+    agent.background_review_enabled = False
+    _stub_agent_for_finalize(agent)
+    _run_finalize(agent)
+    agent._spawn_background_review.assert_not_called()
+    # The master bool gates only the fork; interval accounting is unchanged.
+    assert agent._iters_since_skill == 0
 
 
 def test_cron_construction_sets_skip_background_review() -> None:

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -90,6 +90,27 @@ class TestAgentConfigSignature:
         assert sig1 != sig2
 
 
+    def test_background_review_toggle_change_busts_cache(self):
+        """A live gateway rebuilds its baked-at-construction review gate."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        enabled = GatewayRunner._extract_cache_busting_config(
+            {"agent": {"background_review": {"enabled": True}}}
+        )
+        disabled = GatewayRunner._extract_cache_busting_config(
+            {"agent": {"background_review": {"enabled": False}}}
+        )
+
+        sig_enabled = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "", cache_keys=enabled,
+        )
+        sig_disabled = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "", cache_keys=disabled,
+        )
+        assert sig_enabled != sig_disabled
+
+
     def test_cache_keys_key_order_does_not_matter(self):
         """Signature must be stable regardless of dict key insertion order."""
         from gateway.run import GatewayRunner

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -104,6 +104,21 @@ class TestConfigYamlRouting:
         config = _read_config(_isolated_hermes_home)
         assert "python:3.12" in config
 
+    def test_background_review_gate_is_known_boolean_config(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The documented gate is accepted by the CLI schema without --force."""
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["background_review"]["enabled"] is True
+
+        set_config_value("agent.background_review.enabled", "false")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["agent"]["background_review"]["enabled"] is False
+        assert "not a recognized config key" not in capsys.readouterr().out
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -305,6 +305,45 @@ class TestRunConversationCodexPath:
         # Counter should be reset after the review fires
         assert agent._iters_since_skill == 0
 
+    def test_background_review_config_gate_disables_codex_fork_but_keeps_cadence(
+        self, monkeypatch
+    ):
+        """Codex honors the shared gate without changing interval accounting."""
+        from agent.transports.codex_app_server_session import (
+            CodexAppServerSession, TurnResult,
+        )
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text=f"echo: {user_input}",
+                projected_messages=[
+                    {"role": "assistant", "content": f"echo: {user_input}"},
+                ],
+                tool_iterations=10,
+                turn_id="t1", thread_id="th1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th1"
+        )
+
+        agent = _make_codex_agent()
+        agent.background_review_enabled = False
+        agent._skill_nudge_interval = 10
+        agent._iters_since_skill = 0
+        agent.valid_tool_names = set(getattr(agent, "valid_tool_names", set()))
+        agent.valid_tool_names.add("skill_manage")
+
+        with patch.object(agent, "_spawn_background_review",
+                          return_value=None) as spawn:
+            agent.run_conversation("do tool work")
+
+        spawn.assert_not_called()
+        # The bool is only a fork gate. Existing cadence semantics remain:
+        # crossing the interval still consumes/resets the trigger counter.
+        assert agent._iters_since_skill == 0
+
     def test_background_review_signature_never_breaks(self, fake_session):
         """Even when no trigger fires, the helper must never call
         _spawn_background_review with the wrong signature. Run a turn,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -980,6 +980,40 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+## Background Review
+
+Hermes can start an automatic self-improvement fork after a completed turn when
+the memory or skill cadence reaches its threshold. Use the dedicated master gate
+to disable both automatic post-turn review paths without disabling foreground
+memory or skill tools:
+
+```yaml
+agent:
+  background_review:
+    enabled: true   # true (default) | false
+```
+
+The scriptable CLI equivalent is:
+
+```bash
+hermes config set agent.background_review.enabled false
+```
+
+This switch is independent of the existing cadence settings:
+
+- `memory.nudge_interval` controls the memory-review threshold in user turns.
+- `skills.creation_nudge_interval` controls the skill-review threshold in tool
+  iterations.
+- Setting either interval to `0` still disables only that trigger. Setting
+  `agent.background_review.enabled: false` suppresses the fork when either
+  trigger fires; it does not change their interval values or foreground write
+  semantics.
+
+The default is `true`, preserving behavior for existing installations. On a
+running gateway, changing the value takes effect on the next message: the agent
+cache signature includes this setting and transparently rebuilds the cached
+agent. The default and Codex app-server runtimes honor the same gate.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -214,11 +214,15 @@ How the wiring stays equivalent:
 | `_iters_since_skill` increments | per tool iteration in the chat-completions loop | by `turn.tool_iterations` after the codex turn returns |
 | Memory trigger (`_turns_since_memory >= _memory_nudge_interval`) | computed in pre-loop, fires after response | computed in pre-loop, passed through to codex helper |
 | Skill trigger (`_iters_since_skill >= _skill_nudge_interval`) | computed after the loop | computed after the codex turn |
+| `agent.background_review.enabled` master gate | checked before spawning the fork | checked identically before spawning the fork |
 | `_spawn_background_review(messages_snapshot=..., review_memory=..., review_skills=...)` | called when either trigger fires | called identically when either trigger fires |
 
 One detail: the review fork itself needs to call Hermes' agent-loop tools (`memory`, `skill_manage`), which require Hermes' own dispatch. So when the parent agent is on `codex_app_server`, the review fork is **downgraded to `codex_responses`** — same OAuth credentials, same `openai-codex` provider, but talks to OpenAI's Responses API directly so Hermes owns the loop and the agent-loop tools work. This is invisible to the user.
 
-Net effect: enable the codex runtime and your memory + skill nudges keep firing exactly as they would otherwise.
+Net effect: enable the codex runtime and your memory + skill nudges keep firing
+exactly as they would otherwise. To disable the automatic fork on both runtimes,
+set `agent.background_review.enabled: false`; the individual interval settings
+keep their existing cadence semantics.
 
 ## How approvals work
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -277,6 +277,13 @@ before they affect future sessions. By default it surfaces a short
 `💾 Memory updated` line in chat so you know it happened. Control how chatty
 that is:
 
+To disable the automatic post-turn review itself (memory and skill paths) while
+leaving foreground memory/skill tools available, set
+`agent.background_review.enabled: false`; see
+[Background Review](/user-guide/configuration#background-review). The existing
+`memory.nudge_interval` and `skills.creation_nudge_interval` values continue to
+control the individual trigger cadence.
+
 ```yaml
 display:
   memory_notifications: on    # off | on (default) | verbose


### PR DESCRIPTION
## Summary

- add `agent.background_review.enabled` as a default-on master gate for automatic post-turn memory/skill review forks
- enforce the gate in both the standard finalizer and Codex app-server runtime while preserving existing nudge-counter/interval semantics
- include the nested setting in gateway cache signatures so live config edits rebuild cached agents
- document YAML and `hermes config set` usage in the example config and user docs

## Verification

- `scripts/run_tests.sh tests/agent/test_skip_background_review.py tests/agent/test_codex_app_server_persist.py tests/agent/test_codex_app_server_event_bridge.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_cost_controls.py tests/gateway/test_agent_cache.py tests/gateway/test_config.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_loader_e2e.py` — 328 passed
- focused rerun after final test refinement — 155 passed
- `ruff check` on all changed Python files — passed
- `npm run build` in `website/` (using npm 11.17.0) — passed for English and zh-Hans; existing unrelated broken-link warnings remain

## Full-suite note

A full `scripts/run_tests.sh` run was attempted with the installed Hermes runtime venv. It reached 2,897 passing tests before being stopped after unrelated optional-dependency failures in `tests/agent/test_nous_portal_anthropic_wire.py` because that venv does not include the `anthropic` package. All feature-adjacent suites listed above pass.
