### PR TITLE
fix(checkpoints): snapshot V4A patch targets

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -60,9 +60,60 @@ def _ensure_file_checkpoint(
     effective_task_id: str,
 ) -> None:
     """Checkpoint the same workspace path that the file tool will mutate."""
-    file_path = function_args.get("path", "")
-    if not file_path:
+    is_v4a_patch = (
+        function_name == "patch"
+        and (function_args.get("mode") or "replace") == "patch"
+    )
+    if is_v4a_patch:
+        from tools.patch_parser import parse_v4a_patch
+
+        operations, parse_error = parse_v4a_patch(function_args.get("patch") or "")
+        if parse_error:
+            return
+        file_paths = [
+            path
+            for operation in operations
+            for path in (operation.file_path, operation.new_path)
+            if path
+        ]
+    else:
+        file_path = function_args.get("path", "")
+        file_paths = [file_path] if file_path else []
+
+    if not file_paths:
         return
+
+    if is_v4a_patch:
+        from tools.file_tools import (
+            _check_cross_profile_path,
+            _check_sensitive_path,
+            _protected_instruction_config,
+            _protected_instruction_reason,
+        )
+        from tools.path_security import has_traversal_component
+
+        task_id = effective_task_id or "default"
+        if any(has_traversal_component(path) for path in file_paths):
+            return
+        if any(_check_sensitive_path(path, task_id) for path in file_paths):
+            return
+        if not function_args.get("cross_profile", False) and any(
+            _check_cross_profile_path(path, task_id) for path in file_paths
+        ):
+            return
+        protected_enabled, protected_patterns = _protected_instruction_config()
+        if protected_enabled and any(
+            _protected_instruction_reason(
+                path,
+                task_id,
+                enabled=protected_enabled,
+                extra_patterns=protected_patterns,
+            )
+            for path in file_paths
+        ):
+            # Avoid snapshotting protected files before patch_tool receives
+            # approval.  Calling its approval gate here would prompt twice.
+            return
 
     # File tools resolve relative paths against the task's live/session cwd,
     # which can differ from the Hermes process cwd (notably in Docker).  Resolve
@@ -70,9 +121,14 @@ def _ensure_file_checkpoint(
     # discover the project root.
     from tools.file_tools import _resolve_path_for_task
 
-    resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
-    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
-    agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+    work_dirs = {
+        agent._checkpoint_mgr.get_working_dir_for_path(
+            str(_resolve_path_for_task(path, effective_task_id or "default"))
+        )
+        for path in file_paths
+    }
+    for work_dir in work_dirs:
+        agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
 
 
 def _budget_for_agent(agent) -> BudgetConfig:

--- a/tests/agent/test_tool_executor_checkpoint_paths.py
+++ b/tests/agent/test_tool_executor_checkpoint_paths.py
@@ -38,3 +38,121 @@ def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
 
     assert manager.list_checkpoints(str(workspace_cwd))
     assert manager.list_checkpoints(str(process_cwd)) == []
+
+
+def test_v4a_patch_checkpoint_uses_paths_embedded_in_patch(tmp_path, monkeypatch):
+    """V4A patches must snapshot files whose paths live in the patch body."""
+    workspace_cwd = tmp_path / "workspace"
+    workspace_cwd.mkdir()
+    (workspace_cwd / "pyproject.toml").write_text("[project]\nname = 'workspace'\n")
+    (workspace_cwd / "existing.txt").write_text("before\n")
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace_cwd))
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+
+    _ensure_file_checkpoint(
+        agent,
+        "patch",
+        {
+            "mode": "patch",
+            "patch": """*** Begin Patch
+*** Update File: existing.txt
+@@
+-before
++after
+*** End Patch""",
+        },
+        "gateway-session",
+    )
+
+    checkpoints = manager.list_checkpoints(str(workspace_cwd))
+    assert checkpoints
+
+    (workspace_cwd / "existing.txt").write_text("after\n")
+    result = manager.restore(str(workspace_cwd), checkpoints[0]["hash"])
+
+    assert result["success"] is True
+    assert (workspace_cwd / "existing.txt").read_text() == "before\n"
+
+
+def test_v4a_patch_checkpoint_rejects_traversal_before_snapshot(tmp_path, monkeypatch):
+    """Rejected V4A paths must not copy an out-of-workspace project."""
+    workspace_cwd = tmp_path / "workspace"
+    outside_cwd = tmp_path / "outside"
+    workspace_cwd.mkdir()
+    outside_cwd.mkdir()
+    (workspace_cwd / "pyproject.toml").write_text("[project]\nname = 'workspace'\n")
+    (outside_cwd / "pyproject.toml").write_text("[project]\nname = 'outside'\n")
+    (outside_cwd / "secret.txt").write_text("do not snapshot\n")
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace_cwd))
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+
+    _ensure_file_checkpoint(
+        agent,
+        "patch",
+        {
+            "mode": "patch",
+            "patch": """*** Begin Patch
+*** Update File: ../outside/secret.txt
+@@
+-do not snapshot
++changed
+*** End Patch""",
+        },
+        "gateway-session",
+    )
+
+    assert manager.list_checkpoints(str(outside_cwd)) == []
+
+
+def test_v4a_patch_checkpoint_ignores_headers_after_end_marker(tmp_path, monkeypatch):
+    """Checkpoint targets must match the paths the V4A parser will apply."""
+    workspace_cwd = tmp_path / "workspace"
+    outside_cwd = tmp_path / "outside"
+    workspace_cwd.mkdir()
+    outside_cwd.mkdir()
+    (workspace_cwd / "pyproject.toml").write_text("[project]\nname = 'workspace'\n")
+    (workspace_cwd / "existing.txt").write_text("before\n")
+    (outside_cwd / "pyproject.toml").write_text("[project]\nname = 'outside'\n")
+    (outside_cwd / "secret.txt").write_text("do not snapshot\n")
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace_cwd))
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+
+    _ensure_file_checkpoint(
+        agent,
+        "patch",
+        {
+            "mode": "patch",
+            "patch": f"""*** Begin Patch
+*** Update File: existing.txt
+@@
+-before
++after
+*** End Patch
+*** Update File: {outside_cwd / 'secret.txt'}""",
+        },
+        "gateway-session",
+    )
+
+    assert manager.list_checkpoints(str(workspace_cwd))
+    assert manager.list_checkpoints(str(outside_cwd)) == []


### PR DESCRIPTION
## Summary
- parse canonical V4A operations before file mutation and checkpoint every affected project root
- apply traversal, sensitive-path, cross-profile, and protected-file classification before snapshots
- add regression coverage for restore behavior, traversal rejection, and headers after the end marker

## Reproduction
With checkpoints enabled, a `patch` call using `mode="patch"` stores file paths inside the V4A body rather than the top-level `path` argument. `_ensure_file_checkpoint` previously returned early, so `/rollback` reported no checkpoints after the edit.

## Test plan
- `scripts/run_tests.sh tests/agent/test_tool_executor_checkpoint_paths.py tests/agent/test_tool_dispatch_helpers.py tests/tools/test_patch_parser.py tests/tools/test_checkpoint_manager.py -q` (95 passed)
- `uvx ruff check agent/tool_executor.py tests/agent/test_tool_executor_checkpoint_paths.py`
- `git diff --check`
- manual V4A move + multi-project checkpoint validation
- independent security/code review passed

A broader `tests/agent/` run had 7 failures that reproduce unchanged on `origin/main` in this environment. `tests/tools/test_file_tools.py` also has two macOS `/tmp` vs `/private/tmp` failures that reproduce unchanged on `origin/main`.